### PR TITLE
feat: run the branches of a Parallel state

### DIFF
--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -8,8 +8,8 @@ Types for simulated Step Functions are imported from the `@kensio/yulin/stepfunc
 
 ## What runs today
 
-Six state types run. `Pass`, `Task`, `Succeed`, `Fail`, `Choice` and `Wait`. A definition using
-`Parallel` or `Map` is refused when the state machine is created, naming the state and its type.
+Seven state types run. `Pass`, `Task`, `Succeed`, `Fail`, `Choice`, `Wait` and `Parallel`. A
+definition using `Map` is refused when the state machine is created, naming the state and its type.
 
 The data-flow fields run in full. `InputPath`, `Parameters`, `ResultSelector`, `ResultPath` and
 `OutputPath` apply in that order, reading Reference Paths and the intrinsic functions.
@@ -19,7 +19,8 @@ service, or starts another state machine. A `Resource` this simulator has no ans
 when the state machine is created, naming what the definition asked for.
 
 A `Task` state's `Retry` and `Catch` both run, on the simulation's clock, along with the
-`TimeoutSeconds` and `HeartbeatSeconds` it takes.
+`TimeoutSeconds` and `HeartbeatSeconds` it takes. A `Parallel` state takes the same `Retry` and
+`Catch`.
 
 ## Running a state machine
 
@@ -801,6 +802,133 @@ The execution stops at the instant it was waiting for, and `DescribeExecution` r
 for one that succeeded. [Simulated time](../../time/ "Simulated time docs") covers what else
 advancing the clock runs.
 
+## Running branches at once
+
+A `Parallel` state runs each of its `Branches`, and answers with an array of what they produced. The
+array is in the order the branches were written, whatever order they finished in.
+
+```typescript sim-step-functions-parallel
+/**
+ * Running two branches at once with a Parallel state.
+ */
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Enrol",
+      States: {
+        Enrol: {
+          Type: "Parallel",
+          Branches: [
+            {
+              StartAt: "Settle",
+              States: {
+                Settle: { Type: "Wait", Seconds: 300, Next: "Register" },
+                Register: {
+                  Type: "Pass",
+                  Result: { registered: true },
+                  End: true,
+                },
+              },
+            },
+            {
+              StartAt: "Bill",
+              States: {
+                Bill: { Type: "Pass", Result: { billed: true }, End: true },
+              },
+            },
+          ],
+          Next: "Confirm",
+        },
+        Confirm: { Type: "Pass", End: true },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const waiting = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(waiting.status); // RUNNING
+
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const settled = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(settled.output); // [{"registered":true},{"billed":true}]
+
+console.log(
+  simAws
+    .stepFunctions()
+    .inspection()
+    .branches(started.executionArn)
+    .map((branch) => branch.visitedStates),
+); // [ [ 'Settle', 'Register' ], [ 'Bill' ] ]
+```
+
+Every branch is given the state's effective input. `InputPath` and `Parameters` apply once for the
+state, and not once per branch. `ResultSelector`, `ResultPath` and `OutputPath` then apply to the
+array of branch outputs.
+
+A branch is a state machine of its own, with its own `StartAt` and its own `States`. A `Next` inside
+a branch reaches only the states in that branch, and two branches are free to use the same state
+name. The states inside a branch are read when the state machine is created. A definition using something
+this simulator has no implementation for inside a branch is refused there, naming the branch it was
+written in.
+
+A branch that reaches a `Wait` state waits on the same clock as everything else, and its siblings
+carry on while it waits. The execution reads as `RUNNING` until the last branch has finished.
+
+### When a branch fails
+
+A branch that fails takes the `Parallel` state with it. The state fails with `States.BranchFailed`,
+and the `Cause` names the branch and what it failed with:
+
+```text
+Branch 2 of the Parallel state Enrol failed with NotEligible: no place left on the course
+```
+
+The branches still going are given up on, along with the branches those were running themselves.
+Whatever they had scheduled on the clock finds a branch that has stopped, so a later `advanceBy`
+runs none of it.
+
+`Retry` and `Catch` on the `Parallel` state itself work the way they do on a `Task` state, and are
+written the same way. A retry runs every branch again from its own `StartAt`, on the interval and
+backoff the retrier gives. A catcher matching `States.BranchFailed` (or `States.ALL`) sends the
+execution to the state it names.
+
+### Reading the branches back
+
+The inspection accessor reports branches separately from the states around them:
+
+```typescript
+const branches = simAws.stepFunctions().inspection().branches(executionArn);
+```
+
+Each branch says which `Parallel` state it belongs to, where among its siblings it sits (counting
+from zero), the states it entered and how it ended. A branch given up on because a sibling failed
+reads as `ABANDONED`. A `Parallel` state inside a branch reports its own branches here too, however
+deep they go. `visitedStates` on the execution holds the states outside the branches, while
+`attempts` covers every run of every state, branches included.
+
 ## Through an intercepted SDK client
 
 An `SFNClient` handed to `SimSdk` reaches the same simulated service:
@@ -1034,6 +1162,12 @@ A test asserting on the output of a state machine that used one could only asser
   machine is created.
 - **A cycle in the states fails the execution** after 25,000 transitions, with `States.Runtime`. Real
   Step Functions stops one when it runs out of execution history events.
+- **A branch that failed on the data it was given keeps `States.Runtime`.** Every other branch
+  failure becomes `States.BranchFailed` on the `Parallel` state. `States.Runtime` is the one error
+  nothing catches, and a state around a branch is no more able to carry on than the branch was.
+- **A branch's own states are reported apart from the execution's.** Real Step Functions writes
+  them into one execution history, under events naming the branch. The inspection accessor answers
+  `branches` instead, since a test asserting on a branch is asking about that branch.
 
 - **A state machine is the only resource that holds tags.** An activity and an execution both take
   tags on real Step Functions, and both are unsimulated here. A tag request naming one is refused
@@ -1056,7 +1190,7 @@ two and is what this follows.
 
 ## Still to come
 
-- `Parallel` and `Map` states, and the `Retry` and `Catch` those two take.
+- `Map` states, with `ItemsPath`, `ItemSelector` and `MaxConcurrency`.
 - The `.sync` pattern, task tokens and activities.
 - The context object, `$$`.
 - JSONata as a query language, and the `Assign` variables that go with it.

--- a/docs/services/stepfunctions/sim-step-functions-parallel.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-parallel.example.ts
@@ -1,0 +1,74 @@
+/**
+ * Running two branches at once with a Parallel state.
+ */
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+});
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Enrol",
+      States: {
+        Enrol: {
+          Type: "Parallel",
+          Branches: [
+            {
+              StartAt: "Settle",
+              States: {
+                Settle: { Type: "Wait", Seconds: 300, Next: "Register" },
+                Register: {
+                  Type: "Pass",
+                  Result: { registered: true },
+                  End: true,
+                },
+              },
+            },
+            {
+              StartAt: "Bill",
+              States: {
+                Bill: { Type: "Pass", Result: { billed: true }, End: true },
+              },
+            },
+          ],
+          Next: "Confirm",
+        },
+        Confirm: { Type: "Pass", End: true },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({ student: "Wei" }),
+  },
+});
+
+const waiting = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(waiting.status); // RUNNING
+
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const settled = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(settled.output); // [{"registered":true},{"billed":true}]
+
+console.log(
+  simAws
+    .stepFunctions()
+    .inspection()
+    .branches(started.executionArn)
+    .map((branch) => branch.visitedStates),
+); // [ [ 'Settle', 'Register' ], [ 'Bill' ] ]

--- a/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
@@ -3,6 +3,7 @@ import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-regi
 import { SimStatesExecution } from "../../execution/sim-states-execution.js";
 import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
 import { SimStatesInterpreter } from "../../execution/sim-states-interpreter.js";
+import { simStatesWalks } from "../../execution/sim-states-walks.js";
 import { simStatesExecutionArn } from "../../machine/sim-state-machine-arn.js";
 import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
 import type { SimStatesTaskTargets } from "../../task/sim-states-task-invocation.js";
@@ -93,12 +94,17 @@ export class SimStatesExecutionStart {
 
     this.#executions.add(execution);
 
-    await new SimStatesInterpreter({
-      definition: stateMachine.parsedDefinition,
-      execution,
+    const walks = {
       background: this.#background,
       tasks: this.#tasks,
       roleArn: stateMachine.roleArn,
+    };
+
+    await new SimStatesInterpreter({
+      ...walks,
+      definition: stateMachine.parsedDefinition,
+      record: execution,
+      walkChild: simStatesWalks(walks),
     }).run();
 
     return { executionArn: execution.arn, startDate };

--- a/src/service/stepfunctions/definition/sim-states-definition-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-definition-parse.ts
@@ -16,7 +16,18 @@ import { checkSimStatesTransitions } from "./sim-states-transitions.js";
 export function parseSimStatesDefinition(
   definition: string,
 ): SimStatesDefinition {
-  const document = readDocument(definition);
+  return parseSimStatesDefinitionDocument(readDocument(definition));
+}
+
+/**
+ * Read a definition from the JSON object it was written as.
+ *
+ * A `Parallel` state's branch is a definition of its own, written inside the
+ * one holding it, so a branch is read through here as well.
+ */
+export function parseSimStatesDefinitionDocument(
+  document: Record<string, JSONValue>,
+): SimStatesDefinition {
   const states = readStates(document);
   const startAt = document["StartAt"];
 

--- a/src/service/stepfunctions/definition/sim-states-parallel-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-parallel-parse.ts
@@ -1,0 +1,100 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import {
+  SimStatesInvalidDefinition,
+  SimStatesUnsimulatedInput,
+  SimStepFunctionsError,
+} from "../error/sim-step-functions.error.js";
+import { parseSimStatesErrorHandling } from "../retry/sim-states-error-handling.js";
+import type { SimStatesDefinition } from "./sim-states-definition.js";
+import { parseSimStatesDefinitionDocument } from "./sim-states-definition-parse.js";
+import type { SimStatesParallelState } from "./sim-states-state.js";
+
+/**
+ * Read a `Parallel` state, whose branches are read as the state is.
+ *
+ * A branch is a state machine of its own, so the states inside one are read
+ * the same way the states around it are.
+ */
+export function readSimStatesParallelState(
+  name: string,
+  state: Record<string, JSONValue>,
+): SimStatesParallelState {
+  const named = `Parallel state ${name}`;
+
+  return {
+    ...(state as unknown as SimStatesParallelState),
+    Branches: parseSimStatesBranches(named, state),
+    ...parseSimStatesErrorHandling(named, state),
+  };
+}
+
+/**
+ * Read a `Parallel` state's `Branches`.
+ *
+ * Each branch is a state machine of its own and is read as one, so a branch
+ * using something this simulator does not run is refused when the state
+ * machine is created rather than when an execution reaches the state.
+ */
+function parseSimStatesBranches(
+  named: string,
+  state: Record<string, JSONValue>,
+): readonly SimStatesDefinition[] {
+  const declared = state["Branches"];
+
+  if (!Array.isArray(declared) || declared.length === 0) {
+    throw new SimStatesInvalidDefinition(
+      `The ${named} needs a Branches array holding at least one branch.`,
+    );
+  }
+
+  return declared.map((branch, index) => readBranch(named, index, branch));
+}
+
+/**
+ * Read one branch, saying which branch it was where it cannot be read.
+ *
+ * The refusal a branch raises names the state inside it, so the position of
+ * the branch is put in front of it. Two branches are free to use the same
+ * state name, and without the position the two refusals would read alike.
+ */
+function readBranch(
+  named: string,
+  index: number,
+  branch: JSONValue,
+): SimStatesDefinition {
+  const where = `Branch ${String(index + 1)} of the ${named}`;
+
+  if (!isRecord(branch)) {
+    throw new SimStatesInvalidDefinition(
+      `${where} is not an object. A branch is a state machine of its own, ` +
+        "with its own StartAt and States.",
+    );
+  }
+
+  try {
+    return parseSimStatesDefinitionDocument(branch);
+  } catch (error) {
+    throw branchRefusal(where, error);
+  }
+}
+
+/**
+ * The same refusal, saying which branch raised it.
+ *
+ * A branch using an unsimulated construct keeps that name, since it is the
+ * one telling a reader that the definition is good and this simulator is
+ * behind. Everything else a branch is refused for is a fault in the
+ * definition.
+ */
+function branchRefusal(where: string, error: unknown): unknown {
+  if (error instanceof SimStatesUnsimulatedInput) {
+    return new SimStatesUnsimulatedInput(`${where}: ${error.message}`);
+  }
+
+  if (error instanceof SimStepFunctionsError) {
+    return new SimStatesInvalidDefinition(`${where}: ${error.message}`);
+  }
+
+  return error;
+}

--- a/src/service/stepfunctions/definition/sim-states-parallel-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-parallel-refusals.iso.test.ts
@@ -1,0 +1,126 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import { parseSimStatesDefinition } from "./sim-states-definition-parse.js";
+
+describe("Step Functions Parallel state refusals", () => {
+  /**
+   * Read a definition of one `Parallel` state that is expected to be refused,
+   * and answer with why.
+   */
+  function refusalFor(state: JSONObject): string {
+    return assertThrowsError(() =>
+      parseSimStatesDefinition(
+        JSON.stringify({
+          StartAt: "Fan",
+          States: { Fan: { Type: "Parallel", ...state } },
+        }),
+      ),
+    ).message;
+  }
+
+  /**
+   * A branch that runs on its own.
+   */
+  const enrolling: JSONObject = {
+    StartAt: "Enrol",
+    States: { Enrol: { Type: "Pass", End: true } },
+  };
+
+  it("refuses a Parallel state with no branches to run", () => {
+    // Given a Parallel state carrying no Branches, and one carrying none.
+    // When each is read, each says a Parallel state needs one.
+    assertStringIncludes(
+      refusalFor({ End: true }),
+      "The Parallel state Fan needs a Branches array holding at least one",
+    );
+    assertStringIncludes(
+      refusalFor({ Branches: [], End: true }),
+      "The Parallel state Fan needs a Branches array holding at least one",
+    );
+  });
+
+  it("refuses a branch that is not a state machine of its own", () => {
+    // Given a branch written as something other than an object, and one with
+    // no StartAt.
+    // When each is read, each names the branch it was.
+    assertStringIncludes(
+      refusalFor({ Branches: ["Enrol"], End: true }),
+      "Branch 1 of the Parallel state Fan is not an object",
+    );
+    assertStringIncludes(
+      refusalFor({
+        Branches: [enrolling, { States: { Enrol: { Type: "Succeed" } } }],
+        End: true,
+      }),
+      "Branch 2 of the Parallel state Fan: A state machine definition needs " +
+        "a StartAt",
+    );
+  });
+
+  it("refuses a branch using something this simulator does not run", () => {
+    // Given a branch holding a state type still to come.
+    const refusal = refusalFor({
+      Branches: [
+        {
+          StartAt: "Enrol",
+          States: { Enrol: { Type: "Map", End: true } },
+        },
+      ],
+      End: true,
+    });
+
+    // When it is read, the refusal names the branch and keeps what the state
+    // itself said.
+    assertStringIncludes(refusal, "Branch 1 of the Parallel state Fan:");
+    assertStringIncludes(refusal, "is a Map state, which this simulator does");
+  });
+
+  it("refuses a branch moving to a state outside itself", () => {
+    // Given a branch whose Next names a state in the workflow around it.
+    // When it is read, it is refused: a branch reaches its own states only.
+    assertStringIncludes(
+      refusalFor({
+        Branches: [
+          {
+            StartAt: "Enrol",
+            States: { Enrol: { Type: "Pass", Next: "Fan" } },
+          },
+        ],
+        End: true,
+      }),
+      "Branch 1 of the Parallel state Fan: The state Enrol moves to Fan",
+    );
+  });
+
+  it("refuses the fields a Parallel state does not have", () => {
+    // Given a Parallel state carrying a task's timeout.
+    // When it is read, it names the field and the type.
+    assertStringIncludes(
+      refusalFor({ Branches: [enrolling], TimeoutSeconds: 5, End: true }),
+      "The Parallel state Fan carries TimeoutSeconds",
+    );
+  });
+
+  it("names the Parallel state in what its Retry and Catch are refused for", () => {
+    // Given a retrier and a catcher that cannot be read.
+    // When each is read, each says which state carries it.
+    assertStringIncludes(
+      refusalFor({
+        Branches: [enrolling],
+        Retry: [{ ErrorEquals: ["States.ALL"], MaxAttempts: -1 }],
+        End: true,
+      }),
+      "A retrier in the Parallel state Fan has a MaxAttempts of -1",
+    );
+    assertStringIncludes(
+      refusalFor({
+        Branches: [enrolling],
+        Catch: [{ ErrorEquals: ["States.ALL"], Next: "Compensate" }],
+        End: true,
+      }),
+      "A catcher in the Parallel state Fan moves to Compensate",
+    );
+  });
+});

--- a/src/service/stepfunctions/definition/sim-states-state-fields.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-fields.ts
@@ -13,6 +13,9 @@ const stateFieldsRefused = new Map<string, readonly string[]>([
   // carry the two paths and nothing that reshapes a result.
   ["Choice", ["Parameters", "ResultPath", "ResultSelector"]],
   ["Wait", ["Parameters", "ResultPath", "ResultSelector"]],
+  // Only a Task state, and the state machine itself, take a timeout. A
+  // Parallel state runs for as long as its branches do.
+  ["Parallel", ["TimeoutSeconds", "HeartbeatSeconds"]],
 ]);
 
 /**

--- a/src/service/stepfunctions/definition/sim-states-state-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-parse.ts
@@ -8,11 +8,11 @@ import {
   SimStatesInvalidDefinition,
   SimStatesUnsimulatedInput,
 } from "../error/sim-step-functions.error.js";
-import { parseSimStatesCatchers } from "../retry/sim-states-catch-parse.js";
-import { parseSimStatesRetriers } from "../retry/sim-states-retry-parse.js";
+import { parseSimStatesErrorHandling } from "../retry/sim-states-error-handling.js";
 import { checkSimStatesTaskFields } from "../task/sim-states-task-fields.js";
 import { parseSimStatesTaskResource } from "../task/sim-states-task-resource.js";
 import { checkSimStatesWaitFields } from "../wait/sim-states-wait-fields.js";
+import { readSimStatesParallelState } from "./sim-states-parallel-parse.js";
 import {
   checkSimStatesRefusedFields,
   checkSimStatesTransitionFields,
@@ -67,6 +67,10 @@ export function parseSimStatesState(
     return readTaskState(name, state);
   }
 
+  if (type === "Parallel") {
+    return readSimStatesParallelState(name, state);
+  }
+
   if (type === "Wait") {
     checkSimStatesWaitFields(name, state);
   }
@@ -106,13 +110,9 @@ function readTaskState(
 ): SimStatesTaskState {
   checkSimStatesTaskFields(name, state);
 
-  const retriers = parseSimStatesRetriers(name, state);
-  const catchers = parseSimStatesCatchers(name, state);
-
   return {
     ...(state as unknown as SimStatesTaskState),
     target: parseSimStatesTaskResource(name, state),
-    ...(retriers !== undefined && { Retry: retriers }),
-    ...(catchers !== undefined && { Catch: catchers }),
+    ...parseSimStatesErrorHandling(`Task state ${name}`, state),
   };
 }

--- a/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
@@ -37,17 +37,18 @@ describe("Step Functions state refusals", () => {
   });
 
   it("refuses a state type this simulator does not run yet, by name", () => {
-    // Given the state types still to come.
-    // When each is read, each names itself and what does run.
-    for (const type of ["Parallel", "Map"]) {
-      const refusal = refusalFor({
-        StartAt: "Only",
-        States: { Only: { Type: type, End: true } },
-      });
+    // Given the state type still to come.
+    const refusal = refusalFor({
+      StartAt: "Only",
+      States: { Only: { Type: "Map", End: true } },
+    });
 
-      assertStringIncludes(refusal, `is a ${type} state`);
-      assertStringIncludes(refusal, "Pass, Succeed, Fail, Task, Choice, Wait");
-    }
+    // When it is read, it names itself and what does run.
+    assertStringIncludes(refusal, "is a Map state");
+    assertStringIncludes(
+      refusal,
+      "Pass, Succeed, Fail, Task, Choice, Wait, Parallel",
+    );
   });
 
   it("refuses the fields a Fail or a Succeed state does not have", () => {

--- a/src/service/stepfunctions/definition/sim-states-state.ts
+++ b/src/service/stepfunctions/definition/sim-states-state.ts
@@ -1,8 +1,10 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesChoiceRule } from "../choice/sim-states-choice-rule.js";
 import type { SimStatesDataFlowFields } from "../data/sim-states-data-flow.js";
+import type { SimStatesErrorHandling } from "../retry/sim-states-error-handling.js";
 import type { SimStatesTaskHandling } from "../retry/sim-states-task-handling.js";
 import type { SimStatesTaskTarget } from "../task/sim-states-task-target.js";
+import type { SimStatesDefinition } from "./sim-states-definition.js";
 
 /**
  * Every state type Amazon States Language defines.
@@ -33,6 +35,7 @@ export const simStatesRunnableTypes = [
   "Task",
   "Choice",
   "Wait",
+  "Parallel",
 ] as const;
 
 export type SimStatesRunnableType = (typeof simStatesRunnableTypes)[number];
@@ -68,6 +71,19 @@ export interface SimStatesTaskState
   readonly Type: "Task";
   readonly Resource: string;
   readonly target: SimStatesTaskTarget;
+}
+
+/**
+ * A `Parallel` state, which runs each of its branches on the same input.
+ *
+ * A branch is a state machine of its own, with its own `StartAt` and its own
+ * states. The branches are read when the definition is read, so a `Parallel`
+ * state that runs is one whose branches are already known to be good.
+ */
+export interface SimStatesParallelState
+  extends SimStatesCommonState, SimStatesErrorHandling {
+  readonly Type: "Parallel";
+  readonly Branches: readonly SimStatesDefinition[];
 }
 
 /**
@@ -124,6 +140,7 @@ export interface SimStatesFailState {
 export type SimStatesState =
   | SimStatesPassState
   | SimStatesTaskState
+  | SimStatesParallelState
   | SimStatesSucceedState
   | SimStatesFailState
   | SimStatesChoiceState

--- a/src/service/stepfunctions/definition/sim-states-transitions.ts
+++ b/src/service/stepfunctions/definition/sim-states-transitions.ts
@@ -1,4 +1,5 @@
 import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+import { simStatesErrorHandling } from "../retry/sim-states-error-handling.js";
 import {
   type SimStatesChoiceState,
   type SimStatesState,
@@ -54,17 +55,13 @@ function checkCatchers(
   state: SimStatesState,
   states: ReadonlyMap<string, SimStatesState>,
 ): void {
-  if (state.Type !== "Task") {
-    return;
-  }
-
-  const catchers = state.Catch ?? [];
+  const catchers = simStatesErrorHandling(state)?.Catch ?? [];
 
   for (const catcher of catchers) {
     if (!states.has(catcher.Next)) {
       throw new SimStatesInvalidDefinition(
-        `A catcher in the Task state ${name} moves to ${catcher.Next}, ` +
-          "which is not one of this state machine's states.",
+        `A catcher in the ${state.Type} state ${name} moves to ` +
+          `${catcher.Next}, which is not one of this state machine's states.`,
       );
     }
   }

--- a/src/service/stepfunctions/execution/sim-states-child-failure.ts
+++ b/src/service/stepfunctions/execution/sim-states-child-failure.ts
@@ -1,0 +1,29 @@
+import {
+  simStatesBranchFailedError,
+  simStatesRuntimeError,
+} from "../retry/sim-states-error-name.js";
+import type { SimStatesFailOutcome } from "./sim-states-state-outcome.js";
+
+/**
+ * The failure one child takes the state that ran it down with.
+ *
+ * Amazon States Language gives a state whose child failed an error name of
+ * its own, and the child's name is what the cause says. A child that failed on
+ * the data it was given keeps `States.Runtime`, which nothing catches: a state
+ * around it is no more able to carry on than the child was.
+ */
+export function simStatesChildFailure(
+  named: string,
+  failure: SimStatesFailOutcome,
+): SimStatesFailOutcome {
+  const said = failure.cause === undefined ? "" : `: ${failure.cause}`;
+
+  return {
+    kind: "fail",
+    error:
+      failure.error === simStatesRuntimeError
+        ? simStatesRuntimeError
+        : simStatesBranchFailedError,
+    cause: `${named} failed with ${failure.error}${said}`,
+  };
+}

--- a/src/service/stepfunctions/execution/sim-states-child-run.ts
+++ b/src/service/stepfunctions/execution/sim-states-child-run.ts
@@ -1,0 +1,122 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type {
+  SimStatesChild,
+  SimStatesChildKind,
+  SimStatesChildStatus,
+} from "./sim-states-child.js";
+import type { SimStatesRunRecord } from "./sim-states-run-record.js";
+import type { SimStatesFailOutcome } from "./sim-states-state-outcome.js";
+
+interface SimStatesChildRunProperties {
+  readonly kind: SimStatesChildKind;
+  readonly stateName: string;
+  readonly index: number;
+  readonly input: JSONValue;
+
+  /**
+   * The run the state holding this child belongs to, which is where a child
+   * of its own is recorded.
+   */
+  readonly parent: SimStatesRunRecord;
+}
+
+/**
+ * One branch of a `Parallel` state, as it runs.
+ *
+ * The states a branch visits are its own rather than the execution's, so they
+ * are held here. A branch of a branch is still reported on the execution,
+ * which is why a child run passes one it is told about upwards.
+ */
+export class SimStatesChildRun implements SimStatesRunRecord, SimStatesChild {
+  readonly kind: SimStatesChildKind;
+  readonly stateName: string;
+  readonly index: number;
+  readonly input: JSONValue;
+
+  /**
+   * What the branch answered with, which is `null` until it has.
+   */
+  #output: JSONValue = null;
+  #status: SimStatesChildStatus = "RUNNING";
+  #failure: SimStatesFailOutcome | undefined;
+  readonly #visited: string[] = [];
+  readonly #children: SimStatesChildRun[] = [];
+  readonly #parent: SimStatesRunRecord;
+
+  constructor(properties: SimStatesChildRunProperties) {
+    this.kind = properties.kind;
+    this.stateName = properties.stateName;
+    this.index = properties.index;
+    this.input = properties.input;
+    this.#parent = properties.parent;
+  }
+
+  get status(): SimStatesChildStatus {
+    return this.#status;
+  }
+
+  get output(): JSONValue {
+    return this.#output;
+  }
+
+  /**
+   * What the branch failed with, where it failed.
+   */
+  get failure(): SimStatesFailOutcome | undefined {
+    return this.#failure;
+  }
+
+  get error(): string | undefined {
+    return this.#failure?.error;
+  }
+
+  get visitedStates(): readonly string[] {
+    return [...this.#visited];
+  }
+
+  get stopped(): boolean {
+    return this.#status !== "RUNNING";
+  }
+
+  enter(stateName: string): void {
+    this.#visited.push(stateName);
+  }
+
+  attempt(stateName: string, error: string | undefined): void {
+    this.#parent.attempt(stateName, error);
+  }
+
+  succeed(output: JSONValue): void {
+    this.#status = "SUCCEEDED";
+    this.#output = output;
+  }
+
+  fail(error: string, cause: string | undefined): void {
+    this.#status = "FAILED";
+    this.#failure = { kind: "fail", error, cause };
+  }
+
+  child(child: SimStatesChildRun): void {
+    this.#children.push(child);
+    this.#parent.child(child);
+  }
+
+  /**
+   * Give up on this branch, because one of its siblings failed.
+   *
+   * Whatever it had scheduled on the clock still runs, and finds a branch that
+   * has stopped rather than one to carry on with. The branches this one was
+   * itself running are given up on too, however deep they go.
+   */
+  abandon(): void {
+    if (this.stopped) {
+      return;
+    }
+
+    this.#status = "ABANDONED";
+
+    this.#children.forEach((child) => {
+      child.abandon();
+    });
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-child-runs.ts
+++ b/src/service/stepfunctions/execution/sim-states-child-runs.ts
@@ -1,0 +1,134 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
+import type { SimStatesChildKind } from "./sim-states-child.js";
+import { SimStatesChildRun } from "./sim-states-child-run.js";
+import type { SimStatesStateContext } from "./sim-states-state-outcome.js";
+
+/**
+ * One child of a state that runs states of its own, before it is started.
+ */
+export interface SimStatesChildStart {
+  readonly index: number;
+  readonly definition: SimStatesDefinition;
+  readonly input: JSONValue;
+}
+
+interface SimStatesChildRunsProperties {
+  readonly kind: SimStatesChildKind;
+  readonly context: SimStatesStateContext;
+  readonly children: readonly SimStatesChildStart[];
+
+  /**
+   * What to do once one child has ended.
+   */
+  readonly onSettled: (run: SimStatesChildRun) => Promise<void>;
+}
+
+/**
+ * The children one state runs.
+ *
+ * A child that reaches a `Wait` state is left on the clock rather than waited
+ * for. Its siblings start alongside it.
+ */
+export class SimStatesChildRuns {
+  readonly #kind: SimStatesChildKind;
+  readonly #context: SimStatesStateContext;
+  readonly #onSettled: (run: SimStatesChildRun) => Promise<void>;
+
+  /**
+   * The children still to be started, in the order they were written.
+   */
+  readonly #waiting: SimStatesChildStart[];
+
+  /**
+   * The children that have been started, in the same order.
+   */
+  readonly #started: SimStatesChildRun[] = [];
+
+  readonly #total: number;
+  #ended = 0;
+
+  constructor(properties: SimStatesChildRunsProperties) {
+    this.#kind = properties.kind;
+    this.#context = properties.context;
+    this.#onSettled = properties.onSettled;
+    this.#waiting = [...properties.children];
+    this.#total = properties.children.length;
+  }
+
+  /**
+   * Whether every child has ended.
+   */
+  get finished(): boolean {
+    return this.#ended >= this.#total;
+  }
+
+  /**
+   * What each child produced, in the order the children were written.
+   */
+  get outputs(): readonly JSONValue[] {
+    return this.#started.map((run) => run.output);
+  }
+
+  /**
+   * Start the next child, and the ones after it.
+   *
+   * A child is started once the one before it is either done or waiting on
+   * the clock, since a child waiting is one the state is still running. The
+   * children a failure leaves nothing to do are dropped from the queue, so
+   * this answers as soon as one of them fails.
+   */
+  async start(): Promise<void> {
+    const child = this.#waiting.shift();
+
+    if (child === undefined) {
+      return;
+    }
+
+    await this.#start(child);
+    await this.start();
+  }
+
+  /**
+   * Take in that one child has ended.
+   */
+  ended(): void {
+    this.#ended += 1;
+  }
+
+  /**
+   * Give up on the children a failure leaves nothing to do.
+   */
+  abandon(): void {
+    this.#started.forEach((run) => {
+      run.abandon();
+    });
+    this.#waiting.length = 0;
+  }
+
+  /**
+   * Run one child as far as it goes without waiting on the clock.
+   */
+  async #start(child: SimStatesChildStart): Promise<void> {
+    const run = new SimStatesChildRun({
+      kind: this.#kind,
+      stateName: this.#context.stateName,
+      index: child.index,
+      input: child.input,
+      parent: this.#context.record,
+    });
+
+    this.#started.push(run);
+    this.#context.record.child(run);
+
+    await this.#context
+      .walkChild({
+        definition: child.definition,
+        record: run,
+        onSettled: async (): Promise<void> => {
+          await this.#onSettled(run);
+        },
+      })
+      .run();
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-child-walk.ts
+++ b/src/service/stepfunctions/execution/sim-states-child-walk.ts
@@ -1,0 +1,44 @@
+import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
+import type { SimStatesRunRecord } from "./sim-states-run-record.js";
+
+export interface SimStatesChildWalkProperties {
+  /**
+   * The states the child walks, which is a state machine of its own.
+   */
+  readonly definition: SimStatesDefinition;
+
+  /**
+   * What the child records itself on, and where its input comes from.
+   */
+  readonly record: SimStatesRunRecord;
+
+  /**
+   * What to do once the child has ended, whenever that turns out to be. An
+   * execution's own walk has nothing holding it, and carries none.
+   */
+  readonly onSettled?: () => Promise<void>;
+}
+
+/**
+ * A walk over one branch's states.
+ */
+export interface SimStatesChildWalk {
+  /**
+   * Run the branch as far as it goes without waiting on the clock.
+   *
+   * This answers with the branch either ended or waiting for simulated time
+   * to reach something. The branch says which by settling its own record.
+   */
+  run(): Promise<void>;
+}
+
+/**
+ * How a state that runs states of its own gets a walk over them.
+ *
+ * The interpreter hands this to the states it runs, so a `Parallel` state
+ * reaches the same walk the execution is running on without having to know
+ * how one is built.
+ */
+export type SimStatesChildWalks = (
+  properties: SimStatesChildWalkProperties,
+) => SimStatesChildWalk;

--- a/src/service/stepfunctions/execution/sim-states-child.ts
+++ b/src/service/stepfunctions/execution/sim-states-child.ts
@@ -1,0 +1,50 @@
+/**
+ * Whether a child run is a `Parallel` state's branch or a `Map` state's
+ * iteration.
+ */
+export type SimStatesChildKind = "branch" | "iteration";
+
+/**
+ * Where a child run got to.
+ *
+ * A child a sibling's failure stopped is `ABANDONED` rather than failed: it
+ * was not the one that went wrong, and it never reached an end of its own.
+ */
+export type SimStatesChildStatus =
+  | "RUNNING"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "ABANDONED";
+
+/**
+ * One branch of a `Parallel` state, as an execution ran it.
+ *
+ * A branch runs states of its own, so what it did is held apart from the
+ * states the execution around it visited. A test asserting that four records
+ * were processed counts these.
+ */
+export interface SimStatesChild {
+  readonly kind: SimStatesChildKind;
+
+  /**
+   * The `Parallel` state the child belongs to.
+   */
+  readonly stateName: string;
+
+  /**
+   * Where the child sits among its siblings, counting from zero.
+   */
+  readonly index: number;
+
+  readonly status: SimStatesChildStatus;
+
+  /**
+   * The states the child entered, in the order it entered them.
+   */
+  readonly visitedStates: readonly string[];
+
+  /**
+   * What the child failed with, where it failed.
+   */
+  readonly error: string | undefined;
+}

--- a/src/service/stepfunctions/execution/sim-states-execution.ts
+++ b/src/service/stepfunctions/execution/sim-states-execution.ts
@@ -1,5 +1,8 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesAttempt } from "./sim-states-attempt.js";
+import type { SimStatesChild } from "./sim-states-child.js";
+import type { SimStatesChildRun } from "./sim-states-child-run.js";
+import type { SimStatesRunRecord } from "./sim-states-run-record.js";
 
 export type SimStatesExecutionStatus =
   | "RUNNING"
@@ -24,7 +27,7 @@ interface SimStatesExecutionProperties {
  * on. Real Step Functions keeps the same record and answers it through
  * `GetExecutionHistory`.
  */
-export class SimStatesExecution {
+export class SimStatesExecution implements SimStatesRunRecord {
   readonly arn: string;
   readonly name: string;
   readonly stateMachineArn: string;
@@ -38,6 +41,7 @@ export class SimStatesExecution {
   #stopDate: Date | undefined;
   readonly #visited: string[] = [];
   readonly #attempts: SimStatesAttempt[] = [];
+  readonly #children: SimStatesChild[] = [];
 
   constructor(properties: SimStatesExecutionProperties) {
     this.arn = properties.arn;
@@ -68,6 +72,13 @@ export class SimStatesExecution {
   }
 
   /**
+   * Whether the execution is over, so nothing more of it should run.
+   */
+  get stopped(): boolean {
+    return this.#status !== "RUNNING";
+  }
+
+  /**
    * The states this execution has entered, in the order it entered them.
    */
   get visitedStates(): readonly string[] {
@@ -81,6 +92,14 @@ export class SimStatesExecution {
    */
   get attempts(): readonly SimStatesAttempt[] {
     return [...this.#attempts];
+  }
+
+  /**
+   * Every branch of every `Parallel` state this execution ran, in the order
+   * they were started.
+   */
+  get children(): readonly SimStatesChild[] {
+    return [...this.#children];
   }
 
   /**
@@ -98,6 +117,14 @@ export class SimStatesExecution {
       stateName,
       ...(error !== undefined && { error }),
     });
+  }
+
+  /**
+   * Record a branch this execution ran, however deeply nested the state
+   * running it is.
+   */
+  child(child: SimStatesChildRun): void {
+    this.#children.push(child);
   }
 
   /**

--- a/src/service/stepfunctions/execution/sim-states-fan-out-outcome.ts
+++ b/src/service/stepfunctions/execution/sim-states-fan-out-outcome.ts
@@ -1,0 +1,32 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  type SimStatesDataFlowFields,
+  simStatesEffectiveOutput,
+} from "../data/sim-states-data-flow.js";
+import type { SimStatesMoveOnOutcome } from "./sim-states-state-outcome.js";
+
+/**
+ * The state a fan-out belongs to, as far as its answer is concerned.
+ */
+interface SimStatesFanOutState extends SimStatesDataFlowFields {
+  readonly Next?: string;
+}
+
+/**
+ * What a state that ran states of its own answers with.
+ *
+ * The result is an array of what each child produced, in the order the
+ * children were written rather than the order they finished. The data-flow
+ * fields then apply to that array the way they apply to any other result.
+ */
+export function simStatesFanOutOutcome(
+  state: SimStatesFanOutState,
+  input: JSONValue,
+  outputs: readonly JSONValue[],
+): SimStatesMoveOnOutcome {
+  const output = simStatesEffectiveOutput(input, [...outputs], state);
+
+  return state.Next === undefined
+    ? { kind: "succeed", output }
+    : { kind: "next", output, next: state.Next };
+}

--- a/src/service/stepfunctions/execution/sim-states-fan-out.ts
+++ b/src/service/stepfunctions/execution/sim-states-fan-out.ts
@@ -1,0 +1,151 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesChildKind } from "./sim-states-child.js";
+import { simStatesChildFailure } from "./sim-states-child-failure.js";
+import type { SimStatesChildRun } from "./sim-states-child-run.js";
+import {
+  type SimStatesChildStart,
+  SimStatesChildRuns,
+} from "./sim-states-child-runs.js";
+import { simStatesFailureFrom } from "./sim-states-failure.js";
+import type {
+  SimStatesFailOutcome,
+  SimStatesSettledOutcome,
+  SimStatesStateContext,
+  SimStatesStateOutcome,
+} from "./sim-states-state-outcome.js";
+
+interface SimStatesFanOutProperties {
+  readonly kind: SimStatesChildKind;
+  readonly context: SimStatesStateContext;
+  readonly children: readonly SimStatesChildStart[];
+
+  /**
+   * What one child is called, for the failure the state ends with.
+   */
+  readonly names: (index: number) => string;
+
+  /**
+   * What the state answers, given what every child produced in child order.
+   */
+  readonly answers: (outputs: readonly JSONValue[]) => SimStatesSettledOutcome;
+}
+
+/**
+ * Runs the children of one state, and says what the state made of them.
+ *
+ * A child that reaches a `Wait` state is left on the clock rather than waited
+ * for, so its siblings run while it waits. The state itself suspends when any
+ * of them does, and answers through the walk's `resume` once the last one has
+ * finished.
+ *
+ * A child that fails takes the state with it. The siblings still going are
+ * abandoned, which leaves whatever they had scheduled on the clock to find a
+ * child that has stopped.
+ */
+export class SimStatesFanOut {
+  readonly #context: SimStatesStateContext;
+  readonly #names: (index: number) => string;
+  readonly #answers: (outputs: readonly JSONValue[]) => SimStatesSettledOutcome;
+  readonly #children: SimStatesChildRuns;
+  #failure: SimStatesFailOutcome | undefined;
+
+  /**
+   * Whether the state has told the walk that it suspended, and so owes it an
+   * answer through `resume`.
+   */
+  #suspended = false;
+
+  constructor(properties: SimStatesFanOutProperties) {
+    this.#context = properties.context;
+    this.#names = properties.names;
+    this.#answers = properties.answers;
+    this.#children = new SimStatesChildRuns({
+      kind: properties.kind,
+      context: properties.context,
+      children: properties.children,
+      onSettled: async (run): Promise<void> => {
+        await this.#settled(run);
+      },
+    });
+  }
+
+  /**
+   * Start the children, and say what the state did as far as they have got.
+   *
+   * Everything that answers without waiting on the clock has answered by the
+   * time this does, so a fan-out with nothing to wait for never suspends.
+   */
+  async run(): Promise<SimStatesStateOutcome> {
+    await this.#children.start();
+
+    const outcome = this.#outcome();
+
+    if (outcome !== undefined) {
+      return outcome;
+    }
+
+    this.#suspended = true;
+
+    return { kind: "pending" };
+  }
+
+  /**
+   * Take in that one child has ended, and carry on from there.
+   */
+  async #settled(run: SimStatesChildRun): Promise<void> {
+    if (this.#failure !== undefined) {
+      return;
+    }
+
+    this.#children.ended();
+
+    const failure = run.failure;
+
+    if (failure !== undefined) {
+      this.#failure = simStatesChildFailure(this.#names(run.index), failure);
+      this.#children.abandon();
+    }
+
+    await this.#resumed();
+  }
+
+  /**
+   * Answer the walk, where the state suspended and is now done.
+   */
+  async #resumed(): Promise<void> {
+    if (!this.#suspended) {
+      return;
+    }
+
+    const outcome = this.#outcome();
+
+    if (outcome === undefined) {
+      return;
+    }
+
+    this.#suspended = false;
+
+    await this.#context.resume(outcome);
+  }
+
+  /**
+   * What the state did, where its children are done enough to say.
+   */
+  #outcome(): SimStatesSettledOutcome | undefined {
+    if (this.#failure !== undefined) {
+      return this.#failure;
+    }
+
+    if (!this.#children.finished) {
+      return undefined;
+    }
+
+    try {
+      return this.#answers(this.#children.outputs);
+    } catch (error) {
+      // A ResultPath with nowhere to write fails the state rather than the
+      // clock advance that released the last child.
+      return simStatesFailureFrom(error);
+    }
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
@@ -5,7 +5,7 @@ import type { SimStatesDefinition } from "../definition/sim-states-definition.js
 import type { SimStatesState } from "../definition/sim-states-state.js";
 import { SimStatesNoTaskTargets } from "../task/sim-states-no-task-targets.js";
 import { SimStatesExecution } from "./sim-states-execution.js";
-import { SimStatesInterpreter } from "./sim-states-interpreter.js";
+import { simStatesWalks } from "./sim-states-walks.js";
 
 /**
  * Run a definition the parser would never have let through, to reach the
@@ -24,13 +24,11 @@ async function runDefinition(
     startDate: background.now(),
   });
 
-  await new SimStatesInterpreter({
-    definition,
-    execution,
+  await simStatesWalks({
     background,
     tasks: new SimStatesNoTaskTargets(),
     roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
-  }).run();
+  })({ definition, record: execution }).run();
 
   return execution;
 }

--- a/src/service/stepfunctions/execution/sim-states-interpreter.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.ts
@@ -1,21 +1,26 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
-import type { SimStatesState } from "../definition/sim-states-state.js";
 import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
-import type { SimStatesExecution } from "./sim-states-execution.js";
-import {
-  simStatesCycleFailure,
-  simStatesMaximumTransitions,
-  simStatesUnknownStateFailure,
-} from "./sim-states-failure.js";
+import type {
+  SimStatesChildWalk,
+  SimStatesChildWalks,
+} from "./sim-states-child-walk.js";
+import type { SimStatesRunRecord } from "./sim-states-run-record.js";
 import { SimStatesSettlement } from "./sim-states-settlement.js";
 import { SimStatesStateAttempts } from "./sim-states-state-attempts.js";
 import { SimStatesStateRunner } from "./sim-states-state-runner.js";
+import { SimStatesWalkSteps } from "./sim-states-walk-steps.js";
 
 interface SimStatesInterpreterProperties {
   readonly definition: SimStatesDefinition;
-  readonly execution: SimStatesExecution;
+
+  /**
+   * What the walk records itself on: an execution, or one branch of a
+   * `Parallel` state.
+   */
+  readonly record: SimStatesRunRecord;
+
   readonly background: BackgroundScheduler;
 
   /**
@@ -27,10 +32,21 @@ interface SimStatesInterpreterProperties {
    * The state machine's execution role, which a task assumes.
    */
   readonly roleArn: string;
+
+  /**
+   * How a state that runs states of its own gets a walk over them.
+   */
+  readonly walkChild: SimStatesChildWalks;
+
+  /**
+   * What to do once this walk has ended, which is how a branch tells the
+   * `Parallel` state holding it.
+   */
+  readonly onSettled?: () => Promise<void>;
 }
 
 /**
- * Walks one execution through its state machine.
+ * Walks one execution, or one branch of one, through its states.
  *
  * The walk is a loop over a map of states, which is all Amazon States Language
  * asks for. Everything interesting happens either side of a state, in the
@@ -41,68 +57,85 @@ interface SimStatesInterpreterProperties {
  * something moves simulated time to the instant it is waiting for. A `Retry`
  * pauses it the same way, with the next attempt at the state standing in for
  * the state after it.
+ *
+ * A `Parallel` state runs a walk of its own per branch, on the same clock and
+ * through the same states, so a branch waits the way anything else does and
+ * its siblings carry on while it does.
  */
-export class SimStatesInterpreter {
+export class SimStatesInterpreter implements SimStatesChildWalk {
   readonly #definition: SimStatesDefinition;
-  readonly #execution: SimStatesExecution;
+  readonly #record: SimStatesRunRecord;
   readonly #background: BackgroundScheduler;
-  readonly #settlement: SimStatesSettlement;
+  readonly #steps: SimStatesWalkSteps;
   readonly #attempts: SimStatesStateAttempts;
+  readonly #onSettled: (() => Promise<void>) | undefined;
 
   /**
-   * Transitions made so far, counted across every pause the clock makes.
+   * Whether whatever is holding this walk has been told it ended.
    */
-  #taken = 0;
+  #told = false;
 
   constructor(properties: SimStatesInterpreterProperties) {
     this.#definition = properties.definition;
-    this.#execution = properties.execution;
+    this.#record = properties.record;
     this.#background = properties.background;
-    this.#settlement = new SimStatesSettlement({
-      execution: properties.execution,
+    this.#onSettled = properties.onSettled;
+
+    const settlement = new SimStatesSettlement({
+      record: properties.record,
       background: properties.background,
     });
+
+    this.#steps = new SimStatesWalkSteps(properties.definition, settlement);
     this.#attempts = new SimStatesStateAttempts({
       runner: new SimStatesStateRunner({
-        execution: properties.execution,
         background: properties.background,
-        tasks: properties.tasks,
-        roleArn: properties.roleArn,
+        walk: {
+          record: properties.record,
+          tasks: properties.tasks,
+          roleArn: properties.roleArn,
+          walkChild: properties.walkChild,
+        },
       }),
-      settlement: this.#settlement,
+      settlement,
       background: properties.background,
       walkOn: async (outcome): Promise<void> => {
-        await this.#walk(outcome.next, outcome.output);
+        if (outcome !== undefined) {
+          await this.#walk(outcome.next, outcome.output);
+        }
+
+        await this.#ended();
       },
     });
   }
 
   /**
-   * Run the execution as far as it goes without waiting on the clock.
+   * Run the walk as far as it goes without waiting on the clock.
    *
    * A failure ends the execution and is recorded on it. Nothing raises out of
    * here, since this runs where a caller advancing the clock would otherwise
    * see the raise.
    */
   async run(): Promise<void> {
-    await this.#walk(this.#definition.StartAt, this.#execution.input);
+    await this.#walk(this.#definition.StartAt, this.#record.input);
+    await this.#ended();
   }
 
   /**
-   * Walk from one state until the execution ends or the clock pauses it.
+   * Walk from one state until the walk ends or the clock pauses it.
    */
   async #walk(from: string, value: JSONValue): Promise<void> {
     let current = from;
     let carried = value;
 
-    for (;;) {
-      const state = this.#nextState(current);
+    while (!this.#record.stopped) {
+      const state = this.#steps.next(current);
 
       if (state === undefined) {
         return;
       }
 
-      this.#execution.enter(current);
+      this.#record.enter(current);
       // One sequencing point per state. The states are a chain, so there is
       // nothing here to run in parallel.
       // oxlint-disable-next-line eslint/no-await-in-loop
@@ -127,20 +160,18 @@ export class SimStatesInterpreter {
   }
 
   /**
-   * The state a name stands for, failing the execution where there is none.
+   * Tell whatever is holding this walk that it is over, once it is.
+   *
+   * A walk that answered with states still on the clock is not over, and this
+   * runs again when they release it.
    */
-  #nextState(current: string): SimStatesState | undefined {
-    if (this.#taken++ >= simStatesMaximumTransitions) {
-      this.#settlement.settle(simStatesCycleFailure());
-      return undefined;
+  async #ended(): Promise<void> {
+    if (this.#told || !this.#record.stopped) {
+      return;
     }
 
-    const state = this.#definition.States.get(current);
+    this.#told = true;
 
-    if (state === undefined) {
-      this.#settlement.settle(simStatesUnknownStateFailure(current));
-    }
-
-    return state;
+    await this.#onSettled?.();
   }
 }

--- a/src/service/stepfunctions/execution/sim-states-run-parallel.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-parallel.ts
@@ -1,0 +1,41 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { simStatesEffectiveInput } from "../data/sim-states-data-flow.js";
+import type { SimStatesParallelState } from "../definition/sim-states-state.js";
+import { SimStatesFanOut } from "./sim-states-fan-out.js";
+import { simStatesFanOutOutcome } from "./sim-states-fan-out-outcome.js";
+import type {
+  SimStatesStateContext,
+  SimStatesStateOutcome,
+} from "./sim-states-state-outcome.js";
+
+/**
+ * A `Parallel` state, which runs each of its branches on the same input.
+ *
+ * Every branch is given the state's effective input, so `InputPath` and
+ * `Parameters` are applied once rather than per branch. The result is an array
+ * of what each branch produced, in the order the branches were written, and
+ * `ResultSelector`, `ResultPath` and `OutputPath` then apply to that array.
+ *
+ * All the branches run at once. Nothing bounds how many of them are going,
+ * which is what Amazon States Language says of a `Parallel` state.
+ */
+export async function runSimStatesParallel(
+  state: SimStatesParallelState,
+  input: JSONValue,
+  context: SimStatesStateContext,
+): Promise<SimStatesStateOutcome> {
+  const effective = simStatesEffectiveInput(input, state);
+
+  return await new SimStatesFanOut({
+    context,
+    kind: "branch",
+    children: state.Branches.map((definition, index) => ({
+      index,
+      definition,
+      input: effective,
+    })),
+    names: (index) =>
+      `Branch ${String(index + 1)} of the Parallel state ${context.stateName}`,
+    answers: (outputs) => simStatesFanOutOutcome(state, input, outputs),
+  }).run();
+}

--- a/src/service/stepfunctions/execution/sim-states-run-record.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-record.ts
@@ -1,0 +1,53 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesChildRun } from "./sim-states-child-run.js";
+
+/**
+ * What a walk over a set of states records as it goes.
+ *
+ * An execution is one of these, and so is a `Parallel` state's branch. The
+ * interpreter walks either without knowing which it has, so a branch gets the
+ * same `Wait` states, the same retries and the same clock as the execution
+ * holding it.
+ */
+export interface SimStatesRunRecord {
+  /**
+   * What the walk starts at its first state with.
+   */
+  readonly input: JSONValue;
+
+  /**
+   * Whether the walk is over, so nothing more of it should run.
+   *
+   * A branch a sibling's failure abandoned reads as stopped while its states
+   * are still scheduled on the clock, which is what stops them.
+   */
+  readonly stopped: boolean;
+
+  /**
+   * Record that the walk has entered a state.
+   */
+  enter(stateName: string): void;
+
+  /**
+   * Record that the walk ran a state, and what that run failed with.
+   */
+  attempt(stateName: string, error: string | undefined): void;
+
+  /**
+   * End the walk with the value its last state produced.
+   */
+  succeed(output: JSONValue, at: Date): void;
+
+  /**
+   * End the walk with the error that stopped it.
+   */
+  fail(error: string, cause: string | undefined, at: Date): void;
+
+  /**
+   * Record a branch, which is reported on the execution however deeply
+   * nested the state running it is. A branch that is given up on gives up on
+   * the branches it was running, so the run is held rather than what it
+   * reports.
+   */
+  child(child: SimStatesChildRun): void;
+}

--- a/src/service/stepfunctions/execution/sim-states-run-state.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-state.ts
@@ -10,6 +10,7 @@ import type {
   SimStatesSucceedState,
 } from "../definition/sim-states-state.js";
 import { runSimStatesChoice } from "./sim-states-run-choice.js";
+import { runSimStatesParallel } from "./sim-states-run-parallel.js";
 import { runSimStatesTask } from "./sim-states-run-task.js";
 import { runSimStatesWait } from "./sim-states-run-wait.js";
 import type {
@@ -28,9 +29,10 @@ const unnamedFailError = "States.Unknown";
  * A data-flow field raising is left to the caller, which reads the Amazon
  * States Language error name off whatever came out.
  *
- * This waits on the work a `Task` state does. Every other state type answers
- * without waiting for anything. A `Wait` state pauses the walk rather than
- * blocking it, and answers by saying what it is waiting for.
+ * This waits on the work a `Task` state does, and on the branches a `Parallel`
+ * state runs as far as they get. Every other state type answers without
+ * waiting for anything. A `Wait` state pauses the walk rather than blocking
+ * it, and answers by saying what it is waiting for.
  */
 export async function runSimStatesState(
   state: SimStatesState,
@@ -55,6 +57,10 @@ export async function runSimStatesState(
 
   if (state.Type === "Wait") {
     return runSimStatesWait(state, input, context);
+  }
+
+  if (state.Type === "Parallel") {
+    return await runSimStatesParallel(state, input, context);
   }
 
   return runPass(state, input);

--- a/src/service/stepfunctions/execution/sim-states-settlement.ts
+++ b/src/service/stepfunctions/execution/sim-states-settlement.ts
@@ -1,29 +1,36 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
-import type { SimStatesExecution } from "./sim-states-execution.js";
+import type { SimStatesRunRecord } from "./sim-states-run-record.js";
 import type {
   SimStatesNextOutcome,
   SimStatesSettledOutcome,
 } from "./sim-states-state-outcome.js";
 
 interface SimStatesSettlementProperties {
-  readonly execution: SimStatesExecution;
+  readonly record: SimStatesRunRecord;
   readonly background: BackgroundScheduler;
 }
 
 /**
- * Records on one execution whatever its states leave it as.
+ * Records on one walk whatever its states leave it as.
  *
  * The interpreter walks the states and this holds what the walk did, which
  * keeps the recording in one place for the walk and for a `Wait` state
  * carrying on later.
  */
 export class SimStatesSettlement {
-  readonly #execution: SimStatesExecution;
+  readonly #record: SimStatesRunRecord;
   readonly #background: BackgroundScheduler;
 
   constructor(properties: SimStatesSettlementProperties) {
-    this.#execution = properties.execution;
+    this.#record = properties.record;
     this.#background = properties.background;
+  }
+
+  /**
+   * Whether the walk is over, so nothing waiting on the clock should run.
+   */
+  get stopped(): boolean {
+    return this.#record.stopped;
   }
 
   /**
@@ -38,11 +45,11 @@ export class SimStatesSettlement {
     }
 
     if (outcome.kind === "succeed") {
-      this.#execution.succeed(outcome.output, this.#background.now());
+      this.#record.succeed(outcome.output, this.#background.now());
       return undefined;
     }
 
-    this.#execution.fail(outcome.error, outcome.cause, this.#background.now());
+    this.#record.fail(outcome.error, outcome.cause, this.#background.now());
 
     return undefined;
   }

--- a/src/service/stepfunctions/execution/sim-states-state-attempts.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-attempts.ts
@@ -7,6 +7,8 @@ import type { SimStatesSettlement } from "./sim-states-settlement.js";
 import type { SimStatesStateRunner } from "./sim-states-state-runner.js";
 import type {
   SimStatesNextOutcome,
+  SimStatesSettledOutcome,
+  SimStatesStateOutcome,
   SimStatesWaitOutcome,
 } from "./sim-states-state-outcome.js";
 import type {
@@ -34,10 +36,11 @@ interface SimStatesStateAttemptsProperties {
  * Runs the attempts one state takes, and puts the ones it waits for on the
  * clock.
  *
- * A `Wait` state and a `Retry` both hold the execution `RUNNING` until an
- * instant, and both carry on from where they left off once the clock gets
- * there. That is one job, and it is this one. The interpreter is left walking
- * states.
+ * A `Wait` state and a `Retry` both hold the walk `RUNNING` until an instant,
+ * and both carry on from where they left off once the clock gets there. A
+ * `Parallel` state waits for its branches instead of for an instant, and
+ * carries on the same way. That is one job, and it is this one. The
+ * interpreter is left walking states.
  */
 export class SimStatesStateAttempts {
   readonly #settlement: SimStatesSettlement;
@@ -53,11 +56,10 @@ export class SimStatesStateAttempts {
   }
 
   /**
-   * Run one state until it moves the walk on, ends the execution, or leaves it
-   * waiting on the clock.
+   * Run one state until it moves the walk on, ends it, or leaves it waiting.
    *
    * Answers with the outcome the walk carries on from, and with nothing where
-   * the execution has ended or is waiting.
+   * the walk has ended or is waiting.
    */
   async run(
     entry: SimStatesStateEntry,
@@ -69,51 +71,72 @@ export class SimStatesStateAttempts {
   }
 
   /**
-   * Run the attempts a state has left, from the one it is up to.
-   *
-   * An attempt due at an instant the clock has already reached holds nothing
-   * up, so those run round this loop instead of through the scheduler.
+   * Make one attempt at a state, and see what the walk does about it.
    */
   async #from(
     entry: SimStatesStateEntry,
-    from: SimStatesAttemptState,
+    attempt: SimStatesAttemptState,
   ): Promise<SimStatesNextOutcome | undefined> {
-    let attempt = from;
+    const outcome = await this.#runner.run(entry, attempt, async (settled) => {
+      await this.#resumed(entry, attempt, settled);
+    });
 
-    for (;;) {
-      // One attempt at a time, since each one is only made because the one
-      // before it failed.
-      // oxlint-disable-next-line eslint/no-await-in-loop
-      const outcome = await this.#runner.run(
-        entry.state,
-        entry.input,
-        entry.name,
-        attempt,
-      );
-
-      if (outcome.kind === "wait") {
-        return this.#waited(outcome);
-      }
-
-      if (outcome.kind !== "retry") {
-        return this.#settlement.settle(outcome);
-      }
-
-      if (this.#reached(outcome.until)) {
-        attempt = outcome.attempt;
-        continue;
-      }
-
-      this.#pause(outcome.until, async () =>
-        this.#from(entry, outcome.attempt),
-      );
-
-      return undefined;
-    }
+    return await this.#took(entry, outcome);
   }
 
   /**
-   * Hold the execution until the clock reaches what a `Wait` state waits for.
+   * What the walk does about one attempt's outcome.
+   *
+   * An attempt due at an instant the clock has already reached holds nothing
+   * up, so it is made from here rather than through the scheduler.
+   */
+  async #took(
+    entry: SimStatesStateEntry,
+    outcome: SimStatesStateOutcome,
+  ): Promise<SimStatesNextOutcome | undefined> {
+    if (outcome.kind === "pending") {
+      return undefined;
+    }
+
+    if (outcome.kind === "wait") {
+      return this.#waited(outcome);
+    }
+
+    if (outcome.kind !== "retry") {
+      return this.#settlement.settle(outcome);
+    }
+
+    if (this.#reached(outcome.until)) {
+      return await this.#from(entry, outcome.attempt);
+    }
+
+    this.#pause(outcome.until, async () => this.#from(entry, outcome.attempt));
+
+    return undefined;
+  }
+
+  /**
+   * Carry the walk on from a state that suspended, once it has finished.
+   *
+   * The walk stopped where the state was, so this takes it from there rather
+   * than answering something that is no longer waiting for one.
+   */
+  async #resumed(
+    entry: SimStatesStateEntry,
+    attempt: SimStatesAttemptState,
+    settled: SimStatesSettledOutcome,
+  ): Promise<void> {
+    if (this.#settlement.stopped) {
+      return;
+    }
+
+    const outcome = this.#runner.answered(entry, attempt, settled);
+
+    await this.#walkOn(await this.#took(entry, outcome));
+  }
+
+  /**
+   * Hold the walk until the clock reaches what a `Wait` state waits for.
    *
    * An instant already reached holds nothing up, and the walk carries straight
    * on. Under a frozen clock anything later waits for as long as the test
@@ -135,15 +158,16 @@ export class SimStatesStateAttempts {
    * Put the rest of one state's work on the clock, and the walk after it.
    *
    * One advance covering a whole backoff runs every attempt in it, because
-   * work this schedules is itself due by the time the advance reaches it.
+   * work this schedules is itself due by the time the advance reaches it. A
+   * walk that was abandoned while it waited runs none of it.
    */
   #pause(until: Date, rest: SimStatesPausedWork): void {
     this.#background.scheduleAt(until, async () => {
-      const carrying = await rest();
-
-      if (carrying !== undefined) {
-        await this.#walkOn(carrying);
+      if (this.#settlement.stopped) {
+        return;
       }
+
+      await this.#walkOn(await rest());
     });
   }
 

--- a/src/service/stepfunctions/execution/sim-states-state-outcome.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-outcome.ts
@@ -1,6 +1,8 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesAttemptState } from "../retry/sim-states-attempt-state.js";
 import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
+import type { SimStatesChildWalks } from "./sim-states-child-walk.js";
+import type { SimStatesRunRecord } from "./sim-states-run-record.js";
 
 /**
  * What a state leaves the execution to do once it has run.
@@ -49,18 +51,35 @@ export interface SimStatesWaitOutcome {
   readonly resume: SimStatesMoveOnOutcome;
 }
 
+/**
+ * A state that has suspended, and will say what it did later.
+ *
+ * A `Parallel` state whose branches are waiting on the clock is neither done
+ * nor waiting for an instant of its own. The walk stops here, and the state
+ * carries on through the `resume` it was given once its branches have
+ * finished.
+ */
+export interface SimStatesPendingOutcome {
+  readonly kind: "pending";
+}
+
 export type SimStatesStateOutcome =
   | SimStatesSettledOutcome
   | SimStatesRetryOutcome
-  | SimStatesWaitOutcome;
+  | SimStatesWaitOutcome
+  | SimStatesPendingOutcome;
 
 /**
- * What a state knows about the execution it is running in.
+ * How a state that suspended says what it finally did.
  */
-export interface SimStatesStateContext {
-  readonly stateName: string;
-  readonly now: Date;
+export type SimStatesResume = (
+  outcome: SimStatesSettledOutcome,
+) => Promise<void>;
 
+/**
+ * What every state of one walk is given, whichever state it is.
+ */
+export interface SimStatesWalkContext {
   /**
    * Where a `Task` state does its work.
    */
@@ -70,4 +89,28 @@ export interface SimStatesStateContext {
    * The state machine's execution role, which a task assumes.
    */
   readonly roleArn: string;
+
+  /**
+   * What the walk is recording itself on, which a `Parallel` state's branch
+   * hangs off.
+   */
+  readonly record: SimStatesRunRecord;
+
+  /**
+   * How a state that runs states of its own gets a walk over them.
+   */
+  readonly walkChild: SimStatesChildWalks;
+}
+
+/**
+ * What a state knows about the execution it is running in.
+ */
+export interface SimStatesStateContext extends SimStatesWalkContext {
+  readonly stateName: string;
+  readonly now: Date;
+
+  /**
+   * How a state that suspends says what it finally did.
+   */
+  readonly resume: SimStatesResume;
 }

--- a/src/service/stepfunctions/execution/sim-states-state-runner.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-runner.ts
@@ -1,74 +1,94 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
-import type { JSONValue } from "../../../util/type-guard/json.js";
-import type { SimStatesState } from "../definition/sim-states-state.js";
 import type { SimStatesAttemptState } from "../retry/sim-states-attempt-state.js";
-import { simStatesRecover } from "../retry/sim-states-recover.js";
+import { simStatesRecovered } from "../retry/sim-states-recovered.js";
 import { simStatesTimedOut } from "../retry/sim-states-task-deadline.js";
-import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
-import type { SimStatesExecution } from "./sim-states-execution.js";
 import { simStatesFailureFrom } from "./sim-states-failure.js";
 import { runSimStatesState } from "./sim-states-run-state.js";
-import type { SimStatesStateOutcome } from "./sim-states-state-outcome.js";
+import type {
+  SimStatesResume,
+  SimStatesStateOutcome,
+  SimStatesWalkContext,
+} from "./sim-states-state-outcome.js";
+import type { SimStatesStateEntry } from "./sim-states-walk.js";
 
 interface SimStatesStateRunnerProperties {
-  readonly execution: SimStatesExecution;
   readonly background: BackgroundScheduler;
-  readonly tasks: SimStatesTaskTargets;
-  readonly roleArn: string;
+
+  /**
+   * What this runner gives every state it runs.
+   */
+  readonly walk: SimStatesWalkContext;
 }
 
 /**
- * Runs one attempt at one state of an execution, and never raises.
+ * Runs one attempt at one state of a walk, and never raises.
  *
- * What a state knows about the execution it is running in is gathered here,
- * and so is reading the Amazon States Language error name off whatever a state
- * raised. What a `Task` state's `Retry` and `Catch` make of that name is read
- * here too, so a state that failed answers with what the execution does about
- * it. All three leave the interpreter with the walk alone.
+ * What a state knows about the walk it is running in is gathered here, and so
+ * is reading the Amazon States Language error name off whatever a state
+ * raised. What a state's `Retry` and `Catch` make of that name is read here
+ * too, so a state that failed answers with what the walk does about it. All
+ * three leave the interpreter with the walk alone.
  */
 export class SimStatesStateRunner {
-  readonly #execution: SimStatesExecution;
   readonly #background: BackgroundScheduler;
-  readonly #tasks: SimStatesTaskTargets;
-  readonly #roleArn: string;
+  readonly #walk: SimStatesWalkContext;
 
   constructor(properties: SimStatesStateRunnerProperties) {
-    this.#execution = properties.execution;
     this.#background = properties.background;
-    this.#tasks = properties.tasks;
-    this.#roleArn = properties.roleArn;
+    this.#walk = properties.walk;
   }
 
   /**
    * Run one attempt at a state and say what happened, failure included.
+   *
+   * A state that suspended is recorded when it finishes rather than here, and
+   * says what it did through the `resume` it was given.
    */
   async run(
-    state: SimStatesState,
-    input: JSONValue,
-    stateName: string,
+    entry: SimStatesStateEntry,
     attempt: SimStatesAttemptState,
+    resume: SimStatesResume,
   ): Promise<SimStatesStateOutcome> {
-    const ran = await this.#ran(state, input, stateName, attempt);
+    const ran = await this.#ran(entry, attempt, resume);
 
-    this.#execution.attempt(
-      stateName,
+    return ran.kind === "pending" ? ran : this.answered(entry, attempt, ran);
+  }
+
+  /**
+   * What the walk makes of what one run of a state produced.
+   *
+   * A state that suspended comes back through here once it has finished, so a
+   * `Parallel` state's branches failing is retried and caught the way a task
+   * failing is.
+   */
+  answered(
+    entry: SimStatesStateEntry,
+    attempt: SimStatesAttemptState,
+    ran: SimStatesStateOutcome,
+  ): SimStatesStateOutcome {
+    this.#walk.record.attempt(
+      entry.name,
       ran.kind === "fail" ? ran.error : undefined,
     );
 
-    return this.#recovered(state, input, ran, attempt);
+    return simStatesRecovered({
+      entry,
+      ran,
+      attempt,
+      now: this.#background.now(),
+    });
   }
 
   /**
    * Run the state itself, or give up on it where its deadline has passed.
    */
   async #ran(
-    state: SimStatesState,
-    input: JSONValue,
-    stateName: string,
+    entry: SimStatesStateEntry,
     attempt: SimStatesAttemptState,
+    resume: SimStatesResume,
   ): Promise<SimStatesStateOutcome> {
     const overdue = simStatesTimedOut(
-      stateName,
+      entry.name,
       attempt,
       this.#background.now(),
     );
@@ -78,40 +98,11 @@ export class SimStatesStateRunner {
     }
 
     try {
-      return await runSimStatesState(state, input, {
-        stateName,
+      return await runSimStatesState(entry.state, entry.input, {
+        ...this.#walk,
+        stateName: entry.name,
         now: this.#background.now(),
-        tasks: this.#tasks,
-        roleArn: this.#roleArn,
-      });
-    } catch (error) {
-      return simStatesFailureFrom(error);
-    }
-  }
-
-  /**
-   * What the state's own `Retry` and `Catch` make of a failure.
-   *
-   * A catcher whose `ResultPath` has nowhere to write fails the execution the
-   * way any other data-flow field that cannot be applied does.
-   */
-  #recovered(
-    state: SimStatesState,
-    input: JSONValue,
-    ran: SimStatesStateOutcome,
-    attempt: SimStatesAttemptState,
-  ): SimStatesStateOutcome {
-    if (ran.kind !== "fail" || state.Type !== "Task") {
-      return ran;
-    }
-
-    try {
-      return simStatesRecover({
-        handling: state,
-        input,
-        failure: ran,
-        attempt,
-        now: this.#background.now(),
+        resume,
       });
     } catch (error) {
       return simStatesFailureFrom(error);

--- a/src/service/stepfunctions/execution/sim-states-walk-steps.ts
+++ b/src/service/stepfunctions/execution/sim-states-walk-steps.ts
@@ -1,0 +1,51 @@
+import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
+import type { SimStatesState } from "../definition/sim-states-state.js";
+import {
+  simStatesCycleFailure,
+  simStatesMaximumTransitions,
+  simStatesUnknownStateFailure,
+} from "./sim-states-failure.js";
+import type { SimStatesSettlement } from "./sim-states-settlement.js";
+
+/**
+ * The states one walk steps through, and how many steps it may take.
+ *
+ * Amazon States Language allows a cycle, so a walk can run out of steps rather
+ * than reaching an end. Both that and a transition naming nothing end the walk
+ * here, which leaves the interpreter with the states that do exist.
+ */
+export class SimStatesWalkSteps {
+  readonly #definition: SimStatesDefinition;
+  readonly #settlement: SimStatesSettlement;
+
+  /**
+   * Transitions made so far, counted across every pause the clock makes.
+   */
+  #taken = 0;
+
+  constructor(
+    definition: SimStatesDefinition,
+    settlement: SimStatesSettlement,
+  ) {
+    this.#definition = definition;
+    this.#settlement = settlement;
+  }
+
+  /**
+   * The state a name stands for, failing the walk where there is none.
+   */
+  next(current: string): SimStatesState | undefined {
+    if (this.#taken++ >= simStatesMaximumTransitions) {
+      this.#settlement.settle(simStatesCycleFailure());
+      return undefined;
+    }
+
+    const state = this.#definition.States.get(current);
+
+    if (state === undefined) {
+      this.#settlement.settle(simStatesUnknownStateFailure(current));
+    }
+
+    return state;
+  }
+}

--- a/src/service/stepfunctions/execution/sim-states-walk.ts
+++ b/src/service/stepfunctions/execution/sim-states-walk.ts
@@ -12,6 +12,11 @@ export interface SimStatesStateEntry {
 }
 
 /**
- * How the rest of the walk carries on from a state the clock held up.
+ * How the rest of the walk carries on from a state that held it up.
+ *
+ * A state that ended the walk rather than moving it on carries nothing, and
+ * the walk is over when this answers.
  */
-export type SimStatesWalkOn = (outcome: SimStatesNextOutcome) => Promise<void>;
+export type SimStatesWalkOn = (
+  outcome: SimStatesNextOutcome | undefined,
+) => Promise<void>;

--- a/src/service/stepfunctions/execution/sim-states-walks.ts
+++ b/src/service/stepfunctions/execution/sim-states-walks.ts
@@ -1,0 +1,43 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
+import type { SimStatesChildWalks } from "./sim-states-child-walk.js";
+import { SimStatesInterpreter } from "./sim-states-interpreter.js";
+
+interface SimStatesWalksProperties {
+  readonly background: BackgroundScheduler;
+
+  /**
+   * Where a `Task` state does its work.
+   */
+  readonly tasks: SimStatesTaskTargets;
+
+  /**
+   * The state machine's execution role, which a task assumes.
+   */
+  readonly roleArn: string;
+}
+
+/**
+ * How one execution walks a set of states, its `Parallel` branches included.
+ *
+ * A branch is walked the way the execution around it is, on the same clock and
+ * through the same tasks, so what it reaches is what any other state reaches.
+ * The factory hands itself to the walks it builds, which is what lets a branch
+ * hold a `Parallel` state of its own.
+ */
+export function simStatesWalks(
+  properties: SimStatesWalksProperties,
+): SimStatesChildWalks {
+  const walks: SimStatesChildWalks = (child) =>
+    new SimStatesInterpreter({
+      definition: child.definition,
+      record: child.record,
+      background: properties.background,
+      tasks: properties.tasks,
+      roleArn: properties.roleArn,
+      walkChild: walks,
+      ...(child.onSettled !== undefined && { onSettled: child.onSettled }),
+    });
+
+  return walks;
+}

--- a/src/service/stepfunctions/retry/sim-states-catch-parse.ts
+++ b/src/service/stepfunctions/retry/sim-states-catch-parse.ts
@@ -8,18 +8,18 @@ import {
 } from "./sim-states-error-equals.js";
 
 /**
- * Read a `Task` state's `Catch`, refusing anything this cannot run.
+ * Read a state's `Catch`, refusing anything this cannot run.
  *
  * A catcher's `Next` is checked against the state machine's own states once
  * every state has been read, alongside the other transitions. Answers with
  * nothing where the state carries no `Catch`.
  */
 export function parseSimStatesCatchers(
-  stateName: string,
+  named: string,
   state: Record<string, JSONValue>,
 ): readonly SimStatesCatcher[] | undefined {
-  return readSimStatesHandlers(stateName, state, "Catch", "catcher")?.map(
-    (entry) => readCatcher(stateName, entry),
+  return readSimStatesHandlers(named, state, "Catch", "catcher")?.map((entry) =>
+    readCatcher(named, entry),
   );
 }
 
@@ -27,14 +27,14 @@ export function parseSimStatesCatchers(
  * Read one catcher, which names where a failure it matches goes.
  */
 function readCatcher(
-  stateName: string,
+  named: string,
   entry: SimStatesHandlerEntry,
 ): SimStatesCatcher {
   const next = entry.written["Next"];
 
   if (typeof next !== "string") {
     throw new SimStatesInvalidDefinition(
-      `A catcher in the Task state ${stateName} has no Next naming the ` +
+      `A catcher in the ${named} has no Next naming the ` +
         "state a caught failure goes to.",
     );
   }
@@ -42,7 +42,7 @@ function readCatcher(
   return {
     ErrorEquals: entry.ErrorEquals,
     Next: next,
-    ...resultPath(stateName, entry.written["ResultPath"]),
+    ...resultPath(named, entry.written["ResultPath"]),
   };
 }
 
@@ -53,7 +53,7 @@ function readCatcher(
  * written into can hold it is only known once a failure is caught.
  */
 function resultPath(
-  stateName: string,
+  named: string,
   written: JSONValue | undefined,
 ): { ResultPath?: string | null } {
   if (written === undefined) {
@@ -66,7 +66,7 @@ function resultPath(
 
   if (typeof written !== "string") {
     throw new SimStatesInvalidDefinition(
-      `A catcher in the Task state ${stateName} has a ResultPath that is ` +
+      `A catcher in the ${named} has a ResultPath that is ` +
         "neither a Reference Path nor null.",
     );
   }

--- a/src/service/stepfunctions/retry/sim-states-catcher.ts
+++ b/src/service/stepfunctions/retry/sim-states-catcher.ts
@@ -3,7 +3,7 @@ import { parseSimStatesReferencePath } from "../data/sim-states-reference-path.j
 import { insertAtSimStatesPath } from "../data/sim-states-result-path.js";
 
 /**
- * One entry in a `Task` state's `Catch`.
+ * One entry in a state's `Catch`.
  *
  * `Next` is where a caught failure sends the execution, and `ResultPath` says
  * where in the state's input the error goes. A catcher left without one

--- a/src/service/stepfunctions/retry/sim-states-error-equals.ts
+++ b/src/service/stepfunctions/retry/sim-states-error-equals.ts
@@ -21,7 +21,7 @@ export interface SimStatesHandlerEntry {
  * Answers with nothing where the state carries neither field.
  */
 export function readSimStatesHandlers(
-  stateName: string,
+  named: string,
   state: Record<string, JSONValue>,
   field: "Retry" | "Catch",
   noun: string,
@@ -36,16 +36,13 @@ export function readSimStatesHandlers(
 
   if (!Array.isArray(declared)) {
     throw new SimStatesInvalidDefinition(
-      `The ${field} of the Task state ${stateName} is not an array of ` +
-        `${noun}s.`,
+      `The ${field} of the ${named} is not an array of ${noun}s.`,
     );
   }
 
-  const entries = declared.map((entry) =>
-    readEntry(stateName, field, noun, entry),
-  );
+  const entries = declared.map((entry) => readEntry(named, field, noun, entry));
 
-  checkAllErrorsLast(stateName, field, noun, entries);
+  checkAllErrorsLast(named, field, noun, entries);
 
   return entries;
 }
@@ -54,52 +51,51 @@ export function readSimStatesHandlers(
  * Read one entry, whose `ErrorEquals` says what it handles.
  */
 function readEntry(
-  stateName: string,
+  named: string,
   field: string,
   noun: string,
   entry: JSONValue,
 ): SimStatesHandlerEntry {
   if (!isRecord(entry)) {
     throw new SimStatesInvalidDefinition(
-      `A ${noun} in the ${field} of the Task state ${stateName} is not an ` +
-        "object.",
+      `A ${noun} in the ${field} of the ${named} is not an object.`,
     );
   }
 
   const declared = entry["ErrorEquals"];
-  const named = Array.isArray(declared)
+  const errors = Array.isArray(declared)
     ? declared.filter((error) => typeof error === "string")
     : [];
 
   if (
     !Array.isArray(declared) ||
-    named.length !== declared.length ||
-    named.length === 0
+    errors.length !== declared.length ||
+    errors.length === 0
   ) {
     throw new SimStatesInvalidDefinition(
-      `A ${noun} in the ${field} of the Task state ${stateName} has no ` +
+      `A ${noun} in the ${field} of the ${named} has no ` +
         "ErrorEquals naming the errors it handles.",
     );
   }
 
-  checkAllErrorsAlone(stateName, field, noun, named);
+  checkAllErrorsAlone(named, field, noun, errors);
 
-  return { ErrorEquals: named, written: entry };
+  return { ErrorEquals: errors, written: entry };
 }
 
 /**
  * `States.ALL` matches anything, so it names nothing alongside it.
  */
 function checkAllErrorsAlone(
-  stateName: string,
+  named: string,
   field: string,
   noun: string,
-  named: readonly string[],
+  errors: readonly string[],
 ): void {
-  if (named.includes(simStatesAllErrors) && named.length > 1) {
+  if (errors.includes(simStatesAllErrors) && errors.length > 1) {
     throw new SimStatesInvalidDefinition(
-      `A ${noun} in the ${field} of the Task state ${stateName} names ` +
-        `${simStatesAllErrors} alongside ${named.filter((error) => error !== simStatesAllErrors).join(", ")}. ` +
+      `A ${noun} in the ${field} of the ${named} names ` +
+        `${simStatesAllErrors} alongside ${errors.filter((error) => error !== simStatesAllErrors).join(", ")}. ` +
         `${simStatesAllErrors} matches anything, so it stands on its own.`,
     );
   }
@@ -109,7 +105,7 @@ function checkAllErrorsAlone(
  * `States.ALL` comes last, since nothing written after it could ever match.
  */
 function checkAllErrorsLast(
-  stateName: string,
+  named: string,
   field: string,
   noun: string,
   entries: readonly SimStatesHandlerEntry[],
@@ -120,7 +116,7 @@ function checkAllErrorsLast(
 
   if (at !== -1 && at < entries.length - 1) {
     throw new SimStatesInvalidDefinition(
-      `The ${field} of the Task state ${stateName} names ` +
+      `The ${field} of the ${named} names ` +
         `${simStatesAllErrors} in a ${noun} that is not the last one. ` +
         `${simStatesAllErrors} matches anything, so nothing after it could ` +
         "ever be reached.",

--- a/src/service/stepfunctions/retry/sim-states-error-handling.ts
+++ b/src/service/stepfunctions/retry/sim-states-error-handling.ts
@@ -1,0 +1,53 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { SimStatesState } from "../definition/sim-states-state.js";
+import { parseSimStatesCatchers } from "./sim-states-catch-parse.js";
+import type { SimStatesCatcher } from "./sim-states-catcher.js";
+import type { SimStatesRetrier } from "./sim-states-retrier.js";
+import { parseSimStatesRetriers } from "./sim-states-retry-parse.js";
+
+/**
+ * What a state says about failing.
+ *
+ * A `Task` state and a `Parallel` state both carry these two, and both read
+ * them the same way: the retriers first and the catchers after them.
+ */
+export interface SimStatesErrorHandling {
+  readonly Retry?: readonly SimStatesRetrier[];
+  readonly Catch?: readonly SimStatesCatcher[];
+}
+
+/**
+ * The `Retry` and `Catch` a state carries, where its type has them.
+ *
+ * A `Task` state and a `Parallel` state carry both. Every other state type
+ * fails the walk it is in, since there is nothing on it to say otherwise.
+ */
+export function simStatesErrorHandling(
+  state: SimStatesState,
+): SimStatesErrorHandling | undefined {
+  if (state.Type === "Task" || state.Type === "Parallel") {
+    return state;
+  }
+
+  return undefined;
+}
+
+/**
+ * The `Retry` and `Catch` a state was written with, as the objects a failure
+ * is handled by.
+ *
+ * A state carrying neither is left carrying neither, since the two fields are
+ * spread over the state as it was written.
+ */
+export function parseSimStatesErrorHandling(
+  named: string,
+  state: Record<string, JSONValue>,
+): SimStatesErrorHandling {
+  const retriers = parseSimStatesRetriers(named, state);
+  const catchers = parseSimStatesCatchers(named, state);
+
+  return {
+    ...(retriers !== undefined && { Retry: retriers }),
+    ...(catchers !== undefined && { Catch: catchers }),
+  };
+}

--- a/src/service/stepfunctions/retry/sim-states-error-name.ts
+++ b/src/service/stepfunctions/retry/sim-states-error-name.ts
@@ -17,6 +17,11 @@ export const simStatesTimeoutError = "States.Timeout";
 export const simStatesRuntimeError = "States.Runtime";
 
 /**
+ * The failure a `Parallel` state one of whose branches failed ends with.
+ */
+export const simStatesBranchFailedError = "States.BranchFailed";
+
+/**
  * Whether one retrier's or catcher's `ErrorEquals` names an error.
  *
  * Amazon States Language matches on the error name alone, so a catcher naming

--- a/src/service/stepfunctions/retry/sim-states-recover.ts
+++ b/src/service/stepfunctions/retry/sim-states-recover.ts
@@ -7,13 +7,13 @@ import type { SimStatesAttemptState } from "./sim-states-attempt-state.js";
 import { simStatesCatchOutcome } from "./sim-states-catch-outcome.js";
 import { simStatesTimeoutError } from "./sim-states-error-name.js";
 import { simStatesRetryOutcome } from "./sim-states-retry-outcome.js";
-import type { SimStatesTaskHandling } from "./sim-states-task-handling.js";
+import type { SimStatesErrorHandling } from "./sim-states-error-handling.js";
 
 interface SimStatesRecoverProperties {
   /**
    * The `Retry` and `Catch` of the state that failed.
    */
-  readonly handling: SimStatesTaskHandling;
+  readonly handling: SimStatesErrorHandling;
 
   /**
    * The raw input the state was given, which is what a catcher's `ResultPath`

--- a/src/service/stepfunctions/retry/sim-states-recovered.ts
+++ b/src/service/stepfunctions/retry/sim-states-recovered.ts
@@ -1,0 +1,53 @@
+import { simStatesFailureFrom } from "../execution/sim-states-failure.js";
+import type { SimStatesStateOutcome } from "../execution/sim-states-state-outcome.js";
+import type { SimStatesStateEntry } from "../execution/sim-states-walk.js";
+import type { SimStatesAttemptState } from "./sim-states-attempt-state.js";
+import { simStatesErrorHandling } from "./sim-states-error-handling.js";
+import { simStatesRecover } from "./sim-states-recover.js";
+
+interface SimStatesRecoveredProperties {
+  readonly entry: SimStatesStateEntry;
+
+  /**
+   * What running the state produced, which is only handled where it failed.
+   */
+  readonly ran: SimStatesStateOutcome;
+
+  readonly attempt: SimStatesAttemptState;
+  readonly now: Date;
+}
+
+/**
+ * What the state's own `Retry` and `Catch` make of a failure.
+ *
+ * A state whose type carries neither is left as it was, and its failure ends
+ * the walk. A catcher whose `ResultPath` has nowhere to write fails the walk
+ * the way any other data-flow field that cannot be applied does.
+ */
+export function simStatesRecovered(
+  properties: SimStatesRecoveredProperties,
+): SimStatesStateOutcome {
+  const { attempt, entry, now, ran } = properties;
+
+  if (ran.kind !== "fail") {
+    return ran;
+  }
+
+  const handling = simStatesErrorHandling(entry.state);
+
+  if (handling === undefined) {
+    return ran;
+  }
+
+  try {
+    return simStatesRecover({
+      handling,
+      input: entry.input,
+      failure: ran,
+      attempt,
+      now,
+    });
+  } catch (error) {
+    return simStatesFailureFrom(error);
+  }
+}

--- a/src/service/stepfunctions/retry/sim-states-retrier.ts
+++ b/src/service/stepfunctions/retry/sim-states-retrier.ts
@@ -1,5 +1,5 @@
 /**
- * One entry in a `Task` state's `Retry`.
+ * One entry in a state's `Retry`.
  *
  * The four fields that shape the wait are optional, and the defaults below are
  * the ones Amazon States Language gives them.

--- a/src/service/stepfunctions/retry/sim-states-retry-parse.ts
+++ b/src/service/stepfunctions/retry/sim-states-retry-parse.ts
@@ -20,18 +20,18 @@ import type { SimStatesRetrier } from "./sim-states-retrier.js";
 const jitterField = "JitterStrategy";
 
 /**
- * Read a `Task` state's `Retry`, refusing anything this cannot run.
+ * Read a state's `Retry`, refusing anything this cannot run.
  *
- * The retriers are read when the state machine is created, so a `Task` state
- * that runs is one whose intervals and attempt counts are already known to be
- * good. Answers with nothing where the state carries no `Retry`.
+ * The retriers are read when the state machine is created, so a state that
+ * runs is one whose intervals and attempt counts are already known to be good.
+ * Answers with nothing where the state carries no `Retry`.
  */
 export function parseSimStatesRetriers(
-  stateName: string,
+  named: string,
   state: Record<string, JSONValue>,
 ): readonly SimStatesRetrier[] | undefined {
-  return readSimStatesHandlers(stateName, state, "Retry", "retrier")?.map(
-    (entry) => readRetrier(stateName, entry),
+  return readSimStatesHandlers(named, state, "Retry", "retrier")?.map((entry) =>
+    readRetrier(named, entry),
   );
 }
 
@@ -39,14 +39,14 @@ export function parseSimStatesRetriers(
  * Read one retrier's `ErrorEquals` and the four fields that shape its wait.
  */
 function readRetrier(
-  stateName: string,
+  named: string,
   entry: SimStatesHandlerEntry,
 ): SimStatesRetrier {
   const { written } = entry;
 
   if (Object.hasOwn(written, jitterField)) {
     throw new SimStatesUnsimulatedInput(
-      `A retrier in the Task state ${stateName} carries ${jitterField}, ` +
+      `A retrier in the ${named} carries ${jitterField}, ` +
         "which this simulator does not run. Jitter makes the wait between " +
         "attempts vary, and a test advancing a clock over that wait needs it " +
         "not to.",
@@ -55,10 +55,10 @@ function readRetrier(
 
   return {
     ErrorEquals: entry.ErrorEquals,
-    ...wholeNumber(stateName, written, "IntervalSeconds", 1),
-    ...wholeNumber(stateName, written, "MaxDelaySeconds", 1),
-    ...wholeNumber(stateName, written, "MaxAttempts", 0),
-    ...backoffRate(stateName, written),
+    ...wholeNumber(named, written, "IntervalSeconds", 1),
+    ...wholeNumber(named, written, "MaxDelaySeconds", 1),
+    ...wholeNumber(named, written, "MaxAttempts", 0),
+    ...backoffRate(named, written),
   };
 }
 
@@ -66,7 +66,7 @@ function readRetrier(
  * Read one of the three whole-number fields, where the retrier carries it.
  */
 function wholeNumber(
-  stateName: string,
+  named: string,
   written: Record<string, JSONValue>,
   field: "IntervalSeconds" | "MaxDelaySeconds" | "MaxAttempts",
   least: number,
@@ -86,7 +86,7 @@ function wholeNumber(
     value > simStatesMaximumWaitSeconds
   ) {
     throw new SimStatesInvalidDefinition(
-      `A retrier in the Task state ${stateName} has a ${field} of ` +
+      `A retrier in the ${named} has a ${field} of ` +
         `${JSON.stringify(value)}. It is a whole number from ` +
         `${String(least)} to ${String(simStatesMaximumWaitSeconds)}.`,
     );
@@ -99,7 +99,7 @@ function wholeNumber(
  * Read `BackoffRate`, which multiplies the wait for each retry already taken.
  */
 function backoffRate(
-  stateName: string,
+  named: string,
   written: Record<string, JSONValue>,
 ): Record<string, number> {
   const value = written["BackoffRate"];
@@ -110,7 +110,7 @@ function backoffRate(
 
   if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
     throw new SimStatesInvalidDefinition(
-      `A retrier in the Task state ${stateName} has a BackoffRate of ` +
+      `A retrier in the ${named} has a BackoffRate of ` +
         `${JSON.stringify(value)}. It is at least 1, since a wait that ` +
         "shrank would retry faster the longer a failure went on.",
     );

--- a/src/service/stepfunctions/retry/sim-states-task-handling.ts
+++ b/src/service/stepfunctions/retry/sim-states-task-handling.ts
@@ -1,5 +1,4 @@
-import type { SimStatesCatcher } from "./sim-states-catcher.js";
-import type { SimStatesRetrier } from "./sim-states-retrier.js";
+import type { SimStatesErrorHandling } from "./sim-states-error-handling.js";
 import type { SimStatesTaskTimeouts } from "./sim-states-task-deadline.js";
 
 /**
@@ -9,7 +8,5 @@ import type { SimStatesTaskTimeouts } from "./sim-states-task-deadline.js";
  * fails is retried, then caught, and a task still going at its deadline fails
  * whatever it was doing.
  */
-export interface SimStatesTaskHandling extends SimStatesTaskTimeouts {
-  readonly Retry?: readonly SimStatesRetrier[];
-  readonly Catch?: readonly SimStatesCatcher[];
-}
+export type SimStatesTaskHandling = SimStatesErrorHandling &
+  SimStatesTaskTimeouts;

--- a/src/service/stepfunctions/sim-step-functions-catch.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-catch.iso.test.ts
@@ -6,7 +6,7 @@ import {
 import { describe, it } from "vitest";
 
 import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
-import { statesTaskExecutionFactory } from "../../../test/stepfunctions/states-task-execution.factory.js";
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
 import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
 import type { JSONObject } from "../../util/type-guard/json.js";
 import { SimAws } from "../aws/sim-aws.js";
@@ -35,14 +35,14 @@ describe("Simulated Step Functions Catch", () => {
    */
   async function runWorkflow(
     simAws: SimAws,
-    task: JSONObject,
+    state: JSONObject,
     input = '{"student":"Wei"}',
   ): Promise<{
     readonly described: SimDescribeExecutionCommandOutput;
     readonly executionArn: string;
   }> {
-    const executionArn = await statesTaskExecutionFactory.make(
-      { task, states: compensating, input },
+    const executionArn = await statesExecutionFactory.make(
+      { state, states: compensating, input },
       simAws,
     );
 
@@ -118,9 +118,9 @@ describe("Simulated Step Functions Catch", () => {
   it("catches a task whose retrier has run out of attempts", async () => {
     // Given a task that is retried once and caught after that.
     const simAws = await givenAFailingFunction();
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: {
+        state: {
           ...invokeCheck([{ ErrorEquals: ["States.ALL"], Next: "Compensate" }]),
           Retry: [
             {

--- a/src/service/stepfunctions/sim-step-functions-inspection.ts
+++ b/src/service/stepfunctions/sim-step-functions-inspection.ts
@@ -1,4 +1,5 @@
 import type { SimStatesAttempt } from "./execution/sim-states-attempt.js";
+import type { SimStatesChild } from "./execution/sim-states-child.js";
 import type { SimStatesExecutionStore } from "./execution/sim-states-execution-store.js";
 
 /**
@@ -35,11 +36,35 @@ export class SimStepFunctionsInspection {
   }
 
   /**
+   * Every branch of every `Parallel` state one execution ran.
+   *
+   * A branch runs states of its own, so what it did is reported here rather
+   * than among the states the execution around it visited. The branches are in
+   * the order they were started, and each says where among its siblings it
+   * was.
+   */
+  branches(executionArn: string): readonly SimStatesChild[] {
+    return this.#childrenOf(executionArn, "branch");
+  }
+
+  /**
    * Every execution of one state machine, most recently started first.
    */
   executionsOf(stateMachineArn: string): readonly string[] {
     return this.#executions
       .forStateMachine(stateMachineArn)
       .map((execution) => execution.arn);
+  }
+
+  /**
+   * The child runs of one kind that one execution made.
+   */
+  #childrenOf(
+    executionArn: string,
+    kind: SimStatesChild["kind"],
+  ): readonly SimStatesChild[] {
+    return (this.#executions.find(executionArn)?.children ?? []).filter(
+      (child) => child.kind === kind,
+    );
   }
 }

--- a/src/service/stepfunctions/sim-step-functions-parallel-failure.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-parallel-failure.iso.test.ts
@@ -1,0 +1,338 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
+import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "./command/execution/execution.command.js";
+
+describe("Simulated Step Functions Parallel failures", () => {
+  /**
+   * A branch that fails as soon as it is reached.
+   */
+  const declining: JSONObject = {
+    StartAt: "Decline",
+    States: {
+      Decline: {
+        Type: "Fail",
+        Error: "NotEligible",
+        Cause: "no place left on the course",
+      },
+    },
+  };
+
+  /**
+   * A branch that waits, so a sibling can fail while it is still going.
+   */
+  const settling: JSONObject = {
+    StartAt: "Settle",
+    States: {
+      Settle: { Type: "Wait", Seconds: 300, Next: "Enrol" },
+      Enrol: { Type: "Pass", End: true },
+    },
+  };
+
+  /**
+   * The states a caught failure can be sent to.
+   */
+  const compensating: JSONObject = {
+    Compensate: { Type: "Pass", End: true },
+  };
+
+  /**
+   * Run a workflow whose first state is the `Parallel` state under test, and
+   * read back how the execution ended.
+   */
+  async function runWorkflow(
+    simAws: SimAws,
+    state: JSONObject,
+    states: JSONObject = {},
+  ): Promise<{
+    readonly described: SimDescribeExecutionCommandOutput;
+    readonly executionArn: string;
+  }> {
+    const executionArn = await statesExecutionFactory.make(
+      { state, states },
+      simAws,
+    );
+
+    return {
+      described: await simAws
+        .stepFunctions()
+        .describeExecution({ input: { executionArn } }),
+      executionArn,
+    };
+  }
+
+  it("fails the state with States.BranchFailed, naming the branch", async () => {
+    // Given a Parallel state whose second branch fails.
+    const simAws = new SimAws();
+
+    // When it runs.
+    const { described } = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        { StartAt: "Enrol", States: { Enrol: { Type: "Pass", End: true } } },
+        declining,
+      ],
+      End: true,
+    });
+
+    // Then the state failed under the name Amazon States Language gives a
+    // branch failure, and the cause says which branch and what it failed
+    // with.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.BranchFailed");
+    assertIdentical(
+      described.cause,
+      "Branch 2 of the Parallel state Check failed with NotEligible: no " +
+        "place left on the course",
+    );
+  });
+
+  it("abandons the branches still going when one of them fails", async () => {
+    // Given a Parallel state whose first branch is waiting on the clock when
+    // its sibling fails.
+    const simAws = new SimAws();
+    const { described, executionArn } = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [settling, declining],
+      End: true,
+    });
+
+    // When the clock passes what the waiting branch was waiting for.
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then it never went on to the state after the wait, and reads as
+    // abandoned rather than as failed.
+    assertIdentical(described.status, "FAILED");
+    assertObjectEquals(
+      simAws
+        .stepFunctions()
+        .inspection()
+        .branches(executionArn)
+        .map((branch) => ({
+          status: branch.status,
+          visited: branch.visitedStates,
+        })),
+      [
+        { status: "ABANDONED", visited: ["Settle"] },
+        { status: "FAILED", visited: ["Decline"] },
+      ],
+    );
+    assertObjectEquals(
+      simAws
+        .stepFunctions()
+        .inspection()
+        .branches(executionArn)
+        .map((branch) => branch.error),
+      [undefined, "NotEligible"],
+    );
+  });
+
+  it("gives up on a Parallel state inside an abandoned branch", async () => {
+    // Given a branch that fans out again and is waiting on the clock, beside
+    // one that fails.
+    const simAws = new SimAws();
+    const { executionArn } = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        {
+          StartAt: "Split",
+          States: {
+            Split: {
+              Type: "Parallel",
+              Branches: [settling],
+              End: true,
+            },
+          },
+        },
+        declining,
+      ],
+      End: true,
+    });
+
+    // When the clock passes what the nested branch was waiting for.
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then the branch holding it was abandoned, and never went on to the
+    // state after its own Parallel.
+    assertObjectEquals(
+      simAws
+        .stepFunctions()
+        .inspection()
+        .branches(executionArn)
+        .map((branch) => `${branch.stateName} ${branch.status}`),
+      ["Check ABANDONED", "Split ABANDONED", "Check FAILED"],
+    );
+  });
+
+  it("sends a branch failure to a Catch on the Parallel state", async () => {
+    // Given a Parallel state that compensates for a branch failing.
+    const simAws = new SimAws();
+
+    // When a branch fails.
+    const { described, executionArn } = await runWorkflow(
+      simAws,
+      {
+        Type: "Parallel",
+        Branches: [declining],
+        Catch: [
+          {
+            ErrorEquals: ["States.BranchFailed"],
+            Next: "Compensate",
+            ResultPath: "$.error",
+          },
+        ],
+        End: true,
+      },
+      compensating,
+    );
+
+    // Then the execution went on to the compensating state, carrying the
+    // error beside the input the Parallel state was given.
+    assertIdentical(described.status, "SUCCEEDED");
+    assertObjectEquals(JSON.parse(described.output ?? "null") as unknown, {
+      student: "Wei",
+      error: {
+        Error: "States.BranchFailed",
+        Cause:
+          "Branch 1 of the Parallel state Check failed with NotEligible: no " +
+          "place left on the course",
+      },
+    });
+    assertObjectEquals(
+      simAws.stepFunctions().inspection().visitedStates(executionArn),
+      ["Check", "Compensate"],
+    );
+  });
+
+  it("runs the branches again for a Retry on the Parallel state", async () => {
+    // Given a Parallel state whose branch invokes a function that fails once.
+    const simAws = new SimAws();
+    const check = await statesTaskFunctionFactory.make(
+      { handler: statesFlakyHandlerFactory.make({ failures: 1 }) },
+      simAws,
+    );
+    const { executionArn } = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        {
+          StartAt: "Enrol",
+          States: {
+            Enrol: { Type: "Task", Resource: check.arn, End: true },
+          },
+        },
+      ],
+      Retry: [
+        {
+          ErrorEquals: ["States.BranchFailed"],
+          IntervalSeconds: 5,
+          MaxAttempts: 1,
+        },
+      ],
+      End: true,
+    });
+
+    // When the clock passes the wait before the retry.
+    await simAws.clock().advanceBy({ seconds: 10 });
+
+    // Then the branches ran a second time, and the second run came good.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(described.output, '[{"eligible":true}]');
+    assertObjectEquals(
+      simAws
+        .stepFunctions()
+        .inspection()
+        .branches(executionArn)
+        .map((branch) => branch.status),
+      ["FAILED", "SUCCEEDED"],
+    );
+
+    // The states inside the branches are counted among the execution's
+    // attempts, so the task inside them shows both of its runs.
+    assertObjectEquals(
+      simAws
+        .stepFunctions()
+        .inspection()
+        .attempts(executionArn)
+        .map((attempt) => attempt.stateName),
+      ["Enrol", "Check", "Enrol", "Check"],
+    );
+  });
+
+  it("leaves a branch that failed on its data as States.Runtime", async () => {
+    // Given a Parallel state that catches anything, and a branch whose Choice
+    // rule reads a field that is not there.
+    const simAws = new SimAws();
+
+    // When it runs.
+    const { described } = await runWorkflow(
+      simAws,
+      {
+        Type: "Parallel",
+        Branches: [
+          {
+            StartAt: "Eligible",
+            States: {
+              Eligible: {
+                Type: "Choice",
+                Choices: [
+                  { Variable: "$.term", NumericEquals: 3, Next: "Enrol" },
+                ],
+                Default: "Enrol",
+              },
+              Enrol: { Type: "Pass", End: true },
+            },
+          },
+        ],
+        Catch: [{ ErrorEquals: ["States.ALL"], Next: "Compensate" }],
+        End: true,
+      },
+      compensating,
+    );
+
+    // Then the failure kept the name nothing catches, and the catcher did not
+    // take it.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.Runtime");
+  });
+
+  it("reports a branch that failed without saying why", async () => {
+    // Given a branch reaching a Fail state that carries no Cause.
+    const simAws = new SimAws();
+
+    // When it runs.
+    const { described, executionArn } = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        {
+          StartAt: "Decline",
+          States: { Decline: { Type: "Fail", Error: "NotEligible" } },
+        },
+      ],
+      End: true,
+    });
+
+    // Then the cause says which branch failed and what it failed with, and
+    // nothing more.
+    assertIdentical(
+      described.cause,
+      "Branch 1 of the Parallel state Check failed with NotEligible",
+    );
+    assertArrayLength(
+      simAws.stepFunctions().inspection().branches(executionArn),
+      1,
+    );
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-parallel.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-parallel.iso.test.ts
@@ -1,0 +1,343 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+
+describe("Simulated Step Functions Parallel", () => {
+  /**
+   * A branch of one `Pass` state, which answers with what it is given.
+   */
+  function echoing(name: string): JSONObject {
+    return { StartAt: name, States: { [name]: { Type: "Pass", End: true } } };
+  }
+
+  /**
+   * A branch of one `Pass` state answering with a result of its own.
+   */
+  function answering(name: string, result: JSONObject): JSONObject {
+    return {
+      StartAt: name,
+      States: { [name]: { Type: "Pass", Result: result, End: true } },
+    };
+  }
+
+  /**
+   * Run a workflow whose first state is the `Parallel` state under test.
+   */
+  async function runWorkflow(
+    simAws: SimAws,
+    state: JSONObject,
+    states: JSONObject = {},
+    input = '{"student":"Wei"}',
+  ): Promise<string> {
+    return await statesExecutionFactory.make({ state, states, input }, simAws);
+  }
+
+  /**
+   * What the execution ended as, as the JSON it answered with.
+   */
+  async function outputOf(
+    simAws: SimAws,
+    executionArn: string,
+  ): Promise<unknown> {
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+
+    return JSON.parse(described.output ?? "null") as unknown;
+  }
+
+  it("answers with one output per branch, in the order they were written", async () => {
+    // Given a Parallel state whose first branch waits and whose second does
+    // not, so the two finish in the other order.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        {
+          StartAt: "Settle",
+          States: {
+            Settle: { Type: "Wait", Seconds: 60, Next: "Enrol" },
+            Enrol: { Type: "Pass", Result: { branch: "enrolled" }, End: true },
+          },
+        },
+        answering("Bill", { branch: "billed" }),
+      ],
+      End: true,
+    });
+
+    // When the clock passes what the slow branch is waiting for.
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then the result is an array in branch order rather than in the order
+    // the branches finished.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { branch: "enrolled" },
+      { branch: "billed" },
+    ]);
+  });
+
+  it("holds the execution while a branch is waiting on the clock", async () => {
+    // Given a Parallel state with a branch that waits.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(
+      simAws,
+      {
+        Type: "Parallel",
+        Branches: [
+          {
+            StartAt: "Settle",
+            States: {
+              Settle: { Type: "Wait", Seconds: 300, Next: "Enrol" },
+              Enrol: { Type: "Pass", End: true },
+            },
+          },
+          echoing("Bill"),
+        ],
+        Next: "Confirm",
+      },
+      { Confirm: { Type: "Succeed" } },
+    );
+
+    // When the execution is read back before the clock has moved.
+    const waiting = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then it is still running, and the state after the Parallel has not been
+    // reached.
+    assertIdentical(waiting.status, "RUNNING");
+    assertObjectEquals(
+      simAws.stepFunctions().inspection().visitedStates(executionArn),
+      ["Check"],
+    );
+  });
+
+  it("waits for the last of several branches on the clock", async () => {
+    // Given two branches waiting for different instants.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        {
+          StartAt: "Settle",
+          States: {
+            Settle: { Type: "Wait", Seconds: 60, Next: "Enrol" },
+            Enrol: { Type: "Pass", Result: { branch: "enrolled" }, End: true },
+          },
+        },
+        {
+          StartAt: "Invoice",
+          States: {
+            Invoice: { Type: "Wait", Seconds: 120, Next: "Bill" },
+            Bill: { Type: "Pass", Result: { branch: "billed" }, End: true },
+          },
+        },
+      ],
+      End: true,
+    });
+
+    // When the clock passes the first wait but not the second.
+    await simAws.clock().advanceBy({ seconds: 90 });
+
+    const waiting = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the state is still going, and finishes once the second is up.
+    assertIdentical(waiting.status, "RUNNING");
+
+    await simAws.clock().advanceBy({ seconds: 60 });
+
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { branch: "enrolled" },
+      { branch: "billed" },
+    ]);
+  });
+
+  it("fails the state where the branch outputs have nowhere to go", async () => {
+    // Given a ResultPath writing into a field that holds a string, on a state
+    // whose branch finishes on the clock rather than straight away.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        {
+          StartAt: "Settle",
+          States: {
+            Settle: { Type: "Wait", Seconds: 60, Next: "Enrol" },
+            Enrol: { Type: "Pass", End: true },
+          },
+        },
+      ],
+      ResultPath: "$.student.outcomes",
+      End: true,
+    });
+
+    // When the clock releases the branch.
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then the state failed rather than the clock advance raising.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.ResultPathMatchFailure");
+  });
+
+  it("gives every branch the same effective input", async () => {
+    // Given a Parallel state whose Parameters build what the branches read.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(
+      simAws,
+      {
+        Type: "Parallel",
+        InputPath: "$.enrolment",
+        Parameters: { "student.$": "$.student", term: 3 },
+        Branches: [echoing("Enrol"), echoing("Bill")],
+        End: true,
+      },
+      {},
+      '{"enrolment":{"student":"Wei"}}',
+    );
+
+    // When it runs, both branches were given what the state's own input and
+    // parameter fields produced, once rather than per branch.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { student: "Wei", term: 3 },
+      { student: "Wei", term: 3 },
+    ]);
+  }, 10_000);
+
+  it("shapes the array of branch outputs with the data-flow fields", async () => {
+    // Given a Parallel state that keeps its result beside its own input.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        answering("Enrol", { enrolled: true }),
+        answering("Bill", { billed: true }),
+      ],
+      ResultPath: "$.outcomes",
+      End: true,
+    });
+
+    // When it runs, ResultPath wrote the whole array into the input.
+    assertObjectEquals(await outputOf(simAws, executionArn), {
+      student: "Wei",
+      outcomes: [{ enrolled: true }, { billed: true }],
+    });
+  });
+
+  it("reports what each branch did apart from the states around it", async () => {
+    // Given a Parallel state whose branches visit states of their own.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(
+      simAws,
+      {
+        Type: "Parallel",
+        Branches: [
+          {
+            StartAt: "Enrol",
+            States: {
+              Enrol: { Type: "Pass", Next: "Register" },
+              Register: { Type: "Pass", End: true },
+            },
+          },
+          echoing("Bill"),
+        ],
+        Next: "Confirm",
+      },
+      { Confirm: { Type: "Succeed" } },
+    );
+
+    // When the inspection accessor is read.
+    const inspection = simAws.stepFunctions().inspection();
+    const branches = inspection.branches(executionArn);
+
+    // Then the execution visited the states around the Parallel state, and
+    // each branch reports its own.
+    assertObjectEquals(inspection.visitedStates(executionArn), [
+      "Check",
+      "Confirm",
+    ]);
+    assertArrayLength(branches, 2);
+    assertObjectEquals(
+      branches.map((branch) => branch.visitedStates),
+      [["Enrol", "Register"], ["Bill"]],
+    );
+    assertObjectEquals(
+      branches.map((branch) => ({
+        index: branch.index,
+        kind: branch.kind,
+        stateName: branch.stateName,
+        status: branch.status,
+      })),
+      [
+        {
+          index: 0,
+          kind: "branch",
+          stateName: "Check",
+          status: "SUCCEEDED",
+        },
+        {
+          index: 1,
+          kind: "branch",
+          stateName: "Check",
+          status: "SUCCEEDED",
+        },
+      ],
+    );
+  });
+
+  it("runs a Parallel state inside a branch, and reports both", async () => {
+    // Given a branch that fans out again.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Parallel",
+      Branches: [
+        {
+          StartAt: "Split",
+          States: {
+            Split: {
+              Type: "Parallel",
+              Branches: [
+                answering("Enrol", { enrolled: true }),
+                answering("Bill", { billed: true }),
+              ],
+              End: true,
+            },
+          },
+        },
+      ],
+      End: true,
+    });
+
+    // When it runs, the nested branches are reported on the execution
+    // alongside the one holding them.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      [{ enrolled: true }, { billed: true }],
+    ]);
+    assertObjectEquals(
+      simAws
+        .stepFunctions()
+        .inspection()
+        .branches(executionArn)
+        .map((branch) => ({ state: branch.stateName, index: branch.index })),
+      [
+        { state: "Check", index: 0 },
+        { state: "Split", index: 0 },
+        { state: "Split", index: 1 },
+      ],
+    );
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-retry-matching.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-retry-matching.iso.test.ts
@@ -6,7 +6,7 @@ import {
 import { describe, it } from "vitest";
 
 import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
-import { statesTaskExecutionFactory } from "../../../test/stepfunctions/states-task-execution.factory.js";
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
 import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
 import { SimFixedClock } from "../../util/clock/sim-clock.js";
 import type { JSONObject } from "../../util/type-guard/json.js";
@@ -57,9 +57,9 @@ describe("Which retrier takes a failing task", () => {
   it("fails the execution once a retrier runs out of attempts", async () => {
     // Given a function that never comes good, retried twice.
     const simAws = await givenAFlakyFunction(10);
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: invokeCheck([
+        state: invokeCheck([
           {
             ErrorEquals: ["States.TaskFailed"],
             IntervalSeconds: 2,
@@ -91,9 +91,9 @@ describe("Which retrier takes a failing task", () => {
     // Given a retrier that names a throttled write, and a task that failed
     // for another reason.
     const simAws = await givenAFlakyFunction(10);
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: invokeCheck([
+        state: invokeCheck([
           { ErrorEquals: ["ThrottlingException"], IntervalSeconds: 2 },
         ]),
       },
@@ -115,9 +115,9 @@ describe("Which retrier takes a failing task", () => {
   it("takes the first retrier that names the error", async () => {
     // Given a retrier that does not match ahead of one that does.
     const simAws = await givenAFlakyFunction(1);
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: invokeCheck([
+        state: invokeCheck([
           { ErrorEquals: ["ThrottlingException"], IntervalSeconds: 300 },
           { ErrorEquals: ["States.ALL"], IntervalSeconds: 2 },
         ]),
@@ -160,9 +160,9 @@ describe("Which retrier takes a failing task", () => {
       },
       simAws,
     );
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: {
+        state: {
           Type: "Task",
           Resource: check.arn,
           Retry: [

--- a/src/service/stepfunctions/sim-step-functions-retry.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-retry.iso.test.ts
@@ -6,7 +6,7 @@ import {
 import { describe, it } from "vitest";
 
 import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
-import { statesTaskExecutionFactory } from "../../../test/stepfunctions/states-task-execution.factory.js";
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
 import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
 import { SimFixedClock } from "../../util/clock/sim-clock.js";
 import type { JSONObject } from "../../util/type-guard/json.js";
@@ -46,9 +46,9 @@ describe("Simulated Step Functions Retry on the clock", () => {
   it("runs a task again until it answers, and records every attempt", async () => {
     // Given a function that raises twice and then answers.
     const simAws = await givenAFlakyFunction(2);
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: invokeCheck([
+        state: invokeCheck([
           { ErrorEquals: ["States.TaskFailed"], IntervalSeconds: 2 },
         ]),
       },
@@ -83,8 +83,8 @@ describe("Simulated Step Functions Retry on the clock", () => {
     // Given a retrier written as Amazon States Language allows the shortest
     // one to be, which waits a second and doubles from there.
     const simAws = await givenAFlakyFunction(2);
-    const executionArn = await statesTaskExecutionFactory.make(
-      { task: invokeCheck([{ ErrorEquals: ["States.TaskFailed"] }]) },
+    const executionArn = await statesExecutionFactory.make(
+      { state: invokeCheck([{ ErrorEquals: ["States.TaskFailed"] }]) },
       simAws,
     );
 
@@ -107,9 +107,9 @@ describe("Simulated Step Functions Retry on the clock", () => {
   it("leaves the execution RUNNING between one attempt and the next", async () => {
     // Given a workflow whose second retry falls six seconds in.
     const simAws = await givenAFlakyFunction(2);
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: invokeCheck([
+        state: invokeCheck([
           { ErrorEquals: ["States.TaskFailed"], IntervalSeconds: 2 },
         ]),
       },
@@ -148,9 +148,9 @@ describe("Simulated Step Functions Retry on the clock", () => {
   it("caps the wait between attempts at MaxDelaySeconds", async () => {
     // Given a retrier whose backoff would reach a hundred seconds untouched.
     const simAws = await givenAFlakyFunction(2);
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: invokeCheck([
+        state: invokeCheck([
           {
             ErrorEquals: ["States.ALL"],
             IntervalSeconds: 10,

--- a/src/service/stepfunctions/sim-step-functions-task-timeout.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-task-timeout.iso.test.ts
@@ -6,7 +6,7 @@ import {
 import { describe, it } from "vitest";
 
 import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
-import { statesTaskExecutionFactory } from "../../../test/stepfunctions/states-task-execution.factory.js";
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
 import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
 import { SimFixedClock } from "../../util/clock/sim-clock.js";
 import type { JSONObject } from "../../util/type-guard/json.js";
@@ -39,13 +39,10 @@ describe("How long a Task state waits", () => {
    */
   async function runPastTheDeadline(
     failures: number,
-    task: JSONObject,
+    state: JSONObject,
   ): Promise<SimDescribeExecutionCommandOutput> {
     const simAws = await givenAFlakyFunction(failures);
-    const executionArn = await statesTaskExecutionFactory.make(
-      { task },
-      simAws,
-    );
+    const executionArn = await statesExecutionFactory.make({ state }, simAws);
 
     await simAws.clock().advanceBy({ minutes: 5 });
 
@@ -114,9 +111,9 @@ describe("How long a Task state waits", () => {
   it("sends a timed out task to its Catch", async () => {
     // Given a task that compensates for running long.
     const simAws = await givenAFlakyFunction(10);
-    const executionArn = await statesTaskExecutionFactory.make(
+    const executionArn = await statesExecutionFactory.make(
       {
-        task: {
+        state: {
           ...invokeCheck({ TimeoutSeconds: 15 }),
           Catch: [
             {

--- a/test/stepfunctions/states-execution.factory.ts
+++ b/test/stepfunctions/states-execution.factory.ts
@@ -6,17 +6,18 @@ import { statesExecutionRoleFactory } from "./states-execution-role.factory.js";
 import { statesMachineFactory } from "./states-machine.factory.js";
 
 /**
- * What a `Task` state test asks for when it wants an execution of a workflow
- * built around one task.
+ * What a test asks for when it wants an execution of a workflow built around
+ * one state.
  */
-export interface StatesTaskExecutionInput {
+export interface StatesExecutionInput {
   /**
-   * The task, which the execution starts at under the name `Check`.
+   * The state under test, which the execution starts at under the name
+   * `Check`.
    */
-  readonly task: JSONObject;
+  readonly state: JSONObject;
 
   /**
-   * The states the task can move on to, written as Amazon States Language.
+   * The states that one can move on to, written as Amazon States Language.
    */
   readonly states: JSONObject;
 
@@ -27,26 +28,26 @@ export interface StatesTaskExecutionInput {
 }
 
 /**
- * Creates a state machine of one task, starts an execution of it, and answers
- * with the execution ARN.
+ * Creates a state machine built around one state, starts an execution of it,
+ * and answers with the execution ARN.
  *
  * ```typescript
- * const executionArn = await statesTaskExecutionFactory.make(
- *   { task: { Type: "Task", Resource: check.arn, End: true } },
+ * const executionArn = await statesExecutionFactory.make(
+ *   { state: { Type: "Task", Resource: check.arn, End: true } },
  *   simAws,
  * );
  * ```
  *
  * The execution role is one that may invoke anything, since a test about what
- * a task does when it fails is not a test about what its role is allowed.
+ * a state does when it fails is not a test about what its role is allowed.
  */
-export const statesTaskExecutionFactory = new AsyncMappedFactory<
-  StatesTaskExecutionInput,
+export const statesExecutionFactory = new AsyncMappedFactory<
+  StatesExecutionInput,
   string,
   SimAws
 >(
   () => ({
-    task: { Type: "Succeed" },
+    state: { Type: "Succeed" },
     states: {},
     input: '{"student":"Wei"}',
   }),
@@ -55,7 +56,7 @@ export const statesTaskExecutionFactory = new AsyncMappedFactory<
       {
         roleArn: await statesExecutionRoleFactory.make({}, simAws),
         startAt: "Check",
-        states: { Check: input.task, ...input.states },
+        states: { Check: input.state, ...input.states },
       },
       simAws,
     );


### PR DESCRIPTION
A `Parallel` state runs each of its `Branches` from that branch's own
`StartAt` and answers with an array of branch outputs in branch order. Every
branch is given the state's effective input and walks its own states on the
simulation's clock, so a branch holding a `Wait` leaves its siblings running
and the execution reads as `RUNNING` until the last of them finishes. A
failing branch fails the state with `States.BranchFailed`, naming the branch
in the cause, and the branches still going are abandoned along with any
branches they were running themselves. `Retry` and `Catch` on the `Parallel`
state work the way they do on a `Task`, and the inspection accessor gained
`branches`, which reports what each branch visited apart from the states
around it.

The split is `Parallel` here and `Map` after it. Two states, the concurrency
bound, the context object and the error handling for all of it came to more
than one pull request's worth, and the fan-out a `Map` iteration runs on is
what this builds. `Map` with `ItemsPath`, `ItemSelector` and `MaxConcurrency`,
and the `$$` context object it reads, follow in a second pull request. It
comes to 2,468 lines added, of which 866 are tests and 212 are documentation.

The interpreter now walks a record rather than an execution, since a branch is
walked the way the execution around it is. A branch that suspends leaves the
walk holding a pending outcome and carries on through the `resume` it was
given, which is the seam a `Map` iteration will use as well.

Part of https://github.com/KensioSoftware/yulin/issues/921. `Map` is
outstanding, along with the `$$` context object and the `MaxConcurrency`
bound, so the issue stays open until the second pull request lands.