### PR TITLE
fix: read a cross-Region EdgeFunction ARN

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1270,6 +1270,11 @@ Stacks deploy in an order their manifest dependencies allow, so a Stack that con
 Stack's export goes second. The deployed Stacks come back keyed by name, each one the same
 `SimCfnStack` `deployTemplateFile(...)` answers with.
 
+`cloudfront.experimental.EdgeFunction` in a Stack outside us-east-1 is one construct that needs the
+whole assembly. It puts the function in a us-east-1 support Stack, and the using Stack reads the
+function's ARN back from an SSM parameter that Stack wrote. Both have to deploy for the read to find
+anything. See [simulated Lambda@Edge](../cloudfront/README.md#simulated-lambdaedge).
+
 ### Deploying part of an assembly
 
 Most apps synthesize Stacks a test has no use for, a deployment pipeline among them. `stackNames`
@@ -3268,7 +3273,8 @@ The resource types it creates are:
 - `AWS::SQS::Queue`
 - `AWS::SSM::Parameter`
 - `AWS::StepFunctions::StateMachine`
-- selected CDK custom resources: `Custom::CDKBucketDeployment` and `Custom::S3BucketNotifications`
+- selected CDK custom resources: `Custom::CDKBucketDeployment`, `Custom::S3BucketNotifications` and
+  `Custom::CrossRegionStringParameterReader`
 
 Each service's own docs describe what its resource types support.
 

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1467,9 +1467,23 @@ exports.handler = async (event) => {
 ```
 
 `cloudfront.experimental.EdgeFunction` deploys from a us-east-1 stack, where the construct creates
-the function alongside everything else. From a stack in any other Region it writes the function into
-a second stack and reads the ARN back through a custom resource, and that route is unsupported (see
-[Limitations](#limitations)).
+the function alongside everything else.
+
+From a stack in any other Region the construct writes the function, its published version and an SSM
+parameter holding the version ARN into a support stack in us-east-1. The stack using the function
+reads that parameter back through a `Custom::CrossRegionStringParameterReader` resource, and the
+Behavior's `LambdaFunctionARN` is an `Fn::GetAtt` on it. Simulated CloudFormation makes that read
+itself, against the Region the resource names, and the association ends up holding the ARN the
+support stack published. Both stacks have to deploy, which is what deploying the whole cloud
+assembly does:
+
+```typescript
+await simAws.cloudFormation().deployCdkOut("cdk.out");
+```
+
+Deploy the using stack's template on its own and no parameter has been written. The read finds
+nothing and says so on `stack.ignoredProperties`, the Behavior deploys without the association, and
+the site serves from the Origin (see [Limitations](#limitations)).
 
 ## Web ACLs
 
@@ -2423,12 +2437,12 @@ Where sim CloudFront knowingly behaves differently from AWS:
   rather than accepting one that would never run. A Distribution deployed from a template records
   the association and deploys without it. A site naming one origin function still serves. The
   request pipeline has no hook either side of the Origin fetch yet.
-- **A CDK `EdgeFunction` outside us-east-1 fails the deployment.**
+- **A CDK `EdgeFunction` outside us-east-1 wants the whole cloud assembly.**
   `cloudfront.experimental.EdgeFunction` writes the function into a us-east-1 support stack and
-  reads its ARN back through a custom resource in the stack that uses it. That custom resource
-  goes unresolved here, and the association is left holding the attribute reference. An
-  `EdgeFunction` in a us-east-1 stack deploys, as the construct creates the function there
-  directly. A `lambda.Version` handed to `edgeLambdas` is the route that works from a template.
+  reads its ARN back through a custom resource in the stack that uses it. `deployCdkOut` deploys
+  both stacks and the read finds the ARN. `deployTemplateFile` on the using stack's template alone
+  deploys one of them, the read finds nothing, and the Distribution goes up without the
+  association, recorded on `stack.ignoredProperties`. `cdk deploy` deploys both either way.
 - **Nothing is replicated.** Real Lambda@Edge copies the function out to every Region and creates the
   `AWSServiceRoleForLambdaReplicator` service-linked role to do it. Here the function is invoked
   where it was created. The trust policy and the `lambda:GetFunction` and `lambda:EnableReplication`

--- a/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-edge-function-region.loc.test.ts
+++ b/src/service/cloudformation/cdk/cloudfront/sim-cdk-cf-edge-function-region.loc.test.ts
@@ -1,0 +1,178 @@
+import path from "node:path";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+
+/**
+ * Slower local integration test. Calls the real CDK CLI to synth a cloud
+ * assembly and deploys it through sim CloudFormation.
+ *
+ * `cloudfront.experimental.EdgeFunction` in a Stack outside us-east-1 is two
+ * Stacks: the function and an SSM parameter holding its version ARN go into a
+ * support Stack in us-east-1, and the Stack that uses it reads the parameter
+ * back through a `Custom::CrossRegionStringParameterReader` Resource. The
+ * Behavior's `LambdaFunctionARN` is an `Fn::GetAtt` on that Resource, so
+ * nothing about the association reads as an ARN until both Stacks have
+ * deployed.
+ *
+ * The us-east-1 case, where the construct creates the function alongside
+ * everything else, is in `sim-cdk-cf-edge-lambda.loc.test.ts`.
+ */
+describe("Sim CDK CloudFront EdgeFunction across Regions local integration", () => {
+  it("runs an EdgeFunction a Stack outside us-east-1 reads the ARN of", async () => {
+    // Given a CDK app whose eu-west-1 Stack runs an EdgeFunction at the viewer
+    // request, which puts the function in a us-east-1 support Stack of its
+    // own.
+    const cdkProject = await edgeFunctionProject("cdk-edge-region-bucket");
+
+    // And the CDK app is synthesized to a cloud assembly of both Stacks.
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When the whole assembly is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stacks = await simAws.cloudFormation().deployCdkOut(cdkOutDirectory);
+
+    const stack = stacks.get("TestStack");
+    assertNonNullable(stack);
+    await stack.waitForDeployComplete();
+
+    const distributionId = stack.outputs.get("DistributionId")?.value;
+    assertNonNullable(distributionId);
+
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId as string,
+      "/index.html",
+    );
+
+    // Then the ARN resolved to the version the support Stack published, and
+    // the function answers the viewer itself.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Edge Function</h1>");
+
+    // And nothing was reported as a gap. CDK's provider function for the
+    // reader is left inert, because the read has already happened.
+    assertArrayLength(stack.skippedResources, 0);
+  });
+
+  it("serves the site without the function when the support Stack is left out", async () => {
+    // Given the same CDK app, synthesized to the same two Stacks.
+    const cdkProject = await edgeFunctionProject("cdk-edge-region-only-bucket");
+    const cdkOutDirectory = await cdkProject.synth();
+
+    // When only the Stack using the EdgeFunction is deployed, so nothing has
+    // written the SSM parameter its ARN is read from.
+    const simAws = new SimAws();
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplateFile(
+        path.join(cdkOutDirectory, "TestStack.template.json"),
+      );
+
+    await stack.waitForDeployComplete();
+
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "cdk-edge-region-only-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>Home</h1>",
+      }),
+    );
+
+    const distributionId = stack.outputs.get("DistributionId")?.value;
+    assertNonNullable(distributionId);
+
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId as string,
+      "/index.html",
+    );
+
+    // Then the Distribution deployed without the association and serves the
+    // Origin, rather than taking the Stack down over an ARN that never
+    // arrived.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Home</h1>");
+
+    // And the association it was deployed without is recorded with the reason.
+    const skipped = stack.ignoredProperties.find((ignored) =>
+      ignored.path.endsWith(
+        "DefaultCacheBehavior.LambdaFunctionAssociations.viewer-request",
+      ),
+    );
+
+    assertNonNullable(skipped);
+    assertStringIncludes(skipped.reason, "had no ARN to answer with");
+  });
+});
+
+/**
+ * A CDK project whose eu-west-1 Stack answers the viewer request with an
+ * EdgeFunction, over a Bucket of the given name.
+ */
+async function edgeFunctionProject(
+  bucketName: string,
+): Promise<TestCdkProject> {
+  const cdkProject = new TestCdkProject();
+
+  await cdkProject.writeCdkAppFile(`
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "TestStack", {
+  env: { account: "111111111111", region: "eu-west-1" },
+});
+
+const siteBucket = new s3.Bucket(stack, "SiteBucket", {
+  bucketName: ${JSON.stringify(bucketName)},
+});
+
+const edgeFunction = new cloudfront.experimental.EdgeFunction(stack, "EdgeFn", {
+  runtime: lambda.Runtime.NODEJS_22_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline(\`
+exports.handler = async () => ({
+  status: "200",
+  headers: { "content-type": [{ key: "Content-Type", value: "text/html" }] },
+  body: "<h1>Edge Function</h1>",
+});
+\`),
+});
+
+const distribution = new cloudfront.Distribution(stack, "SiteDistribution", {
+  defaultBehavior: {
+    origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+    edgeLambdas: [
+      {
+        functionVersion: edgeFunction.currentVersion,
+        eventType: cloudfront.LambdaEdgeEventType.VIEWER_REQUEST,
+      },
+    ],
+  },
+});
+
+new cdk.CfnOutput(stack, "DistributionId", {
+  value: distribution.distributionId,
+});
+
+app.synth();
+`);
+
+  return cdkProject;
+}

--- a/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-error.ts
+++ b/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-error.ts
@@ -1,0 +1,24 @@
+/**
+ * The Resource type CDK reads a parameter from another Region through.
+ */
+export const crossRegionParameterResourceTypeName =
+  "CrossRegionStringParameterReader";
+
+/**
+ * Build the error a Custom::CrossRegionStringParameterReader Resource is
+ * refused with.
+ *
+ * Sim CloudFormation turns a failure whose message reads as an unsupported
+ * Resource type into a skip, so none of these says `Unsupported sim`. A reader
+ * that was refused rather than skipped is one whose properties this simulation
+ * did not recognise, and a Stack should stop on that.
+ */
+export function crossRegionParameterError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid Custom::${crossRegionParameterResourceTypeName} Resource ` +
+      `${logicalId}: ${reason}`,
+  );
+}

--- a/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-properties.ts
+++ b/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-properties.ts
@@ -1,0 +1,97 @@
+import { AWS_REGION_NAMES } from "../../../../aws/sim-aws-region.js";
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+import { crossRegionParameterError } from "./sim-cdk-cross-region-parameter-error.js";
+
+/**
+ * The properties CDK puts on a Custom::CrossRegionStringParameterReader
+ * Resource.
+ *
+ * `ServiceToken` is read and ignored. It points at CDK's own provider
+ * function, whose whole job is the GetParameter call this factory makes
+ * instead. `RefreshToken` is the logical ID of the function version the
+ * parameter was written from, and CDK puts it there so that publishing a new
+ * version makes CloudFormation run the reader again. The reader here runs on
+ * every deployment either way, so the token has nothing left to say.
+ */
+const knownPropertyNames: ReadonlySet<string> = new Set([
+  "ParameterName",
+  "Region",
+  "RefreshToken",
+  "ServiceToken",
+]);
+
+/**
+ * Reads the properties of one Custom::CrossRegionStringParameterReader
+ * Resource.
+ *
+ * A property name CDK does not emit is refused rather than ignored, as it is
+ * for Bucket notifications. This Resource is a private contract between CDK
+ * and its own provider function, so a name that turns up here is a version of
+ * CDK asking for something this simulation has not been told about.
+ */
+export class SimCdkCrossRegionParameterProperties {
+  private readonly logicalId: string;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(logicalId: string, properties: SimCfnTemplateValueRecord) {
+    this.logicalId = logicalId;
+    this.properties = properties;
+
+    this.refuseUnknownProperties();
+  }
+
+  /**
+   * The name of the parameter to read.
+   */
+  get parameterName(): string {
+    const parameterName = this.properties["ParameterName"];
+
+    if (typeof parameterName !== "string" || parameterName === "") {
+      throw crossRegionParameterError(
+        this.logicalId,
+        "ParameterName must resolve to a parameter name",
+      );
+    }
+
+    return parameterName;
+  }
+
+  /**
+   * The Region the parameter is read from.
+   *
+   * CDK writes `us-east-1` here for an EdgeFunction, since that is the only
+   * Region CloudFront runs a Lambda@Edge function from, but the Resource type
+   * says nothing about Lambda@Edge and the Region is read as written.
+   */
+  get regionName(): AwsRegionName {
+    const regionName = this.properties["Region"];
+
+    if (
+      typeof regionName !== "string" ||
+      !(AWS_REGION_NAMES as readonly string[]).includes(regionName)
+    ) {
+      throw crossRegionParameterError(
+        this.logicalId,
+        `Region must resolve to a known AWS Region, and ` +
+          `${jsonStringify(regionName)} is not one`,
+      );
+    }
+
+    return regionName as AwsRegionName;
+  }
+
+  private refuseUnknownProperties(): void {
+    for (const name of Object.keys(this.properties)) {
+      if (!knownPropertyNames.has(name)) {
+        throw crossRegionParameterError(
+          this.logicalId,
+          `${name} is not a Custom::CrossRegionStringParameterReader ` +
+            "property this simulation knows about, so it is refused rather " +
+            "than ignored",
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reader.iso.test.ts
+++ b/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reader.iso.test.ts
@@ -1,0 +1,166 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+import { simCdkCrossRegionParameterTemplateFactory } from "./sim-cdk-cross-region-parameter-template.factory.js";
+
+const edgeFunctionArn =
+  "arn:aws:lambda:us-east-1:111111111111:function:site-edge-fn:1";
+const parameterName = "/cdk/EdgeFunctionArn/eu-west-1/SiteStack/EdgeFn";
+
+/**
+ * Write the parameter an EdgeFunction's support Stack writes, in the Region
+ * that Stack deploys into.
+ */
+async function writeSupportStackParameter(
+  simAws: SimAws,
+  value: string,
+): Promise<void> {
+  await simAws
+    .accountRegionScope(undefined, "us-east-1")
+    .ssm()
+    .putParameter({
+      input: { Name: parameterName, Type: "String", Value: value },
+    });
+}
+
+/**
+ * Deploy the reader template into the Region the using Stack lives in, which
+ * is not the Region the parameter was written in.
+ */
+async function deployUsingStack(
+  simAws: SimAws,
+  template: CfnTemplateBodyRecord,
+): ReturnType<ReturnType<SimAws["cloudFormation"]>["deployTemplate"]> {
+  return await simAws
+    .region("eu-west-1")
+    .cloudFormation()
+    .deployTemplate({ stackName: "site-stack", template });
+}
+
+describe("CDK cross-Region parameter reader CloudFormation Resource [iso]", () => {
+  it("reads the parameter the support Stack wrote in another Region", async () => {
+    // Given a simulated SSM parameter holding an edge function's version ARN,
+    // written in us-east-1 as an EdgeFunction's support Stack writes it.
+    const simAws = new SimAws();
+    await writeSupportStackParameter(simAws, edgeFunctionArn);
+
+    // When a Stack in eu-west-1 deploys the reader CDK synthesizes for it.
+    const stack = await deployUsingStack(
+      simAws,
+      simCdkCrossRegionParameterTemplateFactory.make(),
+    );
+
+    await stack.waitForDeployComplete();
+
+    // Then the Fn::GetAtt on the reader answers with the ARN the parameter
+    // holds, rather than with a stand-in for a value that never arrived.
+    assertIdentical(stack.output("EdgeFunctionArn"), edgeFunctionArn);
+  });
+
+  it("reads nothing and says so when no Stack has written the parameter", async () => {
+    // Given nothing has written the parameter, which is what deploying the
+    // using Stack's template on its own leaves behind.
+    const simAws = new SimAws();
+
+    // When the reader is deployed anyway.
+    const stack = await deployUsingStack(
+      simAws,
+      simCdkCrossRegionParameterTemplateFactory.make(),
+    );
+
+    await stack.waitForDeployComplete();
+
+    // Then the Stack deploys, and the attribute answers with the stand-in an
+    // unanswerable Fn::GetAtt resolves to.
+    assertIdentical(stack.output("EdgeFunctionArn"), "ArnReader.FunctionArn");
+
+    // And the read that did not happen is recorded with what to do about it.
+    const [ignored] = stack.ignoredProperties;
+
+    assertNonNullable(ignored);
+    assertIdentical(ignored.path, "ParameterName");
+    assertStringIncludes(
+      ignored.reason,
+      `no simulated SSM parameter ${parameterName} has been written in us-east-1`,
+    );
+  });
+
+  it("refuses a property this simulation has not been told about", async () => {
+    // Given a reader carrying a property CDK does not emit.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployUsingStack(
+        simAws,
+        simCdkCrossRegionParameterTemplateFactory.make({
+          readerProperties: { WithDecryption: true },
+        }),
+      );
+    });
+
+    // Then the Stack fails naming the property, rather than reading the
+    // parameter as though the property had not been asked for.
+    assertStringIncludes(
+      error.message,
+      "Invalid Custom::CrossRegionStringParameterReader Resource ArnReader: " +
+        "WithDecryption is not a Custom::CrossRegionStringParameterReader " +
+        "property this simulation knows about",
+    );
+  });
+
+  it("refuses a Region that is not an AWS Region", async () => {
+    // Given a reader naming a Region no parameter could be written in.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployUsingStack(
+        simAws,
+        simCdkCrossRegionParameterTemplateFactory.make({
+          regionName: "us-east-9",
+        }),
+      );
+    });
+
+    // Then the Stack fails on the Region.
+    assertStringIncludes(
+      error.message,
+      'Region must resolve to a known AWS Region, and "us-east-9" is not one',
+    );
+  });
+
+  it("refuses an attribute CDK's provider function does not answer", async () => {
+    // Given a parameter to read, and a template reading an attribute off the
+    // reader that its provider function never returns.
+    const simAws = new SimAws();
+    await writeSupportStackParameter(simAws, edgeFunctionArn);
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await deployUsingStack(
+        simAws,
+        simCdkCrossRegionParameterTemplateFactory.make({
+          attributeName: "ParameterValue",
+        }),
+      );
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the Stack fails on the attribute, rather than resolving it to
+    // something nothing put there.
+    assertStringIncludes(
+      error.message,
+      "Unsupported Custom::CrossRegionStringParameterReader attribute " +
+        "ParameterValue",
+    );
+  });
+});

--- a/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reader.ts
+++ b/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reader.ts
@@ -1,0 +1,122 @@
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+import { SimSsmParameterNotFound } from "../../../../ssm/error/sim-ssm.error.js";
+import type { SimCfnServiceResourceFactory } from "../../../resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../../resource/sim-cfn-resource.js";
+import {
+  crossRegionParameterError,
+  crossRegionParameterResourceTypeName,
+} from "./sim-cdk-cross-region-parameter-error.js";
+import { SimCdkCrossRegionParameterProperties } from "./sim-cdk-cross-region-parameter-properties.js";
+import { SimCdkCrossRegionParameterReading } from "./sim-cdk-cross-region-parameter-reading.js";
+
+/**
+ * CloudFormation Resource factory for CDK's cross-Region parameter reader.
+ *
+ * `cloudfront.experimental.EdgeFunction` in a Stack outside `us-east-1` puts
+ * the function itself in a support Stack there and writes its version ARN to
+ * an SSM parameter. The using Stack reads that parameter back through a
+ * `Custom::CrossRegionStringParameterReader` Resource, and the Behavior's
+ * `LambdaFunctionARN` is an `Fn::GetAtt` on it. Without the read the ARN never
+ * arrives, and CloudFront refuses the Distribution over a value that is not an
+ * ARN at all.
+ *
+ * The Resource carries the parameter name and the Region, so this factory
+ * makes the GetParameter call CDK's provider function would have made, through
+ * the ordinary command path. Deploy the whole cloud assembly and the support
+ * Stack has written the parameter by the time this runs, because the manifest
+ * says the using Stack comes after it.
+ *
+ * Deploy the using Stack's template on its own and the parameter is not there.
+ * The reader is created holding nothing rather than failing, so the Stack
+ * deploys and the Distribution goes up without the association, which is
+ * recorded on it. A site survives an edge function whose Stack was left out
+ * the way it survives one this simulation cannot run.
+ */
+export class SimCdkCrossRegionParameterReaderResourceFactory implements SimCfnServiceResourceFactory {
+  /**
+   * Read the parameter the Resource names, in the Region it names.
+   */
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<SimCdkCrossRegionParameterReading> {
+    /* v8 ignore if -- defensive catch; the resolver routes on this name */
+    if (resourceTypeName !== crossRegionParameterResourceTypeName) {
+      throw crossRegionParameterError(
+        resource.logicalId,
+        `${resourceTypeName} is not a Resource type this factory creates`,
+      );
+    }
+
+    const properties = new SimCdkCrossRegionParameterProperties(
+      resource.logicalId,
+      context.resolvedProperties ?? resource.properties,
+    );
+    const { parameterName, regionName } = properties;
+
+    return new SimCdkCrossRegionParameterReading({
+      parameterName,
+      regionName,
+      value: await this.read(resource, context, parameterName, regionName),
+    });
+  }
+
+  /**
+   * Forget the reading.
+   *
+   * CDK's provider function does nothing on its Delete event either. The
+   * parameter belongs to the Stack that wrote it, and reading a value leaves
+   * nothing behind to take away.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await Promise.resolve();
+
+    /* v8 ignore if -- defensive catch; the resolver routes on this name */
+    if (resourceTypeName !== crossRegionParameterResourceTypeName) {
+      throw crossRegionParameterError(
+        resource.logicalId,
+        `${resourceTypeName} is not a Resource type this factory deletes`,
+      );
+    }
+  }
+
+  /**
+   * The parameter's value, or nothing where no Stack has written it.
+   */
+  private async read(
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+    parameterName: string,
+    regionName: AwsRegionName,
+  ): Promise<string | undefined> {
+    try {
+      const output = await context.simAws
+        .accountRegionScope(resource.accountRegionScope.accountId, regionName)
+        .ssm()
+        .getParameter({ input: { Name: parameterName } });
+
+      return output.Parameter?.Value;
+    } catch (error) {
+      if (!(error instanceof SimSsmParameterNotFound)) {
+        throw error;
+      }
+
+      resource.ignoreProperty(
+        "ParameterName",
+        `no simulated SSM parameter ${parameterName} has been written in ` +
+          `${regionName}, so this Resource reads nothing. CDK writes that ` +
+          `parameter from a support Stack of its own; deploy the whole cloud ` +
+          `assembly with deployCdkOut to deploy that Stack too`,
+      );
+
+      return undefined;
+    }
+  }
+}

--- a/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reading.ts
+++ b/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reading.ts
@@ -1,0 +1,32 @@
+import type { AwsRegionName } from "../../../../aws/sim-aws-region.js";
+
+interface SimCdkCrossRegionParameterReadingProperties {
+  readonly parameterName: string;
+  readonly regionName: AwsRegionName;
+  readonly value?: string | undefined;
+}
+
+/**
+ * What one Custom::CrossRegionStringParameterReader read.
+ *
+ * This is the simulated object the Resource is created as, and what
+ * `Fn::GetAtt` on it is answered from. CDK's provider function answers with
+ * `Data: { FunctionArn: <value> }` whatever the parameter holds, because the
+ * only construct that builds this Resource is `EdgeFunction`.
+ *
+ * A reading with no value is one whose parameter was not there. That happens
+ * where the Stack holding the parameter was never deployed, which is what
+ * deploying one template of a cloud assembly rather than the assembly comes
+ * to.
+ */
+export class SimCdkCrossRegionParameterReading {
+  public readonly parameterName: string;
+  public readonly regionName: AwsRegionName;
+  public readonly value: string | undefined;
+
+  constructor(properties: SimCdkCrossRegionParameterReadingProperties) {
+    this.parameterName = properties.parameterName;
+    this.regionName = properties.regionName;
+    this.value = properties.value;
+  }
+}

--- a/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-template.factory.ts
+++ b/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-template.factory.ts
@@ -1,0 +1,73 @@
+import { MappedFactory } from "@kensio/part-factory";
+
+import type { CfnTemplateBodyRecord } from "../../../template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../template/value/sim-cfn-template-value.js";
+
+/**
+ * What a test asks for when it wants the template CDK synthesizes for an
+ * `experimental.EdgeFunction` in a Stack outside us-east-1.
+ *
+ * Only the reader is here. The function, the version and the SSM parameter go
+ * into a support Stack of their own, which a test writes the parameter for
+ * directly when it wants one.
+ */
+export interface SimCdkCrossRegionParameterTemplateInput {
+  /** The parameter the reader reads. */
+  readonly parameterName: string;
+
+  /** The Region the reader reads it from. */
+  readonly regionName: string;
+
+  /** Merged in last, so a test states the one property it is about. */
+  readonly readerProperties: SimCfnTemplateValueRecord;
+
+  /** The attribute the Stack Output reads off the reader. */
+  readonly attributeName: string;
+}
+
+/**
+ * Builds the template CDK synthesizes for a cross-Region parameter read.
+ *
+ * ```typescript
+ * const stack = await simAws.cloudFormation().deployTemplate({
+ *   stackName: "site-stack",
+ *   template: simCdkCrossRegionParameterTemplateFactory.make({
+ *     parameterName: "/cdk/EdgeFunctionArn/eu-west-1/SiteStack/EdgeFn",
+ *   }),
+ * });
+ * ```
+ *
+ * The `ServiceToken` points at nothing. CDK's provider function is the one
+ * this factory reads the parameter in place of, and the Resource is read
+ * around the token rather than through it.
+ */
+export const simCdkCrossRegionParameterTemplateFactory = new MappedFactory<
+  SimCdkCrossRegionParameterTemplateInput,
+  CfnTemplateBodyRecord
+>(
+  () => ({
+    parameterName: "/cdk/EdgeFunctionArn/eu-west-1/SiteStack/EdgeFn",
+    regionName: "us-east-1",
+    readerProperties: {},
+    attributeName: "FunctionArn",
+  }),
+  (input) => ({
+    Resources: {
+      ArnReader: {
+        Type: "Custom::CrossRegionStringParameterReader",
+        Properties: {
+          ServiceToken: "arn:aws:lambda:eu-west-1:888888888888:function:cdk",
+          Region: input.regionName,
+          ParameterName: input.parameterName,
+          RefreshToken: "EdgeFnCurrentVersion",
+          ...input.readerProperties,
+        },
+      },
+    },
+    Outputs: {
+      EdgeFunctionArn: {
+        Value: { "Fn::GetAtt": ["ArnReader", input.attributeName] },
+      },
+    },
+  }),
+);

--- a/src/service/cloudformation/resource/cfn/cdk/sim-cdk-cross-region-parameter-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cdk/sim-cdk-cross-region-parameter-cfn.ts
@@ -1,0 +1,54 @@
+import type { SimCdkCrossRegionParameterReading } from "../../../cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reading.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+import { simCfnUnansweredAttribute } from "../sim-cfn-unanswered-attribute.js";
+
+interface SimCdkCrossRegionParameterCfnProperties {
+  readonly logicalId: string;
+  readonly reading: SimCdkCrossRegionParameterReading;
+}
+
+/**
+ * CloudFormation-facing values for a CDK cross-Region parameter reading.
+ */
+export class SimCdkCrossRegionParameterCfn implements SimCfnResourceValueAdapter {
+  private readonly logicalId: string;
+  private readonly reading: SimCdkCrossRegionParameterReading;
+
+  constructor(properties: SimCdkCrossRegionParameterCfnProperties) {
+    this.logicalId = properties.logicalId;
+    this.reading = properties.reading;
+  }
+
+  /**
+   * A custom Resource Ref answers with the physical ID its provider returned,
+   * and CDK's reader returns none, so the logical ID stands in for it as it
+   * does for any other Resource without one.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.logicalId;
+  }
+
+  /**
+   * `FunctionArn` is the one attribute CDK's provider function answers with,
+   * whatever the parameter holds, so it is the one this reading answers.
+   *
+   * A reading whose parameter was never written answers with the stand-in an
+   * unanswerable attribute resolves to everywhere else. The Resource read
+   * nothing, and a service meeting the value can tell that is what happened.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName !== "FunctionArn") {
+      throw new Error(
+        `Unsupported Custom::CrossRegionStringParameterReader attribute ${
+          attributeName
+        }`,
+      );
+    }
+
+    return (
+      this.reading.value ??
+      simCfnUnansweredAttribute(this.logicalId, attributeName)
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/cdk/sim-cdk-custom-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cdk/sim-cdk-custom-resource-value-adapter.ts
@@ -1,0 +1,30 @@
+import { SimCdkCrossRegionParameterReading } from "../../../cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reading.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimCdkCrossRegionParameterCfn } from "./sim-cdk-cross-region-parameter-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a CDK custom Resource this
+ * simulator carries out itself.
+ *
+ * A custom Resource belongs to CDK rather than to an AWS service, so the
+ * adapters for them sit together here rather than beside the service whose
+ * work the Resource does. Most of them answer nothing: a Bucket notification
+ * and a BucketDeployment have no existence for a Ref or an Fn::GetAtt to
+ * reach, and neither is created as a simulated object. The ones listed here
+ * are the custom Resources a template reads a value back out of.
+ */
+export function cdkCustomResourceValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (properties.simResource instanceof SimCdkCrossRegionParameterReading) {
+    return new SimCdkCrossRegionParameterCfn({
+      logicalId: properties.logicalId,
+      reading: properties.simResource,
+    });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.ts
@@ -1,5 +1,6 @@
 import type { SimCfnTemplateValue } from "../../template/value/sim-cfn-template-value.js";
 import type { SimCfnResourceValueAdapter } from "./sim-cfn-resource-value-adapter.js";
+import { simCfnUnansweredAttribute } from "./sim-cfn-unanswered-attribute.js";
 
 interface SimCfnDefaultResourceValueAdapterProperties {
   readonly logicalId: string;
@@ -27,6 +28,6 @@ export class SimCfnDefaultResourceValueAdapter implements SimCfnResourceValueAda
    * Default attribute stand-in.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
-    return `${this.logicalId}.${attributeName}`;
+    return simCfnUnansweredAttribute(this.logicalId, attributeName);
   }
 }

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -1,6 +1,7 @@
 import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
 import { apiGatewayValueAdapter } from "./apigateway/sim-api-gateway-cfn-value-adapter.js";
 import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.js";
+import { cdkCustomResourceValueAdapter } from "./cdk/sim-cdk-custom-resource-value-adapter.js";
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
 import { cloudWatchValueAdapter } from "./cloudwatch/sim-cloudwatch-cfn-value-adapter.js";
 import { cognitoValueAdapter } from "./cognito/sim-cognito-cfn-value-adapter.js";
@@ -33,7 +34,8 @@ import type {
 
 /**
  * Every service that claims Resource types of its own, in the order they are
- * asked.
+ * asked, alongside the CDK custom Resources a template reads a value back out
+ * of.
  *
  * A list rather than a chain of `??`. Each entry is the same one-line
  * delegation and the list only grows, so a chain over it became the most
@@ -46,6 +48,7 @@ export const simCfnServiceValueAdapters: readonly ((
   acmValueAdapter,
   apiGatewayValueAdapter,
   apiGatewayV2ValueAdapter,
+  cdkCustomResourceValueAdapter,
   cloudFrontValueAdapter,
   cloudWatchValueAdapter,
   cognitoValueAdapter,

--- a/src/service/cloudformation/resource/cfn/sim-cfn-unanswered-attribute.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-unanswered-attribute.ts
@@ -1,0 +1,39 @@
+/**
+ * The stand-in an `Fn::GetAtt` resolves to when nothing here can answer it.
+ *
+ * A Resource type this simulator does not create, and an attribute a created
+ * Resource has no value for, both leave the reference with nothing behind it.
+ * Rather than fail the Stack over it, the reference resolves to the Resource's
+ * logical ID and the attribute name, which is a value a template can carry
+ * without meaning anything.
+ *
+ * The format is shared so that a service meeting one of these can tell it
+ * apart from a value the template meant.
+ */
+export function simCfnUnansweredAttribute(
+  logicalId: string,
+  attributeName: string,
+): string {
+  return `${logicalId}.${attributeName}`;
+}
+
+/**
+ * Whether a value is the stand-in for an attribute of a Resource in this
+ * Stack.
+ *
+ * Read by a service deciding what to do about a property whose value never
+ * arrived. Nothing a template writes by hand looks like this, since the
+ * logical ID has to be one the Stack holds.
+ */
+export function namesSimCfnUnansweredAttribute(
+  value: string,
+  logicalIds: Iterable<string>,
+): boolean {
+  for (const logicalId of logicalIds) {
+    if (value.startsWith(`${logicalId}.`)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-unanswered-attribute.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-unanswered-attribute.ts
@@ -18,19 +18,39 @@ export function simCfnUnansweredAttribute(
 }
 
 /**
+ * What every dot-separated part of a stand-in looks like.
+ *
+ * A logical ID is alphanumeric and holds no dot at all, so the part before the
+ * first one is the whole of it. An attribute name does hold dots, as
+ * `Endpoint.Address` and `Outputs.NestedStackOutput` do.
+ */
+const alphanumericPattern = /^[A-Za-z0-9]+$/u;
+
+/**
  * Whether a value is the stand-in for an attribute of a Resource in this
  * Stack.
  *
  * Read by a service deciding what to do about a property whose value never
- * arrived. Nothing a template writes by hand looks like this, since the
- * logical ID has to be one the Stack holds.
+ * arrived. A value has to carry the whole shape and name a Resource the Stack
+ * holds, which is more than a template writes by hand.
  */
 export function namesSimCfnUnansweredAttribute(
   value: string,
   logicalIds: Iterable<string>,
 ): boolean {
+  const parts = value.split(".");
+
+  if (
+    parts.length < 2 ||
+    parts.some((part) => !alphanumericPattern.test(part))
+  ) {
+    return false;
+  }
+
+  const named = parts[0];
+
   for (const logicalId of logicalIds) {
-    if (value.startsWith(`${logicalId}.`)) {
+    if (logicalId === named) {
       return true;
     }
   }

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-custom-resource-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-custom-resource-factories.ts
@@ -1,6 +1,7 @@
 import type { SimCfnServiceResourceFactory } from "../../factory/sim-cfn-resource-factory.type.js";
 import { SimCdkBucketDeploymentResourceFactory } from "../../../cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.js";
 import { SimCdkBucketNotificationsResourceFactory } from "../../../cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.js";
+import { SimCdkCrossRegionParameterReaderResourceFactory } from "../../../cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reader.js";
 
 /**
  * How one CDK custom Resource hands over its factory.
@@ -30,6 +31,11 @@ export const simCdkCustomResourceFactories: ReadonlyMap<
     "CDKBucketDeployment",
     (): SimCfnServiceResourceFactory =>
       new SimCdkBucketDeploymentResourceFactory(),
+  ],
+  [
+    "CrossRegionStringParameterReader",
+    (): SimCfnServiceResourceFactory =>
+      new SimCdkCrossRegionParameterReaderResourceFactory(),
   ],
   [
     "S3BucketNotifications",

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -105,6 +105,16 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
   }
 
   /**
+   * The logical IDs of every Resource in the Stack this Resource belongs to.
+   *
+   * Read by a service that has met a value one of them stands behind, such as
+   * an `Fn::GetAtt` on a Resource that had no attribute to answer with.
+   */
+  public get stackResourceLogicalIds(): ReadonlySet<string> {
+    return this.resourceLogicalIds;
+  }
+
+  /**
    * The DeletionPolicy attribute from the Resource template, if it has one.
    */
   public get deletionPolicy(): string | undefined {

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
@@ -176,6 +176,81 @@ describe("CloudFormation Distribution Lambda@Edge skips", () => {
     );
   });
 
+  it("serves from a Distribution whose association ARN never arrived", async () => {
+    // Given a Bucket holding the page the Distribution serves, and a Resource
+    // this simulation does not create standing where the function ARN comes
+    // from. A CDK EdgeFunction outside us-east-1 leaves the same thing behind
+    // when the support Stack holding its ARN was not deployed.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    // When the template deploys.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "edge-site",
+      template: edgeDistributionTemplateFactory.make({
+        associations: [
+          {
+            EventType: "viewer-request",
+            LambdaFunctionARN: { "Fn::GetAtt": ["ArnSource", "FunctionArn"] },
+          },
+        ],
+        extraResources: {
+          ArnSource: { Type: "AWS::Ivs::Channel", Properties: {} },
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Distribution deployed and serves the page, with the association
+    // recorded rather than refused as a malformed ARN.
+    const response = await simCfSiteRequest(
+      simAws,
+      deployedDistribution(stack).distributionId,
+      "/index.html",
+    );
+
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Home</h1>");
+
+    const ignoredProperty = stack.ignoredProperties.find(
+      (property) => property.resourceType === "AWS::CloudFront::Distribution",
+    );
+    assertNonNullable(ignoredProperty);
+    assertIdentical(
+      ignoredProperty.path,
+      "DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations.viewer-request",
+    );
+    assertStringIncludes(ignoredProperty.reason, "ArnSource.FunctionArn");
+  });
+
+  it("fails the stack over an ARN written by hand that is not one", async () => {
+    // Given a template whose association names something that is not an ARN
+    // and stands for nothing in the Stack either.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {});
+
+    // When it deploys.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "edge-site",
+        template: edgeDistributionTemplateFactory.make({
+          associations: [
+            {
+              EventType: "viewer-request",
+              LambdaFunctionARN: "edge-function",
+            },
+          ],
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment failed on the ARN, as a real deploy fails on it.
+    assertStringIncludes(error.message, "is not a Lambda function ARN");
+  });
+
   it("fails the stack over a role Lambda@Edge cannot assume", async () => {
     // Given a template whose edge function runs as an ordinary Lambda
     // execution role, trusting lambda.amazonaws.com alone.

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
@@ -251,6 +251,33 @@ describe("CloudFormation Distribution Lambda@Edge skips", () => {
     assertStringIncludes(error.message, "is not a Lambda function ARN");
   });
 
+  it("fails the stack over an ARN that only starts like a reference", async () => {
+    // Given an association naming a Resource in the Stack followed by
+    // something no attribute is called.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {});
+
+    // When it deploys.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "edge-site",
+        template: edgeDistributionTemplateFactory.make({
+          associations: [
+            {
+              EventType: "viewer-request",
+              LambdaFunctionARN: "EdgeFunction.the one in us-east-1",
+            },
+          ],
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment failed on the ARN. Only the whole shape an
+    // unanswered Fn::GetAtt resolves to counts as one this simulation wrote.
+    assertStringIncludes(error.message, "is not a Lambda function ARN");
+  });
+
   it("fails the stack over a role Lambda@Edge cannot assume", async () => {
     // Given a template whose edge function runs as an ordinary Lambda
     // execution role, trusting lambda.amazonaws.com alone.

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-association-skips.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-association-skips.ts
@@ -6,22 +6,16 @@ import type {
   SimCloudFrontLambdaFunctionAssociation,
 } from "../../command/create-distribution/create-distribution.command.js";
 import { normalizeSimCfList } from "../../command/create-distribution/sim-cf-normalize-list.js";
-import { isSimulatedEdgeEventType } from "../../edge/sim-cf-edge-association-checks.js";
-import { readEdgeFunctionArnParts } from "../../edge/sim-cf-edge-function-arn.js";
-import { findSimCfEdgeFunctionVersion } from "../../edge/sim-cf-edge-function-version.js";
+import { simCfnCfEdgeSkipReason } from "./sim-cfn-cf-edge-skip-reason.js";
 
 /**
- * Decides which of a template Behavior's Lambda@Edge associations this
- * simulation can run, recording the rest on the CloudFormation Resource.
+ * Leaves out the Lambda@Edge associations of a template Behavior this
+ * simulation cannot run, recording each one on the CloudFormation Resource.
  *
- * An association is left out for two reasons. One names a function version
- * this simulation does not hold, as a template pointing at a function in a
- * real account does. The other is on an event type this simulation has no hook
- * for.
- *
- * Everything else is left where `CreateDistribution` meets it, including the
- * mistakes real CloudFront refuses. A template carrying one of those fails a
- * real deploy too.
+ * Which those are is `simCfnCfEdgeSkipReason`'s to say. This is the
+ * bookkeeping around it: reading the list a template wrote, counting what a
+ * Behavior has to be rewritten for, and recording each skip under the path and
+ * the event type it was on.
  */
 export class SimCfnCfEdgeAssociationSkips {
   /** How many associations have been left out so far. */
@@ -74,50 +68,16 @@ export class SimCfnCfEdgeAssociationSkips {
     association: SimCloudFrontLambdaFunctionAssociation,
     behaviorPath: string,
   ): boolean {
-    const { EventType, LambdaFunctionARN } = association;
+    const eventType = association.EventType;
+    const reason = simCfnCfEdgeSkipReason(association, {
+      simAws: this.simAws,
+      stackResourceLogicalIds: this.resource.stackResourceLogicalIds,
+    });
 
-    if (EventType === undefined || LambdaFunctionARN === undefined) {
+    if (reason === undefined || eventType === undefined) {
       return true;
     }
 
-    if (!isSimulatedEdgeEventType(EventType)) {
-      return this.skip(
-        behaviorPath,
-        EventType,
-        `simulated CloudFront runs a Lambda@Edge function at viewer-request ` +
-          `and viewer-response, so the Behavior is deployed without the ` +
-          `${EventType} function ${LambdaFunctionARN} and runs nothing there`,
-      );
-    }
-
-    const arn = readEdgeFunctionArnParts(LambdaFunctionARN);
-
-    if (arn === undefined) {
-      return true;
-    }
-
-    if (findSimCfEdgeFunctionVersion(this.simAws, arn) !== undefined) {
-      return true;
-    }
-
-    return this.skip(
-      behaviorPath,
-      EventType,
-      `Lambda@Edge function ${LambdaFunctionARN} is not held by this ` +
-        `simulation, so the Behavior is deployed without it and runs nothing ` +
-        `at ${EventType}`,
-    );
-  }
-
-  /**
-   * Record one skipped association, answering with what a filter does about
-   * it.
-   */
-  private skip(
-    behaviorPath: string,
-    eventType: string,
-    reason: string,
-  ): boolean {
     this.count += 1;
     this.resource.ignoreProperty(
       `${behaviorPath}.LambdaFunctionAssociations.${eventType}`,

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-skip-reason.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-skip-reason.ts
@@ -1,0 +1,117 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import { namesSimCfnUnansweredAttribute } from "../../../cloudformation/resource/cfn/sim-cfn-unanswered-attribute.js";
+import type { SimCloudFrontLambdaFunctionAssociation } from "../../command/create-distribution/create-distribution.command.js";
+import { isSimulatedEdgeEventType } from "../../edge/sim-cf-edge-association-checks.js";
+import { readEdgeFunctionArnParts } from "../../edge/sim-cf-edge-function-arn.js";
+import { findSimCfEdgeFunctionVersion } from "../../edge/sim-cf-edge-function-version.js";
+
+/**
+ * What one Lambda@Edge association is decided against.
+ */
+export interface SimCfnCfEdgeSkipContext {
+  /** Where the function version behind an ARN is looked for. */
+  readonly simAws: SimAws;
+
+  /** Every Resource the Stack declaring the Distribution holds. */
+  readonly stackResourceLogicalIds: ReadonlySet<string>;
+}
+
+/**
+ * Why this simulation cannot run one Lambda@Edge association, or nothing where
+ * it can.
+ *
+ * Three answers leave an association out. The event type has no hook here. The
+ * ARN names a function version this simulation does not hold, as a template
+ * pointing at a function in a real account does. Or the ARN is the stand-in a
+ * Resource in this Stack answered an `Fn::GetAtt` with, having no ARN of its
+ * own to give.
+ *
+ * Everything else is left where `CreateDistribution` meets it, including the
+ * mistakes real CloudFront refuses. A template carrying one of those fails a
+ * real deploy too.
+ */
+export function simCfnCfEdgeSkipReason(
+  association: SimCloudFrontLambdaFunctionAssociation,
+  context: SimCfnCfEdgeSkipContext,
+): string | undefined {
+  const { EventType: eventType, LambdaFunctionARN: functionArn } = association;
+
+  if (eventType === undefined || functionArn === undefined) {
+    return undefined;
+  }
+
+  if (!isSimulatedEdgeEventType(eventType)) {
+    return unsimulatedEventReason(eventType, functionArn);
+  }
+
+  const arn = readEdgeFunctionArnParts(functionArn);
+
+  if (arn === undefined) {
+    return unreadableArnReason(eventType, functionArn, context);
+  }
+
+  if (findSimCfEdgeFunctionVersion(context.simAws, arn) !== undefined) {
+    return undefined;
+  }
+
+  return absentFunctionReason(eventType, functionArn);
+}
+
+/**
+ * The association is on an event type this simulation has no hook for.
+ */
+function unsimulatedEventReason(
+  eventType: string,
+  functionArn: string,
+): string {
+  return (
+    `simulated CloudFront runs a Lambda@Edge function at viewer-request and ` +
+    `viewer-response, so the Behavior is deployed without the ${eventType} ` +
+    `function ${functionArn} and runs nothing there`
+  );
+}
+
+/**
+ * The ARN names a function version no simulated Lambda holds.
+ */
+function absentFunctionReason(eventType: string, functionArn: string): string {
+  return (
+    `Lambda@Edge function ${functionArn} is not held by this simulation, so ` +
+    `the Behavior is deployed without it and runs nothing at ${eventType}`
+  );
+}
+
+/**
+ * Why an ARN that does not read as a Lambda@Edge function ARN is left out, or
+ * nothing where it is kept.
+ *
+ * A value written as an ARN is kept, so `CreateDistribution` refuses it the
+ * way real CloudFront refuses a malformed ARN or a function outside us-east-1.
+ * A value naming a Resource in this Stack is a different thing. It is the
+ * stand-in an `Fn::GetAtt` resolves to where the Resource had no attribute to
+ * answer with, and the template that wrote it deploys on AWS. CDK writes one
+ * for an `experimental.EdgeFunction` outside us-east-1, whose ARN comes from
+ * an SSM parameter a support Stack writes and a custom Resource reads back.
+ */
+function unreadableArnReason(
+  eventType: string,
+  functionArn: string,
+  context: SimCfnCfEdgeSkipContext,
+): string | undefined {
+  if (
+    !namesSimCfnUnansweredAttribute(
+      functionArn,
+      context.stackResourceLogicalIds,
+    )
+  ) {
+    return undefined;
+  }
+
+  return (
+    `the Lambda@Edge function ARN is read from ${functionArn}, a Resource in ` +
+    `this Stack that had no ARN to answer with, so the Behavior is deployed ` +
+    `without it and runs nothing at ${eventType}. A CDK EdgeFunction outside ` +
+    `us-east-1 reads its ARN from a support Stack of its own; deploy the ` +
+    `whole cloud assembly with deployCdkOut to deploy that Stack too`
+  );
+}

--- a/test/cloudfront/edge-distribution-template.factory.ts
+++ b/test/cloudfront/edge-distribution-template.factory.ts
@@ -53,6 +53,12 @@ export interface EdgeDistributionTemplateInput {
 
   /** The path-based cache Behaviors, each stated whole. */
   readonly cacheBehaviors: readonly SimCfnTemplateValueRecord[];
+
+  /**
+   * Resources added beside the ones every edge template has, for a test whose
+   * association names something other than the version declared here.
+   */
+  readonly extraResources: SimCfnTemplateValueRecord;
 }
 
 /**
@@ -84,9 +90,11 @@ export const edgeDistributionTemplateFactory = new MappedFactory<
       },
     ],
     cacheBehaviors: [],
+    extraResources: {},
   }),
   (input) => ({
     Resources: {
+      ...input.extraResources,
       EdgeRole: {
         Type: "AWS::IAM::Role",
         Properties: {


### PR DESCRIPTION
A `cloudfront.experimental.EdgeFunction` in a stack outside us-east-1 puts the
function and an SSM parameter holding its version ARN into a us-east-1 support
stack, and the stack using it reads that parameter back through a
`Custom::CrossRegionStringParameterReader` resource. Sim CloudFormation now
makes that read itself, against the Region the resource names. Given the whole
cloud assembly to deploy, `Fn::GetAtt` on the reader answers with the ARN the
support stack published and the Behavior runs the function. Deploying the using
stack's template alone writes no parameter. The reader is then created holding
nothing, the association keeps the stand-in an unanswerable `Fn::GetAtt`
resolves to, and the Behavior deploys without it with the reason recorded on
`stack.ignoredProperties`, leaving the site serving from the Origin.
`CreateDistribution` still refuses a hand-written ARN that is not one, because
only a value naming a Resource in the same stack counts as a reference that
never arrived.

Resolves https://github.com/KensioSoftware/yulin/issues/961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cross-region CloudFront EdgeFunction deployments through a us-east-1 support stack.
  * Added support for cross-region parameter lookups used by CDK custom resources.
  * Deployments can now proceed without unavailable edge associations, while clearly recording skipped resources and reasons.
* **Bug Fixes**
  * Improved handling of unresolved Lambda@Edge ARNs and missing cross-region parameters.
* **Documentation**
  * Documented supported deployment flows, limitations, and partial deployment behavior.
* **Tests**
  * Added coverage for successful, partial, and invalid cross-region deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->