### PR TITLE
fix: deploy without an absent headers policy

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1986,10 +1986,16 @@ a stack reaching for one deploys and serves the headers.
 The managed policies sit in CloudFront's own namespace. A template may create a policy called
 `SecurityHeadersPolicy` of its own, and deleting that stack leaves the managed one where it was.
 
-A Behavior's `ResponseHeadersPolicyId` is still checked when the Distribution is created or updated.
-An ID that is neither managed nor created here, whether mistyped or taken from a real account, fails
-the Stack there. The alternative would be a successful deploy that fails the first request reaching
-the Behavior.
+A CloudFormation Distribution whose Behavior names a policy that is neither managed nor created here
+deploys without one. The `ResponseHeadersPolicyId` lands on `stack.ignoredProperties` under that
+Behavior, and the Behavior serves every response without the headers the policy would have set. A
+template naming a policy from a real account, or one another stack created, is ordinary, and a site
+that failed to deploy over a set of headers would cost a local dev server and a test suite every
+request they make. One Behavior losing its policy leaves the others holding theirs, and a path
+Behavior is recorded under its `PathPattern`, the way a skipped Lambda@Edge association is.
+
+`CreateDistribution` and `UpdateDistribution` still refuse the same ID, as real CloudFront refuses
+it.
 
 ## Origin access controls
 

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
@@ -12,6 +12,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCloudFrontDistributionConfig } from "../../command/create-distribution/create-distribution.command.js";
 import { SimCfnCfDistroConfigValidator } from "./sim-cfn-cf-distro-config-validator.js";
 import { simCfnCfDistroWithRunnableEdgeAssociations } from "./sim-cfn-cf-distro-edge-associations.js";
+import { simCfnCfDistroWithHeldResponseHeadersPolicies } from "./sim-cfn-cf-distro-response-headers-policy.js";
 import { simCfnCfDistroWithoutAbsentWebAcl } from "./sim-cfn-cf-distro-web-acl.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
 
@@ -23,11 +24,12 @@ interface SimCfnCfDistroCreatorProperties {
  * Creates simulated CloudFront Distributions from CloudFormation Resources.
  *
  * A `WebACLId` naming a web ACL this simulation does not hold is left out and
- * recorded, and so is a Lambda@Edge association it cannot run. CloudFront has
- * no association Resource for either, so both live on the Distribution itself,
- * and refusing one would take the Distribution down over something that was
- * never the point of the template. The site a local dev server and a suite of
- * tests make requests to has to survive that.
+ * recorded, and so are a Lambda@Edge association it cannot run and a
+ * `ResponseHeadersPolicyId` naming a policy it does not hold. CloudFront has no
+ * Resource of its own for any of the three, so all of them live on the
+ * Distribution itself, and refusing one would take the Distribution down over
+ * something that was never the point of the template. The site a local dev
+ * server and a suite of tests make requests to has to survive that.
  */
 export class SimCfnCfDistroCreator {
   private readonly cloudFront: SimCloudFront;
@@ -66,6 +68,7 @@ export class SimCfnCfDistroCreator {
           resource,
           validator.validate(),
           context.simAws,
+          this.cloudFront,
         ),
       },
     });
@@ -95,13 +98,18 @@ function deployableConfig(
   resource: SimCfnResource,
   distributionConfig: SimCloudFrontDistributionConfig,
   simAws: SimAws,
+  cloudFront: SimCloudFront,
 ): SimCloudFrontDistributionConfig {
   return simCfnCfDistroWithoutAbsentWebAcl(
     resource,
-    simCfnCfDistroWithRunnableEdgeAssociations(
+    simCfnCfDistroWithHeldResponseHeadersPolicies(
       resource,
-      distributionConfig,
-      simAws,
+      simCfnCfDistroWithRunnableEdgeAssociations(
+        resource,
+        distributionConfig,
+        simAws,
+      ),
+      cloudFront,
     ),
     simAws,
   );

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-policy.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-policy.iso.test.ts
@@ -1,0 +1,265 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { grantPublicObjectRead } from "../../../s3/bucket/sim-s3-public-read.fixture.js";
+import { SimCloudFrontInvalidResponseHeadersPolicyId } from "../../error/sim-cloudfront.error.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { simCfManagedResponseHeadersPolicyIds } from "../../response-headers-policy/sim-cf-managed-response-headers-policies.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteRequest,
+} from "../../../../../test/cloudfront/site-fixture.js";
+
+const bucketName = "held-policy-site-bucket";
+
+/**
+ * An ID that is neither a managed policy nor one a template created here,
+ * which is what a policy ID from a real account looks like.
+ */
+const absentPolicyId = "11111111-2222-3333-4444-555555555555";
+
+/** The pages the Distribution serves, keyed by Object key. */
+const sitePages: Record<string, string> = {
+  "index.html": "<h1>Home</h1>",
+  "images/logo.html": "<img />",
+};
+
+/**
+ * A template with a policy of its own and a Distribution, with the Behaviors
+ * the test is about merged over the default one.
+ */
+function siteTemplate(
+  distributionConfig: SimCfnTemplateValueRecord = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: bucketName },
+      },
+      CacheHeaders: {
+        Type: "AWS::CloudFront::ResponseHeadersPolicy",
+        Properties: {
+          ResponseHeadersPolicyConfig: {
+            Name: "CacheHeaders",
+            CustomHeadersConfig: {
+              Items: [{ Header: "X-Site", Value: "held", Override: true }],
+            },
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "CacheHeaders"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Enabled: true,
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: `${bucketName}.s3.amazonaws.com`,
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              ResponseHeadersPolicyId: absentPolicyId,
+            },
+            ...distributionConfig,
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("CloudFormation Distribution on an absent response headers policy", () => {
+  async function deployedSite(
+    distributionConfig: SimCfnTemplateValueRecord = {},
+  ): Promise<{
+    simAws: SimAws;
+    distributionId: string;
+    ignoredPaths: readonly string[];
+    ignoredReasons: readonly string[];
+  }> {
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "held-policy-stack",
+      template: siteTemplate(distributionConfig),
+    });
+
+    await stack.waitForDeployComplete();
+
+    // The template creates the Bucket, so the pages go in after the deploy.
+    await grantPublicObjectRead(simAws.s3(), bucketName);
+
+    await Promise.all(
+      Object.entries(sitePages).map(
+        async ([key, body]) =>
+          await simAws.s3().putObject(
+            new PutObjectCommand({
+              Bucket: bucketName,
+              Key: key,
+              ContentType: "text/html",
+              Body: body,
+            }),
+          ),
+      ),
+    );
+
+    const resource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+
+    return {
+      simAws,
+      distributionId: resource.simResource.distributionId,
+      ignoredPaths: stack.ignoredProperties.map((ignored) => ignored.path),
+      ignoredReasons: stack.ignoredProperties.map((ignored) => ignored.reason),
+    };
+  }
+
+  it("deploys and serves a Distribution whose policy is not here", async () => {
+    // Given a template naming a policy from some real account.
+    // When the stack is deployed.
+    const { simAws, distributionId } = await deployedSite();
+
+    // Then the site is up, rather than the Distribution taking the stack down
+    // over a set of headers.
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    assertIdentical(home.status, 200);
+    assertIdentical(home.headers.get("x-site"), null);
+  });
+
+  it("records the dropped policy under the Behavior that named it", async () => {
+    // Given the same template.
+    const { ignoredPaths, ignoredReasons } = await deployedSite();
+
+    // Then one property is recorded, naming the Behavior and the policy ID, so
+    // a test that cares about the headers can read why they never arrived.
+    assertArrayLength(ignoredPaths, 1);
+    assertIdentical(
+      ignoredPaths[0],
+      "DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId",
+    );
+    assertStringIncludes(ignoredReasons[0] ?? "", absentPolicyId);
+  });
+
+  it("leaves the other Behaviors of the same Distribution holding theirs", async () => {
+    // Given a Distribution whose path Behavior names a policy that is here and
+    // whose default Behavior names one that is not.
+    const { simAws, distributionId, ignoredPaths } = await deployedSite({
+      CacheBehaviors: [
+        {
+          PathPattern: "/images/*",
+          TargetOriginId: "SiteOrigin",
+          ViewerProtocolPolicy: "allow-all",
+          ResponseHeadersPolicyId: { Ref: "CacheHeaders" },
+        },
+      ],
+    });
+
+    // Then only the default Behavior lost its policy.
+    assertArrayLength(ignoredPaths, 1);
+    assertIdentical(
+      ignoredPaths[0],
+      "DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId",
+    );
+
+    // And the path Behavior still sets the header its policy names.
+    const logo = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/images/logo.html",
+    );
+
+    assertIdentical(logo.headers.get("x-site"), "held");
+  });
+
+  it("records a path Behavior under its PathPattern", async () => {
+    // Given a path Behavior naming a policy that is not here.
+    const { ignoredPaths } = await deployedSite({
+      CacheBehaviors: [
+        {
+          PathPattern: "/images/*",
+          TargetOriginId: "SiteOrigin",
+          ViewerProtocolPolicy: "allow-all",
+          ResponseHeadersPolicyId: absentPolicyId,
+        },
+      ],
+    });
+
+    // Then it is recorded in the terms the template wrote it in, the way a
+    // skipped Lambda@Edge association is.
+    assertArrayLength(ignoredPaths, 2);
+    assertIdentical(
+      ignoredPaths[1],
+      "DistributionConfig.CacheBehaviors./images/*.ResponseHeadersPolicyId",
+    );
+  });
+
+  it("keeps a managed policy, which is one this simulation holds", async () => {
+    // Given a Behavior naming SecurityHeadersPolicy.
+    const { simAws, distributionId, ignoredPaths } = await deployedSite({
+      DefaultCacheBehavior: {
+        TargetOriginId: "SiteOrigin",
+        ViewerProtocolPolicy: "allow-all",
+        ResponseHeadersPolicyId:
+          simCfManagedResponseHeadersPolicyIds.securityHeaders,
+      },
+    });
+
+    // Then nothing is dropped and the policy is applied.
+    assertArrayLength(ignoredPaths, 0);
+
+    const home = await simCfSiteRequest(simAws, distributionId, "/");
+
+    assertIdentical(home.headers.get("x-frame-options"), "SAMEORIGIN");
+  });
+
+  it("still refuses the same policy ID on CreateDistribution", async () => {
+    // Given a simulation holding no such policy.
+    const simAws = new SimAws();
+
+    await simCfSiteBucket(simAws, "create-refusal-bucket", {});
+
+    // When the SDK command names it, then it is refused, as real CloudFront
+    // refuses it. Only a Distribution deployed from a template is let through.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: simCfSiteDistributionConfig(
+            "create-refusal-bucket",
+            {
+              DefaultCacheBehavior: {
+                TargetOriginId: "site-origin",
+                ViewerProtocolPolicy: "allow-all",
+                ResponseHeadersPolicyId: absentPolicyId,
+              },
+            },
+          ),
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimCloudFrontInvalidResponseHeadersPolicyId);
+    assertStringIncludes(error.message, absentPolicyId);
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-policy.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-policy.ts
@@ -1,0 +1,139 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCloudFrontCacheBehaviorConfig,
+  SimCloudFrontDistributionConfig,
+} from "../../command/create-distribution/create-distribution.command.js";
+import { normalizeSimCfList } from "../../command/create-distribution/sim-cf-normalize-list.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+
+/**
+ * The path a dropped policy on the default Behavior is recorded under.
+ */
+const defaultBehaviorPath = "DistributionConfig.DefaultCacheBehavior";
+
+/**
+ * Takes a `ResponseHeadersPolicyId` naming a policy this simulation does not
+ * hold off the Behavior that named it, and records each one.
+ */
+class SimCfnCfDistroPolicyDrops {
+  public count = 0;
+
+  constructor(
+    private readonly resource: SimCfnResource,
+    private readonly cloudFront: SimCloudFront,
+  ) {}
+
+  /**
+   * One Behavior, keeping a policy that is here and dropping one that is not.
+   */
+  heldPolicy(
+    behavior: SimCloudFrontCacheBehaviorConfig,
+    behaviorPath: string,
+  ): SimCloudFrontCacheBehaviorConfig {
+    const policyId = behavior.ResponseHeadersPolicyId;
+
+    if (
+      policyId === undefined ||
+      this.cloudFront.getResponseHeadersPolicyById(policyId) !== undefined
+    ) {
+      return behavior;
+    }
+
+    this.count += 1;
+    this.resource.ignoreProperty(
+      `${behaviorPath}.ResponseHeadersPolicyId`,
+      `response headers policy ${policyId} is not held by this simulation, ` +
+        `so the Behavior is deployed without one and serves every response ` +
+        `without the headers that policy would have set`,
+    );
+
+    return { ...behavior, ResponseHeadersPolicyId: undefined };
+  }
+}
+
+/**
+ * The DistributionConfig to deploy, without a `ResponseHeadersPolicyId` naming
+ * a response headers policy this simulation does not hold.
+ *
+ * `CreateDistribution` refuses such an ID, as real CloudFront refuses one, and
+ * a Distribution deployed from a template is the one place that refusal costs
+ * more than it is worth. A stack naming a policy from a real account is
+ * ordinary, and so is one naming a policy another stack created. Neither says
+ * anything about the site the Distribution serves, and a Distribution that
+ * failed to deploy takes every request a local dev server and a test suite
+ * make with it. That is the same reason an absent `WebACLId` is left out here.
+ *
+ * So the property is left off that Behavior and recorded on
+ * `stack.ignoredProperties`. The Behavior deploys and serves every response
+ * without the policy's headers. A test that cares reads the record.
+ *
+ * One Behavior losing its policy leaves the others holding theirs. CloudFront's
+ * managed policies count as held, so a Behavior naming one keeps it.
+ */
+export function simCfnCfDistroWithHeldResponseHeadersPolicies(
+  resource: SimCfnResource,
+  distributionConfig: SimCloudFrontDistributionConfig,
+  cloudFront: SimCloudFront,
+): SimCloudFrontDistributionConfig {
+  const drops = new SimCfnCfDistroPolicyDrops(resource, cloudFront);
+  const defaultCacheBehavior = distroDefaultBehavior(drops, distributionConfig);
+  const cacheBehaviors = distroCacheBehaviors(drops, distributionConfig);
+
+  if (drops.count === 0) {
+    return distributionConfig;
+  }
+
+  return {
+    ...distributionConfig,
+    DefaultCacheBehavior: defaultCacheBehavior,
+    CacheBehaviors: cacheBehaviors,
+  };
+}
+
+/**
+ * The default cache Behavior, without a policy that is not here.
+ */
+function distroDefaultBehavior(
+  drops: SimCfnCfDistroPolicyDrops,
+  distributionConfig: SimCloudFrontDistributionConfig,
+): SimCloudFrontCacheBehaviorConfig | undefined {
+  const behavior = distributionConfig.DefaultCacheBehavior;
+
+  if (behavior === undefined) {
+    return undefined;
+  }
+
+  return drops.heldPolicy(behavior, defaultBehaviorPath);
+}
+
+/**
+ * Every path-based cache Behavior, each without a policy that is not here.
+ *
+ * A Behavior is recorded under its `PathPattern`, in the terms the template
+ * wrote it in, the way a skipped Lambda@Edge association is. Its position is
+ * the fallback for a hand-written entry that left the pattern out.
+ */
+function distroCacheBehaviors(
+  drops: SimCfnCfDistroPolicyDrops,
+  distributionConfig: SimCloudFrontDistributionConfig,
+): SimCloudFrontDistributionConfig["CacheBehaviors"] {
+  const behaviors = normalizeSimCfList<SimCloudFrontCacheBehaviorConfig>(
+    "CacheBehaviors",
+    distributionConfig.CacheBehaviors,
+  );
+  const items = behaviors?.Items;
+
+  if (items === undefined) {
+    return distributionConfig.CacheBehaviors;
+  }
+
+  return {
+    ...behaviors,
+    Items: items.map((behavior, index) =>
+      drops.heldPolicy(
+        behavior,
+        `DistributionConfig.CacheBehaviors.${behavior.PathPattern ?? String(index)}`,
+      ),
+    ),
+  };
+}

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-sections.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-sections.iso.test.ts
@@ -4,8 +4,6 @@ import {
   assertInstanceOf,
   assertNonNullable,
   assertResponseStatus,
-  assertStringIncludes,
-  assertThrowsErrorAsync,
   describeResponse,
 } from "@kensio/smartass";
 import { PutObjectCommand } from "@aws-sdk/client-s3";
@@ -201,36 +199,5 @@ describe("CloudFormation Distribution response headers policy sections", () => {
     // Then none of the CORS headers are added, as CloudFront sends none
     // rather than a mismatched one.
     assertIdentical(home.headers.get("access-control-allow-origin"), null);
-  });
-
-  it("fails the stack for a Behavior naming a response headers policy that does not exist", async () => {
-    // Given a Distribution whose default Behavior names an ID that is neither
-    // a managed policy nor one this simulation created, which is what a policy
-    // ID from a real account is here.
-    const simAws = new SimAws();
-
-    // When the template is deployed, then it fails at deploy time rather than
-    // deploying successfully and only failing the first request that reaches
-    // the Behavior.
-    const error = await assertThrowsErrorAsync(async () => {
-      const stack = await simAws.cloudFormation().deployTemplate({
-        stackName: "missing-policy-stack",
-        template: siteTemplate(
-          { Name: "CacheHeaders" },
-          {
-            DefaultCacheBehavior: {
-              TargetOriginId: "SiteOrigin",
-              ViewerProtocolPolicy: "redirect-to-https",
-              ResponseHeadersPolicyId: "11111111-2222-3333-4444-555555555555",
-            },
-          },
-        ),
-      });
-
-      await stack.waitForDeployComplete();
-    });
-
-    assertStringIncludes(error.message, "11111111-2222-3333-4444-555555555555");
-    assertStringIncludes(error.message, "does not exist");
   });
 });


### PR DESCRIPTION
A CloudFormation Distribution whose cache Behavior names a response headers policy this simulation does not hold now deploys without one, in place of failing the Resource and taking the stack down with it. The `ResponseHeadersPolicyId` lands on `stack.ignoredProperties` under that Behavior, and the Behavior serves every response without the headers the policy would have set. This is the treatment an absent `WebACLId` and an unrunnable Lambda@Edge association already get on the same Resource, and for the same reason: a template naming a policy from a real account is ordinary, and a site that failed to deploy over a set of headers costs a local dev server and a test suite every request they make. `CreateDistribution` and `UpdateDistribution` keep refusing the same ID.

Resolves #974

## Notes for the reviewer

`simCfnCfDistroWithHeldResponseHeadersPolicies` follows `simCfnCfDistroWithRunnableEdgeAssociations` rather than the web ACL filter, because a policy sits on each Behavior instead of on the DistributionConfig. A path Behavior is recorded under its `PathPattern` for the same reason a skipped association is, with its position as the fallback for a hand-written entry that left the pattern out. The filter takes the `SimCloudFront` the creator is deploying into, not `simAws.cloudFront()`, so the registry it reads is the one `CreateDistribution` is about to check against.

`sim-cfn-cf-distro-response-headers-sections.iso.test.ts` loses its "fails the stack" test, which asserted the behaviour this changes. The deploy-time cases now live in the new file, along with a `CreateDistribution` refusal so the SDK-level check stays covered. That file was already at the line count its own docstring mentions, so the new cases went next door rather than into it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CloudFormation CloudFront distributions can now deploy when they reference unavailable response headers policies.
  - Unsupported policies are omitted, recorded as ignored properties, and distributions continue serving without those headers.
  - Managed policies and policies created during the current simulation remain supported.
  - Both default and path-based cache behaviors are handled consistently.

- **Bug Fixes**
  - Direct distribution creation and updates continue to reject unavailable policy IDs as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->