### PR TITLE
fix: send CORS preflight headers to a preflight

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1960,6 +1960,13 @@ them, matching CloudFront, which sends none in preference to a mismatched one.
 `AccessControlAllowCredentials: false` leaves `Access-Control-Allow-Credentials` off entirely, since
 a header naming `false` means the same as its absence to a browser.
 
+`AccessControlAllowMethods`, `AccessControlAllowHeaders` and `AccessControlMaxAgeSec` answer what a
+preflight asks, and their headers go on a response to an `OPTIONS` request alone. Every other method
+is answered without them, as CloudFront answers it. `Access-Control-Allow-Origin`,
+`Access-Control-Allow-Credentials` and `Access-Control-Expose-Headers` come back either way, and so
+does the `Vary: Origin` a reflected Origin carries. A list left empty sends no header at all, which
+is how `SimpleCORS` answers with the Origin header by itself.
+
 An allow-list entry may use the wildcard on its own, meaning every Origin, or as the leftmost
 subdomain, so `*.example.org` matches `https://site.example.org`. It stands for exactly one label, as
 a wildcard certificate does, and it leaves `https://deep.site.example.org` unmatched. An entry naming
@@ -2758,10 +2765,6 @@ Where sim CloudFront knowingly behaves differently from AWS:
   share of real responses carry `Server-Timing`. This simulation adds it to every response once
   `Enabled` is true. A test asserting on it never depends on chance. The header's value is a
   fixed placeholder, since nothing here measures an Origin fetch the way CloudFront's edge does.
-- **A CORS section sends its preflight headers on every request.** Real CloudFront puts
-  `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` and `Access-Control-Max-Age` on a
-  preflight response alone. This simulation puts them on every response the Behavior serves. A list
-  left empty sends no header at all, so `SimpleCORS` still answers with the Origin header by itself.
 - **`CachePolicyId` and `OriginRequestPolicyId` are accepted and ignored.** Sim CloudFront models no
   edge caching. A Behavior's cache policy, including an AWS managed policy such as
   `CachingOptimized`, is left unvalidated and unapplied to TTLs and the cache key. Every request

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-sections.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-response-headers-sections.iso.test.ts
@@ -166,16 +166,28 @@ describe("CloudFormation Distribution response headers policy sections", () => {
       headers: { Origin: "https://example.com" },
     });
 
-    // Then the CORS headers name it, and the response varies on Origin.
+    // Then the CORS headers name it, and the response varies on Origin. The
+    // method list stays off a simple request, which is where CloudFront keeps
+    // it.
     assertIdentical(
       home.headers.get("access-control-allow-origin"),
       "https://example.com",
     );
+    assertIdentical(home.headers.get("access-control-allow-methods"), null);
+    assertIdentical(home.headers.get("vary"), "Origin");
+
+    // And a preflight to the same page is answered with the method and header
+    // lists it asked for.
+    const preflight = await simCfSiteRequest(simAws, distributionId, "/", {
+      method: "OPTIONS",
+      headers: { Origin: "https://example.com" },
+    });
+
     assertIdentical(
-      home.headers.get("access-control-allow-methods"),
+      preflight.headers.get("access-control-allow-methods"),
       "GET,HEAD",
     );
-    assertIdentical(home.headers.get("vary"), "Origin");
+    assertIdentical(preflight.headers.get("access-control-allow-headers"), "*");
   });
 
   it("omits a policy's CORS headers for an Origin it does not allow", async () => {

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-cors-config.iso.test.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-cors-config.iso.test.ts
@@ -45,10 +45,11 @@ describe("simCfnCfResponseHeadersPolicyCors", () => {
       OriginOverride: true,
     });
 
-    // Then applying it for the allowed Origin sets every header the section
-    // names.
+    // Then applying it to a preflight from the allowed Origin sets every
+    // header the section names. The method, header and max-age lists answer
+    // what a preflight asks, so only an OPTIONS request sees them.
     const headers = new Headers();
-    cors.apply(headers, "https://example.com");
+    cors.apply(headers, "https://example.com", "OPTIONS");
 
     assertIdentical(
       headers.get("access-control-allow-origin"),

--- a/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.ts
+++ b/src/service/cloudfront/controller/response-headers/sim-cf-response-headers-applicator.ts
@@ -39,6 +39,10 @@ export class SimCfResponseHeadersApplicator {
       );
     }
 
-    return policy.apply(response, request.headers.get("origin"));
+    return policy.apply(
+      response,
+      request.headers.get("origin"),
+      request.method,
+    );
   }
 }

--- a/src/service/cloudfront/response-headers-policy/sim-cf-managed-response-headers-policies.iso.test.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-managed-response-headers-policies.iso.test.ts
@@ -18,6 +18,7 @@ describe("Managed CloudFront response headers policies", () => {
     policyId: string,
     originHeaders: Record<string, string> = {},
     requestOrigin: string | null = null,
+    requestMethod = "GET",
   ): Headers {
     const policy = new SimCloudFrontResponseHeadersPolicyRegistry().byId(
       policyId,
@@ -28,6 +29,7 @@ describe("Managed CloudFront response headers policies", () => {
     return policy.apply(
       new Response("body", { headers: originHeaders }),
       requestOrigin,
+      requestMethod,
     ).headers;
   }
 
@@ -108,13 +110,14 @@ describe("Managed CloudFront response headers policies", () => {
     assertIdentical(headers.get("access-control-expose-headers"), null);
   });
 
-  it("names every method CORS-With-Preflight allows", () => {
+  it("names every method CORS-With-Preflight allows, on a preflight", () => {
     // Given a Behavior on CORS-With-Preflight.
-    // When a request naming an Origin passes through it.
+    // When a preflight naming an Origin passes through it.
     const headers = served(
       simCfManagedResponseHeadersPolicyIds.corsWithPreflight,
       {},
       "https://app.example.com",
+      "OPTIONS",
     );
 
     // Then the method list and the wildcard expose list come with the Origin.
@@ -124,6 +127,22 @@ describe("Managed CloudFront response headers policies", () => {
       "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT",
     );
     assertIdentical(headers.get("access-control-expose-headers"), "*");
+  });
+
+  it("holds the method list back from a simple CORS-With-Preflight request", () => {
+    // Given a Behavior on CORS-With-Preflight.
+    // When a plain GET naming an Origin passes through it.
+    const headers = served(
+      simCfManagedResponseHeadersPolicyIds.corsWithPreflight,
+      {},
+      "https://app.example.com",
+    );
+
+    // Then the Origin and the expose list come back without the method list,
+    // which is what AWS documents for a simple CORS request.
+    assertIdentical(headers.get("access-control-allow-origin"), "*");
+    assertIdentical(headers.get("access-control-expose-headers"), "*");
+    assertIdentical(headers.get("access-control-allow-methods"), null);
   });
 
   it("combines both sections in CORS-and-SecurityHeadersPolicy", () => {

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.iso.test.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.iso.test.ts
@@ -81,7 +81,11 @@ describe("SimCloudFrontResponseHeadersPolicyCors", () => {
     // Given a policy allowing every method.
     const headers = new Headers();
 
-    cors({ allowMethods: ["ALL"] }).apply(headers, "https://example.com");
+    cors({ allowMethods: ["ALL"] }).apply(
+      headers,
+      "https://example.com",
+      "OPTIONS",
+    );
 
     // Then the header names every method CloudFront documents for ALL.
     assertIdentical(
@@ -183,5 +187,69 @@ describe("SimCloudFrontResponseHeadersPolicyCors", () => {
       "https://app.example.com",
     );
     assertIdentical(headers.get("vary"), "Origin");
+  });
+
+  it("holds the preflight headers back from a simple request", () => {
+    // Given a policy naming methods, headers and a max age.
+    const headers = new Headers();
+
+    // When a plain GET from the allowed Origin passes through it.
+    cors({
+      allowHeaders: ["X-Custom"],
+      allowMethods: ["GET", "POST"],
+      maxAgeSec: 600,
+    }).apply(headers, "https://example.com");
+
+    // Then the three a preflight asks for stay off. CloudFront documents each
+    // against a preflight request, and a browser reads none of them here.
+    assertIdentical(headers.get("access-control-allow-methods"), null);
+    assertIdentical(headers.get("access-control-allow-headers"), null);
+    assertIdentical(headers.get("access-control-max-age"), null);
+  });
+
+  it("answers a preflight with the methods, headers and max age", () => {
+    // Given the same policy.
+    const headers = new Headers();
+
+    // When an OPTIONS request from the allowed Origin passes through it.
+    cors({
+      allowHeaders: ["X-Custom"],
+      allowMethods: ["GET", "POST"],
+      maxAgeSec: 600,
+    }).apply(headers, "https://example.com", "OPTIONS");
+
+    // Then all three come back.
+    assertIdentical(headers.get("access-control-allow-methods"), "GET,POST");
+    assertIdentical(headers.get("access-control-allow-headers"), "X-Custom");
+    assertIdentical(headers.get("access-control-max-age"), "600");
+  });
+
+  it("sends the Origin, credentials and expose list on either kind", () => {
+    // Given a policy allowing credentials and exposing a header.
+    const properties = {
+      allowCredentials: true,
+      exposeHeaders: ["X-Request-Id"],
+    };
+    const simple = new Headers();
+    const preflight = new Headers();
+
+    // When a simple request and a preflight each pass through it.
+    cors(properties).apply(simple, "https://example.com");
+    cors(properties).apply(preflight, "https://example.com", "OPTIONS");
+
+    // Then the headers CloudFront documents against CORS requests generally
+    // are on both, including the cache Vary.
+    for (const headers of [simple, preflight]) {
+      assertIdentical(
+        headers.get("access-control-allow-origin"),
+        "https://example.com",
+      );
+      assertIdentical(headers.get("access-control-allow-credentials"), "true");
+      assertIdentical(
+        headers.get("access-control-expose-headers"),
+        "X-Request-Id",
+      );
+      assertIdentical(headers.get("vary"), "Origin");
+    }
   });
 });

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.iso.test.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.iso.test.ts
@@ -252,4 +252,31 @@ describe("SimCloudFrontResponseHeadersPolicyCors", () => {
       assertIdentical(headers.get("vary"), "Origin");
     }
   });
+
+  it("leaves an Origin's own preflight headers on a simple response", () => {
+    // Given a policy that overrides the Origin, and an Origin answering a
+    // simple request with CORS headers of its own.
+    const headers = new Headers({
+      "Access-Control-Allow-Methods": "GET",
+      "Access-Control-Max-Age": "60",
+    });
+
+    cors({
+      allowMethods: ["GET", "POST"],
+      maxAgeSec: 600,
+      originOverride: true,
+    }).apply(headers, "https://example.com");
+
+    // Then the policy sets the Origin header it decides and passes the rest
+    // through. `OriginOverride` decides which value wins where the policy sets
+    // a header, and `RemoveHeadersConfig` is the only thing that takes one
+    // away. A CORS section that dropped them here would strip a header the
+    // site sent for itself.
+    assertIdentical(
+      headers.get("access-control-allow-origin"),
+      "https://example.com",
+    );
+    assertIdentical(headers.get("access-control-allow-methods"), "GET");
+    assertIdentical(headers.get("access-control-max-age"), "60");
+  });
 });

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy-cors.ts
@@ -67,15 +67,22 @@ export class SimCloudFrontResponseHeadersPolicyCors {
   }
 
   /**
-   * Set this policy's CORS headers on a response, for the `Origin` header a
-   * viewer request carried.
+   * Set this policy's CORS headers on a response, for the `Origin` header and
+   * the method a viewer request carried.
    *
    * `OriginOverride` decides the whole section rather than one header at a
    * time, unlike a custom or security header: without it, an Origin response
    * carrying any CORS header at all keeps every header this section would have
    * set off the response, whether or not the policy names that header.
+   *
+   * The method defaults to `GET`, which is to say a simple request. Only a
+   * caller with an `OPTIONS` request in hand needs to say so.
    */
-  apply(headers: Headers, requestOrigin: string | null): void {
+  apply(
+    headers: Headers,
+    requestOrigin: string | null,
+    requestMethod = "GET",
+  ): void {
     if (
       !this.originOverride &&
       corsResponseHeaders.some((n) => headers.has(n))
@@ -98,20 +105,6 @@ export class SimCloudFrontResponseHeadersPolicyCors {
       headers.append("Vary", "Origin");
     }
 
-    // An empty list names no method and no header. CloudFront leaves the
-    // header off there, the way it leaves off the expose list below, and a
-    // header carrying an empty value would mean something else to a browser.
-    if (this.allowMethods.length > 0) {
-      headers.set(
-        "Access-Control-Allow-Methods",
-        this.resolvedAllowMethods().join(","),
-      );
-    }
-
-    if (this.allowHeaders.length > 0) {
-      headers.set("Access-Control-Allow-Headers", this.allowHeaders.join(","));
-    }
-
     // A false Access-Control-Allow-Credentials is not a header value the
     // fetch spec recognises, so CloudFront leaves it off rather than sending
     // a value meaning the same as absence.
@@ -124,6 +117,34 @@ export class SimCloudFrontResponseHeadersPolicyCors {
         "Access-Control-Expose-Headers",
         this.exposeHeaders.join(","),
       );
+    }
+
+    if (requestMethod === "OPTIONS") {
+      this.applyPreflight(headers);
+    }
+  }
+
+  /**
+   * Set the headers CloudFront documents against a preflight request alone.
+   *
+   * `AccessControlAllowMethods`, `AccessControlAllowHeaders` and
+   * `AccessControlMaxAgeSec` each answer the question a preflight asks, and a
+   * browser reads none of them off a simple request.
+   *
+   * An empty list names no method and no header. CloudFront leaves the header
+   * off there, the way it leaves off the expose list, and a header carrying an
+   * empty value would mean something else to a browser.
+   */
+  private applyPreflight(headers: Headers): void {
+    if (this.allowMethods.length > 0) {
+      headers.set(
+        "Access-Control-Allow-Methods",
+        this.resolvedAllowMethods().join(","),
+      );
+    }
+
+    if (this.allowHeaders.length > 0) {
+      headers.set("Access-Control-Allow-Headers", this.allowHeaders.join(","));
     }
 
     if (this.maxAgeSec !== undefined) {

--- a/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.ts
+++ b/src/service/cloudfront/response-headers-policy/sim-cf-response-headers-policy.ts
@@ -50,12 +50,20 @@ export class SimCloudFrontResponseHeadersPolicy {
 
   /**
    * Return the response this policy makes of one the Origin gave back, for
-   * the `Origin` header the viewer request carried.
+   * the `Origin` header and the method the viewer request carried.
    *
    * The body is passed straight through. Only the headers change, so a response
    * whose body has already been read stays readable.
+   *
+   * The method reaches the CORS section alone, which answers a preflight with
+   * headers a simple request never sees. Every other section sets the same
+   * headers whatever the viewer asked for.
    */
-  apply(response: Response, requestOrigin: string | null = null): Response {
+  apply(
+    response: Response,
+    requestOrigin: string | null = null,
+    requestMethod = "GET",
+  ): Response {
     const headers = new Headers(response.headers);
 
     for (const headerName of this.headersToRemove) {
@@ -71,7 +79,7 @@ export class SimCloudFrontResponseHeadersPolicy {
     }
 
     this.serverTiming?.applyTo(headers);
-    this.cors?.apply(headers, requestOrigin);
+    this.cors?.apply(headers, requestOrigin, requestMethod);
 
     return new Response(response.body, {
       status: response.status,


### PR DESCRIPTION
A response headers policy's CORS section now puts `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` and `Access-Control-Max-Age` on a response to an `OPTIONS` request alone, which is where CloudFront documents all three. Every other method is answered without them, in place of carrying a method list no browser reads. `Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials` and `Access-Control-Expose-Headers` come back either way, and so does the `Vary: Origin` a reflected Origin carries. The viewer request's method reaches the section from the applicator, alongside the `Origin` header it already had.

Resolves #976

## Notes for the reviewer

`apply` takes the method as a third parameter defaulting to `GET`, on both `SimCloudFrontResponseHeadersPolicy` and its CORS section. The default says "a simple request", so only a caller holding an `OPTIONS` request states one, and the existing call sites that assert simple-request behaviour read the same as before.

Four tests asserted a method or header list on a simple request, which is the behaviour this changes. Two now pass `OPTIONS`, since a preflight is what they were really describing. The end-to-end one in `sim-cfn-cf-distro-response-headers-sections.iso.test.ts` asserts the split on both sides, with a second request through the same Distribution. The managed `CORS-With-Preflight` test gained a sibling covering the simple case.

`OPTIONS` is the whole test, following CloudFront's own wording. The fetch spec also wants an `Access-Control-Request-Method` header before it calls a request a preflight, and AWS documents the method by itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CORS behavior so preflight headers are returned only for `OPTIONS` requests.
  * Simple requests now retain applicable origin, credentials, exposed-header, and `Vary` headers without receiving preflight-only headers.
  * CORS method, header, and max-age headers are now handled correctly for preflight requests.

* **Documentation**
  * Updated CloudFront response-header policy documentation to describe the corrected CORS behavior.

* **Tests**
  * Expanded coverage for simple and preflight CORS requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->