### PR TITLE
feat: apply a managed response headers policy

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1971,8 +1971,23 @@ else, and an entry placing one elsewhere (`example.*`, `test.*.example.org`, `*t
 header decides one header. Without it, an Origin response carrying any CORS header at all, named by
 the policy or otherwise, keeps every header the section would have set off the response.
 
-A Behavior's `ResponseHeadersPolicyId` is checked when the Distribution is created or updated. Naming
-a policy this simulation did not create, whether mistyped or a CloudFront managed policy ID, fails
+### Managed policies
+
+CloudFront's five managed policies are here from the start, under the IDs AWS publishes, and a
+Behavior names one without a template creating anything. `SecurityHeadersPolicy`
+(`67f7725c-6f97-4210-82d7-5512b31e9d03`), `SimpleCORS` (`60669652-455b-4ae9-85a4-c4c02393f86c`),
+`CORS-With-Preflight` (`5cc3b908-e619-4b99-88e5-2cf7f45965bd`), `CORS-and-SecurityHeadersPolicy`
+(`e61eb60c-9c35-4d20-a928-2b84e02af89c`) and `CORS-with-preflight-and-SecurityHeadersPolicy`
+(`eaab4381-ed33-4a86-88ca-d9558dc6cd63`) each carry the sections
+[AWS documents](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html)
+for it. CDK's `ResponseHeadersPolicy.SECURITY_HEADERS` and its four siblings synthesize those IDs, so
+a stack reaching for one deploys and serves the headers.
+
+The managed policies sit in CloudFront's own namespace. A template may create a policy called
+`SecurityHeadersPolicy` of its own, and deleting that stack leaves the managed one where it was.
+
+A Behavior's `ResponseHeadersPolicyId` is still checked when the Distribution is created or updated.
+An ID that is neither managed nor created here, whether mistyped or taken from a real account, fails
 the Stack there. The alternative would be a successful deploy that fails the first request reaching
 the Behavior.
 
@@ -2737,11 +2752,10 @@ Where sim CloudFront knowingly behaves differently from AWS:
   share of real responses carry `Server-Timing`. This simulation adds it to every response once
   `Enabled` is true. A test asserting on it never depends on chance. The header's value is a
   fixed placeholder, since nothing here measures an Origin fetch the way CloudFront's edge does.
-- **A managed policy ID is unknown here.** CloudFront's managed policies belong to AWS, and this
-  simulation creates none of them. A Behavior naming one is refused with
-  `InvalidResponseHeadersPolicyId` when the Distribution is created or updated, the same point real
-  CloudFront refuses one at. The alternative would be a successful deploy that fails the first
-  request reaching the Behavior.
+- **A CORS section sends its preflight headers on every request.** Real CloudFront puts
+  `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` and `Access-Control-Max-Age` on a
+  preflight response alone. This simulation puts them on every response the Behavior serves. A list
+  left empty sends no header at all, so `SimpleCORS` still answers with the Origin header by itself.
 - **`CachePolicyId` and `OriginRequestPolicyId` are accepted and ignored.** Sim CloudFront models no
   edge caching. A Behavior's cache policy, including an AWS managed policy such as
   `CachingOptimized`, is left unvalidated and unapplied to TTLs and the cache key. Every request

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-managed-response-headers.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-managed-response-headers.iso.test.ts
@@ -1,0 +1,128 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import { grantPublicObjectRead } from "../../../s3/bucket/sim-s3-public-read.fixture.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { simCfManagedResponseHeadersPolicyIds } from "../../response-headers-policy/sim-cf-managed-response-headers-policies.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+const bucketName = "managed-policy-site-bucket";
+
+/**
+ * A template naming a managed response headers policy on its default cache
+ * Behavior, with no Resource behind the ID.
+ *
+ * This is the shape `aws-cdk-lib` 2.263.0 synthesizes for a `Distribution`
+ * given `responseHeadersPolicy: ResponseHeadersPolicy.SECURITY_HEADERS`. The
+ * `CachePolicyId` is CDK's `CachingOptimized` default, and it comes along to
+ * keep the Behavior the one CDK writes rather than a tidied version of it.
+ * The template is written out rather than synthesized so this stays an
+ * isolated test.
+ */
+function siteTemplate(responseHeadersPolicyId: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: bucketName },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Enabled: true,
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: `${bucketName}.s3.amazonaws.com`,
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              Compress: true,
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              ResponseHeadersPolicyId: responseHeadersPolicyId,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("CloudFormation Distribution on a managed response headers policy", () => {
+  async function deployedSite(
+    responseHeadersPolicyId: string,
+  ): Promise<{ simAws: SimAws; distributionId: string }> {
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "managed-response-headers-stack",
+      template: siteTemplate(responseHeadersPolicyId),
+    });
+
+    await stack.waitForDeployComplete();
+
+    await grantPublicObjectRead(simAws.s3(), bucketName);
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: "<h1>Home</h1>",
+      }),
+    );
+
+    const resource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+
+    return { simAws, distributionId: resource.simResource.distributionId };
+  }
+
+  it("serves the security headers a CDK stack asks for by managed ID", async () => {
+    // Given a stack whose Behavior names SecurityHeadersPolicy, which is what
+    // ResponseHeadersPolicy.SECURITY_HEADERS synthesizes to.
+    const { simAws, distributionId } = await deployedSite(
+      simCfManagedResponseHeadersPolicyIds.securityHeaders,
+    );
+
+    // When a page is requested.
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    // Then the response carries the headers AWS documents for the policy,
+    // with no Resource in the template having created it.
+    assertIdentical(
+      home.headers.get("strict-transport-security"),
+      "max-age=31536000",
+    );
+    assertIdentical(home.headers.get("x-content-type-options"), "nosniff");
+    assertIdentical(home.headers.get("x-frame-options"), "SAMEORIGIN");
+  });
+
+  it("answers a cross-origin request through a managed CORS policy", async () => {
+    // Given a stack whose Behavior names SimpleCORS.
+    const { simAws, distributionId } = await deployedSite(
+      simCfManagedResponseHeadersPolicyIds.simpleCors,
+    );
+
+    // When a browser on another Origin requests the page.
+    const home = await simCfSiteRequest(simAws, distributionId, "/", {
+      headers: { Origin: "https://app.example.com" },
+    });
+
+    // Then the wildcard comes back, which is the whole of SimpleCORS.
+    assertIdentical(home.headers.get("access-control-allow-origin"), "*");
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-sections.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-sections.iso.test.ts
@@ -204,9 +204,9 @@ describe("CloudFormation Distribution response headers policy sections", () => {
   });
 
   it("fails the stack for a Behavior naming a response headers policy that does not exist", async () => {
-    // Given a Distribution whose default Behavior names an ID nothing in this
-    // simulation created, which is what a CloudFront managed policy ID is
-    // here.
+    // Given a Distribution whose default Behavior names an ID that is neither
+    // a managed policy nor one this simulation created, which is what a policy
+    // ID from a real account is here.
     const simAws = new SimAws();
 
     // When the template is deployed, then it fails at deploy time rather than
@@ -221,7 +221,7 @@ describe("CloudFormation Distribution response headers policy sections", () => {
             DefaultCacheBehavior: {
               TargetOriginId: "SiteOrigin",
               ViewerProtocolPolicy: "redirect-to-https",
-              ResponseHeadersPolicyId: "67f7725c-6f97-4210-82d7-5512b31e9d03",
+              ResponseHeadersPolicyId: "11111111-2222-3333-4444-555555555555",
             },
           },
         ),
@@ -230,7 +230,7 @@ describe("CloudFormation Distribution response headers policy sections", () => {
       await stack.waitForDeployComplete();
     });
 
-    assertStringIncludes(error.message, "67f7725c-6f97-4210-82d7-5512b31e9d03");
-    assertStringIncludes(error.message, "managed policy ID");
+    assertStringIncludes(error.message, "11111111-2222-3333-4444-555555555555");
+    assertStringIncludes(error.message, "does not exist");
   });
 });

--- a/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.iso.test.ts
+++ b/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.iso.test.ts
@@ -94,7 +94,7 @@ describe("SimCfResponseHeadersApplicator", () => {
 
     assertInstanceOf(error, SimCloudFrontNoSuchResponseHeadersPolicy);
     assertStringIncludes(error.message, "658327ea-f89d-4fab-a63d-7e88639e58f6");
-    assertStringIncludes(error.message, "managed policy ID");
+    assertStringIncludes(error.message, "does not exist");
   });
 
   it("forgets a policy that has been removed", () => {

--- a/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.ts
+++ b/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.ts
@@ -33,9 +33,9 @@ export class SimCfResponseHeadersApplicator {
     if (policy === undefined) {
       throw new SimCloudFrontNoSuchResponseHeadersPolicy(
         `Sim CloudFront response headers policy ${policyId} does not exist. ` +
-          `Only a policy created in this simulation can be applied, so a ` +
-          `managed policy ID, which names a policy AWS owns rather than one a ` +
-          `template creates, will not be found.`,
+          `One of CloudFront's five managed policies can be applied, and so ` +
+          `can a policy created in this simulation. A policy ID from a real ` +
+          `account is neither.`,
       );
     }
 

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-response-headers-policy.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-response-headers-policy.ts
@@ -57,10 +57,9 @@ export class SimCfBehaviorResponseHeadersPolicy {
     throw new SimCloudFrontInvalidResponseHeadersPolicyId(
       `Sim CloudFront Behavior for Origin ${targetOriginId} names response ` +
         `headers policy ${responseHeadersPolicyId}, which does not exist. ` +
-        `Only a policy an AWS::CloudFront::ResponseHeadersPolicy Resource ` +
-        `created in this simulation can be named, so a managed policy ID, ` +
-        `which names a policy AWS owns rather than one a template creates, ` +
-        `will not be found.`,
+        `A Behavior names one of CloudFront's five managed policies, or a ` +
+        `policy an AWS::CloudFront::ResponseHeadersPolicy Resource created in ` +
+        `this simulation. A policy ID from a real account is neither.`,
     );
   }
 }

--- a/src/service/cloudfront/distribution/sim-cf-distribution-reconfigure-refusal.iso.test.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-reconfigure-refusal.iso.test.ts
@@ -72,7 +72,7 @@ describe("Refusing a sim CloudFront Distribution update", () => {
               DefaultCacheBehavior: {
                 TargetOriginId: "site-origin",
                 ViewerProtocolPolicy: "allow-all",
-                ResponseHeadersPolicyId: "67f7725c-6f97-4210-82d7-5512b31e9d03",
+                ResponseHeadersPolicyId: "11111111-2222-3333-4444-555555555555",
               },
             },
           ),
@@ -124,7 +124,7 @@ describe("Refusing a sim CloudFront Distribution update", () => {
               DefaultCacheBehavior: {
                 TargetOriginId: "site-origin",
                 ViewerProtocolPolicy: "allow-all",
-                ResponseHeadersPolicyId: "67f7725c-6f97-4210-82d7-5512b31e9d03",
+                ResponseHeadersPolicyId: "11111111-2222-3333-4444-555555555555",
               },
             },
           ),

--- a/src/service/cloudfront/response-headers-policy/sim-cf-managed-response-headers-policies.iso.test.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-managed-response-headers-policies.iso.test.ts
@@ -1,0 +1,181 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simCfManagedResponseHeadersPolicyIds } from "./sim-cf-managed-response-headers-policies.js";
+import { SimCloudFrontResponseHeadersPolicy } from "./sim-cf-response-headers-policy.js";
+import { SimCloudFrontResponseHeadersPolicyRegistry } from "./sim-cf-response-headers-policy-registry.js";
+
+describe("Managed CloudFront response headers policies", () => {
+  /**
+   * The response a Behavior on the given managed policy serves, for an Origin
+   * response carrying the given headers.
+   */
+  function served(
+    policyId: string,
+    originHeaders: Record<string, string> = {},
+    requestOrigin: string | null = null,
+  ): Headers {
+    const policy = new SimCloudFrontResponseHeadersPolicyRegistry().byId(
+      policyId,
+    );
+
+    assertNonNullable(policy);
+
+    return policy.apply(
+      new Response("body", { headers: originHeaders }),
+      requestOrigin,
+    ).headers;
+  }
+
+  it("holds the five policies AWS manages, under the names it publishes", () => {
+    // Given a registry nothing has created a policy in.
+    const registry = new SimCloudFrontResponseHeadersPolicyRegistry();
+
+    // When each managed ID is looked up, then the policy behind it carries
+    // the name the CloudFront console shows.
+    const names = Object.values(simCfManagedResponseHeadersPolicyIds).map(
+      (id) => registry.byId(id)?.name,
+    );
+
+    assertIdentical(
+      names.join(","),
+      [
+        "SimpleCORS",
+        "CORS-With-Preflight",
+        "SecurityHeadersPolicy",
+        "CORS-and-SecurityHeadersPolicy",
+        "CORS-with-preflight-and-SecurityHeadersPolicy",
+      ].join(","),
+    );
+  });
+
+  it("sets every security header SecurityHeadersPolicy documents", () => {
+    // Given a Behavior on SecurityHeadersPolicy.
+    // When an Origin response with none of them passes through it.
+    const headers = served(
+      simCfManagedResponseHeadersPolicyIds.securityHeaders,
+    );
+
+    // Then all five arrive with the values AWS documents.
+    assertIdentical(
+      headers.get("referrer-policy"),
+      "strict-origin-when-cross-origin",
+    );
+    assertIdentical(
+      headers.get("strict-transport-security"),
+      "max-age=31536000",
+    );
+    assertIdentical(headers.get("x-content-type-options"), "nosniff");
+    assertIdentical(headers.get("x-frame-options"), "SAMEORIGIN");
+    assertIdentical(headers.get("x-xss-protection"), "1; mode=block");
+  });
+
+  it("overrides only X-Content-Type-Options on a site that sends its own", () => {
+    // Given an Origin sending two of the security headers itself.
+    // When the response passes through SecurityHeadersPolicy.
+    const headers = served(
+      simCfManagedResponseHeadersPolicyIds.securityHeaders,
+      {
+        "X-Content-Type-Options": "sniff-away",
+        "X-Frame-Options": "DENY",
+      },
+    );
+
+    // Then nosniff replaces the Origin's value and the frame options survive,
+    // which is the one Override AWS sets on this policy.
+    assertIdentical(headers.get("x-content-type-options"), "nosniff");
+    assertIdentical(headers.get("x-frame-options"), "DENY");
+  });
+
+  it("answers a simple CORS request with the wildcard Origin alone", () => {
+    // Given a Behavior on SimpleCORS.
+    // When a request naming an Origin passes through it.
+    const headers = served(
+      simCfManagedResponseHeadersPolicyIds.simpleCors,
+      {},
+      "https://app.example.com",
+    );
+
+    // Then the wildcard is the whole of it. SimpleCORS names no method and no
+    // header, and CloudFront sends neither list.
+    assertIdentical(headers.get("access-control-allow-origin"), "*");
+    assertIdentical(headers.get("access-control-allow-methods"), null);
+    assertIdentical(headers.get("access-control-allow-headers"), null);
+    assertIdentical(headers.get("access-control-expose-headers"), null);
+  });
+
+  it("names every method CORS-With-Preflight allows", () => {
+    // Given a Behavior on CORS-With-Preflight.
+    // When a request naming an Origin passes through it.
+    const headers = served(
+      simCfManagedResponseHeadersPolicyIds.corsWithPreflight,
+      {},
+      "https://app.example.com",
+    );
+
+    // Then the method list and the wildcard expose list come with the Origin.
+    assertIdentical(headers.get("access-control-allow-origin"), "*");
+    assertIdentical(
+      headers.get("access-control-allow-methods"),
+      "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
+    );
+    assertIdentical(headers.get("access-control-expose-headers"), "*");
+  });
+
+  it("combines both sections in CORS-and-SecurityHeadersPolicy", () => {
+    // Given a Behavior on the combined policy.
+    // When a request naming an Origin passes through it.
+    const headers = served(
+      simCfManagedResponseHeadersPolicyIds.corsAndSecurityHeaders,
+      {},
+      "https://app.example.com",
+    );
+
+    // Then the response carries the CORS header and the security headers.
+    assertIdentical(headers.get("access-control-allow-origin"), "*");
+    assertIdentical(headers.get("x-content-type-options"), "nosniff");
+  });
+
+  it("lets a template create a policy under a managed policy's name", () => {
+    // Given a registry holding the managed policies.
+    const registry = new SimCloudFrontResponseHeadersPolicyRegistry();
+
+    // When a template creates one called SecurityHeadersPolicy, which is a
+    // name CloudFront keeps in its own namespace rather than the account's.
+    const created = new SimCloudFrontResponseHeadersPolicy({
+      name: "SecurityHeadersPolicy",
+    });
+
+    registry.add(created);
+
+    // Then both are there, each under its own ID.
+    assertIdentical(registry.byId(created.id)?.name, "SecurityHeadersPolicy");
+    assertIdentical(
+      registry.byId(simCfManagedResponseHeadersPolicyIds.securityHeaders)?.name,
+      "SecurityHeadersPolicy",
+    );
+  });
+
+  it("keeps the managed policies when a stack takes its own away", () => {
+    // Given a registry a template has created a policy in.
+    const registry = new SimCloudFrontResponseHeadersPolicyRegistry();
+    const created = new SimCloudFrontResponseHeadersPolicy({
+      name: "CacheHeaders",
+    });
+
+    registry.add(created);
+
+    // When deleting the stack forgets it.
+    registry.remove(created.id);
+
+    // Then the managed policies are where they were, since no stack owns them.
+    assertUndefined(registry.byId(created.id));
+    assertNonNullable(
+      registry.byId(simCfManagedResponseHeadersPolicyIds.simpleCors),
+    );
+  });
+});

--- a/src/service/cloudfront/response-headers-policy/sim-cf-managed-response-headers-policies.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-managed-response-headers-policies.ts
@@ -1,0 +1,128 @@
+import { SimCloudFrontResponseHeader } from "./sim-cf-response-header.js";
+import { SimCloudFrontResponseHeadersPolicyCors } from "./sim-cf-response-headers-policy-cors.js";
+import {
+  SimCloudFrontResponseHeadersPolicy,
+  type SimCloudFrontResponseHeadersPolicyId,
+  type SimCloudFrontResponseHeadersPolicyMap,
+} from "./sim-cf-response-headers-policy.js";
+
+/**
+ * The IDs AWS publishes for its managed response headers policies.
+ *
+ * A template names one of these directly. CDK's `ResponseHeadersPolicy`
+ * statics carry the same five, and synthesize the ID into a Behavior's
+ * `ResponseHeadersPolicyId` with no Resource behind it.
+ */
+export const simCfManagedResponseHeadersPolicyIds = {
+  simpleCors: "60669652-455b-4ae9-85a4-c4c02393f86c",
+  corsWithPreflight: "5cc3b908-e619-4b99-88e5-2cf7f45965bd",
+  securityHeaders: "67f7725c-6f97-4210-82d7-5512b31e9d03",
+  corsAndSecurityHeaders: "e61eb60c-9c35-4d20-a928-2b84e02af89c",
+  corsWithPreflightAndSecurityHeaders: "eaab4381-ed33-4a86-88ca-d9558dc6cd63",
+} as const;
+
+/**
+ * The security headers section the three managed policies that carry one set.
+ *
+ * All three carry the same list. Only `X-Content-Type-Options` overrides the
+ * Origin, so a site sending its own `X-Frame-Options` keeps it while its
+ * `nosniff` is replaced.
+ */
+function securityHeaders(): SimCloudFrontResponseHeader[] {
+  return [
+    new SimCloudFrontResponseHeader({
+      name: "Referrer-Policy",
+      value: "strict-origin-when-cross-origin",
+    }),
+    new SimCloudFrontResponseHeader({
+      name: "Strict-Transport-Security",
+      value: "max-age=31536000",
+    }),
+    new SimCloudFrontResponseHeader({
+      name: "X-Content-Type-Options",
+      value: "nosniff",
+      override: true,
+    }),
+    new SimCloudFrontResponseHeader({
+      name: "X-Frame-Options",
+      value: "SAMEORIGIN",
+    }),
+    new SimCloudFrontResponseHeader({
+      name: "X-XSS-Protection",
+      value: "1; mode=block",
+    }),
+  ];
+}
+
+/**
+ * The CORS section behind SimpleCORS, allowing a simple request from any
+ * Origin with `Access-Control-Allow-Origin` alone.
+ */
+function simpleCors(): SimCloudFrontResponseHeadersPolicyCors {
+  return new SimCloudFrontResponseHeadersPolicyCors({
+    allowCredentials: false,
+    allowHeaders: [],
+    allowMethods: [],
+    allowOrigins: ["*"],
+    originOverride: false,
+  });
+}
+
+/**
+ * The CORS section behind CORS-With-Preflight, which adds the method list and
+ * a wildcard `Access-Control-Expose-Headers` to the wildcard Origin.
+ */
+function preflightCors(): SimCloudFrontResponseHeadersPolicyCors {
+  return new SimCloudFrontResponseHeadersPolicyCors({
+    allowCredentials: false,
+    allowHeaders: [],
+    allowMethods: ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"],
+    allowOrigins: ["*"],
+    exposeHeaders: ["*"],
+    originOverride: false,
+  });
+}
+
+/**
+ * The five managed response headers policies, built fresh for one simulated
+ * CloudFront.
+ *
+ * CloudFront owns these and every account has them, so a Behavior can name one
+ * without a template creating anything. They are built per registry so that
+ * one simulation never hands another a policy object.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html
+ */
+export function simCfManagedResponseHeadersPolicies(): SimCloudFrontResponseHeadersPolicyMap {
+  const policies = [
+    new SimCloudFrontResponseHeadersPolicy({
+      id: simCfManagedResponseHeadersPolicyIds.simpleCors as SimCloudFrontResponseHeadersPolicyId,
+      name: "SimpleCORS",
+      cors: simpleCors(),
+    }),
+    new SimCloudFrontResponseHeadersPolicy({
+      id: simCfManagedResponseHeadersPolicyIds.corsWithPreflight as SimCloudFrontResponseHeadersPolicyId,
+      name: "CORS-With-Preflight",
+      cors: preflightCors(),
+    }),
+    new SimCloudFrontResponseHeadersPolicy({
+      id: simCfManagedResponseHeadersPolicyIds.securityHeaders as SimCloudFrontResponseHeadersPolicyId,
+      name: "SecurityHeadersPolicy",
+      securityHeaders: securityHeaders(),
+    }),
+    new SimCloudFrontResponseHeadersPolicy({
+      id: simCfManagedResponseHeadersPolicyIds.corsAndSecurityHeaders as SimCloudFrontResponseHeadersPolicyId,
+      name: "CORS-and-SecurityHeadersPolicy",
+      cors: simpleCors(),
+      securityHeaders: securityHeaders(),
+    }),
+    new SimCloudFrontResponseHeadersPolicy({
+      id: simCfManagedResponseHeadersPolicyIds.corsWithPreflightAndSecurityHeaders as SimCloudFrontResponseHeadersPolicyId,
+      name: "CORS-with-preflight-and-SecurityHeadersPolicy",
+      cors: preflightCors(),
+      securityHeaders: securityHeaders(),
+    }),
+  ];
+
+  return new Map(policies.map((policy) => [policy.id, policy]));
+}

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.ts
@@ -98,11 +98,19 @@ export class SimCloudFrontResponseHeadersPolicyCors {
       headers.append("Vary", "Origin");
     }
 
-    headers.set(
-      "Access-Control-Allow-Methods",
-      this.resolvedAllowMethods().join(","),
-    );
-    headers.set("Access-Control-Allow-Headers", this.allowHeaders.join(","));
+    // An empty list names no method and no header. CloudFront leaves the
+    // header off there, the way it leaves off the expose list below, and a
+    // header carrying an empty value would mean something else to a browser.
+    if (this.allowMethods.length > 0) {
+      headers.set(
+        "Access-Control-Allow-Methods",
+        this.resolvedAllowMethods().join(","),
+      );
+    }
+
+    if (this.allowHeaders.length > 0) {
+      headers.set("Access-Control-Allow-Headers", this.allowHeaders.join(","));
+    }
 
     // A false Access-Control-Allow-Credentials is not a header value the
     // fetch spec recognises, so CloudFront leaves it off rather than sending

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-registry.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-registry.ts
@@ -1,4 +1,5 @@
 import { SimCloudFrontResponseHeadersPolicyAlreadyExists } from "../error/sim-cloudfront.error.js";
+import { simCfManagedResponseHeadersPolicies } from "./sim-cf-managed-response-headers-policies.js";
 import type {
   SimCloudFrontResponseHeadersPolicy,
   SimCloudFrontResponseHeadersPolicyId,
@@ -11,13 +12,20 @@ import type {
  * Policies are found by ID, which is what a cache Behavior's
  * `responseHeadersPolicyId` names, and by name, which is what decides whether a
  * new one may be stored.
+ *
+ * AWS's five managed policies are held apart from the ones a template creates.
+ * CloudFront keeps them in its own namespace, so a template may create a policy
+ * called `SecurityHeadersPolicy` of its own, and deleting the stack that
+ * created it leaves the managed one where it was.
  */
 export class SimCloudFrontResponseHeadersPolicyRegistry {
   private readonly policies: SimCloudFrontResponseHeadersPolicyMap = new Map();
+  private readonly managedPolicies: SimCloudFrontResponseHeadersPolicyMap =
+    simCfManagedResponseHeadersPolicies();
 
   /**
-   * Store a policy, refusing a name another policy already holds as CloudFront
-   * does.
+   * Store a policy a template created, refusing a name another such policy
+   * already holds as CloudFront does.
    */
   add(policy: SimCloudFrontResponseHeadersPolicy): void {
     if (this.byName(policy.name) !== undefined) {
@@ -37,16 +45,22 @@ export class SimCloudFrontResponseHeadersPolicyRegistry {
   }
 
   /**
-   * Get a policy by ID.
+   * Get a policy by ID, whether a template created it or AWS manages it.
    */
   byId(
     policyId: SimCloudFrontResponseHeadersPolicyId | string,
   ): SimCloudFrontResponseHeadersPolicy | undefined {
-    return this.policies.get(policyId as SimCloudFrontResponseHeadersPolicyId);
+    const id = policyId as SimCloudFrontResponseHeadersPolicyId;
+
+    return this.policies.get(id) ?? this.managedPolicies.get(id);
   }
 
   /**
-   * Get a policy by name.
+   * Get a policy a template created, by name.
+   *
+   * A managed policy is left out. Its name belongs to CloudFront's own
+   * namespace, and this is what decides whether a template may store a policy
+   * under a name.
    */
   byName(policyName: string): SimCloudFrontResponseHeadersPolicy | undefined {
     return this.policies.values().find((policy) => policy.name === policyName);


### PR DESCRIPTION
CloudFront's five managed response headers policies are now held by every simulated CloudFront, under the IDs AWS publishes, so a Behavior names one without a template creating anything and a CDK stack reaching for `ResponseHeadersPolicy.SECURITY_HEADERS` deploys and serves the headers. They sit apart from the policies a template creates, matching CloudFront's own namespacing, so a stack may still create a policy called `SecurityHeadersPolicy` and deleting it leaves the managed one alone. A CORS section with an empty method or header list now leaves that header off rather than sending an empty value, which is what `SimpleCORS` needs to answer with `Access-Control-Allow-Origin` by itself.

Resolves #973

## Notes for the reviewer

Three tests used `SecurityHeadersPolicy`'s ID as their example of a policy nothing created, which is the behaviour this removes. They now name an ID that is neither managed nor created here, which is what they were covering. Both refusal messages lost their "managed policy ID" wording for the same reason.

`docs/services/cloudfront/README.md` gains a **Managed policies** heading and swaps one limitation for another. The one it drops is the managed policy refusal. The one it gains was already true and undocumented: a CORS section puts `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` and `Access-Control-Max-Age` on every response, where real CloudFront puts them on a preflight response alone. That gap is worth its own issue and is left alone here, since fixing it changes what a template-created policy serves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for five AWS-managed CloudFront response headers policies using their published IDs.
  * Managed policies can be applied directly while remaining separate from user-created policies.
  * Added coverage for security, CORS, combined policies, and policy name collisions.

* **Bug Fixes**
  * Empty CORS method and header lists no longer emit empty response headers.
  * Improved errors for invalid or unavailable response headers policies.
  * Documented CORS preflight header behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->