### PR TITLE
feat: deploy Lambda@Edge from a template

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1353,6 +1353,114 @@ Both kinds of function see the `host` header as the hostname the viewer reached 
 rather than the Yulin-local host a request served on localhost arrives with. As on AWS, `host` is
 read-only at the viewer request, and a host a handler writes is discarded before the Origin sees it.
 
+### From CloudFormation
+
+`AWS::CloudFront::Distribution` takes `LambdaFunctionAssociations` on `DefaultCacheBehavior` and on
+any entry of `CacheBehaviors`. CloudFormation writes the list as a plain array where the SDK writes
+the `Quantity` and `Items` pair. `Ref` on an `AWS::Lambda::Version` answers the qualified function
+ARN. That is the value an association names, and the two fit together directly:
+
+```yaml
+EdgeVersion:
+  Type: AWS::Lambda::Version
+  Properties:
+    FunctionName: !Ref RewriteFunction
+
+SiteDistribution:
+  Type: AWS::CloudFront::Distribution
+  Properties:
+    DistributionConfig:
+      DefaultCacheBehavior:
+        TargetOriginId: SiteOrigin
+        ViewerProtocolPolicy: allow-all
+        LambdaFunctionAssociations:
+          - EventType: viewer-request
+            LambdaFunctionARN: !Ref EdgeVersion
+```
+
+The function still has to live in us-east-1. A stack holding one is a us-east-1 stack.
+
+Two kinds of association are left out of the deployed Distribution and recorded on
+`stack.ignoredProperties`, under the event type each was on. One names a function version this
+simulation does not hold, as a template pointing at a function in a real account does. The other is
+on `origin-request` or `origin-response`. The rest of the Behavior deploys either way, and the
+event the skipped association was on is left empty. A test that cares reads the record.
+
+Everything real CloudFront refuses still fails the deployment. A function outside us-east-1, an ARN
+without a version qualifier, an execution role missing the `edgelambda.amazonaws.com` trust, two
+functions on one event type and a viewer event running both kinds of edge function each fail a real
+deploy of the same template.
+
+CDK reaches a Behavior through `edgeLambdas`, given a `lambda.Version` from the same stack:
+
+```typescript sim-cloudfront-lambda-edge-cdk
+/**
+ * A CDK Distribution running a Lambda@Edge function at the viewer request.
+ */
+
+import { Stack } from "aws-cdk-lib";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import type { Construct } from "constructs";
+
+/**
+ * Example CDK stack whose Distribution rewrites every request at the edge.
+ *
+ * The stack is in us-east-1, the one Region CloudFront runs a Lambda@Edge
+ * function from.
+ */
+export class SiteStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id, { env: { region: "us-east-1" } });
+
+    const siteBucket = new s3.Bucket(this, "SiteBucket");
+
+    // A Lambda@Edge execution role trusts both service principals.
+    const edgeRole = new iam.Role(this, "EdgeRole", {
+      assumedBy: new iam.CompositePrincipal(
+        new iam.ServicePrincipal("lambda.amazonaws.com"),
+        new iam.ServicePrincipal("edgelambda.amazonaws.com"),
+      ),
+    });
+
+    const rewriteFunction = new lambda.Function(this, "RewriteFunction", {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      handler: "index.handler",
+      role: edgeRole,
+      code: lambda.Code.fromInline(`
+exports.handler = async (event) => {
+  const { request } = event.Records[0].cf;
+  request.uri = "/index.html";
+  return request;
+};
+`),
+    });
+
+    new cloudfront.Distribution(this, "SiteDistribution", {
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+        edgeLambdas: [
+          {
+            // edgeLambdas takes a published version, and currentVersion
+            // is one.
+            functionVersion: rewriteFunction.currentVersion,
+            eventType: cloudfront.LambdaEdgeEventType.VIEWER_REQUEST,
+          },
+        ],
+      },
+    });
+  }
+}
+```
+
+`cloudfront.experimental.EdgeFunction` deploys from a us-east-1 stack, where the construct creates
+the function alongside everything else. From a stack in any other Region it writes the function into
+a second stack and reads the ARN back through a custom resource, and that route is unsupported (see
+[Limitations](#limitations)).
+
 ## Web ACLs
 
 A Distribution can put a WAFv2 web ACL in front of everything it serves. Name the web ACL's ARN in
@@ -2282,6 +2390,7 @@ Sim CloudFront currently supports:
 - `DefaultRootObject` and `CustomErrorResponses`, for static sites and single-page apps
 - `viewer-request` and `viewer-response` CloudFront Functions, including async ones
 - `viewer-request` and `viewer-response` Lambda@Edge functions, through `LambdaFunctionAssociations`
+- `LambdaFunctionAssociations` on a template's Distribution, and CDK's `edgeLambdas`
 - CloudFront Functions reading an associated key value store through `cf.kvs()`
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
 - `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
@@ -2299,8 +2408,16 @@ whether the simulator needs them to model the requested behaviour safely.
 Where sim CloudFront knowingly behaves differently from AWS:
 
 - **Lambda@Edge runs at the two viewer events only.** CloudFront runs an edge function at
-  `origin-request` and `origin-response` as well, and both are refused by name rather than being
-  accepted and never run. The request pipeline has no hook either side of the Origin fetch yet.
+  `origin-request` and `origin-response` as well, and `CreateDistribution` refuses both by name
+  rather than accepting one that would never run. A Distribution deployed from a template records
+  the association and deploys without it. A site naming one origin function still serves. The
+  request pipeline has no hook either side of the Origin fetch yet.
+- **A CDK `EdgeFunction` outside us-east-1 fails the deployment.**
+  `cloudfront.experimental.EdgeFunction` writes the function into a us-east-1 support stack and
+  reads its ARN back through a custom resource in the stack that uses it. That custom resource
+  goes unresolved here, and the association is left holding the attribute reference. An
+  `EdgeFunction` in a us-east-1 stack deploys, as the construct creates the function there
+  directly. A `lambda.Version` handed to `edgeLambdas` is the route that works from a template.
 - **Nothing is replicated.** Real Lambda@Edge copies the function out to every Region and creates the
   `AWSServiceRoleForLambdaReplicator` service-linked role to do it. Here the function is invoked
   where it was created. The trust policy and the `lambda:GetFunction` and `lambda:EnableReplication`

--- a/docs/services/cloudfront/sim-cloudfront-lambda-edge-cdk.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-lambda-edge-cdk.example.ts
@@ -1,0 +1,60 @@
+/**
+ * A CDK Distribution running a Lambda@Edge function at the viewer request.
+ */
+
+import { Stack } from "aws-cdk-lib";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import type { Construct } from "constructs";
+
+/**
+ * Example CDK stack whose Distribution rewrites every request at the edge.
+ *
+ * The stack is in us-east-1, the one Region CloudFront runs a Lambda@Edge
+ * function from.
+ */
+export class SiteStack extends Stack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id, { env: { region: "us-east-1" } });
+
+    const siteBucket = new s3.Bucket(this, "SiteBucket");
+
+    // A Lambda@Edge execution role trusts both service principals.
+    const edgeRole = new iam.Role(this, "EdgeRole", {
+      assumedBy: new iam.CompositePrincipal(
+        new iam.ServicePrincipal("lambda.amazonaws.com"),
+        new iam.ServicePrincipal("edgelambda.amazonaws.com"),
+      ),
+    });
+
+    const rewriteFunction = new lambda.Function(this, "RewriteFunction", {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      handler: "index.handler",
+      role: edgeRole,
+      code: lambda.Code.fromInline(`
+exports.handler = async (event) => {
+  const { request } = event.Records[0].cf;
+  request.uri = "/index.html";
+  return request;
+};
+`),
+    });
+
+    new cloudfront.Distribution(this, "SiteDistribution", {
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+        edgeLambdas: [
+          {
+            // edgeLambdas takes a published version, and currentVersion
+            // is one.
+            functionVersion: rewriteFunction.currentVersion,
+            eventType: cloudfront.LambdaEdgeEventType.VIEWER_REQUEST,
+          },
+        ],
+      },
+    });
+  }
+}

--- a/docs/tsconfig.cdk.json
+++ b/docs/tsconfig.cdk.json
@@ -1,0 +1,14 @@
+{
+  // CDK examples compile on their own, because an L2 construct is not
+  // assignable to the interface CDK itself declares for it under
+  // exactOptionalPropertyTypes. A project made by `cdk init` leaves that
+  // setting off, and a stack here is checked the way a reader's project checks
+  // one.
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "exactOptionalPropertyTypes": false,
+    "tsBuildInfoFile": "../tsconfig.docs-cdk.tsbuildinfo"
+  },
+  "include": ["**/*-cdk.example.ts"]
+}

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -41,5 +41,7 @@
       "@kensio/yulin/watch": ["../src/watch/index.ts"]
     }
   },
-  "include": ["**/*.example.ts", "**/*.examples.ts"]
+  "include": ["**/*.example.ts", "**/*.examples.ts"],
+  // A CDK stack example is compiled by tsconfig.cdk.json instead.
+  "exclude": ["**/*-cdk.example.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "test:local": "rm -rf './.tmp/' && vitest run --project localTests",
     "examples:extract": "pnpm tsx scripts/mts/extract-documentation-examples.mts",
     "examples:tsc": "tsc -p docs/tsconfig.json",
+    "examples:tsc:cdk": "tsc -p docs/tsconfig.cdk.json",
     "examples:lint": "oxlint --type-aware --max-warnings=0 docs",
-    "examples:check": "pnpm examples:extract && pnpm examples:tsc && pnpm examples:lint",
+    "examples:check": "pnpm examples:extract && pnpm examples:tsc && pnpm examples:tsc:cdk && pnpm examples:lint",
     "fta": "./scripts/sh/fta.sh",
     "check": "pnpm fmt && pnpm fta && pnpm build:check && pnpm examples:check && pnpm test:coverage",
     "tf:init": "./scripts/sh/tf-init.sh"

--- a/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-edge-lambda.loc.test.ts
+++ b/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-edge-lambda.loc.test.ts
@@ -1,0 +1,196 @@
+import path from "node:path";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth the output
+ * template file and deploys the synthesized Distribution, function and
+ * published version through sim CloudFormation.
+ *
+ * This is the CDK route a Lambda@Edge function reaches a Behavior by: a
+ * `lambda.Version` in the same stack, handed to `edgeLambdas`. The stack is in
+ * `us-east-1`, because that is the only Region CloudFront runs an edge
+ * function from and the alternative,
+ * `cloudfront.experimental.EdgeFunction`, reads its ARN back through a custom
+ * resource in a second stack.
+ */
+describe("Sim CDK CloudFront Lambda@Edge local integration", () => {
+  it("runs the version a CDK Behavior's edgeLambdas names", async () => {
+    // Given a CDK stack whose Distribution runs a published version at the
+    // viewer request, with an execution role Lambda@Edge can assume.
+    const cdkProject = new TestCdkProject();
+
+    await cdkProject.writeCdkAppFile(`
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "us-east-1" },
+});
+
+const siteBucket = new s3.Bucket(stack, "SiteBucket", {
+  bucketName: "cdk-edge-site-bucket",
+});
+
+const edgeRole = new iam.Role(stack, "EdgeRole", {
+  assumedBy: new iam.CompositePrincipal(
+    new iam.ServicePrincipal("lambda.amazonaws.com"),
+    new iam.ServicePrincipal("edgelambda.amazonaws.com"),
+  ),
+});
+
+const edgeFunction = new lambda.Function(stack, "EdgeFunction", {
+  runtime: lambda.Runtime.NODEJS_22_X,
+  handler: "index.handler",
+  role: edgeRole,
+  code: lambda.Code.fromInline(\`
+exports.handler = async () => ({
+  status: "200",
+  headers: { "content-type": [{ key: "Content-Type", value: "text/html" }] },
+  body: "<h1>Edge</h1>",
+});
+\`),
+});
+
+const distribution = new cloudfront.Distribution(stack, "SiteDistribution", {
+  defaultBehavior: {
+    origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+    edgeLambdas: [
+      {
+        functionVersion: edgeFunction.currentVersion,
+        eventType: cloudfront.LambdaEdgeEventType.VIEWER_REQUEST,
+      },
+    ],
+  },
+});
+
+new cdk.CfnOutput(stack, "DistributionId", {
+  value: distribution.distributionId,
+});
+
+app.synth();
+`);
+
+    // And the CDK app is synthesized to a CloudFormation template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the synthesized template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+
+    await stack.waitForDeployComplete();
+
+    const distributionId = stack.outputs.get("DistributionId")?.value;
+    assertNonNullable(distributionId);
+
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId as string,
+      "/index.html",
+    );
+
+    // Then the function answers the viewer itself, without the Origin being
+    // read for a page the Bucket does not hold.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Edge</h1>");
+  });
+
+  it("runs an EdgeFunction a us-east-1 stack created directly", async () => {
+    // Given a CDK stack in us-east-1 whose Distribution runs an
+    // experimental.EdgeFunction, which the construct creates in this stack
+    // rather than in a support stack of its own.
+    const cdkProject = new TestCdkProject();
+
+    await cdkProject.writeCdkAppFile(`
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "us-east-1" },
+});
+
+const siteBucket = new s3.Bucket(stack, "SiteBucket", {
+  bucketName: "cdk-edge-function-bucket",
+});
+
+const edgeFunction = new cloudfront.experimental.EdgeFunction(stack, "EdgeFn", {
+  runtime: lambda.Runtime.NODEJS_22_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(\`
+exports.handler = async () => ({
+  status: "200",
+  headers: { "content-type": [{ key: "Content-Type", value: "text/html" }] },
+  body: "<h1>Edge Function</h1>",
+});
+\`),
+});
+
+const distribution = new cloudfront.Distribution(stack, "SiteDistribution", {
+  defaultBehavior: {
+    origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+    edgeLambdas: [
+      {
+        functionVersion: edgeFunction.currentVersion,
+        eventType: cloudfront.LambdaEdgeEventType.VIEWER_REQUEST,
+      },
+    ],
+  },
+});
+
+new cdk.CfnOutput(stack, "DistributionId", {
+  value: distribution.distributionId,
+});
+
+app.synth();
+`);
+
+    // And the CDK app is synthesized to a CloudFormation template.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the synthesized template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+
+    await stack.waitForDeployComplete();
+
+    const distributionId = stack.outputs.get("DistributionId")?.value;
+    assertNonNullable(distributionId);
+
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId as string,
+      "/index.html",
+    );
+
+    // Then the function runs at the viewer request, as it does for a
+    // lambda.Version written by hand.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Edge Function</h1>");
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
@@ -9,8 +9,11 @@ import type {
 import type { SimCloudFront } from "../../sim-cloudfront.js";
 import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontDistributionConfig } from "../../command/create-distribution/create-distribution.command.js";
 import { SimCfnCfDistroConfigValidator } from "./sim-cfn-cf-distro-config-validator.js";
+import { simCfnCfDistroWithRunnableEdgeAssociations } from "./sim-cfn-cf-distro-edge-associations.js";
 import { simCfnCfDistroWithoutAbsentWebAcl } from "./sim-cfn-cf-distro-web-acl.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
 
 interface SimCfnCfDistroCreatorProperties {
   readonly cloudFront: SimCloudFront;
@@ -20,10 +23,11 @@ interface SimCfnCfDistroCreatorProperties {
  * Creates simulated CloudFront Distributions from CloudFormation Resources.
  *
  * A `WebACLId` naming a web ACL this simulation does not hold is left out and
- * recorded. CloudFront has no association Resource, so the reference lives on
- * the Distribution itself, and refusing it would take the Distribution down
- * over a web ACL that was never the point of the template. The site a local
- * dev server and a suite of tests make requests to has to survive that.
+ * recorded, and so is a Lambda@Edge association it cannot run. CloudFront has
+ * no association Resource for either, so both live on the Distribution itself,
+ * and refusing one would take the Distribution down over something that was
+ * never the point of the template. The site a local dev server and a suite of
+ * tests make requests to has to survive that.
  */
 export class SimCfnCfDistroCreator {
   private readonly cloudFront: SimCloudFront;
@@ -58,7 +62,7 @@ export class SimCfnCfDistroCreator {
     });
     const output = await this.cloudFront.createDistribution({
       input: {
-        DistributionConfig: simCfnCfDistroWithoutAbsentWebAcl(
+        DistributionConfig: deployableConfig(
           resource,
           validator.validate(),
           context.simAws,
@@ -81,4 +85,24 @@ export class SimCfnCfDistroCreator {
 
     return distribution;
   }
+}
+
+/**
+ * The DistributionConfig to deploy, without the parts this simulation cannot
+ * act on, each recorded on the Resource.
+ */
+function deployableConfig(
+  resource: SimCfnResource,
+  distributionConfig: SimCloudFrontDistributionConfig,
+  simAws: SimAws,
+): SimCloudFrontDistributionConfig {
+  return simCfnCfDistroWithoutAbsentWebAcl(
+    resource,
+    simCfnCfDistroWithRunnableEdgeAssociations(
+      resource,
+      distributionConfig,
+      simAws,
+    ),
+    simAws,
+  );
 }

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-associations.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-associations.ts
@@ -75,7 +75,7 @@ function distroCacheBehaviors(
 ): SimCloudFrontDistributionConfig["CacheBehaviors"] {
   const behaviors = normalizeSimCfList<SimCloudFrontCacheBehaviorConfig>(
     "CacheBehaviors",
-    (distributionConfig as Record<string, unknown>)["CacheBehaviors"],
+    distributionConfig.CacheBehaviors,
   );
   const items = behaviors?.Items;
 

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-associations.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-associations.ts
@@ -1,0 +1,119 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCloudFrontCacheBehaviorConfig,
+  SimCloudFrontDistributionConfig,
+} from "../../command/create-distribution/create-distribution.command.js";
+import { normalizeSimCfList } from "../../command/create-distribution/sim-cf-normalize-list.js";
+import { SimCfnCfEdgeAssociationSkips } from "./sim-cfn-cf-edge-association-skips.js";
+
+/**
+ * The path a skipped association on the default Behavior is recorded under.
+ */
+const defaultBehaviorPath = "DistributionConfig.DefaultCacheBehavior";
+
+/**
+ * The DistributionConfig to deploy, without the Lambda@Edge associations this
+ * simulation cannot run.
+ *
+ * Each association left out is recorded on `stack.ignoredProperties` under the
+ * event type it was on, and `SimCfnCfEdgeAssociationSkips` decides which those
+ * are. `CreateDistribution` takes the whole Distribution down over one of
+ * them, and a Distribution that failed to deploy takes every request a local
+ * dev server and a test suite make with it. That is the same reason an absent
+ * `WebACLId` is left out here.
+ *
+ * The Behavior deploys with whatever is left and runs nothing at the event the
+ * skipped association was on. A test that cares reads the record.
+ */
+export function simCfnCfDistroWithRunnableEdgeAssociations(
+  resource: SimCfnResource,
+  distributionConfig: SimCloudFrontDistributionConfig,
+  simAws: SimAws,
+): SimCloudFrontDistributionConfig {
+  const skips = new SimCfnCfEdgeAssociationSkips(resource, simAws);
+  const defaultCacheBehavior = distroDefaultBehavior(skips, distributionConfig);
+  const cacheBehaviors = distroCacheBehaviors(skips, distributionConfig);
+
+  if (skips.count === 0) {
+    return distributionConfig;
+  }
+
+  return {
+    ...distributionConfig,
+    DefaultCacheBehavior: defaultCacheBehavior,
+    CacheBehaviors: cacheBehaviors,
+  };
+}
+
+/**
+ * The default cache Behavior, without its unrunnable associations.
+ */
+function distroDefaultBehavior(
+  skips: SimCfnCfEdgeAssociationSkips,
+  distributionConfig: SimCloudFrontDistributionConfig,
+): SimCloudFrontCacheBehaviorConfig | undefined {
+  const behavior = distributionConfig.DefaultCacheBehavior;
+
+  if (behavior === undefined) {
+    return undefined;
+  }
+
+  return behaviorAssociations(skips, behavior, defaultBehaviorPath);
+}
+
+/**
+ * Every path-based cache Behavior, each without its unrunnable associations.
+ *
+ * A Behavior is recorded under its `PathPattern`, in the terms the template
+ * wrote it in. Its position is the fallback for a hand-written entry that left
+ * the pattern out.
+ */
+function distroCacheBehaviors(
+  skips: SimCfnCfEdgeAssociationSkips,
+  distributionConfig: SimCloudFrontDistributionConfig,
+): SimCloudFrontDistributionConfig["CacheBehaviors"] {
+  const behaviors = normalizeSimCfList<SimCloudFrontCacheBehaviorConfig>(
+    "CacheBehaviors",
+    (distributionConfig as Record<string, unknown>)["CacheBehaviors"],
+  );
+  const items = behaviors?.Items;
+
+  if (items === undefined) {
+    return distributionConfig.CacheBehaviors;
+  }
+
+  return {
+    ...behaviors,
+    Items: items.map((behavior, index) =>
+      behaviorAssociations(
+        skips,
+        behavior,
+        `DistributionConfig.CacheBehaviors.${behavior.PathPattern ?? String(index)}`,
+      ),
+    ),
+  };
+}
+
+/**
+ * One Behavior, without the associations this simulation cannot run.
+ */
+function behaviorAssociations(
+  skips: SimCfnCfEdgeAssociationSkips,
+  behavior: SimCloudFrontCacheBehaviorConfig,
+  behaviorPath: string,
+): SimCloudFrontCacheBehaviorConfig {
+  const runnable = skips.runnableAssociations(behavior, behaviorPath);
+
+  if (runnable === undefined) {
+    return behavior;
+  }
+
+  return {
+    ...behavior,
+    LambdaFunctionAssociations: {
+      Quantity: runnable.length,
+      Items: runnable,
+    },
+  };
+}

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
@@ -1,0 +1,235 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  edgeCacheBehavior,
+  edgeDistributionLogicalId,
+  edgeDistributionTemplateFactory,
+  edgeVersionLogicalId,
+} from "../../../../../test/cloudfront/edge-distribution-template.factory.js";
+import {
+  simCfSiteBucket,
+  simCfSiteRequest,
+} from "../../../../../test/cloudfront/site-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+/**
+ * A version ARN naming a function no simulated Lambda holds, which is what a
+ * template pointing at a function in a real account leaves behind.
+ */
+const absentVersionArn =
+  "arn:aws:lambda:us-east-1:111111111111:function:analytics-edge:3";
+
+/**
+ * The Distribution a deployed stack created.
+ */
+function deployedDistribution(
+  stack: SimCfnDeployedStack,
+): SimCloudFrontDistribution {
+  const distribution = stack.getResource(
+    edgeDistributionLogicalId,
+  )?.simResource;
+  assertInstanceOf(distribution, SimCloudFrontDistribution);
+
+  return distribution;
+}
+
+describe("CloudFormation Distribution Lambda@Edge skips", () => {
+  it("serves from a Distribution whose association named an absent function", async () => {
+    // Given a Bucket holding the page the Distribution serves.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    // When a template whose Behavior names a function this simulation does not
+    // hold deploys.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "edge-site",
+      template: edgeDistributionTemplateFactory.make({
+        associations: [
+          {
+            EventType: "viewer-request",
+            LambdaFunctionARN: absentVersionArn,
+          },
+        ],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Distribution deployed and serves the page itself, with the
+    // association it could not run recorded.
+    const distribution = deployedDistribution(stack);
+    const response = await simCfSiteRequest(
+      simAws,
+      distribution.distributionId,
+      "/index.html",
+    );
+
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Home</h1>");
+    assertUndefined(distribution.behaviors[0]?.lambdaFunctionAssociations);
+
+    const [ignoredProperty] = stack.ignoredProperties;
+    assertNonNullable(ignoredProperty);
+    assertIdentical(
+      ignoredProperty.path,
+      "DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations.viewer-request",
+    );
+    assertStringIncludes(ignoredProperty.reason, absentVersionArn);
+  });
+
+  it("deploys the rest of a Behavior whose association is on an origin event", async () => {
+    // Given a Bucket holding the page the edge function rewrites requests to.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {
+      "edge.html": "<h1>Edge</h1>",
+      "index.html": "<h1>Home</h1>",
+    });
+
+    // When a template whose Behavior runs the same function at the viewer and
+    // at the Origin deploys.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "edge-site",
+      template: edgeDistributionTemplateFactory.make({
+        associations: [
+          {
+            EventType: "viewer-request",
+            LambdaFunctionARN: { Ref: edgeVersionLogicalId },
+          },
+          {
+            EventType: "origin-request",
+            LambdaFunctionARN: { Ref: edgeVersionLogicalId },
+          },
+        ],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the viewer-request function still runs, and the origin-request one
+    // is recorded as the part that was left out.
+    const response = await simCfSiteRequest(
+      simAws,
+      deployedDistribution(stack).distributionId,
+      "/index.html",
+    );
+
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Edge</h1>");
+
+    const [ignoredProperty] = stack.ignoredProperties;
+    assertNonNullable(ignoredProperty);
+    assertIdentical(
+      ignoredProperty.path,
+      "DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations.origin-request",
+    );
+    assertStringIncludes(ignoredProperty.reason, "viewer-request");
+  });
+
+  it("records a skipped association under the Behavior's path pattern", async () => {
+    // Given a Bucket holding the page a path-based Behavior serves.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {
+      "images/logo.svg": "<svg />",
+    });
+
+    // When the Behavior for that path names a function this simulation does
+    // not hold.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "edge-site",
+      template: edgeDistributionTemplateFactory.make({
+        associations: [],
+        cacheBehaviors: [
+          edgeCacheBehavior("/images/*", [
+            {
+              EventType: "viewer-response",
+              LambdaFunctionARN: absentVersionArn,
+            },
+          ]),
+        ],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Behavior serves its path, and the record names the pattern the
+    // template wrote it under.
+    const response = await simCfSiteRequest(
+      simAws,
+      deployedDistribution(stack).distributionId,
+      "/images/logo.svg",
+    );
+
+    assertResponseStatus(response, 200);
+    assertIdentical(
+      stack.ignoredProperties[0]?.path,
+      "DistributionConfig.CacheBehaviors./images/*.LambdaFunctionAssociations.viewer-response",
+    );
+  });
+
+  it("fails the stack over a function outside us-east-1", async () => {
+    // Given a template whose association names a function in the Region the
+    // rest of the stack is in.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {});
+
+    // When it deploys.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "edge-site",
+        template: edgeDistributionTemplateFactory.make({
+          associations: [
+            {
+              EventType: "viewer-request",
+              LambdaFunctionARN:
+                "arn:aws:lambda:eu-west-2:111111111111:function:edge-function:1",
+            },
+          ],
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment failed on the Region, as a real deploy fails on it,
+    // rather than deploying a site missing the function it was written with.
+    assertStringIncludes(error.message, "us-east-1");
+  });
+
+  it("fails the stack over an ARN naming no published version", async () => {
+    // Given a template whose association names the function rather than a
+    // version of it.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {});
+
+    // When it deploys.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "edge-site",
+        template: edgeDistributionTemplateFactory.make({
+          associations: [
+            {
+              EventType: "viewer-request",
+              LambdaFunctionARN: {
+                "Fn::GetAtt": ["EdgeFunction", "Arn"],
+              },
+            },
+          ],
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment failed on the qualifier, which is the mistake an
+    // unpublished Lambda@Edge function is made with.
+    assertStringIncludes(error.message, "published Lambda function version");
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
@@ -176,6 +176,28 @@ describe("CloudFormation Distribution Lambda@Edge skips", () => {
     );
   });
 
+  it("fails the stack over a role Lambda@Edge cannot assume", async () => {
+    // Given a template whose edge function runs as an ordinary Lambda
+    // execution role, trusting lambda.amazonaws.com alone.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {});
+
+    // When it deploys.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "edge-site",
+        template: edgeDistributionTemplateFactory.make({
+          trustedServices: ["lambda.amazonaws.com"],
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment failed on the trust policy. The function version is
+    // here, so the association is left where CreateDistribution refuses it.
+    assertStringIncludes(error.message, "edgelambda.amazonaws.com");
+  });
+
   it("fails the stack over a function outside us-east-1", async () => {
     // Given a template whose association names a function in the Region the
     // rest of the stack is in.

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge.iso.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, it } from "vitest";
 
 import {
+  edgeCacheBehavior,
   edgeDistributionLogicalId,
   edgeDistributionTemplateFactory,
   edgeVersionLogicalId,
@@ -45,6 +46,48 @@ describe("CloudFormation Distribution Lambda@Edge associations", () => {
       simAws,
       distribution.distributionId,
       "/index.html",
+    );
+
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Edge</h1>");
+  });
+
+  it("runs the function a path-based Behavior associates", async () => {
+    // Given a Bucket holding the page the edge function rewrites requests to.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {
+      "edge.html": "<h1>Edge</h1>",
+      "images/logo.svg": "<svg />",
+    });
+
+    // When the Behavior for one path associates the published version and the
+    // default Behavior associates nothing.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "edge-site",
+      template: edgeDistributionTemplateFactory.make({
+        associations: [],
+        cacheBehaviors: [
+          edgeCacheBehavior("/images/*", [
+            {
+              EventType: "viewer-request",
+              LambdaFunctionARN: { Ref: edgeVersionLogicalId },
+            },
+          ]),
+        ],
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then a request that Behavior matches runs the function.
+    const distribution = stack.getResource(
+      edgeDistributionLogicalId,
+    )?.simResource;
+    assertInstanceOf(distribution, SimCloudFrontDistribution);
+
+    const response = await simCfSiteRequest(
+      simAws,
+      distribution.distributionId,
+      "/images/logo.svg",
     );
 
     assertResponseStatus(response, 200);

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge.iso.test.ts
@@ -1,0 +1,84 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertResponseStatus,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  edgeDistributionLogicalId,
+  edgeDistributionTemplateFactory,
+  edgeVersionLogicalId,
+} from "../../../../../test/cloudfront/edge-distribution-template.factory.js";
+import {
+  simCfSiteBucket,
+  simCfSiteRequest,
+} from "../../../../../test/cloudfront/site-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambdaFunction } from "../../../lambda/function/sim-lambda-function.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+describe("CloudFormation Distribution Lambda@Edge associations", () => {
+  it("runs the function version a Behavior's association names", async () => {
+    // Given a Bucket holding the page the edge function rewrites requests to.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {
+      "edge.html": "<h1>Edge</h1>",
+      "index.html": "<h1>Home</h1>",
+    });
+
+    // When a template whose Behavior associates a published version deploys.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "edge-site",
+      template: edgeDistributionTemplateFactory.make(),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Distribution runs the function at the viewer request.
+    const distribution = stack.getResource(
+      edgeDistributionLogicalId,
+    )?.simResource;
+    assertInstanceOf(distribution, SimCloudFrontDistribution);
+
+    const response = await simCfSiteRequest(
+      simAws,
+      distribution.distributionId,
+      "/index.html",
+    );
+
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Edge</h1>");
+  });
+
+  it("binds the version ARN the association's Ref resolves to", async () => {
+    // Given a deployed template naming its published version by Ref.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {
+      "edge.html": "<h1>Edge</h1>",
+    });
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "edge-site",
+      template: edgeDistributionTemplateFactory.make(),
+    });
+    await stack.waitForDeployComplete();
+
+    // When the Behavior's association is read.
+    const distribution = stack.getResource(
+      edgeDistributionLogicalId,
+    )?.simResource;
+    assertInstanceOf(distribution, SimCloudFrontDistribution);
+
+    const association =
+      distribution.behaviors[0]?.lambdaFunctionAssociations?.viewerRequest;
+
+    // Then it holds the qualified ARN of the version the template published,
+    // which is what AWS::Lambda::Version answers a Ref with.
+    const version = stack.getResource(edgeVersionLogicalId)?.simResource;
+    assertInstanceOf(version, SimLambdaFunction);
+    assertNonNullable(association);
+    assertIdentical(association.functionArn, version.arn);
+    assertIdentical(version.version, "1");
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-association-skips.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-association-skips.ts
@@ -48,7 +48,7 @@ export class SimCfnCfEdgeAssociationSkips {
   ): readonly SimCloudFrontLambdaFunctionAssociation[] | undefined {
     const items = normalizeSimCfList<SimCloudFrontLambdaFunctionAssociation>(
       "LambdaFunctionAssociations",
-      (behavior as Record<string, unknown>)["LambdaFunctionAssociations"],
+      behavior.LambdaFunctionAssociations,
     )?.Items;
 
     if (items === undefined) {

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-association-skips.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-association-skips.ts
@@ -1,0 +1,129 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCloudFrontCacheBehaviorConfig,
+  SimCloudFrontDefaultCacheBehaviorConfig,
+  SimCloudFrontLambdaFunctionAssociation,
+} from "../../command/create-distribution/create-distribution.command.js";
+import { normalizeSimCfList } from "../../command/create-distribution/sim-cf-normalize-list.js";
+import { isSimulatedEdgeEventType } from "../../edge/sim-cf-edge-association-checks.js";
+import { readEdgeFunctionArnParts } from "../../edge/sim-cf-edge-function-arn.js";
+import { findSimCfEdgeFunctionVersion } from "../../edge/sim-cf-edge-function-version.js";
+
+/**
+ * Decides which of a template Behavior's Lambda@Edge associations this
+ * simulation can run, recording the rest on the CloudFormation Resource.
+ *
+ * An association is left out for two reasons. One names a function version
+ * this simulation does not hold, as a template pointing at a function in a
+ * real account does. The other is on an event type this simulation has no hook
+ * for.
+ *
+ * Everything else is left where `CreateDistribution` meets it, including the
+ * mistakes real CloudFront refuses. A template carrying one of those fails a
+ * real deploy too.
+ */
+export class SimCfnCfEdgeAssociationSkips {
+  /** How many associations have been left out so far. */
+  public count = 0;
+
+  constructor(
+    private readonly resource: SimCfnResource,
+    private readonly simAws: SimAws,
+  ) {}
+
+  /**
+   * The associations of one Behavior this simulation can run, answering with
+   * nothing where it can run all of them and the Behavior needs no rewriting.
+   *
+   * The list is read through the normalizer, because a template writes it as a
+   * plain array where the CloudFront API writes the Quantity and Items pair,
+   * and both arrive here.
+   */
+  runnableAssociations(
+    behavior:
+      | SimCloudFrontDefaultCacheBehaviorConfig
+      | SimCloudFrontCacheBehaviorConfig,
+    behaviorPath: string,
+  ): readonly SimCloudFrontLambdaFunctionAssociation[] | undefined {
+    const items = normalizeSimCfList<SimCloudFrontLambdaFunctionAssociation>(
+      "LambdaFunctionAssociations",
+      (behavior as Record<string, unknown>)["LambdaFunctionAssociations"],
+    )?.Items;
+
+    if (items === undefined) {
+      return undefined;
+    }
+
+    const runnable = items.filter((association) =>
+      this.canRun(association, behaviorPath),
+    );
+
+    if (runnable.length === items.length) {
+      return undefined;
+    }
+
+    return runnable;
+  }
+
+  /**
+   * Whether this simulation can run one association, recording it where it
+   * cannot.
+   */
+  private canRun(
+    association: SimCloudFrontLambdaFunctionAssociation,
+    behaviorPath: string,
+  ): boolean {
+    const { EventType, LambdaFunctionARN } = association;
+
+    if (EventType === undefined || LambdaFunctionARN === undefined) {
+      return true;
+    }
+
+    if (!isSimulatedEdgeEventType(EventType)) {
+      return this.skip(
+        behaviorPath,
+        EventType,
+        `simulated CloudFront runs a Lambda@Edge function at viewer-request ` +
+          `and viewer-response, so the Behavior is deployed without the ` +
+          `${EventType} function ${LambdaFunctionARN} and runs nothing there`,
+      );
+    }
+
+    const arn = readEdgeFunctionArnParts(LambdaFunctionARN);
+
+    if (arn === undefined) {
+      return true;
+    }
+
+    if (findSimCfEdgeFunctionVersion(this.simAws, arn) !== undefined) {
+      return true;
+    }
+
+    return this.skip(
+      behaviorPath,
+      EventType,
+      `Lambda@Edge function ${LambdaFunctionARN} is not held by this ` +
+        `simulation, so the Behavior is deployed without it and runs nothing ` +
+        `at ${EventType}`,
+    );
+  }
+
+  /**
+   * Record one skipped association, answering with what a filter does about
+   * it.
+   */
+  private skip(
+    behaviorPath: string,
+    eventType: string,
+    reason: string,
+  ): boolean {
+    this.count += 1;
+    this.resource.ignoreProperty(
+      `${behaviorPath}.LambdaFunctionAssociations.${eventType}`,
+      reason,
+    );
+
+    return false;
+  }
+}

--- a/src/service/cloudfront/edge/sim-aws-cf-edge-functions.ts
+++ b/src/service/cloudfront/edge/sim-aws-cf-edge-functions.ts
@@ -8,6 +8,7 @@ import {
 import { SimCloudFrontInvalidLambdaFunctionAssociation } from "../error/sim-cloudfront.error.js";
 import { edgeFunctionArnParts } from "./sim-cf-edge-function-arn.js";
 import type { SimCfEdgeFunctions } from "./sim-cf-edge-functions.js";
+import { findSimCfEdgeFunctionVersion } from "./sim-cf-edge-function-version.js";
 
 /**
  * The service principal Lambda@Edge runs a function's execution role as.
@@ -54,10 +55,7 @@ export class SimAwsCfEdgeFunctions implements SimCfEdgeFunctions {
    */
   private target(functionArn: string): SimLambdaFunctionTarget {
     const arn = edgeFunctionArnParts(functionArn);
-    const found = this.simAws
-      .accountRegionScope(arn.accountId, arn.regionName)
-      .lambda()
-      .getSimFunctionTarget(arn.functionName, arn.qualifier);
+    const found = findSimCfEdgeFunctionVersion(this.simAws, arn);
 
     if (found === undefined) {
       throw new SimCloudFrontInvalidLambdaFunctionAssociation(

--- a/src/service/cloudfront/edge/sim-cf-edge-association-checks.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-association-checks.ts
@@ -29,7 +29,7 @@ type BehaviorConfig =
 export function assertSimulatedEventType(
   eventType: string | undefined,
 ): asserts eventType is SimulatedEdgeEventType {
-  if (eventType === "viewer-request" || eventType === "viewer-response") {
+  if (isSimulatedEdgeEventType(eventType)) {
     return;
   }
 
@@ -38,6 +38,15 @@ export function assertSimulatedEventType(
       `simulated. Simulated CloudFront runs a Lambda@Edge function at ` +
       `viewer-request and viewer-response.`,
   );
+}
+
+/**
+ * Whether this simulation runs a Lambda@Edge function at this event type.
+ */
+export function isSimulatedEdgeEventType(
+  eventType: string | undefined,
+): eventType is SimulatedEdgeEventType {
+  return eventType === "viewer-request" || eventType === "viewer-response";
 }
 
 /**

--- a/src/service/cloudfront/edge/sim-cf-edge-function-arn.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-function-arn.ts
@@ -45,18 +45,38 @@ export function edgeFunctionArnParts(
 }
 
 /**
- * Refuse an ARN naming anything but a published version.
+ * Read the parts of an ARN CloudFront would associate, answering with nothing
+ * where it would refuse the ARN itself.
  *
- * A version qualifier is a number, and an alias is a name, which is the whole
- * of the difference between the two in an ARN.
+ * A caller that has something to do about such an ARN other than throw reads
+ * it here. A Distribution deployed from a template skips an association naming
+ * a function this simulation does not hold, and it can only tell whether the
+ * function is here once it knows the ARN names a function at all.
+ */
+export function readEdgeFunctionArnParts(
+  functionArn: string,
+): SimLambdaFunctionArnParts | undefined {
+  const arn = parseSimLambdaFunctionArn(functionArn);
+
+  if (arn?.regionName !== lambdaEdgeRegion) {
+    return undefined;
+  }
+
+  if (!isPublishedVersion(arn.qualifier)) {
+    return undefined;
+  }
+
+  return arn;
+}
+
+/**
+ * Refuse an ARN naming anything but a published version.
  */
 function assertVersionQualifier(
   arn: SimLambdaFunctionArnParts,
   functionArn: string,
 ): void {
-  const { qualifier } = arn;
-
-  if (qualifier !== undefined && /^\d+$/u.test(qualifier)) {
+  if (isPublishedVersion(arn.qualifier)) {
     return;
   }
 
@@ -66,4 +86,14 @@ function assertVersionQualifier(
       `qualifier such as :1, and takes neither $LATEST nor an alias. ` +
       `Publish a version with PublishVersion or AWS::Lambda::Version.`,
   );
+}
+
+/**
+ * Whether an ARN's qualifier names a published version.
+ *
+ * A version qualifier is a number, and an alias is a name, which is the whole
+ * of the difference between the two in an ARN.
+ */
+function isPublishedVersion(qualifier: string | undefined): boolean {
+  return qualifier !== undefined && /^\d+$/u.test(qualifier);
 }

--- a/src/service/cloudfront/edge/sim-cf-edge-function-version.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-function-version.ts
@@ -1,0 +1,22 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaFunctionArnParts } from "../../lambda/function/sim-lambda-function-arn-parts.js";
+import type { SimLambdaFunctionTarget } from "../../lambda/function/version/sim-lambda-function-target.js";
+
+/**
+ * The simulated Lambda function version a Lambda@Edge association names.
+ *
+ * A `LambdaFunctionARN` can name any Account, so the version is looked up in
+ * the scope its own ARN names rather than in CloudFront's. Nothing is thrown
+ * here: a caller that refuses an absent function says so in its own words, and
+ * a Distribution deployed from a template deploys without the association
+ * instead.
+ */
+export function findSimCfEdgeFunctionVersion(
+  simAws: SimAws,
+  arn: SimLambdaFunctionArnParts,
+): SimLambdaFunctionTarget | undefined {
+  return simAws
+    .accountRegionScope(arn.accountId, arn.regionName)
+    .lambda()
+    .getSimFunctionTarget(arn.functionName, arn.qualifier);
+}

--- a/test/cloudfront/edge-distribution-template.factory.ts
+++ b/test/cloudfront/edge-distribution-template.factory.ts
@@ -1,0 +1,158 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../src/service/cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../src/service/cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The logical ID of the published version a Behavior's association names.
+ */
+export const edgeVersionLogicalId = "EdgeVersion";
+
+/**
+ * The logical ID of the Distribution the template declares.
+ */
+export const edgeDistributionLogicalId = "SiteDistribution";
+
+/**
+ * The Origin the Distribution serves from.
+ */
+const originId = "site-origin";
+
+/**
+ * A handler that sends every request to the one page the site has.
+ */
+const rewriteHandlerSource = `
+exports.handler = async (event) => {
+  const { request } = event.Records[0].cf;
+  request.uri = "/edge.html";
+  return request;
+};
+`;
+
+/**
+ * What a test asks for when it wants a template whose Distribution runs a
+ * Lambda@Edge function.
+ */
+export interface EdgeDistributionTemplateInput {
+  /** The Bucket the Distribution's S3 Origin serves from. */
+  readonly bucketName: string;
+
+  /** The source of the function the associations name. */
+  readonly handlerSource: string;
+
+  /**
+   * The service principals the execution role trusts.
+   *
+   * A Lambda@Edge role trusts both `lambda.amazonaws.com` and
+   * `edgelambda.amazonaws.com`. A test about the refusal names one of them.
+   */
+  readonly trustedServices: readonly string[];
+
+  /** The `LambdaFunctionAssociations` of the default cache Behavior. */
+  readonly associations: readonly SimCfnTemplateValueRecord[];
+
+  /** The path-based cache Behaviors, each stated whole. */
+  readonly cacheBehaviors: readonly SimCfnTemplateValueRecord[];
+}
+
+/**
+ * Builds a template declaring an execution role, a function, a published
+ * version and a Distribution whose default Behavior associates that version.
+ *
+ * ```typescript
+ * const template = edgeDistributionTemplateFactory.make({
+ *   bucketName: "edge-site",
+ * });
+ * ```
+ *
+ * The stack deploys into whichever Region it is given, so a test that wants a
+ * function CloudFront will run deploys it into `us-east-1`, which is the
+ * default Region of a `SimAws`.
+ */
+export const edgeDistributionTemplateFactory = new MappedFactory<
+  EdgeDistributionTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({
+    bucketName: "edge-site",
+    handlerSource: rewriteHandlerSource,
+    trustedServices: ["lambda.amazonaws.com", "edgelambda.amazonaws.com"],
+    associations: [
+      {
+        EventType: "viewer-request",
+        LambdaFunctionARN: { Ref: edgeVersionLogicalId },
+      },
+    ],
+    cacheBehaviors: [],
+  }),
+  (input) => ({
+    Resources: {
+      EdgeRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "EdgeFunctionRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: [...input.trustedServices] },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+        },
+      },
+      EdgeFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          FunctionName: "edge-function",
+          Role: { "Fn::GetAtt": ["EdgeRole", "Arn"] },
+          Handler: "index.handler",
+          Runtime: "nodejs22.x",
+          Code: { ZipFile: input.handlerSource },
+        },
+      },
+      [edgeVersionLogicalId]: {
+        Type: "AWS::Lambda::Version",
+        Properties: { FunctionName: { Ref: "EdgeFunction" } },
+      },
+      [edgeDistributionLogicalId]: {
+        Type: "AWS::CloudFront::Distribution",
+        Properties: {
+          DistributionConfig: {
+            Enabled: true,
+            Origins: [
+              {
+                Id: originId,
+                DomainName: `${input.bucketName}.s3.amazonaws.com`,
+                S3OriginConfig: {},
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: originId,
+              ViewerProtocolPolicy: "allow-all",
+              LambdaFunctionAssociations: [...input.associations],
+            },
+            CacheBehaviors: [...input.cacheBehaviors],
+          },
+        },
+      },
+    },
+  }),
+);
+
+/**
+ * A path-based cache Behavior running these associations.
+ */
+export function edgeCacheBehavior(
+  pathPattern: string,
+  associations: readonly SimCfnTemplateValueRecord[],
+): SimCfnTemplateValueRecord {
+  return {
+    PathPattern: pathPattern,
+    TargetOriginId: originId,
+    ViewerProtocolPolicy: "allow-all",
+    LambdaFunctionAssociations: [...associations],
+  };
+}


### PR DESCRIPTION
A cache Behavior's `LambdaFunctionAssociations` deploys from
`AWS::CloudFront::Distribution` now, binding the function version a `Ref` to an
`AWS::Lambda::Version` answers with. An association this simulation cannot run
is left out of the Distribution and recorded on `stack.ignoredProperties` under
the event type it was on, and the Behavior deploys with whatever is left. That
covers a `LambdaFunctionARN` naming a function version this simulation does not
hold, and an association on `origin-request` or `origin-response`. A site
survives an edge function that cannot run here, the way it survives an absent
`WebACLId`. The two origin events are the ones #941 widens this to. Everything
real CloudFront refuses still fails the deployment, from a function outside
us-east-1 to an execution role missing the `edgelambda.amazonaws.com` trust. A
CDK stack in us-east-1 handing a `lambda.Version` to a Behavior's `edgeLambdas`
deploys and runs the function, and so does an `experimental.EdgeFunction` that
same stack creates. An `EdgeFunction` from a stack in any other Region reads its
ARN back through a custom resource and still fails, which #961 covers. CDK
examples under `docs/` compile through a tsconfig of their own, because an L2
construct is not assignable to the interface CDK declares for it under
`exactOptionalPropertyTypes`.

Resolves https://github.com/KensioSoftware/yulin/issues/942


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for simulating CloudFront Lambda@Edge integrations through CloudFormation and CDK.
  * Added examples for viewer-request rewriting with published Lambda versions.
  * Added documentation covering setup requirements, supported events, deployment behavior, and limitations.

* **Bug Fixes**
  * CloudFront deployments now gracefully skip unsupported or unavailable Lambda@Edge associations while preserving usable distributions.
  * Added validation for supported events, published versions, and regional requirements.

* **Tests**
  * Added integration coverage for manually configured and CDK-based Lambda@Edge distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->