### PR TITLE
fix: answer a read with the Object's content type

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -56,8 +56,8 @@ console.log(objectOut.Metadata?.["source"]);
 `PutObjectCommand` currently accepts `string`, `Uint8Array`, or `undefined` for `Body`. An undefined
 body is stored as an empty Object.
 
-`ContentType` is exposed as Object metadata under the `content-type` header name and is used when
-serving Bucket website responses. It is one of several headers a write can say about an Object. See
+A read hands `ContentType` back in the field of the same name, and Bucket website responses are
+served with it. It is one of several headers a write can say about an Object. See
 [Object system metadata](#object-system-metadata).
 
 ## Accounts and Regions
@@ -2512,9 +2512,9 @@ when a test needs deletion to work.
 When reading files from filesystem-backed storage, Yulin infers common `content-type` metadata from
 file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.xml`, and common
 font and image formats. A served file whose extension falls outside that set gets
-`application/octet-stream`, as S3 reports for an object whose type it was never told. That only
-comes up for an extension a mount named itself, below. No other file is served at all, with or
-without a type.
+`binary/octet-stream`, as S3 reports for an Object whose type it was never told. That only comes up
+for an extension a mount named itself, below. No other file is served at all, with or without a
+type.
 
 ### Serving a file extension of your own
 
@@ -2667,6 +2667,10 @@ Sim S3 stores and returns `cache-control`, `content-disposition`, `content-encod
 `content-language`, `content-type` and `expires`, alongside a `content-length` describing the body
 being served.
 
+`GetObjectCommand` and `HeadObjectCommand` answer with these in fields of their own (`ContentType`,
+`CacheControl` and the rest), the way real S3 does. `Metadata` carries the user-defined metadata a
+write attached, and nothing else.
+
 Every path that serves an Object goes through the same mapping. The REST endpoint, the
 [website endpoint](#static-website-hosting) and a CloudFront S3 Origin all report the same headers
 for it. `content-encoding` is the one that matters most. Bytes served without it are bytes no client
@@ -2708,14 +2712,18 @@ const objectOut = await simS3.getObject(
   new GetObjectCommand({ Bucket: "site", Key: "app.js" }),
 );
 
-// Each header is stored under the name a read returns it as.
-console.log(objectOut.Metadata?.["content-encoding"]); // br
-console.log(objectOut.Metadata?.["expires"]); // Sat, 02 Jan 2027 03:04:05 GMT
+// Each header comes back in the field a read describes an Object with.
+console.log(objectOut.ContentEncoding); // br
+console.log(objectOut.ExpiresString); // Sat, 02 Jan 2027 03:04:05 GMT
 ```
 
 A header the write says nothing about is left unset, and never stored empty, so a read leaves it
-out. `Expires` is the one field that takes something other than a string. The SDK takes a `Date`,
-stored as the HTTP date a read hands back.
+out. Content type is the exception. S3 gives an Object one whether the write named it or not, and a
+read of an Object written without one reports `binary/octet-stream`.
+
+`Expires` is the one field that takes something other than a string. The SDK takes a `Date` on the
+way in. A read hands back the stored HTTP date as `ExpiresString`, alongside the same value parsed
+into a `Date` as `Expires`.
 
 A CDK BucketDeployment's `SystemMetadata` sets the same headers on every Object it copies. See
 [CDK S3 BucketDeployment](https://yulinsim.dev/services/cloudformation/#cdk-s3-bucketdeployment). A
@@ -2813,9 +2821,6 @@ These apply across the page. The sections above each list what is specific to th
 - Object tags, ACLs, lifecycle rules, replication and server-side encryption are left out.
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
   notifications, because it swaps the whole storage backend in place of putting Objects.
-- `GetObjectCommand` returns system metadata through `Metadata`, under the header name it is stored
-  as, rather than through the `ContentType`, `CacheControl` and other response fields real S3 uses.
-  See [Object system metadata](#object-system-metadata).
 - An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, leaving
   a presigned `PUT` unable to set the rest. A `PutObjectCommand` through the SDK keeps all of them.
 - A presigned `GetObject` ignores the `response-content-type`, `response-cache-control` and other

--- a/docs/services/s3/sim-s3-object-system-metadata.example.ts
+++ b/docs/services/s3/sim-s3-object-system-metadata.example.ts
@@ -31,6 +31,6 @@ const objectOut = await simS3.getObject(
   new GetObjectCommand({ Bucket: "site", Key: "app.js" }),
 );
 
-// Each header is stored under the name a read returns it as.
-console.log(objectOut.Metadata?.["content-encoding"]); // br
-console.log(objectOut.Metadata?.["expires"]); // Sat, 02 Jan 2027 03:04:05 GMT
+// Each header comes back in the field a read describes an Object with.
+console.log(objectOut.ContentEncoding); // br
+console.log(objectOut.ExpiresString); // Sat, 02 Jan 2027 03:04:05 GMT

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-object-loader.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-object-loader.ts
@@ -2,10 +2,8 @@ import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3BucketName } from "../../../s3/bucket/sim-s3-bucket.js";
 import type { SimS3RequestOptions } from "../../../s3/command/sim-s3-request-options.js";
 import { SimS3NoSuchKey } from "../../../s3/error/sim-s3.error.js";
-import {
-  SimS3Object,
-  SimS3ObjectMetadata,
-} from "../../../s3/object/s3-object.js";
+import { SimS3Object } from "../../../s3/object/s3-object.js";
+import { simS3WriteMetadata } from "../../../s3/object/s3-write-metadata.js";
 import type { SimS3 } from "../../../s3/sim-s3.js";
 import { simS3BodyToBuffer } from "../../../s3/storage/s3-body-buffer.js";
 import type { SimCfS3OriginBucket } from "./sim-cf-s3-origin-bucket.js";
@@ -49,10 +47,14 @@ export class SimCfS3OriginObjectLoader {
         requestOptions,
       );
 
+      // A read answers with the same metadata members a write carries, so the
+      // Object the Origin serves is rebuilt from them the way one being stored
+      // would be. Reading only `Metadata` would drop the content type and the
+      // encoding, and the Distribution would serve bytes no client can decode.
       return new SimS3Object({
         key: objectKey,
         body: await simS3BodyToBuffer(output.Body as AsyncIterable<Buffer>),
-        metadata: new SimS3ObjectMetadata({ ...output.Metadata }),
+        metadata: simS3WriteMetadata(output),
       });
     } catch (error) {
       if (error instanceof SimS3NoSuchKey) {

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -240,8 +240,13 @@ Metadata is stored separately from the object body. `object/s3-write-metadata.ts
 what the Object is. `object/s3-write-body.ts` does the same for the body forms an upload can carry,
 which `PutObject` and `UploadPart` share.
 
-`GetObjectCommandHandler` returns object bodies as Node `Readable` streams and returns stored
-metadata through `Metadata`, alongside the Object's `ETag` and `LastModified`.
+`GetObjectCommandHandler` returns object bodies as Node `Readable` streams, alongside the Object's
+`ETag` and `LastModified`. What S3 was told about the Object comes back in fields of its own
+(`ContentType`, `CacheControl` and the rest), and `Metadata` carries the user-defined metadata. One
+map of headers is stored, and `SimS3ObjectMetadata` splits it for a read.
+`object/s3-system-metadata-read.ts` owns that split, in both directions. The endpoints that serve an
+Object read it through GetObject, so they put the fields back under their header names on the way
+out.
 
 `object/s3-object-etag.ts` computes an Object's ETag as the MD5 of its body and quotes it for a
 response. The digest is what `SimS3Object` holds, computed on demand, because the two surfaces
@@ -256,7 +261,9 @@ because the part count is a fact about how the bytes arrived that the joined byt
 request field a write sets each one with against the lowercase key it is stored under. Both sides
 read that list, so a header cannot be written without being served or served without being writable.
 `SimPutObjectCommandInput` declares one field per entry, and the builder indexes the input by those
-field names, which makes a missing field a type error rather than a silently dropped header.
+field names, which makes a missing field a type error rather than a silently dropped header. It also
+holds the content type S3 falls back to (`binary/octet-stream`), which a write that names no type
+gets.
 
 `object/s3-object-response-headers.ts` is the single mapping from stored metadata to HTTP response
 headers, and every path that serves an Object goes through it: the S3 REST endpoint reader, the

--- a/src/service/s3/command/copy-object/copy-object.iso.test.ts
+++ b/src/service/s3/command/copy-object/copy-object.iso.test.ts
@@ -16,6 +16,7 @@ import { faker } from "@faker-js/faker";
 import { Readable } from "node:stream";
 import { describe, it } from "vitest";
 
+import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimSdk } from "../../../../sdk/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
@@ -137,9 +138,8 @@ describe("S3 CopyObjectCommand", () => {
       new GetObjectCommand({ Bucket: bucketName, Key: "logo-backup.svg" }),
     );
 
-    const metadata = copied.Metadata ?? {};
-    assertIdentical(metadata["content-type"], "image/svg+xml");
-    assertIdentical(metadata["designer"], "in-house");
+    assertIdentical(copied.ContentType, "image/svg+xml");
+    assertIdentical(copied.Metadata?.["designer"], "in-house");
   });
 
   it("takes the copy's metadata from the request under REPLACE", async () => {
@@ -177,10 +177,10 @@ describe("S3 CopyObjectCommand", () => {
       new GetObjectCommand({ Bucket: bucketName, Key: "page.html" }),
     );
 
-    const metadata = copied.Metadata ?? {};
-    assertIdentical(metadata["content-type"], "text/html");
-    assertIdentical(metadata["reviewed"], "2026-08");
-    assertUndefined(metadata["stale"]);
+    assertIdentical(copied.ContentType, "text/html");
+    assertDefined(copied.Metadata, "the copied Object metadata");
+    assertIdentical(copied.Metadata["reviewed"], "2026-08");
+    assertUndefined(copied.Metadata["stale"]);
   });
 
   it("copies a key holding a slash and a space", async () => {

--- a/src/service/s3/command/get-object/get-object-loader.ts
+++ b/src/service/s3/command/get-object/get-object-loader.ts
@@ -21,7 +21,8 @@ import type { SimGetObjectCommandOutput } from "./get-object.command.js";
  * - a missing storage entry becomes the S3 NoSuchKey error;
  * - the stored Buffer, or the part of it the read asked for, becomes the
  *   readable response body;
- * - stored metadata becomes SDK response metadata;
+ * - what S3 was told about the Object becomes the response's own fields, and
+ *   what the caller attached to it becomes the response metadata;
  * - the Object's content hash and write time become its ETag and LastModified.
  *
  * Bucket resolution remains in the command handler because AWS request ordering
@@ -50,8 +51,9 @@ export class GetObjectLoader {
         : object.body.subarray(range.start, range.end + 1);
 
     return {
+      ...object.metadata.system,
       Body: Readable.from([body]),
-      Metadata: object.metadata.values,
+      Metadata: object.metadata.userDefined,
       // The ETag identifies the Object rather than the bytes being sent. A
       // client reading it in pieces compares the value across them to see
       // whether the Object changed underneath it.

--- a/src/service/s3/command/get-object/get-object.command.ts
+++ b/src/service/s3/command/get-object/get-object.command.ts
@@ -1,5 +1,6 @@
 import type { Readable } from "node:stream";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3SystemMetadataOutput } from "../../object/s3-system-metadata-read.js";
 
 /**
  * Minimal structural sim S3 GetObject command.
@@ -32,8 +33,12 @@ export interface SimGetObjectCommandInput {
  * ranged read reports the size of its slice. `ContentRange` says which bytes
  * of the Object those are, and is set only for a read that asked for some of
  * them.
+ *
+ * The system metadata fields it extends are what S3 was told about the Object
+ * when it was written. `Metadata` is what the caller attached to it, and holds
+ * nothing else.
  */
-export interface SimGetObjectCommandOutput {
+export interface SimGetObjectCommandOutput extends SimS3SystemMetadataOutput {
   readonly Body?: Readable;
   readonly Metadata?: Record<string, string>;
   readonly ETag?: string;

--- a/src/service/s3/command/head-object/head-object-loader.ts
+++ b/src/service/s3/command/head-object/head-object-loader.ts
@@ -25,8 +25,9 @@ export class HeadObjectLoader {
     }
 
     return {
+      ...object.metadata.system,
       ContentLength: object.body.length,
-      Metadata: object.metadata.values,
+      Metadata: object.metadata.userDefined,
       ETag: simS3QuotedETag(object.etag),
       LastModified: object.lastModified,
       $metadata: {},

--- a/src/service/s3/command/head-object/head-object.command.ts
+++ b/src/service/s3/command/head-object/head-object.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3SystemMetadataOutput } from "../../object/s3-system-metadata-read.js";
 
 /**
  * Minimal structural sim S3 HeadObject command.
@@ -22,7 +23,7 @@ export interface SimHeadObjectCommandInput {
  * the Object itself, so this is a GetObject output without its body and with
  * the length that body would have had.
  */
-export interface SimHeadObjectCommandOutput {
+export interface SimHeadObjectCommandOutput extends SimS3SystemMetadataOutput {
   readonly ContentLength?: number;
   readonly Metadata?: Record<string, string>;
   readonly ETag?: string;

--- a/src/service/s3/command/multipart/sim-s3-multipart-upload.iso.test.ts
+++ b/src/service/s3/command/multipart/sim-s3-multipart-upload.iso.test.ts
@@ -209,11 +209,11 @@ describe("Simulated S3 multipart upload", () => {
     );
 
     // Then the Object carries it, as one written by a PutObject would: the
-    // system metadata under the header names a read hands back, and the
+    // system metadata in the fields a read describes an Object with, and the
     // user-defined metadata as it was given.
+    assertIdentical(read.ContentType, "text/html");
+    assertIdentical(read.CacheControl, "max-age=60");
     assertDefined(read.Metadata, "the read Object metadata");
-    assertIdentical(read.Metadata["content-type"], "text/html");
-    assertIdentical(read.Metadata["cache-control"], "max-age=60");
     assertIdentical(read.Metadata["author"], "yulin");
   });
 

--- a/src/service/s3/command/put-object/put-object-system-metadata.iso.test.ts
+++ b/src/service/s3/command/put-object/put-object-system-metadata.iso.test.ts
@@ -1,10 +1,15 @@
 import {
   CreateBucketCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import {
@@ -13,7 +18,7 @@ import {
 } from "../../../../../test/s3/presign-simulation.js";
 
 describe("S3 PutObjectCommand system metadata", () => {
-  it("stores every system metadata header S3 keeps about an Object", async () => {
+  it("hands back every system metadata header S3 keeps about an Object", async () => {
     // Given a Bucket.
     const simS3 = new SimAws().s3();
     await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
@@ -33,44 +38,74 @@ describe("S3 PutObjectCommand system metadata", () => {
       }),
     );
 
-    // Then each one is remembered under the header name a read returns it as.
+    // Then each one comes back in the field a read carries it in, which is
+    // where a caller reading the Object looks for it.
     const objectOut = await simS3.getObject(
       new GetObjectCommand({ Bucket: "bucket-a", Key: "report.csv" }),
     );
-    assertObjectEquals(objectOut.Metadata, {
-      "cache-control": "public, max-age=31536000, immutable",
-      "content-disposition": 'attachment; filename="report.csv"',
-      "content-encoding": "br",
-      "content-language": "en-GB",
-      "content-type": "text/csv",
-      expires: "Wed, 21 Oct 2026 07:28:00 GMT",
-    });
+    assertIdentical(
+      objectOut.CacheControl,
+      "public, max-age=31536000, immutable",
+    );
+    assertIdentical(
+      objectOut.ContentDisposition,
+      'attachment; filename="report.csv"',
+    );
+    assertIdentical(objectOut.ContentEncoding, "br");
+    assertIdentical(objectOut.ContentLanguage, "en-GB");
+    assertIdentical(objectOut.ContentType, "text/csv");
+    assertIdentical(objectOut.ExpiresString, "Wed, 21 Oct 2026 07:28:00 GMT");
   });
 
-  it("records an expiry as the HTTP date a read hands back", async () => {
+  it("keeps user-defined metadata apart from what S3 remembers about the Object", async () => {
     // Given a Bucket.
     const simS3 = new SimAws().s3();
     await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
 
-    // When an Object is written with the Date the SDK takes for an expiry.
+    // When an Object is written with both.
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "bucket-a",
-        Key: "menu.json",
-        Body: "{}",
-        Expires: new Date("2027-01-02T03:04:05Z"),
+        Key: "styles.css",
+        Body: "body{}",
+        Metadata: { author: "hg" },
+        ContentEncoding: "gzip",
+        ContentType: "text/css",
       }),
     );
 
-    // Then it is stored as the header value itself, not as an object a read
-    // would have nothing to do with.
+    // Then the user-defined metadata is the whole of `Metadata`. S3 carries
+    // what it remembers about the Object in its own fields, so a caller
+    // reading `Metadata` gets back what it put there and nothing else.
     const objectOut = await simS3.getObject(
-      new GetObjectCommand({ Bucket: "bucket-a", Key: "menu.json" }),
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "styles.css" }),
     );
-    assertIdentical(
-      objectOut.Metadata?.["expires"],
-      "Sat, 02 Jan 2027 03:04:05 GMT",
+    assertObjectEquals(objectOut.Metadata, { author: "hg" });
+    assertIdentical(objectOut.ContentEncoding, "gzip");
+    assertIdentical(objectOut.ContentType, "text/css");
+  });
+
+  it("reports the type S3 gives an Object that was written without one", async () => {
+    // Given a Bucket.
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
+
+    // When an Object is written with a body alone.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "bucket-a",
+        Key: "notes.txt",
+        Body: "nothing to say",
+      }),
     );
+
+    // Then it has the type S3 falls back to rather than no type at all. S3
+    // guesses nothing from the key, so a `.txt` file uploaded without a type
+    // is served as bytes.
+    const objectOut = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "notes.txt" }),
+    );
+    assertIdentical(objectOut.ContentType, "binary/octet-stream");
   });
 
   it("leaves out a system metadata header the write did not carry", async () => {
@@ -88,63 +123,45 @@ describe("S3 PutObjectCommand system metadata", () => {
       }),
     );
 
-    // Then the content type is the only thing stored: the five headers it said
-    // nothing about are absent, rather than undefined values a read would serve
-    // as empty headers.
+    // Then the five headers the write said nothing about are absent, rather
+    // than empty values a caller would have to tell apart from real ones.
     const objectOut = await simS3.getObject(
       new GetObjectCommand({ Bucket: "bucket-a", Key: "index.html" }),
     );
-    assertObjectEquals(objectOut.Metadata, { "content-type": "text/html" });
-  });
-
-  it("remembers nothing about an Object written without system metadata", async () => {
-    // Given a Bucket.
-    const simS3 = new SimAws().s3();
-    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
-
-    // When an Object is written with a body alone.
-    await simS3.putObject(
-      new PutObjectCommand({
-        Bucket: "bucket-a",
-        Key: "notes.txt",
-        Body: "nothing to say",
-      }),
-    );
-
-    // Then nothing is stored about it.
-    const objectOut = await simS3.getObject(
-      new GetObjectCommand({ Bucket: "bucket-a", Key: "notes.txt" }),
-    );
+    assertIdentical(objectOut.ContentType, "text/html");
+    assertUndefined(objectOut.CacheControl);
+    assertUndefined(objectOut.ContentDisposition);
+    assertUndefined(objectOut.ContentEncoding);
+    assertUndefined(objectOut.ContentLanguage);
+    assertUndefined(objectOut.ExpiresString);
     assertObjectEquals(objectOut.Metadata, {});
   });
 
-  it("keeps user-defined metadata alongside system metadata", async () => {
-    // Given a Bucket.
+  it("describes an Object for a HEAD as a read describes it", async () => {
+    // Given an Object written with system and user metadata.
     const simS3 = new SimAws().s3();
     await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
-
-    // When an Object is written with both.
     await simS3.putObject(
       new PutObjectCommand({
         Bucket: "bucket-a",
-        Key: "styles.css",
-        Body: "body{}",
+        Key: "menu.json",
+        Body: "{}",
+        CacheControl: "max-age=60",
+        ContentType: "application/json",
         Metadata: { author: "hg" },
-        ContentEncoding: "gzip",
-        ContentType: "text/css",
       }),
     );
 
-    // Then the two sit side by side, since S3 keeps user metadata as well as
-    // what it remembers about the Object itself.
-    const objectOut = await simS3.getObject(
-      new GetObjectCommand({ Bucket: "bucket-a", Key: "styles.css" }),
+    // When it is described rather than read.
+    const headOut = await simS3.headObject(
+      new HeadObjectCommand({ Bucket: "bucket-a", Key: "menu.json" }),
     );
-    assertObjectEquals(objectOut.Metadata, {
-      author: "hg",
-      "content-encoding": "gzip",
-      "content-type": "text/css",
-    });
+
+    // Then a HEAD says what a read says, since it is the same answer without
+    // the body.
+    assertIdentical(headOut.CacheControl, "max-age=60");
+    assertIdentical(headOut.ContentType, "application/json");
+    assertObjectEquals(headOut.Metadata, { author: "hg" });
   });
 
   it("serves what a write said about an Object back over the REST endpoint", async () => {

--- a/src/service/s3/command/put-object/put-object-system-metadata.iso.test.ts
+++ b/src/service/s3/command/put-object/put-object-system-metadata.iso.test.ts
@@ -85,6 +85,34 @@ describe("S3 PutObjectCommand system metadata", () => {
     assertIdentical(objectOut.ContentType, "text/css");
   });
 
+  it("keeps a user metadata key that names a header S3 sets itself", async () => {
+    // Given a Bucket.
+    const simS3 = new SimAws().s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "bucket-a" }));
+
+    // When an Object is written with a user metadata key called content-type,
+    // and no content type of its own.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "bucket-a",
+        Key: "notes.txt",
+        Body: "nothing to say",
+        Metadata: { "content-type": "whatever the caller meant" },
+      }),
+    );
+
+    // Then the two stay apart. Real S3 carries user metadata under
+    // `x-amz-meta-`, so a caller's key can name a header S3 sets itself
+    // without becoming it.
+    const objectOut = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "bucket-a", Key: "notes.txt" }),
+    );
+    assertObjectEquals(objectOut.Metadata, {
+      "content-type": "whatever the caller meant",
+    });
+    assertIdentical(objectOut.ContentType, "binary/octet-stream");
+  });
+
   it("reports the type S3 gives an Object that was written without one", async () => {
     // Given a Bucket.
     const simS3 = new SimAws().s3();

--- a/src/service/s3/object/s3-object.ts
+++ b/src/service/s3/object/s3-object.ts
@@ -1,10 +1,42 @@
 import { simS3ObjectETag } from "./s3-object-etag.js";
+import {
+  isSimS3SystemMetadataHeader,
+  simS3SystemMetadataOutput,
+  type SimS3SystemMetadataOutput,
+} from "./s3-system-metadata-read.js";
 
 /**
  * Simulated S3 object metadata.
+ *
+ * Held as one map of header names because that is the form every endpoint
+ * serving the Object wants it in. A read through the SDK wants the two halves
+ * apart, since S3 answers with what it knows about the Object in fields of its
+ * own and keeps `Metadata` for what the caller attached.
  */
 export class SimS3ObjectMetadata {
   constructor(public readonly values: Record<string, string> = {}) {}
+
+  /**
+   * What S3 knows about the Object, as the fields a read hands it back in.
+   */
+  get system(): SimS3SystemMetadataOutput {
+    return simS3SystemMetadataOutput(this.values);
+  }
+
+  /**
+   * What the caller attached to the Object.
+   *
+   * Real S3 carries these as `x-amz-meta-` headers, which is what keeps them
+   * from colliding with the ones S3 sets itself. The simulation stores one map,
+   * so the system metadata headers are taken back out here.
+   */
+  get userDefined(): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(this.values).filter(
+        ([key]) => !isSimS3SystemMetadataHeader(key),
+      ),
+    );
+  }
 }
 
 interface SimS3ObjectProperties {

--- a/src/service/s3/object/s3-object.ts
+++ b/src/service/s3/object/s3-object.ts
@@ -1,7 +1,7 @@
 import { simS3ObjectETag } from "./s3-object-etag.js";
 import {
-  isSimS3SystemMetadataHeader,
   simS3SystemMetadataOutput,
+  simS3UserDefinedMetadata,
   type SimS3SystemMetadataOutput,
 } from "./s3-system-metadata-read.js";
 
@@ -24,18 +24,10 @@ export class SimS3ObjectMetadata {
   }
 
   /**
-   * What the caller attached to the Object.
-   *
-   * Real S3 carries these as `x-amz-meta-` headers, which is what keeps them
-   * from colliding with the ones S3 sets itself. The simulation stores one map,
-   * so the system metadata headers are taken back out here.
+   * What the caller attached to the Object, under the keys it was given with.
    */
   get userDefined(): Record<string, string> {
-    return Object.fromEntries(
-      Object.entries(this.values).filter(
-        ([key]) => !isSimS3SystemMetadataHeader(key),
-      ),
-    );
+    return simS3UserDefinedMetadata(this.values);
   }
 }
 

--- a/src/service/s3/object/s3-system-metadata-read.ts
+++ b/src/service/s3/object/s3-system-metadata-read.ts
@@ -1,0 +1,117 @@
+import {
+  simS3SystemMetadataHeaders,
+  type SimS3SystemMetadataField,
+  type SimS3SystemMetadataHeader,
+} from "./s3-system-metadata.js";
+
+/**
+ * The field a read of an Object hands a system metadata header back in.
+ *
+ * The same names a write sets them with, apart from the expiry. The SDK reads
+ * that header into `ExpiresString` and parses it into `Expires` alongside, so
+ * the two are separate fields on the way out where they are one on the way in.
+ */
+export type SimS3SystemMetadataOutputField =
+  | Exclude<SimS3SystemMetadataField, "Expires">
+  | "ExpiresString";
+
+/**
+ * What a read of an Object says about it, beyond the bytes themselves.
+ *
+ * S3 answers a `GetObject` or a `HeadObject` with these as fields of their
+ * own. They are what S3 knows about the Object. `Metadata` is what the caller
+ * attached to it.
+ */
+export interface SimS3SystemMetadataOutput {
+  readonly CacheControl?: string;
+  readonly ContentDisposition?: string;
+  readonly ContentEncoding?: string;
+  readonly ContentLanguage?: string;
+  readonly ContentType?: string;
+  /** The expiry header, parsed as the SDK parses it. */
+  readonly Expires?: Date;
+  /** The expiry header as S3 stored it. */
+  readonly ExpiresString?: string;
+}
+
+/**
+ * Describe an Object's stored headers as the fields a read of it carries.
+ *
+ * A header the Object does not hold leaves its field absent rather than
+ * present and undefined, so a caller can tell a header S3 has nothing to say
+ * about from one it reports as empty.
+ */
+export function simS3SystemMetadataOutput(
+  headers: Readonly<Record<string, string>>,
+): SimS3SystemMetadataOutput {
+  const output: SimS3MutableSystemMetadataOutput = {};
+
+  for (const header of simS3SystemMetadataHeaders) {
+    const value = headers[header.name];
+
+    if (value !== undefined) {
+      output[outputFieldOf(header)] = value;
+    }
+  }
+
+  if (output.ExpiresString !== undefined) {
+    output.Expires = new Date(output.ExpiresString);
+  }
+
+  return output;
+}
+
+/**
+ * The headers to serve an Object with, from what a read of it answered.
+ *
+ * The endpoints that serve an Object read it through the ordinary GetObject
+ * command, so what they build a response from is the read's own fields. This
+ * puts them back under the header names the response carries.
+ *
+ * The values are checked on the way through, because a read output reaches
+ * here loosely typed from the SDK-facing router (which has only the command
+ * name to go on).
+ */
+export function simS3SystemMetadataHeadersFrom(
+  output: Readonly<Partial<Record<SimS3SystemMetadataOutputField, unknown>>>,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  for (const header of simS3SystemMetadataHeaders) {
+    const value = output[outputFieldOf(header)];
+
+    if (typeof value === "string") {
+      headers[header.name] = value;
+    }
+  }
+
+  return headers;
+}
+
+/**
+ * Whether a metadata key is one of the headers S3 keeps about an Object.
+ *
+ * What is left over is the user-defined metadata. That is the whole of what
+ * real S3 answers a read's `Metadata` with.
+ */
+export function isSimS3SystemMetadataHeader(key: string): boolean {
+  return simS3SystemMetadataHeaders.some((header) => header.name === key);
+}
+
+/** The output field a stored header is reported in. */
+function outputFieldOf(
+  header: SimS3SystemMetadataHeader,
+): SimS3SystemMetadataOutputField {
+  if (header.field === "Expires") {
+    return "ExpiresString";
+  }
+
+  return header.field;
+}
+
+/** The output being built, before it is handed out as read-only. */
+type SimS3MutableSystemMetadataOutput = {
+  -readonly [
+    Field in keyof SimS3SystemMetadataOutput
+  ]: SimS3SystemMetadataOutput[Field];
+};

--- a/src/service/s3/object/s3-system-metadata-read.ts
+++ b/src/service/s3/object/s3-system-metadata-read.ts
@@ -1,5 +1,6 @@
 import {
   simS3SystemMetadataHeaders,
+  simS3UserMetadataPrefix,
   type SimS3SystemMetadataField,
   type SimS3SystemMetadataHeader,
 } from "./s3-system-metadata.js";
@@ -89,13 +90,24 @@ export function simS3SystemMetadataHeadersFrom(
 }
 
 /**
- * Whether a metadata key is one of the headers S3 keeps about an Object.
+ * The metadata a caller attached to an Object, under the keys it used.
  *
- * What is left over is the user-defined metadata. That is the whole of what
- * real S3 answers a read's `Metadata` with.
+ * Stored under the `x-amz-meta-` prefix and answered without it, which is what
+ * real S3 does with a read's `Metadata`. A key naming a header S3 sets itself
+ * survives the round trip and stays out of the Object's own fields.
  */
-export function isSimS3SystemMetadataHeader(key: string): boolean {
-  return simS3SystemMetadataHeaders.some((header) => header.name === key);
+export function simS3UserDefinedMetadata(
+  headers: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const metadata: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.startsWith(simS3UserMetadataPrefix)) {
+      metadata[key.slice(simS3UserMetadataPrefix.length)] = value;
+    }
+  }
+
+  return metadata;
 }
 
 /** The output field a stored header is reported in. */

--- a/src/service/s3/object/s3-system-metadata.ts
+++ b/src/service/s3/object/s3-system-metadata.ts
@@ -60,6 +60,16 @@ export const simS3SystemMetadataHeaders: readonly SimS3SystemMetadataHeader[] =
   ];
 
 /**
+ * The prefix S3 carries user-defined metadata under.
+ *
+ * It is what keeps a caller's own key from colliding with a header S3 sets
+ * itself. A write attaching `content-type` as user metadata is stored under
+ * `x-amz-meta-content-type` and is a different thing from the Object's content
+ * type.
+ */
+export const simS3UserMetadataPrefix = "x-amz-meta-";
+
+/**
  * The type S3 gives an Object whose write named none.
  *
  * S3 guesses nothing from the key, so a `.txt` file uploaded without a content

--- a/src/service/s3/object/s3-system-metadata.ts
+++ b/src/service/s3/object/s3-system-metadata.ts
@@ -60,6 +60,15 @@ export const simS3SystemMetadataHeaders: readonly SimS3SystemMetadataHeader[] =
   ];
 
 /**
+ * The type S3 gives an Object whose write named none.
+ *
+ * S3 guesses nothing from the key, so a `.txt` file uploaded without a content
+ * type is served as bytes. Tooling that appears to guess, such as `aws s3
+ * sync`, sets the header itself before the upload.
+ */
+export const simS3DefaultContentType = "binary/octet-stream";
+
+/**
  * Read system metadata written as headers back into the fields it is declared
  * with.
  *

--- a/src/service/s3/object/s3-write-metadata.ts
+++ b/src/service/s3/object/s3-write-metadata.ts
@@ -1,5 +1,8 @@
 import { SimS3ObjectMetadata } from "./s3-object.js";
-import { simS3SystemMetadataHeaders } from "./s3-system-metadata.js";
+import {
+  simS3DefaultContentType,
+  simS3SystemMetadataHeaders,
+} from "./s3-system-metadata.js";
 
 /**
  * The metadata members of a request that says what an Object is.
@@ -31,6 +34,9 @@ export interface SimS3ObjectWriteMetadata {
  * looks the value up by, so a write and a read agree on what S3 remembers
  * about an Object. An omitted header leaves its key absent rather than
  * assigning an undefined value.
+ *
+ * Content type is the exception, because S3 gives an Object one whether the
+ * write named it or not.
  */
 export function simS3WriteMetadata(
   input: SimS3ObjectWriteMetadata,
@@ -44,6 +50,8 @@ export function simS3WriteMetadata(
       metadata[header.name] = value;
     }
   }
+
+  metadata["content-type"] ??= simS3DefaultContentType;
 
   return new SimS3ObjectMetadata(metadata);
 }

--- a/src/service/s3/object/s3-write-metadata.ts
+++ b/src/service/s3/object/s3-write-metadata.ts
@@ -2,6 +2,7 @@ import { SimS3ObjectMetadata } from "./s3-object.js";
 import {
   simS3DefaultContentType,
   simS3SystemMetadataHeaders,
+  simS3UserMetadataPrefix,
 } from "./s3-system-metadata.js";
 
 /**
@@ -29,11 +30,12 @@ export interface SimS3ObjectWriteMetadata {
 /**
  * Convert the metadata members of a write into what an Object stores.
  *
- * User-defined metadata is retained as supplied. System metadata is read by
- * the same list of headers a read returns, under the lowercase key that read
- * looks the value up by, so a write and a read agree on what S3 remembers
- * about an Object. An omitted header leaves its key absent rather than
- * assigning an undefined value.
+ * User-defined metadata is stored under the `x-amz-meta-` prefix S3 carries it
+ * with, which keeps a caller's own `content-type` key apart from the Object's
+ * content type. System metadata is read by the same list of headers a read
+ * returns, under the lowercase key that read looks the value up by, so a write
+ * and a read agree on what S3 remembers about an Object. An omitted header
+ * leaves its key absent rather than assigning an undefined value.
  *
  * Content type is the exception, because S3 gives an Object one whether the
  * write named it or not.
@@ -41,7 +43,12 @@ export interface SimS3ObjectWriteMetadata {
 export function simS3WriteMetadata(
   input: SimS3ObjectWriteMetadata,
 ): SimS3ObjectMetadata {
-  const metadata: Record<string, string> = { ...input.Metadata };
+  const metadata: Record<string, string> = {};
+  const userDefined = Object.entries(input.Metadata ?? {});
+
+  for (const [key, value] of userDefined) {
+    metadata[`${simS3UserMetadataPrefix}${key}`] = value;
+  }
 
   for (const header of simS3SystemMetadataHeaders) {
     const value = metadataValue(input[header.field]);

--- a/src/service/s3/serve/api/sim-s3-api-copy.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-copy.loc.test.ts
@@ -215,7 +215,7 @@ describe("Copying an Object over the served S3 REST endpoint", () => {
     const read = await simS3.getObject(
       new GetObjectCommand({ Bucket: "archive", Key: "typed.pdf" }),
     );
-    assertIdentical(read.Metadata?.["content-type"], "application/pdf");
+    assertIdentical(read.ContentType, "application/pdf");
   });
 
   it("takes the destination's own metadata under REPLACE", async () => {
@@ -245,7 +245,7 @@ describe("Copying an Object over the served S3 REST endpoint", () => {
     const read = await simS3.getObject(
       new GetObjectCommand({ Bucket: "archive", Key: "retyped.txt" }),
     );
-    assertIdentical(read.Metadata?.["content-type"], "text/plain");
+    assertIdentical(read.ContentType, "text/plain");
   });
 
   it("answers a copy a Bucket policy refuses with the S3 error document", async () => {

--- a/src/service/s3/serve/api/sim-s3-api-head-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-head-output.ts
@@ -1,4 +1,5 @@
 import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-headers.js";
+import { simS3SystemMetadataHeadersFrom } from "../../object/s3-system-metadata-read.js";
 
 /**
  * The responses a HEAD is answered with.
@@ -20,7 +21,7 @@ export function simS3HeadObjectResponse(
   return new Response(undefined, {
     status: 200,
     headers: simS3ObjectResponseHeaders({
-      metadata: output["Metadata"] as Record<string, string> | undefined,
+      metadata: simS3SystemMetadataHeadersFrom(output),
       bodyLength: (output["ContentLength"] as number | undefined) ?? 0,
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,

--- a/src/service/s3/serve/api/sim-s3-api-object-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-output.ts
@@ -1,5 +1,6 @@
 import { xmlDocument, xmlValue } from "../../../../util/xml/xml-writer.js";
 import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-headers.js";
+import { simS3SystemMetadataHeadersFrom } from "../../object/s3-system-metadata-read.js";
 
 interface CopyObjectOutput {
   readonly CopyObjectResult?:
@@ -40,7 +41,7 @@ export async function simS3GetObjectResponse(
   return new Response(body, {
     status: contentRange === undefined ? 200 : 206,
     headers: simS3ObjectResponseHeaders({
-      metadata: output["Metadata"] as Record<string, string> | undefined,
+      metadata: simS3SystemMetadataHeadersFrom(output),
       bodyLength: body.length,
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,

--- a/src/service/s3/serve/sim-s3-controller.loc.test.ts
+++ b/src/service/s3/serve/sim-s3-controller.loc.test.ts
@@ -47,9 +47,7 @@ describe("Simulated S3 local HTTP controller", () => {
         Bucket: "foo-site",
         Key: "index.html",
         Body: "<h1>Hello, world!</h1>",
-        Metadata: {
-          "content-type": "text/html; charset=utf-8",
-        },
+        ContentType: "text/html; charset=utf-8",
       }),
     );
 
@@ -88,9 +86,7 @@ describe("Simulated S3 local HTTP controller", () => {
         Bucket: "head-site",
         Key: "index.html",
         Body: "<h1>Hello, world!</h1>",
-        Metadata: {
-          "content-type": "text/html; charset=utf-8",
-        },
+        ContentType: "text/html; charset=utf-8",
       }),
     );
 
@@ -130,9 +126,7 @@ describe("Simulated S3 local HTTP controller", () => {
         Bucket: "encoded-path-site",
         Key: "folder/hello world.txt",
         Body: "Hello from an encoded path",
-        Metadata: {
-          "content-type": "text/plain; charset=utf-8",
-        },
+        ContentType: "text/plain; charset=utf-8",
       }),
     );
 
@@ -166,9 +160,7 @@ describe("Simulated S3 local HTTP controller", () => {
         Bucket: "folder-index-redirect-site",
         Key: "docs/index.html",
         Body: "<h1>Docs index</h1>",
-        Metadata: {
-          "content-type": "text/html; charset=utf-8",
-        },
+        ContentType: "text/html; charset=utf-8",
       }),
     );
 
@@ -206,9 +198,7 @@ describe("Simulated S3 local HTTP controller", () => {
         Bucket: "folder-index-follow-site",
         Key: "docs/index.html",
         Body: "<h1>Docs index after redirect</h1>",
-        Metadata: {
-          "content-type": "text/html; charset=utf-8",
-        },
+        ContentType: "text/html; charset=utf-8",
       }),
     );
 

--- a/src/service/s3/serve/sim-s3-rest-object-reader.ts
+++ b/src/service/s3/serve/sim-s3-rest-object-reader.ts
@@ -2,6 +2,7 @@ import type { SimS3 } from "../sim-s3.js";
 import type { SimS3RestObjectRoute } from "./sim-s3-route.js";
 import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
 import { simS3ObjectResponseHeaders } from "../object/s3-object-response-headers.js";
+import { simS3SystemMetadataHeadersFrom } from "../object/s3-system-metadata-read.js";
 
 /**
  * Answers a `GET` or `HEAD` at the simulated S3 REST endpoint.
@@ -40,7 +41,7 @@ export class SimS3RestObjectReader {
 
     const body = await bodyBytes(output.Body);
     const headers = simS3ObjectResponseHeaders({
-      metadata: output.Metadata,
+      metadata: simS3SystemMetadataHeadersFrom(output),
       bodyLength: body.length,
       etag: output.ETag,
       lastModified: output.LastModified,

--- a/src/service/s3/serve/website/sim-s3-website-object-loader.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object-loader.ts
@@ -5,6 +5,7 @@ import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3WebsiteRoute } from "../sim-s3-route.js";
 import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
 import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
+import { simS3SystemMetadataHeadersFrom } from "../../object/s3-system-metadata-read.js";
 import type { SimS3 } from "../../sim-s3.js";
 import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
 import { SimS3WebsiteObject } from "./sim-s3-website-object.js";
@@ -71,7 +72,7 @@ export class SimS3WebsiteObjectLoader {
 
       return new SimS3WebsiteObject({
         body: await simS3BodyToBuffer(output.Body as AsyncIterable<Buffer>),
-        metadata: output.Metadata,
+        metadata: simS3SystemMetadataHeadersFrom(output),
         etag: output.ETag,
         lastModified: output.LastModified,
       });

--- a/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { SimS3ObjectMetadata } from "../../object/s3-object.js";
+import { simS3DefaultContentType } from "../../object/s3-system-metadata.js";
 
 /**
  * Make up reasonable metadata for an Object based on the file on disk.
@@ -15,11 +16,11 @@ export function metadataForFilesystemS3ObjectKey(
 ): SimS3ObjectMetadata {
   return new SimS3ObjectMetadata({
     // Octet-stream for anything the table below has never heard of, which is
-    // what S3 reports for an object whose type it was never told. That case
+    // what S3 reports for an Object whose type it was never told. That case
     // arrives by way of `additionalFileExtensions`: the table is the web's own
     // types, and the option exists for files that are not one of them.
     "content-type":
-      contentTypeForFilesystemS3ObjectKey(key) ?? "application/octet-stream",
+      contentTypeForFilesystemS3ObjectKey(key) ?? simS3DefaultContentType,
     ...declaredHeaders,
   });
 }

--- a/src/service/s3/storage/filesystem/s3-filesystem-safety.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-safety.iso.test.ts
@@ -142,7 +142,7 @@ describe("Filesystem simulated S3 storage safety", () => {
     // every extension a mount names for itself.
     assertIdentical(
       stored.metadata.values["content-type"],
-      "application/octet-stream",
+      "binary/octet-stream",
     );
   });
 

--- a/src/service/s3/storage/filesystem/s3-filesystem-system-metadata.loc.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-system-metadata.loc.test.ts
@@ -5,11 +5,7 @@ import {
   GetObjectCommand,
   PutBucketWebsiteCommand,
 } from "@aws-sdk/client-s3";
-import {
-  assertIdentical,
-  assertObjectMatches,
-  assertUndefined,
-} from "@kensio/smartass";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
 
 import { SimAwsLocalServer } from "../../../../serve/index.js";
@@ -65,14 +61,12 @@ describe("System metadata declared for a mounted directory", () => {
     );
 
     // Then the mirrored copy is brotli, still typed by its own extension.
-    assertObjectMatches(mirrored.Metadata, {
-      "content-encoding": "br",
-      "content-type": "text/javascript",
-    });
+    assertIdentical(mirrored.ContentEncoding, "br");
+    assertIdentical(mirrored.ContentType, "text/javascript");
 
     // And the copy outside the mirror is left as it is on disk.
-    assertUndefined(plain.Metadata?.["content-encoding"]);
-    assertIdentical(plain.Metadata?.["content-type"], "text/javascript");
+    assertUndefined(plain.ContentEncoding);
+    assertIdentical(plain.ContentType, "text/javascript");
   });
 
   it("serves a mounted mirror as bytes a client can decode", async () => {


### PR DESCRIPTION
A read of an Object now answers with the system metadata headers in fields of
its own. `GetObject` and `HeadObject` carry `ContentType`, `CacheControl`,
`ContentEncoding`, `ContentDisposition` and `ContentLanguage`, and the expiry
comes back twice, as `ExpiresString` holding the stored HTTP date and as
`Expires` holding the same value parsed into a `Date`. `Metadata` holds what
the caller attached and only that, which is what real S3 answers with. The
values were already stored, and were being handed back inside `Metadata` under
the lowercase header names. That was recorded under Limitations, and the entry
goes with this.

A write that names no content type gets `binary/octet-stream`, as S3 gives an
Object it was never told the type of. The mounted-directory fallback said
`application/octet-stream` under a comment claiming the same thing, and now
says what S3 says.

`SimS3ObjectMetadata` stores one map of header names still, because that is the
form every endpoint serving an Object wants. It gained `system` and
`userDefined` to split the map for a read, and `s3-system-metadata-read.ts`
owns the split in both directions. The REST endpoint, the website endpoint and
a CloudFront S3 Origin all read through `GetObject`, so each puts the fields
back under their header names on the way out. Without that last part a
CloudFront Origin would serve brotli with no encoding header.

User-defined metadata moved under the `x-amz-meta-` prefix S3 carries it with,
raised in review. One flat map held both halves before, so a caller attaching a
key called `content-type` set the Object's content type. It now keeps its own
key and leaves the Object's fields alone.

Existing tests asserted the old shape and were changed rather than kept, on the
rule that a test asserting unrealistic behaviour is the test's problem. Three of
them in `sim-s3-controller.loc.test.ts` set a content type through `Metadata`,
which is the collision above.

The read side sits in a module of its own because FTA scored the combined file
at 51.8. The split stands on its own merits, and the gate is what prompted it.

Resolves https://github.com/KensioSoftware/yulin/issues/969
