### PR TITLE
feat: run a Map state over its items

### DIFF
--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -8,8 +8,8 @@ Types for simulated Step Functions are imported from the `@kensio/yulin/stepfunc
 
 ## What runs today
 
-Seven state types run. `Pass`, `Task`, `Succeed`, `Fail`, `Choice`, `Wait` and `Parallel`. A
-definition using `Map` is refused when the state machine is created, naming the state and its type.
+Every state type Amazon States Language defines runs. `Pass`, `Task`, `Succeed`, `Fail`, `Choice`,
+`Wait`, `Parallel` and `Map`.
 
 The data-flow fields run in full. `InputPath`, `Parameters`, `ResultSelector`, `ResultPath` and
 `OutputPath` apply in that order, reading Reference Paths and the intrinsic functions.
@@ -19,8 +19,11 @@ service, or starts another state machine. A `Resource` this simulator has no ans
 when the state machine is created, naming what the definition asked for.
 
 A `Task` state's `Retry` and `Catch` both run, on the simulation's clock, along with the
-`TimeoutSeconds` and `HeartbeatSeconds` it takes. A `Parallel` state takes the same `Retry` and
-`Catch`.
+`TimeoutSeconds` and `HeartbeatSeconds` it takes. A `Parallel` state and a `Map` state take the same
+`Retry` and `Catch`.
+
+The context object runs, so `$$.Execution`, `$$.StateMachine`, `$$.State` and `$$.Map` are all
+readable.
 
 ## Running a state machine
 
@@ -929,6 +932,98 @@ reads as `ABANDONED`. A `Parallel` state inside a branch reports its own branche
 deep they go. `visitedStates` on the execution holds the states outside the branches, while
 `attempts` covers every run of every state, branches included.
 
+## Running a state per item
+
+A `Map` state runs its `ItemProcessor` once per item, and answers with an array of what the
+iterations produced. The array is in the order the items were in, whatever order the iterations
+finished in.
+
+```typescript sim-step-functions-map
+/**
+ * Running a state per item with a Map state.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Enrol",
+      States: {
+        Enrol: {
+          Type: "Map",
+          ItemsPath: "$.students",
+          MaxConcurrency: 2,
+          ItemSelector: {
+            "id.$": "$$.Map.Item.Value.id",
+            "at.$": "$$.Map.Item.Index",
+            "term.$": "$.term",
+          },
+          ItemProcessor: {
+            StartAt: "Register",
+            States: { Register: { Type: "Pass", End: true } },
+          },
+          End: true,
+        },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({
+      term: 3,
+      students: [{ id: "wei" }, { id: "mei" }],
+    }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.output);
+// [{"id":"wei","at":0,"term":3},{"id":"mei","at":1,"term":3}]
+
+console.log(
+  simAws.stepFunctions().inspection().iterations(started.executionArn).length,
+); // 2
+```
+
+`ItemsPath` says where the items are, and a `Map` state carrying none runs over its whole effective
+input. What it selects has to be an array. Anything else fails the state with `States.Runtime`,
+which is the failure real Step Functions gives it, and no `Catch` takes that one.
+
+`ItemSelector` builds what each iteration is given. It reads the `Map` state's own input through `$`
+and the item it is building for through `$$.Map.Item`, which holds `Value` and `Index`. The states
+inside the iteration read `$$.Map.Item` as well. A `Map` state carrying no `ItemSelector` gives each
+iteration the item itself.
+
+`MaxConcurrency` bounds how many iterations run at once. A bound of 0, and a `Map` state carrying no
+bound at all, runs every iteration together. An iteration reaching a `Wait` state is still one of
+the iterations running, so a bound of 1 holds the next item back until the wait is over.
+
+`Parameters` and `Iterator` are the older spellings of `ItemSelector` and `ItemProcessor`, and both
+are read. CDK still writes them for a `Map` built with its deprecated `parameters` property or its
+`iterator()` call. A state carrying both spellings of either is refused.
+
+An iteration that fails fails the `Map` state, the way a branch failing fails a `Parallel` state.
+The state fails with `States.BranchFailed`, the iterations still going are abandoned, and the items
+that had not started are left alone. `Retry` and `Catch` on the `Map` state work as they do on a
+`Task` state, and a retry runs every iteration again.
+
+Reading the iterations back is the same accessor the branches use:
+
+```typescript
+const iterations = simAws.stepFunctions().inspection().iterations(executionArn);
+```
+
 ## Through an intercepted SDK client
 
 An `SFNClient` handed to `SimSdk` reaches the same simulated service:
@@ -1110,8 +1205,42 @@ raise. A path that would have selected the wrong node fails, and no state is ans
 data. A dotted field name is held to the JsonPath `member-name-shorthand` rule. `$.a-b` is refused,
 and `$['a-b']` is the way to write it.
 
-`$$`, the context object, is unsimulated. A path reading it fails the state with
-`States.QueryEvaluationError`, saying that only paths rooted at `$` are read.
+A path rooted at `$$` reads the context object rather than the state's data. See below.
+
+## The context object
+
+`$$` reads what the execution knows about itself. It is read in `InputPath`, `OutputPath`,
+`ItemsPath`, the Payload Template fields (`Parameters`, `ResultSelector` and `ItemSelector`) and an
+intrinsic function's arguments.
+
+```json
+{
+  "Execution": {
+    "Id": "arn:aws:states:eu-west-2:123456789012:execution:Enrolment:execution-1",
+    "Input": { "student": "Wei" },
+    "Name": "execution-1",
+    "RoleArn": "arn:aws:iam::123456789012:role/WorkflowRole",
+    "StartTime": "2026-07-26T09:00:00.000Z"
+  },
+  "StateMachine": {
+    "Id": "arn:aws:states:eu-west-2:123456789012:stateMachine:Enrolment",
+    "Name": "Enrolment"
+  },
+  "State": {
+    "EnteredTime": "2026-07-26T09:00:00.000Z",
+    "Name": "Check",
+    "RetryCount": 0
+  },
+  "Map": { "Item": { "Index": 0, "Value": { "id": "wei" } } }
+}
+```
+
+`State` is the state now running, and `RetryCount` counts the retries this entry to it has taken.
+`Map` is there inside a `Map` state's `ItemSelector` and inside the iteration it built.
+
+`$$.Task.Token` is unsimulated, along with the task tokens it belongs to. A path reading it selects
+nothing and fails the state that read it. A field that writes, such as `ResultPath`, takes a path
+rooted at `$`, since the context object is read rather than written.
 
 ## Intrinsic functions
 
@@ -1167,7 +1296,15 @@ A test asserting on the output of a state machine that used one could only asser
   nothing catches, and a state around a branch is no more able to carry on than the branch was.
 - **A branch's own states are reported apart from the execution's.** Real Step Functions writes
   them into one execution history, under events naming the branch. The inspection accessor answers
-  `branches` instead, since a test asserting on a branch is asking about that branch.
+  `branches` and `iterations` instead, since a test asserting on a branch is asking about that
+  branch.
+- **A Distributed Map is refused.** `ItemReader`, `ResultWriter`, `ItemBatcher`, the two
+  `ToleratedFailure` fields and a `ProcessorConfig` asking for `DISTRIBUTED` are all refused when
+  the state machine is created. A Distributed Map reads its items from S3 and runs a child
+  execution per batch, which is a second execution model rather than a field or two on this one.
+- **A `Map` state's iterations that had not started are left alone when one fails.** The ones
+  running are abandoned, and `inspection().iterations()` reports only the iterations that ran. Real
+  Step Functions stops the same work, and its execution history says as much.
 
 - **A state machine is the only resource that holds tags.** An activity and an execution both take
   tags on real Step Functions, and both are unsimulated here. A tag request naming one is refused
@@ -1190,7 +1327,6 @@ two and is what this follows.
 
 ## Still to come
 
-- `Map` states, with `ItemsPath`, `ItemSelector` and `MaxConcurrency`.
+- Distributed Map, with `ItemReader`, `ResultWriter` and the `ToleratedFailure` fields.
 - The `.sync` pattern, task tokens and activities.
-- The context object, `$$`.
 - JSONata as a query language, and the `Assign` variables that go with it.

--- a/docs/services/stepfunctions/sim-step-functions-map.example.ts
+++ b/docs/services/stepfunctions/sim-step-functions-map.example.ts
@@ -1,0 +1,55 @@
+/**
+ * Running a state per item with a Map state.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const created = await simAws.stepFunctions().createStateMachine({
+  input: {
+    name: "Enrolment",
+    roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
+    definition: JSON.stringify({
+      StartAt: "Enrol",
+      States: {
+        Enrol: {
+          Type: "Map",
+          ItemsPath: "$.students",
+          MaxConcurrency: 2,
+          ItemSelector: {
+            "id.$": "$$.Map.Item.Value.id",
+            "at.$": "$$.Map.Item.Index",
+            "term.$": "$.term",
+          },
+          ItemProcessor: {
+            StartAt: "Register",
+            States: { Register: { Type: "Pass", End: true } },
+          },
+          End: true,
+        },
+      },
+    }),
+  },
+});
+
+const started = await simAws.stepFunctions().startExecution({
+  input: {
+    stateMachineArn: created.stateMachineArn,
+    input: JSON.stringify({
+      term: 3,
+      students: [{ id: "wei" }, { id: "mei" }],
+    }),
+  },
+});
+
+const described = await simAws
+  .stepFunctions()
+  .describeExecution({ input: { executionArn: started.executionArn } });
+
+console.log(described.output);
+// [{"id":"wei","at":0,"term":3},{"id":"mei","at":1,"term":3}]
+
+console.log(
+  simAws.stepFunctions().inspection().iterations(started.executionArn).length,
+); // 2

--- a/src/service/stepfunctions/cfn/sim-cfn-state-machine-refusals.iso.test.ts
+++ b/src/service/stepfunctions/cfn/sim-cfn-state-machine-refusals.iso.test.ts
@@ -10,10 +10,6 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
-import {
-  simStatesRunnableTypes,
-  simStatesStateTypes,
-} from "../definition/sim-states-state.js";
 import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
@@ -76,34 +72,27 @@ describe("What a deployed AWS::StepFunctions::StateMachine refuses", () => {
     return { simAws, stack };
   }
 
-  /**
-   * A state type Amazon States Language defines and this simulator has no
-   * implementation for.
-   *
-   * Read from Step Functions' own two lists rather than named here. The
-   * interpreter keeps taking state types on, and a test naming one starts
-   * failing the day that one lands.
-   */
-  function unrunStateType(): string {
-    const type = simStatesStateTypes.find(
-      (candidate) => !simStatesRunnableTypes.includes(candidate as never),
-    );
-    assertNonNullable(type);
-
-    return type;
-  }
-
-  it("drops a state machine using a state the interpreter does not run", async () => {
-    // Given a workflow holding a state type this simulator has no
-    // implementation for yet.
-    const stateType = unrunStateType();
+  it("drops a state machine using something the interpreter does not run", async () => {
+    // Given a workflow holding a Distributed Map, which this simulator has no
+    // implementation for.
     const body = workflowTemplate({
       StateMachineName: "Enrolment",
       RoleArn: roleArn,
       DefinitionString: JSON.stringify({
         StartAt: "Step",
         States: {
-          Step: { Type: stateType, Next: "Done" },
+          Step: {
+            Type: "Map",
+            ItemReader: {
+              Resource: "arn:aws:states:::s3:getObject",
+              Parameters: { Bucket: "enrolments", Key: "students.json" },
+            },
+            ItemProcessor: {
+              StartAt: "Enrol",
+              States: { Enrol: { Type: "Pass", End: true } },
+            },
+            Next: "Done",
+          },
           Done: { Type: "Succeed" },
         },
       }),
@@ -121,10 +110,7 @@ describe("What a deployed AWS::StepFunctions::StateMachine refuses", () => {
     assertNonNullable(skipped);
     assertTrue(skipped.skipped);
     assertIdentical(skipped.logicalId, "Workflow");
-    assertStringIncludes(
-      skipped.skippedReason ?? "",
-      `is a ${stateType} state`,
-    );
+    assertStringIncludes(skipped.skippedReason ?? "", "carries ItemReader");
     assertIdentical(
       stack.getResource("OrdersQueue")?.status,
       "CREATE_COMPLETE",

--- a/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
+++ b/src/service/stepfunctions/command/execution/sim-states-execution-start.ts
@@ -1,8 +1,8 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { simStatesContextObject } from "../../data/sim-states-context-object.js";
 import { SimStatesExecution } from "../../execution/sim-states-execution.js";
 import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
-import { SimStatesInterpreter } from "../../execution/sim-states-interpreter.js";
 import { simStatesWalks } from "../../execution/sim-states-walks.js";
 import { simStatesExecutionArn } from "../../machine/sim-state-machine-arn.js";
 import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
@@ -94,17 +94,22 @@ export class SimStatesExecutionStart {
 
     this.#executions.add(execution);
 
-    const walks = {
+    await simStatesWalks({
       background: this.#background,
       tasks: this.#tasks,
       roleArn: stateMachine.roleArn,
-    };
-
-    await new SimStatesInterpreter({
-      ...walks,
+    })({
       definition: stateMachine.parsedDefinition,
       record: execution,
-      walkChild: simStatesWalks(walks),
+      contextObject: simStatesContextObject({
+        executionArn: execution.arn,
+        executionName: execution.name,
+        input: execution.input,
+        startDate,
+        stateMachineArn: stateMachine.arn,
+        stateMachineName: stateMachine.name,
+        roleArn: stateMachine.roleArn,
+      }),
     }).run();
 
     return { executionArn: execution.arn, startDate };

--- a/src/service/stepfunctions/data/sim-states-context-object.ts
+++ b/src/service/stepfunctions/data/sim-states-context-object.ts
@@ -1,0 +1,86 @@
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
+
+/**
+ * What the context object says about the execution and its state machine.
+ *
+ * These are the same for every state one execution runs, the states inside a
+ * `Parallel` branch and a `Map` iteration included, so they are built once
+ * when the execution starts.
+ */
+export interface SimStatesExecutionContext {
+  readonly executionArn: string;
+  readonly executionName: string;
+  readonly input: JSONValue;
+  readonly startDate: Date;
+  readonly stateMachineArn: string;
+  readonly stateMachineName: string;
+  readonly roleArn: string;
+}
+
+/**
+ * What one state adds to the context object while it runs.
+ */
+export interface SimStatesStateContextEntry {
+  readonly name: string;
+  readonly enteredTime: Date;
+  readonly retryCount: number;
+}
+
+/**
+ * The context object an execution's states read through `$$`.
+ *
+ * Real Step Functions also carries `$$.Task.Token`, which belongs with the
+ * task tokens this simulator has no implementation for. A path reading one
+ * selects nothing and fails the state that read it.
+ */
+export function simStatesContextObject(
+  execution: SimStatesExecutionContext,
+): JSONObject {
+  return {
+    Execution: {
+      Id: execution.executionArn,
+      Input: execution.input,
+      Name: execution.executionName,
+      RoleArn: execution.roleArn,
+      StartTime: execution.startDate.toISOString(),
+    },
+    StateMachine: {
+      Id: execution.stateMachineArn,
+      Name: execution.stateMachineName,
+    },
+  };
+}
+
+/**
+ * The same context object with what the state now running adds to it.
+ */
+export function simStatesStateContext(
+  contextObject: JSONObject,
+  state: SimStatesStateContextEntry,
+): JSONObject {
+  return {
+    ...contextObject,
+    State: {
+      EnteredTime: state.enteredTime.toISOString(),
+      Name: state.name,
+      RetryCount: state.retryCount,
+    },
+  };
+}
+
+/**
+ * The same context object with the item one `Map` iteration is running for.
+ *
+ * `ItemSelector` reads this while the `Map` state builds the iteration's
+ * input, and so do the states inside the iteration once it starts.
+ */
+export function simStatesMapItemContext(
+  contextObject: JSONObject,
+  index: number,
+  value: JSONValue,
+): JSONObject {
+  return {
+    ...contextObject,
+    Map: { Item: { Index: index, Value: value } },
+  };
+}

--- a/src/service/stepfunctions/data/sim-states-context-path.ts
+++ b/src/service/stepfunctions/data/sim-states-context-path.ts
@@ -1,0 +1,55 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import {
+  type SimStatesPathSegment,
+  selectSimStatesPath,
+} from "./sim-states-path-segment.js";
+import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
+
+/**
+ * A path as it was written, and which document it reads.
+ */
+export interface SimStatesReadPath {
+  readonly segments: readonly SimStatesPathSegment[];
+  readonly fromContext: boolean;
+}
+
+/**
+ * What a path rooted at the context object starts with.
+ */
+const contextRoot = "$$";
+
+/**
+ * Read a path that is allowed to read the context object.
+ *
+ * Amazon States Language roots a path at `$` for the value the state is
+ * working on and at `$$` for the context object. Both are read the same way
+ * once the root has said which of the two to read.
+ */
+export function parseSimStatesReadPath(path: string): SimStatesReadPath {
+  if (path.startsWith(contextRoot)) {
+    return {
+      fromContext: true,
+      segments: parseSimStatesReferencePath(
+        `$${path.slice(contextRoot.length)}`,
+      ),
+    };
+  }
+
+  return { fromContext: false, segments: parseSimStatesReferencePath(path) };
+}
+
+/**
+ * The value a path selects, from the state's data or from the context object.
+ */
+export function selectSimStatesReadPath(
+  path: string,
+  document: JSONValue,
+  context: JSONValue,
+): JSONValue | undefined {
+  const read = parseSimStatesReadPath(path);
+
+  return selectSimStatesPath(
+    read.fromContext ? context : document,
+    read.segments,
+  );
+}

--- a/src/service/stepfunctions/data/sim-states-data-flow.ts
+++ b/src/service/stepfunctions/data/sim-states-data-flow.ts
@@ -1,7 +1,7 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import { SimStatesPathMatchFailure } from "../error/sim-step-functions.error.js";
+import { selectSimStatesReadPath } from "./sim-states-context-path.js";
 import { evaluateSimStatesPayloadTemplate } from "./sim-states-payload-template.js";
-import { selectSimStatesPath } from "./sim-states-path-segment.js";
 import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
 import { insertAtSimStatesPath } from "./sim-states-result-path.js";
 
@@ -25,16 +25,18 @@ export interface SimStatesDataFlowFields {
  *
  * `InputPath` narrows the raw input and `Parameters` then builds a value from
  * what is left, which is the order Amazon States Language applies them in.
+ * Both read the context object where the caller has one.
  */
 export function simStatesEffectiveInput(
   rawInput: JSONValue,
   fields: SimStatesDataFlowFields,
+  context: JSONValue = null,
 ): JSONValue {
-  const narrowed = applyPath(rawInput, fields.InputPath, "InputPath");
+  const narrowed = applyPath(rawInput, fields.InputPath, "InputPath", context);
 
   return fields.Parameters === undefined
     ? narrowed
-    : evaluateSimStatesPayloadTemplate(fields.Parameters, narrowed);
+    : evaluateSimStatesPayloadTemplate(fields.Parameters, narrowed, context);
 }
 
 /**
@@ -49,16 +51,22 @@ export function simStatesEffectiveOutput(
   rawInput: JSONValue,
   result: JSONValue,
   fields: SimStatesDataFlowFields,
+  context: JSONValue = null,
 ): JSONValue {
   const selected =
     fields.ResultSelector === undefined
       ? result
-      : evaluateSimStatesPayloadTemplate(fields.ResultSelector, result);
+      : evaluateSimStatesPayloadTemplate(
+          fields.ResultSelector,
+          result,
+          context,
+        );
 
   return applyPath(
     applyResultPath(rawInput, selected, fields.ResultPath),
     fields.OutputPath,
     "OutputPath",
+    context,
   );
 }
 
@@ -97,6 +105,7 @@ function applyPath(
   value: JSONValue,
   path: string | null | undefined,
   field: string,
+  context: JSONValue,
 ): JSONValue {
   if (path === null) {
     return {};
@@ -106,10 +115,7 @@ function applyPath(
     return value;
   }
 
-  const selected = selectSimStatesPath(
-    value,
-    parseSimStatesReferencePath(path),
-  );
+  const selected = selectSimStatesReadPath(path, value, context);
 
   if (selected === undefined) {
     throw new SimStatesPathMatchFailure(

--- a/src/service/stepfunctions/data/sim-states-intrinsic.ts
+++ b/src/service/stepfunctions/data/sim-states-intrinsic.ts
@@ -1,10 +1,9 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import { SimStatesIntrinsicFailure } from "../error/sim-step-functions.error.js";
 import type { SimStatesIntrinsicArgument } from "./sim-states-intrinsic-argument.js";
+import { selectSimStatesReadPath } from "./sim-states-context-path.js";
 import { simStatesIntrinsics } from "./sim-states-intrinsic-functions.js";
 import { parseSimStatesIntrinsic } from "./sim-states-intrinsic-parse.js";
-import { selectSimStatesPath } from "./sim-states-path-segment.js";
-import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
 
 /**
  * The names this simulator answers, for a message listing them.
@@ -19,6 +18,7 @@ export const simStatesIntrinsicNames: readonly string[] = simStatesIntrinsics
 export function evaluateSimStatesIntrinsic(
   expression: string,
   document: JSONValue,
+  context: JSONValue = null,
 ): JSONValue {
   const call = parseSimStatesIntrinsic(expression);
   const intrinsic = simStatesIntrinsics.get(call.name);
@@ -32,7 +32,7 @@ export function evaluateSimStatesIntrinsic(
 
   return intrinsic(
     call.arguments.map((argument) =>
-      resolveArgument(argument, document, expression),
+      resolveArgument(argument, document, expression, context),
     ),
     expression,
   );
@@ -45,19 +45,17 @@ function resolveArgument(
   argument: SimStatesIntrinsicArgument,
   document: JSONValue,
   expression: string,
+  context: JSONValue,
 ): JSONValue {
   if (argument.kind === "literal") {
     return argument.value;
   }
 
   if (argument.kind === "call") {
-    return evaluateSimStatesIntrinsic(argument.expression, document);
+    return evaluateSimStatesIntrinsic(argument.expression, document, context);
   }
 
-  const selected = selectSimStatesPath(
-    document,
-    parseSimStatesReferencePath(argument.path),
-  );
+  const selected = selectSimStatesReadPath(argument.path, document, context);
 
   if (selected === undefined) {
     throw new SimStatesIntrinsicFailure(

--- a/src/service/stepfunctions/data/sim-states-payload-template.ts
+++ b/src/service/stepfunctions/data/sim-states-payload-template.ts
@@ -6,29 +6,32 @@ import {
   SimStatesPathMatchFailure,
   SimStatesUnsimulatedInput,
 } from "../error/sim-step-functions.error.js";
+import { selectSimStatesReadPath } from "./sim-states-context-path.js";
 import { isSimStatesIntrinsic } from "./sim-states-intrinsic-argument.js";
 import { evaluateSimStatesIntrinsic } from "./sim-states-intrinsic.js";
-import { selectSimStatesPath } from "./sim-states-path-segment.js";
-import { parseSimStatesReferencePath } from "./sim-states-reference-path.js";
 
 const resolvedKeySuffix = ".$";
 
 /**
  * Build a value from a Payload Template.
  *
- * `Parameters` and `ResultSelector` are both Payload Templates. A field whose
- * name ends in `.$` takes its value from a Reference Path or an intrinsic
- * function, and the `.$` comes off the name. Every other field is copied as it
- * stands, with objects and arrays walked so a `.$` field nested inside one is
- * still resolved.
+ * `Parameters`, `ResultSelector` and `ItemSelector` are all Payload Templates.
+ * A field whose name ends in `.$` takes its value from a Reference Path or an
+ * intrinsic function, and the `.$` comes off the name. Every other field is
+ * copied as it stands, with objects and arrays walked so a `.$` field nested
+ * inside one is still resolved.
+ *
+ * A path rooted at `$$` reads the context object the caller was given. One
+ * given none reads nothing there, and the field fails the state.
  */
 export function evaluateSimStatesPayloadTemplate(
   template: JSONValue,
   document: JSONValue,
+  context: JSONValue = null,
 ): JSONValue {
   if (Array.isArray(template)) {
     return template.map((element) =>
-      evaluateSimStatesPayloadTemplate(element, document),
+      evaluateSimStatesPayloadTemplate(element, document, context),
     );
   }
 
@@ -50,8 +53,8 @@ export function evaluateSimStatesPayloadTemplate(
     }
 
     built[field] = resolved
-      ? resolveField(key, value, document)
-      : evaluateSimStatesPayloadTemplate(value, document);
+      ? resolveField(key, value, document, context)
+      : evaluateSimStatesPayloadTemplate(value, document, context);
   }
 
   return built;
@@ -64,6 +67,7 @@ function resolveField(
   key: string,
   value: JSONValue,
   document: JSONValue,
+  context: JSONValue,
 ): JSONValue {
   if (typeof value !== "string") {
     throw new SimStatesUnsimulatedInput(
@@ -73,13 +77,10 @@ function resolveField(
   }
 
   if (isSimStatesIntrinsic(value)) {
-    return evaluateSimStatesIntrinsic(value, document);
+    return evaluateSimStatesIntrinsic(value, document, context);
   }
 
-  const selected = selectSimStatesPath(
-    document,
-    parseSimStatesReferencePath(value),
-  );
+  const selected = selectSimStatesReadPath(value, document, context);
 
   if (selected === undefined) {
     throw new SimStatesPathMatchFailure(

--- a/src/service/stepfunctions/data/sim-states-reference-path.ts
+++ b/src/service/stepfunctions/data/sim-states-reference-path.ts
@@ -30,8 +30,10 @@ export function parseSimStatesReferencePath(
 
   if (path.startsWith("$$")) {
     throw new SimStatesPathError(
-      `${path} reads the context object, which is not simulated. Only paths ` +
-        "rooted at $ are read.",
+      `${path} reads the context object, which is read in InputPath, ` +
+        "OutputPath, ItemsPath, Parameters, ResultSelector, ItemSelector and " +
+        "an intrinsic function's arguments. A path in any other field is " +
+        "rooted at $.",
     );
   }
 

--- a/src/service/stepfunctions/definition/sim-states-map-fields.ts
+++ b/src/service/stepfunctions/definition/sim-states-map-fields.ts
@@ -1,0 +1,92 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import { parseSimStatesReadPath } from "../data/sim-states-context-path.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
+
+/**
+ * Read what builds each iteration's input.
+ *
+ * `Parameters` is what `ItemSelector` used to be called, and a `Map` state
+ * carrying both says the same thing twice.
+ */
+export function readSimStatesItemSelector(
+  named: string,
+  state: Record<string, JSONValue>,
+  parameters: JSONValue | undefined,
+): { ItemSelector?: JSONValue } {
+  const selector = state["ItemSelector"];
+
+  if (selector !== undefined && parameters !== undefined) {
+    throw new SimStatesInvalidDefinition(
+      `The ${named} carries both ItemSelector and Parameters. Parameters is ` +
+        "the older spelling of ItemSelector, and a Map state carries one of " +
+        "them.",
+    );
+  }
+
+  const written = selector ?? parameters;
+
+  if (written === undefined) {
+    return {};
+  }
+
+  if (!isRecord(written)) {
+    throw new SimStatesInvalidDefinition(
+      `The ${named} has an ItemSelector that is not an object. It is a ` +
+        "Payload Template, which builds what each iteration is given.",
+    );
+  }
+
+  return { ItemSelector: written };
+}
+
+/**
+ * Read where the items come from, which is the whole input by default.
+ */
+export function readSimStatesItemsPath(
+  named: string,
+  state: Record<string, JSONValue>,
+): { ItemsPath?: string } {
+  const written = state["ItemsPath"];
+
+  if (written === undefined) {
+    return {};
+  }
+
+  if (typeof written !== "string") {
+    throw new SimStatesInvalidDefinition(
+      `The ${named} has an ItemsPath that is not a Reference Path.`,
+    );
+  }
+
+  parseSimStatesReadPath(written);
+
+  return { ItemsPath: written };
+}
+
+/**
+ * Read how many iterations may run at once.
+ */
+export function readSimStatesMaxConcurrency(
+  named: string,
+  state: Record<string, JSONValue>,
+): { MaxConcurrency?: number } {
+  const written = state["MaxConcurrency"];
+
+  if (written === undefined) {
+    return {};
+  }
+
+  if (
+    typeof written !== "number" ||
+    !Number.isSafeInteger(written) ||
+    written < 0
+  ) {
+    throw new SimStatesInvalidDefinition(
+      `The ${named} has a MaxConcurrency of ${JSON.stringify(written)}. It ` +
+        "is a whole number from 0, where 0 runs every iteration at once.",
+    );
+  }
+
+  return { MaxConcurrency: written };
+}

--- a/src/service/stepfunctions/definition/sim-states-map-fields.ts
+++ b/src/service/stepfunctions/definition/sim-states-map-fields.ts
@@ -24,7 +24,10 @@ export function readSimStatesItemSelector(
     );
   }
 
-  const written = selector ?? parameters;
+  // A field written as null is a Payload Template that is not an object, and
+  // is refused below. Falling back to the other spelling would take it for a
+  // Map state that carries neither.
+  const written = selector === undefined ? parameters : selector;
 
   if (written === undefined) {
     return {};

--- a/src/service/stepfunctions/definition/sim-states-map-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-map-parse.ts
@@ -1,0 +1,78 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { SimStatesUnsimulatedInput } from "../error/sim-step-functions.error.js";
+import { parseSimStatesErrorHandling } from "../retry/sim-states-error-handling.js";
+import {
+  readSimStatesItemSelector,
+  readSimStatesItemsPath,
+  readSimStatesMaxConcurrency,
+} from "./sim-states-map-fields.js";
+import { readSimStatesMapProcessor } from "./sim-states-map-processor.js";
+import type { SimStatesMapState } from "./sim-states-state.js";
+
+/**
+ * The fields of a `Map` state this simulator has no implementation for.
+ *
+ * All of them belong to a Distributed Map, which reads its items from S3, runs
+ * a child execution per batch and writes the results back. That is a second
+ * execution model rather than a field or two on this one.
+ */
+const mapFieldsUnsimulated = [
+  "ItemReader",
+  "ItemBatcher",
+  "ResultWriter",
+  "ToleratedFailureCount",
+  "ToleratedFailureCountPath",
+  "ToleratedFailurePercentage",
+  "ToleratedFailurePercentagePath",
+  "Label",
+  "MaxConcurrencyPath",
+  "Items",
+] as const;
+
+/**
+ * Read a `Map` state, whose item processor is read as the state is.
+ *
+ * The processor is a state machine of its own, so the states inside it are
+ * read the same way the states around them are. `Parameters` is the older
+ * spelling of `ItemSelector` and arrives as one, which leaves a `Map` state
+ * with no data-flow `Parameters` of its own.
+ */
+export function readSimStatesMapState(
+  name: string,
+  state: Record<string, JSONValue>,
+): SimStatesMapState {
+  const named = `Map state ${name}`;
+
+  checkUnsimulated(named, state);
+
+  const { Parameters, ...written } = state;
+
+  return {
+    ...(written as unknown as SimStatesMapState),
+    ItemProcessor: readSimStatesMapProcessor(named, state),
+    ...readSimStatesItemSelector(named, state, Parameters),
+    ...readSimStatesItemsPath(named, state),
+    ...readSimStatesMaxConcurrency(named, state),
+    ...parseSimStatesErrorHandling(named, state),
+  };
+}
+
+/**
+ * Refuse the fields a Distributed Map carries.
+ */
+function checkUnsimulated(
+  named: string,
+  state: Record<string, JSONValue>,
+): void {
+  const present = mapFieldsUnsimulated.filter((field) =>
+    Object.hasOwn(state, field),
+  );
+
+  if (present.length > 0) {
+    throw new SimStatesUnsimulatedInput(
+      `The ${named} carries ${present.join(", ")}, which this simulator does ` +
+        "not run. Those fields belong to a Distributed Map, which reads its " +
+        "items from S3 and runs a child execution per batch.",
+    );
+  }
+}

--- a/src/service/stepfunctions/definition/sim-states-map-processor.ts
+++ b/src/service/stepfunctions/definition/sim-states-map-processor.ts
@@ -1,0 +1,85 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { isRecord } from "../../../util/type-guard/record.js";
+import {
+  SimStatesInvalidDefinition,
+  SimStatesUnsimulatedInput,
+} from "../error/sim-step-functions.error.js";
+import type { SimStatesDefinition } from "./sim-states-definition.js";
+import { parseSimStatesDefinitionDocument } from "./sim-states-definition-parse.js";
+import { simStatesNestedRefusal } from "./sim-states-nested-refusal.js";
+
+/**
+ * The execution model a `Map` state's processor runs under.
+ */
+const inlineMode = "INLINE";
+
+/**
+ * Read the states one `Map` state runs per item.
+ *
+ * `Iterator` is what `ItemProcessor` used to be called, and CDK still emits it
+ * for a `Map` built with the deprecated `iterator()` call, so both are read.
+ * A state machine carrying both says the same thing twice.
+ */
+export function readSimStatesMapProcessor(
+  named: string,
+  state: Record<string, JSONValue>,
+): SimStatesDefinition {
+  const processor = state["ItemProcessor"];
+  const iterator = state["Iterator"];
+
+  if (processor !== undefined && iterator !== undefined) {
+    throw new SimStatesInvalidDefinition(
+      `The ${named} carries both ItemProcessor and Iterator. Iterator is the ` +
+        "older spelling of ItemProcessor, and a Map state carries one of them.",
+    );
+  }
+
+  const written = processor ?? iterator;
+
+  if (!isRecord(written)) {
+    throw new SimStatesInvalidDefinition(
+      `The ${named} needs an ItemProcessor holding the states it runs for ` +
+        "each item.",
+    );
+  }
+
+  checkProcessorConfig(named, written["ProcessorConfig"]);
+
+  return read(named, written);
+}
+
+/**
+ * Refuse a processor that runs as a Distributed Map.
+ */
+function checkProcessorConfig(
+  named: string,
+  config: JSONValue | undefined,
+): void {
+  if (!isRecord(config)) {
+    return;
+  }
+
+  const mode = config["Mode"];
+
+  if (mode !== undefined && mode !== inlineMode) {
+    throw new SimStatesUnsimulatedInput(
+      `The ${named} has a ProcessorConfig Mode of ${JSON.stringify(mode)}, ` +
+        `which this simulator does not run. It runs ${inlineMode}, where the ` +
+        "iterations are states of the execution that reached the Map state.",
+    );
+  }
+}
+
+/**
+ * Read the processor's states, saying which state they belong to.
+ */
+function read(
+  named: string,
+  written: Record<string, JSONValue>,
+): SimStatesDefinition {
+  try {
+    return parseSimStatesDefinitionDocument(written);
+  } catch (error) {
+    throw simStatesNestedRefusal(`The ItemProcessor of the ${named}`, error);
+  }
+}

--- a/src/service/stepfunctions/definition/sim-states-map-processor.ts
+++ b/src/service/stepfunctions/definition/sim-states-map-processor.ts
@@ -50,6 +50,10 @@ export function readSimStatesMapProcessor(
 
 /**
  * Refuse a processor that runs as a Distributed Map.
+ *
+ * `ExecutionType` says what a Distributed Map's child executions run as, and
+ * an inline processor has none of those, so it is refused alongside the mode
+ * that gives it a meaning.
  */
 function checkProcessorConfig(
   named: string,
@@ -60,12 +64,14 @@ function checkProcessorConfig(
   }
 
   const mode = config["Mode"];
+  const distributed = mode !== undefined && mode !== inlineMode;
 
-  if (mode !== undefined && mode !== inlineMode) {
+  if (distributed || Object.hasOwn(config, "ExecutionType")) {
     throw new SimStatesUnsimulatedInput(
-      `The ${named} has a ProcessorConfig Mode of ${JSON.stringify(mode)}, ` +
-        `which this simulator does not run. It runs ${inlineMode}, where the ` +
-        "iterations are states of the execution that reached the Map state.",
+      `The ${named} has a ProcessorConfig of ${JSON.stringify(config)}, ` +
+        `which this simulator does not run. It runs a Mode of ${inlineMode} ` +
+        "with no ExecutionType, where the iterations are states of the " +
+        "execution that reached the Map state.",
     );
   }
 }

--- a/src/service/stepfunctions/definition/sim-states-map-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-map-refusals.iso.test.ts
@@ -55,8 +55,9 @@ describe("Step Functions Map state refusals", () => {
   });
 
   it("refuses a processor that runs as a Distributed Map", () => {
-    // Given an ItemProcessor whose ProcessorConfig asks for DISTRIBUTED.
-    // When it is read, it is refused by the mode it named.
+    // Given an ItemProcessor asking for DISTRIBUTED, and one asking for an
+    // execution type without saying so.
+    // When each is read, each is refused by the configuration it carries.
     assertStringIncludes(
       refusalFor({
         ItemProcessor: {
@@ -64,7 +65,16 @@ describe("Step Functions Map state refusals", () => {
           ProcessorConfig: { Mode: "DISTRIBUTED", ExecutionType: "STANDARD" },
         },
       }),
-      'ProcessorConfig Mode of "DISTRIBUTED"',
+      '"Mode":"DISTRIBUTED"',
+    );
+    assertStringIncludes(
+      refusalFor({
+        ItemProcessor: {
+          ...registering,
+          ProcessorConfig: { Mode: "INLINE", ExecutionType: "EXPRESS" },
+        },
+      }),
+      "which this simulator does not run",
     );
   });
 
@@ -86,10 +96,15 @@ describe("Step Functions Map state refusals", () => {
   });
 
   it("refuses an ItemSelector that is not a Payload Template", () => {
-    // Given an ItemSelector written as something other than an object.
-    // When it is read, it says what an ItemSelector is.
+    // Given an ItemSelector written as a path, and one written as null.
+    // When each is read, each says what an ItemSelector is. A null one is
+    // refused rather than read as a Map state that carries none.
     assertStringIncludes(
       refusalFor({ ItemProcessor: registering, ItemSelector: "$.students" }),
+      "has an ItemSelector that is not an object",
+    );
+    assertStringIncludes(
+      refusalFor({ ItemProcessor: registering, ItemSelector: null }),
       "has an ItemSelector that is not an object",
     );
   });

--- a/src/service/stepfunctions/definition/sim-states-map-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-map-refusals.iso.test.ts
@@ -1,0 +1,154 @@
+import { assertStringIncludes, assertThrowsError } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { JSONObject } from "../../../util/type-guard/json.js";
+import { parseSimStatesDefinition } from "./sim-states-definition-parse.js";
+
+describe("Step Functions Map state refusals", () => {
+  /**
+   * The states one `Map` state runs per item.
+   */
+  const registering: JSONObject = {
+    StartAt: "Register",
+    States: { Register: { Type: "Pass", End: true } },
+  };
+
+  /**
+   * Read a definition of one `Map` state that is expected to be refused, and
+   * answer with why.
+   */
+  function refusalFor(state: JSONObject): string {
+    return assertThrowsError(() =>
+      parseSimStatesDefinition(
+        JSON.stringify({
+          StartAt: "Enrol",
+          States: { Enrol: { Type: "Map", End: true, ...state } },
+        }),
+      ),
+    ).message;
+  }
+
+  it("refuses a Map state with nothing to run per item", () => {
+    // Given a Map state carrying no ItemProcessor.
+    // When it is read, it says a Map state needs one.
+    assertStringIncludes(
+      refusalFor({}),
+      "The Map state Enrol needs an ItemProcessor holding the states it runs",
+    );
+  });
+
+  it("refuses a Distributed Map by the fields that make it one", () => {
+    // Given a Map state reading its items from S3 and writing them back.
+    // When it is read, the refusal names the fields and what they are for.
+    const refusal = refusalFor({
+      ItemProcessor: registering,
+      ItemReader: { Resource: "arn:aws:states:::s3:getObject" },
+      ResultWriter: { Resource: "arn:aws:states:::s3:putObject" },
+      ToleratedFailureCount: 2,
+    });
+
+    assertStringIncludes(
+      refusal,
+      "carries ItemReader, ResultWriter, ToleratedFailureCount",
+    );
+    assertStringIncludes(refusal, "belong to a Distributed Map");
+  });
+
+  it("refuses a processor that runs as a Distributed Map", () => {
+    // Given an ItemProcessor whose ProcessorConfig asks for DISTRIBUTED.
+    // When it is read, it is refused by the mode it named.
+    assertStringIncludes(
+      refusalFor({
+        ItemProcessor: {
+          ...registering,
+          ProcessorConfig: { Mode: "DISTRIBUTED", ExecutionType: "STANDARD" },
+        },
+      }),
+      'ProcessorConfig Mode of "DISTRIBUTED"',
+    );
+  });
+
+  it("refuses a Map state carrying both spellings of a field", () => {
+    // Given a Map state carrying the old field name beside the new one.
+    // When each is read, each says which is the older spelling.
+    assertStringIncludes(
+      refusalFor({ ItemProcessor: registering, Iterator: registering }),
+      "carries both ItemProcessor and Iterator",
+    );
+    assertStringIncludes(
+      refusalFor({
+        ItemProcessor: registering,
+        ItemSelector: { "id.$": "$$.Map.Item.Value.id" },
+        Parameters: { "id.$": "$$.Map.Item.Value.id" },
+      }),
+      "carries both ItemSelector and Parameters",
+    );
+  });
+
+  it("refuses an ItemSelector that is not a Payload Template", () => {
+    // Given an ItemSelector written as something other than an object.
+    // When it is read, it says what an ItemSelector is.
+    assertStringIncludes(
+      refusalFor({ ItemProcessor: registering, ItemSelector: "$.students" }),
+      "has an ItemSelector that is not an object",
+    );
+  });
+
+  it("refuses an ItemsPath that is not a Reference Path", () => {
+    // Given an ItemsPath written as a number, and one written as a path this
+    // simulator does not read.
+    // When each is read, each is refused.
+    assertStringIncludes(
+      refusalFor({ ItemProcessor: registering, ItemsPath: 3 }),
+      "has an ItemsPath that is not a Reference Path",
+    );
+    assertStringIncludes(
+      refusalFor({
+        ItemProcessor: registering,
+        ItemsPath: "$.students[*].id",
+      }),
+      "uses a bracket this simulator does not read",
+    );
+  });
+
+  it("refuses a MaxConcurrency outside what it can be", () => {
+    // Given bounds that are not a whole number of iterations.
+    // When each is read, each says what the field takes.
+    for (const bound of [-1, 1.5, "2"]) {
+      assertStringIncludes(
+        refusalFor({ ItemProcessor: registering, MaxConcurrency: bound }),
+        `has a MaxConcurrency of ${JSON.stringify(bound)}`,
+      );
+    }
+  });
+
+  it("refuses an item processor using something this simulator does not run", () => {
+    // Given a processor holding a Distributed Map of its own.
+    // When it is read, the refusal names the processor it was written in.
+    assertStringIncludes(
+      refusalFor({
+        ItemProcessor: {
+          StartAt: "Register",
+          States: {
+            Register: {
+              Type: "Map",
+              ItemReader: { Resource: "arn:aws:states:::s3:getObject" },
+              ItemProcessor: registering,
+              End: true,
+            },
+          },
+        },
+      }),
+      "The ItemProcessor of the Map state Enrol:",
+    );
+  });
+
+  it("refuses the fields a Map state does not have", () => {
+    // Given a Map state carrying a task's timeout.
+    // When it is read, it names the field and the type.
+    assertStringIncludes(
+      refusalFor({ ItemProcessor: registering, TimeoutSeconds: 5 }),
+      "The Map state Enrol carries TimeoutSeconds",
+    );
+  });
+});

--- a/src/service/stepfunctions/definition/sim-states-nested-refusal.ts
+++ b/src/service/stepfunctions/definition/sim-states-nested-refusal.ts
@@ -1,0 +1,29 @@
+import {
+  SimStatesInvalidDefinition,
+  SimStatesUnsimulatedInput,
+  SimStepFunctionsError,
+} from "../error/sim-step-functions.error.js";
+
+/**
+ * The same refusal, saying which nested state machine raised it.
+ *
+ * A `Parallel` state's branch and a `Map` state's item processor are both
+ * state machines written inside another one, and the refusal a state inside
+ * one raises names that state alone. Two branches are free to use the same
+ * state name, and without the position the two refusals would read alike.
+ *
+ * A nested definition using an unsimulated construct keeps that name, since it
+ * is the one telling a reader that the definition is good and this simulator
+ * is behind. Everything else is a fault in the definition.
+ */
+export function simStatesNestedRefusal(where: string, error: unknown): unknown {
+  if (error instanceof SimStatesUnsimulatedInput) {
+    return new SimStatesUnsimulatedInput(`${where}: ${error.message}`);
+  }
+
+  if (error instanceof SimStepFunctionsError) {
+    return new SimStatesInvalidDefinition(`${where}: ${error.message}`);
+  }
+
+  return error;
+}

--- a/src/service/stepfunctions/definition/sim-states-parallel-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-parallel-parse.ts
@@ -1,13 +1,10 @@
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import { isRecord } from "../../../util/type-guard/record.js";
-import {
-  SimStatesInvalidDefinition,
-  SimStatesUnsimulatedInput,
-  SimStepFunctionsError,
-} from "../error/sim-step-functions.error.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
 import { parseSimStatesErrorHandling } from "../retry/sim-states-error-handling.js";
 import type { SimStatesDefinition } from "./sim-states-definition.js";
 import { parseSimStatesDefinitionDocument } from "./sim-states-definition-parse.js";
+import { simStatesNestedRefusal } from "./sim-states-nested-refusal.js";
 import type { SimStatesParallelState } from "./sim-states-state.js";
 
 /**
@@ -53,10 +50,6 @@ function parseSimStatesBranches(
 
 /**
  * Read one branch, saying which branch it was where it cannot be read.
- *
- * The refusal a branch raises names the state inside it, so the position of
- * the branch is put in front of it. Two branches are free to use the same
- * state name, and without the position the two refusals would read alike.
  */
 function readBranch(
   named: string,
@@ -75,26 +68,6 @@ function readBranch(
   try {
     return parseSimStatesDefinitionDocument(branch);
   } catch (error) {
-    throw branchRefusal(where, error);
+    throw simStatesNestedRefusal(where, error);
   }
-}
-
-/**
- * The same refusal, saying which branch raised it.
- *
- * A branch using an unsimulated construct keeps that name, since it is the
- * one telling a reader that the definition is good and this simulator is
- * behind. Everything else a branch is refused for is a fault in the
- * definition.
- */
-function branchRefusal(where: string, error: unknown): unknown {
-  if (error instanceof SimStatesUnsimulatedInput) {
-    return new SimStatesUnsimulatedInput(`${where}: ${error.message}`);
-  }
-
-  if (error instanceof SimStepFunctionsError) {
-    return new SimStatesInvalidDefinition(`${where}: ${error.message}`);
-  }
-
-  return error;
 }

--- a/src/service/stepfunctions/definition/sim-states-parallel-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-parallel-refusals.iso.test.ts
@@ -60,12 +60,22 @@ describe("Step Functions Parallel state refusals", () => {
   });
 
   it("refuses a branch using something this simulator does not run", () => {
-    // Given a branch holding a state type still to come.
+    // Given a branch holding a Distributed Map.
     const refusal = refusalFor({
       Branches: [
         {
           StartAt: "Enrol",
-          States: { Enrol: { Type: "Map", End: true } },
+          States: {
+            Enrol: {
+              Type: "Map",
+              ItemReader: { Resource: "arn:aws:states:::s3:getObject" },
+              ItemProcessor: {
+                StartAt: "Register",
+                States: { Register: { Type: "Pass", End: true } },
+              },
+              End: true,
+            },
+          },
         },
       ],
       End: true,
@@ -74,7 +84,7 @@ describe("Step Functions Parallel state refusals", () => {
     // When it is read, the refusal names the branch and keeps what the state
     // itself said.
     assertStringIncludes(refusal, "Branch 1 of the Parallel state Fan:");
-    assertStringIncludes(refusal, "is a Map state, which this simulator does");
+    assertStringIncludes(refusal, "carries ItemReader, which this simulator");
   });
 
   it("refuses a branch moving to a state outside itself", () => {

--- a/src/service/stepfunctions/definition/sim-states-state-fields.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-fields.ts
@@ -14,8 +14,10 @@ const stateFieldsRefused = new Map<string, readonly string[]>([
   ["Choice", ["Parameters", "ResultPath", "ResultSelector"]],
   ["Wait", ["Parameters", "ResultPath", "ResultSelector"]],
   // Only a Task state, and the state machine itself, take a timeout. A
-  // Parallel state runs for as long as its branches do.
+  // Parallel state runs for as long as its branches do, and a Map state for
+  // as long as its iterations do.
   ["Parallel", ["TimeoutSeconds", "HeartbeatSeconds"]],
+  ["Map", ["TimeoutSeconds", "HeartbeatSeconds"]],
 ]);
 
 /**

--- a/src/service/stepfunctions/definition/sim-states-state-parse.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-parse.ts
@@ -4,14 +4,12 @@ import {
   checkSimStatesChoiceDefault,
   parseSimStatesChoices,
 } from "../choice/sim-states-choice-parse.js";
-import {
-  SimStatesInvalidDefinition,
-  SimStatesUnsimulatedInput,
-} from "../error/sim-step-functions.error.js";
+import { SimStatesInvalidDefinition } from "../error/sim-step-functions.error.js";
 import { parseSimStatesErrorHandling } from "../retry/sim-states-error-handling.js";
 import { checkSimStatesTaskFields } from "../task/sim-states-task-fields.js";
 import { parseSimStatesTaskResource } from "../task/sim-states-task-resource.js";
 import { checkSimStatesWaitFields } from "../wait/sim-states-wait-fields.js";
+import { readSimStatesMapState } from "./sim-states-map-parse.js";
 import { readSimStatesParallelState } from "./sim-states-parallel-parse.js";
 import {
   checkSimStatesRefusedFields,
@@ -21,7 +19,6 @@ import {
   type SimStatesChoiceState,
   type SimStatesState,
   type SimStatesTaskState,
-  simStatesRunnableTypes,
   simStatesStateTypes,
 } from "./sim-states-state.js";
 
@@ -49,13 +46,6 @@ export function parseSimStatesState(
     );
   }
 
-  if (!simStatesRunnableTypes.includes(type as never)) {
-    throw new SimStatesUnsimulatedInput(
-      `The state ${name} is a ${type} state, which this simulator does not ` +
-        `run yet. It runs ${simStatesRunnableTypes.join(", ")}.`,
-    );
-  }
-
   checkSimStatesRefusedFields(name, type, state);
   checkSimStatesTransitionFields(name, state);
 
@@ -69,6 +59,10 @@ export function parseSimStatesState(
 
   if (type === "Parallel") {
     return readSimStatesParallelState(name, state);
+  }
+
+  if (type === "Map") {
+    return readSimStatesMapState(name, state);
   }
 
   if (type === "Wait") {

--- a/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
+++ b/src/service/stepfunctions/definition/sim-states-state-refusals.iso.test.ts
@@ -36,21 +36,6 @@ describe("Step Functions state refusals", () => {
     );
   });
 
-  it("refuses a state type this simulator does not run yet, by name", () => {
-    // Given the state type still to come.
-    const refusal = refusalFor({
-      StartAt: "Only",
-      States: { Only: { Type: "Map", End: true } },
-    });
-
-    // When it is read, it names itself and what does run.
-    assertStringIncludes(refusal, "is a Map state");
-    assertStringIncludes(
-      refusal,
-      "Pass, Succeed, Fail, Task, Choice, Wait, Parallel",
-    );
-  });
-
   it("refuses the fields a Fail or a Succeed state does not have", () => {
     // Given data-flow fields on states that have no input or output
     // processing.

--- a/src/service/stepfunctions/definition/sim-states-state.ts
+++ b/src/service/stepfunctions/definition/sim-states-state.ts
@@ -7,10 +7,7 @@ import type { SimStatesTaskTarget } from "../task/sim-states-task-target.js";
 import type { SimStatesDefinition } from "./sim-states-definition.js";
 
 /**
- * Every state type Amazon States Language defines.
- *
- * The ones this simulator has no implementation for are named here so a
- * definition using one can be refused by its own name.
+ * Every state type Amazon States Language defines, all of which run.
  */
 export const simStatesStateTypes = [
   "Pass",
@@ -24,21 +21,6 @@ export const simStatesStateTypes = [
 ] as const;
 
 export type SimStatesStateType = (typeof simStatesStateTypes)[number];
-
-/**
- * The state types this simulator runs.
- */
-export const simStatesRunnableTypes = [
-  "Pass",
-  "Succeed",
-  "Fail",
-  "Task",
-  "Choice",
-  "Wait",
-  "Parallel",
-] as const;
-
-export type SimStatesRunnableType = (typeof simStatesRunnableTypes)[number];
 
 /**
  * What every state carries, whatever its type.
@@ -84,6 +66,24 @@ export interface SimStatesParallelState
   extends SimStatesCommonState, SimStatesErrorHandling {
   readonly Type: "Parallel";
   readonly Branches: readonly SimStatesDefinition[];
+}
+
+/**
+ * A `Map` state, which runs its `ItemProcessor` once per item.
+ *
+ * `ItemsPath` says where the items are, `ItemSelector` builds what each
+ * iteration is given, and `MaxConcurrency` bounds how many iterations run at
+ * once. A `Map` state has no `Parameters` of its own. Amazon States Language
+ * gave that field to the item, and it arrives here as the `ItemSelector` it
+ * was the older spelling of.
+ */
+export interface SimStatesMapState
+  extends Omit<SimStatesCommonState, "Parameters">, SimStatesErrorHandling {
+  readonly Type: "Map";
+  readonly ItemProcessor: SimStatesDefinition;
+  readonly ItemsPath?: string;
+  readonly ItemSelector?: JSONValue;
+  readonly MaxConcurrency?: number;
 }
 
 /**
@@ -141,6 +141,7 @@ export type SimStatesState =
   | SimStatesPassState
   | SimStatesTaskState
   | SimStatesParallelState
+  | SimStatesMapState
   | SimStatesSucceedState
   | SimStatesFailState
   | SimStatesChoiceState

--- a/src/service/stepfunctions/execution/sim-states-child-run.ts
+++ b/src/service/stepfunctions/execution/sim-states-child-run.ts
@@ -21,11 +21,12 @@ interface SimStatesChildRunProperties {
 }
 
 /**
- * One branch of a `Parallel` state, as it runs.
+ * One branch of a `Parallel` state, or one iteration of a `Map` state, as it
+ * runs.
  *
- * The states a branch visits are its own rather than the execution's, so they
- * are held here. A branch of a branch is still reported on the execution,
- * which is why a child run passes one it is told about upwards.
+ * The states a child visits are its own rather than the execution's, so they
+ * are held here. A child of a child is still reported on the execution, which
+ * is why a child run passes one it is told about upwards.
  */
 export class SimStatesChildRun implements SimStatesRunRecord, SimStatesChild {
   readonly kind: SimStatesChildKind;

--- a/src/service/stepfunctions/execution/sim-states-child-runs.ts
+++ b/src/service/stepfunctions/execution/sim-states-child-runs.ts
@@ -1,4 +1,4 @@
-import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
 import type { SimStatesChildKind } from "./sim-states-child.js";
 import { SimStatesChildRun } from "./sim-states-child-run.js";
@@ -11,12 +11,23 @@ export interface SimStatesChildStart {
   readonly index: number;
   readonly definition: SimStatesDefinition;
   readonly input: JSONValue;
+
+  /**
+   * What the child's states read through `$$`.
+   */
+  readonly contextObject: JSONObject;
 }
 
 interface SimStatesChildRunsProperties {
   readonly kind: SimStatesChildKind;
   readonly context: SimStatesStateContext;
   readonly children: readonly SimStatesChildStart[];
+
+  /**
+   * How many children may be running at once. A state with no bound of its
+   * own is given an infinite one.
+   */
+  readonly limit: number;
 
   /**
    * What to do once one child has ended.
@@ -34,6 +45,7 @@ export class SimStatesChildRuns {
   readonly #kind: SimStatesChildKind;
   readonly #context: SimStatesStateContext;
   readonly #onSettled: (run: SimStatesChildRun) => Promise<void>;
+  readonly #limit: number;
 
   /**
    * The children still to be started, in the order they were written.
@@ -46,12 +58,14 @@ export class SimStatesChildRuns {
   readonly #started: SimStatesChildRun[] = [];
 
   readonly #total: number;
+  #running = 0;
   #ended = 0;
 
   constructor(properties: SimStatesChildRunsProperties) {
     this.#kind = properties.kind;
     this.#context = properties.context;
     this.#onSettled = properties.onSettled;
+    this.#limit = properties.limit;
     this.#waiting = [...properties.children];
     this.#total = properties.children.length;
   }
@@ -71,15 +85,16 @@ export class SimStatesChildRuns {
   }
 
   /**
-   * Start the next child, and the ones after it.
+   * Start the next child, and the ones after it there is room for.
    *
    * A child is started once the one before it is either done or waiting on
-   * the clock, since a child waiting is one the state is still running. The
-   * children a failure leaves nothing to do are dropped from the queue, so
-   * this answers as soon as one of them fails.
+   * the clock, since a child waiting is one that is still running. This
+   * answers where the bound is reached, and the children left over start as
+   * the ones running end. The children a failure leaves nothing to do are
+   * dropped from the queue, so this answers as soon as one of them fails.
    */
   async start(): Promise<void> {
-    const child = this.#waiting.shift();
+    const child = this.#next();
 
     if (child === undefined) {
       return;
@@ -90,9 +105,10 @@ export class SimStatesChildRuns {
   }
 
   /**
-   * Take in that one child has ended.
+   * Take in that one child has ended, which leaves room for another.
    */
   ended(): void {
+    this.#running -= 1;
     this.#ended += 1;
   }
 
@@ -107,6 +123,18 @@ export class SimStatesChildRuns {
   }
 
   /**
+   * The next child to start, where there is room to start one.
+   *
+   * The room is arithmetic rather than a test, since a state with no bound
+   * has an infinite one and takes the same subtraction.
+   */
+  #next(): SimStatesChildStart | undefined {
+    return this.#waiting
+      .splice(0, Math.min(1, this.#limit - this.#running))
+      .at(0);
+  }
+
+  /**
    * Run one child as far as it goes without waiting on the clock.
    */
   async #start(child: SimStatesChildStart): Promise<void> {
@@ -118,6 +146,7 @@ export class SimStatesChildRuns {
       parent: this.#context.record,
     });
 
+    this.#running += 1;
     this.#started.push(run);
     this.#context.record.child(run);
 
@@ -125,6 +154,7 @@ export class SimStatesChildRuns {
       .walkChild({
         definition: child.definition,
         record: run,
+        contextObject: child.contextObject,
         onSettled: async (): Promise<void> => {
           await this.#onSettled(run);
         },

--- a/src/service/stepfunctions/execution/sim-states-child-walk.ts
+++ b/src/service/stepfunctions/execution/sim-states-child-walk.ts
@@ -1,3 +1,4 @@
+import type { JSONObject } from "../../../util/type-guard/json.js";
 import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
 import type { SimStatesRunRecord } from "./sim-states-run-record.js";
 
@@ -11,6 +12,11 @@ export interface SimStatesChildWalkProperties {
    * What the child records itself on, and where its input comes from.
    */
   readonly record: SimStatesRunRecord;
+
+  /**
+   * What the child's states read through `$$`.
+   */
+  readonly contextObject: JSONObject;
 
   /**
    * What to do once the child has ended, whenever that turns out to be. An

--- a/src/service/stepfunctions/execution/sim-states-child.ts
+++ b/src/service/stepfunctions/execution/sim-states-child.ts
@@ -17,17 +17,18 @@ export type SimStatesChildStatus =
   | "ABANDONED";
 
 /**
- * One branch of a `Parallel` state, as an execution ran it.
+ * One branch of a `Parallel` state or one iteration of a `Map` state, as an
+ * execution ran it.
  *
- * A branch runs states of its own, so what it did is held apart from the
- * states the execution around it visited. A test asserting that four records
- * were processed counts these.
+ * Both run states of their own, so what they did is held apart from the states
+ * the execution around them visited. A test asserting that four records were
+ * processed counts these.
  */
 export interface SimStatesChild {
   readonly kind: SimStatesChildKind;
 
   /**
-   * The `Parallel` state the child belongs to.
+   * The `Parallel` or `Map` state the child belongs to.
    */
   readonly stateName: string;
 

--- a/src/service/stepfunctions/execution/sim-states-fan-out-outcome.ts
+++ b/src/service/stepfunctions/execution/sim-states-fan-out-outcome.ts
@@ -23,8 +23,9 @@ export function simStatesFanOutOutcome(
   state: SimStatesFanOutState,
   input: JSONValue,
   outputs: readonly JSONValue[],
+  context: JSONValue,
 ): SimStatesMoveOnOutcome {
-  const output = simStatesEffectiveOutput(input, [...outputs], state);
+  const output = simStatesEffectiveOutput(input, [...outputs], state, context);
 
   return state.Next === undefined
     ? { kind: "succeed", output }

--- a/src/service/stepfunctions/execution/sim-states-fan-out.ts
+++ b/src/service/stepfunctions/execution/sim-states-fan-out.ts
@@ -20,6 +20,11 @@ interface SimStatesFanOutProperties {
   readonly children: readonly SimStatesChildStart[];
 
   /**
+   * How many children may be running at once.
+   */
+  readonly limit: number;
+
+  /**
    * What one child is called, for the failure the state ends with.
    */
   readonly names: (index: number) => string;
@@ -63,6 +68,7 @@ export class SimStatesFanOut {
       kind: properties.kind,
       context: properties.context,
       children: properties.children,
+      limit: properties.limit,
       onSettled: async (run): Promise<void> => {
         await this.#settled(run);
       },
@@ -106,6 +112,7 @@ export class SimStatesFanOut {
       this.#children.abandon();
     }
 
+    await this.#children.start();
     await this.#resumed();
   }
 

--- a/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.iso.test.ts
@@ -28,7 +28,7 @@ async function runDefinition(
     background,
     tasks: new SimStatesNoTaskTargets(),
     roleArn: "arn:aws:iam::123456789012:role/WorkflowRole",
-  })({ definition, record: execution }).run();
+  })({ definition, record: execution, contextObject: {} }).run();
 
   return execution;
 }

--- a/src/service/stepfunctions/execution/sim-states-interpreter.ts
+++ b/src/service/stepfunctions/execution/sim-states-interpreter.ts
@@ -1,12 +1,9 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesDefinition } from "../definition/sim-states-definition.js";
-import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
-import type {
-  SimStatesChildWalk,
-  SimStatesChildWalks,
-} from "./sim-states-child-walk.js";
+import type { SimStatesChildWalk } from "./sim-states-child-walk.js";
 import type { SimStatesRunRecord } from "./sim-states-run-record.js";
+import type { SimStatesWalkContext } from "./sim-states-state-outcome.js";
 import { SimStatesSettlement } from "./sim-states-settlement.js";
 import { SimStatesStateAttempts } from "./sim-states-state-attempts.js";
 import { SimStatesStateRunner } from "./sim-states-state-runner.js";
@@ -14,29 +11,13 @@ import { SimStatesWalkSteps } from "./sim-states-walk-steps.js";
 
 interface SimStatesInterpreterProperties {
   readonly definition: SimStatesDefinition;
-
-  /**
-   * What the walk records itself on: an execution, or one branch of a
-   * `Parallel` state.
-   */
-  readonly record: SimStatesRunRecord;
-
   readonly background: BackgroundScheduler;
 
   /**
-   * Where a `Task` state does its work.
+   * What every state of this walk is given, the record it writes itself on
+   * included.
    */
-  readonly tasks: SimStatesTaskTargets;
-
-  /**
-   * The state machine's execution role, which a task assumes.
-   */
-  readonly roleArn: string;
-
-  /**
-   * How a state that runs states of its own gets a walk over them.
-   */
-  readonly walkChild: SimStatesChildWalks;
+  readonly walk: SimStatesWalkContext;
 
   /**
    * What to do once this walk has ended, which is how a branch tells the
@@ -77,12 +58,12 @@ export class SimStatesInterpreter implements SimStatesChildWalk {
 
   constructor(properties: SimStatesInterpreterProperties) {
     this.#definition = properties.definition;
-    this.#record = properties.record;
+    this.#record = properties.walk.record;
     this.#background = properties.background;
     this.#onSettled = properties.onSettled;
 
     const settlement = new SimStatesSettlement({
-      record: properties.record,
+      record: properties.walk.record,
       background: properties.background,
     });
 
@@ -90,12 +71,7 @@ export class SimStatesInterpreter implements SimStatesChildWalk {
     this.#attempts = new SimStatesStateAttempts({
       runner: new SimStatesStateRunner({
         background: properties.background,
-        walk: {
-          record: properties.record,
-          tasks: properties.tasks,
-          roleArn: properties.roleArn,
-          walkChild: properties.walkChild,
-        },
+        walk: properties.walk,
       }),
       settlement,
       background: properties.background,

--- a/src/service/stepfunctions/execution/sim-states-map-items.ts
+++ b/src/service/stepfunctions/execution/sim-states-map-items.ts
@@ -1,0 +1,61 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { selectSimStatesReadPath } from "../data/sim-states-context-path.js";
+import type { SimStatesMapState } from "../definition/sim-states-state.js";
+import { SimStatesRuntimeFailure } from "../error/sim-step-functions.error.js";
+import type { SimStatesStateContext } from "./sim-states-state-outcome.js";
+
+/**
+ * The items one `Map` state runs its `ItemProcessor` over.
+ *
+ * `ItemsPath` selects them out of the state's effective input, and a state
+ * carrying none runs over that input itself. Real Step Functions fails the
+ * execution with `States.Runtime` where what it finds is not an array, and so
+ * does this.
+ */
+export function simStatesMapItems(
+  state: SimStatesMapState,
+  effective: JSONValue,
+  context: SimStatesStateContext,
+): readonly JSONValue[] {
+  const items = selected(state, effective, context);
+
+  if (!Array.isArray(items)) {
+    throw new SimStatesRuntimeFailure(
+      `The Map state ${context.stateName} reads its items from ` +
+        `${state.ItemsPath ?? "$"}, which holds ${found(items)} rather than ` +
+        "an array.",
+    );
+  }
+
+  return items;
+}
+
+/**
+ * What the state found there, for the failure it ends with.
+ */
+function found(items: JSONValue | undefined): string {
+  if (items === undefined) {
+    return "nothing";
+  }
+
+  return JSON.stringify(items);
+}
+
+/**
+ * What the state's `ItemsPath` selects, which may be nothing at all.
+ */
+function selected(
+  state: SimStatesMapState,
+  effective: JSONValue,
+  context: SimStatesStateContext,
+): JSONValue | undefined {
+  if (state.ItemsPath === undefined) {
+    return effective;
+  }
+
+  return selectSimStatesReadPath(
+    state.ItemsPath,
+    effective,
+    context.contextObject,
+  );
+}

--- a/src/service/stepfunctions/execution/sim-states-map-iteration.ts
+++ b/src/service/stepfunctions/execution/sim-states-map-iteration.ts
@@ -1,0 +1,70 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { simStatesMapItemContext } from "../data/sim-states-context-object.js";
+import { evaluateSimStatesPayloadTemplate } from "../data/sim-states-payload-template.js";
+import type { SimStatesMapState } from "../definition/sim-states-state.js";
+import type { SimStatesChildStart } from "./sim-states-child-runs.js";
+import type { SimStatesStateContext } from "./sim-states-state-outcome.js";
+
+/**
+ * What a `MaxConcurrency` of 0 means, which is every iteration at once.
+ */
+const unbounded = Infinity;
+
+interface SimStatesMapIterationProperties {
+  readonly state: SimStatesMapState;
+
+  /**
+   * The `Map` state's effective input, which `ItemSelector` reads through `$`.
+   */
+  readonly effective: JSONValue;
+
+  readonly item: JSONValue;
+  readonly index: number;
+  readonly context: SimStatesStateContext;
+}
+
+/**
+ * How many iterations one `Map` state runs at once.
+ *
+ * A state carrying no `MaxConcurrency`, or one of 0, runs all of them. Both
+ * arrive here as an infinite bound, which is the bound the fan-out subtracts
+ * from.
+ */
+export function simStatesMapConcurrency(state: SimStatesMapState): number {
+  const bound = state.MaxConcurrency ?? 0;
+
+  return bound === 0 ? unbounded : bound;
+}
+
+/**
+ * One iteration, and what it is given to work on.
+ *
+ * `ItemSelector` reads the state's own effective input through `$`, and the
+ * item it is building for through `$$.Map.Item`. A state carrying none gives
+ * the iteration the item itself.
+ */
+export function simStatesMapIteration(
+  properties: SimStatesMapIterationProperties,
+): SimStatesChildStart {
+  const { context, effective, index, item, state } = properties;
+
+  const contextObject = simStatesMapItemContext(
+    context.contextObject,
+    index,
+    item,
+  );
+
+  return {
+    index,
+    definition: state.ItemProcessor,
+    contextObject,
+    input:
+      state.ItemSelector === undefined
+        ? item
+        : evaluateSimStatesPayloadTemplate(
+            state.ItemSelector,
+            effective,
+            contextObject,
+          ),
+  };
+}

--- a/src/service/stepfunctions/execution/sim-states-run-choice.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-choice.ts
@@ -22,7 +22,11 @@ export function runSimStatesChoice(
   input: JSONValue,
   context: SimStatesStateContext,
 ): SimStatesStateOutcome {
-  const effective = simStatesEffectiveInput(input, state);
+  const effective = simStatesEffectiveInput(
+    input,
+    state,
+    context.contextObject,
+  );
   const matched = state.Choices.find((rule) => rule.matches(effective));
   const next = matched?.next ?? state.Default;
 
@@ -35,7 +39,12 @@ export function runSimStatesChoice(
 
   return {
     kind: "next",
-    output: simStatesEffectiveOutput(effective, effective, state),
+    output: simStatesEffectiveOutput(
+      effective,
+      effective,
+      state,
+      context.contextObject,
+    ),
     next,
   };
 }

--- a/src/service/stepfunctions/execution/sim-states-run-map.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-map.ts
@@ -1,0 +1,47 @@
+import type { JSONValue } from "../../../util/type-guard/json.js";
+import { simStatesEffectiveInput } from "../data/sim-states-data-flow.js";
+import type { SimStatesMapState } from "../definition/sim-states-state.js";
+import { SimStatesFanOut } from "./sim-states-fan-out.js";
+import { simStatesFanOutOutcome } from "./sim-states-fan-out-outcome.js";
+import {
+  simStatesMapConcurrency,
+  simStatesMapIteration,
+} from "./sim-states-map-iteration.js";
+import { simStatesMapItems } from "./sim-states-map-items.js";
+import type {
+  SimStatesStateContext,
+  SimStatesStateOutcome,
+} from "./sim-states-state-outcome.js";
+
+/**
+ * A `Map` state, which runs its `ItemProcessor` once per item.
+ *
+ * The result is an array of what each iteration produced, in the order the
+ * items were in rather than the order the iterations finished. An empty array
+ * of items runs the processor no times and answers with an empty array.
+ */
+export async function runSimStatesMap(
+  state: SimStatesMapState,
+  input: JSONValue,
+  context: SimStatesStateContext,
+): Promise<SimStatesStateOutcome> {
+  const effective = simStatesEffectiveInput(
+    input,
+    state,
+    context.contextObject,
+  );
+  const items = simStatesMapItems(state, effective, context);
+
+  return await new SimStatesFanOut({
+    context,
+    kind: "iteration",
+    limit: simStatesMapConcurrency(state),
+    children: items.map((item, index) =>
+      simStatesMapIteration({ state, effective, item, index, context }),
+    ),
+    names: (index) =>
+      `Iteration ${String(index)} of the Map state ${context.stateName}`,
+    answers: (outputs) =>
+      simStatesFanOutOutcome(state, input, outputs, context.contextObject),
+  }).run();
+}

--- a/src/service/stepfunctions/execution/sim-states-run-parallel.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-parallel.ts
@@ -24,18 +24,25 @@ export async function runSimStatesParallel(
   input: JSONValue,
   context: SimStatesStateContext,
 ): Promise<SimStatesStateOutcome> {
-  const effective = simStatesEffectiveInput(input, state);
+  const effective = simStatesEffectiveInput(
+    input,
+    state,
+    context.contextObject,
+  );
 
   return await new SimStatesFanOut({
     context,
     kind: "branch",
+    limit: Infinity,
     children: state.Branches.map((definition, index) => ({
       index,
       definition,
       input: effective,
+      contextObject: context.contextObject,
     })),
     names: (index) =>
       `Branch ${String(index + 1)} of the Parallel state ${context.stateName}`,
-    answers: (outputs) => simStatesFanOutOutcome(state, input, outputs),
+    answers: (outputs) =>
+      simStatesFanOutOutcome(state, input, outputs, context.contextObject),
   }).run();
 }

--- a/src/service/stepfunctions/execution/sim-states-run-state.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-state.ts
@@ -10,6 +10,7 @@ import type {
   SimStatesSucceedState,
 } from "../definition/sim-states-state.js";
 import { runSimStatesChoice } from "./sim-states-run-choice.js";
+import { runSimStatesMap } from "./sim-states-run-map.js";
 import { runSimStatesParallel } from "./sim-states-run-parallel.js";
 import { runSimStatesTask } from "./sim-states-run-task.js";
 import { runSimStatesWait } from "./sim-states-run-wait.js";
@@ -29,8 +30,8 @@ const unnamedFailError = "States.Unknown";
  * A data-flow field raising is left to the caller, which reads the Amazon
  * States Language error name off whatever came out.
  *
- * This waits on the work a `Task` state does, and on the branches a `Parallel`
- * state runs as far as they get. Every other state type answers without
+ * This waits on the work a `Task` state does, and on the branches or
+ * iterations a `Parallel` or a `Map` state runs as far as they get. Every other state type answers without
  * waiting for anything. A `Wait` state pauses the walk rather than blocking
  * it, and answers by saying what it is waiting for.
  */
@@ -48,7 +49,7 @@ export async function runSimStatesState(
   }
 
   if (state.Type === "Succeed") {
-    return runSucceed(state, input);
+    return runSucceed(state, input, context);
   }
 
   if (state.Type === "Choice") {
@@ -63,7 +64,11 @@ export async function runSimStatesState(
     return await runSimStatesParallel(state, input, context);
   }
 
-  return runPass(state, input);
+  if (state.Type === "Map") {
+    return await runSimStatesMap(state, input, context);
+  }
+
+  return runPass(state, input, context);
 }
 
 /**
@@ -72,10 +77,20 @@ export async function runSimStatesState(
 function runPass(
   state: SimStatesPassState,
   input: JSONValue,
+  context: SimStatesStateContext,
 ): SimStatesStateOutcome {
-  const effective = simStatesEffectiveInput(input, state);
+  const effective = simStatesEffectiveInput(
+    input,
+    state,
+    context.contextObject,
+  );
   const result = state.Result === undefined ? effective : state.Result;
-  const output = simStatesEffectiveOutput(input, result, state);
+  const output = simStatesEffectiveOutput(
+    input,
+    result,
+    state,
+    context.contextObject,
+  );
 
   return state.Next === undefined
     ? { kind: "succeed", output }
@@ -88,12 +103,22 @@ function runPass(
 function runSucceed(
   state: SimStatesSucceedState,
   input: JSONValue,
+  context: SimStatesStateContext,
 ): SimStatesStateOutcome {
-  const effective = simStatesEffectiveInput(input, state);
+  const effective = simStatesEffectiveInput(
+    input,
+    state,
+    context.contextObject,
+  );
 
   return {
     kind: "succeed",
-    output: simStatesEffectiveOutput(effective, effective, state),
+    output: simStatesEffectiveOutput(
+      effective,
+      effective,
+      state,
+      context.contextObject,
+    ),
   };
 }
 

--- a/src/service/stepfunctions/execution/sim-states-run-task.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-task.ts
@@ -26,11 +26,16 @@ export async function runSimStatesTask(
   const result = await context.tasks.invoke({
     stateName: context.stateName,
     target: state.target,
-    payload: simStatesEffectiveInput(input, state),
+    payload: simStatesEffectiveInput(input, state, context.contextObject),
     roleArn: context.roleArn,
   });
 
-  const output = simStatesEffectiveOutput(input, result, state);
+  const output = simStatesEffectiveOutput(
+    input,
+    result,
+    state,
+    context.contextObject,
+  );
 
   return state.Next === undefined
     ? { kind: "succeed", output }

--- a/src/service/stepfunctions/execution/sim-states-run-wait.ts
+++ b/src/service/stepfunctions/execution/sim-states-run-wait.ts
@@ -22,8 +22,17 @@ export function runSimStatesWait(
   input: JSONValue,
   context: SimStatesStateContext,
 ): SimStatesStateOutcome {
-  const effective = simStatesEffectiveInput(input, state);
-  const output = simStatesEffectiveOutput(effective, effective, state);
+  const effective = simStatesEffectiveInput(
+    input,
+    state,
+    context.contextObject,
+  );
+  const output = simStatesEffectiveOutput(
+    effective,
+    effective,
+    state,
+    context.contextObject,
+  );
   const resume: SimStatesMoveOnOutcome =
     state.Next === undefined
       ? { kind: "succeed", output }

--- a/src/service/stepfunctions/execution/sim-states-state-outcome.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-outcome.ts
@@ -1,4 +1,4 @@
-import type { JSONValue } from "../../../util/type-guard/json.js";
+import type { JSONObject, JSONValue } from "../../../util/type-guard/json.js";
 import type { SimStatesAttemptState } from "../retry/sim-states-attempt-state.js";
 import type { SimStatesTaskTargets } from "../task/sim-states-task-invocation.js";
 import type { SimStatesChildWalks } from "./sim-states-child-walk.js";
@@ -100,6 +100,12 @@ export interface SimStatesWalkContext {
    * How a state that runs states of its own gets a walk over them.
    */
   readonly walkChild: SimStatesChildWalks;
+
+  /**
+   * What `$$` reads. The state running adds its own `State` to this, and a
+   * `Map` iteration is given one carrying the item it runs for.
+   */
+  readonly contextObject: JSONObject;
 }
 
 /**

--- a/src/service/stepfunctions/execution/sim-states-state-runner.ts
+++ b/src/service/stepfunctions/execution/sim-states-state-runner.ts
@@ -1,5 +1,9 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
-import type { SimStatesAttemptState } from "../retry/sim-states-attempt-state.js";
+import { simStatesStateContext } from "../data/sim-states-context-object.js";
+import {
+  type SimStatesAttemptState,
+  simStatesRetriesSoFar,
+} from "../retry/sim-states-attempt-state.js";
 import { simStatesRecovered } from "../retry/sim-states-recovered.js";
 import { simStatesTimedOut } from "../retry/sim-states-task-deadline.js";
 import { simStatesFailureFrom } from "./sim-states-failure.js";
@@ -97,12 +101,19 @@ export class SimStatesStateRunner {
       return overdue;
     }
 
+    const now = this.#background.now();
+
     try {
       return await runSimStatesState(entry.state, entry.input, {
         ...this.#walk,
         stateName: entry.name,
-        now: this.#background.now(),
+        now,
         resume,
+        contextObject: simStatesStateContext(this.#walk.contextObject, {
+          name: entry.name,
+          enteredTime: now,
+          retryCount: simStatesRetriesSoFar(attempt),
+        }),
       });
     } catch (error) {
       return simStatesFailureFrom(error);

--- a/src/service/stepfunctions/execution/sim-states-walks.ts
+++ b/src/service/stepfunctions/execution/sim-states-walks.ts
@@ -31,11 +31,14 @@ export function simStatesWalks(
   const walks: SimStatesChildWalks = (child) =>
     new SimStatesInterpreter({
       definition: child.definition,
-      record: child.record,
       background: properties.background,
-      tasks: properties.tasks,
-      roleArn: properties.roleArn,
-      walkChild: walks,
+      walk: {
+        record: child.record,
+        contextObject: child.contextObject,
+        tasks: properties.tasks,
+        roleArn: properties.roleArn,
+        walkChild: walks,
+      },
       ...(child.onSettled !== undefined && { onSettled: child.onSettled }),
     });
 

--- a/src/service/stepfunctions/index.ts
+++ b/src/service/stepfunctions/index.ts
@@ -20,12 +20,11 @@ export { SimStatesExecution } from "./execution/sim-states-execution.js";
 export type { SimStatesExecutionStatus } from "./execution/sim-states-execution.js";
 export type { SimStatesAttempt } from "./execution/sim-states-attempt.js";
 export type { SimStatesDefinition } from "./definition/sim-states-definition.js";
-export {
-  simStatesRunnableTypes,
-  simStatesStateTypes,
-} from "./definition/sim-states-state.js";
+export { simStatesStateTypes } from "./definition/sim-states-state.js";
 export type {
   SimStatesChoiceState,
+  SimStatesMapState,
+  SimStatesParallelState,
   SimStatesState,
   SimStatesStateType,
   SimStatesTaskState,

--- a/src/service/stepfunctions/retry/sim-states-attempt-state.ts
+++ b/src/service/stepfunctions/retry/sim-states-attempt-state.ts
@@ -44,6 +44,16 @@ export function simStatesRetriesTaken(
 }
 
 /**
+ * How many retries this entry to a state has taken, across its retriers.
+ *
+ * The context object reports this as `$$.State.RetryCount`, which counts the
+ * state rather than the retrier that asked for each one.
+ */
+export function simStatesRetriesSoFar(attempt: SimStatesAttemptState): number {
+  return attempt.taken.reduce((total, taken) => total + taken, 0);
+}
+
+/**
  * The same attempt state with one more retry counted against a retrier.
  */
 export function simStatesRetryTaken(

--- a/src/service/stepfunctions/retry/sim-states-error-handling.ts
+++ b/src/service/stepfunctions/retry/sim-states-error-handling.ts
@@ -8,8 +8,9 @@ import { parseSimStatesRetriers } from "./sim-states-retry-parse.js";
 /**
  * What a state says about failing.
  *
- * A `Task` state and a `Parallel` state both carry these two, and both read
- * them the same way: the retriers first and the catchers after them.
+ * A `Task` state, a `Parallel` state and a `Map` state all carry these two,
+ * and all read them the same way. The retriers come first and the catchers
+ * after them.
  */
 export interface SimStatesErrorHandling {
   readonly Retry?: readonly SimStatesRetrier[];
@@ -19,17 +20,26 @@ export interface SimStatesErrorHandling {
 /**
  * The `Retry` and `Catch` a state carries, where its type has them.
  *
- * A `Task` state and a `Parallel` state carry both. Every other state type
- * fails the walk it is in, since there is nothing on it to say otherwise.
+ * Every other state type fails the walk it is in, since there is nothing on
+ * it to say otherwise.
  */
 export function simStatesErrorHandling(
   state: SimStatesState,
 ): SimStatesErrorHandling | undefined {
-  if (state.Type === "Task" || state.Type === "Parallel") {
-    return state;
+  switch (state.Type) {
+    case "Task":
+    case "Parallel":
+    case "Map": {
+      return state;
+    }
+    case "Choice":
+    case "Fail":
+    case "Pass":
+    case "Succeed":
+    case "Wait": {
+      return undefined;
+    }
   }
-
-  return undefined;
 }
 
 /**

--- a/src/service/stepfunctions/sim-step-functions-context-object.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-context-object.iso.test.ts
@@ -1,0 +1,174 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+
+describe("Simulated Step Functions context object", () => {
+  const startedAt = new Date("2026-07-26T09:00:00.000Z");
+
+  /**
+   * Run a workflow of one state and read back what it produced.
+   */
+  async function outputOf(simAws: SimAws, state: JSONObject): Promise<unknown> {
+    const executionArn = await statesExecutionFactory.make(
+      { state, input: '{"student":"Wei"}' },
+      simAws,
+    );
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+
+    return JSON.parse(described.output ?? "null") as unknown;
+  }
+
+  it("reads what the execution and its state machine are called", async () => {
+    // Given a Pass state building its result out of the context object.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+
+    // When it runs.
+    const output = await outputOf(simAws, {
+      Type: "Pass",
+      Parameters: {
+        "execution.$": "$$.Execution.Name",
+        "id.$": "$$.Execution.Id",
+        "started.$": "$$.Execution.StartTime",
+        "role.$": "$$.Execution.RoleArn",
+        "input.$": "$$.Execution.Input",
+        "machine.$": "$$.StateMachine.Name",
+      },
+      End: true,
+    });
+
+    // Then each field holds what the execution was started with.
+    assertObjectEquals(output, {
+      execution: "execution-1",
+      id: `arn:aws:states:${simAws.defaultRegionName}:${simAws.defaultAccountId}:execution:Enrolment:execution-1`,
+      started: "2026-07-26T09:00:00.000Z",
+      role: `arn:aws:iam::${simAws.defaultAccountId}:role/WorkflowRole`,
+      input: { student: "Wei" },
+      machine: "Enrolment",
+    });
+  });
+
+  it("reads what the state running is called and when it was entered", async () => {
+    // Given a state reading its own entry in the context object.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+
+    // When it runs.
+    const output = await outputOf(simAws, {
+      Type: "Pass",
+      Parameters: {
+        "state.$": "$$.State.Name",
+        "entered.$": "$$.State.EnteredTime",
+        "retries.$": "$$.State.RetryCount",
+      },
+      End: true,
+    });
+
+    // Then the state names itself, and has taken no retries.
+    assertObjectEquals(output, {
+      state: "Check",
+      entered: "2026-07-26T09:00:00.000Z",
+      retries: 0,
+    });
+  });
+
+  it("counts the retries one entry to a state has taken", async () => {
+    // Given a task that fails once, and answers with what it was sent after
+    // that.
+    const simAws = new SimAws();
+    let called = 0;
+    const check = await statesTaskFunctionFactory.make(
+      {
+        handler: (event: unknown): unknown => {
+          called += 1;
+
+          if (called === 1) {
+            throw new Error("the enrolment service is down");
+          }
+
+          return event;
+        },
+      },
+      simAws,
+    );
+    const executionArn = await statesExecutionFactory.make(
+      {
+        state: {
+          Type: "Task",
+          Resource: check.arn,
+          Parameters: { "retries.$": "$$.State.RetryCount" },
+          Retry: [{ ErrorEquals: ["States.ALL"], IntervalSeconds: 5 }],
+          End: true,
+        },
+      },
+      simAws,
+    );
+
+    // When the clock passes the wait before the retry.
+    await simAws.clock().advanceBy({ seconds: 10 });
+
+    // Then the attempt that came good was the first retry.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.output, '{"retries":1}');
+  });
+
+  it("reads the context object from a path and an intrinsic function", async () => {
+    // Given an OutputPath and an intrinsic argument reading `$$`.
+    const simAws = new SimAws();
+
+    // When each runs.
+    const narrowed = await outputOf(simAws, {
+      Type: "Pass",
+      OutputPath: "$$.Execution.Input",
+      End: true,
+    });
+    const formatted = await outputOf(new SimAws(), {
+      Type: "Pass",
+      Parameters: {
+        "greeting.$":
+          "States.Format('Enrolling {}', $$.Execution.Input.student)",
+      },
+      End: true,
+    });
+
+    // Then both read the context object rather than the state's input.
+    assertObjectEquals(narrowed, { student: "Wei" });
+    assertObjectEquals(formatted, { greeting: "Enrolling Wei" });
+  });
+
+  it("refuses a path that writes into the context object", async () => {
+    // Given a state whose ResultPath writes into the context object.
+    const simAws = new SimAws();
+    const executionArn = await statesExecutionFactory.make(
+      {
+        state: { Type: "Pass", ResultPath: "$$.State.Name", End: true },
+      },
+      simAws,
+    );
+
+    // When it runs.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    // Then the state failed, since the context object is read rather than
+    // written.
+    assertIdentical(described.status, "FAILED");
+    assertIdentical(described.error, "States.QueryEvaluationError");
+    assertStringIncludes(described.cause ?? "", "context object");
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-inspection.ts
+++ b/src/service/stepfunctions/sim-step-functions-inspection.ts
@@ -48,6 +48,18 @@ export class SimStepFunctionsInspection {
   }
 
   /**
+   * Every iteration of every `Map` state one execution ran.
+   *
+   * An iteration runs states of its own, the way a `Parallel` state's branch
+   * does, and is reported here rather than among the states the execution
+   * around it visited. Each says which item it was for by its index, counting
+   * from zero.
+   */
+  iterations(executionArn: string): readonly SimStatesChild[] {
+    return this.#childrenOf(executionArn, "iteration");
+  }
+
+  /**
    * Every execution of one state machine, most recently started first.
    */
   executionsOf(stateMachineArn: string): readonly string[] {

--- a/src/service/stepfunctions/sim-step-functions-map-iterations.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-map-iterations.iso.test.ts
@@ -1,0 +1,236 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
+import { statesFlakyHandlerFactory } from "../../../test/stepfunctions/states-flaky-handler.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+
+describe("Simulated Step Functions Map iterations", () => {
+  const startedAt = new Date("2026-07-26T09:00:00.000Z");
+
+  /**
+   * Three students to run a Map state over.
+   */
+  const students = '{"students":[{"id":"wei"},{"id":"mei"},{"id":"jun"}]}';
+
+  /**
+   * A simulation whose clock stands still where the test put it.
+   */
+  function givenAFrozenClock(): SimAws {
+    return new SimAws({ clock: new SimFixedClock(startedAt) });
+  }
+
+  /**
+   * Run a workflow whose first state is the `Map` state under test.
+   */
+  async function runWorkflow(
+    simAws: SimAws,
+    state: JSONObject,
+    states: JSONObject = {},
+  ): Promise<string> {
+    return await statesExecutionFactory.make(
+      { state, states, input: students },
+      simAws,
+    );
+  }
+
+  /**
+   * An item processor that waits a minute and then records the clock.
+   */
+  function stamping(functionArn: string): JSONObject {
+    return {
+      StartAt: "Settle",
+      States: {
+        Settle: { Type: "Wait", Seconds: 60, Next: "Stamp" },
+        Stamp: { Type: "Task", Resource: functionArn, End: true },
+      },
+    };
+  }
+
+  /**
+   * A function answering with the instant the simulation was at when it ran.
+   */
+  async function givenAStampingFunction(simAws: SimAws): Promise<string> {
+    const stamp = await statesTaskFunctionFactory.make(
+      {
+        functionName: "stamp-enrolment",
+        handler: (): unknown => ({ at: new Date().toISOString() }),
+      },
+      simAws,
+    );
+
+    return stamp.arn;
+  }
+
+  it("runs the iterations one at a time under a MaxConcurrency of 1", async () => {
+    // Given a Map state bounded to one iteration at a time, whose processor
+    // waits a minute before it records the clock.
+    const simAws = givenAFrozenClock();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Map",
+      ItemsPath: "$.students",
+      MaxConcurrency: 1,
+      ItemProcessor: stamping(await givenAStampingFunction(simAws)),
+      End: true,
+    });
+
+    // When simulated time passes all three waits.
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then each iteration waited its own minute, which it could only have
+    // done by starting after the one before it finished.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+    assertObjectEquals(JSON.parse(described.output ?? "null") as unknown, [
+      { at: "2026-07-26T09:01:00.000Z" },
+      { at: "2026-07-26T09:02:00.000Z" },
+      { at: "2026-07-26T09:03:00.000Z" },
+    ]);
+  });
+
+  it("runs every iteration at once where nothing bounds them", async () => {
+    // Given the same workflow with a MaxConcurrency of 0, which is what a
+    // Map state carrying none means.
+    const simAws = givenAFrozenClock();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Map",
+      ItemsPath: "$.students",
+      MaxConcurrency: 0,
+      ItemProcessor: stamping(await givenAStampingFunction(simAws)),
+      End: true,
+    });
+
+    // When simulated time passes the one wait they share.
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then all three ran their task at the same instant.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertObjectEquals(JSON.parse(described.output ?? "null") as unknown, [
+      { at: "2026-07-26T09:01:00.000Z" },
+      { at: "2026-07-26T09:01:00.000Z" },
+      { at: "2026-07-26T09:01:00.000Z" },
+    ]);
+  });
+
+  it("fails the state when an iteration fails, and catches it", async () => {
+    // Given a Map state whose processor declines the second student, and a
+    // Catch that compensates for the state failing.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(
+      simAws,
+      {
+        Type: "Map",
+        ItemsPath: "$.students",
+        ItemProcessor: {
+          StartAt: "Eligible",
+          States: {
+            Eligible: {
+              Type: "Choice",
+              Choices: [
+                { Variable: "$.id", StringEquals: "mei", Next: "Decline" },
+              ],
+              Default: "Register",
+            },
+            Register: { Type: "Pass", End: true },
+            Decline: { Type: "Fail", Error: "NotEligible", Cause: "no place" },
+          },
+        },
+        Catch: [
+          {
+            ErrorEquals: ["States.BranchFailed"],
+            Next: "Compensate",
+            ResultPath: "$.error",
+          },
+        ],
+        End: true,
+      },
+      { Compensate: { Type: "Pass", End: true } },
+    );
+
+    // When it runs, the catcher took the failure and the cause names the
+    // iteration that failed.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+    assertObjectEquals(
+      (JSON.parse(described.output ?? "null") as { error: unknown }).error,
+      {
+        Error: "States.BranchFailed",
+        Cause:
+          "Iteration 1 of the Map state Check failed with NotEligible: no place",
+      },
+    );
+    // The third student was never reached: an iteration failing leaves the
+    // ones that have not started nothing to do.
+    assertObjectEquals(
+      simAws
+        .stepFunctions()
+        .inspection()
+        .iterations(executionArn)
+        .map((iteration) => iteration.status),
+      ["SUCCEEDED", "FAILED"],
+    );
+  });
+
+  it("runs the iterations again for a Retry on the Map state", async () => {
+    // Given a Map state whose task fails the first time it is called.
+    const simAws = new SimAws();
+    const enrol = await statesTaskFunctionFactory.make(
+      {
+        functionName: "enrol-student",
+        handler: statesFlakyHandlerFactory.make({ failures: 1 }),
+      },
+      simAws,
+    );
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Map",
+      ItemsPath: "$.students",
+      MaxConcurrency: 1,
+      ItemProcessor: {
+        StartAt: "Enrol",
+        States: { Enrol: { Type: "Task", Resource: enrol.arn, End: true } },
+      },
+      Retry: [
+        {
+          ErrorEquals: ["States.BranchFailed"],
+          IntervalSeconds: 5,
+          MaxAttempts: 1,
+        },
+      ],
+      End: true,
+    });
+
+    // When the clock passes the wait before the retry.
+    await simAws.clock().advanceBy({ seconds: 10 });
+
+    // Then every iteration ran again, and the second run came good.
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+    assertIdentical(
+      described.output,
+      '[{"eligible":true},{"eligible":true},{"eligible":true}]',
+    );
+    assertObjectEquals(
+      simAws
+        .stepFunctions()
+        .inspection()
+        .iterations(executionArn)
+        .map((iteration) => `${String(iteration.index)} ${iteration.status}`),
+      ["0 FAILED", "0 SUCCEEDED", "1 SUCCEEDED", "2 SUCCEEDED"],
+    );
+  });
+});

--- a/src/service/stepfunctions/sim-step-functions-map.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-map.iso.test.ts
@@ -92,6 +92,37 @@ describe("Simulated Step Functions Map", () => {
     );
   });
 
+  it("answers in item order whatever order the iterations finished in", async () => {
+    // Given iterations that wait for as long as their own item says, so the
+    // last item is the first one done.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(
+      simAws,
+      {
+        Type: "Map",
+        ItemProcessor: {
+          StartAt: "Settle",
+          States: {
+            Settle: { Type: "Wait", SecondsPath: "$.wait", Next: "Register" },
+            Register: { Type: "Pass", End: true },
+          },
+        },
+        End: true,
+      },
+      '[{"id":"wei","wait":180},{"id":"mei","wait":120},{"id":"jun","wait":60}]',
+    );
+
+    // When simulated time passes all three waits.
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then the result is in the order the items were in.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { id: "wei", wait: 180 },
+      { id: "mei", wait: 120 },
+      { id: "jun", wait: 60 },
+    ]);
+  });
+
   it("builds each iteration's input from the ItemSelector", async () => {
     // Given a Map state whose ItemSelector reads the item, its index and the
     // state's own input, and a task that answers with what it was given.

--- a/src/service/stepfunctions/sim-step-functions-map.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-map.iso.test.ts
@@ -168,6 +168,28 @@ describe("Simulated Step Functions Map", () => {
     ]);
   });
 
+  it("reads the older spellings CDK still writes", async () => {
+    // Given a Map state written with Iterator and Parameters, as CDK writes
+    // one built through its deprecated call and property.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Map",
+      ItemsPath: "$.students",
+      Parameters: { "id.$": "$$.Map.Item.Value.id", "term.$": "$.term" },
+      Iterator: echoing,
+      End: true,
+    });
+
+    // When it runs, Iterator ran as the item processor and Parameters built
+    // each iteration's input.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { id: "wei", term: 3 },
+      { id: "mei", term: 3 },
+      { id: "jun", term: 3 },
+      { id: "lan", term: 3 },
+    ]);
+  });
+
   it("answers with an empty array where there are no items", async () => {
     // Given a Map state over an array holding nothing.
     const simAws = new SimAws();

--- a/src/service/stepfunctions/sim-step-functions-map.iso.test.ts
+++ b/src/service/stepfunctions/sim-step-functions-map.iso.test.ts
@@ -1,0 +1,251 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { statesExecutionFactory } from "../../../test/stepfunctions/states-execution.factory.js";
+import { statesTaskFunctionFactory } from "../../../test/stepfunctions/states-task-function.factory.js";
+import type { JSONObject } from "../../util/type-guard/json.js";
+import { SimAws } from "../aws/sim-aws.js";
+import type { SimDescribeExecutionCommandOutput } from "./command/execution/execution.command.js";
+
+describe("Simulated Step Functions Map", () => {
+  /**
+   * The students a Map state runs over, as the execution input holds them.
+   */
+  const students = JSON.stringify({
+    term: 3,
+    students: [{ id: "wei" }, { id: "mei" }, { id: "jun" }, { id: "lan" }],
+  });
+
+  /**
+   * An item processor of one `Pass` state, which answers with its input.
+   */
+  const echoing: JSONObject = {
+    StartAt: "Register",
+    States: { Register: { Type: "Pass", End: true } },
+  };
+
+  /**
+   * Run a workflow whose first state is the `Map` state under test.
+   */
+  async function runWorkflow(
+    simAws: SimAws,
+    state: JSONObject,
+    input = students,
+  ): Promise<string> {
+    return await statesExecutionFactory.make({ state, input }, simAws);
+  }
+
+  /**
+   * What the execution ended as, as the JSON it answered with.
+   */
+  async function outputOf(
+    simAws: SimAws,
+    executionArn: string,
+  ): Promise<unknown> {
+    const described = await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+
+    assertIdentical(described.status, "SUCCEEDED");
+
+    return JSON.parse(described.output ?? "null") as unknown;
+  }
+
+  it("runs the processor once per item, in input order", async () => {
+    // Given a Map state over four records.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Map",
+      ItemsPath: "$.students",
+      ItemProcessor: echoing,
+      End: true,
+    });
+
+    // When it runs, the result holds one output per item, in the order the
+    // items were in.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { id: "wei" },
+      { id: "mei" },
+      { id: "jun" },
+      { id: "lan" },
+    ]);
+
+    // Then the iterations are reported apart from the states around them.
+    const iterations = simAws
+      .stepFunctions()
+      .inspection()
+      .iterations(executionArn);
+
+    assertArrayLength(iterations, 4);
+    assertObjectEquals(
+      iterations.map((iteration) => iteration.index),
+      [0, 1, 2, 3],
+    );
+    assertObjectEquals(
+      iterations.map((iteration) => iteration.visitedStates),
+      [["Register"], ["Register"], ["Register"], ["Register"]],
+    );
+  });
+
+  it("builds each iteration's input from the ItemSelector", async () => {
+    // Given a Map state whose ItemSelector reads the item, its index and the
+    // state's own input, and a task that answers with what it was given.
+    const simAws = new SimAws();
+    const enrol = await statesTaskFunctionFactory.make(
+      { functionName: "enrol-student", handler: (event: unknown) => event },
+      simAws,
+    );
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Map",
+      ItemsPath: "$.students",
+      ItemSelector: {
+        "id.$": "$$.Map.Item.Value.id",
+        "at.$": "$$.Map.Item.Index",
+        "term.$": "$.term",
+      },
+      ItemProcessor: {
+        StartAt: "Enrol",
+        States: { Enrol: { Type: "Task", Resource: enrol.arn, End: true } },
+      },
+      End: true,
+    });
+
+    // When it runs, each iteration's task was given what the selector built.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { id: "wei", at: 0, term: 3 },
+      { id: "mei", at: 1, term: 3 },
+      { id: "jun", at: 2, term: 3 },
+      { id: "lan", at: 3, term: 3 },
+    ]);
+  });
+
+  it("reads the item inside the iteration as well", async () => {
+    // Given an item processor reading the context object itself.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(simAws, {
+      Type: "Map",
+      ItemsPath: "$.students",
+      ItemProcessor: {
+        StartAt: "Register",
+        States: {
+          Register: {
+            Type: "Pass",
+            Parameters: { "student.$": "$$.Map.Item.Value.id" },
+            End: true,
+          },
+        },
+      },
+      End: true,
+    });
+
+    // When it runs, the states inside the iteration read the item too.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { student: "wei" },
+      { student: "mei" },
+      { student: "jun" },
+      { student: "lan" },
+    ]);
+  });
+
+  it("runs over the whole input where no ItemsPath says otherwise", async () => {
+    // Given a Map state whose input is the array itself.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(
+      simAws,
+      { Type: "Map", ItemProcessor: echoing, End: true },
+      '[{"id":"wei"},{"id":"mei"}]',
+    );
+
+    // When it runs, every item went through the processor.
+    assertObjectEquals(await outputOf(simAws, executionArn), [
+      { id: "wei" },
+      { id: "mei" },
+    ]);
+  });
+
+  it("answers with an empty array where there are no items", async () => {
+    // Given a Map state over an array holding nothing.
+    const simAws = new SimAws();
+    const executionArn = await runWorkflow(
+      simAws,
+      {
+        Type: "Map",
+        ItemsPath: "$.students",
+        ItemProcessor: echoing,
+        ResultPath: "$.enrolled",
+        End: true,
+      },
+      '{"students":[]}',
+    );
+
+    // When it runs, the processor ran no times and the state still answered.
+    assertObjectEquals(await outputOf(simAws, executionArn), {
+      students: [],
+      enrolled: [],
+    });
+    assertArrayLength(
+      simAws.stepFunctions().inspection().iterations(executionArn),
+      0,
+    );
+  });
+
+  /**
+   * Run a Map state that is expected to fail, and read back how it did.
+   */
+  async function failureFrom(
+    simAws: SimAws,
+    state: JSONObject,
+    input: string,
+  ): Promise<SimDescribeExecutionCommandOutput> {
+    const executionArn = await runWorkflow(
+      simAws,
+      { Type: "Map", ItemProcessor: echoing, End: true, ...state },
+      input,
+    );
+
+    return await simAws
+      .stepFunctions()
+      .describeExecution({ input: { executionArn } });
+  }
+
+  it("fails the state where the items are not an array", async () => {
+    // Given an ItemsPath naming a field holding something else, and one
+    // naming a field that is not there at all.
+    // When each runs, each fails the state saying what it found.
+    const failures = await Promise.all([
+      failureFrom(
+        new SimAws(),
+        { ItemsPath: "$.students" },
+        '{"students":{"id":"wei"}}',
+      ),
+      failureFrom(new SimAws(), { ItemsPath: "$.enrolled" }, students),
+      failureFrom(new SimAws(), {}, students),
+    ]);
+
+    const [anObject, nothing, wholeInput] = failures;
+
+    assertObjectEquals(
+      failures.map((described) => described.error),
+      ["States.Runtime", "States.Runtime", "States.Runtime"],
+    );
+    assertIdentical(
+      anObject.cause,
+      "The Map state Check reads its items from $.students, which holds " +
+        '{"id":"wei"} rather than an array.',
+    );
+    assertIdentical(
+      nothing.cause,
+      "The Map state Check reads its items from $.enrolled, which holds " +
+        "nothing rather than an array.",
+    );
+    assertStringIncludes(
+      wholeInput.cause ?? "",
+      "reads its items from $, which holds",
+    );
+  });
+});


### PR DESCRIPTION
A `Map` state runs its `ItemProcessor` once per item and answers with an array
of iteration outputs in item order. `ItemsPath` selects the items,
`ItemSelector` builds what each iteration is given, and `MaxConcurrency` bounds
how many run at once, where 0 runs all of them. An iteration reaching a `Wait`
state is still one of the iterations running, so a bound of 1 holds the next
item back until that wait is over, which a task recording the clock proves. A
failing iteration fails the state with `States.BranchFailed`, abandons the
iterations still going and leaves the items that had not started alone. `Retry`
and `Catch` on the `Map` state work the way they do on a `Task`. `Parameters`
and `Iterator`, the older spellings of `ItemSelector` and `ItemProcessor`, are
both read, since the CDK version in use still writes them for a `Map` built
through its deprecated property and call.

The context object came with it. `$$.Execution`, `$$.StateMachine`, `$$.State`
and `$$.Map` are read in `InputPath`, `OutputPath`, `ItemsPath`, the Payload
Template fields and an intrinsic function's arguments. `ItemSelector` is what
needed it, since an iteration's input is built from `$$.Map.Item.Value` and
`$$.Map.Item.Index`. A field that writes still takes a path rooted at `$`.

Distributed Map stays out. `ItemReader`, `ResultWriter`, `ItemBatcher`, the two
`ToleratedFailure` fields and a `ProcessorConfig` asking for `DISTRIBUTED` are
all refused when the state machine is created.

This is the second half of the split named in
https://github.com/KensioSoftware/yulin/pull/963, which landed `Parallel` and
the fan-out an iteration runs on. It is rebased on that, and comes to 1,944
lines added. Every state type Amazon States Language defines now runs, so
`simStatesRunnableTypes` went with it.

Resolves https://github.com/KensioSoftware/yulin/issues/921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inline Step Functions `Map` states, including item selection, concurrency limits, legacy field aliases, retries, error handling, and ordered results.
  * Added execution and state context access through `$$` paths and intrinsic functions.
  * Added inspection of individual Map iterations.
  * Added an example workflow demonstrating Map processing.
* **Documentation**
  * Updated Step Functions documentation with Map states, context objects, iteration behavior, limitations, and unsupported Distributed Map features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->