### PR TITLE
fix: skip viewer-response on an Origin error

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -259,8 +259,10 @@ with a 200 for a URL the Bucket has no object for. It is one of the same error c
 CloudFront allows. Where the response page is itself missing, the viewer gets the status from
 fetching it, as in CloudFront.
 
-Custom error responses are applied before a `viewer-response` CloudFront Function runs. The function
-sees the response the viewer is about to get. `ErrorCachingMinTTL` is accepted and ignored, along
+A viewer-response function never sees a custom error page. CloudFront runs no viewer-response
+function once the Origin has answered 400 or higher, and simulated CloudFront does the same, for a
+CloudFront Function and a Lambda@Edge function alike. The status the Origin returned is what decides
+that, whatever `ResponseCode` puts in its place. `ErrorCachingMinTTL` is accepted and ignored, along
 with a rule that sets nothing else, since sim CloudFront has no cache to apply it to.
 
 ## Serve simulated CloudFront on localhost
@@ -906,6 +908,10 @@ Function code.
 
 The sim CloudFront supports `viewer-request` and `viewer-response` CloudFront Functions.
 
+A `viewer-response` Function runs for an Origin status below 400. CloudFront skips the
+viewer-response event once the Origin has answered 400 or higher (see
+[Limitations](#limitations)), and so does this simulation.
+
 Use `makeCffFunctionCodeInput` to pass a JavaScript handler function to `CreateFunctionCommand`.
 
 The `host` header a function sees is the hostname the request was made to CloudFront with, being the
@@ -1349,6 +1355,10 @@ Lambda@Edge at the viewer events. A Behavior with a viewer-request CloudFront Fu
 viewer-response Lambda@Edge function is refused, and so is a Behavior naming both at one event type.
 Simulated CloudFront refuses the same combinations.
 
+Neither kind runs at the viewer response once the Origin has answered 400 or higher. CloudFront
+skips that event for an Origin error, and the status the Origin returned is what decides it (see
+[Limitations](#limitations)).
+
 Both kinds of function see the `host` header as the hostname the viewer reached CloudFront with,
 rather than the Yulin-local host a request served on localhost arrives with. As on AWS, `host` is
 read-only at the viewer request, and a host a handler writes is discarded before the Origin sees it.
@@ -1627,9 +1637,10 @@ header the Origin left out is added either way.
 `RemoveHeadersConfig` takes headers away, and is applied before the added ones. A header named in
 both sections ends up present with the policy's value.
 
-The policy is applied after a custom error response is fetched and before a `viewer-response`
-CloudFront Function runs, as CloudFront does. An error page carries the policy's headers, and a
-function sees them in `event.response.headers` and can change them.
+The policy is applied after a custom error response is fetched and before the viewer-response event,
+as CloudFront does. An error page carries the policy's headers. A viewer-response Function sees them
+in `event.response.headers` and can change them, where the Origin answered below 400 and the
+Function ran at all.
 
 `SecurityHeadersConfig` is what CDK's `ResponseHeadersPolicy` construct synthesizes from
 `securityHeadersBehavior`, and every one of its sections is modelled. `ContentSecurityPolicy`,
@@ -2310,6 +2321,13 @@ Where sim CloudFront knowingly behaves differently from AWS:
   function and reports `inputTruncated` when it had to cut one. Every simulated body arrives whole
   and `inputTruncated` is always false, so a test finds out nothing about whether its request would
   be too large for a real edge function.
+- **The Origin's status decides whether a viewer-response function runs.** CloudFront skips the
+  viewer-response event once the Origin answers 400 or higher, and both kinds of function are
+  skipped here on that rule. Where a custom error response turns that status into another one, such
+  as the 200 a single-page app serves its shell with, the Origin's own status still decides. AWS
+  documents the restriction against the Origin's status and says nothing about the status a custom
+  error response puts in its place. A Distribution combining the two is where this simulation is
+  guessing.
 - **CloudFront's disallowed and read-only header lists go unchecked.** Real CloudFront answers 502
   when an edge function adds `Connection` or edits `Content-Length`. Both kinds of function here
   write what they like, apart from the viewer-request `host`, which is restored.

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -185,13 +185,15 @@ HTTP request behaviour is split across a few directories:
   `controller/root-object/` substitutes the default root object for a request to the Distribution
   root, before Behavior resolution so that everything downstream sees the object being served.
   `controller/error/` replaces an Origin error with the Distribution's response page, after the
-  Origin fetch and before the viewer-response CloudFront Function. The response page is fetched
-  through the same Behavior resolution and Origin fetching as any other request, so it can come from
-  an Origin of its own.
+  Origin fetch. The response page is fetched through the same Behavior resolution and Origin
+  fetching as any other request, so it can come from an Origin of its own.
   `controller/response-headers/` applies the Behavior's response headers policy, after the custom
-  error response and before the viewer-response CloudFront Function. That ordering is CloudFront's
-  own: an error page carries the policy's headers, and a function sees them in its event and can
-  change them.
+  error response and before the viewer-response event. That ordering is CloudFront's own. An error
+  page carries the policy's headers, and a viewer-response function that runs sees them in its event
+  and can change them.
+  The pipeline runs neither viewer-response applicator once the Origin has answered 400 or higher.
+  CloudFront restricts both kinds of edge function that way. The status the pipeline reads is the
+  Origin's, taken before the custom error response can replace it.
   `controller/web-acl/` puts the request through the Distribution's web ACL, first of all the stages
   and before Behavior resolution. CloudFront asks WAF ahead of every content-handling stage. A
   blocked request is answered with the web ACL's 403, and no Behavior, viewer-request function or

--- a/src/service/cloudfront/cff/sim-cloudfront-functions.loc.test.ts
+++ b/src/service/cloudfront/cff/sim-cloudfront-functions.loc.test.ts
@@ -6,7 +6,7 @@ import {
   CreateDistributionCommand,
   CreateFunctionCommand,
 } from "@aws-sdk/client-cloudfront";
-import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { makeCffFunctionCodeInput } from "./function-code-input/cff-function-code-input.js";
 import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
@@ -192,6 +192,14 @@ describe("Serve sim CloudFront Functions on localhost", () => {
       new CreateBucketCommand({ Bucket: "foobar-bucket" }),
     );
     await grantPublicObjectRead(simS3, "foobar-bucket");
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "foobar-bucket",
+        Key: "foobar/something.html",
+        ContentType: "text/html",
+        Body: "<h1>Something</h1>",
+      }),
+    );
 
     function viewerResponseHandlerFunction(
       event: CloudFrontFunction.ViewerResponseEvent,
@@ -246,12 +254,15 @@ describe("Serve sim CloudFront Functions on localhost", () => {
     const distroId = distributionCreation.Distribution?.Id;
     assertNonNullable(distroId);
 
-    const redirectedResponse = await fetch(
+    // The Object has to be there for the Origin to answer below 400. A
+    // viewer-response CFF runs for an Origin error in neither CloudFront nor
+    // this simulation.
+    const servedResponse = await fetch(
       `http://${distroId.toLowerCase()}.cloudfront.net.sim-aws.localhost:${srv.port}/foobar/something.html`,
     );
-    assertIdentical(redirectedResponse.status, 404);
+    assertIdentical(servedResponse.status, 200);
     assertIdentical(
-      redirectedResponse.headers.get("x-changed-by"),
+      servedResponse.headers.get("x-changed-by"),
       "foobar handler",
     );
   });

--- a/src/service/cloudfront/controller/sim-cf-controller-viewer-response-cff.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-viewer-response-cff.iso.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   CreateDistributionCommand,
   CreateFunctionCommand,
+  type DistributionConfig,
 } from "@aws-sdk/client-cloudfront";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
@@ -24,6 +25,60 @@ import {
 } from "../../../../test/cloudfront/site-fixture.js";
 
 describe("Simulated CloudFront local HTTP controller CFF", () => {
+  /**
+   * A viewer-response CFF marking the response with the status it saw, so a
+   * test can tell whether the function ran at all.
+   */
+  async function markerCffArn(simAws: SimAws, name: string): Promise<string> {
+    const creation = await simAws.cloudFront().createFunction(
+      new CreateFunctionCommand({
+        Name: name,
+        FunctionConfig: {
+          Comment: "Viewer-response marker CFF",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(
+          (event: CloudFrontFunction.ViewerResponseEvent) => {
+            event.response.headers["x-served-status"] = {
+              value: String(event.response.statusCode),
+            };
+            return event.response;
+          },
+        ),
+      }),
+    );
+
+    assertNonNullable(creation.FunctionMetadata.FunctionARN);
+
+    return creation.FunctionMetadata.FunctionARN;
+  }
+
+  /**
+   * A Distribution serving one Bucket through a viewer-response CFF, with the
+   * given config merged on top.
+   */
+  async function markerCffSite(
+    simAws: SimAws,
+    bucketName: string,
+    functionArn: string,
+    distributionConfig: Partial<DistributionConfig> = {},
+  ): Promise<string> {
+    return await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig(bucketName, {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          FunctionAssociations: {
+            Quantity: 1,
+            Items: [{ EventType: "viewer-response", FunctionARN: functionArn }],
+          },
+        },
+        ...distributionConfig,
+      }),
+    );
+  }
+
   it("preserves the Origin response body when a viewer-response CFF only changes headers", async () => {
     const simAws = new SimAws();
     const body = "<h1>Hello from S3</h1>";
@@ -129,68 +184,63 @@ describe("Simulated CloudFront local HTTP controller CFF", () => {
     assertFalse(response.headers.has("transfer-encoding"));
   });
 
-  it("runs the viewer-response CFF on a custom error response", async () => {
-    // Given a site whose 404s are answered with its own error page.
+  it("skips the viewer-response CFF when the Origin answered with an error", async () => {
+    // Given a site with a viewer-response CFF and no custom error pages.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "cff-origin-error-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const distributionId = await markerCffSite(
+      simAws,
+      "cff-origin-error-site",
+      await markerCffArn(simAws, "origin-error-marker-cff"),
+    );
+
+    // When a key the Bucket does not hold is requested, so the Origin
+    // answers 404.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the function did not run, as CloudFront runs no viewer-response
+    // function for an Origin status of 400 or higher.
+    assertResponseStatus(response, 404);
+    assertFalse(response.headers.has("x-served-status"));
+  });
+
+  it("skips the viewer-response CFF when a custom error page answers 200", async () => {
+    // Given a site serving its shell with a 200 for any path the Bucket has
+    // no Object for, which is how a single-page app is configured.
     const simAws = new SimAws();
     await simCfSiteBucket(simAws, "cff-error-page-site", {
       "404.html": "<h1>Not found</h1>",
     });
 
-    // And a viewer-response CFF marking whatever the viewer is about to get.
-    const cffOutput = await simAws.cloudFront().createFunction(
-      new CreateFunctionCommand({
-        Name: "error-page-marker-cff",
-        FunctionConfig: {
-          Comment: "Error page marker CFF",
-          Runtime: "cloudfront-js-2.0",
-        },
-        FunctionCode: makeCffFunctionCodeInput(
-          (event: CloudFrontFunction.ViewerResponseEvent) => {
-            event.response.headers["x-served-status"] = {
-              value: String(event.response.statusCode),
-            };
-            return event.response;
-          },
-        ),
-      }),
-    );
-
-    const distributionId = await simCfSiteDistributionId(
+    const distributionId = await markerCffSite(
       simAws,
-      simCfSiteDistributionConfig("cff-error-page-site", {
-        DefaultCacheBehavior: {
-          TargetOriginId: "site-origin",
-          ViewerProtocolPolicy: "allow-all",
-          FunctionAssociations: {
-            Quantity: 1,
-            Items: [
-              {
-                EventType: "viewer-response",
-                FunctionARN: cffOutput.FunctionMetadata.FunctionARN,
-              },
-            ],
-          },
-        },
+      "cff-error-page-site",
+      await markerCffArn(simAws, "error-page-marker-cff"),
+      {
         CustomErrorResponses: {
           Quantity: 1,
           Items: [
             {
               ErrorCode: 404,
               ResponsePagePath: "/404.html",
-              ResponseCode: "404",
+              ResponseCode: "200",
             },
           ],
         },
-      }),
+      },
     );
 
     // When a page that does not exist is requested.
     const response = await simCfSiteRequest(simAws, distributionId, "/missing");
 
-    // Then the function saw the custom error response rather than the Origin's
-    // own, so the error page is what the CFF gets to act on.
-    assertResponseStatus(response, 404);
+    // Then the viewer gets the error page as a 200, and the function still
+    // did not run. The status the Origin returned is what decides the skip,
+    // not the one the custom error response put in its place.
+    assertResponseStatus(response, 200);
     assertIdentical(await response.text(), "<h1>Not found</h1>");
-    assertIdentical(response.headers.get("x-served-status"), "404");
+    assertFalse(response.headers.has("x-served-status"));
   });
 });

--- a/src/service/cloudfront/controller/sim-cf-controller-viewer-response-edge.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-viewer-response-edge.iso.test.ts
@@ -1,5 +1,11 @@
-import { assertIdentical, assertResponseStatus } from "@kensio/smartass";
+import {
+  assertFalse,
+  assertIdentical,
+  assertResponseStatus,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
+
+import type { DistributionConfig } from "@aws-sdk/client-cloudfront";
 
 import { SimAws } from "../../aws/sim-aws.js";
 import type { LambdaAtEdge } from "../typings/lambda-at-edge.namespace.js";
@@ -18,6 +24,7 @@ async function edgeResponseSite(
   simAws: SimAws,
   bucketName: string,
   versionArn: string,
+  distributionConfig: Partial<DistributionConfig> = {},
 ): Promise<string> {
   return await simCfSiteDistributionId(
     simAws,
@@ -32,8 +39,25 @@ async function edgeResponseSite(
           ],
         },
       },
+      ...distributionConfig,
     }),
   );
+}
+
+/**
+ * A viewer-response handler marking the response with the status it saw, so a
+ * test can tell whether the function ran at all.
+ */
+function markerHandler(
+  event: LambdaAtEdge.ResponseEvent,
+): LambdaAtEdge.Response {
+  const { response } = event.Records[0].cf;
+  response.headers ??= {};
+  response.headers["x-served-status"] = [
+    { key: "X-Served-Status", value: response.status },
+  ];
+
+  return response;
 }
 
 describe("Simulated CloudFront viewer-response Lambda@Edge", () => {
@@ -137,5 +161,73 @@ describe("Simulated CloudFront viewer-response Lambda@Edge", () => {
     );
 
     assertIdentical(await response.text(), "<h1>Rewritten</h1>");
+  });
+
+  it("skips the viewer-response function when the Origin answered with an error", async () => {
+    // Given a site with a viewer-response function and no custom error pages.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-origin-error-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const distributionId = await edgeResponseSite(
+      simAws,
+      "edge-origin-error-site",
+      await makeEdgeFunctionVersionArn({
+        simAws,
+        functionName: "origin-error-marker",
+        handler: markerHandler,
+      }),
+    );
+
+    // When a key the Bucket does not hold is requested, so the Origin
+    // answers 404.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the handler did not run, as CloudFront runs no viewer-response
+    // function for an Origin status of 400 or higher.
+    assertResponseStatus(response, 404);
+    assertFalse(response.headers.has("x-served-status"));
+  });
+
+  it("skips the viewer-response function when a custom error page answers 200", async () => {
+    // Given a site serving its shell with a 200 for any path the Bucket has
+    // no Object for, which is how a single-page app is configured.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-error-page-site", {
+      "404.html": "<h1>Not found</h1>",
+    });
+
+    const distributionId = await edgeResponseSite(
+      simAws,
+      "edge-error-page-site",
+      await makeEdgeFunctionVersionArn({
+        simAws,
+        functionName: "error-page-marker",
+        handler: markerHandler,
+      }),
+      {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "200",
+            },
+          ],
+        },
+      },
+    );
+
+    // When a page that does not exist is requested.
+    const response = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the viewer gets the error page as a 200, and the handler still did
+    // not run. The status the Origin returned is what decides the skip, not
+    // the one the custom error response put in its place.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Not found</h1>");
+    assertFalse(response.headers.has("x-served-status"));
   });
 });

--- a/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
@@ -7,7 +7,8 @@ import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root
  * apply the default root object, resolve the matching Behavior, run
  * viewer-request hooks, fetch from the Origin, replace an error response with
  * the Distribution's custom error page, apply the Behavior's response headers
- * policy, then run viewer-response hooks.
+ * policy, then run viewer-response hooks where the Origin did not answer with
+ * an error.
  *
  * A viewer hook is a CloudFront Function or a Lambda@Edge function. A Behavior
  * carries at most one of the two kinds at the viewer events, which
@@ -91,8 +92,7 @@ export class SimCloudFrontRequestPipeline {
     );
 
     // Replace an Origin error with the Distribution's custom error page, if it
-    // configures one for that status. This happens before the viewer-response
-    // CFF so that a function sees the response the viewer is about to get.
+    // configures one for that status.
     const errorResponse = await this.stages.customErrorResponder.apply(
       requestReference,
       distro,
@@ -102,13 +102,21 @@ export class SimCloudFrontRequestPipeline {
     // Apply the Behavior's response headers policy, if it names one. CloudFront
     // does this after the response leaves the cache and before the
     // viewer-response event, so the custom error page above carries the
-    // policy's headers and a viewer-response function sees them.
+    // policy's headers and a viewer-response function that runs sees them.
     const response = this.stages.responseHeadersApplicator.apply(
       cloudFront,
       requestReference,
       errorResponse,
       behaviour,
     );
+
+    // CloudFront runs no viewer-response function when the Origin answered
+    // 400 or higher, for either kind of function. The status that decides it
+    // is the one the Origin returned, so a custom error response carrying
+    // `ResponseCode: 200` above does not bring the function back.
+    if (originResponse.status >= 400) {
+      return response;
+    }
 
     // Handle viewer-response CFF, if any.
     // A viewer-response CFF can inspect the original request and replace or


### PR DESCRIPTION
CloudFront runs no viewer-response edge function once the Origin has answered 400 or higher, and simulated CloudFront ran one on every response. The request pipeline now stops before both viewer-response applicators, covering a CloudFront Function and a Lambda@Edge function alike. The status it reads is the one the Origin returned, taken before a custom error response can replace it. A `ResponseCode` of 200 leaves the function skipped, and that decision is recorded under Limitations with what AWS documents about it.

Resolves #943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CloudFront viewer-response behavior for Origin responses with status 400 or higher.
  * Viewer-response functions are now skipped even when custom error pages replace the final response status.
  * Response headers policies continue to apply before viewer-response processing when execution is permitted.

* **Documentation**
  * Updated CloudFront documentation to clarify response handling and custom error interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->