### PR TITLE
feat: call a simulated service from a Task state

### DIFF
--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -14,8 +14,9 @@ Six state types run. `Pass`, `Task`, `Succeed`, `Fail`, `Choice` and `Wait`. A d
 The data-flow fields run in full. `InputPath`, `Parameters`, `ResultSelector`, `ResultPath` and
 `OutputPath` apply in that order, reading Reference Paths and the intrinsic functions.
 
-A `Task` state invokes a simulated Lambda function. Every other `Resource` is refused when the state
-machine is created, naming what the definition asked for.
+A `Task` state invokes a simulated Lambda function, calls an operation on any other simulated
+service, or starts another state machine. A `Resource` this simulator has no answer for is refused
+when the state machine is created, naming what the definition asked for.
 
 A `Task` state's `Retry` and `Catch` both run, on the simulation's clock, along with the
 `TimeoutSeconds` and `HeartbeatSeconds` it takes.
@@ -465,6 +466,189 @@ its retries in it, and a task that reaches the deadline gives up where it stands
 states took, and what each run failed with. A test asserting that a task ran three times counts the
 rows.
 
+## Calling a simulated service
+
+A `Task` state can call an operation on any service this simulation holds, through both of the forms
+Amazon States Language gives a service integration.
+
+`arn:aws:states:::aws-sdk:<service>:<operation>` is the SDK integration. The state's `Parameters` are
+the request and the operation's response is its result. The service is named the way the AWS SDK
+names it, in lower case with nothing between the words (`dynamodb`, `sqs`, `eventbridge`, `sfn`,
+`secretsmanager`, `cloudwatchlogs`). Every simulated service answers one, and a service this
+simulation has no simulation of is refused when the state machine is created.
+
+Seven integrations are the ones Step Functions optimises, and each carries the request shape that
+integration defines.
+
+| `Resource`                               | Calls                           |
+| ---------------------------------------- | ------------------------------- |
+| `arn:aws:states:::dynamodb:putItem`      | DynamoDB `PutItem`              |
+| `arn:aws:states:::dynamodb:getItem`      | DynamoDB `GetItem`              |
+| `arn:aws:states:::dynamodb:updateItem`   | DynamoDB `UpdateItem`           |
+| `arn:aws:states:::dynamodb:deleteItem`   | DynamoDB `DeleteItem`           |
+| `arn:aws:states:::sns:publish`           | SNS `Publish`                   |
+| `arn:aws:states:::sqs:sendMessage`       | SQS `SendMessage`               |
+| `arn:aws:states:::events:putEvents`      | EventBridge `PutEvents`         |
+| `arn:aws:states:::states:startExecution` | Step Functions `StartExecution` |
+
+Four of them carry a message, and an optimized integration lets that message be written as JSON.
+`Message` on `sns:publish`, `MessageBody` on `sqs:sendMessage`, the `Detail` of each
+`events:putEvents` entry and `Input` on `states:startExecution` are all serialised on the way out.
+`Parameters` build a message the way they build anything else.
+
+```typescript sim-step-functions-service-task
+/**
+ * A workflow that records an enrolment in DynamoDB and announces it on SNS.
+ */
+
+import { CreateTableCommand, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateTopicCommand } from "@aws-sdk/client-sns";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "enrolments",
+    KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+const topic = await simAws
+  .sns()
+  .createTopic(new CreateTopicCommand({ Name: "enrolments" }));
+
+// The execution assumes this role, and every call it makes is authorized as it.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "WorkflowRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "states.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "WorkflowRole",
+    PolicyName: "RecordEnrolments",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: ["dynamodb:PutItem", "sns:Publish"],
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: role.Role.Arn,
+    definition: JSON.stringify({
+      StartAt: "Record",
+      States: {
+        Record: {
+          Type: "Task",
+          Resource: "arn:aws:states:::dynamodb:putItem",
+          Parameters: {
+            TableName: "enrolments",
+            Item: { id: { "S.$": "$.student" }, term: { S: "2026-autumn" } },
+          },
+          // PutItem answers with nothing, and the announcement needs the input.
+          ResultPath: null,
+          Next: "Announce",
+        },
+        Announce: {
+          Type: "Task",
+          Resource: "arn:aws:states:::sns:publish",
+          Parameters: {
+            TopicArn: topic.TopicArn,
+            Message: { "student.$": "$.student", enrolled: true },
+          },
+          End: true,
+        },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // SUCCEEDED
+
+const recorded = await simAws.dynamoDb().getItem(
+  new GetItemCommand({
+    TableName: "enrolments",
+    Key: { id: { S: "Wei" } },
+  }),
+);
+
+console.log(recorded.Item?.["term"]); // { S: '2026-autumn' }
+```
+
+The five data-flow fields apply around one of these calls the way they apply around any other state.
+`Parameters` build the request, and `ResultSelector`, `ResultPath` and `OutputPath` shape the
+response. A `Parameters` field written with `.$` reads a Reference Path or an intrinsic. The `Item`
+above takes its key out of the execution's input that way.
+
+The call is made in the state machine's own Account and Region. A resource in another one is reached
+by naming it in the request, where the operation takes an ARN.
+
+### What the execution role has to allow
+
+Each call carries the role the execution assumed, and simulated IAM answers it against that role's
+policies and the resource the request names. The action is the one AWS documents for the operation,
+so `dynamodb:PutItem` for a `putItem` and `sns:Publish` for a `publish`. A role that has not been
+granted it fails the task with an access denied error, naming the action and the resource.
+
+`states:startExecution` is the exception. Simulated Step Functions authorizes none of its own
+operations yet. A task starting another state machine runs whatever the role allows.
+
+### When a service refuses a call
+
+The task fails under the name Amazon States Language gives a service error. That name is the service
+and the error joined by a dot. A conditional write that did not hold is
+`DynamoDb.ConditionalCheckFailedException`, and a request the service would not accept is
+`DynamoDb.ValidationException`. `Retry` and `Catch` match on that name.
+
+The error is the service's own name for what it refused, and simulated IAM calls a refusal
+`AccessDenied`. A task an execution role may not make is `DynamoDb.AccessDenied` here, where real
+Step Functions writes `DynamoDb.AccessDeniedException`.
+
+Anything that stopped the call from reaching the service fails the task with `States.TaskFailed`. An
+operation this simulator has no implementation for is one of these, and the cause names the operation
+and lists what that simulated service does run. That refusal comes when the task runs, because the
+operations a service runs belong to the simulated service and there is none to ask while a state
+machine is being created.
+
+### What a Resource is refused for
+
+`.sync` and `.waitForTaskToken` are refused when the state machine is created, naming the pattern. A
+task here calls and answers, and both of those hold a state open until something else happens. An
+integration for a service this simulation has no simulation of is refused the same way, naming the
+service and the operation the definition asked for.
+
 ## Branching on the input
 
 A `Choice` state takes the first rule its input matches, and its `Default` where none of them do.
@@ -831,6 +1015,12 @@ A test asserting on the output of a state machine that used one could only asser
 - **A task's `Invoke` response carries three fields.** `ExecutedVersion`, `Payload` and
   `StatusCode`. Real Step Functions adds `SdkHttpMetadata` and `SdkResponseMetadata`, which describe
   a call over a network there was none of here.
+- **A service call an execution role may not make fails as `AccessDenied`.** Simulated IAM names a
+  refusal that way, and the task error is the service and that name joined by a dot. Real Step
+  Functions writes the service's own `AccessDeniedException`.
+- **An operation a simulated service has no implementation for is refused when the task runs.** The
+  operations a service runs belong to the simulated service, and there is none to ask while the
+  state machine is being created. The service itself is refused there.
 - **A failed task's `Cause` is the handler's message.** Real Step Functions writes the JSON error
   document Lambda answered with, holding `errorMessage`, `errorType` and a stack trace.
 - **A task's timeout covers the whole state.** Real Step Functions gives every attempt its own
@@ -867,6 +1057,6 @@ two and is what this follows.
 ## Still to come
 
 - `Parallel` and `Map` states, and the `Retry` and `Catch` those two take.
-- Service integrations beyond Lambda, task tokens and activities.
+- The `.sync` pattern, task tokens and activities.
 - The context object, `$$`.
 - JSONata as a query language, and the `Assign` variables that go with it.

--- a/docs/services/stepfunctions/sim-step-functions-service-task.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-service-task.example.ts
@@ -1,0 +1,108 @@
+/**
+ * A workflow that records an enrolment in DynamoDB and announces it on SNS.
+ */
+
+import { CreateTableCommand, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateTopicCommand } from "@aws-sdk/client-sns";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "enrolments",
+    KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+const topic = await simAws
+  .sns()
+  .createTopic(new CreateTopicCommand({ Name: "enrolments" }));
+
+// The execution assumes this role, and every call it makes is authorized as it.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "WorkflowRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "states.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "WorkflowRole",
+    PolicyName: "RecordEnrolments",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: ["dynamodb:PutItem", "sns:Publish"],
+        Resource: "*",
+      },
+    }),
+  }),
+);
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: role.Role.Arn,
+    definition: JSON.stringify({
+      StartAt: "Record",
+      States: {
+        Record: {
+          Type: "Task",
+          Resource: "arn:aws:states:::dynamodb:putItem",
+          Parameters: {
+            TableName: "enrolments",
+            Item: { id: { "S.$": "$.student" }, term: { S: "2026-autumn" } },
+          },
+          // PutItem answers with nothing, and the announcement needs the input.
+          ResultPath: null,
+          Next: "Announce",
+        },
+        Announce: {
+          Type: "Task",
+          Resource: "arn:aws:states:::sns:publish",
+          Parameters: {
+            TopicArn: topic.TopicArn,
+            Message: { "student.$": "$.student", enrolled: true },
+          },
+          End: true,
+        },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.status); // SUCCEEDED
+
+const recorded = await simAws.dynamoDb().getItem(
+  new GetItemCommand({
+    TableName: "enrolments",
+    Key: { id: { S: "Wei" } },
+  }),
+);
+
+console.log(recorded.Item?.["term"]); // { S: '2026-autumn' }

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -142,6 +142,17 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
 ]);
 
 /**
+ * Every AWS service SDK interception can reach a simulation of.
+ *
+ * Read by anything that resolves a service from something other than an SDK
+ * client, such as a Step Functions `Task` state whose `Resource` names a
+ * service and an operation.
+ */
+export function simSdkInterceptedServiceIds(): readonly string[] {
+  return scopedRouters.keys().toArray();
+}
+
+/**
  * Resolve the scoped simulated service SDK Command router for an intercepted
  * client's AWS service.
  *

--- a/src/service/stepfunctions/error/sim-step-functions.error.ts
+++ b/src/service/stepfunctions/error/sim-step-functions.error.ts
@@ -107,6 +107,18 @@ export class SimStatesTaskHandlerFailure extends SimStepFunctionsError {
 }
 
 /**
+ * A service that refused the call a `Task` state made.
+ *
+ * Amazon States Language names a service error after the service and the error
+ * together, so `DynamoDb.ConditionalCheckFailedException` is a conditional
+ * write that did not hold. The name is given where this is raised, because it
+ * is read off what the service said rather than fixed by the class.
+ */
+export class SimStatesServiceFailure extends SimStepFunctionsError {
+  public override readonly name = "SimStatesServiceFailure";
+}
+
+/**
  * A state that could not run on the data it was given.
  *
  * A `Choice` rule comparing a field that is not there, or a `Wait` reading a

--- a/src/service/stepfunctions/task/service/sim-states-optimized-integrations.iso.test.ts
+++ b/src/service/stepfunctions/task/service/sim-states-optimized-integrations.iso.test.ts
@@ -1,0 +1,311 @@
+import { GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { PutRuleCommand, PutTargetsCommand } from "@aws-sdk/client-eventbridge";
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simSnsSubscribedFunction } from "../../../../../test/sns/function-fixture.js";
+import { simAwsWithTopic } from "../../../../../test/sns/topic-fixture.js";
+import { simAwsWithQueue } from "../../../../../test/sqs/queue-fixture.js";
+import { statesExecutionRoleFactory } from "../../../../../test/stepfunctions/states-execution-role.factory.js";
+import { runSimStatesTaskState } from "../../../../../test/stepfunctions/states-task-fixture.js";
+import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCreatedTableFactory } from "../../../dynamodb/table/sim-dynamodb-created-table.factory.js";
+
+describe("The Task state integrations Step Functions optimises", () => {
+  it("writes an item a GetItem afterwards reads back", async () => {
+    // Given a table, and a role allowed to write to that table alone.
+    const simAws = new SimAws();
+    const table = await simDynamoDbCreatedTableFactory.make(
+      { tableName: "enrolments" },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          {
+            Effect: "Allow",
+            Action: "dynamodb:PutItem",
+            Resource: table.arn,
+          },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task writes an item it built from the execution's input.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::dynamodb:putItem",
+        Parameters: {
+          TableName: "enrolments",
+          Item: { id: { "S.$": "$.student" }, term: { S: "2026-autumn" } },
+        },
+        End: true,
+      },
+      input: JSON.stringify({ student: "Wei" }),
+    });
+
+    // Then the item is on the table.
+    assertIdentical(described.status, "SUCCEEDED");
+
+    const read = await simAws.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: "enrolments",
+        Key: { id: { S: "Wei" } },
+      }),
+    );
+
+    assertObjectEquals(read.Item ?? {}, {
+      id: { S: "Wei" },
+      term: { S: "2026-autumn" },
+    });
+  });
+
+  it("answers a getItem with the item the table holds", async () => {
+    // Given a table with an item on it.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "enrolments" },
+      simAws,
+    );
+    await simAws.dynamoDb().putItem({
+      input: {
+        TableName: "enrolments",
+        Item: { id: { S: "Wei" }, term: { S: "2026-autumn" } },
+      },
+    });
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "dynamodb:GetItem", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task reads it.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::dynamodb:getItem",
+        Parameters: { TableName: "enrolments", Key: { id: { S: "Wei" } } },
+        ResultSelector: { "term.$": "$.Item.term.S" },
+        End: true,
+      },
+    });
+
+    // Then the response is the task's result, with no SDK metadata around it.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '{"term":"2026-autumn"}');
+  });
+
+  it("publishes a message a subscribed function is delivered", async () => {
+    // Given a topic with a function subscribed to it.
+    const simAws = new SimAws();
+    const { topicArn } = await simAwsWithTopic(undefined, simAws);
+    const subscribed = await simSnsSubscribedFunction(
+      simAws,
+      "announce-enrolment",
+      topicArn,
+    );
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "sns:Publish", Resource: topicArn },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task publishes a message written as JSON rather than as a string.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::sns:publish",
+        Parameters: {
+          TopicArn: topicArn,
+          Message: { "student.$": "$.student", enrolled: true },
+        },
+        End: true,
+      },
+      input: JSON.stringify({ student: "Wei" }),
+    });
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the subscribed function was delivered the message as a string, the
+    // way a real publish carries it.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertStringIncludes(described.output ?? "", '"MessageId"');
+
+    const record = subscribed.events[0]?.Records[0];
+
+    assertNonNullable(record, "The subscribed function was delivered a record");
+    assertIdentical(record.Sns["Message"], '{"student":"Wei","enrolled":true}');
+  });
+
+  it("sends a message written as a string as it was written", async () => {
+    // Given a queue, and a role allowed to send to it.
+    const simAws = new SimAws();
+    const { queueUrl } = await simAwsWithQueue(undefined, simAws);
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "sqs:SendMessage", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task sends a message body that is already a string.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::sqs:sendMessage",
+        Parameters: { QueueUrl: queueUrl, "MessageBody.$": "$.student" },
+        End: true,
+      },
+      input: JSON.stringify({ student: "Wei" }),
+    });
+
+    // Then the queue holds what the state built, with no quotes around it.
+    assertIdentical(described.status, "SUCCEEDED");
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(received.Messages?.[0]?.Body, "Wei");
+  });
+
+  it("sends a message a receive afterwards takes off the queue", async () => {
+    // Given a queue, and a role allowed to send to it.
+    const simAws = new SimAws();
+    const { queueUrl } = await simAwsWithQueue(undefined, simAws);
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "sqs:SendMessage", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task sends a message body written as JSON.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::sqs:sendMessage",
+        Parameters: {
+          QueueUrl: queueUrl,
+          MessageBody: { "student.$": "$.student" },
+        },
+        End: true,
+      },
+      input: JSON.stringify({ student: "Wei" }),
+    });
+
+    // Then a receive takes it off the queue.
+    assertIdentical(described.status, "SUCCEEDED");
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(received.Messages?.[0]?.Body, '{"student":"Wei"}');
+  });
+
+  it("puts an event a rule matches and delivers", async () => {
+    // Given a rule that invokes a function for enrolment events.
+    const simAws = new SimAws();
+    const details: unknown[] = [];
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "record-enrolment",
+        Role: "arn:aws:iam::123456789012:role/FunctionRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: { detail: unknown }) => {
+            details.push(event.detail);
+
+            return "recorded";
+          }),
+        },
+      },
+    });
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "record-enrolment",
+        StatementId: "AllowEvents",
+        Action: "lambda:InvokeFunction",
+        Principal: "events.amazonaws.com",
+      }),
+    );
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "enrolments",
+        EventPattern: JSON.stringify({ source: ["enrolment.service"] }),
+      }),
+    );
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "enrolments",
+        Targets: [
+          {
+            Id: "record",
+            Arn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:record-enrolment`,
+          },
+        ],
+      }),
+    );
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "events:PutEvents", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task puts an event whose Detail is written as JSON.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::events:putEvents",
+        Parameters: {
+          Entries: [
+            {
+              Source: "enrolment.service",
+              DetailType: "Enrolled",
+              Detail: { "student.$": "$.student" },
+            },
+          ],
+        },
+        End: true,
+      },
+      input: JSON.stringify({ student: "Wei" }),
+    });
+
+    await simAws.backgroundTasksComplete();
+
+    // Then the rule matched the event and the target read the detail.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertStringIncludes(described.output ?? "", '"FailedEntryCount":0');
+    assertObjectEquals(details[0] ?? {}, { student: "Wei" });
+  });
+});

--- a/src/service/stepfunctions/task/service/sim-states-optimized-integrations.ts
+++ b/src/service/stepfunctions/task/service/sim-states-optimized-integrations.ts
@@ -1,0 +1,157 @@
+import type {
+  JSONObject,
+  JSONValue,
+} from "../../../../util/type-guard/json.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimStatesServiceShape } from "./sim-states-service-shape.js";
+
+/**
+ * One of the integrations Step Functions optimises, and the call it makes.
+ */
+export interface SimStatesOptimizedIntegration {
+  /**
+   * The AWS SDK service the integration calls. A `Resource` can name it by
+   * another.
+   */
+  readonly serviceId: string;
+
+  /**
+   * The operation as the API writes it.
+   */
+  readonly operation: string;
+
+  /**
+   * What the integration does to the request and the result, where its shape
+   * is not the API's own.
+   */
+  readonly shape?: SimStatesServiceShape;
+}
+
+/**
+ * The integrations Step Functions optimises, by what a `Resource` writes after
+ * `arn:aws:states:::`.
+ *
+ * An optimized integration is the same call an `aws-sdk` integration makes,
+ * with a shape of its own around it. The three that carry a message let it be
+ * written as JSON rather than as a string, and `states:startExecution` writes
+ * the request in the capitals Amazon States Language uses rather than the ones
+ * the Step Functions API does.
+ *
+ * `lambda:invoke` is not here. A `Task` state invoking a function talks to the
+ * function rather than to a simulated service, and reads a handler raising as
+ * a task failure of its own.
+ */
+export const simStatesOptimizedIntegrations: ReadonlyMap<
+  string,
+  SimStatesOptimizedIntegration
+> = new Map<string, SimStatesOptimizedIntegration>([
+  ["dynamodb:putItem", { serviceId: "DynamoDB", operation: "putItem" }],
+  ["dynamodb:getItem", { serviceId: "DynamoDB", operation: "getItem" }],
+  ["dynamodb:updateItem", { serviceId: "DynamoDB", operation: "updateItem" }],
+  ["dynamodb:deleteItem", { serviceId: "DynamoDB", operation: "deleteItem" }],
+  [
+    "sns:publish",
+    {
+      serviceId: "SNS",
+      operation: "publish",
+      shape: { request: (parameters) => serialised(parameters, "Message") },
+    },
+  ],
+  [
+    "sqs:sendMessage",
+    {
+      serviceId: "SQS",
+      operation: "sendMessage",
+      shape: { request: (parameters) => serialised(parameters, "MessageBody") },
+    },
+  ],
+  [
+    "events:putEvents",
+    {
+      serviceId: "EventBridge",
+      operation: "putEvents",
+      shape: { request: putEventsRequest },
+    },
+  ],
+  [
+    "states:startExecution",
+    {
+      serviceId: "SFN",
+      operation: "startExecution",
+      shape: { request: startExecutionRequest, answer: startExecutionAnswer },
+    },
+  ],
+]);
+
+/**
+ * Write a field that carries a message as the string the API takes.
+ *
+ * An optimized integration lets the message be built as JSON, the way
+ * `Parameters` build anything else, and sends it as the string a real call
+ * carries.
+ */
+function serialised(parameters: JSONObject, field: string): JSONObject {
+  // The field is one of this file's own, rather than anything a definition
+  // wrote.
+  // oxlint-disable-next-line security/detect-object-injection
+  const value = parameters[field];
+
+  if (value === undefined || typeof value === "string") {
+    return parameters;
+  }
+
+  return { ...parameters, [field]: JSON.stringify(value) };
+}
+
+/**
+ * Serialise the `Detail` of every entry. That is where a `PutEvents` carries
+ * its message.
+ */
+function putEventsRequest(parameters: JSONObject): JSONObject {
+  const entries = parameters["Entries"];
+
+  if (!Array.isArray(entries)) {
+    return parameters;
+  }
+
+  return {
+    ...parameters,
+    Entries: entries.map((entry) =>
+      isRecord(entry) ? serialised(entry, "Detail") : entry,
+    ),
+  };
+}
+
+/**
+ * Write a `StartExecution` the way the Step Functions API takes it.
+ *
+ * The integration names the fields with a capital and the API does not, and
+ * the input can be written as JSON rather than as the string a real call
+ * carries.
+ */
+function startExecutionRequest(parameters: JSONObject): JSONObject {
+  const input = parameters["Input"];
+
+  return {
+    stateMachineArn: parameters["StateMachineArn"] ?? null,
+    ...(parameters["Name"] !== undefined && { name: parameters["Name"] }),
+    ...(input !== undefined && {
+      input: typeof input === "string" ? input : JSON.stringify(input),
+    }),
+  };
+}
+
+/**
+ * Answer the way the integration does. The result is the execution that
+ * started, and when it started.
+ */
+function startExecutionAnswer(result: JSONValue): JSONValue {
+  if (!isRecord(result)) {
+    return result;
+  }
+
+  return {
+    ExecutionArn: result["executionArn"] ?? null,
+    StartDate: result["startDate"] ?? null,
+  };
+}

--- a/src/service/stepfunctions/task/service/sim-states-sdk-integration.iso.test.ts
+++ b/src/service/stepfunctions/task/service/sim-states-sdk-integration.iso.test.ts
@@ -1,0 +1,119 @@
+import { ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import { assertIdentical, assertStringIncludes } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithQueue } from "../../../../../test/sqs/queue-fixture.js";
+import { statesExecutionRoleFactory } from "../../../../../test/stepfunctions/states-execution-role.factory.js";
+import { runSimStatesTaskState } from "../../../../../test/stepfunctions/states-task-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCreatedTableFactory } from "../../../dynamodb/table/sim-dynamodb-created-table.factory.js";
+
+describe("A Task state calling a simulated service through the SDK", () => {
+  it("sends a message a receive afterwards takes off the queue", async () => {
+    // Given a queue, and a role allowed to send to it.
+    const simAws = new SimAws();
+    const { queueUrl } = await simAwsWithQueue(undefined, simAws);
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "sqs:SendMessage", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task sends one through the SDK integration, whose Parameters are
+    // the request itself.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::aws-sdk:sqs:sendMessage",
+        Parameters: {
+          QueueUrl: queueUrl,
+          "MessageBody.$": "States.JsonToString($)",
+        },
+        End: true,
+      },
+      input: JSON.stringify({ student: "Wei" }),
+    });
+
+    // Then the message is on the queue, and the response is the task's result.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertStringIncludes(described.output ?? "", '"MD5OfMessageBody"');
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertIdentical(received.Messages?.[0]?.Body, '{"student":"Wei"}');
+  });
+
+  it("reads an item, and the response is the task's result", async () => {
+    // Given a table with an item on it.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "enrolments" },
+      simAws,
+    );
+    await simAws.dynamoDb().putItem({
+      input: {
+        TableName: "enrolments",
+        Item: { id: { S: "Wei" }, term: { S: "2026-autumn" } },
+      },
+    });
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "dynamodb:GetItem", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task reads it through the SDK integration.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::aws-sdk:dynamodb:getItem",
+        Parameters: { TableName: "enrolments", Key: { id: { S: "Wei" } } },
+        End: true,
+      },
+    });
+
+    // Then the answer is the API's own, with no SDK metadata around it.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.output,
+      '{"Item":{"id":{"S":"Wei"},"term":{"S":"2026-autumn"}}}',
+    );
+  });
+
+  it("fails a task naming an operation the service does not run", async () => {
+    // Given a simulated service, and an operation of it this simulator has no
+    // implementation for.
+    const simAws = new SimAws();
+    const { queueUrl } = await simAwsWithQueue(undefined, simAws);
+    const roleArn = await statesExecutionRoleFactory.make(
+      { statements: [{ Effect: "Allow", Action: "sqs:*", Resource: "*" }] },
+      simAws,
+    );
+
+    // When an execution reaches the task.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::aws-sdk:sqs:listQueueTags",
+        Parameters: { QueueUrl: queueUrl },
+        End: true,
+      },
+    });
+
+    // Then the task failed, naming the operation and what SQS does run.
+    assertIdentical(described.error, "States.TaskFailed");
+    assertStringIncludes(described.cause ?? "", "listQueueTags");
+    assertStringIncludes(described.cause ?? "", "sendMessage");
+  });
+});

--- a/src/service/stepfunctions/task/service/sim-states-service-call.ts
+++ b/src/service/stepfunctions/task/service/sim-states-service-call.ts
@@ -1,0 +1,71 @@
+import { resolveSimSdkCommandRouter } from "../../../../sdk/router/resolve-sim-sdk-command-router.js";
+import type { SimSdkCommandRoute } from "../../../../sdk/router/sim-sdk-command-router.type.js";
+import type { JSONValue } from "../../../../util/type-guard/json.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { SimStatesTaskFailure } from "../../error/sim-step-functions.error.js";
+import type { SimStatesTaskRequest } from "../sim-states-task-target.js";
+import type { SimStatesServiceCall } from "./sim-states-service-shape.js";
+
+/**
+ * Find one operation on a simulated service, in the state machine's own
+ * Account and Region.
+ *
+ * The service comes into existence here, on the first task that calls it, so a
+ * state machine that is never run reaches nothing. An operation the simulated
+ * service has no implementation for is refused here rather than when the state
+ * machine was created, because the operations a service runs belong to the
+ * service and there was none to ask then.
+ */
+export function simStatesServiceRoute(
+  task: SimStatesTaskRequest,
+  call: SimStatesServiceCall,
+): SimSdkCommandRoute {
+  const { serviceId } = call.service;
+  const router = resolveSimSdkCommandRouter(
+    task.simAws,
+    serviceId,
+    task.scope.accountId,
+    task.scope.regionName,
+  );
+  const route = router.route(call.commandName);
+
+  if (route === undefined) {
+    throw new SimStatesTaskFailure(
+      `The Task state ${task.stateName} calls ${call.operation} on ` +
+        `${serviceId}, which this simulator does not run. It runs ` +
+        `${operationNames(router.supportedCommandNames()).join(", ")}.`,
+    );
+  }
+
+  return route;
+}
+
+/**
+ * Read what the service answered as the JSON the execution carries on with.
+ *
+ * The SDK's own response metadata is dropped, because a task's result is the
+ * API's answer rather than the client's. The rest crosses the same JSON
+ * serialisation a real response does, so a date the service stamped reaches
+ * the next state as the string it would there.
+ */
+export function simStatesServiceResult(answered: unknown): JSONValue {
+  if (!isRecord(answered)) {
+    return (answered ?? null) as JSONValue;
+  }
+
+  const { $metadata: _metadata, ...rest } = answered;
+  const serialised = JSON.stringify(rest);
+
+  return JSON.parse(serialised) as JSONValue;
+}
+
+/**
+ * The operations a simulated service runs, written the way an integration
+ * names them.
+ */
+function operationNames(commandNames: readonly string[]): readonly string[] {
+  return commandNames
+    .map((name) => name.replace(/Command$/, ""))
+    .map((name) => `${name.charAt(0).toLowerCase()}${name.slice(1)}`)
+    .toSorted((one, other) => one.localeCompare(other));
+}

--- a/src/service/stepfunctions/task/service/sim-states-service-failure.ts
+++ b/src/service/stepfunctions/task/service/sim-states-service-failure.ts
@@ -1,0 +1,58 @@
+import {
+  SimStatesServiceFailure,
+  SimStatesTaskFailure,
+} from "../../error/sim-step-functions.error.js";
+import type { SimStatesServiceCall } from "./sim-states-service-shape.js";
+
+/**
+ * The error names JavaScript gives its own failures.
+ *
+ * A service names what it refused, and anything raising under one of these
+ * names is not the service answering: it is something going wrong on the way
+ * there.
+ */
+const javascriptErrorNames = new Set([
+  "AggregateError",
+  "Error",
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+]);
+
+/**
+ * What a service refusing a task's call is called.
+ *
+ * Amazon States Language names a service error after the service and the error
+ * together, so `Retry` and `Catch` can tell one refusal from another. A
+ * conditional write that did not hold fails the task as
+ * `DynamoDb.ConditionalCheckFailedException`, and a role that may not write
+ * fails it as `DynamoDb.AccessDenied`, the name simulated IAM gives a
+ * refusal.
+ *
+ * Anything raising under a JavaScript error name never reached the service, so
+ * it fails the task as `States.TaskFailed` rather than being reported as
+ * something the service said.
+ */
+export function simStatesServiceFailure(
+  error: unknown,
+  call: SimStatesServiceCall,
+  stateName: string,
+): Error {
+  const raised = error instanceof Error ? error.name : "";
+  const said = error instanceof Error ? error.message : String(error);
+  const message =
+    `The ${call.operation} call the Task state ${stateName} made was ` +
+    `refused: ${said}`;
+
+  if (raised === "" || javascriptErrorNames.has(raised)) {
+    return new SimStatesTaskFailure(message);
+  }
+
+  return new SimStatesServiceFailure(
+    message,
+    `${call.service.errorPrefix}.${raised}`,
+  );
+}

--- a/src/service/stepfunctions/task/service/sim-states-service-failures.iso.test.ts
+++ b/src/service/stepfunctions/task/service/sim-states-service-failures.iso.test.ts
@@ -1,0 +1,236 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionRoleFactory } from "../../../../../test/stepfunctions/states-execution-role.factory.js";
+import { statesMachineFactory } from "../../../../../test/stepfunctions/states-machine.factory.js";
+import { runSimStatesTaskState } from "../../../../../test/stepfunctions/states-task-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simDynamoDbCreatedTableFactory } from "../../../dynamodb/table/sim-dynamodb-created-table.factory.js";
+
+describe("What a service refusing a Task state's call is called", () => {
+  it("names a conditional check the way Amazon States Language does", async () => {
+    // Given a table already holding the item a guarded write would add.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "enrolments" },
+      simAws,
+    );
+    await simAws.dynamoDb().putItem({
+      input: { TableName: "enrolments", Item: { id: { S: "Wei" } } },
+    });
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "dynamodb:PutItem", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task writes it under a condition that does not hold.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::dynamodb:putItem",
+        Parameters: {
+          TableName: "enrolments",
+          Item: { id: { S: "Wei" }, term: { S: "2026-autumn" } },
+          ConditionExpression: "attribute_not_exists(id)",
+        },
+        End: true,
+      },
+    });
+
+    // Then the task failed under the name a Retry or a Catch matches on.
+    assertIdentical(
+      described.error,
+      "DynamoDb.ConditionalCheckFailedException",
+    );
+    assertStringIncludes(described.cause ?? "", "conditional request failed");
+  });
+
+  it("hands the failure to a Catch naming it", async () => {
+    // Given a table already holding the item a guarded write would add.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "enrolments" },
+      simAws,
+    );
+    await simAws.dynamoDb().putItem({
+      input: { TableName: "enrolments", Item: { id: { S: "Wei" } } },
+    });
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "dynamodb:PutItem", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When the task that writes it catches the conditional check by name.
+    const stateMachineArn = await statesMachineFactory.make(
+      {
+        roleArn,
+        startAt: "Record",
+        states: {
+          Record: {
+            Type: "Task",
+            Resource: "arn:aws:states:::dynamodb:putItem",
+            Parameters: {
+              TableName: "enrolments",
+              Item: { id: { S: "Wei" } },
+              ConditionExpression: "attribute_not_exists(id)",
+            },
+            Catch: [
+              {
+                ErrorEquals: ["DynamoDb.ConditionalCheckFailedException"],
+                Next: "Enrolled",
+              },
+            ],
+            End: true,
+          },
+          Enrolled: { Type: "Succeed" },
+        },
+      },
+      simAws,
+    );
+    const started = await simAws
+      .stepFunctions()
+      .startExecution({ input: { stateMachineArn } });
+
+    // Then the execution carried on at the state the catcher named.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn: started.executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+    assertArrayEquals(
+      simAws.stepFunctions().inspection().visitedStates(started.executionArn),
+      ["Record", "Enrolled"],
+    );
+  });
+
+  it("fails a task whose role may not do what it asked", async () => {
+    // Given a role allowed to read the table and nothing else.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "enrolments" },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "dynamodb:GetItem", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task writes to it.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::dynamodb:putItem",
+        Parameters: { TableName: "enrolments", Item: { id: { S: "Wei" } } },
+        End: true,
+      },
+    });
+
+    // Then the task failed as access denied, which is what simulated IAM calls
+    // a refusal, and the cause names the action the role was missing.
+    assertIdentical(described.error, "DynamoDb.AccessDenied");
+    assertStringIncludes(described.cause ?? "", "dynamodb:PutItem");
+  });
+
+  it("names a request the service would not accept", async () => {
+    // Given a table whose key an item has to carry.
+    const simAws = new SimAws();
+    await simDynamoDbCreatedTableFactory.make(
+      { tableName: "enrolments" },
+      simAws,
+    );
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "dynamodb:PutItem", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task writes an item without it.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::dynamodb:putItem",
+        Parameters: {
+          TableName: "enrolments",
+          Item: { term: { S: "2026-autumn" } },
+        },
+        End: true,
+      },
+    });
+
+    // Then the service's own name for what it refused is the task's error.
+    assertIdentical(described.error, "DynamoDb.ValidationException");
+  });
+
+  it("names the service that refused, whichever service it was", async () => {
+    // Given a role allowed to put events on the default bus.
+    const simAws = new SimAws();
+    const roleArn = await statesExecutionRoleFactory.make(
+      {
+        statements: [
+          { Effect: "Allow", Action: "events:PutEvents", Resource: "*" },
+        ],
+      },
+      simAws,
+    );
+
+    // When a task puts events without saying what any of them are.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::events:putEvents",
+        Parameters: { Source: "enrolment.service" },
+        End: true,
+      },
+    });
+
+    // Then the error carries EventBridge's own name for what it refused.
+    assertIdentical(described.error, "EventBridge.ValidationException");
+    assertStringIncludes(described.cause ?? "", "between 1 and 10 entries");
+  });
+
+  it("fails a task whose Parameters built no request", async () => {
+    // Given a task sending what its InputPath selected, which is a name rather
+    // than a request.
+    const simAws = new SimAws();
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+
+    // When an execution reaches it.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::dynamodb:putItem",
+        InputPath: "$.student",
+        End: true,
+      },
+      input: JSON.stringify({ student: "Wei" }),
+    });
+
+    // Then the execution failed saying the call had nothing to send.
+    assertIdentical(described.error, "States.Runtime");
+    assertStringIncludes(described.cause ?? "", "built no request");
+  });
+});

--- a/src/service/stepfunctions/task/service/sim-states-service-name.ts
+++ b/src/service/stepfunctions/task/service/sim-states-service-name.ts
@@ -1,0 +1,101 @@
+import { simSdkInterceptedServiceIds } from "../../../../sdk/router/resolve-sim-sdk-command-router.js";
+
+/**
+ * A simulated service a `Task` state calls, and what its failures are called.
+ */
+export interface SimStatesService {
+  /**
+   * The AWS SDK's own service id, and what finds the simulated service.
+   */
+  readonly serviceId: string;
+
+  /**
+   * The name Step Functions puts in front of an error the service raised, so
+   * that a `Retry` or a `Catch` matching `DynamoDb.ConditionalCheckFailedException`
+   * matches.
+   */
+  readonly errorPrefix: string;
+}
+
+/**
+ * The simulated services an `aws-sdk` integration can name, by the name Amazon
+ * States Language writes them under.
+ *
+ * `arn:aws:states:::aws-sdk:dynamodb:putItem` names the service the way the
+ * AWS SDK does, in lower case and with nothing between the words. Every
+ * service the SDK interception reaches is here, because a state machine
+ * calling a service and a test calling it through an intercepted client are
+ * reaching the same simulation.
+ *
+ * The table is built for each `Resource` that needs one. Reading the services
+ * as this module loads would read them before the table they come from is
+ * there, since a simulated service and the SDK interception that reaches it
+ * know about each other. Nothing reads this after a state machine has been
+ * created, so building it costs a definition rather than an execution.
+ */
+function servicesByName(): ReadonlyMap<string, SimStatesService> {
+  return new Map<string, SimStatesService>(
+    simSdkInterceptedServiceIds().map((serviceId) => [
+      serviceId.toLowerCase().replaceAll(" ", ""),
+      { serviceId, errorPrefix: errorPrefixOf(serviceId) },
+    ]),
+  );
+}
+
+/**
+ * The service an `aws-sdk` integration named, when this simulation has one.
+ */
+export function simStatesSdkService(
+  serviceName: string,
+): SimStatesService | undefined {
+  return servicesByName().get(serviceName);
+}
+
+/**
+ * The names an `aws-sdk` integration can call a service, in the order they
+ * read best in a refusal.
+ */
+export function simStatesSdkServiceNames(): readonly string[] {
+  return servicesByName()
+    .keys()
+    .toArray()
+    .toSorted((one, other) => one.localeCompare(other));
+}
+
+/**
+ * The service one of the optimized integrations calls.
+ *
+ * The integration names its own SDK service, since the two do not always agree
+ * on what a service is called: `arn:aws:states:::events:putEvents` calls
+ * EventBridge and `arn:aws:states:::states:startExecution` calls Step
+ * Functions itself.
+ */
+export function simStatesServiceOf(serviceId: string): SimStatesService {
+  return { serviceId, errorPrefix: errorPrefixOf(serviceId) };
+}
+
+/**
+ * The SDK Command an operation names.
+ *
+ * An integration writes the operation the way the API documents it, with a
+ * lower-case first letter, and the SDK Command is the same word as a class
+ * name.
+ */
+export function simStatesCommandName(operation: string): string {
+  return `${operation.charAt(0).toUpperCase()}${operation.slice(1)}Command`;
+}
+
+/**
+ * How Step Functions writes a service's name in an error.
+ *
+ * The SDK's own service id, with the runs of capitals it spells acronyms with
+ * written as words. `DynamoDB` is `DynamoDb` and `SNS` is `Sns`, and a `Catch`
+ * in a real definition matches on that.
+ */
+function errorPrefixOf(serviceId: string): string {
+  const words = serviceId
+    .replaceAll(" ", "")
+    .replaceAll(/[A-Z]+/g, (run) => run.charAt(0) + run.slice(1).toLowerCase());
+
+  return `${words.charAt(0).toUpperCase()}${words.slice(1)}`;
+}

--- a/src/service/stepfunctions/task/service/sim-states-service-refusals.iso.test.ts
+++ b/src/service/stepfunctions/task/service/sim-states-service-refusals.iso.test.ts
@@ -1,0 +1,71 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { parseSimStatesDefinition } from "../../definition/sim-states-definition-parse.js";
+
+describe("Step Functions service integration refusals", () => {
+  /**
+   * Read a definition of one Task state, and answer with why it was refused.
+   */
+  function refusalForResource(resource: string): string {
+    return assertThrowsError(() =>
+      parseSimStatesDefinition(
+        JSON.stringify({
+          StartAt: "Work",
+          States: {
+            Work: { Type: "Task", Resource: resource, End: true },
+          },
+        }),
+      ),
+    ).message;
+  }
+
+  it("refuses a service this simulation does not have, naming the call", () => {
+    // Given an SDK integration calling a service nothing here simulates.
+    // When the state machine is created, the refusal names what it asked for.
+    const refusal = refusalForResource(
+      "arn:aws:states:::aws-sdk:athena:startQueryExecution",
+    );
+
+    assertStringIncludes(refusal, "startQueryExecution");
+    assertStringIncludes(refusal, "athena");
+    assertStringIncludes(refusal, "dynamodb");
+  });
+
+  it("refuses an optimized integration it has no implementation for", () => {
+    // Given the integrations for services this simulator does not reach.
+    // When each is read, each names the Resource and what is on offer.
+    for (const resource of [
+      "arn:aws:states:::ecs:runTask",
+      "arn:aws:states:::glue:startJobRun",
+      "arn:aws:states:::dynamodb:query",
+    ]) {
+      const refusal = refusalForResource(resource);
+
+      assertStringIncludes(refusal, resource);
+      assertStringIncludes(refusal, "aws-sdk:<service>:<operation>");
+    }
+  });
+
+  it("refuses the patterns that hold a task open, naming the pattern", () => {
+    // Given the two patterns a Task state waits under.
+    // When each is read, each says which one it was.
+    assertStringIncludes(
+      refusalForResource("arn:aws:states:::ecs:runTask.sync"),
+      ".sync",
+    );
+    assertStringIncludes(
+      refusalForResource("arn:aws:states:::sqs:sendMessage.waitForTaskToken"),
+      ".waitForTaskToken",
+    );
+  });
+
+  it("refuses an SDK integration that names no operation", () => {
+    // Given an SDK integration written with a service and nothing else.
+    // When it is read, it says what one looks like.
+    assertStringIncludes(
+      refusalForResource("arn:aws:states:::aws-sdk:dynamodb"),
+      "arn:aws:states:::aws-sdk:dynamodb:putItem",
+    );
+  });
+});

--- a/src/service/stepfunctions/task/service/sim-states-service-resource.ts
+++ b/src/service/stepfunctions/task/service/sim-states-service-resource.ts
@@ -1,0 +1,114 @@
+import { SimStatesUnsimulatedInput } from "../../error/sim-step-functions.error.js";
+import type { SimStatesTaskTarget } from "../sim-states-task-target.js";
+import { simStatesOptimizedIntegrations } from "./sim-states-optimized-integrations.js";
+import {
+  simStatesCommandName,
+  simStatesSdkService,
+  simStatesSdkServiceNames,
+  simStatesServiceOf,
+} from "./sim-states-service-name.js";
+import { SimStatesServiceTarget } from "./sim-states-service-target.js";
+
+/**
+ * What a `Resource` writes in front of an SDK integration's service.
+ */
+const sdkIntegration = "aws-sdk:";
+
+/**
+ * The patterns that hold a `Task` state open, which this simulator has no
+ * implementation for.
+ */
+const heldPatterns = [".sync", ".waitForTaskToken"];
+
+/**
+ * Read a `Task` state's `Resource` as a call on a simulated service.
+ *
+ * `call` is what the `Resource` wrote after `arn:aws:states:::`. It is either
+ * `aws-sdk:<service>:<operation>` or one of the integrations Step Functions
+ * optimises.
+ */
+export function parseSimStatesServiceResource(
+  stateName: string,
+  resource: string,
+  call: string,
+): SimStatesTaskTarget {
+  const held = heldPatterns.find((pattern) => call.includes(pattern));
+
+  if (held !== undefined) {
+    throw new SimStatesUnsimulatedInput(
+      `The Task state ${stateName} has a Resource of ${resource}, which asks ` +
+        `for ${held}. This simulator runs a task that calls and answers, and ` +
+        "has no way to hold a state open until a job finishes or until a " +
+        "task token comes back.",
+    );
+  }
+
+  if (call.startsWith(sdkIntegration)) {
+    return sdkTarget(stateName, resource, call.slice(sdkIntegration.length));
+  }
+
+  const optimized = simStatesOptimizedIntegrations.get(call);
+
+  if (optimized === undefined) {
+    throw new SimStatesUnsimulatedInput(
+      `The Task state ${stateName} has a Resource of ${resource}, which this ` +
+        `simulator does not run. It runs ${integrationNames().join(", ")}, ` +
+        "and any operation of a simulated service through " +
+        "arn:aws:states:::aws-sdk:<service>:<operation>.",
+    );
+  }
+
+  return new SimStatesServiceTarget({
+    service: simStatesServiceOf(optimized.serviceId),
+    operation: optimized.operation,
+    commandName: simStatesCommandName(optimized.operation),
+    ...(optimized.shape !== undefined && { shape: optimized.shape }),
+  });
+}
+
+/**
+ * Read the service and the operation an `aws-sdk` integration names.
+ *
+ * A service this simulation does not have is refused here, when the state
+ * machine is created, rather than at the task that would have called it. The
+ * operation is refused at the task instead, since the operations a service
+ * runs belong to the simulated service and there is none to ask yet.
+ */
+function sdkTarget(
+  stateName: string,
+  resource: string,
+  call: string,
+): SimStatesTaskTarget {
+  const [serviceName = "", operation = "", ...beyond] = call.split(":");
+
+  if (serviceName === "" || operation === "" || beyond.length > 0) {
+    throw new SimStatesUnsimulatedInput(
+      `The Task state ${stateName} has a Resource of ${resource}, which is ` +
+        "not an SDK integration. One names a service and an operation, as " +
+        "arn:aws:states:::aws-sdk:dynamodb:putItem does.",
+    );
+  }
+
+  const service = simStatesSdkService(serviceName);
+
+  if (service === undefined) {
+    throw new SimStatesUnsimulatedInput(
+      `The Task state ${stateName} calls ${operation} on ${serviceName}, ` +
+        `which this simulator has no simulation of. It calls ` +
+        `${simStatesSdkServiceNames().join(", ")}.`,
+    );
+  }
+
+  return new SimStatesServiceTarget({
+    service,
+    operation,
+    commandName: simStatesCommandName(operation),
+  });
+}
+
+/**
+ * The optimized integrations this simulator runs, as a `Resource` writes them.
+ */
+function integrationNames(): readonly string[] {
+  return simStatesOptimizedIntegrations.keys().toArray();
+}

--- a/src/service/stepfunctions/task/service/sim-states-service-shape.ts
+++ b/src/service/stepfunctions/task/service/sim-states-service-shape.ts
@@ -1,0 +1,34 @@
+import type {
+  JSONObject,
+  JSONValue,
+} from "../../../../util/type-guard/json.js";
+import type { SimStatesService } from "./sim-states-service-name.js";
+
+/**
+ * What one of the optimized integrations does to the request and the result,
+ * where the shape it defines is not the API's own.
+ */
+export interface SimStatesServiceShape {
+  readonly request?: (parameters: JSONObject) => JSONObject;
+  readonly answer?: (result: JSONValue) => JSONValue;
+}
+
+/**
+ * The call a `Task` state's `Resource` resolved to.
+ */
+export interface SimStatesServiceCall {
+  readonly service: SimStatesService;
+
+  /**
+   * The operation as the API writes it, and what a refusal names.
+   */
+  readonly operation: string;
+
+  /**
+   * The SDK Command the operation is, and what the simulated service routes
+   * on.
+   */
+  readonly commandName: string;
+
+  readonly shape?: SimStatesServiceShape;
+}

--- a/src/service/stepfunctions/task/service/sim-states-service-target.ts
+++ b/src/service/stepfunctions/task/service/sim-states-service-target.ts
@@ -1,0 +1,82 @@
+import type {
+  JSONObject,
+  JSONValue,
+} from "../../../../util/type-guard/json.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { SimStatesRuntimeFailure } from "../../error/sim-step-functions.error.js";
+import {
+  type SimStatesTaskRequest,
+  SimStatesTaskTarget,
+} from "../sim-states-task-target.js";
+import {
+  simStatesServiceResult,
+  simStatesServiceRoute,
+} from "./sim-states-service-call.js";
+import { simStatesServiceFailure } from "./sim-states-service-failure.js";
+import type { SimStatesServiceCall } from "./sim-states-service-shape.js";
+
+/**
+ * A `Task` state that calls an operation on a simulated service.
+ *
+ * Both integration forms end here. An `aws-sdk` integration sends its
+ * `Parameters` as the request and answers with the response, and an optimized
+ * integration is the same call with the request and the result shaped the way
+ * that integration defines.
+ *
+ * The call reaches the simulated service the way an intercepted SDK client's
+ * would, carrying the assumed execution role, so simulated IAM answers it
+ * against the role's policies and the resource the request names.
+ */
+export class SimStatesServiceTarget extends SimStatesTaskTarget {
+  readonly #call: SimStatesServiceCall;
+
+  constructor(call: SimStatesServiceCall) {
+    super();
+    this.#call = call;
+  }
+
+  /**
+   * Call the operation in the state machine's own Account and Region.
+   */
+  override async run(request: SimStatesTaskRequest): Promise<JSONValue> {
+    const route = simStatesServiceRoute(request, this.#call);
+    const input = this.parameters(request);
+
+    let answered: unknown;
+
+    try {
+      answered = await route({ input }, { caller: request.caller });
+    } catch (error) {
+      throw this.handlerFailure(error, request.stateName);
+    }
+
+    const result = simStatesServiceResult(answered);
+
+    return this.#call.shape?.answer?.(result) ?? result;
+  }
+
+  /**
+   * A service refusing the call fails the task under the name Amazon States
+   * Language gives that service's error.
+   */
+  override handlerFailure(error: unknown, stateName: string): Error {
+    return simStatesServiceFailure(error, this.#call, stateName);
+  }
+
+  /**
+   * Read the request the state's `Parameters` built.
+   */
+  private parameters(request: SimStatesTaskRequest): JSONObject {
+    const { payload } = request;
+
+    if (!isRecord(payload)) {
+      throw new SimStatesRuntimeFailure(
+        `The Task state ${request.stateName} calls ` +
+          `${this.#call.operation} and built no request. Its Parameters are ` +
+          "what the call is sent.",
+      );
+    }
+
+    return this.#call.shape?.request?.(payload) ?? payload;
+  }
+}

--- a/src/service/stepfunctions/task/service/sim-states-start-execution.iso.test.ts
+++ b/src/service/stepfunctions/task/service/sim-states-start-execution.iso.test.ts
@@ -1,0 +1,65 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionRoleFactory } from "../../../../../test/stepfunctions/states-execution-role.factory.js";
+import { statesMachineFactory } from "../../../../../test/stepfunctions/states-machine.factory.js";
+import { runSimStatesTaskState } from "../../../../../test/stepfunctions/states-task-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { JSONObject } from "../../../../util/type-guard/json.js";
+
+describe("A Task state starting another state machine", () => {
+  it("answers with the execution it started", async () => {
+    // Given a state machine that records what it was started with.
+    const simAws = new SimAws();
+    const roleArn = await statesExecutionRoleFactory.make({}, simAws);
+    const recording = await statesMachineFactory.make(
+      {
+        name: "Recording",
+        roleArn,
+        startAt: "Record",
+        states: {
+          Record: { Type: "Pass", ResultPath: "$.recorded", End: true },
+        },
+      },
+      simAws,
+    );
+
+    // When a task starts it, with an Input written as JSON.
+    const described = await runSimStatesTaskState(simAws, {
+      roleArn,
+      task: {
+        Type: "Task",
+        Resource: "arn:aws:states:::states:startExecution",
+        Parameters: {
+          StateMachineArn: recording,
+          Input: { "student.$": "$.student" },
+        },
+        End: true,
+      },
+      input: JSON.stringify({ student: "Wei" }),
+    });
+
+    // Then the task's result is the execution that started.
+    assertIdentical(described.status, "SUCCEEDED");
+
+    const output = JSON.parse(described.output ?? "{}") as JSONObject;
+    const executionArn = output["ExecutionArn"];
+
+    assertTypeString(executionArn);
+    assertStringIncludes(executionArn, ":execution:Recording:");
+    assertNonNullable(output["StartDate"], "The answer carries a StartDate");
+
+    // And the execution it started ran on the input the task built.
+    const inner = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(inner.status, "SUCCEEDED");
+    assertIdentical(inner.input, '{"student":"Wei"}');
+  });
+});

--- a/src/service/stepfunctions/task/sim-aws-states-task-targets.ts
+++ b/src/service/stepfunctions/task/sim-aws-states-task-targets.ts
@@ -5,8 +5,6 @@ import {
   assumeSimStatesExecutionRole,
   simStatesExecutionRoleTarget,
 } from "./sim-states-execution-role.js";
-import { simStatesFunctionLocation } from "./sim-states-function-location.js";
-import { SimStatesTaskFunction } from "./sim-states-task-function.js";
 import type {
   SimStatesTaskInvocation,
   SimStatesTaskTargets,
@@ -18,15 +16,16 @@ interface SimAwsStatesTaskTargetsProperties {
 }
 
 /**
- * Everywhere the state machines of one simulated AWS instance can invoke.
+ * Everywhere the state machines of one simulated AWS instance can reach.
  *
- * The function is looked up when a task runs, never when this is built:
+ * What a task calls is looked up when it runs, never when this is built:
  * reaching another service while this one is being constructed is a cycle with
  * no bottom to it.
  *
- * A function in another Account or Region is allowed, since a real execution
- * invokes across both, and it is the function's own Account that decides
- * whether the execution role may.
+ * This owns the execution role and nothing else. Which function, table, topic,
+ * queue or bus a task talks to is the target's own business, and a target in
+ * another Account or Region is allowed, since a real execution reaches across
+ * both.
  */
 export class SimAwsStatesTaskTargets implements SimStatesTaskTargets {
   readonly #simAws: SimAws;
@@ -38,38 +37,28 @@ export class SimAwsStatesTaskTargets implements SimStatesTaskTargets {
   }
 
   /**
-   * Assume the state machine's execution role, then invoke the function as
-   * that role.
+   * Assume the state machine's execution role, then do the task's work as that
+   * role.
    *
-   * The role is assumed in its own Account, and the function is reached in the
-   * function's, which are not necessarily the same one.
+   * The role is assumed in its own Account, and that is not always the state
+   * machine's. Every call the task goes on to make carries the session that
+   * makes. Simulated IAM answers each of them against the role's policies.
    */
   async invoke(invocation: SimStatesTaskInvocation): Promise<JSONValue> {
     const { stateName, target } = invocation;
-    const call = target.call(invocation.payload, stateName);
-    const where = simStatesFunctionLocation(
-      call.functionNameOrArn,
-      this.#accountRegionScope,
-      stateName,
-    );
     const role = simStatesExecutionRoleTarget(invocation.roleArn, stateName);
     const iam = this.#simAws
-      .accountRegionScope(role.accountId, where.regionName)
+      .accountRegionScope(role.accountId, this.#accountRegionScope.regionName)
       .iam();
 
     const caller = await assumeSimStatesExecutionRole(role, iam);
-    const scope = this.#simAws.accountRegionScope(
-      where.accountId,
-      where.regionName,
-    );
 
-    return await new SimStatesTaskFunction({ scope }).invoke({
+    return await target.run({
       stateName,
-      target,
-      reference: where.reference,
-      named: call.functionNameOrArn,
-      payload: call.payload,
+      payload: invocation.payload,
       caller,
+      simAws: this.#simAws,
+      scope: this.#accountRegionScope,
     });
   }
 }

--- a/src/service/stepfunctions/task/sim-states-function-arn-target.ts
+++ b/src/service/stepfunctions/task/sim-states-function-arn-target.ts
@@ -2,9 +2,9 @@ import { functionErrorDocument } from "../../lambda/command/invoke/invoke-payloa
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import { SimStatesTaskHandlerFailure } from "../error/sim-step-functions.error.js";
 import {
+  SimStatesLambdaTarget,
   type SimStatesTaskCall,
-  SimStatesTaskTarget,
-} from "./sim-states-task-target.js";
+} from "./sim-states-lambda-target.js";
 
 interface SimStatesFunctionArnTargetProperties {
   readonly functionArn: string;
@@ -17,7 +17,7 @@ interface SimStatesFunctionArnTargetProperties {
  * it sends is its own input and what it gets back is what the handler
  * answered. CDK's `LambdaInvoke` emits this form for `payloadResponseOnly`.
  */
-export class SimStatesFunctionArnTarget extends SimStatesTaskTarget {
+export class SimStatesFunctionArnTarget extends SimStatesLambdaTarget {
   readonly #functionArn: string;
 
   constructor(properties: SimStatesFunctionArnTargetProperties) {

--- a/src/service/stepfunctions/task/sim-states-lambda-invoke-parameters.ts
+++ b/src/service/stepfunctions/task/sim-states-lambda-invoke-parameters.ts
@@ -1,0 +1,60 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import {
+  SimStatesInvalidDefinition,
+  SimStatesUnsimulatedInput,
+} from "../error/sim-step-functions.error.js";
+import {
+  simStatesLambdaInvokeParameters,
+  simStatesLambdaInvokeResource,
+} from "./sim-states-lambda-invoke-target.js";
+
+/**
+ * Check the `Invoke` request the state's `Parameters` build.
+ *
+ * The field naming the function is required, as it is on real Step Functions,
+ * and the fields of an `Invoke` this does not make are refused by name.
+ */
+export function checkSimStatesLambdaInvokeParameters(
+  stateName: string,
+  parameters: JSONValue | undefined,
+): void {
+  if (!isRecord(parameters)) {
+    throw new SimStatesInvalidDefinition(
+      `The Task state ${stateName} invokes a function and carries no ` +
+        "Parameters. A Parameters naming the function to invoke is what " +
+        `${simStatesLambdaInvokeResource} takes.`,
+    );
+  }
+
+  const fields = Object.keys(parameters).map(fieldName);
+
+  if (!fields.includes("FunctionName")) {
+    throw new SimStatesInvalidDefinition(
+      `The Parameters of the Task state ${stateName} carry no FunctionName ` +
+        "naming the function to invoke.",
+    );
+  }
+
+  const beyond = fields.filter(
+    (field) => !simStatesLambdaInvokeParameters.includes(field as never),
+  );
+
+  if (beyond.length > 0) {
+    throw new SimStatesUnsimulatedInput(
+      `The Parameters of the Task state ${stateName} carry ` +
+        `${beyond.join(", ")}. This simulator invokes a function with ` +
+        `${simStatesLambdaInvokeParameters.join(" and ")}.`,
+    );
+  }
+}
+
+/**
+ * The field one Payload Template key stands for.
+ *
+ * A key ending in `.$` holds a path to read rather than a value, and both
+ * spellings name the same field of the request.
+ */
+function fieldName(key: string): string {
+  return key.endsWith(".$") ? key.slice(0, -2) : key;
+}

--- a/src/service/stepfunctions/task/sim-states-lambda-invoke-target.ts
+++ b/src/service/stepfunctions/task/sim-states-lambda-invoke-target.ts
@@ -6,9 +6,9 @@ import {
   SimStatesTaskFailure,
 } from "../error/sim-step-functions.error.js";
 import {
+  SimStatesLambdaTarget,
   type SimStatesTaskCall,
-  SimStatesTaskTarget,
-} from "./sim-states-task-target.js";
+} from "./sim-states-lambda-target.js";
 
 /**
  * The `Resource` of the Lambda integration Step Functions optimises.
@@ -30,7 +30,7 @@ export const simStatesLambdaInvokeParameters = [
  * `Parameters` are an `Invoke` request and its result is an `Invoke` response.
  * That is the form CDK's `LambdaInvoke` emits by default.
  */
-export class SimStatesLambdaInvokeTarget extends SimStatesTaskTarget {
+export class SimStatesLambdaInvokeTarget extends SimStatesLambdaTarget {
   /**
    * Read the `Invoke` request the state's `Parameters` built.
    */

--- a/src/service/stepfunctions/task/sim-states-lambda-target.ts
+++ b/src/service/stepfunctions/task/sim-states-lambda-target.ts
@@ -1,0 +1,68 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { simStatesFunctionLocation } from "./sim-states-function-location.js";
+import { SimStatesTaskFunction } from "./sim-states-task-function.js";
+import {
+  type SimStatesTaskRequest,
+  SimStatesTaskTarget,
+} from "./sim-states-task-target.js";
+
+/**
+ * The function one `Task` state invocation names, and what it sends.
+ */
+export interface SimStatesTaskCall {
+  readonly functionNameOrArn: string;
+  readonly payload: JSONValue;
+}
+
+/**
+ * A `Task` state whose work is a Lambda function.
+ *
+ * The two forms a state invokes a function through agree on everything the
+ * invocation itself does. They differ in which function is named, what the
+ * state gets back and what a handler raising is called, and a subclass says
+ * which.
+ *
+ * The function is looked up when the task runs rather than when the state
+ * machine was created, so an alias moved to another version moves what runs
+ * and a permission taken away stops the task.
+ */
+export abstract class SimStatesLambdaTarget extends SimStatesTaskTarget {
+  /**
+   * Invoke the function in its own Account and Region, which need not be the
+   * state machine's.
+   */
+  override async run(request: SimStatesTaskRequest): Promise<JSONValue> {
+    const { stateName } = request;
+    const call = this.call(request.payload, stateName);
+    const where = simStatesFunctionLocation(
+      call.functionNameOrArn,
+      request.scope,
+      stateName,
+    );
+
+    return await new SimStatesTaskFunction({
+      scope: request.simAws.accountRegionScope(
+        where.accountId,
+        where.regionName,
+      ),
+    }).invoke({
+      stateName,
+      target: this,
+      reference: where.reference,
+      named: call.functionNameOrArn,
+      payload: call.payload,
+      caller: request.caller,
+    });
+  }
+
+  /**
+   * The function to invoke and the payload to send it, read from what the
+   * state's data-flow fields produced.
+   */
+  abstract call(payload: JSONValue, stateName: string): SimStatesTaskCall;
+
+  /**
+   * The result the state produces from what the handler answered.
+   */
+  abstract answer(result: JSONValue, executedVersion: string): JSONValue;
+}

--- a/src/service/stepfunctions/task/sim-states-task-function.ts
+++ b/src/service/stepfunctions/task/sim-states-task-function.ts
@@ -4,7 +4,7 @@ import type { SimLambdaFunction } from "../../lambda/function/sim-lambda-functio
 import type { SimLambdaFunctionReference } from "../../lambda/function/sim-lambda-function-reference.js";
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import { SimStatesTaskFailure } from "../error/sim-step-functions.error.js";
-import type { SimStatesTaskTarget } from "./sim-states-task-target.js";
+import type { SimStatesLambdaTarget } from "./sim-states-lambda-target.js";
 
 /**
  * The action an execution needs to invoke a function.
@@ -20,7 +20,7 @@ interface SimStatesTaskFunctionProperties {
  */
 export interface SimStatesTaskFunctionRequest {
   readonly stateName: string;
-  readonly target: SimStatesTaskTarget;
+  readonly target: SimStatesLambdaTarget;
   readonly reference: SimLambdaFunctionReference;
 
   /**

--- a/src/service/stepfunctions/task/sim-states-task-refusals.iso.test.ts
+++ b/src/service/stepfunctions/task/sim-states-task-refusals.iso.test.ts
@@ -15,14 +15,12 @@ describe("Step Functions Task state refusals", () => {
     ).message;
   }
 
-  it("refuses a Resource that is not a Lambda invoke, naming it", () => {
-    // Given the service integrations this simulator has no implementation for.
+  it("refuses a Resource that names no work, naming it", () => {
+    // Given a Resource that is neither a function nor a service integration.
     // When each is read, each names what the definition asked for.
     for (const resource of [
-      "arn:aws:states:::sns:publish",
-      "arn:aws:states:::dynamodb:putItem",
-      "arn:aws:states:::lambda:invoke.waitForTaskToken",
       "arn:aws:sqs:eu-west-2:123456789012:enrolments",
+      "check-enrolment",
     ]) {
       const refusal = refusalForTask({
         Type: "Task",

--- a/src/service/stepfunctions/task/sim-states-task-resource.ts
+++ b/src/service/stepfunctions/task/sim-states-task-resource.ts
@@ -1,25 +1,30 @@
 import { parseSimLambdaFunctionArn } from "../../lambda/function/sim-lambda-function-arn-parts.js";
 import type { JSONValue } from "../../../util/type-guard/json.js";
-import { isRecord } from "../../../util/type-guard/record.js";
 import {
   SimStatesInvalidDefinition,
   SimStatesUnsimulatedInput,
 } from "../error/sim-step-functions.error.js";
 import { SimStatesFunctionArnTarget } from "./sim-states-function-arn-target.js";
+import { checkSimStatesLambdaInvokeParameters } from "./sim-states-lambda-invoke-parameters.js";
 import {
   SimStatesLambdaInvokeTarget,
-  simStatesLambdaInvokeParameters,
   simStatesLambdaInvokeResource,
 } from "./sim-states-lambda-invoke-target.js";
+import { parseSimStatesServiceResource } from "./service/sim-states-service-resource.js";
 import type { SimStatesTaskTarget } from "./sim-states-task-target.js";
+
+/**
+ * What every service integration's `Resource` starts with.
+ */
+const statesIntegrationPrefix = "arn:aws:states:::";
 
 /**
  * Read what a `Task` state's `Resource` names.
  *
  * This runs when the state machine is created, so a `Resource` this simulator
  * cannot reach is refused there rather than when an execution arrives at the
- * state. The service integrations beyond Lambda are refused here by name, and
- * are where each of them will be added.
+ * state. Every refusal is reached from here, so a definition is told once what
+ * this simulator does and does not run.
  */
 export function parseSimStatesTaskResource(
   stateName: string,
@@ -34,7 +39,7 @@ export function parseSimStatesTaskResource(
   }
 
   if (resource === simStatesLambdaInvokeResource) {
-    checkInvokeParameters(stateName, state["Parameters"]);
+    checkSimStatesLambdaInvokeParameters(stateName, state["Parameters"]);
 
     return new SimStatesLambdaInvokeTarget();
   }
@@ -43,60 +48,19 @@ export function parseSimStatesTaskResource(
     return new SimStatesFunctionArnTarget({ functionArn: resource });
   }
 
+  if (resource.startsWith(statesIntegrationPrefix)) {
+    return parseSimStatesServiceResource(
+      stateName,
+      resource,
+      resource.slice(statesIntegrationPrefix.length),
+    );
+  }
+
   throw new SimStatesUnsimulatedInput(
     `The Task state ${stateName} has a Resource of ${resource}, which this ` +
       "simulator does not run. A Task state invokes a simulated Lambda " +
-      `function, through ${simStatesLambdaInvokeResource} or through a ` +
-      "function ARN.",
+      "function, through a function ARN or " +
+      `${simStatesLambdaInvokeResource}, or calls a simulated service ` +
+      "through a service integration.",
   );
-}
-
-/**
- * Check the `Invoke` request the state's `Parameters` build.
- *
- * The field naming the function is required, as it is on real Step Functions,
- * and the fields of an `Invoke` this does not make are refused by name.
- */
-function checkInvokeParameters(
-  stateName: string,
-  parameters: JSONValue | undefined,
-): void {
-  if (!isRecord(parameters)) {
-    throw new SimStatesInvalidDefinition(
-      `The Task state ${stateName} invokes a function and carries no ` +
-        "Parameters. A Parameters naming the function to invoke is what " +
-        `${simStatesLambdaInvokeResource} takes.`,
-    );
-  }
-
-  const fields = Object.keys(parameters).map(fieldName);
-
-  if (!fields.includes("FunctionName")) {
-    throw new SimStatesInvalidDefinition(
-      `The Parameters of the Task state ${stateName} carry no FunctionName ` +
-        "naming the function to invoke.",
-    );
-  }
-
-  const beyond = fields.filter(
-    (field) => !simStatesLambdaInvokeParameters.includes(field as never),
-  );
-
-  if (beyond.length > 0) {
-    throw new SimStatesUnsimulatedInput(
-      `The Parameters of the Task state ${stateName} carry ` +
-        `${beyond.join(", ")}. This simulator invokes a function with ` +
-        `${simStatesLambdaInvokeParameters.join(" and ")}.`,
-    );
-  }
-}
-
-/**
- * The field one Payload Template key stands for.
- *
- * A key ending in `.$` holds a path to read rather than a value, and both
- * spellings name the same field of the request.
- */
-function fieldName(key: string): string {
-  return key.endsWith(".$") ? key.slice(0, -2) : key;
 }

--- a/src/service/stepfunctions/task/sim-states-task-target.ts
+++ b/src/service/stepfunctions/task/sim-states-task-target.ts
@@ -1,39 +1,58 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../aws/sim-aws.js";
 import type { JSONValue } from "../../../util/type-guard/json.js";
 
 /**
- * The function one `Task` state invocation names, and what it sends.
+ * One `Task` state's work, as the target receives it.
  */
-export interface SimStatesTaskCall {
-  readonly functionNameOrArn: string;
+export interface SimStatesTaskRequest {
+  readonly stateName: string;
+
+  /**
+   * What the state's `InputPath` and `Parameters` produced. That is the
+   * request the target sends.
+   */
   readonly payload: JSONValue;
+
+  /**
+   * The state machine's execution role, already assumed. Everything the task
+   * reaches, it reaches as this.
+   */
+  readonly caller: SimAwsCaller;
+
+  /**
+   * The whole simulation, because a task can reach another Account or Region.
+   */
+  readonly simAws: SimAws;
+
+  /**
+   * The state machine's own Account and Region. A target naming no other one
+   * does its work there.
+   */
+  readonly scope: SimAwsAccountRegionScope;
 }
 
 /**
  * What a `Task` state's `Resource` named.
  *
- * The two forms a `Task` state invokes a function through differ in three
- * places, and this is each of them: which function the state is talking to,
- * what the state gets back, and what a handler raising is called. Everything
- * between those, from assuming the execution role to running the handler, is
- * the same for both.
+ * The `Resource` forms differ in what they call, what the state gets back and
+ * what a failure is called, and this is each of them. What is the same for all
+ * of them is around this: the execution role is assumed once per invocation,
+ * and the data-flow fields build the request and shape the result.
  */
 export abstract class SimStatesTaskTarget {
   /**
-   * The function to invoke and the payload to send it, read from what the
-   * state's data-flow fields produced.
+   * Do the task's work, as the execution role, and answer with the result the
+   * state carries on with.
    */
-  abstract call(payload: JSONValue, stateName: string): SimStatesTaskCall;
+  abstract run(request: SimStatesTaskRequest): Promise<JSONValue>;
 
   /**
-   * The result the state produces from what the handler answered.
-   */
-  abstract answer(result: JSONValue, executedVersion: string): JSONValue;
-
-  /**
-   * What a handler raising fails the task with.
+   * What a failure the work raised is called.
    *
    * The Amazon States Language error name is read here rather than where the
-   * failure is recorded, because the two forms report a handler error
+   * failure is recorded, because each `Resource` form reports the same failure
    * differently and `Retry` and `Catch` match on exactly that name.
    */
   abstract handlerFailure(error: unknown, stateName: string): Error;

--- a/test/stepfunctions/states-task-fixture.ts
+++ b/test/stepfunctions/states-task-fixture.ts
@@ -1,0 +1,63 @@
+/**
+ * Running one `Task` state and reading back how the execution ended, which
+ * every test about what a task does needs before it can say anything.
+ *
+ * This lives under `test/` for the same reasons as `test/sns/topic-fixture.ts`:
+ * the linter rejects a test file that exports helpers alongside its own
+ * `describe` calls, and `test/**` is type-checked with everything else,
+ * excluded from the published build, not collected as a suite, and not counted
+ * in coverage.
+ */
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "../../src/service/stepfunctions/command/execution/execution.command.js";
+import type { JSONObject } from "../../src/util/type-guard/json.js";
+import { statesMachineFactory } from "./states-machine.factory.js";
+
+/**
+ * What a test says when it wants one `Task` state run.
+ */
+export interface SimStatesTaskRun {
+  /**
+   * The role the execution assumes. Every call the task makes is authorized
+   * as it.
+   */
+  readonly roleArn: string;
+
+  /**
+   * The state, written as Amazon States Language.
+   */
+  readonly task: JSONObject;
+
+  /**
+   * The execution's input, as the JSON string `StartExecution` takes.
+   */
+  readonly input?: string;
+}
+
+/**
+ * Run a state machine of one `Task` state and answer with how it ended.
+ *
+ * A failing execution is recorded rather than raised, so a test about a task
+ * that fails reads the error and the cause off the same answer as one about a
+ * task that worked.
+ */
+export async function runSimStatesTaskState(
+  simAws: SimAws,
+  run: SimStatesTaskRun,
+): Promise<SimDescribeExecutionCommandOutput> {
+  const stateMachineArn = await statesMachineFactory.make(
+    { roleArn: run.roleArn, startAt: "Work", states: { Work: run.task } },
+    simAws,
+  );
+  const started = await simAws.stepFunctions().startExecution({
+    input: {
+      stateMachineArn,
+      ...(run.input !== undefined && { input: run.input }),
+    },
+  });
+
+  return await simAws
+    .stepFunctions()
+    .describeExecution({ input: { executionArn: started.executionArn } });
+}


### PR DESCRIPTION
A `Task` state calls an operation on a simulated service.
`arn:aws:states:::aws-sdk:<service>:<operation>` reaches every service this
simulation holds, and the optimized integrations cover DynamoDB `putItem`,
`getItem`, `updateItem` and `deleteItem`, SNS `publish`, SQS `sendMessage`,
EventBridge `putEvents` and `states:startExecution`. The state's `Parameters`
are the request and the operation's response is the task's result. Each call
carries the execution role the task assumed, and simulated IAM answers it
against that role's policies and the resource the request names. A service
refusing a call fails the task under the name Amazon States Language gives it,
such as `DynamoDb.ConditionalCheckFailedException`. The target abstraction now
says what a target calls and what its failures are called, with the Lambda
targets doing their own function lookup behind it, and the `Resource` refusal
widened to cover `.sync`, `.waitForTaskToken` and services this simulation has
no simulation of.

The split is none. The generalised target abstraction is most of the work here,
and the four services, the SDK integration and `startExecution` are a table and
a request shape each on top of it, so holding any of them back would have cost a
second pull request for about 150 lines of production code. It comes to 2,019
lines added, of which 805 are tests and 301 are documentation.

This is rebased on https://github.com/KensioSoftware/yulin/pull/958, which
landed `Retry` and `Catch` while this was being written. The two meet at the
`handlerFailure` seam, where each target names its own failures, and a test here
catches a conditional check failure by writing
`DynamoDb.ConditionalCheckFailedException` in a `Catch`.

One note on the acceptance criteria. A `Resource` naming an unsimulated service
is refused when the state machine is created, while an operation a simulated
service has no implementation for is refused when the task runs. The operations
a service runs belong to the simulated service, and there is none to ask while a
state machine is being created. The refusal names the operation and lists what
that service does run.

Resolves https://github.com/KensioSoftware/yulin/issues/922
