### PR TITLE
feat: run Lambda@Edge at the origin events

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1343,9 +1343,11 @@ A `viewer-request` handler returning the request carries on to the Origin with w
 Returning a response answers the viewer there and then, and the Origin is never read. A
 `viewer-response` handler returns the response the viewer gets.
 
-Set `IncludeBody` to give a `viewer-request` handler the request body, which arrives base64 encoded
-under `request.body.data`. A handler setting `request.body.action` to `replace` sends its own body
-to the Origin.
+Set `IncludeBody` to give a `viewer-request` or `origin-request` handler the request body, which
+arrives base64 encoded under `request.body.data`. A handler setting `request.body.action` to
+`replace` sends its own body to the Origin. The field belongs to the two request events, and an
+association setting it on `viewer-response` or `origin-response` is refused, as CloudFront refuses
+one.
 
 A handler that throws answers the viewer with a 502, as CloudFront answers a failed edge function.
 The error reaches the function's own output and nothing else.
@@ -2607,10 +2609,12 @@ whether the simulator needs them to model the requested behaviour safely.
 
 Where sim CloudFront knowingly behaves differently from AWS:
 
-- **Both origin events run on every request.** Real CloudFront runs `origin-request` and
-  `origin-response` on a cache miss, and serves a cache hit without reaching either. Simulated
-  CloudFront holds no cache. Every request is a miss here, and both functions run every time. A
-  test counting invocations is counting requests.
+- **The origin events run on every request that reaches the Origin.** Real CloudFront runs
+  `origin-request` and `origin-response` on a cache miss, and serves a cache hit without reaching
+  either. Simulated CloudFront holds no cache, and every request that gets as far as the Origin is a
+  miss here. A request a web ACL blocked or a viewer-request function answered reaches neither
+  event, and an `origin-request` function that returns a response leaves the Origin unread with no
+  `origin-response` event after it.
 - **An Origin keeps its kind and its Bucket through an origin-request function.** Real CloudFront
   lets a handler hand back `origin.s3` where it was given `origin.custom`, or point an S3 Origin at
   another Bucket. Both need something a simulated Origin does not hold, the dispatcher that reaches

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1219,10 +1219,12 @@ covers what the factories have in common.
 
 ## Simulated Lambda@Edge
 
-A cache Behavior can run a Lambda function at `viewer-request` and `viewer-response` through
-`LambdaFunctionAssociations`. Where a CloudFront Function is a small piece of JavaScript running in
-CloudFront's own runtime, a Lambda@Edge function is an ordinary simulated Lambda function, with an
-execution role, an environment and whatever SDK calls its handler makes.
+A cache Behavior can run a Lambda function at any of CloudFront's four events through
+`LambdaFunctionAssociations`. Those are `viewer-request` and `viewer-response` at the edge, and
+`origin-request` and `origin-response` either side of the Origin fetch. Where a CloudFront Function
+is a small piece of JavaScript running in CloudFront's own runtime, a Lambda@Edge function is an
+ordinary simulated Lambda function, with an execution role, an environment and whatever SDK calls
+its handler makes.
 
 Three things about Lambda@Edge catch people out on AWS, and simulated CloudFront refuses all three
 the way AWS refuses them, when the Distribution is written rather than when a request arrives.
@@ -1348,12 +1350,186 @@ to the Origin.
 A handler that throws answers the viewer with a 502, as CloudFront answers a failed edge function.
 The error reaches the function's own output and nothing else.
 
+### The origin events
+
+An `origin-request` function runs after the Behavior has resolved the Origin and before the fetch.
+Its event carries `request.origin`, holding the Origin the fetch is about to read, under `custom` or
+`s3` for the kind it is. A handler rewriting `origin.custom.domainName` sends the fetch to another
+Origin, and one rewriting `path` reads under another prefix. A header added to `customHeaders`
+reaches the Origin and the viewer never sees it. A handler returning a response answers the viewer
+with the Origin unread.
+
+An `origin-response` function runs after the fetch and before the custom error page replaces an
+error status. It runs on whatever the Origin answered, including a 400 and above. That is where the
+origin events differ from the viewer events, and CloudFront documents it. Returning a response
+replaces what the viewer gets.
+
+At both origin events the `host` header holds the Origin's own domain name. A viewer event shows the
+domain the viewer used.
+
+```typescript sim-cloudfront-lambda-edge-origin
+/**
+ * A Lambda@Edge function choosing the Origin, and another one stamping what
+ * that Origin answered.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import type { LambdaAtEdge } from "@kensio/yulin/cloudfront";
+
+const simAws = new SimAws();
+
+// A Lambda@Edge execution role trusts both service principals, at the origin
+// events as at the viewer events.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "EdgeOriginRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: {
+          Service: ["lambda.amazonaws.com", "edgelambda.amazonaws.com"],
+        },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+const edgeLambda = simAws.region("us-east-1").lambda();
+
+await edgeLambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "route-origin",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: LambdaAtEdge.OriginRequestEvent) => {
+          const { request } = event.Records[0].cf;
+          const { custom } = request.origin;
+
+          if (custom === undefined) {
+            return request;
+          }
+
+          // Everything under /api is served by the second Origin.
+          if (request.uri.startsWith("/api/")) {
+            custom.domainName = "orders.example.test";
+          }
+
+          // A header the viewer never sent and never sees.
+          custom.customHeaders["x-from-cloudfront"] = [
+            { key: "X-From-CloudFront", value: "yes" },
+          ];
+
+          return request;
+        },
+      ),
+    },
+  }),
+);
+
+const routeVersion = await edgeLambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "route-origin" }),
+);
+
+await edgeLambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "stamp-origin-response",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: LambdaAtEdge.OriginResponseEvent): LambdaAtEdge.Response => {
+          const { response } = event.Records[0].cf;
+
+          // This runs for an Origin error too, so the status is worth keeping.
+          return {
+            ...response,
+            headers: {
+              ...response.headers,
+              "x-origin-status": [
+                { key: "X-Origin-Status", value: response.status },
+              ],
+            },
+          };
+        },
+      ),
+    },
+  }),
+);
+
+const stampVersion = await edgeLambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "stamp-origin-response" }),
+);
+
+const customOriginConfig = {
+  HTTPPort: 80,
+  HTTPSPort: 443,
+  OriginProtocolPolicy: "https-only",
+} as const;
+
+await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "edge-origin-routing",
+      Comment: "Choosing the Origin at the edge",
+      Enabled: true,
+      Origins: {
+        Quantity: 2,
+        Items: [
+          {
+            Id: "site-origin",
+            DomainName: "site.example.test",
+            CustomOriginConfig: customOriginConfig,
+          },
+          {
+            Id: "orders-origin",
+            DomainName: "orders.example.test",
+            CustomOriginConfig: customOriginConfig,
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "site-origin",
+        ViewerProtocolPolicy: "allow-all",
+        LambdaFunctionAssociations: {
+          Quantity: 2,
+          Items: [
+            {
+              EventType: "origin-request",
+              LambdaFunctionARN: routeVersion.FunctionArn,
+            },
+            {
+              EventType: "origin-response",
+              LambdaFunctionARN: stampVersion.FunctionArn,
+            },
+          ],
+        },
+      },
+    },
+  }),
+);
+```
+
+Two Origin rewrites are refused, and the viewer gets the 502 a failed edge function gets, carrying
+the reason (see [Limitations](#limitations)). One switches an Origin between `custom` and `s3`. The
+other moves an S3 Origin to another Bucket.
+
 ### Which edge function runs where
 
 CloudFront takes one edge function per event type, and it does not combine CloudFront Functions with
 Lambda@Edge at the viewer events. A Behavior with a viewer-request CloudFront Function and a
 viewer-response Lambda@Edge function is refused, and so is a Behavior naming both at one event type.
-Simulated CloudFront refuses the same combinations.
+Simulated CloudFront refuses the same combinations. The rule stops at the viewer. A viewer-request
+CloudFront Function runs alongside a Lambda@Edge function on either origin event.
 
 Neither kind runs at the viewer response once the Origin has answered 400 or higher. CloudFront
 skips that event for an Origin error, and the status the Origin returned is what decides it (see
@@ -1390,16 +1566,15 @@ SiteDistribution:
 
 The function still has to live in us-east-1. A stack holding one is a us-east-1 stack.
 
-Two kinds of association are left out of the deployed Distribution and recorded on
-`stack.ignoredProperties`, under the event type each was on. One names a function version this
-simulation does not hold, as a template pointing at a function in a real account does. The other is
-on `origin-request` or `origin-response`. The rest of the Behavior deploys either way, and the
-event the skipped association was on is left empty. A test that cares reads the record.
+An association naming a function version this simulation does not hold is left out of the deployed
+Distribution and recorded on `stack.ignoredProperties`, under the event type it was on. A template
+pointing at a function in a real account is the usual reason. The rest of the Behavior deploys, and
+the event the skipped association was on is left empty. A test that cares reads the record.
 
 Everything real CloudFront refuses still fails the deployment. A function outside us-east-1, an ARN
-without a version qualifier, an execution role missing the `edgelambda.amazonaws.com` trust, two
-functions on one event type and a viewer event running both kinds of edge function each fail a real
-deploy of the same template.
+without a version qualifier, an execution role missing the `edgelambda.amazonaws.com` trust, an
+`EventType` that is none of CloudFront's four, two functions on one event type and a viewer event
+running both kinds of edge function each fail a real deploy of the same template.
 
 CDK reaches a Behavior through `edgeLambdas`, given a `lambda.Version` from the same stack:
 
@@ -2414,7 +2589,7 @@ Sim CloudFront currently supports:
 - Default cache Behavior and path-based cache Behaviors
 - `DefaultRootObject` and `CustomErrorResponses`, for static sites and single-page apps
 - `viewer-request` and `viewer-response` CloudFront Functions, including async ones
-- `viewer-request` and `viewer-response` Lambda@Edge functions, through `LambdaFunctionAssociations`
+- Lambda@Edge functions at all four events, through `LambdaFunctionAssociations`
 - `LambdaFunctionAssociations` on a template's Distribution, and CDK's `edgeLambdas`
 - CloudFront Functions reading an associated key value store through `cf.kvs()`
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
@@ -2432,11 +2607,26 @@ whether the simulator needs them to model the requested behaviour safely.
 
 Where sim CloudFront knowingly behaves differently from AWS:
 
-- **Lambda@Edge runs at the two viewer events only.** CloudFront runs an edge function at
-  `origin-request` and `origin-response` as well, and `CreateDistribution` refuses both by name
-  rather than accepting one that would never run. A Distribution deployed from a template records
-  the association and deploys without it. A site naming one origin function still serves. The
-  request pipeline has no hook either side of the Origin fetch yet.
+- **Both origin events run on every request.** Real CloudFront runs `origin-request` and
+  `origin-response` on a cache miss, and serves a cache hit without reaching either. Simulated
+  CloudFront holds no cache. Every request is a miss here, and both functions run every time. A
+  test counting invocations is counting requests.
+- **An Origin keeps its kind and its Bucket through an origin-request function.** Real CloudFront
+  lets a handler hand back `origin.s3` where it was given `origin.custom`, or point an S3 Origin at
+  another Bucket. Both need something a simulated Origin does not hold, the dispatcher that reaches
+  a custom Origin and the Bucket a domain name resolved to when the Distribution was written. Each
+  is refused with the 502 a failed edge function gets, carrying the reason. The domain name, the
+  Origin path and the custom headers are the parts a handler can rewrite.
+- **A custom Origin reports CloudFront's default connection settings.** `keepaliveTimeout`,
+  `port`, `protocol`, `readTimeout` and `sslProtocols` are what an origin event carries for every
+  custom Origin, whatever `CustomOriginConfig` said, and a handler writing them changes nothing
+  about the fetch. Nothing here opens a socket for them to apply to. The `customHeaders` of an S3
+  Origin are empty for the same kind of reason. An S3 Origin reads its Bucket through GetObject and
+  builds no request for a header to travel on.
+- **A custom error page is fetched without the origin events.** CloudFront fetches
+  `ResponsePagePath` from the Origin, and an origin function runs for that fetch as it does for any
+  other. Here the page is fetched directly. An `origin-request` function that rewrote the Origin
+  leaves the error page coming from the Behavior's own Origin.
 - **A CDK `EdgeFunction` outside us-east-1 wants the whole cloud assembly.**
   `cloudfront.experimental.EdgeFunction` writes the function into a us-east-1 support stack and
   reads its ARN back through a custom resource in the stack that uses it. `deployCdkOut` deploys
@@ -2454,11 +2644,12 @@ Where sim CloudFront knowingly behaves differently from AWS:
   be too large for a real edge function.
 - **The Origin's status decides whether a viewer-response function runs.** CloudFront skips the
   viewer-response event once the Origin answers 400 or higher, and both kinds of function are
-  skipped here on that rule. Where a custom error response turns that status into another one, such
-  as the 200 a single-page app serves its shell with, the Origin's own status still decides. AWS
-  documents the restriction against the Origin's status and says nothing about the status a custom
-  error response puts in its place. A Distribution combining the two is where this simulation is
-  guessing.
+  skipped here on that rule. Where the status is replaced further down the pipeline, by a custom
+  error response or by an `origin-response` function, the Origin's own status still decides. AWS
+  documents the restriction against the Origin's status and says nothing about the status something
+  else puts in its place. A Distribution combining the two is where this simulation is guessing. A
+  response an `origin-request` function generated has no Origin status behind it, and its own status
+  stands in.
 - **CloudFront's disallowed and read-only header lists go unchecked.** Real CloudFront answers 502
   when an edge function adds `Connection` or edits `Content-Length`. Both kinds of function here
   write what they like, apart from the viewer-request `host`, which is restored.

--- a/docs/services/cloudfront/sim-cloudfront-lambda-edge-origin.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-lambda-edge-origin.example.ts
@@ -1,0 +1,149 @@
+/**
+ * A Lambda@Edge function choosing the Origin, and another one stamping what
+ * that Origin answered.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  CreateFunctionCommand,
+  PublishVersionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import type { LambdaAtEdge } from "@kensio/yulin/cloudfront";
+
+const simAws = new SimAws();
+
+// A Lambda@Edge execution role trusts both service principals, at the origin
+// events as at the viewer events.
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "EdgeOriginRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: {
+          Service: ["lambda.amazonaws.com", "edgelambda.amazonaws.com"],
+        },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+const edgeLambda = simAws.region("us-east-1").lambda();
+
+await edgeLambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "route-origin",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: LambdaAtEdge.OriginRequestEvent) => {
+          const { request } = event.Records[0].cf;
+          const { custom } = request.origin;
+
+          if (custom === undefined) {
+            return request;
+          }
+
+          // Everything under /api is served by the second Origin.
+          if (request.uri.startsWith("/api/")) {
+            custom.domainName = "orders.example.test";
+          }
+
+          // A header the viewer never sent and never sees.
+          custom.customHeaders["x-from-cloudfront"] = [
+            { key: "X-From-CloudFront", value: "yes" },
+          ];
+
+          return request;
+        },
+      ),
+    },
+  }),
+);
+
+const routeVersion = await edgeLambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "route-origin" }),
+);
+
+await edgeLambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "stamp-origin-response",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: LambdaAtEdge.OriginResponseEvent): LambdaAtEdge.Response => {
+          const { response } = event.Records[0].cf;
+
+          // This runs for an Origin error too, so the status is worth keeping.
+          return {
+            ...response,
+            headers: {
+              ...response.headers,
+              "x-origin-status": [
+                { key: "X-Origin-Status", value: response.status },
+              ],
+            },
+          };
+        },
+      ),
+    },
+  }),
+);
+
+const stampVersion = await edgeLambda.publishVersion(
+  new PublishVersionCommand({ FunctionName: "stamp-origin-response" }),
+);
+
+const customOriginConfig = {
+  HTTPPort: 80,
+  HTTPSPort: 443,
+  OriginProtocolPolicy: "https-only",
+} as const;
+
+await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "edge-origin-routing",
+      Comment: "Choosing the Origin at the edge",
+      Enabled: true,
+      Origins: {
+        Quantity: 2,
+        Items: [
+          {
+            Id: "site-origin",
+            DomainName: "site.example.test",
+            CustomOriginConfig: customOriginConfig,
+          },
+          {
+            Id: "orders-origin",
+            DomainName: "orders.example.test",
+            CustomOriginConfig: customOriginConfig,
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "site-origin",
+        ViewerProtocolPolicy: "allow-all",
+        LambdaFunctionAssociations: {
+          Quantity: 2,
+          Items: [
+            {
+              EventType: "origin-request",
+              LambdaFunctionARN: routeVersion.FunctionArn,
+            },
+            {
+              EventType: "origin-response",
+              LambdaFunctionARN: stampVersion.FunctionArn,
+            },
+          ],
+        },
+      },
+    },
+  }),
+);

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-edge-skips.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  assertArrayLength,
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
@@ -89,7 +90,7 @@ describe("CloudFormation Distribution Lambda@Edge skips", () => {
     assertStringIncludes(ignoredProperty.reason, absentVersionArn);
   });
 
-  it("deploys the rest of a Behavior whose association is on an origin event", async () => {
+  it("runs the origin-request function a template's Behavior associates", async () => {
     // Given a Bucket holding the page the edge function rewrites requests to.
     const simAws = new SimAws();
     await simCfSiteBucket(simAws, "edge-site", {
@@ -97,16 +98,11 @@ describe("CloudFormation Distribution Lambda@Edge skips", () => {
       "index.html": "<h1>Home</h1>",
     });
 
-    // When a template whose Behavior runs the same function at the viewer and
-    // at the Origin deploys.
+    // When a template whose Behavior runs the function at the Origin deploys.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "edge-site",
       template: edgeDistributionTemplateFactory.make({
         associations: [
-          {
-            EventType: "viewer-request",
-            LambdaFunctionARN: { Ref: edgeVersionLogicalId },
-          },
           {
             EventType: "origin-request",
             LambdaFunctionARN: { Ref: edgeVersionLogicalId },
@@ -116,8 +112,7 @@ describe("CloudFormation Distribution Lambda@Edge skips", () => {
     });
     await stack.waitForDeployComplete();
 
-    // Then the viewer-request function still runs, and the origin-request one
-    // is recorded as the part that was left out.
+    // Then the function runs before the fetch, and nothing was left out.
     const response = await simCfSiteRequest(
       simAws,
       deployedDistribution(stack).distributionId,
@@ -126,14 +121,34 @@ describe("CloudFormation Distribution Lambda@Edge skips", () => {
 
     assertResponseStatus(response, 200);
     assertIdentical(await response.text(), "<h1>Edge</h1>");
+    assertArrayLength(stack.ignoredProperties, 0);
+  });
 
-    const [ignoredProperty] = stack.ignoredProperties;
-    assertNonNullable(ignoredProperty);
-    assertIdentical(
-      ignoredProperty.path,
-      "DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations.origin-request",
-    );
-    assertStringIncludes(ignoredProperty.reason, "viewer-request");
+  it("fails the stack over an event type CloudFront has no such event for", async () => {
+    // Given a template whose association names something that is not one of
+    // CloudFront's four events.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "edge-site", {});
+
+    // When it deploys.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "edge-site",
+        template: edgeDistributionTemplateFactory.make({
+          associations: [
+            {
+              EventType: "viewer-redirect",
+              LambdaFunctionARN: { Ref: edgeVersionLogicalId },
+            },
+          ],
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment failed, as a real one fails a template CloudFront
+    // will not take.
+    assertStringIncludes(error.message, "not a CloudFront event type");
   });
 
   it("records a skipped association under the Behavior's path pattern", async () => {

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-skip-reason.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-edge-skip-reason.ts
@@ -1,7 +1,6 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
 import { namesSimCfnUnansweredAttribute } from "../../../cloudformation/resource/cfn/sim-cfn-unanswered-attribute.js";
 import type { SimCloudFrontLambdaFunctionAssociation } from "../../command/create-distribution/create-distribution.command.js";
-import { isSimulatedEdgeEventType } from "../../edge/sim-cf-edge-association-checks.js";
 import { readEdgeFunctionArnParts } from "../../edge/sim-cf-edge-function-arn.js";
 import { findSimCfEdgeFunctionVersion } from "../../edge/sim-cf-edge-function-version.js";
 
@@ -20,11 +19,10 @@ export interface SimCfnCfEdgeSkipContext {
  * Why this simulation cannot run one Lambda@Edge association, or nothing where
  * it can.
  *
- * Three answers leave an association out. The event type has no hook here. The
- * ARN names a function version this simulation does not hold, as a template
- * pointing at a function in a real account does. Or the ARN is the stand-in a
- * Resource in this Stack answered an `Fn::GetAtt` with, having no ARN of its
- * own to give.
+ * Two answers leave an association out. The ARN names a function version this
+ * simulation does not hold, as a template pointing at a function in a real
+ * account does. Or the ARN is the stand-in a Resource in this Stack answered an
+ * `Fn::GetAtt` with, having no ARN of its own to give.
  *
  * Everything else is left where `CreateDistribution` meets it, including the
  * mistakes real CloudFront refuses. A template carrying one of those fails a
@@ -40,10 +38,6 @@ export function simCfnCfEdgeSkipReason(
     return undefined;
   }
 
-  if (!isSimulatedEdgeEventType(eventType)) {
-    return unsimulatedEventReason(eventType, functionArn);
-  }
-
   const arn = readEdgeFunctionArnParts(functionArn);
 
   if (arn === undefined) {
@@ -55,20 +49,6 @@ export function simCfnCfEdgeSkipReason(
   }
 
   return absentFunctionReason(eventType, functionArn);
-}
-
-/**
- * The association is on an event type this simulation has no hook for.
- */
-function unsimulatedEventReason(
-  eventType: string,
-  functionArn: string,
-): string {
-  return (
-    `simulated CloudFront runs a Lambda@Edge function at viewer-request and ` +
-    `viewer-response, so the Behavior is deployed without the ${eventType} ` +
-    `function ${functionArn} and runs nothing there`
-  );
 }
 
 /**

--- a/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
+++ b/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
@@ -6,8 +6,10 @@ import type { SimCloudFrontBehaviorResolver } from "../../resolver/sim-cloud-fro
 import { SimCloudFrontBehaviorResolver as DefaultSimCloudFrontBehaviorResolver } from "../../resolver/sim-cloud-front-behavior-resolver.js";
 import { SimCffApplicator } from "../cff/sim-cff-applicator.js";
 import { SimLambdaEdgeApplicator } from "../edge/sim-lambda-edge-applicator.js";
+import { SimLambdaEdgeOriginApplicator } from "../edge/sim-lambda-edge-origin-applicator.js";
 import { SimAwsCfEdgeFunctions } from "../../edge/sim-aws-cf-edge-functions.js";
 import { SimCloudFrontOriginFetcher } from "../origin/sim-cloudfront-origin-fetcher.js";
+import { SimCfOriginStage } from "../origin/sim-cf-origin-stage.js";
 import { SimCfCustomErrorResponder } from "../error/sim-cf-custom-error-responder.js";
 import { SimCfResponseHeadersApplicator } from "../response-headers/sim-cf-response-headers-applicator.js";
 import { SimCfWebAclGuard } from "../web-acl/sim-cf-web-acl-guard.js";
@@ -21,6 +23,7 @@ export interface SimCloudFrontServiceControllerProperties {
   readonly behaviourResolver?: SimCloudFrontBehaviorResolver;
   readonly cffApplicator?: SimCffApplicator;
   readonly edgeApplicator?: SimLambdaEdgeApplicator;
+  readonly edgeOriginApplicator?: SimLambdaEdgeOriginApplicator;
   readonly originFetcher?: SimCloudFrontOriginFetcher;
   readonly customErrorResponder?: SimCfCustomErrorResponder;
   readonly responseHeadersApplicator?: SimCfResponseHeadersApplicator;
@@ -32,7 +35,7 @@ export interface SimCloudFrontControllerDependencies {
   readonly behaviourResolver: SimCloudFrontBehaviorResolver;
   readonly cffApplicator: SimCffApplicator;
   readonly edgeApplicator: SimLambdaEdgeApplicator;
-  readonly originFetcher: SimCloudFrontOriginFetcher;
+  readonly originStage: SimCfOriginStage;
   readonly customErrorResponder: SimCfCustomErrorResponder;
   readonly responseHeadersApplicator: SimCfResponseHeadersApplicator;
 }
@@ -59,6 +62,7 @@ export class SimCloudFrontControllerDependenciesFactory {
       new DefaultSimCloudFrontBehaviorResolver();
     const originFetcher =
       properties.originFetcher ?? new SimCloudFrontOriginFetcher();
+    const edgeFunctions = new SimAwsCfEdgeFunctions(simAws);
 
     return {
       distroRouter:
@@ -74,10 +78,12 @@ export class SimCloudFrontControllerDependenciesFactory {
       cffApplicator: properties.cffApplicator ?? new SimCffApplicator(),
       edgeApplicator:
         properties.edgeApplicator ??
-        new SimLambdaEdgeApplicator({
-          edgeFunctions: new SimAwsCfEdgeFunctions(simAws),
-        }),
-      originFetcher,
+        new SimLambdaEdgeApplicator({ edgeFunctions }),
+      originStage: new SimCfOriginStage(
+        originFetcher,
+        properties.edgeOriginApplicator ??
+          new SimLambdaEdgeOriginApplicator({ edgeFunctions }),
+      ),
       customErrorResponder:
         properties.customErrorResponder ??
         new SimCfCustomErrorResponder({ behaviourResolver, originFetcher }),

--- a/src/service/cloudfront/controller/edge/sim-lambda-edge-applicator.ts
+++ b/src/service/cloudfront/controller/edge/sim-lambda-edge-applicator.ts
@@ -2,9 +2,9 @@ import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
 import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
 import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
 import { SimLambdaEdgeEventAdapter } from "../../edge/adapter/sim-lambda-edge-event-adapter.js";
-import type { SimCfEdgeAssociation } from "../../edge/sim-cf-edge-association.js";
 import type { SimCfEdgeFunctions } from "../../edge/sim-cf-edge-functions.js";
 import { simCfEdgeDistributionConfig } from "./sim-lambda-edge-distribution.js";
+import { runEdgeFunction } from "./sim-lambda-edge-run.js";
 
 interface SimLambdaEdgeApplicatorProperties {
   /**
@@ -17,7 +17,9 @@ interface SimLambdaEdgeApplicatorProperties {
 }
 
 /**
- * Runs the Lambda@Edge functions a resolved Behavior associates.
+ * Runs the Lambda@Edge functions a resolved Behavior associates at the viewer
+ * events. `SimLambdaEdgeOriginApplicator` runs the two either side of the
+ * Origin fetch.
  *
  * A function that throws answers the viewer with a 502 and takes the request
  * no further, which is what CloudFront does with a failed edge function. The
@@ -50,7 +52,7 @@ export class SimLambdaEdgeApplicator {
       return request;
     }
 
-    return await this.running(association, async () => {
+    return await runEdgeFunction(association, async () => {
       const event = await this.eventAdapter.toRequestEvent(
         request,
         association.includeBody,
@@ -83,7 +85,7 @@ export class SimLambdaEdgeApplicator {
       return response;
     }
 
-    return await this.running(association, async () => {
+    return await runEdgeFunction(association, async () => {
       const event = await this.eventAdapter.toResponseEvent(
         request,
         response,
@@ -98,28 +100,5 @@ export class SimLambdaEdgeApplicator {
         response,
       );
     });
-  }
-
-  /**
-   * Run one edge function, answering with the 502 a failed one gets.
-   *
-   * A handler that threw, a handler that answered with something the adapter
-   * cannot read as a request or a response, and a request whose body could not
-   * be read into the event, are all the same thing to CloudFront. Each is a
-   * failure at the edge the viewer sees as a 502, which is why building the
-   * event happens in here rather than before it.
-   */
-  private async running<TResult extends Request | Response>(
-    association: SimCfEdgeAssociation,
-    run: () => Promise<TResult>,
-  ): Promise<TResult | Response> {
-    try {
-      return await run();
-    } catch {
-      return new Response(
-        `The Lambda@Edge function ${association.functionArn} failed`,
-        { status: 502 },
-      );
-    }
   }
 }

--- a/src/service/cloudfront/controller/edge/sim-lambda-edge-distribution.ts
+++ b/src/service/cloudfront/controller/edge/sim-lambda-edge-distribution.ts
@@ -1,5 +1,5 @@
 import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
-import type { SimLambdaEdgeDistributionConfig } from "../../edge/adapter/sim-lambda-edge-event-adapter.js";
+import type { SimLambdaEdgeDistributionConfig } from "../../edge/adapter/sim-lambda-edge-event-config.js";
 
 /**
  * What an edge function is told about the Distribution it is running for.

--- a/src/service/cloudfront/controller/edge/sim-lambda-edge-origin-applicator.ts
+++ b/src/service/cloudfront/controller/edge/sim-lambda-edge-origin-applicator.ts
@@ -1,0 +1,120 @@
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { SimLambdaEdgeOriginEventAdapter } from "../../edge/adapter/sim-lambda-edge-origin-event-adapter.js";
+import type { SimCfEdgeFunctions } from "../../edge/sim-cf-edge-functions.js";
+import type { SimCfOriginBoundRequest } from "../origin/sim-cf-origin-bound-request.js";
+import { simCfEdgeDistributionConfig } from "./sim-lambda-edge-distribution.js";
+import { runEdgeFunction } from "./sim-lambda-edge-run.js";
+
+interface SimLambdaEdgeOriginApplicatorProperties {
+  /**
+   * Where the associated function versions are found and run. A controller
+   * built without a simulated Lambda to reach has none, and a Behavior
+   * associating a function answers the viewer with a 502.
+   */
+  readonly edgeFunctions?: SimCfEdgeFunctions | undefined;
+}
+
+/**
+ * Runs the Lambda@Edge functions a resolved Behavior associates at the two
+ * origin events, either side of the Origin fetch.
+ *
+ * An origin-request function is told which Origin the Behavior resolved, and
+ * what it hands back is what the fetch uses. An origin-response function is
+ * told what the Origin answered, and what it hands back is what carries on
+ * towards the viewer.
+ */
+export class SimLambdaEdgeOriginApplicator {
+  private readonly eventAdapter = new SimLambdaEdgeOriginEventAdapter();
+  private readonly edgeFunctions: SimCfEdgeFunctions | undefined;
+
+  constructor(properties: SimLambdaEdgeOriginApplicatorProperties = {}) {
+    this.edgeFunctions = properties.edgeFunctions;
+  }
+
+  /**
+   * Run the origin-request function, if the Behavior associates one.
+   *
+   * Answers with the request and the Origin to fetch it from, or with the
+   * response a handler generated instead, which the Origin is never read for.
+   */
+  async applyOriginRequest(
+    bound: SimCfOriginBoundRequest,
+    distribution: SimCloudFrontDistribution,
+    behaviour: SimCloudFrontBehavior,
+  ): Promise<SimCfOriginBoundRequest | Response> {
+    const association = behaviour.lambdaFunctionAssociations?.originRequest;
+    const edgeFunctions = this.edgeFunctions;
+
+    if (association === undefined || edgeFunctions === undefined) {
+      return bound;
+    }
+
+    return await runEdgeFunction(association, async () => {
+      const edgeOrigin = bound.origin.toEdgeOrigin();
+      const event = await this.eventAdapter.toOriginRequestEvent(
+        bound.request,
+        association.includeBody,
+        simCfEdgeDistributionConfig(distribution),
+        edgeOrigin,
+      );
+
+      const result = this.eventAdapter.fromOriginRequestResult(
+        (await edgeFunctions.invoke(
+          association.functionArn,
+          event,
+        )) as LambdaAtEdge.RequestResult,
+        bound.request,
+        edgeOrigin,
+      );
+
+      if (result instanceof Response) {
+        return result;
+      }
+
+      return {
+        request: result.request,
+        origin: bound.origin.withEdgeOrigin(result.origin),
+      };
+    });
+  }
+
+  /**
+   * Run the origin-response function, if the Behavior associates one.
+   *
+   * This one runs whatever the Origin answered, including a 400 and above.
+   * That is where the origin events differ from the viewer events, and
+   * CloudFront states it.
+   */
+  async applyOriginResponse(
+    bound: SimCfOriginBoundRequest,
+    response: Response,
+    distribution: SimCloudFrontDistribution,
+    behaviour: SimCloudFrontBehavior,
+  ): Promise<Response> {
+    const association = behaviour.lambdaFunctionAssociations?.originResponse;
+    const edgeFunctions = this.edgeFunctions;
+
+    if (association === undefined || edgeFunctions === undefined) {
+      return response;
+    }
+
+    return await runEdgeFunction(association, async () => {
+      const event = await this.eventAdapter.toOriginResponseEvent(
+        bound.request,
+        response,
+        simCfEdgeDistributionConfig(distribution),
+        bound.origin.toEdgeOrigin(),
+      );
+
+      return this.eventAdapter.fromResponseResult(
+        (await edgeFunctions.invoke(
+          association.functionArn,
+          event,
+        )) as LambdaAtEdge.Response,
+        response,
+      );
+    });
+  }
+}

--- a/src/service/cloudfront/controller/edge/sim-lambda-edge-run.ts
+++ b/src/service/cloudfront/controller/edge/sim-lambda-edge-run.ts
@@ -1,0 +1,41 @@
+import type { SimCfEdgeAssociation } from "../../edge/sim-cf-edge-association.js";
+import { SimCfEdgeOriginNotSimulated } from "../../origin/sim-cf-edge-origin-not-simulated.error.js";
+
+/**
+ * Run one edge function, answering with the 502 a failed one gets.
+ *
+ * A handler that threw, a handler that answered with something the adapter
+ * cannot read as a request or a response, and a request whose body could not
+ * be read into the event, are all the same thing to CloudFront. Each is a
+ * failure at the edge the viewer sees as a 502, which is why building the
+ * event happens inside the callback rather than before it.
+ *
+ * An Origin rewrite this simulation cannot carry out is a 502 as well, and
+ * that one says what it was, because nothing about it would have failed on
+ * AWS and the reason is not in the function's own output.
+ */
+export async function runEdgeFunction<TResult>(
+  association: SimCfEdgeAssociation,
+  run: () => Promise<TResult>,
+): Promise<TResult | Response> {
+  try {
+    return await run();
+  } catch (error) {
+    return new Response(
+      `The Lambda@Edge function ${association.functionArn} failed${edgeFailureDetail(error)}`,
+      { status: 502 },
+    );
+  }
+}
+
+/**
+ * What the 502 says about the failure, where this simulation is the reason
+ * for it rather than the handler.
+ */
+function edgeFailureDetail(error: unknown): string {
+  if (error instanceof SimCfEdgeOriginNotSimulated) {
+    return `: ${error.message}`;
+  }
+
+  return "";
+}

--- a/src/service/cloudfront/controller/origin/sim-cf-origin-bound-request.ts
+++ b/src/service/cloudfront/controller/origin/sim-cf-origin-bound-request.ts
@@ -4,8 +4,9 @@ import type { SimCloudFrontOrigin } from "../../origin/sim-cloudfront-origin.js"
  * A request and the Origin it is about to be fetched from.
  *
  * The two travel together between the origin-request event and the fetch,
- * because a handler can rewrite either of them: the request's URI and headers,
- * and the Origin's domain name, path and custom headers.
+ * because a handler can rewrite either of them. The request has its URI and its
+ * headers, and the Origin has its domain name, its path and its custom
+ * headers.
  */
 export interface SimCfOriginBoundRequest {
   readonly request: Request;

--- a/src/service/cloudfront/controller/origin/sim-cf-origin-bound-request.ts
+++ b/src/service/cloudfront/controller/origin/sim-cf-origin-bound-request.ts
@@ -1,0 +1,13 @@
+import type { SimCloudFrontOrigin } from "../../origin/sim-cloudfront-origin.js";
+
+/**
+ * A request and the Origin it is about to be fetched from.
+ *
+ * The two travel together between the origin-request event and the fetch,
+ * because a handler can rewrite either of them: the request's URI and headers,
+ * and the Origin's domain name, path and custom headers.
+ */
+export interface SimCfOriginBoundRequest {
+  readonly request: Request;
+  readonly origin: SimCloudFrontOrigin;
+}

--- a/src/service/cloudfront/controller/origin/sim-cf-origin-stage.ts
+++ b/src/service/cloudfront/controller/origin/sim-cf-origin-stage.ts
@@ -1,0 +1,97 @@
+import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import type { SimLambdaEdgeOriginApplicator } from "../edge/sim-lambda-edge-origin-applicator.js";
+import type { SimCloudFrontOriginFetcher } from "./sim-cloudfront-origin-fetcher.js";
+
+/**
+ * What the Origin stage produced for the rest of the pipeline.
+ */
+export interface SimCfOriginStageResult {
+  /**
+   * The response carrying on towards the viewer.
+   */
+  readonly response: Response;
+
+  /**
+   * The status the Origin answered with, before an origin-response function
+   * could replace it.
+   *
+   * The pipeline reads this to decide whether a viewer-response function runs,
+   * so a 500 an origin-response function turned into a 200 still counts as the
+   * Origin error it was. A response an origin-request function generated has
+   * no Origin status behind it, and its own status stands in.
+   */
+  readonly originStatus: number;
+}
+
+/**
+ * Fetches from the Behavior's Origin, running the Lambda@Edge functions on
+ * either side of the fetch.
+ *
+ * Real CloudFront runs the origin events on a cache miss only. Nothing here
+ * caches, so every request is a miss and both events run every time.
+ */
+export class SimCfOriginStage {
+  constructor(
+    private readonly originFetcher: SimCloudFrontOriginFetcher,
+    private readonly edgeOriginApplicator: SimLambdaEdgeOriginApplicator,
+  ) {}
+
+  /**
+   * Take one request through the origin-request event, the fetch and the
+   * origin-response event.
+   */
+  async fetch(
+    request: Request,
+    distribution: SimCloudFrontDistribution,
+    behaviour: SimCloudFrontBehavior,
+  ): Promise<SimCfOriginStageResult> {
+    const origin = distribution.getOrigin(behaviour.targetOriginName);
+
+    // A Behavior naming an Origin the Distribution does not hold has nothing
+    // to tell an origin-request function about, and the fetcher answers with
+    // the same misconfiguration response it always has.
+    if (origin === undefined) {
+      return this.fetched(
+        await this.originFetcher.fetch(request, distribution, behaviour),
+      );
+    }
+
+    const bound = await this.edgeOriginApplicator.applyOriginRequest(
+      { request, origin },
+      distribution,
+      behaviour,
+    );
+
+    // A response the origin-request function generated answers the viewer
+    // without the Origin being read, and the origin-response function has no
+    // Origin response to run on.
+    if (bound instanceof Response) {
+      return this.fetched(bound);
+    }
+
+    const response = await this.originFetcher.fetch(
+      bound.request,
+      distribution,
+      behaviour,
+      bound.origin,
+    );
+
+    return {
+      response: await this.edgeOriginApplicator.applyOriginResponse(
+        bound,
+        response,
+        distribution,
+        behaviour,
+      ),
+      originStatus: response.status,
+    };
+  }
+
+  /**
+   * A response nothing ran after, whose own status is the Origin's.
+   */
+  private fetched(response: Response): SimCfOriginStageResult {
+    return { response, originStatus: response.status };
+  }
+}

--- a/src/service/cloudfront/controller/origin/sim-cloudfront-origin-fetcher.ts
+++ b/src/service/cloudfront/controller/origin/sim-cloudfront-origin-fetcher.ts
@@ -1,5 +1,6 @@
 import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
 import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import type { SimCloudFrontOrigin } from "../../origin/sim-cloudfront-origin.js";
 
 /**
  * Fetches a request from the Behavior's configured CloudFront Origin.
@@ -7,13 +8,18 @@ import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfron
 export class SimCloudFrontOriginFetcher {
   /**
    * Fetch the request from the Origin targeted by the resolved Behavior.
+   *
+   * An Origin passed in is fetched from instead of the one the Behavior
+   * targets, which is how an origin-request function's rewriting reaches the
+   * fetch.
    */
   async fetch(
     request: Request,
     distro: SimCloudFrontDistribution,
     behaviour: SimCloudFrontBehavior,
+    targetOrigin?: SimCloudFrontOrigin,
   ): Promise<Response> {
-    const origin = distro.getOrigin(behaviour.targetOriginName);
+    const origin = targetOrigin ?? distro.getOrigin(behaviour.targetOriginName);
     if (origin === undefined) {
       return new Response(
         `Sim CloudFront Distribution misconfigured for Origin ${behaviour.targetOriginName}`,

--- a/src/service/cloudfront/controller/sim-cf-controller-origin-request-custom.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-origin-request-custom.iso.test.ts
@@ -1,0 +1,212 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { LambdaAtEdge } from "../typings/lambda-at-edge.namespace.js";
+import { makeEdgeFunctionVersionArn } from "../../../../test/cloudfront/edge-function-fixture.js";
+import {
+  customOrigin,
+  edgeOriginDistributionHostname,
+  edgeOriginViewerFetch,
+  functionUrlHostname,
+  respondingWith,
+} from "../../../../test/cloudfront/edge-origin-fixture.js";
+
+describe("Simulated CloudFront origin-request Lambda@Edge on a custom Origin", () => {
+  it("sends the fetch to the Origin a function rewrote the domain name to", async () => {
+    // Given two services behind two Origins of one Distribution.
+    const simAws = new SimAws();
+    const primaryHost = await functionUrlHostname(
+      simAws,
+      "primary-origin",
+      respondingWith("From the primary Origin"),
+    );
+    const failoverHost = await functionUrlHostname(
+      simAws,
+      "failover-origin",
+      respondingWith("From the failover Origin"),
+    );
+
+    // And a function moving the request to the second one.
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "route-origin",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+        assertNonNullable(request.origin.custom, "the Origin is a custom one");
+        request.origin.custom.domainName = failoverHost;
+
+        return request;
+      },
+    });
+
+    const distroHostname = await edgeOriginDistributionHostname(
+      simAws,
+      [
+        customOrigin("primary", primaryHost),
+        customOrigin("failover", failoverHost),
+      ],
+      [{ EventType: "origin-request", LambdaFunctionARN: versionArn }],
+    );
+
+    // When a request arrives for the Behavior targeting the first Origin.
+    const response = await edgeOriginViewerFetch(
+      simAws,
+      distroHostname,
+      "/greeting",
+    );
+
+    // Then the second Origin is the one that answered.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "From the failover Origin");
+  });
+
+  it("reaches the Origin with a custom header a function added", async () => {
+    // Given an Origin telling the viewer which header it was sent.
+    const simAws = new SimAws();
+    const originHost = await functionUrlHostname(
+      simAws,
+      "header-reading-origin",
+      (event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(event.headers),
+      }),
+    );
+
+    // And a function adding that header to the Origin request.
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "add-origin-header",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+        assertNonNullable(request.origin.custom, "the Origin is a custom one");
+        request.origin.custom.customHeaders["x-origin-secret"] = [
+          { key: "X-Origin-Secret", value: "from-the-edge" },
+        ];
+
+        return request;
+      },
+    });
+
+    const distroHostname = await edgeOriginDistributionHostname(
+      simAws,
+      [customOrigin("api", originHost)],
+      [{ EventType: "origin-request", LambdaFunctionARN: versionArn }],
+    );
+
+    // When a viewer that sent no such header makes a request.
+    const response = await edgeOriginViewerFetch(
+      simAws,
+      distroHostname,
+      "/greeting",
+    );
+
+    // Then the Origin was sent it, and it is nowhere in what the viewer got
+    // back.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertStringIncludes(await response.text(), "from-the-edge");
+    assertIdentical(response.headers.get("x-origin-secret"), null);
+  });
+
+  it("fails the request when a function moved the Origin to a domain naming nothing here", async () => {
+    // Given a function pointing the Origin at a domain outside the simulation.
+    const simAws = new SimAws();
+    const originHost = await functionUrlHostname(
+      simAws,
+      "reachable-origin",
+      respondingWith("Never served"),
+    );
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "route-off-simulation",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+        assertNonNullable(request.origin.custom, "the Origin is a custom one");
+        request.origin.custom.domainName = "api.example.test";
+
+        return request;
+      },
+    });
+
+    const distroHostname = await edgeOriginDistributionHostname(
+      simAws,
+      [customOrigin("api", originHost)],
+      [{ EventType: "origin-request", LambdaFunctionARN: versionArn }],
+    );
+
+    // When a request arrives.
+    const response = await edgeOriginViewerFetch(
+      simAws,
+      distroHostname,
+      "/greeting",
+    );
+
+    // Then it fails the way a misconfigured Origin does, naming the domain
+    // rather than the request being sent to the real one.
+    assertResponseStatus(response, 500, await describeResponse(response));
+    assertStringIncludes(
+      await response.text(),
+      "does not resolve to a simulated AWS service",
+    );
+  });
+
+  it("answers with a 502 when a function turned a custom Origin into an S3 Origin", async () => {
+    // Given a function handing back the other kind of Origin.
+    const simAws = new SimAws();
+    const originHost = await functionUrlHostname(
+      simAws,
+      "swapped-custom-origin",
+      respondingWith("Never served"),
+    );
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "swap-to-s3",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+
+        request.origin = {
+          s3: {
+            authMethod: "none",
+            customHeaders: {},
+            domainName: "assets.s3.amazonaws.com",
+            path: "",
+            region: "us-east-1",
+          },
+        };
+
+        return request;
+      },
+    });
+
+    const distroHostname = await edgeOriginDistributionHostname(
+      simAws,
+      [customOrigin("api", originHost)],
+      [{ EventType: "origin-request", LambdaFunctionARN: versionArn }],
+    );
+
+    // When a request arrives.
+    const response = await edgeOriginViewerFetch(
+      simAws,
+      distroHostname,
+      "/greeting",
+    );
+
+    // Then the viewer gets the 502 a failed edge function gets, saying what
+    // this simulation could not do.
+    assertResponseStatus(response, 502, await describeResponse(response));
+    assertStringIncludes(
+      await response.text(),
+      "Switching an Origin between the two kinds is not simulated",
+    );
+  });
+});

--- a/src/service/cloudfront/controller/sim-cf-controller-origin-request-edge.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-origin-request-edge.iso.test.ts
@@ -1,0 +1,389 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import {
+  CreateFunctionCommand,
+  type DistributionConfig,
+} from "@aws-sdk/client-cloudfront";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeCffFunctionCodeInput } from "../cff/function-code-input/cff-function-code-input.js";
+import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
+import type { LambdaAtEdge } from "../typings/lambda-at-edge.namespace.js";
+import { makeEdgeFunctionVersionArn } from "../../../../test/cloudfront/edge-function-fixture.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+  simCfSiteRequest,
+} from "../../../../test/cloudfront/site-fixture.js";
+
+describe("Simulated CloudFront origin-request Lambda@Edge", () => {
+  /**
+   * A site DistributionConfig whose default Behavior runs this function at the
+   * origin request, with the rest of the Behavior left as the fixture has it.
+   */
+  function originRequestConfig(
+    bucketName: string,
+    versionArn: string,
+  ): DistributionConfig {
+    return simCfSiteDistributionConfig(bucketName, {
+      DefaultCacheBehavior: {
+        TargetOriginId: "site-origin",
+        ViewerProtocolPolicy: "allow-all",
+        LambdaFunctionAssociations: {
+          Quantity: 1,
+          Items: [
+            { EventType: "origin-request", LambdaFunctionARN: versionArn },
+          ],
+        },
+      },
+    });
+  }
+
+  it("tells the handler which Origin the fetch is about to read", async () => {
+    // Given a site whose Origin the Behavior resolved before the function ran.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "origin-event-site", {});
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "echo-origin",
+      handler: (
+        event: LambdaAtEdge.OriginRequestEvent,
+      ): LambdaAtEdge.Response => {
+        const { request } = event.Records[0].cf;
+
+        return {
+          status: "200",
+          body: JSON.stringify({
+            origin: request.origin,
+            host: request.headers["host"]?.[0]?.value,
+            eventType: event.Records[0].cf.config.eventType,
+          }),
+        };
+      },
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      originRequestConfig("origin-event-site", versionArn),
+    );
+
+    // When a request arrives.
+    const response = await simCfSiteRequest(simAws, distributionId, "/any");
+
+    // Then the event carried the S3 Origin the Behavior targets, and the host
+    // is the Origin's domain rather than the one the viewer used.
+    const seen = (await response.json()) as {
+      origin: LambdaAtEdge.Origin;
+      host: string;
+      eventType: string;
+    };
+
+    assertIdentical(seen.eventType, "origin-request");
+    assertIdentical(seen.host, "origin-event-site.s3.amazonaws.com");
+    assertNonNullable(seen.origin.s3, "the event carried an S3 Origin");
+    assertIdentical(
+      seen.origin.s3.domainName,
+      "origin-event-site.s3.amazonaws.com",
+    );
+    assertIdentical(seen.origin.s3.authMethod, "none");
+    assertIdentical(seen.origin.s3.region, "us-east-1");
+  });
+
+  it("reads the Bucket prefix a function rewrote the Origin path to", async () => {
+    // Given a site holding two releases of the same page.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "release-site", {
+      "v1/index.html": "<h1>Old</h1>",
+      "v2/index.html": "<h1>New</h1>",
+    });
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "pick-release",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+        assertNonNullable(request.origin.s3, "the Origin is an S3 one");
+        request.origin.s3.path = "/v2";
+
+        return request;
+      },
+    });
+
+    // And an Origin serving the older release.
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("release-site", {
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "release-site.s3.amazonaws.com",
+              OriginPath: "/v1",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          LambdaFunctionAssociations: {
+            Quantity: 1,
+            Items: [
+              { EventType: "origin-request", LambdaFunctionARN: versionArn },
+            ],
+          },
+        },
+      }),
+    );
+
+    // When a request arrives.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the newer release is what the fetch read.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>New</h1>");
+  });
+
+  it("answers the viewer from a function that returned a response, without reading the Origin", async () => {
+    // Given a site whose one object the function never lets the fetch reach.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "origin-short-circuit-site", {
+      "index.html": "<h1>Never served</h1>",
+    });
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "answer-at-origin",
+      handler: (): LambdaAtEdge.Response => ({
+        status: "200",
+        statusDescription: "OK",
+        headers: {
+          "content-type": [{ key: "Content-Type", value: "text/html" }],
+        },
+        body: "<h1>From the edge</h1>",
+      }),
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      originRequestConfig("origin-short-circuit-site", versionArn),
+    );
+
+    // When a request arrives for the object.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the handler's response is what the viewer gets, and the Bucket was
+    // never read.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>From the edge</h1>");
+  });
+
+  it("keeps the Behavior's Origin where the handler built a request without one", async () => {
+    // Given a handler that answers with a request object of its own, which
+    // carries no Origin for the fetch to read.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "rebuilt-request-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "rebuild-request",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+
+        return {
+          clientIp: request.clientIp,
+          method: request.method,
+          uri: "/index.html",
+          querystring: request.querystring,
+          headers: request.headers,
+        };
+      },
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      originRequestConfig("rebuilt-request-site", versionArn),
+    );
+
+    // When a request arrives.
+    const response = await simCfSiteRequest(simAws, distributionId, "/any");
+
+    // Then the fetch went to the Origin the Behavior targets.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Home</h1>");
+  });
+
+  it("runs a viewer-request CloudFront Function alongside an origin-request Lambda@Edge function", async () => {
+    // Given a CloudFront Function rewriting the URI at the viewer.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "both-kinds-site", {
+      "v2/index.html": "<h1>New</h1>",
+    });
+
+    const cff = await simAws.cloudFront().createFunction(
+      new CreateFunctionCommand({
+        Name: "rewrite-uri",
+        FunctionConfig: {
+          Comment: "Rewrite to the page",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: makeCffFunctionCodeInput(
+          (event: CloudFrontFunction.ViewerRequestEvent) => {
+            event.request.uri = "/index.html";
+
+            return event.request;
+          },
+        ),
+      }),
+    );
+    const functionArn = cff.FunctionMetadata.FunctionARN;
+
+    // And a Lambda@Edge function picking the Origin prefix at the Origin.
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "pick-prefix",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+        assertNonNullable(request.origin.s3, "the Origin is an S3 one");
+        request.origin.s3.path = "/v2";
+
+        return request;
+      },
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("both-kinds-site", {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          FunctionAssociations: {
+            Quantity: 1,
+            Items: [{ EventType: "viewer-request", FunctionARN: functionArn }],
+          },
+          LambdaFunctionAssociations: {
+            Quantity: 1,
+            Items: [
+              { EventType: "origin-request", LambdaFunctionARN: versionArn },
+            ],
+          },
+        },
+      }),
+    );
+
+    // When a request arrives for the site root.
+    const response = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then both functions ran: the CloudFront Function named the page, and the
+    // Lambda@Edge function named the prefix it was read from.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>New</h1>");
+  });
+
+  it("answers with a 502 when a function moved an S3 Origin to another Bucket", async () => {
+    // Given a handler pointing the S3 Origin at a Bucket the Distribution was
+    // never written with.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "moved-origin-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "move-bucket",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+        assertNonNullable(request.origin.s3, "the Origin is an S3 one");
+        request.origin.s3.domainName = "somewhere-else.s3.amazonaws.com";
+
+        return request;
+      },
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      originRequestConfig("moved-origin-site", versionArn),
+    );
+
+    // When a request arrives.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the viewer gets the 502 a failed edge function gets, saying what
+    // this simulation could not do.
+    assertResponseStatus(response, 502);
+    assertStringIncludes(await response.text(), "moving one is not simulated");
+  });
+
+  it("answers with a 502 when a function turned an S3 Origin into a custom Origin", async () => {
+    // Given a handler handing back the other kind of Origin.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "swapped-origin-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "swap-origin-kind",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+
+        request.origin = {
+          custom: {
+            customHeaders: {},
+            domainName: "api.example.test",
+            keepaliveTimeout: 5,
+            path: "",
+            port: 443,
+            protocol: "https",
+            readTimeout: 30,
+            sslProtocols: ["TLSv1.2"],
+          },
+        };
+
+        return request;
+      },
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      originRequestConfig("swapped-origin-site", versionArn),
+    );
+
+    // When a request arrives.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the viewer gets a 502 naming the switch as the part that is not
+    // simulated.
+    assertResponseStatus(response, 502);
+    assertStringIncludes(
+      await response.text(),
+      "Switching an Origin between the two kinds is not simulated",
+    );
+  });
+});

--- a/src/service/cloudfront/controller/sim-cf-controller-origin-request-edge.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-origin-request-edge.iso.test.ts
@@ -2,7 +2,6 @@ import {
   assertIdentical,
   assertNonNullable,
   assertResponseStatus,
-  assertStringIncludes,
 } from "@kensio/smartass";
 import {
   CreateFunctionCommand,
@@ -231,6 +230,56 @@ describe("Simulated CloudFront origin-request Lambda@Edge", () => {
     assertIdentical(await response.text(), "<h1>Home</h1>");
   });
 
+  it("gives the handler the request body when the association includes it", async () => {
+    // Given an association that reads the body at the origin request.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "origin-body-site", {});
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "echo-origin-body",
+      handler: (
+        event: LambdaAtEdge.OriginRequestEvent,
+      ): LambdaAtEdge.Response => ({
+        status: "200",
+        body: Buffer.from(
+          event.Records[0].cf.request.body?.data ?? "",
+          "base64",
+        ).toString(),
+      }),
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("origin-body-site", {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          AllowedMethods: { Quantity: 3, Items: ["GET", "HEAD", "POST"] },
+          LambdaFunctionAssociations: {
+            Quantity: 1,
+            Items: [
+              {
+                EventType: "origin-request",
+                LambdaFunctionARN: versionArn,
+                IncludeBody: true,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    // When a request arrives carrying one.
+    const response = await simCfSiteRequest(simAws, distributionId, "/orders", {
+      method: "POST",
+      body: "order=1042",
+    });
+
+    // Then the handler was given it.
+    assertIdentical(await response.text(), "order=1042");
+  });
+
   it("runs a viewer-request CloudFront Function alongside an origin-request Lambda@Edge function", async () => {
     // Given a CloudFront Function rewriting the URI at the viewer.
     const simAws = new SimAws();
@@ -292,98 +341,9 @@ describe("Simulated CloudFront origin-request Lambda@Edge", () => {
     // When a request arrives for the site root.
     const response = await simCfSiteRequest(simAws, distributionId, "/");
 
-    // Then both functions ran: the CloudFront Function named the page, and the
+    // Then both functions ran. The CloudFront Function named the page, and the
     // Lambda@Edge function named the prefix it was read from.
     assertResponseStatus(response, 200);
     assertIdentical(await response.text(), "<h1>New</h1>");
-  });
-
-  it("answers with a 502 when a function moved an S3 Origin to another Bucket", async () => {
-    // Given a handler pointing the S3 Origin at a Bucket the Distribution was
-    // never written with.
-    const simAws = new SimAws();
-    await simCfSiteBucket(simAws, "moved-origin-site", {
-      "index.html": "<h1>Home</h1>",
-    });
-
-    const versionArn = await makeEdgeFunctionVersionArn({
-      simAws,
-      functionName: "move-bucket",
-      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
-        const { request } = event.Records[0].cf;
-        assertNonNullable(request.origin.s3, "the Origin is an S3 one");
-        request.origin.s3.domainName = "somewhere-else.s3.amazonaws.com";
-
-        return request;
-      },
-    });
-
-    const distributionId = await simCfSiteDistributionId(
-      simAws,
-      originRequestConfig("moved-origin-site", versionArn),
-    );
-
-    // When a request arrives.
-    const response = await simCfSiteRequest(
-      simAws,
-      distributionId,
-      "/index.html",
-    );
-
-    // Then the viewer gets the 502 a failed edge function gets, saying what
-    // this simulation could not do.
-    assertResponseStatus(response, 502);
-    assertStringIncludes(await response.text(), "moving one is not simulated");
-  });
-
-  it("answers with a 502 when a function turned an S3 Origin into a custom Origin", async () => {
-    // Given a handler handing back the other kind of Origin.
-    const simAws = new SimAws();
-    await simCfSiteBucket(simAws, "swapped-origin-site", {
-      "index.html": "<h1>Home</h1>",
-    });
-
-    const versionArn = await makeEdgeFunctionVersionArn({
-      simAws,
-      functionName: "swap-origin-kind",
-      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
-        const { request } = event.Records[0].cf;
-
-        request.origin = {
-          custom: {
-            customHeaders: {},
-            domainName: "api.example.test",
-            keepaliveTimeout: 5,
-            path: "",
-            port: 443,
-            protocol: "https",
-            readTimeout: 30,
-            sslProtocols: ["TLSv1.2"],
-          },
-        };
-
-        return request;
-      },
-    });
-
-    const distributionId = await simCfSiteDistributionId(
-      simAws,
-      originRequestConfig("swapped-origin-site", versionArn),
-    );
-
-    // When a request arrives.
-    const response = await simCfSiteRequest(
-      simAws,
-      distributionId,
-      "/index.html",
-    );
-
-    // Then the viewer gets a 502 naming the switch as the part that is not
-    // simulated.
-    assertResponseStatus(response, 502);
-    assertStringIncludes(
-      await response.text(),
-      "Switching an Origin between the two kinds is not simulated",
-    );
   });
 });

--- a/src/service/cloudfront/controller/sim-cf-controller-origin-request-refusal.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-origin-request-refusal.iso.test.ts
@@ -1,0 +1,130 @@
+import {
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import type { DistributionConfig } from "@aws-sdk/client-cloudfront";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { LambdaAtEdge } from "../typings/lambda-at-edge.namespace.js";
+import { makeEdgeFunctionVersionArn } from "../../../../test/cloudfront/edge-function-fixture.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+  simCfSiteRequest,
+} from "../../../../test/cloudfront/site-fixture.js";
+
+describe("Simulated CloudFront origin-request Lambda@Edge refusals", () => {
+  /**
+   * A site DistributionConfig whose default Behavior runs this function at the
+   * origin request, with the rest of the Behavior left as the fixture has it.
+   */
+  function originRequestConfig(
+    bucketName: string,
+    versionArn: string,
+  ): DistributionConfig {
+    return simCfSiteDistributionConfig(bucketName, {
+      DefaultCacheBehavior: {
+        TargetOriginId: "site-origin",
+        ViewerProtocolPolicy: "allow-all",
+        LambdaFunctionAssociations: {
+          Quantity: 1,
+          Items: [
+            { EventType: "origin-request", LambdaFunctionARN: versionArn },
+          ],
+        },
+      },
+    });
+  }
+
+  it("answers with a 502 when a function moved an S3 Origin to another Bucket", async () => {
+    // Given a handler pointing the S3 Origin at a Bucket the Distribution was
+    // never written with.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "moved-origin-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "move-bucket",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+        assertNonNullable(request.origin.s3, "the Origin is an S3 one");
+        request.origin.s3.domainName = "somewhere-else.s3.amazonaws.com";
+
+        return request;
+      },
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      originRequestConfig("moved-origin-site", versionArn),
+    );
+
+    // When a request arrives.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the viewer gets the 502 a failed edge function gets, saying what
+    // this simulation could not do.
+    assertResponseStatus(response, 502);
+    assertStringIncludes(await response.text(), "moving one is not simulated");
+  });
+
+  it("answers with a 502 when a function turned an S3 Origin into a custom Origin", async () => {
+    // Given a handler handing back the other kind of Origin.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "swapped-origin-site", {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "swap-origin-kind",
+      handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+        const { request } = event.Records[0].cf;
+
+        request.origin = {
+          custom: {
+            customHeaders: {},
+            domainName: "api.example.test",
+            keepaliveTimeout: 5,
+            path: "",
+            port: 443,
+            protocol: "https",
+            readTimeout: 30,
+            sslProtocols: ["TLSv1.2"],
+          },
+        };
+
+        return request;
+      },
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      originRequestConfig("swapped-origin-site", versionArn),
+    );
+
+    // When a request arrives.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the viewer gets a 502 naming the switch as the part that is not
+    // simulated.
+    assertResponseStatus(response, 502);
+    assertStringIncludes(
+      await response.text(),
+      "Switching an Origin between the two kinds is not simulated",
+    );
+  });
+});

--- a/src/service/cloudfront/controller/sim-cf-controller-origin-response-edge.iso.test.ts
+++ b/src/service/cloudfront/controller/sim-cf-controller-origin-response-edge.iso.test.ts
@@ -1,0 +1,249 @@
+import {
+  assertIdentical,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { LambdaAtEdge } from "../typings/lambda-at-edge.namespace.js";
+import { makeEdgeFunctionVersionArn } from "../../../../test/cloudfront/edge-function-fixture.js";
+import {
+  customOrigin,
+  edgeOriginDistributionHostname,
+  edgeOriginViewerFetch,
+  functionUrlHostname,
+  respondingWith,
+} from "../../../../test/cloudfront/edge-origin-fixture.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+  simCfSiteRequest,
+} from "../../../../test/cloudfront/site-fixture.js";
+
+describe("Simulated CloudFront origin-response Lambda@Edge", () => {
+  it("replaces the body the viewer receives", async () => {
+    // Given a site serving a page the function rewrites once the Origin has
+    // answered.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "origin-response-site", {
+      "index.html": "<h1>From the Bucket</h1>",
+    });
+
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "rewrite-origin-response",
+      handler: (
+        event: LambdaAtEdge.OriginResponseEvent,
+      ): LambdaAtEdge.Response => {
+        const { request, response } = event.Records[0].cf;
+
+        return {
+          ...response,
+          headers: {
+            ...response.headers,
+            "x-origin-domain": [
+              {
+                key: "X-Origin-Domain",
+                value: request.origin.s3?.domainName ?? "none",
+              },
+            ],
+          },
+          body: "<h1>From the edge</h1>",
+        };
+      },
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("origin-response-site", {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          LambdaFunctionAssociations: {
+            Quantity: 1,
+            Items: [
+              { EventType: "origin-response", LambdaFunctionARN: versionArn },
+            ],
+          },
+        },
+      }),
+    );
+
+    // When a request arrives for the page.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then the viewer gets the function's body, and the event carried the
+    // Origin the response came from.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>From the edge</h1>");
+    assertIdentical(
+      response.headers.get("x-origin-domain"),
+      "origin-response-site.s3.amazonaws.com",
+    );
+  });
+
+  it("runs on a 500 from the Origin", async () => {
+    // Given an Origin that is failing.
+    const simAws = new SimAws();
+    const originHost = await functionUrlHostname(
+      simAws,
+      "failing-origin",
+      respondingWith("Origin blew up", 500),
+    );
+
+    // And a function turning that into the page the site serves instead.
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "repair-origin-error",
+      handler: (
+        event: LambdaAtEdge.OriginResponseEvent,
+      ): LambdaAtEdge.Response => ({
+        status: "200",
+        statusDescription: "OK",
+        headers: {
+          "x-origin-status": [
+            {
+              key: "X-Origin-Status",
+              value: event.Records[0].cf.response.status,
+            },
+          ],
+        },
+        body: "<h1>Back shortly</h1>",
+      }),
+    });
+
+    const distroHostname = await edgeOriginDistributionHostname(
+      simAws,
+      [customOrigin("api", originHost)],
+      [{ EventType: "origin-response", LambdaFunctionARN: versionArn }],
+    );
+
+    // When a request arrives.
+    const response = await edgeOriginViewerFetch(
+      simAws,
+      distroHostname,
+      "/greeting",
+    );
+
+    // Then the function ran on the Origin's error and replaced it, which is
+    // where the origin events differ from the viewer events.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "<h1>Back shortly</h1>");
+    assertIdentical(response.headers.get("x-origin-status"), "500");
+  });
+
+  it("runs before the custom error page replaces a 404", async () => {
+    // Given a site with a custom error page for a 404.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "custom-error-site", {
+      "404.html": "<h1>Not found</h1>",
+    });
+
+    // And a function answering the missing page itself.
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "answer-missing-page",
+      handler: (): LambdaAtEdge.Response => ({
+        status: "200",
+        statusDescription: "OK",
+        body: "<h1>Answered at the Origin</h1>",
+      }),
+    });
+
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("custom-error-site", {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          LambdaFunctionAssociations: {
+            Quantity: 1,
+            Items: [
+              { EventType: "origin-response", LambdaFunctionARN: versionArn },
+            ],
+          },
+        },
+      }),
+    );
+
+    // When a request arrives for a page the Bucket does not hold.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/missing.html",
+    );
+
+    // Then the function had already turned the 404 into something else by the
+    // time the custom error page would have replaced it.
+    assertResponseStatus(response, 200);
+    assertIdentical(await response.text(), "<h1>Answered at the Origin</h1>");
+  });
+
+  it("leaves the viewer-response function skipped when it repaired an Origin error", async () => {
+    // Given an Origin that is failing, an origin-response function repairing
+    // the status, and a viewer-response function that would add a header.
+    const simAws = new SimAws();
+    const originHost = await functionUrlHostname(
+      simAws,
+      "still-failing-origin",
+      respondingWith("Origin blew up", 500),
+    );
+
+    const originVersionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "repair-status",
+      handler: (): LambdaAtEdge.Response => ({
+        status: "200",
+        body: "<h1>Back shortly</h1>",
+      }),
+    });
+
+    const viewerVersionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "stamp-viewer-response",
+      handler: (event: LambdaAtEdge.ResponseEvent): LambdaAtEdge.Response => ({
+        ...event.Records[0].cf.response,
+        headers: {
+          "x-viewer-response": [{ key: "X-Viewer-Response", value: "ran" }],
+        },
+      }),
+    });
+
+    const distroHostname = await edgeOriginDistributionHostname(
+      simAws,
+      [customOrigin("api", originHost)],
+      [
+        { EventType: "origin-response", LambdaFunctionARN: originVersionArn },
+        { EventType: "viewer-response", LambdaFunctionARN: viewerVersionArn },
+      ],
+    );
+
+    // When a request arrives.
+    const response = await edgeOriginViewerFetch(
+      simAws,
+      distroHostname,
+      "/greeting",
+    );
+
+    // Then the status the Origin returned is still what decides the viewer
+    // event, so the repaired response reaches the viewer unstamped.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(response.headers.get("x-viewer-response"), null);
+  });
+});

--- a/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
@@ -5,10 +5,10 @@ import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root
  * Runs a single simulated CloudFront request through its lifecycle:
  * route to a Distribution, put the request through the Distribution's web ACL,
  * apply the default root object, resolve the matching Behavior, run
- * viewer-request hooks, fetch from the Origin, replace an error response with
- * the Distribution's custom error page, apply the Behavior's response headers
- * policy, then run viewer-response hooks where the Origin did not answer with
- * an error.
+ * viewer-request hooks, fetch from the Origin with the origin hooks either
+ * side of the fetch, replace an error response with the Distribution's custom
+ * error page, apply the Behavior's response headers policy, then run
+ * viewer-response hooks where the Origin did not answer with an error.
  *
  * A viewer hook is a CloudFront Function or a Lambda@Edge function. A Behavior
  * carries at most one of the two kinds at the viewer events, which
@@ -85,7 +85,11 @@ export class SimCloudFrontRequestPipeline {
     }
     requestReference = edgeResult;
 
-    const originResponse = await this.stages.originFetcher.fetch(
+    // Fetch from the Origin, running the origin-request and origin-response
+    // Lambda@Edge functions on either side of the fetch. An origin-request
+    // function that answered with a response of its own leaves the Origin
+    // unread, and the response takes the Origin response's place from here on.
+    const originResult = await this.stages.originStage.fetch(
       requestReference,
       distro,
       behaviour,
@@ -96,7 +100,7 @@ export class SimCloudFrontRequestPipeline {
     const errorResponse = await this.stages.customErrorResponder.apply(
       requestReference,
       distro,
-      originResponse,
+      originResult.response,
     );
 
     // Apply the Behavior's response headers policy, if it names one. CloudFront
@@ -112,9 +116,10 @@ export class SimCloudFrontRequestPipeline {
 
     // CloudFront runs no viewer-response function when the Origin answered
     // 400 or higher, for either kind of function. The status that decides it
-    // is the one the Origin returned, so a custom error response carrying
-    // `ResponseCode: 200` above does not bring the function back.
-    if (originResponse.status >= 400) {
+    // is the one the Origin returned, so neither a custom error response
+    // carrying `ResponseCode: 200` above nor an origin-response function that
+    // replaced the status brings the function back.
+    if (originResult.originStatus >= 400) {
       return response;
     }
 

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
@@ -67,6 +67,7 @@ export class SimCloudFrontOriginConfigurator {
         origin.Id,
         new SimCloudFrontS3Origin({
           originBucket,
+          domainName: origin.DomainName,
           originPath: origin.OriginPath,
           ...(originAccessControl !== undefined && { originAccessControl }),
         }),

--- a/src/service/cloudfront/distribution/sim-cloudfront-distribution.iso.test.ts
+++ b/src/service/cloudfront/distribution/sim-cloudfront-distribution.iso.test.ts
@@ -129,7 +129,11 @@ describe("SimCloudFrontDistribution", () => {
 });
 
 function makeOrigin(): SimCloudFrontOrigin {
-  return {
+  const origin: SimCloudFrontOrigin = {
     fetch: () => Promise.resolve(new Response("ok")),
+    toEdgeOrigin: () => ({}),
+    withEdgeOrigin: () => origin,
   };
+
+  return origin;
 }

--- a/src/service/cloudfront/edge/adapter/sim-lambda-edge-event-adapter.ts
+++ b/src/service/cloudfront/edge/adapter/sim-lambda-edge-event-adapter.ts
@@ -1,16 +1,10 @@
-import { randomUUID } from "node:crypto";
-
 import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import {
+  edgeEventConfig,
+  type SimLambdaEdgeDistributionConfig,
+} from "./sim-lambda-edge-event-config.js";
 import { SimLambdaEdgeRequestAdapter } from "./sim-lambda-edge-request-adapter.js";
 import { SimLambdaEdgeResponseAdapter } from "./sim-lambda-edge-response-adapter.js";
-
-/**
- * Which Distribution an edge function is told it is running for.
- */
-export interface SimLambdaEdgeDistributionConfig {
-  readonly distributionId: string;
-  readonly distributionDomainName: string;
-}
 
 /**
  * Converts between native Fetch API Request and Response objects and the
@@ -32,7 +26,7 @@ export class SimLambdaEdgeEventAdapter {
       Records: [
         {
           cf: {
-            config: this.config(distribution, "viewer-request"),
+            config: edgeEventConfig(distribution, "viewer-request"),
             request: await this.requestAdapter.toEdgeRequest(
               request,
               includeBody,
@@ -59,7 +53,7 @@ export class SimLambdaEdgeEventAdapter {
       Records: [
         {
           cf: {
-            config: this.config(distribution, "viewer-response"),
+            config: edgeEventConfig(distribution, "viewer-response"),
             request: await this.requestAdapter.toEdgeRequest(request, false),
             response: this.responseAdapter.toEdgeResponse(response),
           },
@@ -84,28 +78,16 @@ export class SimLambdaEdgeEventAdapter {
   }
 
   /**
-   * Read what a viewer-response handler answered with.
+   * Read what a viewer-response or origin-response handler answered with.
    */
   fromResponseResult(
     result: LambdaAtEdge.Response,
     originalResponse: Response,
   ): Response {
-    return this.responseAdapter.fromEdgeViewerResponse(
+    return this.responseAdapter.fromEdgeHandlerResponse(
       result,
       originalResponse,
     );
-  }
-
-  private config<TEvent extends LambdaAtEdge.EventType>(
-    distribution: SimLambdaEdgeDistributionConfig,
-    eventType: TEvent,
-  ): LambdaAtEdge.Config & { eventType: TEvent } {
-    return {
-      distributionId: distribution.distributionId,
-      distributionDomainName: distribution.distributionDomainName,
-      eventType,
-      requestId: randomUUID(),
-    };
   }
 }
 

--- a/src/service/cloudfront/edge/adapter/sim-lambda-edge-event-config.ts
+++ b/src/service/cloudfront/edge/adapter/sim-lambda-edge-event-config.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from "node:crypto";
+
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+
+/**
+ * Which Distribution an edge function is told it is running for.
+ */
+export interface SimLambdaEdgeDistributionConfig {
+  readonly distributionId: string;
+  readonly distributionDomainName: string;
+}
+
+/**
+ * The `config` every edge event carries, naming the Distribution and the event
+ * the function is running at.
+ */
+export function edgeEventConfig<TEvent extends LambdaAtEdge.EventType>(
+  distribution: SimLambdaEdgeDistributionConfig,
+  eventType: TEvent,
+): LambdaAtEdge.Config & { eventType: TEvent } {
+  return {
+    distributionId: distribution.distributionId,
+    distributionDomainName: distribution.distributionDomainName,
+    eventType,
+    requestId: randomUUID(),
+  };
+}

--- a/src/service/cloudfront/edge/adapter/sim-lambda-edge-origin-event-adapter.ts
+++ b/src/service/cloudfront/edge/adapter/sim-lambda-edge-origin-event-adapter.ts
@@ -7,8 +7,8 @@ import { SimLambdaEdgeRequestAdapter } from "./sim-lambda-edge-request-adapter.j
 import { SimLambdaEdgeResponseAdapter } from "./sim-lambda-edge-response-adapter.js";
 
 /**
- * What an origin-request handler left for the fetch to use: the request to
- * send, and the Origin to send it to.
+ * What an origin-request handler left for the fetch to use. The request to send
+ * travels with the Origin to send it to.
  */
 export interface SimLambdaEdgeOriginRequest {
   readonly request: Request;
@@ -19,7 +19,7 @@ export interface SimLambdaEdgeOriginRequest {
  * Converts between Fetch API objects and the shapes the two origin events
  * carry. `SimLambdaEdgeEventAdapter` does the same for the viewer events.
  *
- * What sets an origin event apart is the Origin: the request carries the one
+ * The Origin is what sets an origin event apart. The request carries the one
  * the fetch is about to read, and a handler rewriting it sends the fetch
  * somewhere else.
  */
@@ -60,7 +60,7 @@ export class SimLambdaEdgeOriginEventAdapter {
    * Build the event an origin-response function is invoked with.
    *
    * The request travels with the response and carries no body, for the same
-   * reason a viewer-response event's does not: CloudFront has sent the request
+   * reason a viewer-response event's does not. CloudFront has sent the request
    * on by this point.
    */
   async toOriginResponseEvent(

--- a/src/service/cloudfront/edge/adapter/sim-lambda-edge-origin-event-adapter.ts
+++ b/src/service/cloudfront/edge/adapter/sim-lambda-edge-origin-event-adapter.ts
@@ -1,0 +1,132 @@
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import {
+  edgeEventConfig,
+  type SimLambdaEdgeDistributionConfig,
+} from "./sim-lambda-edge-event-config.js";
+import { SimLambdaEdgeRequestAdapter } from "./sim-lambda-edge-request-adapter.js";
+import { SimLambdaEdgeResponseAdapter } from "./sim-lambda-edge-response-adapter.js";
+
+/**
+ * What an origin-request handler left for the fetch to use: the request to
+ * send, and the Origin to send it to.
+ */
+export interface SimLambdaEdgeOriginRequest {
+  readonly request: Request;
+  readonly origin: LambdaAtEdge.Origin;
+}
+
+/**
+ * Converts between Fetch API objects and the shapes the two origin events
+ * carry. `SimLambdaEdgeEventAdapter` does the same for the viewer events.
+ *
+ * What sets an origin event apart is the Origin: the request carries the one
+ * the fetch is about to read, and a handler rewriting it sends the fetch
+ * somewhere else.
+ */
+export class SimLambdaEdgeOriginEventAdapter {
+  private readonly requestAdapter = new SimLambdaEdgeRequestAdapter();
+  private readonly responseAdapter = new SimLambdaEdgeResponseAdapter();
+
+  /**
+   * Build the event an origin-request function is invoked with.
+   *
+   * The event carries the Origin the Behavior resolved, which is what the
+   * handler reads to find out where the request is going and rewrites to send
+   * it somewhere else.
+   */
+  async toOriginRequestEvent(
+    request: Request,
+    includeBody: boolean,
+    distribution: SimLambdaEdgeDistributionConfig,
+    origin: LambdaAtEdge.Origin,
+  ): Promise<LambdaAtEdge.OriginRequestEvent> {
+    return {
+      Records: [
+        {
+          cf: {
+            config: edgeEventConfig(distribution, "origin-request"),
+            request: await this.requestAdapter.toOriginEdgeRequest(
+              request,
+              includeBody,
+              origin,
+            ),
+          },
+        },
+      ],
+    };
+  }
+
+  /**
+   * Build the event an origin-response function is invoked with.
+   *
+   * The request travels with the response and carries no body, for the same
+   * reason a viewer-response event's does not: CloudFront has sent the request
+   * on by this point.
+   */
+  async toOriginResponseEvent(
+    request: Request,
+    response: Response,
+    distribution: SimLambdaEdgeDistributionConfig,
+    origin: LambdaAtEdge.Origin,
+  ): Promise<LambdaAtEdge.OriginResponseEvent> {
+    return {
+      Records: [
+        {
+          cf: {
+            config: edgeEventConfig(distribution, "origin-response"),
+            request: await this.requestAdapter.toOriginEdgeRequest(
+              request,
+              false,
+              origin,
+            ),
+            response: this.responseAdapter.toEdgeResponse(response),
+          },
+        },
+      ],
+    };
+  }
+
+  /**
+   * Read what an origin-request handler answered with.
+   *
+   * A result carrying a status is a response the viewer gets without the
+   * Origin being read. Anything else is the request carrying on, with whatever
+   * Origin the handler left on it.
+   */
+  fromOriginRequestResult(
+    result: LambdaAtEdge.RequestResult,
+    originalRequest: Request,
+    origin: LambdaAtEdge.Origin,
+  ): SimLambdaEdgeOriginRequest | Response {
+    if (isEdgeResponse(result)) {
+      return this.responseAdapter.fromEdgeResponse(result);
+    }
+
+    return {
+      request: this.requestAdapter.fromEdgeRequest(result, originalRequest),
+      origin: result.origin ?? origin,
+    };
+  }
+
+  /**
+   * Read what an origin-response handler answered with.
+   */
+  fromResponseResult(
+    result: LambdaAtEdge.Response,
+    originalResponse: Response,
+  ): Response {
+    return this.responseAdapter.fromEdgeHandlerResponse(
+      result,
+      originalResponse,
+    );
+  }
+}
+
+/**
+ * Whether an origin-request handler answered with a response.
+ */
+function isEdgeResponse(
+  result: LambdaAtEdge.RequestResult,
+): result is LambdaAtEdge.Response {
+  return "status" in result;
+}

--- a/src/service/cloudfront/edge/adapter/sim-lambda-edge-origin.ts
+++ b/src/service/cloudfront/edge/adapter/sim-lambda-edge-origin.ts
@@ -1,0 +1,37 @@
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import { fromEdgeHeaders, toEdgeHeaders } from "./sim-lambda-edge-headers.js";
+
+/**
+ * Convert an Origin's own custom headers into the Lambda@Edge header shape.
+ *
+ * An Origin holds one value per header name, and an origin event presents it
+ * as the same list of `{ key, value }` pairs every other header arrives as.
+ */
+export function toEdgeOriginHeaders(
+  customHeaders: Readonly<Record<string, string>>,
+): LambdaAtEdge.Headers {
+  return toEdgeHeaders(new Headers({ ...customHeaders }));
+}
+
+/**
+ * Convert the custom headers a handler left on the Origin back again.
+ *
+ * A handler that wrote the same name twice has the values joined, because an
+ * Origin sends one value per header name whatever the event carried.
+ */
+export function fromEdgeOriginHeaders(
+  edgeHeaders: LambdaAtEdge.Headers | undefined,
+): Record<string, string> {
+  return Object.fromEntries(fromEdgeHeaders(edgeHeaders).entries());
+}
+
+/**
+ * The domain name of the Origin a request is on its way to.
+ *
+ * An Origin built here is one kind or the other, and both carry a domain name.
+ * The empty string is what an Origin with neither would report.
+ */
+export function edgeOriginDomainName(origin: LambdaAtEdge.Origin): string {
+  /* v8 ignore next */
+  return origin.custom?.domainName ?? origin.s3?.domainName ?? "";
+}

--- a/src/service/cloudfront/edge/adapter/sim-lambda-edge-request-adapter.ts
+++ b/src/service/cloudfront/edge/adapter/sim-lambda-edge-request-adapter.ts
@@ -1,6 +1,7 @@
 import { simAwsRequestHostname } from "../../../../serve/http/url/sim-aws-request-hostname.js";
 import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
 import { edgeRequestBody, replacementBody } from "./sim-lambda-edge-body.js";
+import { edgeOriginDomainName } from "./sim-lambda-edge-origin.js";
 import { fromEdgeHeaders, toEdgeHeaders } from "./sim-lambda-edge-headers.js";
 
 /**
@@ -37,6 +38,31 @@ export class SimLambdaEdgeRequestAdapter {
       querystring: url.search.replace(/^\?/u, ""),
       headers: this.viewerEdgeHeaders(request),
       ...(includeBody && { body: await edgeRequestBody(request) }),
+    };
+  }
+
+  /**
+   * Convert a Node fetch Request into the shape an origin event carries.
+   *
+   * The Origin the request is on its way to travels with it, and the host is
+   * the Origin's domain name rather than the one the viewer used. CloudFront
+   * has picked an Origin by this point and states the host it is about to send
+   * the request to.
+   */
+  async toOriginEdgeRequest(
+    request: Request,
+    includeBody: boolean,
+    origin: LambdaAtEdge.Origin,
+  ): Promise<LambdaAtEdge.OriginRequest> {
+    const edgeRequest = await this.toEdgeRequest(request, includeBody);
+
+    return {
+      ...edgeRequest,
+      headers: {
+        ...edgeRequest.headers,
+        host: [{ key: "Host", value: edgeOriginDomainName(origin) }],
+      },
+      origin,
     };
   }
 

--- a/src/service/cloudfront/edge/adapter/sim-lambda-edge-response-adapter.ts
+++ b/src/service/cloudfront/edge/adapter/sim-lambda-edge-response-adapter.ts
@@ -30,15 +30,15 @@ export class SimLambdaEdgeResponseAdapter {
   }
 
   /**
-   * Convert a viewer-response handler's result into a Node fetch Response,
-   * keeping the origin's body.
+   * Convert a response handler's result into a Node fetch Response, keeping
+   * the origin's body.
    *
-   * A viewer-response event carries no body, and a handler that returns
+   * Neither response event carries a body, and a handler that returns
    * `event.Records[0].cf.response` returns none either. Treating that as an
    * empty body would drop the page while leaving the origin's content-length
    * header describing it. A handler that did write a body replaces it.
    */
-  fromEdgeViewerResponse(
+  fromEdgeHandlerResponse(
     edgeResponse: LambdaAtEdge.Response,
     originalResponse: Response,
   ): Response {

--- a/src/service/cloudfront/edge/sim-cf-edge-association-checks.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-association-checks.ts
@@ -66,6 +66,33 @@ export function isSimulatedEdgeEventType(
 }
 
 /**
+ * Refuse an association reading a body at an event that carries none.
+ *
+ * `IncludeBody` is valid at `viewer-request` and `origin-request`, and
+ * CloudFront documents it that way. A response event runs once the request has
+ * been forwarded, and the event it builds carries no body for the flag to
+ * apply to.
+ */
+export function assertIncludableBody(
+  eventType: SimulatedEdgeEventType,
+  includeBody: boolean | undefined,
+): void {
+  if (includeBody !== true) {
+    return;
+  }
+
+  if (eventType === "viewer-request" || eventType === "origin-request") {
+    return;
+  }
+
+  throw new SimCloudFrontInvalidLambdaFunctionAssociation(
+    `Sim CloudFront Lambda@Edge association for ${eventType} sets ` +
+      `IncludeBody. CloudFront takes IncludeBody at viewer-request and ` +
+      `origin-request, the events that carry a request body.`,
+  );
+}
+
+/**
  * Refuse a Behavior that runs both kinds of edge function at the viewer.
  *
  * CloudFront takes one function per event type, and it takes CloudFront

--- a/src/service/cloudfront/edge/sim-cf-edge-association-checks.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-association-checks.ts
@@ -11,20 +11,36 @@ import { SimCloudFrontInvalidLambdaFunctionAssociation } from "../error/sim-clou
  */
 
 /**
- * The event types this simulation runs a Lambda@Edge function at.
+ * The event types this simulation runs a Lambda@Edge function at, which are
+ * all four of CloudFront's own.
  */
-export type SimulatedEdgeEventType = "viewer-request" | "viewer-response";
+export type SimulatedEdgeEventType =
+  | "viewer-request"
+  | "origin-request"
+  | "origin-response"
+  | "viewer-response";
+
+/**
+ * The same event types to match a name against, in the order a request meets
+ * them.
+ */
+const simulatedEdgeEventTypes = new Set<string>([
+  "viewer-request",
+  "origin-request",
+  "origin-response",
+  "viewer-response",
+] satisfies SimulatedEdgeEventType[]);
 
 type BehaviorConfig =
   | SimCloudFrontDefaultCacheBehaviorConfig
   | SimCloudFrontCacheBehaviorConfig;
 
 /**
- * Refuse an event type this simulation has no hook for.
+ * Refuse an event type CloudFront has no such event for.
  *
- * CloudFront runs a Lambda@Edge function at all four events, and this runs one
- * at the two viewer events. An origin association is told so here rather than
- * being configured into a Behavior that would never run it.
+ * All four of CloudFront's own event types run here, so what this catches is a
+ * name that is not one of them, rather than one this simulation has no hook
+ * for.
  */
 export function assertSimulatedEventType(
   eventType: string | undefined,
@@ -34,9 +50,9 @@ export function assertSimulatedEventType(
   }
 
   throw new SimCloudFrontInvalidLambdaFunctionAssociation(
-    `Sim CloudFront Lambda@Edge association EventType ${eventType} is not ` +
-      `simulated. Simulated CloudFront runs a Lambda@Edge function at ` +
-      `viewer-request and viewer-response.`,
+    `Sim CloudFront Lambda@Edge association EventType ${eventType} is not a ` +
+      `CloudFront event type. A Lambda@Edge function runs at viewer-request, ` +
+      `origin-request, origin-response or viewer-response.`,
   );
 }
 
@@ -46,7 +62,7 @@ export function assertSimulatedEventType(
 export function isSimulatedEdgeEventType(
   eventType: string | undefined,
 ): eventType is SimulatedEdgeEventType {
-  return eventType === "viewer-request" || eventType === "viewer-response";
+  return eventType !== undefined && simulatedEdgeEventTypes.has(eventType);
 }
 
 /**

--- a/src/service/cloudfront/edge/sim-cf-edge-association-refusal.iso.test.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-association-refusal.iso.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@kensio/smartass";
 import {
   CreateDistributionCommand,
+  type EventType,
   UpdateDistributionCommand,
 } from "@aws-sdk/client-cloudfront";
 import { describe, it } from "vitest";
@@ -90,20 +91,25 @@ describe("Simulated CloudFront Lambda@Edge association refusals", () => {
     assertStringIncludes(error.message, "AssumeRolePolicyDocument");
   });
 
-  it("refuses an origin event type, which this simulation does not run", async () => {
+  it("refuses an event type CloudFront has no such event for", async () => {
     const simAws = new SimAws();
     const functionArn = await makeEdgeFunctionVersionArn({
       simAws,
-      functionName: "origin-request-edge",
+      functionName: "unknown-event-edge",
       handler: (event: unknown) => event,
     });
 
     const error = await refusalFor(simAws, {
-      edge: [{ EventType: "origin-request", LambdaFunctionARN: functionArn }],
+      edge: [
+        {
+          EventType: "viewer-redirect" as EventType,
+          LambdaFunctionARN: functionArn,
+        },
+      ],
     });
 
-    assertStringIncludes(error.message, "origin-request");
-    assertStringIncludes(error.message, "not simulated");
+    assertStringIncludes(error.message, "viewer-redirect");
+    assertStringIncludes(error.message, "not a CloudFront event type");
   });
 
   it("refuses a Behavior mixing a CloudFront Function and Lambda@Edge at the viewer events", async () => {

--- a/src/service/cloudfront/edge/sim-cf-edge-association-refusal.iso.test.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-association-refusal.iso.test.ts
@@ -112,6 +112,28 @@ describe("Simulated CloudFront Lambda@Edge association refusals", () => {
     assertStringIncludes(error.message, "not a CloudFront event type");
   });
 
+  it("refuses a body on an association at an event that carries none", async () => {
+    const simAws = new SimAws();
+    const functionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "body-reading-edge",
+      handler: (event: unknown) => event,
+    });
+
+    const error = await refusalFor(simAws, {
+      edge: [
+        {
+          EventType: "origin-response",
+          LambdaFunctionARN: functionArn,
+          IncludeBody: true,
+        },
+      ],
+    });
+
+    assertStringIncludes(error.message, "IncludeBody");
+    assertStringIncludes(error.message, "origin-response");
+  });
+
   it("refuses a Behavior mixing a CloudFront Function and Lambda@Edge at the viewer events", async () => {
     const simAws = new SimAws();
     const functionArn = await makeEdgeFunctionVersionArn({

--- a/src/service/cloudfront/edge/sim-cf-edge-association-validator.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-association-validator.ts
@@ -8,6 +8,7 @@ import type {
 import { authorizeEdgeAssociation } from "./sim-cf-edge-association-auth-z.js";
 import {
   assertAssociatedFunctionArn,
+  assertIncludableBody,
   assertNoViewerFunctionMix,
   assertOneFunctionPerEvent,
   assertSimulatedEventType,
@@ -92,11 +93,12 @@ export class SimCfEdgeAssociationValidator {
     const eventTypes = new Set<string>();
 
     for (const association of associations) {
-      const { EventType, LambdaFunctionARN } = association;
+      const { EventType, IncludeBody, LambdaFunctionARN } = association;
 
       assertSimulatedEventType(EventType);
       assertOneFunctionPerEvent(eventTypes, EventType);
       assertAssociatedFunctionArn(LambdaFunctionARN, EventType);
+      assertIncludableBody(EventType, IncludeBody);
 
       // Read for the refusals reading it produces. The parts themselves
       // matter only where the function behind the ARN is looked up.

--- a/src/service/cloudfront/edge/sim-cf-edge-association.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-association.ts
@@ -15,10 +15,13 @@ export interface SimCfEdgeAssociation {
 /**
  * The Lambda@Edge functions one cache Behavior runs, by event type.
  *
- * Only the two viewer events are here. The two origin events run either side
- * of the Origin fetch, which the request pipeline has no hook for yet.
+ * All four of CloudFront's events are here, in the order a request meets them:
+ * the two viewer events at the edge, and the two origin events either side of
+ * the Origin fetch.
  */
 export interface SimCfEdgeAssociations {
   readonly viewerRequest?: SimCfEdgeAssociation;
+  readonly originRequest?: SimCfEdgeAssociation;
+  readonly originResponse?: SimCfEdgeAssociation;
   readonly viewerResponse?: SimCfEdgeAssociation;
 }

--- a/src/service/cloudfront/edge/sim-cf-edge-associations-configure.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-associations-configure.ts
@@ -4,7 +4,11 @@ import type {
   SimCloudFrontCacheBehaviorConfig,
   SimCloudFrontDefaultCacheBehaviorConfig,
 } from "../command/create-distribution/create-distribution.command.js";
-import type { SimCfEdgeAssociations } from "./sim-cf-edge-association.js";
+import type {
+  SimCfEdgeAssociation,
+  SimCfEdgeAssociations,
+} from "./sim-cf-edge-association.js";
+import type { SimulatedEdgeEventType } from "./sim-cf-edge-association-checks.js";
 
 /**
  * Configure the Lambda@Edge associations of one cache Behavior.
@@ -12,9 +16,9 @@ import type { SimCfEdgeAssociations } from "./sim-cf-edge-association.js";
  * Returns undefined where the Behavior associates none. A Behavior without an
  * edge function carries no empty object describing that.
  *
- * Only the two viewer events are mapped. An association on an origin event has
- * already been refused by `SimCfEdgeAssociationValidator`, which runs before
- * any Distribution state is touched.
+ * All four event types are mapped. An event type CloudFront has no such event
+ * for has already been refused by `SimCfEdgeAssociationValidator`, which runs
+ * before any Distribution state is touched.
  */
 export function configureEdgeAssociations(
   cacheBehavior:
@@ -27,9 +31,7 @@ export function configureEdgeAssociations(
     return undefined;
   }
 
-  const associations: {
-    -readonly [Key in keyof SimCfEdgeAssociations]: SimCfEdgeAssociations[Key];
-  } = {};
+  let associations: SimCfEdgeAssociations = {};
 
   for (const association of items) {
     const { EventType, LambdaFunctionARN, IncludeBody } = association;
@@ -45,15 +47,34 @@ export function configureEdgeAssociations(
       includeBody: IncludeBody ?? false,
     };
 
-    if (EventType === "viewer-request") {
-      associations.viewerRequest = configured;
-      continue;
-    }
-
-    if (EventType === "viewer-response") {
-      associations.viewerResponse = configured;
-    }
+    associations = {
+      ...associations,
+      ...associationFor(EventType, configured),
+    };
   }
 
   return Object.keys(associations).length > 0 ? associations : undefined;
+}
+
+/**
+ * The association an event type is held under.
+ */
+function associationFor(
+  eventType: SimulatedEdgeEventType,
+  association: SimCfEdgeAssociation,
+): SimCfEdgeAssociations {
+  switch (eventType) {
+    case "viewer-request": {
+      return { viewerRequest: association };
+    }
+    case "origin-request": {
+      return { originRequest: association };
+    }
+    case "origin-response": {
+      return { originResponse: association };
+    }
+    case "viewer-response": {
+      return { viewerResponse: association };
+    }
+  }
 }

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-edge.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-edge.ts
@@ -1,0 +1,68 @@
+import {
+  fromEdgeOriginHeaders,
+  toEdgeOriginHeaders,
+} from "../../edge/adapter/sim-lambda-edge-origin.js";
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import { SimCfEdgeOriginNotSimulated } from "../sim-cf-edge-origin-not-simulated.error.js";
+
+/**
+ * The parts of a custom Origin an origin event carries and a handler can
+ * rewrite. `SimCloudFrontCustomOrigin` holds the rest.
+ */
+export interface SimCfCustomOriginEdgeParts {
+  readonly domainName: string;
+  readonly originPath: string;
+  readonly customHeaders: Readonly<Record<string, string>>;
+}
+
+/**
+ * A custom Origin as an origin event presents it.
+ *
+ * The connection settings are the ones CloudFront defaults a custom Origin to.
+ * Nothing here opens a socket, so a handler reading them sees what a
+ * Distribution would report and a handler writing them changes nothing.
+ */
+export function customOriginEdgeOrigin(
+  parts: SimCfCustomOriginEdgeParts,
+): LambdaAtEdge.Origin {
+  return {
+    custom: {
+      customHeaders: toEdgeOriginHeaders(parts.customHeaders),
+      domainName: parts.domainName,
+      path: parts.originPath,
+      keepaliveTimeout: 5,
+      port: 443,
+      protocol: "https",
+      readTimeout: 30,
+      sslProtocols: ["TLSv1.2"],
+    },
+  };
+}
+
+/**
+ * The custom Origin an origin-request handler left, ready to fetch from.
+ *
+ * A handler that handed back an S3 Origin asked for a switch this simulation
+ * cannot make: the Bucket behind a domain name is resolved when the
+ * Distribution is written.
+ */
+export function customOriginEdgeParts(
+  originId: string,
+  edgeOrigin: LambdaAtEdge.Origin,
+): SimCfCustomOriginEdgeParts {
+  const { custom } = edgeOrigin;
+
+  if (custom === undefined) {
+    throw new SimCfEdgeOriginNotSimulated(
+      `Sim CloudFront Origin ${originId} is a custom Origin, and a ` +
+        `Lambda@Edge function handed back an S3 Origin at origin-request. ` +
+        `Switching an Origin between the two kinds is not simulated.`,
+    );
+  }
+
+  return {
+    domainName: custom.domainName,
+    originPath: custom.path,
+    customHeaders: fromEdgeOriginHeaders(custom.customHeaders),
+  };
+}

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-edge.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-edge.ts
@@ -43,7 +43,7 @@ export function customOriginEdgeOrigin(
  * The custom Origin an origin-request handler left, ready to fetch from.
  *
  * A handler that handed back an S3 Origin asked for a switch this simulation
- * cannot make: the Bucket behind a domain name is resolved when the
+ * cannot make. The Bucket behind a domain name is resolved when the
  * Distribution is written.
  */
 export function customOriginEdgeParts(

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
@@ -1,4 +1,9 @@
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
 import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
+import {
+  customOriginEdgeOrigin,
+  customOriginEdgeParts,
+} from "./sim-cf-custom-origin-edge.js";
 import type { SimCloudFrontOrigin } from "../sim-cloudfront-origin.js";
 import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
 import type { SimCfCustomOriginDispatcher } from "./sim-cf-custom-origin-dispatcher.js";
@@ -40,14 +45,21 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
     | SimCloudFrontOriginAccessControl
     | undefined;
 
+  /**
+   * The parts of this Origin an origin event carries, which
+   * `SimCfCustomOriginEdgeParts` names.
+   */
+  public readonly domainName: string;
+  public readonly originPath: string;
+  public readonly customHeaders: Readonly<Record<string, string>>;
+
   private readonly originId: string;
-  private readonly domainName: string;
-  private readonly originPath: string;
   private readonly dispatcher: SimCfCustomOriginDispatcher;
   private readonly signer: SimCfCustomOriginSigner;
-  private readonly customHeaders: Readonly<Record<string, string>>;
 
-  constructor(properties: SimCloudFrontCustomOriginProperties) {
+  constructor(
+    private readonly properties: SimCloudFrontCustomOriginProperties,
+  ) {
     this.originId = properties.originId;
     this.domainName = properties.domainName;
     this.originPath = properties.originPath ?? "";
@@ -82,5 +94,28 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
     }
 
     return await this.dispatcher.fetch(originRequest);
+  }
+
+  /**
+   * This Origin as an origin event presents it.
+   */
+  toEdgeOrigin(): LambdaAtEdge.Origin {
+    return customOriginEdgeOrigin(this);
+  }
+
+  /**
+   * This Origin as an origin-request handler left it.
+   *
+   * The domain name, the Origin path and the custom headers are the parts the
+   * fetch reads, so a handler that rewrote any of them sends the request
+   * somewhere else, under another path, or carrying another header. A domain
+   * name naming nothing in this simulation fails the same way a misconfigured
+   * Origin does.
+   */
+  withEdgeOrigin(edgeOrigin: LambdaAtEdge.Origin): SimCloudFrontOrigin {
+    return new SimCloudFrontCustomOrigin({
+      ...this.properties,
+      ...customOriginEdgeParts(this.originId, edgeOrigin),
+    });
   }
 }

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-edge.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-edge.ts
@@ -1,0 +1,90 @@
+import { toEdgeOriginHeaders } from "../../edge/adapter/sim-lambda-edge-origin.js";
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import { SimCfEdgeOriginNotSimulated } from "../sim-cf-edge-origin-not-simulated.error.js";
+import type { SimCloudFrontS3OriginProperties } from "./sim-cloudfront-s3-origin.js";
+
+/**
+ * The domain name an Origin was configured with.
+ *
+ * An Origin built without one, as a narrow test does, reports the Bucket's
+ * REST endpoint.
+ */
+export function s3OriginDomainName(
+  properties: SimCloudFrontS3OriginProperties,
+): string {
+  return (
+    properties.domainName ??
+    `${properties.originBucket.bucket.bucketName}.s3.amazonaws.com`
+  );
+}
+
+/**
+ * An S3 Origin as an origin event presents it.
+ *
+ * The custom headers are empty whatever the Origin was configured with. An S3
+ * Origin here reads its Bucket through GetObject rather than building an HTTP
+ * request, so there is nothing for a header to travel on.
+ */
+export function s3OriginEdgeOrigin(
+  properties: SimCloudFrontS3OriginProperties,
+  domainName: string,
+): LambdaAtEdge.Origin {
+  return {
+    s3: {
+      authMethod: s3EdgeAuthMethod(
+        properties.originAccessControl !== undefined,
+      ),
+      customHeaders: toEdgeOriginHeaders({}),
+      domainName,
+      path: properties.originPath ?? "",
+      region: properties.originBucket.bucket.getAccountRegionScope().regionName,
+    },
+  };
+}
+
+/**
+ * The Origin path an origin-request handler left on an S3 Origin.
+ *
+ * The path is the part the read obeys. The domain name is fixed, because the
+ * Bucket behind it was resolved when the Distribution was written and nothing
+ * here can resolve another one at request time, and so is the kind of Origin.
+ */
+export function s3OriginEdgePath(
+  domainName: string,
+  edgeOrigin: LambdaAtEdge.Origin,
+): string {
+  const { s3 } = edgeOrigin;
+
+  if (s3 === undefined) {
+    throw new SimCfEdgeOriginNotSimulated(
+      `Sim CloudFront Origin ${domainName} is an S3 Origin, and a ` +
+        `Lambda@Edge function handed back a custom Origin at origin-request. ` +
+        `Switching an Origin between the two kinds is not simulated.`,
+    );
+  }
+
+  if (s3.domainName !== domainName) {
+    throw new SimCfEdgeOriginNotSimulated(
+      `A Lambda@Edge function moved sim CloudFront S3 Origin ${domainName} ` +
+        `to ${s3.domainName} at origin-request. An S3 Origin reads the Bucket ` +
+        `its domain name resolved to when the Distribution was written, so ` +
+        `moving one is not simulated.`,
+    );
+  }
+
+  return s3.path;
+}
+
+/**
+ * Whether CloudFront signs what it reads from the Bucket, in the terms an
+ * origin event states it in.
+ */
+function s3EdgeAuthMethod(
+  signed: boolean,
+): LambdaAtEdge.S3Origin["authMethod"] {
+  if (signed) {
+    return "origin-access-identity";
+  }
+
+  return "none";
+}

--- a/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.iso.test.ts
+++ b/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.iso.test.ts
@@ -16,6 +16,7 @@ import {
   SimS3ObjectMetadata,
 } from "../../../s3/object/s3-object.js";
 import { simCloudFrontBehaviorFactory } from "../../behaviour/sim-cloud-front-behavior.js";
+import { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
 import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
 import { bucketNameFromCfS3OriginDomainName } from "./sim-cf-s3-origin-bucket-name.js";
 import { SimCloudFrontS3Origin } from "./sim-cloudfront-s3-origin.js";
@@ -122,6 +123,34 @@ describe("sim CloudFront S3 Origin", () => {
 
     // Then the failure reaches the caller instead of becoming a 404.
     assertInstanceOf(error, SimS3NoSuchBucket);
+  });
+
+  it("tells an origin event that the Bucket read is signed", async () => {
+    // Given an Origin whose origin access control signs what it reads.
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket({ input: { Bucket: "private-bucket" } });
+
+    const bucket = simS3.getSimBucketByName("private-bucket");
+    assertNonNullable(bucket);
+
+    const origin = new SimCloudFrontS3Origin({
+      originBucket: { bucket, simS3 },
+      domainName: "private-bucket.s3.amazonaws.com",
+      originAccessControl: new SimCloudFrontOriginAccessControl({
+        name: "site-oac",
+        originType: "s3",
+        signingBehavior: "always",
+      }),
+    });
+
+    // When an origin event asks what the Origin is.
+    const { s3 } = origin.toEdgeOrigin();
+
+    // Then the handler is told the read is signed, in CloudFront's own terms
+    // for it.
+    assertNonNullable(s3);
+    assertIdentical(s3.authMethod, "origin-access-identity");
+    assertIdentical(s3.domainName, "private-bucket.s3.amazonaws.com");
   });
 
   it("resolves bucket name fallback from non-S3 origin domain name", () => {

--- a/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.ts
+++ b/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.ts
@@ -1,4 +1,10 @@
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import {
+  s3OriginDomainName,
+  s3OriginEdgeOrigin,
+  s3OriginEdgePath,
+} from "./sim-cf-s3-origin-edge.js";
 import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
 import type { SimCloudFrontOrigin } from "../sim-cloudfront-origin.js";
 import type { SimCloudFrontOriginAccessControl } from "../../origin-access-control/sim-cf-origin-access-control.js";
@@ -20,10 +26,15 @@ export function emptyCloudFrontS3OriginResolver(): undefined {
   return;
 }
 
-interface SimCloudFrontS3OriginProperties {
+export interface SimCloudFrontS3OriginProperties {
   readonly originBucket: SimCfS3OriginBucket;
   readonly originPath?: string | undefined;
   readonly originAccessControl?: SimCloudFrontOriginAccessControl | undefined;
+  /**
+   * The domain name the Origin was configured with, which an origin event
+   * reports. An Origin built without one reports the Bucket's REST endpoint.
+   */
+  readonly domainName?: string | undefined;
 }
 
 /**
@@ -55,8 +66,9 @@ export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
   private readonly responses: SimCfS3OriginResponses;
   private readonly objectKey: SimCfS3OriginObjectKey;
   private readonly signer: SimCfS3OriginSigner;
+  private readonly domainName: string;
 
-  constructor(properties: SimCloudFrontS3OriginProperties) {
+  constructor(private readonly properties: SimCloudFrontS3OriginProperties) {
     this.loader = new SimCfS3OriginObjectLoader(properties.originBucket);
     this.signer = new SimCfS3OriginSigner(properties.originAccessControl);
     this.responses = new SimCfS3OriginResponses(
@@ -64,6 +76,7 @@ export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
     );
     this.objectKey = new SimCfS3OriginObjectKey(properties.originPath ?? "");
     this.originAccessControl = properties.originAccessControl;
+    this.domainName = s3OriginDomainName(properties);
   }
 
   /**
@@ -91,6 +104,23 @@ export class SimCloudFrontS3Origin implements SimCloudFrontOrigin {
     }
 
     return this.responses.foundObject(object, request.req);
+  }
+
+  /**
+   * This Origin as an origin event presents it.
+   */
+  toEdgeOrigin(): LambdaAtEdge.Origin {
+    return s3OriginEdgeOrigin(this.properties, this.domainName);
+  }
+
+  /**
+   * This Origin as an origin-request handler left it.
+   */
+  withEdgeOrigin(edgeOrigin: LambdaAtEdge.Origin): SimCloudFrontOrigin {
+    return new SimCloudFrontS3Origin({
+      ...this.properties,
+      originPath: s3OriginEdgePath(this.domainName, edgeOrigin),
+    });
   }
 
   private methodSupported(method: string): boolean {

--- a/src/service/cloudfront/origin/sim-cf-edge-origin-not-simulated.error.ts
+++ b/src/service/cloudfront/origin/sim-cf-edge-origin-not-simulated.error.ts
@@ -4,9 +4,9 @@
  *
  * Real CloudFront lets a handler hand back either kind of Origin, whichever
  * kind the Behavior started with, and lets it point an S3 Origin at another
- * Bucket. Both need something a simulated Origin does not hold: the dispatcher
- * that reaches a custom Origin, and the Bucket a domain name resolved to when
- * the Distribution was written. Rather than fetch from the Origin the handler
+ * Bucket. Both need something a simulated Origin does not hold. One is the
+ * dispatcher that reaches a custom Origin. The other is the Bucket a domain
+ * name resolved to when the Distribution was written. Rather than fetch from the Origin the handler
  * did not ask for, the rewrite is refused, and the viewer gets the 502 a
  * failed edge function gets.
  */

--- a/src/service/cloudfront/origin/sim-cf-edge-origin-not-simulated.error.ts
+++ b/src/service/cloudfront/origin/sim-cf-edge-origin-not-simulated.error.ts
@@ -1,0 +1,13 @@
+/**
+ * An Origin rewrite an origin-request handler asked for that this simulation
+ * cannot carry out.
+ *
+ * Real CloudFront lets a handler hand back either kind of Origin, whichever
+ * kind the Behavior started with, and lets it point an S3 Origin at another
+ * Bucket. Both need something a simulated Origin does not hold: the dispatcher
+ * that reaches a custom Origin, and the Bucket a domain name resolved to when
+ * the Distribution was written. Rather than fetch from the Origin the handler
+ * did not ask for, the rewrite is refused, and the viewer gets the 502 a
+ * failed edge function gets.
+ */
+export class SimCfEdgeOriginNotSimulated extends Error {}

--- a/src/service/cloudfront/origin/sim-cloudfront-origin.ts
+++ b/src/service/cloudfront/origin/sim-cloudfront-origin.ts
@@ -1,3 +1,4 @@
+import type { LambdaAtEdge } from "../typings/lambda-at-edge.namespace.js";
 import type { SimCloudFrontOriginRequest } from "./sim-cloudfront-request-response.js";
 
 /**
@@ -5,4 +6,18 @@ import type { SimCloudFrontOriginRequest } from "./sim-cloudfront-request-respon
  */
 export interface SimCloudFrontOrigin {
   fetch(request: SimCloudFrontOriginRequest): Promise<Response>;
+
+  /**
+   * This Origin as an origin event presents it, under `request.origin`.
+   */
+  toEdgeOrigin(): LambdaAtEdge.Origin;
+
+  /**
+   * This Origin as an origin-request handler left it, ready to fetch from.
+   *
+   * Throws `SimCfEdgeOriginNotSimulated` where the handler asked for an Origin
+   * this simulation cannot build, which the applicator turns into the 502 a
+   * failed edge function gets.
+   */
+  withEdgeOrigin(edgeOrigin: LambdaAtEdge.Origin): SimCloudFrontOrigin;
 }

--- a/src/service/cloudfront/typings/lambda-at-edge.namespace.ts
+++ b/src/service/cloudfront/typings/lambda-at-edge.namespace.ts
@@ -43,6 +43,55 @@ export declare namespace LambdaAtEdge {
     querystring: string;
     headers: Headers;
     body?: Body;
+    /**
+     * The Origin the request is on its way to, present at an origin event and
+     * absent at a viewer event.
+     */
+    origin?: Origin;
+  }
+
+  /**
+   * A custom Origin as an origin event presents it.
+   */
+  export interface CustomOrigin {
+    /** The Origin's own headers, keyed by lowercase name. */
+    customHeaders: Headers;
+    domainName: string;
+    keepaliveTimeout: number;
+    /** The Origin path, which goes in front of `request.uri`. */
+    path: string;
+    port: number;
+    protocol: "http" | "https";
+    readTimeout: number;
+    sslProtocols: string[];
+  }
+
+  /**
+   * An S3 Origin as an origin event presents it.
+   */
+  export interface S3Origin {
+    /** Whether CloudFront signs what it reads from the Bucket. */
+    authMethod: "origin-access-identity" | "none";
+    customHeaders: Headers;
+    domainName: string;
+    /** The Origin path, which goes in front of the object key. */
+    path: string;
+    region: string;
+  }
+
+  /**
+   * The Origin a request is on its way to, one kind or the other.
+   */
+  export interface Origin {
+    custom?: CustomOrigin;
+    s3?: S3Origin;
+  }
+
+  /**
+   * A request at an origin event, which always carries the Origin.
+   */
+  export interface OriginRequest extends Request {
+    origin: Origin;
   }
 
   export interface Response {
@@ -54,7 +103,11 @@ export declare namespace LambdaAtEdge {
     bodyEncoding?: "text" | "base64";
   }
 
-  export type EventType = "viewer-request" | "viewer-response";
+  export type EventType =
+    | "viewer-request"
+    | "viewer-response"
+    | "origin-request"
+    | "origin-response";
 
   export interface Config {
     distributionDomainName: string;
@@ -78,6 +131,21 @@ export declare namespace LambdaAtEdge {
     };
   }
 
+  export interface OriginRequestRecord {
+    cf: {
+      config: Config & { eventType: "origin-request" };
+      request: OriginRequest;
+    };
+  }
+
+  export interface OriginResponseRecord {
+    cf: {
+      config: Config & { eventType: "origin-response" };
+      request: OriginRequest;
+      response: Response;
+    };
+  }
+
   export interface RequestEvent {
     Records: [RequestRecord];
   }
@@ -86,10 +154,22 @@ export declare namespace LambdaAtEdge {
     Records: [ResponseRecord];
   }
 
-  export type Event = RequestEvent | ResponseEvent;
+  export interface OriginRequestEvent {
+    Records: [OriginRequestRecord];
+  }
+
+  export interface OriginResponseEvent {
+    Records: [OriginResponseRecord];
+  }
+
+  export type Event =
+    | RequestEvent
+    | ResponseEvent
+    | OriginRequestEvent
+    | OriginResponseEvent;
 
   /**
-   * What a viewer-request handler answers with.
+   * What a request handler answers with, at the viewer or at the Origin.
    *
    * Returning the request carries on to the origin with whatever the handler
    * changed. Returning a response answers the viewer there and then.

--- a/test/cloudfront/edge-origin-fixture.ts
+++ b/test/cloudfront/edge-origin-fixture.ts
@@ -2,12 +2,12 @@
  * A Distribution whose Origins are simulated Lambda Function URLs, for tests
  * about the Lambda@Edge functions running either side of the Origin fetch.
  *
- * A custom Origin is what an origin event has the most to say about: it is the
+ * A custom Origin is what an origin event has the most to say about. It is the
  * kind whose domain name, path and custom headers a handler can rewrite, and
  * the kind that can answer with a status of its own. This lives under `test/`
- * for the same reasons as the rest of `test/cloudfront/`: eslint rejects an
- * AWS SDK import from `src/` outside a test file, and more than one suite
- * needs the same steps.
+ * for the same reasons as the rest of `test/cloudfront/`. Eslint rejects an
+ * AWS SDK import from `src/` outside a test file, and more than one suite needs
+ * the same steps.
  */
 
 import { assertNonNullable } from "@kensio/smartass";

--- a/test/cloudfront/edge-origin-fixture.ts
+++ b/test/cloudfront/edge-origin-fixture.ts
@@ -1,0 +1,141 @@
+/**
+ * A Distribution whose Origins are simulated Lambda Function URLs, for tests
+ * about the Lambda@Edge functions running either side of the Origin fetch.
+ *
+ * A custom Origin is what an origin event has the most to say about: it is the
+ * kind whose domain name, path and custom headers a handler can rewrite, and
+ * the kind that can answer with a status of its own. This lives under `test/`
+ * for the same reasons as the rest of `test/cloudfront/`: eslint rejects an
+ * AWS SDK import from `src/` outside a test file, and more than one suite
+ * needs the same steps.
+ */
+
+import { assertNonNullable } from "@kensio/smartass";
+import {
+  CreateDistributionCommand,
+  type LambdaFunctionAssociation,
+  type Origin,
+} from "@aws-sdk/client-cloudfront";
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAwsHttp } from "../../src/serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../src/serve/http/url/sim-aws-local-url.js";
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+
+/**
+ * Create a public Function URL served by this handler, and answer with the
+ * hostname a custom Origin reaches it on.
+ */
+export async function functionUrlHostname(
+  simAws: SimAws,
+  functionName: string,
+  handler: SimLambdaHandler,
+): Promise<string> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: "arn:aws:iam::111111111111:role/OriginRole",
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  const { FunctionUrl: functionUrl } = await simAws
+    .lambda()
+    .createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: functionName,
+        AuthType: "NONE",
+      }),
+    );
+  assertNonNullable(functionUrl, "the Function URL was created");
+
+  return new URL(functionUrl).hostname;
+}
+
+/**
+ * A handler answering with a fixed status and body, for an Origin a test only
+ * needs to tell apart from another one.
+ */
+export function respondingWith(
+  body: string,
+  statusCode = 200,
+): SimLambdaHandler {
+  return () => ({
+    statusCode,
+    headers: { "content-type": "text/plain" },
+    body,
+  });
+}
+
+/**
+ * A custom Origin reaching the given hostname.
+ */
+export function customOrigin(originId: string, domainName: string): Origin {
+  return {
+    Id: originId,
+    DomainName: domainName,
+    CustomOriginConfig: {
+      HTTPPort: 80,
+      HTTPSPort: 443,
+      OriginProtocolPolicy: "https-only",
+    },
+  };
+}
+
+/**
+ * Create a Distribution serving these Origins, whose default Behavior targets
+ * the first one and runs these edge functions. Answers with the hostname a
+ * viewer reaches it on.
+ */
+export async function edgeOriginDistributionHostname(
+  simAws: SimAws,
+  origins: readonly Origin[],
+  associations: readonly LambdaFunctionAssociation[],
+): Promise<string> {
+  const [targetOrigin] = origins;
+  assertNonNullable(targetOrigin, "the Distribution has an Origin");
+
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "edge-origin",
+        Comment: "Custom Origin CDN",
+        Enabled: true,
+        Origins: { Quantity: origins.length, Items: [...origins] },
+        DefaultCacheBehavior: {
+          TargetOriginId: targetOrigin.Id,
+          ViewerProtocolPolicy: "allow-all",
+          LambdaFunctionAssociations: {
+            Quantity: associations.length,
+            Items: [...associations],
+          },
+        },
+      },
+    }),
+  );
+
+  const distroHostname = creation.Distribution?.DomainName;
+  assertNonNullable(distroHostname, "the Distribution was created");
+
+  return distroHostname;
+}
+
+/**
+ * Fetch a path through the Distribution as a viewer would.
+ */
+export async function edgeOriginViewerFetch(
+  simAws: SimAws,
+  distroHostname: string,
+  path: string,
+): Promise<Response> {
+  return await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `https://${distroHostname}${path}`,
+    }).toString(),
+  );
+}


### PR DESCRIPTION
A cache Behavior now runs a Lambda@Edge function at origin-request and
origin-response, either side of the Origin fetch. The origin-request event
carries `request.origin`, and a handler rewriting the domain name, the Origin
path or the custom headers changes what the fetch does. A handler returning a
response answers the viewer with the Origin unread. An origin-response function
runs on whatever the Origin answered, including a 400 and above, and it runs
before the custom error page replaces an error status. The status the Origin
returned still decides whether a viewer-response function runs, the rule #960
settled. `LambdaFunctionAssociations` from a template widens to the two origin
events, and a CDK Behavior carrying one deploys and runs it where it used to
record a skip. An `EventType` that is none of CloudFront's four fails the
deployment now, as a real one does. `IncludeBody` is taken at the two request events, and an
association setting it on a response event is refused when the Distribution is
written. Real CloudFront runs the origin events on a cache miss, and simulated
CloudFront holds no cache. Every request that reaches the Origin runs both here.
That divergence is under Limitations, with the two Origin rewrites this
simulation refuses.

The change came to about 2,400 lines rather than the 1,500 to 2,000 it was
sized at, and it is not split. Taking origin-request first and origin-response
after leaves roughly 2,050 lines in the first half, because the typings, the
Origin model, the request pipeline, the template path and the docs example all
belong to origin-request. The origin-response half is one test file and about
80 lines of code on top of machinery the first half already has. Say the word
and it can still be split.

Resolves https://github.com/KensioSoftware/yulin/issues/941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for CloudFront Lambda@Edge origin-request and origin-response events.
  - Origin-request handlers can rewrite origins, modify requests, or return responses directly.
  - Origin-response handlers can update response bodies, headers, and status-related behavior.
  - Added support for custom and S3 origin event handling, including origin paths and headers.
  - Added a complete Lambda@Edge origin-routing example.

- **Bug Fixes**
  - Improved handling of unsupported rewrites and unavailable function associations with clearer responses and validation.

- **Documentation**
  - Expanded CloudFront guidance, limitations, compatibility rules, and supported event coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
