### PR TITLE
feat: set up CloudWatch Logs delivery

### DIFF
--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -376,6 +376,11 @@ rules from real AWS are modelled here, each of them a deploy that looks fine unt
 - **One delivery source per resource.** A second source over a distribution that already has one
   fails with `ConflictException`, carrying the message an account gives, "This ResourceId has
   already been used in another Delivery Source in this account".
+- **A delivery holds both its ends.** Deleting the source or the destination while a delivery joins
+  them fails with `ConflictException`. The delivery goes first, and CloudFormation orders that
+  itself when a stack is deleted.
+- **CloudFront delivers `ACCESS_LOGS` and nothing else.** Any other `logType` over a distribution is
+  refused.
 - **CloudFront delivery is set up from `us-east-1`**, whatever region the destination bucket is in.
   A CloudFront delivery source put from anywhere else is refused.
 - **Output format is fixed once the destination exists.** A `PutDeliveryDestination` that would
@@ -385,7 +390,7 @@ rules from real AWS are modelled here, each of them a deploy that looks fine unt
 The suffix path decides the key each log file lands under. `{DistributionId}`, `{distributionid}`,
 `{yyyy}`, `{MM}`, `{dd}`, `{HH}` and `{accountid}` are substituted, and a variable outside that set
 is refused. Delivery would write the text out literally, and the bucket would look partitioned when
-it was not.
+it was not. A path over the 256 characters CloudWatch Logs takes is refused too.
 
 ### Declaring delivery in a template
 
@@ -422,9 +427,10 @@ The template carries the S3 layout as two flat properties, and the API takes the
 `Ref` resolves to the name on the source and the destination, and to the delivery ID on the
 delivery. CloudWatch Logs issues that ID. A template cannot predict it.
 
-`Fn::GetAtt` gives `Arn` on all three. The source also publishes `Service` and `ResourceArns`, the
-destination `DeliveryDestinationType`, and the delivery `DeliveryId`, `DeliverySourceName`,
-`DeliveryDestinationArn` and `DeliveryDestinationType`.
+`Fn::GetAtt` gives `Arn` on all three. The source also publishes `Service` and `ResourceArns`, and
+the delivery publishes `DeliveryId` and `DeliveryDestinationType`. The destination publishes nothing
+else, and `DeliveryDestinationType` is a property of it rather than an attribute, so read that one
+off the delivery. Anything outside this set is refused here, as CloudFormation refuses it.
 
 `Tags` and `DeliveryDestinationPolicy` are recorded as ignored properties, and the stack still
 deploys.
@@ -773,13 +779,13 @@ console.log(described.logGroups?.[0]?.logGroupArn);
   log group and the three delivery resource types are what simulated CloudFormation deploys here.
 - **Nothing is actually delivered.** A delivery records that a source was joined to a destination
   and how the records would be written. No access log file ever reaches the bucket.
-- **A delivery source can be deleted while a delivery still uses it.** Real CloudWatch Logs has its
-  own rule about the order, and this simulation does not model it.
 - **`GetDeliverySource`, `GetDeliveryDestination` and `GetDelivery`.** Absent. The three `Describe`
   operations report the same resources.
 - **Delivery resource tags and cross-account delivery.** `PutDeliverySource`,
   `PutDeliveryDestination` and `CreateDelivery` refuse tags outright. `DeliveryDestinationPolicy` in
   a template is recorded and acted on by nothing.
+- **Log types for services other than CloudFront.** Any `logType` is taken over a resource that is
+  not a distribution, because the valid set varies by service and this simulation does not carry it.
 - **Logs Insights, export tasks, tags, encryption and data protection policies.** Absent. Tags and
   `kmsKeyId` on `CreateLogGroup` are refused outright. A property cannot look set here and behave
   differently in an account.

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -301,6 +301,134 @@ Two divergences to know about:
   resource whose template entry changed is deleted and created again. The retention ends up correct,
   but the events the group held are gone, where a real update to `RetentionInDays` keeps them.
 
+## Delivering logs from another service
+
+CloudWatch Logs delivery carries the logs of another service somewhere. CloudFront standard logging
+v2 is the clearest case. A distribution has no logging property of its own, and turning logging on
+means three CloudWatch Logs resources.
+
+A delivery source names what is being logged and which of its logs. A delivery destination names
+where they land and in what form. A delivery joins one to the other.
+
+```typescript sim-logs-delivery
+/**
+ * Setting up CloudFront standard logging v2 delivery into a bucket.
+ */
+
+import {
+  CreateDeliveryCommand,
+  DescribeDeliveriesCommand,
+  PutDeliveryDestinationCommand,
+  PutDeliverySourceCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logs = simAws.logs();
+
+await logs.putDeliverySource(
+  new PutDeliverySourceCommand({
+    name: "site-access-logs",
+    resourceArn: "arn:aws:cloudfront::123456789012:distribution/E1EXAMPLE",
+    logType: "ACCESS_LOGS",
+  }),
+);
+
+const destination = await logs.putDeliveryDestination(
+  new PutDeliveryDestinationCommand({
+    name: "site-access-logs",
+    outputFormat: "json",
+    deliveryDestinationConfiguration: {
+      destinationResourceArn: "arn:aws:s3:::example-access-logs",
+    },
+  }),
+);
+
+await logs.createDelivery(
+  new CreateDeliveryCommand({
+    deliverySourceName: "site-access-logs",
+    deliveryDestinationArn: destination.deliveryDestination?.arn,
+    s3DeliveryConfiguration: {
+      suffixPath: "{DistributionId}/{yyyy}/{MM}/{dd}/{HH}",
+      enableHiveCompatiblePath: true,
+    },
+  }),
+);
+
+const deliveries = await logs.describeDeliveries(
+  new DescribeDeliveriesCommand({}),
+);
+
+// S3, and the layout the bucket will be partitioned by.
+console.log(
+  deliveries.deliveries?.[0]?.deliveryDestinationType,
+  deliveries.deliveries?.[0]?.s3DeliveryConfiguration?.suffixPath,
+);
+```
+
+The delivery destination has an ARN of its own, and `CreateDelivery` names that one. The bucket
+behind it keeps its own ARN, and the two are easy to mix up.
+
+The service a delivery source is for is read off the resource ARN. A caller never states it. Four
+rules from real AWS are modelled here, each of them a deploy that looks fine until it runs:
+
+- **One delivery source per resource.** A second source over a distribution that already has one
+  fails with `ConflictException`, carrying the message an account gives, "This ResourceId has
+  already been used in another Delivery Source in this account".
+- **CloudFront delivery is set up from `us-east-1`**, whatever region the destination bucket is in.
+  A CloudFront delivery source put from anywhere else is refused.
+- **Output format is fixed once the destination exists.** A `PutDeliveryDestination` that would
+  change it is refused. Changing a format means deleting the destination and making it again.
+- **Parquet is written to S3 only.** A log group or Firehose destination asking for it is refused.
+
+The suffix path decides the key each log file lands under. `{DistributionId}`, `{distributionid}`,
+`{yyyy}`, `{MM}`, `{dd}`, `{HH}` and `{accountid}` are substituted, and a variable outside that set
+is refused. Delivery would write the text out literally, and the bucket would look partitioned when
+it was not.
+
+### Declaring delivery in a template
+
+The same three resources in a template, which is the whole of what a CDK construct for CloudFront
+logging synthesises.
+
+```yaml
+AccessLogsSource:
+  Type: AWS::Logs::DeliverySource
+  Properties:
+    Name: site-access-logs
+    ResourceArn: arn:aws:cloudfront::123456789012:distribution/E1EXAMPLE
+    LogType: ACCESS_LOGS
+
+AccessLogsDestination:
+  Type: AWS::Logs::DeliveryDestination
+  Properties:
+    Name: site-access-logs
+    DestinationResourceArn: arn:aws:s3:::example-access-logs
+    OutputFormat: json
+
+AccessLogsDelivery:
+  Type: AWS::Logs::Delivery
+  Properties:
+    DeliverySourceName: !Ref AccessLogsSource
+    DeliveryDestinationArn: !GetAtt AccessLogsDestination.Arn
+    S3SuffixPath: "{DistributionId}/{yyyy}/{MM}/{dd}/{HH}"
+    S3EnableHiveCompatiblePath: true
+```
+
+The template carries the S3 layout as two flat properties, and the API takes them nested under
+`s3DeliveryConfiguration`.
+
+`Ref` resolves to the name on the source and the destination, and to the delivery ID on the
+delivery. CloudWatch Logs issues that ID. A template cannot predict it.
+
+`Fn::GetAtt` gives `Arn` on all three. The source also publishes `Service` and `ResourceArns`, the
+destination `DeliveryDestinationType`, and the delivery `DeliveryId`, `DeliverySourceName`,
+`DeliveryDestinationArn` and `DeliveryDestinationType`.
+
+`Tags` and `DeliveryDestinationPolicy` are recorded as ignored properties, and the stack still
+deploys.
+
 ## Subscription filters
 
 A subscription filter delivers the events matching its pattern to a Lambda function. Code written to
@@ -641,8 +769,17 @@ console.log(described.logGroups?.[0]?.logGroupArn);
 - **Metric filters.** Absent, so `metricFilterCount` is always zero.
 - **Subscription filter destinations other than Lambda**, and `Distribution`. `Distribution` is
   accepted and reported, and with no shards to spread across it has no effect.
-- **`AWS::Logs::SubscriptionFilter` and `AWS::Logs::MetricFilter`.** `AWS::Logs::LogGroup` is the
-  only CloudFormation resource type here, and the others are recorded as gaps.
+- **`AWS::Logs::SubscriptionFilter` and `AWS::Logs::MetricFilter`.** Both are recorded as gaps. The
+  log group and the three delivery resource types are what simulated CloudFormation deploys here.
+- **Nothing is actually delivered.** A delivery records that a source was joined to a destination
+  and how the records would be written. No access log file ever reaches the bucket.
+- **A delivery source can be deleted while a delivery still uses it.** Real CloudWatch Logs has its
+  own rule about the order, and this simulation does not model it.
+- **`GetDeliverySource`, `GetDeliveryDestination` and `GetDelivery`.** Absent. The three `Describe`
+  operations report the same resources.
+- **Delivery resource tags and cross-account delivery.** `PutDeliverySource`,
+  `PutDeliveryDestination` and `CreateDelivery` refuse tags outright. `DeliveryDestinationPolicy` in
+  a template is recorded and acted on by nothing.
 - **Logs Insights, export tasks, tags, encryption and data protection policies.** Absent. Tags and
   `kmsKeyId` on `CreateLogGroup` are refused outright. A property cannot look set here and behave
   differently in an account.

--- a/docs/services/logs/sim-logs-delivery.example.ts
+++ b/docs/services/logs/sim-logs-delivery.example.ts
@@ -1,0 +1,54 @@
+/**
+ * Setting up CloudFront standard logging v2 delivery into a bucket.
+ */
+
+import {
+  CreateDeliveryCommand,
+  DescribeDeliveriesCommand,
+  PutDeliveryDestinationCommand,
+  PutDeliverySourceCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logs = simAws.logs();
+
+await logs.putDeliverySource(
+  new PutDeliverySourceCommand({
+    name: "site-access-logs",
+    resourceArn: "arn:aws:cloudfront::123456789012:distribution/E1EXAMPLE",
+    logType: "ACCESS_LOGS",
+  }),
+);
+
+const destination = await logs.putDeliveryDestination(
+  new PutDeliveryDestinationCommand({
+    name: "site-access-logs",
+    outputFormat: "json",
+    deliveryDestinationConfiguration: {
+      destinationResourceArn: "arn:aws:s3:::example-access-logs",
+    },
+  }),
+);
+
+await logs.createDelivery(
+  new CreateDeliveryCommand({
+    deliverySourceName: "site-access-logs",
+    deliveryDestinationArn: destination.deliveryDestination?.arn,
+    s3DeliveryConfiguration: {
+      suffixPath: "{DistributionId}/{yyyy}/{MM}/{dd}/{HH}",
+      enableHiveCompatiblePath: true,
+    },
+  }),
+);
+
+const deliveries = await logs.describeDeliveries(
+  new DescribeDeliveriesCommand({}),
+);
+
+// S3, and the layout the bucket will be partitioned by.
+console.log(
+  deliveries.deliveries?.[0]?.deliveryDestinationType,
+  deliveries.deliveries?.[0]?.s3DeliveryConfiguration?.suffixPath,
+);

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-cfn-value-adapter.ts
@@ -1,8 +1,14 @@
+import { SimLogsDeliveryDestination } from "../../../../logs/delivery/sim-logs-delivery-destination.js";
+import { SimLogsDeliverySource } from "../../../../logs/delivery/sim-logs-delivery-source.js";
+import { SimLogsDelivery } from "../../../../logs/delivery/sim-logs-delivery.js";
 import { SimLogsLogGroup } from "../../../../logs/group/sim-logs-log-group.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
 } from "../sim-cfn-resource-value-adapter.js";
+import { SimLogsDeliveryDestinationCfn } from "./sim-logs-delivery-destination-cfn.js";
+import { SimLogsDeliverySourceCfn } from "./sim-logs-delivery-source-cfn.js";
+import { SimLogsDeliveryCfn } from "./sim-logs-delivery-cfn.js";
 import { SimLogsLogGroupCfn } from "./sim-logs-log-group-cfn.js";
 
 /**
@@ -12,11 +18,34 @@ import { SimLogsLogGroupCfn } from "./sim-logs-log-group-cfn.js";
 export function logsValueAdapter(
   properties: SimCfnResourceValueAdapterProperties,
 ): SimCfnServiceValueAdapter {
+  const { type, simResource } = properties;
+
   if (
-    properties.type === "AWS::Logs::LogGroup" &&
-    properties.simResource instanceof SimLogsLogGroup
+    type === "AWS::Logs::LogGroup" &&
+    simResource instanceof SimLogsLogGroup
   ) {
-    return new SimLogsLogGroupCfn({ group: properties.simResource });
+    return new SimLogsLogGroupCfn({ group: simResource });
+  }
+
+  if (
+    type === "AWS::Logs::DeliverySource" &&
+    simResource instanceof SimLogsDeliverySource
+  ) {
+    return new SimLogsDeliverySourceCfn({ source: simResource });
+  }
+
+  if (
+    type === "AWS::Logs::DeliveryDestination" &&
+    simResource instanceof SimLogsDeliveryDestination
+  ) {
+    return new SimLogsDeliveryDestinationCfn({ destination: simResource });
+  }
+
+  if (
+    type === "AWS::Logs::Delivery" &&
+    simResource instanceof SimLogsDelivery
+  ) {
+    return new SimLogsDeliveryCfn({ delivery: simResource });
   }
 
   return undefined;

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-cfn.ts
@@ -1,0 +1,56 @@
+import type { SimLogsDelivery } from "../../../../logs/delivery/sim-logs-delivery.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLogsDeliveryCfnProperties {
+  readonly delivery: SimLogsDelivery;
+}
+
+/**
+ * CloudFormation-facing values for a simulated delivery.
+ */
+export class SimLogsDeliveryCfn implements SimCfnResourceValueAdapter {
+  readonly #delivery: SimLogsDelivery;
+
+  constructor(properties: SimLogsDeliveryCfnProperties) {
+    this.#delivery = properties.delivery;
+  }
+
+  /**
+   * AWS::Logs::Delivery Ref returns the delivery ID.
+   *
+   * CloudWatch Logs issues that ID. A template can predict the physical name
+   * of the other two delivery Resources and never this one.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#delivery.id;
+  }
+
+  /**
+   * AWS::Logs::Delivery attributes.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.#delivery.arn;
+      }
+      case "DeliveryId": {
+        return this.#delivery.id;
+      }
+      case "DeliverySourceName": {
+        return this.#delivery.deliverySourceName;
+      }
+      case "DeliveryDestinationArn": {
+        return this.#delivery.deliveryDestinationArn;
+      }
+      case "DeliveryDestinationType": {
+        return this.#delivery.deliveryDestinationType;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::Logs::Delivery attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-cfn.ts
@@ -28,6 +28,11 @@ export class SimLogsDeliveryCfn implements SimCfnResourceValueAdapter {
 
   /**
    * AWS::Logs::Delivery attributes.
+   *
+   * These three are the whole of what CloudFormation publishes.
+   * `DeliverySourceName` and `DeliveryDestinationArn` are properties of this
+   * Resource rather than attributes of it, so a template reading either back
+   * through `Fn::GetAtt` is refused here as CloudFormation refuses it.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
     switch (attributeName) {
@@ -36,12 +41,6 @@ export class SimLogsDeliveryCfn implements SimCfnResourceValueAdapter {
       }
       case "DeliveryId": {
         return this.#delivery.id;
-      }
-      case "DeliverySourceName": {
-        return this.#delivery.deliverySourceName;
-      }
-      case "DeliveryDestinationArn": {
-        return this.#delivery.deliveryDestinationArn;
       }
       case "DeliveryDestinationType": {
         return this.#delivery.deliveryDestinationType;

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-destination-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-destination-cfn.ts
@@ -1,0 +1,48 @@
+import type { SimLogsDeliveryDestination } from "../../../../logs/delivery/sim-logs-delivery-destination.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLogsDeliveryDestinationCfnProperties {
+  readonly destination: SimLogsDeliveryDestination;
+}
+
+/**
+ * CloudFormation-facing values for a simulated delivery destination.
+ */
+export class SimLogsDeliveryDestinationCfn implements SimCfnResourceValueAdapter {
+  readonly #destination: SimLogsDeliveryDestination;
+
+  constructor(properties: SimLogsDeliveryDestinationCfnProperties) {
+    this.#destination = properties.destination;
+  }
+
+  /**
+   * AWS::Logs::DeliveryDestination Ref returns the destination name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#destination.name;
+  }
+
+  /**
+   * AWS::Logs::DeliveryDestination attributes.
+   *
+   * The ARN here is the destination's own, and a delivery names that one. The
+   * bucket or log group behind it keeps its own ARN, and the two are easy to
+   * confuse in a template.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.#destination.arn;
+      }
+      case "DeliveryDestinationType": {
+        return this.#destination.destinationType;
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::Logs::DeliveryDestination attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-destination-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-destination-cfn.ts
@@ -26,23 +26,22 @@ export class SimLogsDeliveryDestinationCfn implements SimCfnResourceValueAdapter
   /**
    * AWS::Logs::DeliveryDestination attributes.
    *
-   * The ARN here is the destination's own, and a delivery names that one. The
-   * bucket or log group behind it keeps its own ARN, and the two are easy to
-   * confuse in a template.
+   * The ARN is the only one CloudFormation publishes. It is the destination's
+   * own, and a delivery names that one. The bucket or log group behind it
+   * keeps its own ARN, and the two are easy to confuse in a template.
+   *
+   * `DeliveryDestinationType` is a property of this Resource rather than an
+   * attribute of it, so a template reading it back through `Fn::GetAtt` is
+   * refused here as CloudFormation refuses it. Read it off the delivery, which
+   * does publish it.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
-    switch (attributeName) {
-      case "Arn": {
-        return this.#destination.arn;
-      }
-      case "DeliveryDestinationType": {
-        return this.#destination.destinationType;
-      }
-      default: {
-        throw new Error(
-          `Unsupported AWS::Logs::DeliveryDestination attribute ${attributeName}`,
-        );
-      }
+    if (attributeName === "Arn") {
+      return this.#destination.arn;
     }
+
+    throw new Error(
+      `Unsupported AWS::Logs::DeliveryDestination attribute ${attributeName}`,
+    );
   }
 }

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-source-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-delivery-source-cfn.ts
@@ -1,0 +1,51 @@
+import type { SimLogsDeliverySource } from "../../../../logs/delivery/sim-logs-delivery-source.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLogsDeliverySourceCfnProperties {
+  readonly source: SimLogsDeliverySource;
+}
+
+/**
+ * CloudFormation-facing values for a simulated delivery source.
+ */
+export class SimLogsDeliverySourceCfn implements SimCfnResourceValueAdapter {
+  readonly #source: SimLogsDeliverySource;
+
+  constructor(properties: SimLogsDeliverySourceCfnProperties) {
+    this.#source = properties.source;
+  }
+
+  /**
+   * AWS::Logs::DeliverySource Ref returns the delivery source name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#source.name;
+  }
+
+  /**
+   * AWS::Logs::DeliverySource attributes.
+   *
+   * `Service` is worked out from the resource ARN rather than declared, so a
+   * template reading it back gets what CloudWatch Logs decided the source is
+   * for.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.#source.arn;
+      }
+      case "Service": {
+        return this.#source.service;
+      }
+      case "ResourceArns": {
+        return [...this.#source.resourceArns];
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::Logs::DeliverySource attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -101,8 +101,8 @@ ignored here would be applied in an account.
 
 ## CloudFormation
 
-`cfn/` creates `AWS::Logs::LogGroup` from a template, following the shape every other service's
-resource factory has. `SimCfnLogGroupProperties` reads the two properties this simulation acts on
+`cfn/` creates `AWS::Logs::LogGroup` and the three delivery Resource types from a template,
+following the shape every other service's resource factory has. `SimCfnLogGroupProperties` reads the two properties this simulation acts on
 and `SimCfnLogGroupPropertyRules` records the rest, so a reader can tell a real property this
 simulation chose not to act on from one CloudWatch Logs has never had.
 
@@ -150,6 +150,43 @@ Failures are kept rather than thrown. Real CloudWatch Logs tells nobody about a 
 which would leave a test with a handler that mysteriously never ran, so every failure lands in
 `subscriptionFailures` for a test to read.
 
+## Delivery
+
+`delivery/` holds the three resources that carry another service's logs somewhere. CloudFront
+standard logging v2 is what they were built for here. A distribution has no logging property of its
+own, and a template that turns logging on is these three resources and nothing else.
+
+Each of the three has its own store, because their identities differ. A source and a destination are
+named by the caller, and a delivery is named by an identifier `SimLogsDeliveryIds` issues. In two of
+the three the key that matters most is a second one. A source is unique by the resource it covers,
+and that is what refuses a second delivery source over one distribution. A delivery is unique by the
+source and destination pair it joins.
+
+`requiredSimLogsDeliveredService` reads the service off the resource ARN, as CloudWatch Logs does,
+and `requireSimLogsDeliveryRegion` is where the CloudFront region rule lives. That one rule is the
+only one modelled. CloudFront is the one service whose delivery is pinned to a region other than its
+own resource's.
+
+The output format rule lives in `SimLogsDeliveryDestinationStore`. It compares two puts, and a
+destination on its own holds only the one value. A put that would change the format is refused, and
+a caller changing a format has to delete the destination and make it again. In a template that is a
+replacement, which sim CloudFormation already does to any Resource whose entry changed.
+
+The errors here are `ValidationException` and `ConflictException`. The delivery operations were
+added to CloudWatch Logs long after the log group operations and carry the error shape AWS gives
+newer APIs. The two halves of one service therefore report a bad input under different names, and a
+caller catching by name has to know which half it is talking to.
+
+The CloudFormation creators go through the ordinary commands, unlike the log group creator, which
+writes to its store directly. There is no equivalent here of a log group a function already made for
+itself. A
+template therefore hits the same refusals an SDK caller would, down to the region rule and the one
+source per distribution.
+
+`SimLogsDeliveryOperations` and `SimLogsDeliveryInspection` hold the facade's nine delivery methods
+and its delivery accessors. `SimLogs` grows by one delegating method per simulated operation and was
+already at the length this codebase allows.
+
 ## Writing from the rest of the simulation
 
 `SimLogsServiceWriter`, under `write/`, is how a simulated service records its own output. It is
@@ -175,6 +212,10 @@ Nothing expires, as above. Metric filters, Logs Insights queries, export tasks, 
 and data protection policies are all absent, and `metricFilterCount` is always zero. A stream's
 `storedBytes` is always zero too, which matches real CloudWatch Logs: it stopped reporting the
 figure per stream in 2019.
+
+No log file is ever delivered. A delivery records that a source was joined to a destination and how
+the records would be written, which is what a test of a construct that sets logging up has to assert
+on. Writing CloudFront access log files into the bucket is a separate piece of work.
 
 Subscription filters deliver to a Lambda destination only. Kinesis, Firehose and the logical
 destinations that reach another Account are refused rather than accepted and never delivered to,

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-creator.ts
@@ -1,0 +1,74 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLogsDelivery } from "../../delivery/sim-logs-delivery.js";
+import type { SimLogs } from "../../sim-logs.js";
+import { simCfnDeliveryInput } from "./sim-cfn-delivery-input.js";
+import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
+import { deliveryUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
+
+const resourceType = "AWS::Logs::Delivery";
+const actedOnProperties = new Set([
+  "DeliverySourceName",
+  "DeliveryDestinationArn",
+  "RecordFields",
+  "FieldDelimiter",
+  "S3SuffixPath",
+  "S3EnableHiveCompatiblePath",
+]);
+
+interface SimCfnDeliveryCreatorProperties {
+  readonly logs: SimLogs;
+}
+
+/**
+ * Creates simulated deliveries from AWS::Logs::Delivery Resources.
+ *
+ * A delivery is the join between a source and a destination, and both have to
+ * be deployed before it. A template gets that ordering from naming them
+ * through `Ref` and `Fn::GetAtt`.
+ */
+export class SimCfnDeliveryCreator {
+  readonly #logs: SimLogs;
+
+  constructor(properties: SimCfnDeliveryCreatorProperties) {
+    this.#logs = properties.logs;
+  }
+
+  /**
+   * Create a delivery from an AWS::Logs::Delivery Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimLogsDelivery> {
+    const reader = new SimCfnDeliveryProperties({
+      resource,
+      properties,
+      resourceType,
+      actedOnProperties,
+      unsimulatedReasons: deliveryUnsimulatedReasons,
+    });
+
+    reader.recordIgnoredProperties();
+
+    const created = await this.#logs.createDelivery({
+      input: simCfnDeliveryInput(reader),
+    });
+    const delivery = this.#logs.findDelivery(created.delivery?.id ?? "");
+
+    assertDefined(
+      delivery,
+      `sim CloudWatch Logs delivery for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    return delivery;
+  }
+
+  /**
+   * Delete a delivery created from a CloudFormation Resource.
+   */
+  async delete(delivery: SimLogsDelivery): Promise<void> {
+    await this.#logs.deleteDelivery({ input: { id: delivery.id } });
+  }
+}

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-destination-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-destination-creator.ts
@@ -1,0 +1,84 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLogsDeliveryDestination } from "../../delivery/sim-logs-delivery-destination.js";
+import type { SimLogs } from "../../sim-logs.js";
+import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
+import { deliveryDestinationUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
+
+const resourceType = "AWS::Logs::DeliveryDestination";
+const actedOnProperties = new Set([
+  "Name",
+  "DestinationResourceArn",
+  "OutputFormat",
+]);
+
+interface SimCfnDeliveryDestinationCreatorProperties {
+  readonly logs: SimLogs;
+}
+
+/**
+ * Creates simulated delivery destinations from AWS::Logs::DeliveryDestination
+ * Resources.
+ *
+ * The output format is fixed once the destination is there, so a template that
+ * changes it replaces the Resource. Sim CloudFormation replaces a Resource
+ * whose template entry changed at all, which lands on the same behaviour
+ * without the destination having to say so.
+ */
+export class SimCfnDeliveryDestinationCreator {
+  readonly #logs: SimLogs;
+
+  constructor(properties: SimCfnDeliveryDestinationCreatorProperties) {
+    this.#logs = properties.logs;
+  }
+
+  /**
+   * Create a delivery destination from a CloudFormation Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimLogsDeliveryDestination> {
+    const reader = new SimCfnDeliveryProperties({
+      resource,
+      properties,
+      resourceType,
+      actedOnProperties,
+      unsimulatedReasons: deliveryDestinationUnsimulatedReasons,
+    });
+    const name = reader.requiredString("Name");
+
+    reader.recordIgnoredProperties();
+
+    await this.#logs.putDeliveryDestination({
+      input: {
+        name,
+        outputFormat: reader.optionalString("OutputFormat"),
+        deliveryDestinationConfiguration: {
+          destinationResourceArn: reader.requiredString(
+            "DestinationResourceArn",
+          ),
+        },
+      },
+    });
+
+    const destination = this.#logs.findDeliveryDestination(name);
+
+    assertDefined(
+      destination,
+      `sim CloudWatch Logs delivery destination for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    return destination;
+  }
+
+  /**
+   * Delete a delivery destination created from a CloudFormation Resource.
+   */
+  async delete(destination: SimLogsDeliveryDestination): Promise<void> {
+    await this.#logs.deleteDeliveryDestination({
+      input: { name: destination.name },
+    });
+  }
+}

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-input.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-input.ts
@@ -1,0 +1,31 @@
+import type { SimCreateDeliveryCommandInput } from "../../command/delivery/delivery.command.js";
+import type { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
+
+/**
+ * The CreateDelivery request an AWS::Logs::Delivery Resource asks for.
+ *
+ * The template carries the S3 layout as two flat properties, and the API takes
+ * them nested. Neither is passed on unless the template set one of them, so a
+ * delivery to a log group or a Firehose stream is created without the S3
+ * configuration the API would refuse.
+ */
+export function simCfnDeliveryInput(
+  reader: SimCfnDeliveryProperties,
+): SimCreateDeliveryCommandInput {
+  const suffixPath = reader.optionalString("S3SuffixPath");
+  const enableHiveCompatiblePath = reader.optionalBoolean(
+    "S3EnableHiveCompatiblePath",
+  );
+  const laidOut =
+    suffixPath !== undefined || enableHiveCompatiblePath !== undefined;
+
+  return {
+    deliverySourceName: reader.requiredString("DeliverySourceName"),
+    deliveryDestinationArn: reader.requiredString("DeliveryDestinationArn"),
+    recordFields: reader.optionalStringList("RecordFields"),
+    fieldDelimiter: reader.optionalString("FieldDelimiter"),
+    s3DeliveryConfiguration: laidOut
+      ? { suffixPath, enableHiveCompatiblePath }
+      : undefined,
+  };
+}

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-properties.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-properties.ts
@@ -1,0 +1,173 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * A refusal naming the Resource whose properties could not be read.
+ */
+export function deliveryPropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid sim CloudWatch Logs CloudFormation Resource ${logicalId}: ${reason}`,
+  );
+}
+
+interface SimCfnDeliveryPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly resourceType: string;
+
+  /** The properties this Resource type is actually created from. */
+  readonly actedOnProperties: ReadonlySet<string>;
+
+  /** The real properties this simulation has nothing to act on, and why. */
+  readonly unsimulatedReasons: ReadonlyMap<string, string>;
+}
+
+/**
+ * Reads the CloudFormation properties of a delivery Resource.
+ *
+ * The three delivery Resource types read a handful of strings, a boolean and a
+ * list of strings between them, so one reader serves all three rather than
+ * each carrying a near identical copy. What differs between them is which
+ * property names it acts on, and that is passed in.
+ */
+export class SimCfnDeliveryProperties {
+  readonly #resource: SimCfnResource;
+  readonly #resourceType: string;
+  readonly #actedOnProperties: ReadonlySet<string>;
+  readonly #unsimulatedReasons: ReadonlyMap<string, string>;
+
+  /**
+   * The template's properties, keyed for reading by name.
+   *
+   * A map rather than the record they arrived in, because every read here
+   * names a property the Resource type decided on and a template's keys are
+   * whatever it happened to carry.
+   */
+  readonly #values: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(properties: SimCfnDeliveryPropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#resourceType = properties.resourceType;
+    this.#actedOnProperties = properties.actedOnProperties;
+    this.#unsimulatedReasons = properties.unsimulatedReasons;
+    this.#values = new Map(Object.entries(properties.properties));
+  }
+
+  /**
+   * A property the Resource cannot be created without.
+   */
+  requiredString(name: string): string {
+    const value = this.optionalString(name);
+
+    if (value === undefined) {
+      throw deliveryPropertyError(
+        this.#resource.logicalId,
+        `${name} is required on ${this.#resourceType}`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * A string property, or undefined where the template leaves it out.
+   */
+  optionalString(name: string): string | undefined {
+    const value = this.#values.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "string") {
+      throw deliveryPropertyError(
+        this.#resource.logicalId,
+        `${name} must be a string`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * A boolean property, or undefined where the template leaves it out.
+   */
+  optionalBoolean(name: string): boolean | undefined {
+    const value = this.#values.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "boolean") {
+      throw deliveryPropertyError(
+        this.#resource.logicalId,
+        `${name} must be a boolean`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * A list of strings property, or undefined where the template leaves it out.
+   */
+  optionalStringList(name: string): readonly string[] | undefined {
+    const value = this.#values.get(name);
+
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (
+      !Array.isArray(value) ||
+      value.some((entry) => typeof entry !== "string")
+    ) {
+      throw deliveryPropertyError(
+        this.#resource.logicalId,
+        `${name} must be a list of strings`,
+      );
+    }
+
+    return value as readonly string[];
+  }
+
+  /**
+   * Record every property the Resource is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    for (const name of this.#values.keys()) {
+      this.recordIgnoredProperty(name);
+    }
+  }
+
+  private recordIgnoredProperty(name: string): void {
+    if (this.#actedOnProperties.has(name)) {
+      return;
+    }
+
+    const unsimulatedReason = this.#unsimulatedReasons.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.#resource.ignoreProperty(
+        name,
+        `${name} is not a property simulated CloudWatch Logs knows about, ` +
+          `so the Resource is created without it`,
+      );
+
+      return;
+    }
+
+    this.#resource.ignoreProperty(
+      name,
+      `${name} is a real ${this.#resourceType} property simulated CloudWatch ` +
+        `Logs does not act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-source-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-source-creator.ts
@@ -1,0 +1,73 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLogsDeliverySource } from "../../delivery/sim-logs-delivery-source.js";
+import type { SimLogs } from "../../sim-logs.js";
+import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
+import { deliverySourceUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
+
+const resourceType = "AWS::Logs::DeliverySource";
+const actedOnProperties = new Set(["Name", "ResourceArn", "LogType"]);
+
+interface SimCfnDeliverySourceCreatorProperties {
+  readonly logs: SimLogs;
+}
+
+/**
+ * Creates simulated delivery sources from AWS::Logs::DeliverySource Resources.
+ *
+ * Creation goes through the ordinary command rather than straight to the
+ * store, so a template hits the same refusals an SDK caller would: a
+ * distribution that already has a delivery source, and a CloudFront source
+ * declared in a stack outside us-east-1.
+ */
+export class SimCfnDeliverySourceCreator {
+  readonly #logs: SimLogs;
+
+  constructor(properties: SimCfnDeliverySourceCreatorProperties) {
+    this.#logs = properties.logs;
+  }
+
+  /**
+   * Create a delivery source from an AWS::Logs::DeliverySource Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimLogsDeliverySource> {
+    const reader = new SimCfnDeliveryProperties({
+      resource,
+      properties,
+      resourceType,
+      actedOnProperties,
+      unsimulatedReasons: deliverySourceUnsimulatedReasons,
+    });
+    const name = reader.requiredString("Name");
+
+    reader.recordIgnoredProperties();
+
+    await this.#logs.putDeliverySource({
+      input: {
+        name,
+        resourceArn: reader.requiredString("ResourceArn"),
+        logType: reader.requiredString("LogType"),
+      },
+    });
+
+    const source = this.#logs.findDeliverySource(name);
+
+    assertDefined(
+      source,
+      `sim CloudWatch Logs delivery source for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    return source;
+  }
+
+  /**
+   * Delete a delivery source created from a CloudFormation Resource.
+   */
+  async delete(source: SimLogsDeliverySource): Promise<void> {
+    await this.#logs.deleteDeliverySource({ input: { name: source.name } });
+  }
+}

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-unsimulated-properties.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-unsimulated-properties.ts
@@ -7,7 +7,14 @@ const tagsReason =
  * on, and why.
  */
 export const deliverySourceUnsimulatedReasons: ReadonlyMap<string, string> =
-  new Map([["Tags", tagsReason]]);
+  new Map([
+    ["Tags", tagsReason],
+    [
+      "DeliverySourceConfiguration",
+      "the configuration map only matters to the services whose delivery " +
+        "takes one, and CloudFront is the only source modelled here",
+    ],
+  ]);
 
 /**
  * The AWS::Logs::DeliveryDestination properties this simulation has nothing to
@@ -18,6 +25,11 @@ export const deliveryDestinationUnsimulatedReasons: ReadonlyMap<
   string
 > = new Map([
   ["Tags", tagsReason],
+  [
+    "DeliveryDestinationType",
+    "the kind of destination is read off DestinationResourceArn here, as " +
+      "CloudWatch Logs reads it, so a declared one would be ignored or wrong",
+  ],
   [
     "DeliveryDestinationPolicy",
     "the policy only decides which other accounts may deliver here, and " +

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-unsimulated-properties.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-unsimulated-properties.ts
@@ -1,0 +1,34 @@
+const tagsReason =
+  "delivery resource tags are not simulated, so nothing reads them back and " +
+  "nothing is billed or grouped by them";
+
+/**
+ * The AWS::Logs::DeliverySource properties this simulation has nothing to act
+ * on, and why.
+ */
+export const deliverySourceUnsimulatedReasons: ReadonlyMap<string, string> =
+  new Map([["Tags", tagsReason]]);
+
+/**
+ * The AWS::Logs::DeliveryDestination properties this simulation has nothing to
+ * act on, and why.
+ */
+export const deliveryDestinationUnsimulatedReasons: ReadonlyMap<
+  string,
+  string
+> = new Map([
+  ["Tags", tagsReason],
+  [
+    "DeliveryDestinationPolicy",
+    "the policy only decides which other accounts may deliver here, and " +
+      "cross-account delivery is not simulated",
+  ],
+]);
+
+/**
+ * The AWS::Logs::Delivery properties this simulation has nothing to act on,
+ * and why.
+ */
+export const deliveryUnsimulatedReasons: ReadonlyMap<string, string> = new Map([
+  ["Tags", tagsReason],
+]);

--- a/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
@@ -118,6 +118,47 @@ describe("AWS::Logs delivery Resource refusals", () => {
     assertStringIncludes(error.message, "{DistributionID}");
   });
 
+  it("refuses a Resource property read back as an attribute", async () => {
+    // Given a template reading DeliveryDestinationType off the delivery
+    // destination, which carries it as a property and publishes it on the
+    // delivery instead.
+    const error = await assertThrowsErrorAsync(async () => {
+      await new SimAws().cloudFormation().deployTemplate({
+        stackName: "site-logging",
+        template: {
+          Resources: {
+            AccessLogsDestination: {
+              Type: "AWS::Logs::DeliveryDestination",
+              Properties: {
+                Name: sourceName,
+                DestinationResourceArn: bucketArn,
+              },
+            },
+          },
+          Outputs: {
+            Kind: {
+              Value: {
+                "Fn::GetAtt": [
+                  "AccessLogsDestination",
+                  "DeliveryDestinationType",
+                ],
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then it is refused here, as CloudFormation refuses it. Resolving it
+    // would give a template that deploys against this simulation and fails
+    // against an account.
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::Logs::DeliveryDestination attribute " +
+        "DeliveryDestinationType",
+    );
+  });
+
   it("refuses a delivery attribute CloudFormation does not publish", async () => {
     // Given a template reading an attribute off a delivery source that
     // AWS::Logs::DeliverySource does not have.

--- a/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
@@ -1,0 +1,178 @@
+import {
+  assertArrayLength,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
+const bucketArn = "arn:aws:s3:::example-access-logs";
+const sourceName = "site-access-logs";
+
+async function deploySource(
+  properties: SimCfnTemplateValueRecord,
+  regionName?: AwsRegionName,
+): Promise<void> {
+  const simAws = new SimAws();
+  const cloudFormation =
+    regionName === undefined
+      ? simAws.cloudFormation()
+      : simAws.account().region(regionName).cloudFormation();
+
+  await cloudFormation.deployTemplate({
+    stackName: "site-logging",
+    template: {
+      Resources: {
+        AccessLogsSource: {
+          Type: "AWS::Logs::DeliverySource",
+          Properties: properties,
+        },
+      },
+    },
+  });
+}
+
+const sourceProperties: SimCfnTemplateValueRecord = {
+  Name: sourceName,
+  ResourceArn: distributionArn,
+  LogType: "ACCESS_LOGS",
+};
+
+describe("AWS::Logs delivery Resource refusals", () => {
+  it("fails a stack that sets CloudFront logging up outside us-east-1", async () => {
+    // Given the delivery Resources declared in a stack in the region the rest
+    // of an application lives in, which is the mistake worth catching.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deploySource(sourceProperties, "eu-west-2");
+    });
+
+    // Then the deploy fails here rather than on a real one later.
+    assertStringIncludes(error.message, "only be created in us-east-1");
+  });
+
+  it("fails a Resource missing a property the API requires", async () => {
+    // Given a template declaring a delivery source with no resource to log.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deploySource({ Name: sourceName, LogType: "ACCESS_LOGS" });
+    });
+
+    // Then it names the Resource and the property, rather than failing later
+    // inside the API call.
+    assertStringIncludes(error.message, "AccessLogsSource");
+    assertStringIncludes(
+      error.message,
+      "ResourceArn is required on AWS::Logs::DeliverySource",
+    );
+  });
+
+  it("fails a Resource whose property types the template got wrong", async () => {
+    // Given a template giving a string property a value of another type.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deploySource({ ...sourceProperties, LogType: 42 });
+    });
+
+    // Then it says which property was wrong.
+    assertStringIncludes(error.message, "LogType must be a string");
+  });
+
+  it("fails a delivery whose suffix path names an unknown variable", async () => {
+    // Given a whole logging stack whose suffix path has a partition variable
+    // spelled the way a template author would guess at it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await new SimAws().cloudFormation().deployTemplate({
+        stackName: "site-logging",
+        template: {
+          Resources: {
+            AccessLogsSource: {
+              Type: "AWS::Logs::DeliverySource",
+              Properties: sourceProperties,
+            },
+            AccessLogsDestination: {
+              Type: "AWS::Logs::DeliveryDestination",
+              Properties: {
+                Name: sourceName,
+                DestinationResourceArn: bucketArn,
+              },
+            },
+            AccessLogsDelivery: {
+              Type: "AWS::Logs::Delivery",
+              Properties: {
+                DeliverySourceName: { Ref: "AccessLogsSource" },
+                DeliveryDestinationArn: {
+                  "Fn::GetAtt": ["AccessLogsDestination", "Arn"],
+                },
+                S3SuffixPath: "{DistributionID}/{yyyy}",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the deploy fails rather than partitioning the bucket by a literal
+    // folder named after the variable.
+    assertStringIncludes(error.message, "{DistributionID}");
+  });
+
+  it("refuses a delivery attribute CloudFormation does not publish", async () => {
+    // Given a template reading an attribute off a delivery source that
+    // AWS::Logs::DeliverySource does not have.
+    const error = await assertThrowsErrorAsync(async () => {
+      await new SimAws().cloudFormation().deployTemplate({
+        stackName: "site-logging",
+        template: {
+          Resources: {
+            AccessLogsSource: {
+              Type: "AWS::Logs::DeliverySource",
+              Properties: sourceProperties,
+            },
+          },
+          Outputs: {
+            LogType: {
+              Value: { "Fn::GetAtt": ["AccessLogsSource", "LogType"] },
+            },
+          },
+        },
+      });
+    });
+
+    // Then it says which attribute, rather than leaving an Output that
+    // quietly resolves to nothing.
+    assertStringIncludes(
+      error.message,
+      "Unsupported AWS::Logs::DeliverySource attribute LogType",
+    );
+  });
+
+  it("still records a CloudWatch Logs Resource type it has none for", async () => {
+    // Given a template declaring a delivery source and a metric filter.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "site-logging",
+      template: {
+        Resources: {
+          AccessLogsSource: {
+            Type: "AWS::Logs::DeliverySource",
+            Properties: sourceProperties,
+          },
+          SiteMetrics: {
+            Type: "AWS::Logs::MetricFilter",
+            Properties: { LogGroupName: "/site", FilterPattern: "ERROR" },
+          },
+        },
+      },
+    });
+
+    // Then the delivery source deploys and the metric filter is recorded as a
+    // gap, which is what adding delivery to this factory must not change.
+    assertArrayLength(stack.skippedResources, 1);
+    assertStringIncludes(
+      stack.skippedResources.at(0)?.skippedReason ?? "",
+      "Unsupported sim CloudWatch Logs CloudFormation Resource MetricFilter",
+    );
+  });
+});

--- a/src/service/logs/cfn/sim-cfn-delivery.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery.iso.test.ts
@@ -1,0 +1,225 @@
+import {
+  DeleteStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import { DescribeDeliveriesCommand } from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
+const bucketArn = "arn:aws:s3:::example-access-logs";
+const sourceName = "site-access-logs";
+const suffixPath = "{DistributionId}/{yyyy}/{MM}/{dd}/{HH}";
+
+/**
+ * The three Resources a CloudFront standard logging v2 construct is made of.
+ */
+function loggingTemplate(
+  deliveryProperties: SimCfnTemplateValueRecord = {},
+  outputFormat = "json",
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      AccessLogsSource: {
+        Type: "AWS::Logs::DeliverySource",
+        Properties: {
+          Name: sourceName,
+          ResourceArn: distributionArn,
+          LogType: "ACCESS_LOGS",
+        },
+      },
+      AccessLogsDestination: {
+        Type: "AWS::Logs::DeliveryDestination",
+        Properties: {
+          Name: sourceName,
+          DestinationResourceArn: bucketArn,
+          OutputFormat: outputFormat,
+        },
+      },
+      AccessLogsDelivery: {
+        Type: "AWS::Logs::Delivery",
+        Properties: {
+          DeliverySourceName: { Ref: "AccessLogsSource" },
+          DeliveryDestinationArn: {
+            "Fn::GetAtt": ["AccessLogsDestination", "Arn"],
+          },
+          ...deliveryProperties,
+        },
+      },
+    },
+    Outputs: {
+      SourceName: { Value: { Ref: "AccessLogsSource" } },
+      SourceArn: { Value: { "Fn::GetAtt": ["AccessLogsSource", "Arn"] } },
+      SourceService: {
+        Value: { "Fn::GetAtt": ["AccessLogsSource", "Service"] },
+      },
+      DestinationName: { Value: { Ref: "AccessLogsDestination" } },
+      DestinationType: {
+        Value: {
+          "Fn::GetAtt": ["AccessLogsDestination", "DeliveryDestinationType"],
+        },
+      },
+      DeliveryId: { Value: { Ref: "AccessLogsDelivery" } },
+      DeliveryArn: { Value: { "Fn::GetAtt": ["AccessLogsDelivery", "Arn"] } },
+    },
+  };
+}
+
+async function deployLogging(
+  deliveryProperties: SimCfnTemplateValueRecord = {},
+  simAws: SimAws = new SimAws(),
+): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnDeployedStack }> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "site-logging",
+    template: loggingTemplate(deliveryProperties),
+  });
+
+  return { simAws, stack };
+}
+
+describe("AWS::Logs delivery Resources", () => {
+  it("deploys the three Resources CloudFront logging is made of", async () => {
+    // Given a template that turns CloudFront standard logging v2 on, which is
+    // these three Resources and nothing else.
+    const { simAws, stack } = await deployLogging();
+
+    // Then none of them is recorded as a gap, and the delivery is there to
+    // assert on.
+    assertArrayLength(stack.skippedResources, 0);
+
+    const described = await simAws
+      .logs()
+      .describeDeliveries(new DescribeDeliveriesCommand({}));
+    const delivery = described.deliveries?.at(0);
+
+    assertNonNullable(delivery);
+    assertIdentical(delivery.deliverySourceName, sourceName);
+    assertIdentical(delivery.deliveryDestinationType, "S3");
+  });
+
+  it("resolves Ref and Fn::GetAtt on all three Resources", async () => {
+    // Given the same template, whose outputs name each Resource both ways.
+    const { stack } = await deployLogging();
+    const sourceArn = stack.outputs.get("SourceArn")?.value;
+    const deliveryId = stack.outputs.get("DeliveryId")?.value;
+    const deliveryArn = stack.outputs.get("DeliveryArn")?.value;
+
+    // Then Ref is the name for the two Resources the template names, and the
+    // identifier CloudWatch Logs issued for the delivery.
+    assertIdentical(stack.outputs.get("SourceName")?.value, sourceName);
+    assertIdentical(stack.outputs.get("DestinationName")?.value, sourceName);
+    assertIdentical(stack.outputs.get("SourceService")?.value, "cloudfront");
+    assertIdentical(stack.outputs.get("DestinationType")?.value, "S3");
+
+    assertTypeString(sourceArn);
+    assertTypeString(deliveryId);
+    assertTypeString(deliveryArn);
+    assertStringIncludes(sourceArn, `:delivery-source:${sourceName}`);
+    assertStringIncludes(deliveryArn, `:delivery:${deliveryId}`);
+  });
+
+  it("joins the delivery to the destination the template built", async () => {
+    // Given a template whose delivery names its destination through
+    // Fn::GetAtt rather than by a literal ARN.
+    const { simAws } = await deployLogging();
+
+    // Then the delivery reaches the destination that Resource created, which
+    // is the join the whole stack exists to make.
+    const destination = simAws.logs().findDeliveryDestination(sourceName);
+    const delivery = simAws.logs().allDeliveries().at(0);
+
+    assertNonNullable(destination);
+    assertIdentical(delivery?.deliveryDestinationArn, destination.arn);
+  });
+
+  it("carries the S3 layout a template asks for", async () => {
+    // Given a template asking for Hive compatible paths under a suffix path.
+    const { simAws } = await deployLogging({
+      S3SuffixPath: suffixPath,
+      S3EnableHiveCompatiblePath: true,
+    });
+
+    // Then both reach the delivery, so a test can assert on the layout the
+    // bucket will be partitioned by.
+    const configuration = simAws
+      .logs()
+      .allDeliveries()
+      .at(0)?.s3DeliveryConfiguration;
+
+    assertNonNullable(configuration);
+    assertIdentical(configuration.suffixPath, suffixPath);
+    assertTrue(configuration.enableHiveCompatiblePath);
+  });
+
+  it("replaces the destination when a template changes its format", async () => {
+    // Given a deployed logging stack writing JSON.
+    const { simAws } = await deployLogging();
+
+    // When the stack is updated to write plain text, which real CloudWatch
+    // Logs refuses to change on a destination that already exists.
+    const plainText = jsonStringify(loggingTemplate({}, "plain"));
+
+    await simAws.cloudFormation().updateStack(
+      new UpdateStackCommand({
+        StackName: "site-logging",
+        TemplateBody: plainText,
+      }),
+    );
+    await simAws.cloudFormation().waitForStackUpdateComplete("site-logging");
+
+    // Then the destination was replaced rather than updated, so the format
+    // changed. The delivery naming it was replaced with it.
+    assertIdentical(
+      simAws.logs().findDeliveryDestination(sourceName)?.outputFormat,
+      "plain",
+    );
+    assertArrayLength(simAws.logs().allDeliveries(), 1);
+  });
+
+  it("deletes all three when the stack is deleted", async () => {
+    // Given the deployed logging stack.
+    const { simAws } = await deployLogging();
+
+    // When the stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "site-logging" }));
+    await simAws.cloudFormation().waitForStackDeleteComplete("site-logging");
+
+    // Then the account is left with none of them.
+    assertArrayEquals(simAws.logs().allDeliverySources(), []);
+    assertArrayEquals(simAws.logs().allDeliveryDestinations(), []);
+    assertArrayEquals(simAws.logs().allDeliveries(), []);
+  });
+
+  it("records the delivery Resource properties it does not act on", async () => {
+    // Given a template tagging its delivery, as a stack usually does.
+    const { stack } = await deployLogging({
+      Tags: [{ Key: "App", Value: "site" }],
+    });
+    const ignored = stack
+      .getResource("AccessLogsDelivery")
+      ?.ignoredProperties.find((property) => property.path === "Tags");
+
+    // Then the delivery is created without them and says so, rather than the
+    // whole stack failing over a tag nothing reads back.
+    assertNonNullable(ignored);
+    assertStringIncludes(ignored.reason, "not simulated");
+    assertUndefined(stack.skippedResources.at(0));
+  });
+});

--- a/src/service/logs/cfn/sim-cfn-delivery.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery.iso.test.ts
@@ -71,7 +71,7 @@ function loggingTemplate(
       DestinationName: { Value: { Ref: "AccessLogsDestination" } },
       DestinationType: {
         Value: {
-          "Fn::GetAtt": ["AccessLogsDestination", "DeliveryDestinationType"],
+          "Fn::GetAtt": ["AccessLogsDelivery", "DeliveryDestinationType"],
         },
       },
       DeliveryId: { Value: { Ref: "AccessLogsDelivery" } },

--- a/src/service/logs/cfn/sim-logs-cfn-resource-deleter.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-deleter.ts
@@ -1,0 +1,86 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimLogsDeliveryDestination } from "../delivery/sim-logs-delivery-destination.js";
+import type { SimLogsDeliverySource } from "../delivery/sim-logs-delivery-source.js";
+import type { SimLogsDelivery } from "../delivery/sim-logs-delivery.js";
+import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
+import type { SimCfnDeliveryCreator } from "./delivery/sim-cfn-delivery-creator.js";
+import type { SimCfnDeliveryDestinationCreator } from "./delivery/sim-cfn-delivery-destination-creator.js";
+import type { SimCfnDeliverySourceCreator } from "./delivery/sim-cfn-delivery-source-creator.js";
+import type { SimCfnLogGroupCreator } from "./group/sim-cfn-log-group-creator.js";
+import { unsupportedSimLogsResourceType } from "./sim-logs-cfn-unsupported-resource.js";
+
+interface SimLogsCfnResourceDeleterProperties {
+  readonly logGroups: SimCfnLogGroupCreator;
+  readonly deliverySources: SimCfnDeliverySourceCreator;
+  readonly deliveryDestinations: SimCfnDeliveryDestinationCreator;
+  readonly deliveries: SimCfnDeliveryCreator;
+}
+
+/**
+ * Removes the simulated CloudWatch Logs resources a Stack created.
+ *
+ * Each Resource type is given back to whatever created it. A deletion
+ * therefore goes through the same command a caller would have used.
+ */
+export class SimLogsCfnResourceDeleter {
+  readonly #creators: SimLogsCfnResourceDeleterProperties;
+
+  constructor(properties: SimLogsCfnResourceDeleterProperties) {
+    this.#creators = properties;
+  }
+
+  /**
+   * Delete the resource a CloudFormation Resource created.
+   */
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    switch (resourceTypeName) {
+      case "LogGroup": {
+        this.#creators.logGroups.delete(created<SimLogsLogGroup>(resource));
+
+        return;
+      }
+      case "DeliverySource": {
+        await this.#creators.deliverySources.delete(
+          created<SimLogsDeliverySource>(resource),
+        );
+
+        return;
+      }
+      case "DeliveryDestination": {
+        await this.#creators.deliveryDestinations.delete(
+          created<SimLogsDeliveryDestination>(resource),
+        );
+
+        return;
+      }
+      case "Delivery": {
+        await this.#creators.deliveries.delete(
+          created<SimLogsDelivery>(resource),
+        );
+
+        return;
+      }
+      default: {
+        throw unsupportedSimLogsResourceType(resourceTypeName, " deletion");
+      }
+    }
+  }
+}
+
+/**
+ * The simulated resource a CloudFormation Resource was created as.
+ */
+function created<T>(resource: SimCfnResource): T {
+  const simResource = resource.simResource as T | undefined;
+
+  assertDefined(
+    simResource,
+    `sim CloudWatch Logs resource for CloudFormation Resource ${resource.logicalId}`,
+  );
+
+  return simResource;
+}

--- a/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
@@ -1,14 +1,15 @@
-import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
-import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
 import type { SimLogs } from "../sim-logs.js";
+import { SimCfnDeliveryCreator } from "./delivery/sim-cfn-delivery-creator.js";
+import { SimCfnDeliveryDestinationCreator } from "./delivery/sim-cfn-delivery-destination-creator.js";
+import { SimCfnDeliverySourceCreator } from "./delivery/sim-cfn-delivery-source-creator.js";
 import { SimCfnLogGroupCreator } from "./group/sim-cfn-log-group-creator.js";
-
-const logGroupResourceTypeName = "LogGroup";
+import { SimLogsCfnResourceDeleter } from "./sim-logs-cfn-resource-deleter.js";
+import { unsupportedSimLogsResourceType } from "./sim-logs-cfn-unsupported-resource.js";
 
 interface SimLogsCfnResourceFactoryProperties {
   readonly logs: SimLogs;
@@ -17,16 +18,34 @@ interface SimLogsCfnResourceFactoryProperties {
 /**
  * CloudFormation Resource factory for simulated CloudWatch Logs resources.
  *
- * AWS::Logs::LogGroup is the only Resource type here so far. The others,
- * subscription filters and metric filters most of all, need machinery this
- * simulation does not have yet.
+ * Log groups and the three delivery Resource types. Delivery is the whole of
+ * CloudFront standard logging v2 in a template. A distribution carries no
+ * logging property of its own, and a stack that turns logging on is made of
+ * those three Resources and nothing else.
+ *
+ * Subscription filters and metric filters are not created here. Both need
+ * machinery this simulation does not have yet, and a stack declaring one
+ * records it as a skip.
  */
 export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
-  readonly #logGroupCreator: SimCfnLogGroupCreator;
+  readonly #logGroups: SimCfnLogGroupCreator;
+  readonly #deliverySources: SimCfnDeliverySourceCreator;
+  readonly #deliveryDestinations: SimCfnDeliveryDestinationCreator;
+  readonly #deliveries: SimCfnDeliveryCreator;
+  readonly #deleter: SimLogsCfnResourceDeleter;
 
   constructor(properties: SimLogsCfnResourceFactoryProperties) {
-    this.#logGroupCreator = new SimCfnLogGroupCreator({
-      logs: properties.logs,
+    this.#logGroups = new SimCfnLogGroupCreator(properties);
+    this.#deliverySources = new SimCfnDeliverySourceCreator(properties);
+    this.#deliveryDestinations = new SimCfnDeliveryDestinationCreator(
+      properties,
+    );
+    this.#deliveries = new SimCfnDeliveryCreator(properties);
+    this.#deleter = new SimLogsCfnResourceDeleter({
+      logGroups: this.#logGroups,
+      deliverySources: this.#deliverySources,
+      deliveryDestinations: this.#deliveryDestinations,
+      deliveries: this.#deliveries,
     });
   }
 
@@ -34,49 +53,40 @@ export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
    * Create a simulated CloudWatch Logs resource from a CloudFormation
    * Resource.
    */
-  create(
+  async create(
     resourceTypeName: string,
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
-    requireLogGroupResourceType(resourceTypeName, "");
+    const values = context.resolvedProperties ?? resource.properties;
 
-    return Promise.resolve(
-      this.#logGroupCreator.create(
-        resource,
-        context.resolvedProperties ?? resource.properties,
-      ),
-    );
+    switch (resourceTypeName) {
+      case "LogGroup": {
+        return this.#logGroups.create(resource, values);
+      }
+      case "DeliverySource": {
+        return await this.#deliverySources.create(resource, values);
+      }
+      case "DeliveryDestination": {
+        return await this.#deliveryDestinations.create(resource, values);
+      }
+      case "Delivery": {
+        return await this.#deliveries.create(resource, values);
+      }
+      default: {
+        throw unsupportedSimLogsResourceType(resourceTypeName, "");
+      }
+    }
   }
 
   /**
    * Delete a simulated CloudWatch Logs resource created from a CloudFormation
    * Resource.
    */
-  delete(resourceTypeName: string, resource: SimCfnResource): Promise<void> {
-    requireLogGroupResourceType(resourceTypeName, " deletion");
-
-    const group = resource.simResource as SimLogsLogGroup | undefined;
-
-    assertDefined(
-      group,
-      `sim CloudWatch Logs log group for CloudFormation Resource ${resource.logicalId}`,
-    );
-
-    this.#logGroupCreator.delete(group);
-
-    return Promise.resolve();
-  }
-}
-
-function requireLogGroupResourceType(
-  resourceTypeName: string,
-  operationSuffix: string,
-): void {
-  if (resourceTypeName !== logGroupResourceTypeName) {
-    throw new Error(
-      `Unsupported sim CloudWatch Logs CloudFormation Resource ` +
-        `${resourceTypeName}${operationSuffix}`,
-    );
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+  ): Promise<void> {
+    await this.#deleter.delete(resourceTypeName, resource);
   }
 }

--- a/src/service/logs/cfn/sim-logs-cfn-unsupported-resource.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-unsupported-resource.ts
@@ -1,0 +1,17 @@
+/**
+ * A refusal for a CloudWatch Logs Resource type this simulation has no
+ * implementation for.
+ *
+ * The Stack lifecycle reads this differently from an ordinary failure. The
+ * Resource is recorded as a skip and stepped over, and the rest of the Stack
+ * still deploys and still tears down.
+ */
+export function unsupportedSimLogsResourceType(
+  resourceTypeName: string,
+  operationSuffix: string,
+): Error {
+  return new Error(
+    `Unsupported sim CloudWatch Logs CloudFormation Resource ` +
+      `${resourceTypeName}${operationSuffix}`,
+  );
+}

--- a/src/service/logs/command/authorize/sim-logs-authorizer.ts
+++ b/src/service/logs/command/authorize/sim-logs-authorizer.ts
@@ -71,7 +71,15 @@ export class SimLogsAuthorizer {
     );
   }
 
-  private authorizeResource(
+  /**
+   * Ensure the caller may perform an action on a named resource ARN.
+   *
+   * The delivery operations authorize through this rather than through a
+   * method of their own. Each of the three delivery resource types has its own
+   * ARN form, and adding a pair of methods per type would make this class
+   * mostly ARN building.
+   */
+  authorizeResource(
     action: string,
     resource: string,
     caller: SimAwsCaller | undefined,

--- a/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
+++ b/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
@@ -3,6 +3,7 @@ import {
   CreateLogStreamCommand,
   DescribeLogGroupsCommand,
   FilterLogEventsCommand,
+  PutDeliverySourceCommand,
   PutLogEventsCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
@@ -11,6 +12,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -211,5 +213,48 @@ describe("CloudWatch Logs IAM authorization", () => {
 
     // Then it is denied before the missing group is ever looked for.
     assertInstanceOf(error, SimIamAccessDenied);
+  });
+});
+
+describe("CloudWatch Logs delivery IAM authorization", () => {
+  const putSource = new PutDeliverySourceCommand({
+    name: "site-access-logs",
+    resourceArn: "arn:aws:cloudfront::111111111111:distribution/E1EX",
+    logType: "ACCESS_LOGS",
+  });
+
+  it("refuses a delivery source the Role has no permission for", async () => {
+    // Given a Role allowed to write logs and nothing else.
+    const simAws = await simAwsWithRole({
+      Action: "logs:PutLogEvents",
+      Resource: "*",
+    });
+
+    // When it puts a delivery source.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().putDeliverySource(putSource, asRole);
+    });
+
+    // Then it is denied, on the delivery source ARN the request reaches.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertUndefined(simAws.logs().findDeliverySource("site-access-logs"));
+  });
+
+  it("allows a delivery source a policy names", async () => {
+    // Given a Role allowed to put delivery sources.
+    const simAws = await simAwsWithRole({
+      Action: "logs:PutDeliverySource",
+      Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:delivery-source:*`,
+    });
+
+    // When it puts a delivery source.
+    await simAws.logs().putDeliverySource(putSource, asRole);
+
+    // Then the source is there, so the ARN the policy names is the one the
+    // request authorizes against.
+    assertIdentical(
+      simAws.logs().findDeliverySource("site-access-logs")?.name,
+      "site-access-logs",
+    );
   });
 });

--- a/src/service/logs/command/delivery/delivery-destination.command.ts
+++ b/src/service/logs/command/delivery/delivery-destination.command.ts
@@ -1,0 +1,81 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Which resource a delivery destination writes into.
+ */
+export interface SimLogsDeliveryDestinationConfiguration {
+  readonly destinationResourceArn?: string | undefined;
+}
+
+/**
+ * What DescribeDeliveryDestinations reports about one delivery destination.
+ */
+export interface SimLogsDeliveryDestinationDetail {
+  readonly name: string;
+  readonly arn: string;
+  readonly deliveryDestinationType: string;
+  readonly outputFormat: string;
+  readonly deliveryDestinationConfiguration: SimLogsDeliveryDestinationConfiguration;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs PutDeliveryDestination command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/PutDeliveryDestinationCommand/
+ */
+export interface SimPutDeliveryDestinationCommand {
+  readonly input: SimPutDeliveryDestinationCommandInput;
+}
+
+export interface SimPutDeliveryDestinationCommandInput {
+  readonly name?: string | undefined;
+  readonly outputFormat?: string | undefined;
+  readonly deliveryDestinationConfiguration?:
+    | SimLogsDeliveryDestinationConfiguration
+    | undefined;
+  readonly tags?: Record<string, string> | undefined;
+}
+
+export interface SimPutDeliveryDestinationCommandOutput {
+  readonly deliveryDestination?: SimLogsDeliveryDestinationDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DescribeDeliveryDestinations command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DescribeDeliveryDestinationsCommand/
+ */
+export interface SimDescribeDeliveryDestinationsCommand {
+  readonly input: SimDescribeDeliveryDestinationsCommandInput;
+}
+
+export interface SimDescribeDeliveryDestinationsCommandInput {
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimDescribeDeliveryDestinationsCommandOutput {
+  readonly deliveryDestinations?:
+    | readonly SimLogsDeliveryDestinationDetail[]
+    | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DeleteDeliveryDestination command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DeleteDeliveryDestinationCommand/
+ */
+export interface SimDeleteDeliveryDestinationCommand {
+  readonly input: SimDeleteDeliveryDestinationCommandInput;
+}
+
+export interface SimDeleteDeliveryDestinationCommandInput {
+  readonly name?: string | undefined;
+}
+
+export interface SimDeleteDeliveryDestinationCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/logs/command/delivery/delivery-source.command.ts
+++ b/src/service/logs/command/delivery/delivery-source.command.ts
@@ -1,0 +1,70 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * What DescribeDeliverySources reports about one delivery source.
+ */
+export interface SimLogsDeliverySourceDetail {
+  readonly name: string;
+  readonly arn: string;
+  readonly resourceArns: readonly string[];
+  readonly service: string;
+  readonly logType: string;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs PutDeliverySource command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/PutDeliverySourceCommand/
+ */
+export interface SimPutDeliverySourceCommand {
+  readonly input: SimPutDeliverySourceCommandInput;
+}
+
+export interface SimPutDeliverySourceCommandInput {
+  readonly name?: string | undefined;
+  readonly resourceArn?: string | undefined;
+  readonly logType?: string | undefined;
+  readonly tags?: Record<string, string> | undefined;
+}
+
+export interface SimPutDeliverySourceCommandOutput {
+  readonly deliverySource?: SimLogsDeliverySourceDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DescribeDeliverySources command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DescribeDeliverySourcesCommand/
+ */
+export interface SimDescribeDeliverySourcesCommand {
+  readonly input: SimDescribeDeliverySourcesCommandInput;
+}
+
+export interface SimDescribeDeliverySourcesCommandInput {
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimDescribeDeliverySourcesCommandOutput {
+  readonly deliverySources?: readonly SimLogsDeliverySourceDetail[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DeleteDeliverySource command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DeleteDeliverySourceCommand/
+ */
+export interface SimDeleteDeliverySourceCommand {
+  readonly input: SimDeleteDeliverySourceCommandInput;
+}
+
+export interface SimDeleteDeliverySourceCommandInput {
+  readonly name?: string | undefined;
+}
+
+export interface SimDeleteDeliverySourceCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/logs/command/delivery/delivery.command.ts
+++ b/src/service/logs/command/delivery/delivery.command.ts
@@ -1,0 +1,83 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * How a delivery lays out what it writes into an S3 bucket.
+ */
+export interface SimLogsS3DeliveryConfiguration {
+  readonly suffixPath?: string | undefined;
+  readonly enableHiveCompatiblePath?: boolean | undefined;
+}
+
+/**
+ * What DescribeDeliveries reports about one delivery.
+ */
+export interface SimLogsDeliveryDetail {
+  readonly id: string;
+  readonly arn: string;
+  readonly deliverySourceName: string;
+  readonly deliveryDestinationArn: string;
+  readonly deliveryDestinationType: string;
+  readonly recordFields?: readonly string[] | undefined;
+  readonly fieldDelimiter?: string | undefined;
+  readonly s3DeliveryConfiguration?: SimLogsS3DeliveryConfiguration | undefined;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs CreateDelivery command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/CreateDeliveryCommand/
+ */
+export interface SimCreateDeliveryCommand {
+  readonly input: SimCreateDeliveryCommandInput;
+}
+
+export interface SimCreateDeliveryCommandInput {
+  readonly deliverySourceName?: string | undefined;
+  readonly deliveryDestinationArn?: string | undefined;
+  readonly recordFields?: readonly string[] | undefined;
+  readonly fieldDelimiter?: string | undefined;
+  readonly s3DeliveryConfiguration?: SimLogsS3DeliveryConfiguration | undefined;
+  readonly tags?: Record<string, string> | undefined;
+}
+
+export interface SimCreateDeliveryCommandOutput {
+  readonly delivery?: SimLogsDeliveryDetail | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DescribeDeliveries command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DescribeDeliveriesCommand/
+ */
+export interface SimDescribeDeliveriesCommand {
+  readonly input: SimDescribeDeliveriesCommandInput;
+}
+
+export interface SimDescribeDeliveriesCommandInput {
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimDescribeDeliveriesCommandOutput {
+  readonly deliveries?: readonly SimLogsDeliveryDetail[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DeleteDelivery command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DeleteDeliveryCommand/
+ */
+export interface SimDeleteDeliveryCommand {
+  readonly input: SimDeleteDeliveryCommandInput;
+}
+
+export interface SimDeleteDeliveryCommandInput {
+  readonly id?: string | undefined;
+}
+
+export interface SimDeleteDeliveryCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/logs/command/delivery/sim-logs-created-delivery.ts
+++ b/src/service/logs/command/delivery/sim-logs-created-delivery.ts
@@ -1,0 +1,69 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimLogsDeliveryDestination } from "../../delivery/sim-logs-delivery-destination.js";
+import { SimLogsDeliveryS3Configuration } from "../../delivery/sim-logs-delivery-s3-configuration.js";
+import { SimLogsDelivery } from "../../delivery/sim-logs-delivery.js";
+import { SimLogsValidationException } from "../../error/sim-logs.error.js";
+import type {
+  SimCreateDeliveryCommandInput,
+  SimLogsS3DeliveryConfiguration,
+} from "./delivery.command.js";
+
+interface SimLogsCreatedDeliveryProperties {
+  readonly id: string;
+  readonly deliverySourceName: string;
+  readonly destination: SimLogsDeliveryDestination;
+  readonly input: SimCreateDeliveryCommandInput;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The delivery a CreateDelivery request asked for.
+ *
+ * The destination decides two of the delivery's own fields. Its kind is
+ * reported on every delivery that reaches it, and it is what says whether an
+ * S3 layout means anything.
+ */
+export function simLogsCreatedDelivery(
+  properties: SimLogsCreatedDeliveryProperties,
+): SimLogsDelivery {
+  const { input, destination } = properties;
+
+  return new SimLogsDelivery({
+    id: properties.id,
+    deliverySourceName: properties.deliverySourceName,
+    deliveryDestinationArn: destination.arn,
+    deliveryDestinationType: destination.destinationType,
+    recordFields: input.recordFields,
+    fieldDelimiter: input.fieldDelimiter,
+    s3DeliveryConfiguration: s3Configuration(
+      input.s3DeliveryConfiguration,
+      destination,
+    ),
+    accountRegionScope: properties.accountRegionScope,
+  });
+}
+
+/**
+ * The S3 layout a delivery was asked for, refused where its destination has no
+ * keys to lay anything out under.
+ */
+function s3Configuration(
+  configuration: SimLogsS3DeliveryConfiguration | undefined,
+  destination: SimLogsDeliveryDestination,
+): SimLogsDeliveryS3Configuration | undefined {
+  if (configuration === undefined) {
+    return undefined;
+  }
+
+  if (destination.destinationType !== "S3") {
+    throw new SimLogsValidationException(
+      `s3DeliveryConfiguration only applies to an S3 delivery destination, ` +
+        `and '${destination.name}' is ${destination.destinationType}`,
+    );
+  }
+
+  return new SimLogsDeliveryS3Configuration({
+    suffixPath: configuration.suffixPath,
+    enableHiveCompatiblePath: configuration.enableHiveCompatiblePath,
+  });
+}

--- a/src/service/logs/command/delivery/sim-logs-delivery-commands.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-commands.ts
@@ -25,8 +25,8 @@ import {
   requiredSimLogsDeliveryValue,
 } from "./sim-logs-delivery-input.js";
 
-/** The largest page of deliveries this simulation reports at once. */
-const maximumDescribeLimit = 100;
+/** The largest page the delivery listings take, as real CloudWatch Logs does. */
+const maximumDescribeLimit = 50;
 
 interface SimLogsDeliveryCommandsProperties {
   readonly sources: SimLogsDeliverySourceStore;

--- a/src/service/logs/command/delivery/sim-logs-delivery-commands.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-commands.ts
@@ -1,0 +1,148 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  simLogsAnyDeliveryArn,
+  simLogsDeliveryArn,
+} from "../../delivery/sim-logs-delivery-arn.js";
+import type { SimLogsDeliveryDestinationStore } from "../../delivery/sim-logs-delivery-destination-store.js";
+import { SimLogsDeliveryIds } from "../../delivery/sim-logs-delivery-ids.js";
+import type { SimLogsDeliverySourceStore } from "../../delivery/sim-logs-delivery-source-store.js";
+import type { SimLogsDeliveryStore } from "../../delivery/sim-logs-delivery-store.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import { SimLogsPage } from "../sim-logs-page.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type {
+  SimCreateDeliveryCommand,
+  SimCreateDeliveryCommandOutput,
+  SimDeleteDeliveryCommand,
+  SimDeleteDeliveryCommandOutput,
+  SimDescribeDeliveriesCommand,
+  SimDescribeDeliveriesCommandOutput,
+} from "./delivery.command.js";
+import { simLogsCreatedDelivery } from "./sim-logs-created-delivery.js";
+import { simLogsDeliveryDetail } from "./sim-logs-delivery-detail.js";
+import {
+  refuseUnsimulatedDeliveryTags,
+  requiredSimLogsDeliveryValue,
+} from "./sim-logs-delivery-input.js";
+
+/** The largest page of deliveries this simulation reports at once. */
+const maximumDescribeLimit = 100;
+
+interface SimLogsDeliveryCommandsProperties {
+  readonly sources: SimLogsDeliverySourceStore;
+  readonly destinations: SimLogsDeliveryDestinationStore;
+  readonly deliveries: SimLogsDeliveryStore;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The commands that create, describe and remove deliveries.
+ */
+export class SimLogsDeliveryCommands {
+  readonly #sources: SimLogsDeliverySourceStore;
+  readonly #destinations: SimLogsDeliveryDestinationStore;
+  readonly #deliveries: SimLogsDeliveryStore;
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #scope: SimAwsAccountRegionScope;
+  readonly #ids = new SimLogsDeliveryIds();
+
+  constructor(properties: SimLogsDeliveryCommandsProperties) {
+    this.#sources = properties.sources;
+    this.#destinations = properties.destinations;
+    this.#deliveries = properties.deliveries;
+    this.#authorizer = properties.authorizer;
+    this.#scope = properties.accountRegionScope;
+  }
+
+  /**
+   * Join a delivery source to a delivery destination.
+   *
+   * Both have to be there already. CloudWatch Logs issues the identifier, and
+   * this is the one delivery resource a caller cannot name.
+   */
+  createDelivery(
+    command: SimCreateDeliveryCommand,
+    options?: SimLogsRequestOptions,
+  ): SimCreateDeliveryCommandOutput {
+    const input = command.input;
+    const deliverySourceName = requiredSimLogsDeliveryValue(
+      input.deliverySourceName,
+      "deliverySourceName",
+    );
+    const deliveryDestinationArn = requiredSimLogsDeliveryValue(
+      input.deliveryDestinationArn,
+      "deliveryDestinationArn",
+    );
+
+    refuseUnsimulatedDeliveryTags(input.tags, "CreateDelivery");
+    this.#authorizer.authorizeResource(
+      "logs:CreateDelivery",
+      simLogsAnyDeliveryArn(this.#scope),
+      options?.caller,
+    );
+
+    this.#sources.require(deliverySourceName);
+
+    const delivery = simLogsCreatedDelivery({
+      id: this.#ids.next(),
+      deliverySourceName,
+      destination: this.#destinations.requireByArn(deliveryDestinationArn),
+      input,
+      accountRegionScope: this.#scope,
+    });
+
+    this.#deliveries.add(delivery);
+
+    return { $metadata: {}, delivery: simLogsDeliveryDetail(delivery) };
+  }
+
+  /**
+   * Describe the deliveries in this scope, in the order they were created.
+   */
+  describeDeliveries(
+    command: SimDescribeDeliveriesCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDescribeDeliveriesCommandOutput {
+    const input = command.input;
+
+    this.#authorizer.authorizeResource(
+      "logs:DescribeDeliveries",
+      simLogsAnyDeliveryArn(this.#scope),
+      options?.caller,
+    );
+
+    const page = new SimLogsPage({
+      listed: this.#deliveries.all,
+      limit: input.limit,
+      nextToken: input.nextToken,
+      maximumLimit: maximumDescribeLimit,
+    });
+
+    return {
+      $metadata: {},
+      deliveries: page.items.map((delivery) => simLogsDeliveryDetail(delivery)),
+      nextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Remove a delivery, leaving its source and destination in place.
+   */
+  deleteDelivery(
+    command: SimDeleteDeliveryCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDeleteDeliveryCommandOutput {
+    const id = requiredSimLogsDeliveryValue(command.input.id, "id");
+
+    this.#authorizer.authorizeResource(
+      "logs:DeleteDelivery",
+      simLogsDeliveryArn(this.#scope, id),
+      options?.caller,
+    );
+
+    this.#deliveries.delete(id);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/logs/command/delivery/sim-logs-delivery-destination-commands.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-destination-commands.ts
@@ -5,6 +5,7 @@ import {
 } from "../../delivery/sim-logs-delivery-arn.js";
 import { SimLogsDeliveryDestination } from "../../delivery/sim-logs-delivery-destination.js";
 import type { SimLogsDeliveryDestinationStore } from "../../delivery/sim-logs-delivery-destination-store.js";
+import type { SimLogsDeliveryStore } from "../../delivery/sim-logs-delivery-store.js";
 import { requiredSimLogsDeliveryDestinationType } from "../../delivery/sim-logs-delivery-destination-type.js";
 import { requiredSimLogsDeliveryOutputFormat } from "../../delivery/sim-logs-delivery-output-format.js";
 import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
@@ -19,16 +20,18 @@ import type {
   SimPutDeliveryDestinationCommandOutput,
 } from "./delivery-destination.command.js";
 import { simLogsDeliveryDestinationDetail } from "./sim-logs-delivery-detail.js";
+import { refuseSimLogsDeliveryDestinationInUse } from "./sim-logs-delivery-in-use.js";
 import {
   refuseUnsimulatedDeliveryTags,
   requiredSimLogsDeliveryValue,
 } from "./sim-logs-delivery-input.js";
 
-/** The largest page of delivery destinations this simulation reports at once. */
-const maximumDescribeLimit = 100;
+/** The largest page the delivery listings take, as real CloudWatch Logs does. */
+const maximumDescribeLimit = 50;
 
 interface SimLogsDeliveryDestinationCommandsProperties {
   readonly destinations: SimLogsDeliveryDestinationStore;
+  readonly deliveries: SimLogsDeliveryStore;
   readonly authorizer: SimLogsAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
@@ -38,11 +41,13 @@ interface SimLogsDeliveryDestinationCommandsProperties {
  */
 export class SimLogsDeliveryDestinationCommands {
   readonly #destinations: SimLogsDeliveryDestinationStore;
+  readonly #deliveries: SimLogsDeliveryStore;
   readonly #authorizer: SimLogsAuthorizer;
   readonly #scope: SimAwsAccountRegionScope;
 
   constructor(properties: SimLogsDeliveryDestinationCommandsProperties) {
     this.#destinations = properties.destinations;
+    this.#deliveries = properties.deliveries;
     this.#authorizer = properties.authorizer;
     this.#scope = properties.accountRegionScope;
   }
@@ -127,7 +132,7 @@ export class SimLogsDeliveryDestinationCommands {
   }
 
   /**
-   * Remove a delivery destination.
+   * Remove a delivery destination no delivery is writing to.
    */
   deleteDeliveryDestination(
     command: SimDeleteDeliveryDestinationCommand,
@@ -141,6 +146,10 @@ export class SimLogsDeliveryDestinationCommands {
       options?.caller,
     );
 
+    refuseSimLogsDeliveryDestinationInUse(
+      this.#deliveries,
+      this.#destinations.require(name),
+    );
     this.#destinations.delete(name);
 
     return { $metadata: {} };

--- a/src/service/logs/command/delivery/sim-logs-delivery-destination-commands.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-destination-commands.ts
@@ -1,0 +1,148 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  simLogsAnyDeliveryDestinationArn,
+  simLogsDeliveryDestinationArn,
+} from "../../delivery/sim-logs-delivery-arn.js";
+import { SimLogsDeliveryDestination } from "../../delivery/sim-logs-delivery-destination.js";
+import type { SimLogsDeliveryDestinationStore } from "../../delivery/sim-logs-delivery-destination-store.js";
+import { requiredSimLogsDeliveryDestinationType } from "../../delivery/sim-logs-delivery-destination-type.js";
+import { requiredSimLogsDeliveryOutputFormat } from "../../delivery/sim-logs-delivery-output-format.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import { SimLogsPage } from "../sim-logs-page.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type {
+  SimDeleteDeliveryDestinationCommand,
+  SimDeleteDeliveryDestinationCommandOutput,
+  SimDescribeDeliveryDestinationsCommand,
+  SimDescribeDeliveryDestinationsCommandOutput,
+  SimPutDeliveryDestinationCommand,
+  SimPutDeliveryDestinationCommandOutput,
+} from "./delivery-destination.command.js";
+import { simLogsDeliveryDestinationDetail } from "./sim-logs-delivery-detail.js";
+import {
+  refuseUnsimulatedDeliveryTags,
+  requiredSimLogsDeliveryValue,
+} from "./sim-logs-delivery-input.js";
+
+/** The largest page of delivery destinations this simulation reports at once. */
+const maximumDescribeLimit = 100;
+
+interface SimLogsDeliveryDestinationCommandsProperties {
+  readonly destinations: SimLogsDeliveryDestinationStore;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The commands that put, describe and remove delivery destinations.
+ */
+export class SimLogsDeliveryDestinationCommands {
+  readonly #destinations: SimLogsDeliveryDestinationStore;
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #scope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimLogsDeliveryDestinationCommandsProperties) {
+    this.#destinations = properties.destinations;
+    this.#authorizer = properties.authorizer;
+    this.#scope = properties.accountRegionScope;
+  }
+
+  /**
+   * Put a delivery destination over the resource logs are to be written into.
+   *
+   * The kind of destination is read from the ARN, and the output format is
+   * fixed from here on: a put that would change it is refused rather than
+   * applied.
+   */
+  putDeliveryDestination(
+    command: SimPutDeliveryDestinationCommand,
+    options?: SimLogsRequestOptions,
+  ): SimPutDeliveryDestinationCommandOutput {
+    const input = command.input;
+    const name = requiredSimLogsDeliveryValue(input.name, "name");
+    const destinationResourceArn = requiredSimLogsDeliveryValue(
+      input.deliveryDestinationConfiguration?.destinationResourceArn,
+      "deliveryDestinationConfiguration.destinationResourceArn",
+    );
+
+    refuseUnsimulatedDeliveryTags(input.tags, "PutDeliveryDestination");
+    this.#authorizer.authorizeResource(
+      "logs:PutDeliveryDestination",
+      simLogsDeliveryDestinationArn(this.#scope, name),
+      options?.caller,
+    );
+
+    const destinationType = requiredSimLogsDeliveryDestinationType(
+      destinationResourceArn,
+    );
+    const destination = new SimLogsDeliveryDestination({
+      name,
+      destinationResourceArn,
+      destinationType,
+      outputFormat: requiredSimLogsDeliveryOutputFormat(
+        input.outputFormat,
+        destinationType,
+      ),
+      accountRegionScope: this.#scope,
+    });
+
+    this.#destinations.put(destination);
+
+    return {
+      $metadata: {},
+      deliveryDestination: simLogsDeliveryDestinationDetail(destination),
+    };
+  }
+
+  /**
+   * Describe the delivery destinations in this scope, in the order they were
+   * put.
+   */
+  describeDeliveryDestinations(
+    command: SimDescribeDeliveryDestinationsCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDescribeDeliveryDestinationsCommandOutput {
+    const input = command.input;
+
+    this.#authorizer.authorizeResource(
+      "logs:DescribeDeliveryDestinations",
+      simLogsAnyDeliveryDestinationArn(this.#scope),
+      options?.caller,
+    );
+
+    const page = new SimLogsPage({
+      listed: this.#destinations.all,
+      limit: input.limit,
+      nextToken: input.nextToken,
+      maximumLimit: maximumDescribeLimit,
+    });
+
+    return {
+      $metadata: {},
+      deliveryDestinations: page.items.map((destination) =>
+        simLogsDeliveryDestinationDetail(destination),
+      ),
+      nextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Remove a delivery destination.
+   */
+  deleteDeliveryDestination(
+    command: SimDeleteDeliveryDestinationCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDeleteDeliveryDestinationCommandOutput {
+    const name = requiredSimLogsDeliveryValue(command.input.name, "name");
+
+    this.#authorizer.authorizeResource(
+      "logs:DeleteDeliveryDestination",
+      simLogsDeliveryDestinationArn(this.#scope, name),
+      options?.caller,
+    );
+
+    this.#destinations.delete(name);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/logs/command/delivery/sim-logs-delivery-detail.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-detail.ts
@@ -1,0 +1,74 @@
+import type { SimLogsDeliveryDestination } from "../../delivery/sim-logs-delivery-destination.js";
+import type { SimLogsDeliverySource } from "../../delivery/sim-logs-delivery-source.js";
+import type { SimLogsDelivery } from "../../delivery/sim-logs-delivery.js";
+import type { SimLogsDeliveryDestinationDetail } from "./delivery-destination.command.js";
+import type { SimLogsDeliverySourceDetail } from "./delivery-source.command.js";
+import type {
+  SimLogsDeliveryDetail,
+  SimLogsS3DeliveryConfiguration,
+} from "./delivery.command.js";
+
+/**
+ * What DescribeDeliverySources reports about one delivery source.
+ */
+export function simLogsDeliverySourceDetail(
+  source: SimLogsDeliverySource,
+): SimLogsDeliverySourceDetail {
+  return {
+    name: source.name,
+    arn: source.arn,
+    resourceArns: source.resourceArns,
+    service: source.service,
+    logType: source.logType,
+  };
+}
+
+/**
+ * What DescribeDeliveryDestinations reports about one delivery destination.
+ */
+export function simLogsDeliveryDestinationDetail(
+  destination: SimLogsDeliveryDestination,
+): SimLogsDeliveryDestinationDetail {
+  return {
+    name: destination.name,
+    arn: destination.arn,
+    deliveryDestinationType: destination.destinationType,
+    outputFormat: destination.outputFormat,
+    deliveryDestinationConfiguration: {
+      destinationResourceArn: destination.destinationResourceArn,
+    },
+  };
+}
+
+/**
+ * What DescribeDeliveries reports about one delivery.
+ */
+export function simLogsDeliveryDetail(
+  delivery: SimLogsDelivery,
+): SimLogsDeliveryDetail {
+  return {
+    id: delivery.id,
+    arn: delivery.arn,
+    deliverySourceName: delivery.deliverySourceName,
+    deliveryDestinationArn: delivery.deliveryDestinationArn,
+    deliveryDestinationType: delivery.deliveryDestinationType,
+    recordFields: delivery.recordFields,
+    fieldDelimiter: delivery.fieldDelimiter,
+    s3DeliveryConfiguration: s3DeliveryConfigurationDetail(delivery),
+  };
+}
+
+function s3DeliveryConfigurationDetail(
+  delivery: SimLogsDelivery,
+): SimLogsS3DeliveryConfiguration | undefined {
+  const configuration = delivery.s3DeliveryConfiguration;
+
+  if (configuration === undefined) {
+    return undefined;
+  }
+
+  return {
+    suffixPath: configuration.suffixPath,
+    enableHiveCompatiblePath: configuration.enableHiveCompatiblePath,
+  };
+}

--- a/src/service/logs/command/delivery/sim-logs-delivery-in-use.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-in-use.ts
@@ -1,0 +1,45 @@
+import type { SimLogsDeliveryDestination } from "../../delivery/sim-logs-delivery-destination.js";
+import type { SimLogsDeliveryStore } from "../../delivery/sim-logs-delivery-store.js";
+import { SimLogsConflictException } from "../../error/sim-logs.error.js";
+
+/**
+ * Refuse deleting a delivery source a delivery still carries logs from.
+ *
+ * Real CloudWatch Logs refuses the same, and points a caller at
+ * `DescribeDeliveries` to find out which delivery is holding on to it. The
+ * delivery goes first, and in a template CloudFormation orders that itself.
+ */
+export function refuseSimLogsDeliverySourceInUse(
+  deliveries: SimLogsDeliveryStore,
+  name: string,
+): void {
+  const held = deliveries.all.some(
+    (delivery) => delivery.deliverySourceName === name,
+  );
+
+  if (held) {
+    throw new SimLogsConflictException(
+      `Delivery source '${name}' cannot be deleted while a delivery is ` +
+        `associated with it`,
+    );
+  }
+}
+
+/**
+ * Refuse deleting a delivery destination a delivery still writes to.
+ */
+export function refuseSimLogsDeliveryDestinationInUse(
+  deliveries: SimLogsDeliveryStore,
+  destination: SimLogsDeliveryDestination,
+): void {
+  const held = deliveries.all.some(
+    (delivery) => delivery.deliveryDestinationArn === destination.arn,
+  );
+
+  if (held) {
+    throw new SimLogsConflictException(
+      `Delivery destination '${destination.name}' cannot be deleted while a ` +
+        `delivery is associated with it`,
+    );
+  }
+}

--- a/src/service/logs/command/delivery/sim-logs-delivery-input.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-input.ts
@@ -1,0 +1,43 @@
+import {
+  SimLogsUnsupportedOperationException,
+  SimLogsValidationException,
+} from "../../error/sim-logs.error.js";
+
+/**
+ * Read a value a delivery operation requires.
+ *
+ * The delivery operations report a missing field as a `ValidationException`
+ * rather than the `InvalidParameterException` the log group operations use,
+ * which is why this exists beside the readers those share.
+ */
+export function requiredSimLogsDeliveryValue(
+  value: string | undefined,
+  field: string,
+): string {
+  if (value === undefined || value.length === 0) {
+    throw new SimLogsValidationException(
+      `1 validation error detected: Value at '${field}' failed to satisfy ` +
+        `constraint: Member must not be null`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Refuse tags on a delivery resource.
+ *
+ * Nothing reads a tag back here, so a resource created with them would look
+ * tagged to the request that made it and untagged to everything else.
+ */
+export function refuseUnsimulatedDeliveryTags(
+  tags: Record<string, string> | undefined,
+  operation: string,
+): void {
+  if (tags !== undefined) {
+    throw new SimLogsUnsupportedOperationException(
+      `Delivery resource tags are not simulated, so ${operation} refuses ` +
+        `them rather than dropping them`,
+    );
+  }
+}

--- a/src/service/logs/command/delivery/sim-logs-delivery-source-commands.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-source-commands.ts
@@ -4,11 +4,12 @@ import {
   simLogsDeliverySourceArn,
 } from "../../delivery/sim-logs-delivery-arn.js";
 import {
-  requireSimLogsDeliveryRegion,
+  requireSimLogsDeliverySource,
   requiredSimLogsDeliveredService,
 } from "../../delivery/sim-logs-delivery-source-service.js";
 import { SimLogsDeliverySource } from "../../delivery/sim-logs-delivery-source.js";
 import type { SimLogsDeliverySourceStore } from "../../delivery/sim-logs-delivery-source-store.js";
+import type { SimLogsDeliveryStore } from "../../delivery/sim-logs-delivery-store.js";
 import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
 import { SimLogsPage } from "../sim-logs-page.js";
 import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
@@ -21,16 +22,18 @@ import type {
   SimPutDeliverySourceCommandOutput,
 } from "./delivery-source.command.js";
 import { simLogsDeliverySourceDetail } from "./sim-logs-delivery-detail.js";
+import { refuseSimLogsDeliverySourceInUse } from "./sim-logs-delivery-in-use.js";
 import {
   refuseUnsimulatedDeliveryTags,
   requiredSimLogsDeliveryValue,
 } from "./sim-logs-delivery-input.js";
 
-/** The largest page of delivery sources this simulation reports at once. */
-const maximumDescribeLimit = 100;
+/** The largest page the delivery listings take, as real CloudWatch Logs does. */
+const maximumDescribeLimit = 50;
 
 interface SimLogsDeliverySourceCommandsProperties {
   readonly sources: SimLogsDeliverySourceStore;
+  readonly deliveries: SimLogsDeliveryStore;
   readonly authorizer: SimLogsAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
@@ -40,11 +43,13 @@ interface SimLogsDeliverySourceCommandsProperties {
  */
 export class SimLogsDeliverySourceCommands {
   readonly #sources: SimLogsDeliverySourceStore;
+  readonly #deliveries: SimLogsDeliveryStore;
   readonly #authorizer: SimLogsAuthorizer;
   readonly #scope: SimAwsAccountRegionScope;
 
   constructor(properties: SimLogsDeliverySourceCommandsProperties) {
     this.#sources = properties.sources;
+    this.#deliveries = properties.deliveries;
     this.#authorizer = properties.authorizer;
     this.#scope = properties.accountRegionScope;
   }
@@ -77,7 +82,11 @@ export class SimLogsDeliverySourceCommands {
 
     const service = requiredSimLogsDeliveredService(resourceArn);
 
-    requireSimLogsDeliveryRegion(service, this.#scope.regionName);
+    requireSimLogsDeliverySource({
+      service,
+      regionName: this.#scope.regionName,
+      logType,
+    });
 
     const source = new SimLogsDeliverySource({
       name,
@@ -127,7 +136,7 @@ export class SimLogsDeliverySourceCommands {
   }
 
   /**
-   * Remove a delivery source.
+   * Remove a delivery source no delivery is carrying logs from.
    */
   deleteDeliverySource(
     command: SimDeleteDeliverySourceCommand,
@@ -141,6 +150,7 @@ export class SimLogsDeliverySourceCommands {
       options?.caller,
     );
 
+    refuseSimLogsDeliverySourceInUse(this.#deliveries, name);
     this.#sources.delete(name);
 
     return { $metadata: {} };

--- a/src/service/logs/command/delivery/sim-logs-delivery-source-commands.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-source-commands.ts
@@ -1,0 +1,148 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  simLogsAnyDeliverySourceArn,
+  simLogsDeliverySourceArn,
+} from "../../delivery/sim-logs-delivery-arn.js";
+import {
+  requireSimLogsDeliveryRegion,
+  requiredSimLogsDeliveredService,
+} from "../../delivery/sim-logs-delivery-source-service.js";
+import { SimLogsDeliverySource } from "../../delivery/sim-logs-delivery-source.js";
+import type { SimLogsDeliverySourceStore } from "../../delivery/sim-logs-delivery-source-store.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import { SimLogsPage } from "../sim-logs-page.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type {
+  SimDeleteDeliverySourceCommand,
+  SimDeleteDeliverySourceCommandOutput,
+  SimDescribeDeliverySourcesCommand,
+  SimDescribeDeliverySourcesCommandOutput,
+  SimPutDeliverySourceCommand,
+  SimPutDeliverySourceCommandOutput,
+} from "./delivery-source.command.js";
+import { simLogsDeliverySourceDetail } from "./sim-logs-delivery-detail.js";
+import {
+  refuseUnsimulatedDeliveryTags,
+  requiredSimLogsDeliveryValue,
+} from "./sim-logs-delivery-input.js";
+
+/** The largest page of delivery sources this simulation reports at once. */
+const maximumDescribeLimit = 100;
+
+interface SimLogsDeliverySourceCommandsProperties {
+  readonly sources: SimLogsDeliverySourceStore;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The commands that put, describe and remove delivery sources.
+ */
+export class SimLogsDeliverySourceCommands {
+  readonly #sources: SimLogsDeliverySourceStore;
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #scope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimLogsDeliverySourceCommandsProperties) {
+    this.#sources = properties.sources;
+    this.#authorizer = properties.authorizer;
+    this.#scope = properties.accountRegionScope;
+  }
+
+  /**
+   * Put a delivery source over a resource whose logs are to be delivered.
+   *
+   * The service is read from the resource ARN, as real CloudWatch Logs reads
+   * it, and the region the request was made in has to be one that service's
+   * delivery can be set up from.
+   */
+  putDeliverySource(
+    command: SimPutDeliverySourceCommand,
+    options?: SimLogsRequestOptions,
+  ): SimPutDeliverySourceCommandOutput {
+    const input = command.input;
+    const name = requiredSimLogsDeliveryValue(input.name, "name");
+    const resourceArn = requiredSimLogsDeliveryValue(
+      input.resourceArn,
+      "resourceArn",
+    );
+    const logType = requiredSimLogsDeliveryValue(input.logType, "logType");
+
+    refuseUnsimulatedDeliveryTags(input.tags, "PutDeliverySource");
+    this.#authorizer.authorizeResource(
+      "logs:PutDeliverySource",
+      simLogsDeliverySourceArn(this.#scope, name),
+      options?.caller,
+    );
+
+    const service = requiredSimLogsDeliveredService(resourceArn);
+
+    requireSimLogsDeliveryRegion(service, this.#scope.regionName);
+
+    const source = new SimLogsDeliverySource({
+      name,
+      resourceArn,
+      logType,
+      service,
+      accountRegionScope: this.#scope,
+    });
+
+    this.#sources.put(source);
+
+    return {
+      $metadata: {},
+      deliverySource: simLogsDeliverySourceDetail(source),
+    };
+  }
+
+  /**
+   * Describe the delivery sources in this scope, in the order they were put.
+   */
+  describeDeliverySources(
+    command: SimDescribeDeliverySourcesCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDescribeDeliverySourcesCommandOutput {
+    const input = command.input;
+
+    this.#authorizer.authorizeResource(
+      "logs:DescribeDeliverySources",
+      simLogsAnyDeliverySourceArn(this.#scope),
+      options?.caller,
+    );
+
+    const page = new SimLogsPage({
+      listed: this.#sources.all,
+      limit: input.limit,
+      nextToken: input.nextToken,
+      maximumLimit: maximumDescribeLimit,
+    });
+
+    return {
+      $metadata: {},
+      deliverySources: page.items.map((source) =>
+        simLogsDeliverySourceDetail(source),
+      ),
+      nextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Remove a delivery source.
+   */
+  deleteDeliverySource(
+    command: SimDeleteDeliverySourceCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDeleteDeliverySourceCommandOutput {
+    const name = requiredSimLogsDeliveryValue(command.input.name, "name");
+
+    this.#authorizer.authorizeResource(
+      "logs:DeleteDeliverySource",
+      simLogsDeliverySourceArn(this.#scope, name),
+      options?.caller,
+    );
+
+    this.#sources.delete(name);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/logs/command/sim-logs-command.types.ts
+++ b/src/service/logs/command/sim-logs-command.types.ts
@@ -54,3 +54,41 @@ export type {
   SimPutSubscriptionFilterCommandInput,
   SimPutSubscriptionFilterCommandOutput,
 } from "./subscription/subscription.command.js";
+export type {
+  SimDeleteDeliverySourceCommand,
+  SimDeleteDeliverySourceCommandInput,
+  SimDeleteDeliverySourceCommandOutput,
+  SimDescribeDeliverySourcesCommand,
+  SimDescribeDeliverySourcesCommandInput,
+  SimDescribeDeliverySourcesCommandOutput,
+  SimLogsDeliverySourceDetail,
+  SimPutDeliverySourceCommand,
+  SimPutDeliverySourceCommandInput,
+  SimPutDeliverySourceCommandOutput,
+} from "./delivery/delivery-source.command.js";
+export type {
+  SimDeleteDeliveryDestinationCommand,
+  SimDeleteDeliveryDestinationCommandInput,
+  SimDeleteDeliveryDestinationCommandOutput,
+  SimDescribeDeliveryDestinationsCommand,
+  SimDescribeDeliveryDestinationsCommandInput,
+  SimDescribeDeliveryDestinationsCommandOutput,
+  SimLogsDeliveryDestinationConfiguration,
+  SimLogsDeliveryDestinationDetail,
+  SimPutDeliveryDestinationCommand,
+  SimPutDeliveryDestinationCommandInput,
+  SimPutDeliveryDestinationCommandOutput,
+} from "./delivery/delivery-destination.command.js";
+export type {
+  SimCreateDeliveryCommand,
+  SimCreateDeliveryCommandInput,
+  SimCreateDeliveryCommandOutput,
+  SimDeleteDeliveryCommand,
+  SimDeleteDeliveryCommandInput,
+  SimDeleteDeliveryCommandOutput,
+  SimDescribeDeliveriesCommand,
+  SimDescribeDeliveriesCommandInput,
+  SimDescribeDeliveriesCommandOutput,
+  SimLogsDeliveryDetail,
+  SimLogsS3DeliveryConfiguration,
+} from "./delivery/delivery.command.js";

--- a/src/service/logs/delivery/sim-logs-deliveries.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-deliveries.iso.test.ts
@@ -1,0 +1,148 @@
+import {
+  CreateDeliveryCommand,
+  DeleteDeliveryCommand,
+  DescribeDeliveriesCommand,
+  PutDeliveryDestinationCommand,
+  PutDeliverySourceCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
+const bucketArn = "arn:aws:s3:::example-access-logs";
+const sourceName = "site-access-logs";
+const destinationName = "site-access-logs";
+const suffixPath = "{DistributionId}/{yyyy}/{MM}/{dd}/{HH}";
+
+/**
+ * The source and destination a delivery joins, and the destination's ARN.
+ */
+async function givenSourceAndDestination(simAws: SimAws): Promise<string> {
+  await simAws.logs().putDeliverySource(
+    new PutDeliverySourceCommand({
+      name: sourceName,
+      resourceArn: distributionArn,
+      logType: "ACCESS_LOGS",
+    }),
+  );
+
+  const put = await simAws.logs().putDeliveryDestination(
+    new PutDeliveryDestinationCommand({
+      name: destinationName,
+      deliveryDestinationConfiguration: {
+        destinationResourceArn: bucketArn,
+      },
+    }),
+  );
+
+  return put.deliveryDestination?.arn ?? "";
+}
+
+describe("simulated CloudWatch Logs deliveries", () => {
+  it("joins a delivery source to a delivery destination", async () => {
+    // Given a delivery source over a distribution and a destination over a
+    // bucket.
+    const simAws = new SimAws();
+    const deliveryDestinationArn = await givenSourceAndDestination(simAws);
+
+    // When a delivery joins the two.
+    const created = await simAws.logs().createDelivery(
+      new CreateDeliveryCommand({
+        deliverySourceName: sourceName,
+        deliveryDestinationArn,
+      }),
+    );
+
+    // Then it comes back under an identifier CloudWatch Logs issued, carrying
+    // the kind of destination it reaches.
+    const delivery = created.delivery;
+
+    assertNonNullable(delivery);
+    assertIdentical(delivery.deliverySourceName, sourceName);
+    assertIdentical(delivery.deliveryDestinationType, "S3");
+    assertStringIncludes(delivery.arn, `:delivery:${delivery.id}`);
+  });
+
+  it("keeps the S3 layout a delivery was created with", async () => {
+    // Given a delivery source and an S3 destination.
+    const simAws = new SimAws();
+    const deliveryDestinationArn = await givenSourceAndDestination(simAws);
+
+    // When a delivery asks for Hive compatible paths under a suffix path.
+    const created = await simAws.logs().createDelivery(
+      new CreateDeliveryCommand({
+        deliverySourceName: sourceName,
+        deliveryDestinationArn,
+        s3DeliveryConfiguration: {
+          suffixPath,
+          enableHiveCompatiblePath: true,
+        },
+      }),
+    );
+
+    // Then both read back, which is what a test of a logging construct has to
+    // assert on.
+    const configuration = created.delivery?.s3DeliveryConfiguration;
+
+    assertNonNullable(configuration);
+    assertIdentical(configuration.suffixPath, suffixPath);
+    assertTrue(configuration.enableHiveCompatiblePath ?? false);
+  });
+
+  it("describes the deliveries in the account", async () => {
+    // Given a delivery.
+    const simAws = new SimAws();
+    const deliveryDestinationArn = await givenSourceAndDestination(simAws);
+
+    await simAws.logs().createDelivery(
+      new CreateDeliveryCommand({
+        deliverySourceName: sourceName,
+        deliveryDestinationArn,
+      }),
+    );
+
+    // When the deliveries are described.
+    const described = await simAws
+      .logs()
+      .describeDeliveries(new DescribeDeliveriesCommand({}));
+
+    // Then the delivery is reported with the source it carries logs from.
+    assertArrayEquals(
+      (described.deliveries ?? []).map(
+        (delivery) => delivery.deliverySourceName,
+      ),
+      [sourceName],
+    );
+  });
+
+  it("deletes a delivery and leaves its source and destination", async () => {
+    // Given a delivery.
+    const simAws = new SimAws();
+    const deliveryDestinationArn = await givenSourceAndDestination(simAws);
+    const created = await simAws.logs().createDelivery(
+      new CreateDeliveryCommand({
+        deliverySourceName: sourceName,
+        deliveryDestinationArn,
+      }),
+    );
+    const id = created.delivery?.id ?? "";
+
+    // When the delivery is deleted.
+    await simAws.logs().deleteDelivery(new DeleteDeliveryCommand({ id }));
+
+    // Then only the join is gone: the source and destination are still there
+    // for another delivery to use.
+    assertUndefined(simAws.logs().findDelivery(id));
+    assertNonNullable(simAws.logs().findDeliverySource(sourceName));
+    assertNonNullable(simAws.logs().findDeliveryDestination(destinationName));
+  });
+});

--- a/src/service/logs/delivery/sim-logs-delivery-arn.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-arn.ts
@@ -1,0 +1,61 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simLogsArnPrefix } from "../group/sim-logs-arn.js";
+
+/**
+ * The ARN of a delivery source.
+ *
+ * A delivery source is named by the caller, so its ARN carries that name. The
+ * delivery itself is the only one of the three resources named by an
+ * identifier CloudWatch Logs issues.
+ */
+export function simLogsDeliverySourceArn(
+  scope: SimAwsAccountRegionScope,
+  name: string,
+): string {
+  return `${simLogsArnPrefix(scope)}delivery-source:${name}`;
+}
+
+/**
+ * The ARN of every delivery source in one account and region.
+ */
+export function simLogsAnyDeliverySourceArn(
+  scope: SimAwsAccountRegionScope,
+): string {
+  return simLogsDeliverySourceArn(scope, "*");
+}
+
+/**
+ * The ARN of a delivery destination.
+ */
+export function simLogsDeliveryDestinationArn(
+  scope: SimAwsAccountRegionScope,
+  name: string,
+): string {
+  return `${simLogsArnPrefix(scope)}delivery-destination:${name}`;
+}
+
+/**
+ * The ARN of every delivery destination in one account and region.
+ */
+export function simLogsAnyDeliveryDestinationArn(
+  scope: SimAwsAccountRegionScope,
+): string {
+  return simLogsDeliveryDestinationArn(scope, "*");
+}
+
+/**
+ * The ARN of a delivery.
+ */
+export function simLogsDeliveryArn(
+  scope: SimAwsAccountRegionScope,
+  deliveryId: string,
+): string {
+  return `${simLogsArnPrefix(scope)}delivery:${deliveryId}`;
+}
+
+/**
+ * The ARN of every delivery in one account and region.
+ */
+export function simLogsAnyDeliveryArn(scope: SimAwsAccountRegionScope): string {
+  return simLogsDeliveryArn(scope, "*");
+}

--- a/src/service/logs/delivery/sim-logs-delivery-destination-refusals.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-destination-refusals.iso.test.ts
@@ -1,0 +1,115 @@
+import {
+  type OutputFormat,
+  PutDeliveryDestinationCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const bucketArn = "arn:aws:s3:::example-access-logs";
+const logGroupArn = "arn:aws:logs:us-east-1:123456789012:log-group:/site";
+const destinationName = "site-access-logs";
+
+async function putDestination(
+  simAws: SimAws,
+  destinationResourceArn: string,
+  outputFormat?: OutputFormat,
+): Promise<void> {
+  await simAws.logs().putDeliveryDestination(
+    new PutDeliveryDestinationCommand({
+      name: destinationName,
+      outputFormat,
+      deliveryDestinationConfiguration: { destinationResourceArn },
+    }),
+  );
+}
+
+describe("simulated CloudWatch Logs delivery destination refusals", () => {
+  it("refuses an output format change on an existing destination", async () => {
+    // Given a delivery destination written in plain text.
+    const simAws = new SimAws();
+
+    await putDestination(simAws, bucketArn, "plain");
+
+    // When the same destination is put again asking for JSON.
+    const error = await assertThrowsErrorAsync(async () => {
+      await putDestination(simAws, bucketArn, "json");
+    });
+
+    // Then it is refused: the format is fixed once the destination exists, so
+    // changing it means deleting and making it again.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "cannot be changed");
+    assertIdentical(
+      simAws.logs().findDeliveryDestination(destinationName)?.outputFormat,
+      "plain",
+    );
+  });
+
+  it("refuses parquet anywhere but S3", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a log group destination asks for parquet.
+    const error = await assertThrowsErrorAsync(async () => {
+      await putDestination(simAws, logGroupArn, "parquet");
+    });
+
+    // Then it is refused, since a log group has no columnar form to hold it.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "only written to an S3 destination");
+  });
+
+  it("refuses an output format CloudWatch Logs has no name for", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a destination asks for a format written the way a template author
+    // would guess at it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await putDestination(simAws, bucketArn, "JSON" as OutputFormat);
+    });
+
+    // Then it is refused, listing what the API takes.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "json, plain, w3c, raw, parquet");
+  });
+
+  it("refuses a destination ARN naming nothing logs can be written to", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a destination names a queue.
+    const error = await assertThrowsErrorAsync(async () => {
+      await putDestination(simAws, "arn:aws:sqs:us-east-1:123456789012:orders");
+    });
+
+    // Then it is refused rather than accepting a destination that would drop
+    // everything sent to it.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "names no delivery destination");
+  });
+
+  it("refuses a destination with no resource ARN", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a destination is put with an empty configuration.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .putDeliveryDestination(
+          new PutDeliveryDestinationCommand({ name: destinationName }),
+        );
+    });
+
+    // Then it names the field that was missing.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "destinationResourceArn");
+  });
+});

--- a/src/service/logs/delivery/sim-logs-delivery-destination-store.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-destination-store.ts
@@ -1,0 +1,93 @@
+import {
+  SimLogsResourceNotFoundException,
+  SimLogsValidationException,
+} from "../error/sim-logs.error.js";
+import type { SimLogsDeliveryDestination } from "./sim-logs-delivery-destination.js";
+
+/**
+ * The delivery destinations of one simulated CloudWatch Logs scope.
+ *
+ * Destinations are keyed by name. The output format is fixed once the
+ * destination exists, so changing it means deleting the destination and making
+ * it again, which is a replacement in a template and a two step change through
+ * the SDK.
+ */
+export class SimLogsDeliveryDestinationStore {
+  readonly #destinations = new Map<string, SimLogsDeliveryDestination>();
+
+  /**
+   * Every delivery destination in this scope, in the order they were put.
+   */
+  get all(): readonly SimLogsDeliveryDestination[] {
+    return this.#destinations.values().toArray();
+  }
+
+  /**
+   * Put a delivery destination, updating one of the same name.
+   *
+   * A put that would change the output format is refused rather than applied,
+   * because a destination silently rewritten to another format would leave
+   * every reader of what it wrote parsing the wrong thing.
+   */
+  put(destination: SimLogsDeliveryDestination): void {
+    const existing = this.find(destination.name);
+
+    if (
+      existing !== undefined &&
+      existing.outputFormat !== destination.outputFormat
+    ) {
+      throw new SimLogsValidationException(
+        `Delivery destination '${destination.name}' was created with ` +
+          `output format '${existing.outputFormat}', which cannot be ` +
+          `changed to '${destination.outputFormat}'`,
+      );
+    }
+
+    this.#destinations.set(destination.name, destination);
+  }
+
+  /**
+   * Find a delivery destination by name.
+   */
+  find(name: string): SimLogsDeliveryDestination | undefined {
+    return this.#destinations.get(name);
+  }
+
+  /**
+   * Get a delivery destination by name, refusing one that is not there.
+   */
+  require(name: string): SimLogsDeliveryDestination {
+    const destination = this.find(name);
+
+    if (destination === undefined) {
+      throw new SimLogsResourceNotFoundException(
+        `Delivery destination '${name}' does not exist`,
+      );
+    }
+
+    return destination;
+  }
+
+  /**
+   * Get a delivery destination by its own ARN, refusing one that is not there.
+   */
+  requireByArn(arn: string): SimLogsDeliveryDestination {
+    const destination = this.all.find((candidate) => candidate.arn === arn);
+
+    if (destination === undefined) {
+      throw new SimLogsResourceNotFoundException(
+        `Delivery destination '${arn}' does not exist`,
+      );
+    }
+
+    return destination;
+  }
+
+  /**
+   * Remove a delivery destination, refusing one that is not there.
+   */
+  delete(name: string): void {
+    this.require(name);
+    this.#destinations.delete(name);
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery-destination-type.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-destination-type.ts
@@ -1,0 +1,43 @@
+import { SimLogsValidationException } from "../error/sim-logs.error.js";
+
+/**
+ * Where a delivery destination puts what it receives.
+ *
+ * The three values are the abbreviations real CloudWatch Logs reports: an S3
+ * bucket, a CloudWatch Logs log group, and a Firehose delivery stream.
+ */
+export type SimLogsDeliveryDestinationType = "S3" | "CWL" | "FH";
+
+const destinationTypesByArnService = new Map<
+  string,
+  SimLogsDeliveryDestinationType
+>([
+  ["s3", "S3"],
+  ["logs", "CWL"],
+  ["firehose", "FH"],
+]);
+
+/**
+ * Which kind of destination an ARN names.
+ *
+ * Real CloudWatch Logs works this out from the ARN rather than taking it from
+ * the caller, and reports it back on the destination and on every delivery
+ * that uses it. An ARN naming anything else is refused, because a destination
+ * of no known kind would accept a delivery and drop everything sent to it.
+ */
+export function requiredSimLogsDeliveryDestinationType(
+  destinationResourceArn: string,
+): SimLogsDeliveryDestinationType {
+  const service = destinationResourceArn.split(":", 3)[2];
+  const destinationType = destinationTypesByArnService.get(service ?? "");
+
+  if (destinationType === undefined) {
+    throw new SimLogsValidationException(
+      `destinationResourceArn '${destinationResourceArn}' names no ` +
+        `delivery destination: it has to be an S3 bucket, a CloudWatch Logs ` +
+        `log group or a Firehose delivery stream`,
+    );
+  }
+
+  return destinationType;
+}

--- a/src/service/logs/delivery/sim-logs-delivery-destination.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-destination.ts
@@ -1,0 +1,38 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simLogsDeliveryDestinationArn } from "./sim-logs-delivery-arn.js";
+import type { SimLogsDeliveryDestinationType } from "./sim-logs-delivery-destination-type.js";
+import type { SimLogsDeliveryOutputFormat } from "./sim-logs-delivery-output-format.js";
+
+interface SimLogsDeliveryDestinationProperties {
+  readonly name: string;
+  readonly destinationResourceArn: string;
+  readonly destinationType: SimLogsDeliveryDestinationType;
+  readonly outputFormat: SimLogsDeliveryOutputFormat;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * One delivery destination: where logs land, and in what form.
+ *
+ * The destination has its own ARN, which is what a delivery names. The bucket
+ * or log group behind it keeps its own, so the two ARNs in play here are easy
+ * to confuse and mean different things.
+ */
+export class SimLogsDeliveryDestination {
+  readonly name: string;
+  readonly destinationResourceArn: string;
+  readonly destinationType: SimLogsDeliveryDestinationType;
+  readonly outputFormat: SimLogsDeliveryOutputFormat;
+  readonly arn: string;
+
+  constructor(properties: SimLogsDeliveryDestinationProperties) {
+    this.name = properties.name;
+    this.destinationResourceArn = properties.destinationResourceArn;
+    this.destinationType = properties.destinationType;
+    this.outputFormat = properties.outputFormat;
+    this.arn = simLogsDeliveryDestinationArn(
+      properties.accountRegionScope,
+      properties.name,
+    );
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery-destinations.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-destinations.iso.test.ts
@@ -1,0 +1,150 @@
+import {
+  DeleteDeliveryDestinationCommand,
+  DescribeDeliveryDestinationsCommand,
+  type OutputFormat,
+  PutDeliveryDestinationCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const bucketArn = "arn:aws:s3:::example-access-logs";
+const destinationName = "site-access-logs";
+
+async function putDestination(
+  simAws: SimAws,
+  name: string,
+  destinationResourceArn: string,
+  outputFormat?: OutputFormat,
+): Promise<void> {
+  await simAws.logs().putDeliveryDestination(
+    new PutDeliveryDestinationCommand({
+      name,
+      outputFormat,
+      deliveryDestinationConfiguration: { destinationResourceArn },
+    }),
+  );
+}
+
+describe("simulated CloudWatch Logs delivery destinations", () => {
+  it("puts a delivery destination over a bucket", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a delivery destination is put over a bucket without naming a
+    // format.
+    const put = await simAws.logs().putDeliveryDestination(
+      new PutDeliveryDestinationCommand({
+        name: destinationName,
+        deliveryDestinationConfiguration: {
+          destinationResourceArn: bucketArn,
+        },
+      }),
+    );
+
+    // Then the kind of destination is read off the ARN and the format is the
+    // AWS default.
+    const destination = put.deliveryDestination;
+
+    assertNonNullable(destination);
+    assertIdentical(destination.deliveryDestinationType, "S3");
+    assertIdentical(destination.outputFormat, "json");
+    assertIdentical(
+      destination.deliveryDestinationConfiguration.destinationResourceArn,
+      bucketArn,
+    );
+    assertStringIncludes(
+      destination.arn,
+      `:delivery-destination:${destinationName}`,
+    );
+  });
+
+  it("reads the destination kind off a log group or stream ARN", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When delivery destinations are put over a log group and a delivery
+    // stream.
+    await putDestination(
+      simAws,
+      "to-log-group",
+      "arn:aws:logs:us-east-1:123456789012:log-group:/aws/vendedlogs/site",
+    );
+    await putDestination(
+      simAws,
+      "to-firehose",
+      "arn:aws:firehose:us-east-1:123456789012:deliverystream/site",
+    );
+
+    // Then each reports the abbreviation CloudWatch Logs uses for its kind.
+    assertIdentical(
+      simAws.logs().findDeliveryDestination("to-log-group")?.destinationType,
+      "CWL",
+    );
+    assertIdentical(
+      simAws.logs().findDeliveryDestination("to-firehose")?.destinationType,
+      "FH",
+    );
+  });
+
+  it("takes parquet on an S3 destination", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a destination over a bucket asks for parquet.
+    await putDestination(simAws, destinationName, bucketArn, "parquet");
+
+    // Then it is accepted, since S3 is the one kind that holds it.
+    assertIdentical(
+      simAws.logs().findDeliveryDestination(destinationName)?.outputFormat,
+      "parquet",
+    );
+  });
+
+  it("describes the delivery destinations in the account", async () => {
+    // Given two delivery destinations.
+    const simAws = new SimAws();
+
+    await putDestination(simAws, destinationName, bucketArn);
+    await putDestination(simAws, "other-access-logs", `${bucketArn}-other`);
+
+    // When they are described.
+    const described = await simAws
+      .logs()
+      .describeDeliveryDestinations(
+        new DescribeDeliveryDestinationsCommand({}),
+      );
+
+    // Then both are reported, in the order they were put.
+    assertArrayEquals(
+      (described.deliveryDestinations ?? []).map(
+        (destination) => destination.name,
+      ),
+      [destinationName, "other-access-logs"],
+    );
+  });
+
+  it("deletes a delivery destination", async () => {
+    // Given a delivery destination.
+    const simAws = new SimAws();
+
+    await putDestination(simAws, destinationName, bucketArn);
+
+    // When it is deleted.
+    await simAws
+      .logs()
+      .deleteDeliveryDestination(
+        new DeleteDeliveryDestinationCommand({ name: destinationName }),
+      );
+
+    // Then it is gone.
+    assertUndefined(simAws.logs().findDeliveryDestination(destinationName));
+  });
+});

--- a/src/service/logs/delivery/sim-logs-delivery-ids.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-ids.ts
@@ -1,0 +1,22 @@
+const deliveryIdDigits = 16;
+
+/**
+ * Source of the identifiers deliveries are reported under.
+ *
+ * Real CloudWatch Logs issues an opaque identifier here rather than taking a
+ * name from the caller, so a delivery is the one resource of the three a
+ * template cannot predict the physical name of. A counter is enough: unique
+ * within the service is all a caller can rely on about the real one.
+ */
+export class SimLogsDeliveryIds {
+  #issued = 0;
+
+  /**
+   * The next delivery identifier.
+   */
+  next(): string {
+    this.#issued += 1;
+
+    return String(this.#issued).padStart(deliveryIdDigits, "0");
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery-output-format.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-output-format.ts
@@ -1,0 +1,66 @@
+import { SimLogsValidationException } from "../error/sim-logs.error.js";
+import type { SimLogsDeliveryDestinationType } from "./sim-logs-delivery-destination-type.js";
+
+/**
+ * How a delivery destination writes what it receives.
+ */
+export type SimLogsDeliveryOutputFormat =
+  | "json"
+  | "plain"
+  | "w3c"
+  | "raw"
+  | "parquet";
+
+/**
+ * The output formats real CloudWatch Logs accepts, in the lower case the API
+ * uses. A template writing `JSON` is refused by an account and is refused
+ * here.
+ */
+export const simLogsDeliveryOutputFormats: readonly SimLogsDeliveryOutputFormat[] =
+  ["json", "plain", "w3c", "raw", "parquet"];
+
+/**
+ * What a delivery destination writes when the caller names no format.
+ */
+export const simLogsDefaultDeliveryOutputFormat: SimLogsDeliveryOutputFormat =
+  "json";
+
+/**
+ * Read the output format a request named, refusing anything else.
+ *
+ * Parquet is only written to S3. The other two destination kinds have no
+ * columnar form to write it into, and a destination that accepted it would
+ * deliver something else.
+ */
+export function requiredSimLogsDeliveryOutputFormat(
+  outputFormat: string | undefined,
+  destinationType: SimLogsDeliveryDestinationType,
+): SimLogsDeliveryOutputFormat {
+  if (outputFormat === undefined) {
+    return simLogsDefaultDeliveryOutputFormat;
+  }
+
+  if (!isSimLogsDeliveryOutputFormat(outputFormat)) {
+    throw new SimLogsValidationException(
+      `outputFormat '${outputFormat}' is not one CloudWatch Logs delivery ` +
+        `accepts: ${simLogsDeliveryOutputFormats.join(", ")}`,
+    );
+  }
+
+  if (outputFormat === "parquet" && destinationType !== "S3") {
+    throw new SimLogsValidationException(
+      `outputFormat 'parquet' is only written to an S3 destination, and ` +
+        `this one is ${destinationType}`,
+    );
+  }
+
+  return outputFormat;
+}
+
+function isSimLogsDeliveryOutputFormat(
+  outputFormat: string,
+): outputFormat is SimLogsDeliveryOutputFormat {
+  return simLogsDeliveryOutputFormats.includes(
+    outputFormat as SimLogsDeliveryOutputFormat,
+  );
+}

--- a/src/service/logs/delivery/sim-logs-delivery-refusals.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-refusals.iso.test.ts
@@ -1,5 +1,7 @@
 import {
   CreateDeliveryCommand,
+  DeleteDeliveryDestinationCommand,
+  DeleteDeliverySourceCommand,
   PutDeliveryDestinationCommand,
   PutDeliverySourceCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
@@ -178,5 +180,76 @@ describe("simulated CloudWatch Logs delivery refusals", () => {
     // Then it is refused: a log group has no keys to lay anything out under.
     assertIdentical(error.name, "ValidationException");
     assertStringIncludes(error.message, "only applies to an S3");
+  });
+
+  it("refuses deleting a source or destination a delivery holds", async () => {
+    // Given a source and a destination joined by a delivery.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "site-access-logs",
+      bucketArn,
+    );
+
+    await simAws.logs().createDelivery(
+      new CreateDeliveryCommand({
+        deliverySourceName: sourceName,
+        deliveryDestinationArn,
+      }),
+    );
+
+    // When either end of the delivery is deleted.
+    const source = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .deleteDeliverySource(
+          new DeleteDeliverySourceCommand({ name: sourceName }),
+        );
+    });
+    const destination = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .deleteDeliveryDestination(
+          new DeleteDeliveryDestinationCommand({ name: "site-access-logs" }),
+        );
+    });
+
+    // Then both are refused, as an account refuses them. The delivery has to
+    // go first.
+    assertIdentical(source.name, "ConflictException");
+    assertStringIncludes(source.message, "while a delivery is associated");
+    assertIdentical(destination.name, "ConflictException");
+    assertStringIncludes(destination.message, "while a delivery is associated");
+  });
+
+  it("refuses a suffix path longer than CloudWatch Logs takes", async () => {
+    // Given a source and an S3 destination.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "site-access-logs",
+      bucketArn,
+    );
+
+    // When a delivery asks for a suffix path one character over the limit.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().createDelivery(
+        new CreateDeliveryCommand({
+          deliverySourceName: sourceName,
+          deliveryDestinationArn,
+          s3DeliveryConfiguration: { suffixPath: "a".repeat(257) },
+        }),
+      );
+    });
+
+    // Then it is refused here rather than on a real deploy.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "takes at most 256");
   });
 });

--- a/src/service/logs/delivery/sim-logs-delivery-refusals.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-refusals.iso.test.ts
@@ -1,0 +1,182 @@
+import {
+  CreateDeliveryCommand,
+  PutDeliveryDestinationCommand,
+  PutDeliverySourceCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
+const bucketArn = "arn:aws:s3:::example-access-logs";
+const logGroupArn = "arn:aws:logs:us-east-1:123456789012:log-group:/site";
+const sourceName = "site-access-logs";
+
+async function givenSource(simAws: SimAws): Promise<void> {
+  await simAws.logs().putDeliverySource(
+    new PutDeliverySourceCommand({
+      name: sourceName,
+      resourceArn: distributionArn,
+      logType: "ACCESS_LOGS",
+    }),
+  );
+}
+
+async function givenDestination(
+  simAws: SimAws,
+  name: string,
+  destinationResourceArn: string,
+): Promise<string> {
+  const put = await simAws.logs().putDeliveryDestination(
+    new PutDeliveryDestinationCommand({
+      name,
+      deliveryDestinationConfiguration: { destinationResourceArn },
+    }),
+  );
+
+  return put.deliveryDestination?.arn ?? "";
+}
+
+describe("simulated CloudWatch Logs delivery refusals", () => {
+  it("refuses a delivery from a source that is not there", async () => {
+    // Given a destination and no delivery source.
+    const simAws = new SimAws();
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "site-access-logs",
+      bucketArn,
+    );
+
+    // When a delivery names a source that was never put.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().createDelivery(
+        new CreateDeliveryCommand({
+          deliverySourceName: sourceName,
+          deliveryDestinationArn,
+        }),
+      );
+    });
+
+    // Then it is reported as missing rather than left pointing at nothing.
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertStringIncludes(error.message, sourceName);
+  });
+
+  it("refuses a delivery to a destination that is not there", async () => {
+    // Given a delivery source and no destination.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    // When a delivery names a destination ARN nothing was created under.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().createDelivery(
+        new CreateDeliveryCommand({
+          deliverySourceName: sourceName,
+          deliveryDestinationArn:
+            "arn:aws:logs:us-east-1:123456789012:delivery-destination:gone",
+        }),
+      );
+    });
+
+    // Then it is reported as missing.
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertStringIncludes(error.message, "delivery-destination:gone");
+  });
+
+  it("refuses a second delivery joining the same pair", async () => {
+    // Given a source and destination already joined.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "site-access-logs",
+      bucketArn,
+    );
+
+    await simAws.logs().createDelivery(
+      new CreateDeliveryCommand({
+        deliverySourceName: sourceName,
+        deliveryDestinationArn,
+      }),
+    );
+
+    // When the same pair is joined again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().createDelivery(
+        new CreateDeliveryCommand({
+          deliverySourceName: sourceName,
+          deliveryDestinationArn,
+        }),
+      );
+    });
+
+    // Then it is refused rather than left duplicating the first.
+    assertIdentical(error.name, "ConflictException");
+    assertStringIncludes(error.message, "already delivers to");
+  });
+
+  it("refuses a suffix path naming a variable nothing substitutes", async () => {
+    // Given a source and an S3 destination.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "site-access-logs",
+      bucketArn,
+    );
+
+    // When a delivery asks for a partition variable spelled the wrong way.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().createDelivery(
+        new CreateDeliveryCommand({
+          deliverySourceName: sourceName,
+          deliveryDestinationArn,
+          s3DeliveryConfiguration: { suffixPath: "{DistributionID}/{yyyy}" },
+        }),
+      );
+    });
+
+    // Then it is refused, because delivery would write the text out literally
+    // and the bucket would look partitioned when it was not.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "{DistributionID}");
+  });
+
+  it("refuses an S3 layout on a destination that is not S3", async () => {
+    // Given a source and a log group destination.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "to-log-group",
+      logGroupArn,
+    );
+
+    // When a delivery to it asks for an S3 layout.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().createDelivery(
+        new CreateDeliveryCommand({
+          deliverySourceName: sourceName,
+          deliveryDestinationArn,
+          s3DeliveryConfiguration: { enableHiveCompatiblePath: true },
+        }),
+      );
+    });
+
+    // Then it is refused: a log group has no keys to lay anything out under.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "only applies to an S3");
+  });
+});

--- a/src/service/logs/delivery/sim-logs-delivery-s3-configuration.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-s3-configuration.ts
@@ -1,0 +1,67 @@
+import { SimLogsValidationException } from "../error/sim-logs.error.js";
+
+/**
+ * The partition variables an S3 suffix path may carry.
+ *
+ * These are the ones CloudFront standard logging v2 substitutes. A variable
+ * outside the set is written out as the literal text it is, so a template with
+ * `{DistributionID}` in it would produce a folder of that name and look like
+ * it had partitioned nothing.
+ */
+export const simLogsDeliverySuffixPathVariables: readonly string[] = [
+  "DistributionId",
+  "distributionid",
+  "yyyy",
+  "MM",
+  "dd",
+  "HH",
+  "accountid",
+];
+
+const suffixPathVariablePattern = /{([^{}]*)}/g;
+
+interface SimLogsDeliveryS3ConfigurationProperties {
+  readonly suffixPath: string | undefined;
+  readonly enableHiveCompatiblePath: boolean | undefined;
+}
+
+/**
+ * How a delivery lays out what it writes into an S3 bucket.
+ *
+ * The suffix path decides the key each log file lands under, and the Hive
+ * compatible flag decides whether that key is written in the `name=value` form
+ * Athena and Glue partition on.
+ */
+export class SimLogsDeliveryS3Configuration {
+  readonly suffixPath: string | undefined;
+  readonly enableHiveCompatiblePath: boolean;
+
+  constructor(properties: SimLogsDeliveryS3ConfigurationProperties) {
+    if (properties.suffixPath !== undefined) {
+      requireSimLogsDeliverySuffixPath(properties.suffixPath);
+    }
+
+    this.suffixPath = properties.suffixPath;
+    this.enableHiveCompatiblePath =
+      properties.enableHiveCompatiblePath ?? false;
+  }
+}
+
+/**
+ * Refuse a suffix path naming a partition variable that would never be
+ * substituted.
+ */
+export function requireSimLogsDeliverySuffixPath(suffixPath: string): void {
+  for (const match of suffixPath.matchAll(suffixPathVariablePattern)) {
+    const variable = match[1] ?? "";
+
+    if (!simLogsDeliverySuffixPathVariables.includes(variable)) {
+      throw new SimLogsValidationException(
+        `suffixPath '${suffixPath}' names partition variable '{${variable}}', ` +
+          `which delivery does not substitute. The ones it does are ${simLogsDeliverySuffixPathVariables
+            .map((name) => `{${name}}`)
+            .join(", ")}`,
+      );
+    }
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery-s3-configuration.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-s3-configuration.ts
@@ -20,6 +20,9 @@ export const simLogsDeliverySuffixPathVariables: readonly string[] = [
 
 const suffixPathVariablePattern = /{([^{}]*)}/g;
 
+/** How long a suffix path real CloudWatch Logs accepts. */
+const maximumSuffixPathLength = 256;
+
 interface SimLogsDeliveryS3ConfigurationProperties {
   readonly suffixPath: string | undefined;
   readonly enableHiveCompatiblePath: boolean | undefined;
@@ -48,10 +51,20 @@ export class SimLogsDeliveryS3Configuration {
 }
 
 /**
- * Refuse a suffix path naming a partition variable that would never be
- * substituted.
+ * Refuse a suffix path real CloudWatch Logs would refuse.
+ *
+ * A variable outside the set delivery substitutes is written out as the
+ * literal text it is, so a path with a typo in it looks partitioned and is
+ * not.
  */
 export function requireSimLogsDeliverySuffixPath(suffixPath: string): void {
+  if (suffixPath.length > maximumSuffixPathLength) {
+    throw new SimLogsValidationException(
+      `suffixPath is ${suffixPath.length} characters, and CloudWatch Logs ` +
+        `takes at most ${maximumSuffixPathLength}`,
+    );
+  }
+
   for (const match of suffixPath.matchAll(suffixPathVariablePattern)) {
     const variable = match[1] ?? "";
 

--- a/src/service/logs/delivery/sim-logs-delivery-source-refusals.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source-refusals.iso.test.ts
@@ -1,0 +1,153 @@
+import {
+  DeleteDeliverySourceCommand,
+  PutDeliverySourceCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
+const sourceName = "site-access-logs";
+
+function putSourceInput(
+  overrides: Record<string, unknown> = {},
+): ConstructorParameters<typeof PutDeliverySourceCommand>[0] {
+  return {
+    name: sourceName,
+    resourceArn: distributionArn,
+    logType: "ACCESS_LOGS",
+    ...overrides,
+  };
+}
+
+describe("simulated CloudWatch Logs delivery source refusals", () => {
+  it("refuses a second delivery source over the same distribution", async () => {
+    // Given a distribution that already has a delivery source.
+    const simAws = new SimAws();
+
+    await simAws
+      .logs()
+      .putDeliverySource(new PutDeliverySourceCommand(putSourceInput()));
+
+    // When a second source is put over the same distribution.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .putDeliverySource(
+          new PutDeliverySourceCommand(
+            putSourceInput({ name: "second-access-logs" }),
+          ),
+        );
+    });
+
+    // Then it is refused the way an account refuses it, which is what anyone
+    // adding a second logging construct to a distribution runs into.
+    assertIdentical(error.name, "ConflictException");
+    assertIdentical(
+      error.message,
+      "This ResourceId has already been used in another Delivery Source in " +
+        "this account",
+    );
+  });
+
+  it("refuses a CloudFront delivery source outside us-east-1", async () => {
+    // Given a simulated account in the region the rest of a stack lives in.
+    const simAws = new SimAws();
+
+    // When a CloudFront delivery source is put from there.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .account()
+        .region("eu-west-2")
+        .logs()
+        .putDeliverySource(new PutDeliverySourceCommand(putSourceInput()));
+    });
+
+    // Then it is refused, rather than creating a source the distribution
+    // would never deliver to.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "only be created in us-east-1");
+    assertStringIncludes(error.message, "made in eu-west-2");
+  });
+
+  it("refuses a resourceArn that is not an ARN", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a delivery source names something that is not an ARN.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .putDeliverySource(
+          new PutDeliverySourceCommand(putSourceInput({ resourceArn: "E1EX" })),
+        );
+    });
+
+    // Then it is refused: the service being logged is read from the ARN, and
+    // a source with no service delivers nothing.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "is not an ARN");
+  });
+
+  it("refuses tags rather than dropping them", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a delivery source is put with tags on it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .putDeliverySource(
+          new PutDeliverySourceCommand(
+            putSourceInput({ tags: { Environment: "test" } }),
+          ),
+        );
+    });
+
+    // Then it is refused, because nothing reads a tag back here.
+    assertIdentical(error.name, "UnsupportedOperationException");
+    assertStringIncludes(error.message, "PutDeliverySource");
+  });
+
+  it("refuses a delivery source with no name", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a delivery source is put without a name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .putDeliverySource(
+          new PutDeliverySourceCommand(putSourceInput({ name: undefined })),
+        );
+    });
+
+    // Then it is refused as a validation error, which is how the delivery
+    // operations report a missing field.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "Value at 'name'");
+  });
+
+  it("refuses deleting a delivery source that is not there", async () => {
+    // Given a simulated account with no delivery sources.
+    const simAws = new SimAws();
+
+    // When one is deleted anyway.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .deleteDeliverySource(
+          new DeleteDeliverySourceCommand({ name: sourceName }),
+        );
+    });
+
+    // Then it is reported as missing rather than passing silently.
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertStringIncludes(error.message, sourceName);
+  });
+});

--- a/src/service/logs/delivery/sim-logs-delivery-source-refusals.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source-refusals.iso.test.ts
@@ -75,23 +75,54 @@ describe("simulated CloudWatch Logs delivery source refusals", () => {
     assertStringIncludes(error.message, "made in eu-west-2");
   });
 
-  it("refuses a resourceArn that is not an ARN", async () => {
+  it("refuses a resourceArn that is not the ARN of a resource", async () => {
     // Given a simulated account.
     const simAws = new SimAws();
 
-    // When a delivery source names something that is not an ARN.
-    const error = await assertThrowsErrorAsync(async () => {
+    // When a delivery source names something that is not an ARN, and then a
+    // string naming a service and no resource.
+    const bare = await assertThrowsErrorAsync(async () => {
       await simAws
         .logs()
         .putDeliverySource(
           new PutDeliverySourceCommand(putSourceInput({ resourceArn: "E1EX" })),
         );
     });
+    const serviceOnly = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .putDeliverySource(
+          new PutDeliverySourceCommand(
+            putSourceInput({ resourceArn: "arn:aws:cloudfront" }),
+          ),
+        );
+    });
 
-    // Then it is refused: the service being logged is read from the ARN, and
-    // a source with no service delivers nothing.
+    // Then both are refused. The service being logged is read from the ARN,
+    // and a source over a service with no resource delivers nothing.
+    assertIdentical(bare.name, "ValidationException");
+    assertStringIncludes(bare.message, "is not the ARN of a resource");
+    assertIdentical(serviceOnly.name, "ValidationException");
+    assertStringIncludes(serviceOnly.message, "is not the ARN of a resource");
+  });
+
+  it("refuses a log type CloudFront does not deliver", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a delivery source over a distribution asks for another log type.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .putDeliverySource(
+          new PutDeliverySourceCommand(putSourceInput({ logType: "OTHER" })),
+        );
+    });
+
+    // Then it is refused. Standard logging v2 carries access logs and nothing
+    // else.
     assertIdentical(error.name, "ValidationException");
-    assertStringIncludes(error.message, "is not an ARN");
+    assertStringIncludes(error.message, "ACCESS_LOGS is the only one it has");
   });
 
   it("refuses tags rather than dropping them", async () => {

--- a/src/service/logs/delivery/sim-logs-delivery-source-service.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source-service.ts
@@ -18,42 +18,81 @@ export const simLogsCloudFrontDeliveryService = "cloudfront";
 export const simLogsCloudFrontDeliveryRegion: AwsRegionName = "us-east-1";
 
 /**
+ * The one kind of log CloudFront delivers.
+ *
+ * Standard logging v2 carries access logs and nothing else, so an account
+ * refuses a source over a distribution asking for anything else.
+ */
+export const simLogsCloudFrontLogType = "ACCESS_LOGS";
+
+/** How many colon separated segments the shortest ARN has. */
+const arnSegmentCount = 6;
+
+/**
  * The AWS service a delivery source's resource belongs to.
  *
  * Real CloudWatch Logs works this out from the ARN and reports it as the
- * source's `service`, so a caller never states it. A malformed ARN is refused
- * here, because a source whose service could not be read would deliver
- * nothing and say nothing about why.
+ * source's `service`, so a caller never states it. The whole ARN is checked
+ * rather than the service segment alone. `arn:aws:cloudfront` names a service
+ * and no resource, and a source over it would deliver nothing and say nothing
+ * about why.
  */
 export function requiredSimLogsDeliveredService(resourceArn: string): string {
-  const [prefix, , service] = resourceArn.split(":", 3);
+  const segments = resourceArn.split(":");
+  const [prefix, , service] = segments;
+  const resource = segments.slice(arnSegmentCount - 1).join(":");
 
-  if (service === undefined || service === "" || prefix !== "arn") {
+  if (
+    service === undefined ||
+    service === "" ||
+    resource === "" ||
+    prefix !== "arn" ||
+    segments.length < arnSegmentCount
+  ) {
     throw new SimLogsValidationException(
-      `resourceArn '${resourceArn}' is not an ARN, so the service the ` +
-        `delivery source is for cannot be read from it`,
+      `resourceArn '${resourceArn}' is not the ARN of a resource, so the ` +
+        `service the delivery source is for cannot be read from it`,
     );
   }
 
   return service;
 }
 
+interface SimLogsDeliverySourceRules {
+  readonly service: string;
+  readonly regionName: AwsRegionName;
+  readonly logType: string;
+}
+
 /**
- * Refuse a delivery source for a service the request's region cannot reach.
+ * Refuse a delivery source an account would refuse.
  *
- * Only the CloudFront rule is modelled, because CloudFront is the one service
- * whose delivery is pinned to a region other than its resource's own.
+ * Only the CloudFront rules are modelled. CloudFront is the one service whose
+ * delivery is pinned to a region other than its own resource's, and the log
+ * types the other services take vary by service in a way this simulation does
+ * not carry.
  */
-export function requireSimLogsDeliveryRegion(
-  service: string,
-  regionName: AwsRegionName,
+export function requireSimLogsDeliverySource(
+  properties: SimLogsDeliverySourceRules,
 ): void {
-  if (
-    service === simLogsCloudFrontDeliveryService &&
-    regionName !== simLogsCloudFrontDeliveryRegion
-  ) {
+  const { service, regionName, logType } = properties;
+
+  if (service !== simLogsCloudFrontDeliveryService) {
+    return;
+  }
+
+  if (regionName !== simLogsCloudFrontDeliveryRegion) {
     throw new SimLogsValidationException(
-      `A CloudFront delivery source can only be created in ${simLogsCloudFrontDeliveryRegion}, and this request was made in ${regionName}`,
+      `A CloudFront delivery source can only be created in ` +
+        `${simLogsCloudFrontDeliveryRegion}, and this request was made in ` +
+        regionName,
+    );
+  }
+
+  if (logType !== simLogsCloudFrontLogType) {
+    throw new SimLogsValidationException(
+      `logType '${logType}' is not one CloudFront delivers. ` +
+        `${simLogsCloudFrontLogType} is the only one it has`,
     );
   }
 }

--- a/src/service/logs/delivery/sim-logs-delivery-source-service.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source-service.ts
@@ -1,0 +1,59 @@
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import { SimLogsValidationException } from "../error/sim-logs.error.js";
+
+/**
+ * The service name a CloudFront delivery source reports.
+ */
+export const simLogsCloudFrontDeliveryService = "cloudfront";
+
+/**
+ * The one region CloudFront delivery is set up from.
+ *
+ * CloudFront is global and its standard logging v2 delivery lives in
+ * `us-east-1`, whatever region the bucket the logs land in belongs to. A
+ * caller anywhere else has nothing to create the delivery source through, and
+ * the mistake is easy to make because the rest of the stack is usually
+ * somewhere else.
+ */
+export const simLogsCloudFrontDeliveryRegion: AwsRegionName = "us-east-1";
+
+/**
+ * The AWS service a delivery source's resource belongs to.
+ *
+ * Real CloudWatch Logs works this out from the ARN and reports it as the
+ * source's `service`, so a caller never states it. A malformed ARN is refused
+ * here, because a source whose service could not be read would deliver
+ * nothing and say nothing about why.
+ */
+export function requiredSimLogsDeliveredService(resourceArn: string): string {
+  const [prefix, , service] = resourceArn.split(":", 3);
+
+  if (service === undefined || service === "" || prefix !== "arn") {
+    throw new SimLogsValidationException(
+      `resourceArn '${resourceArn}' is not an ARN, so the service the ` +
+        `delivery source is for cannot be read from it`,
+    );
+  }
+
+  return service;
+}
+
+/**
+ * Refuse a delivery source for a service the request's region cannot reach.
+ *
+ * Only the CloudFront rule is modelled, because CloudFront is the one service
+ * whose delivery is pinned to a region other than its resource's own.
+ */
+export function requireSimLogsDeliveryRegion(
+  service: string,
+  regionName: AwsRegionName,
+): void {
+  if (
+    service === simLogsCloudFrontDeliveryService &&
+    regionName !== simLogsCloudFrontDeliveryRegion
+  ) {
+    throw new SimLogsValidationException(
+      `A CloudFront delivery source can only be created in ${simLogsCloudFrontDeliveryRegion}, and this request was made in ${regionName}`,
+    );
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery-source-service.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source-service.ts
@@ -83,9 +83,7 @@ export function requireSimLogsDeliverySource(
 
   if (regionName !== simLogsCloudFrontDeliveryRegion) {
     throw new SimLogsValidationException(
-      `A CloudFront delivery source can only be created in ` +
-        `${simLogsCloudFrontDeliveryRegion}, and this request was made in ` +
-        regionName,
+      `A CloudFront delivery source can only be created in ${simLogsCloudFrontDeliveryRegion}, and this request was made in ${regionName}`,
     );
   }
 

--- a/src/service/logs/delivery/sim-logs-delivery-source-store.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source-store.ts
@@ -1,0 +1,82 @@
+import {
+  SimLogsConflictException,
+  SimLogsResourceNotFoundException,
+} from "../error/sim-logs.error.js";
+import type { SimLogsDeliverySource } from "./sim-logs-delivery-source.js";
+
+/**
+ * The delivery sources of one simulated CloudWatch Logs scope.
+ *
+ * Sources are keyed by name, and a second key matters just as much: one
+ * resource may have only one delivery source in an account. A distribution
+ * that already has logging set up therefore refuses a second source, which is
+ * the failure anyone adding a second construct to an existing distribution
+ * runs into.
+ */
+export class SimLogsDeliverySourceStore {
+  readonly #sources = new Map<string, SimLogsDeliverySource>();
+
+  /**
+   * Every delivery source in this scope, in the order they were put.
+   */
+  get all(): readonly SimLogsDeliverySource[] {
+    return this.#sources.values().toArray();
+  }
+
+  /**
+   * Put a delivery source, replacing one of the same name.
+   *
+   * Putting an existing name again is an update, as it is on real CloudWatch
+   * Logs. Putting a new name for a resource that already has a source is the
+   * conflict.
+   */
+  put(source: SimLogsDeliverySource): void {
+    const holder = this.withResourceArn(source.resourceArn);
+
+    if (holder !== undefined && holder.name !== source.name) {
+      throw new SimLogsConflictException(
+        "This ResourceId has already been used in another Delivery Source " +
+          "in this account",
+      );
+    }
+
+    this.#sources.set(source.name, source);
+  }
+
+  /**
+   * The delivery source covering a resource, if it has one.
+   */
+  withResourceArn(resourceArn: string): SimLogsDeliverySource | undefined {
+    return this.all.find((source) => source.resourceArn === resourceArn);
+  }
+
+  /**
+   * Find a delivery source by name.
+   */
+  find(name: string): SimLogsDeliverySource | undefined {
+    return this.#sources.get(name);
+  }
+
+  /**
+   * Get a delivery source by name, refusing one that is not there.
+   */
+  require(name: string): SimLogsDeliverySource {
+    const source = this.find(name);
+
+    if (source === undefined) {
+      throw new SimLogsResourceNotFoundException(
+        `Delivery source '${name}' does not exist`,
+      );
+    }
+
+    return source;
+  }
+
+  /**
+   * Remove a delivery source, refusing one that is not there.
+   */
+  delete(name: string): void {
+    this.require(name);
+    this.#sources.delete(name);
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery-source.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source.ts
@@ -1,0 +1,43 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simLogsDeliverySourceArn } from "./sim-logs-delivery-arn.js";
+
+interface SimLogsDeliverySourceProperties {
+  readonly name: string;
+  readonly resourceArn: string;
+  readonly logType: string;
+  readonly service: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * One delivery source: what is being logged, and which of its logs.
+ *
+ * A source names one resource. Real CloudWatch Logs lets a source hold several
+ * ARNs in `resourceArns` and has never accepted more than one, which is why
+ * the field is a list and this holds a single ARN behind it.
+ */
+export class SimLogsDeliverySource {
+  readonly name: string;
+  readonly resourceArn: string;
+  readonly logType: string;
+  readonly service: string;
+  readonly arn: string;
+
+  constructor(properties: SimLogsDeliverySourceProperties) {
+    this.name = properties.name;
+    this.resourceArn = properties.resourceArn;
+    this.logType = properties.logType;
+    this.service = properties.service;
+    this.arn = simLogsDeliverySourceArn(
+      properties.accountRegionScope,
+      properties.name,
+    );
+  }
+
+  /**
+   * The resources this source covers, as CloudWatch Logs reports them.
+   */
+  get resourceArns(): readonly string[] {
+    return [this.resourceArn];
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery-sources.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-sources.iso.test.ts
@@ -3,6 +3,7 @@ import {
   DescribeDeliverySourcesCommand,
   PutDeliverySourceCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
+import { assertThrowsErrorAsync } from "@kensio/smartass";
 import {
   assertArrayEquals,
   assertArrayLength,
@@ -161,5 +162,31 @@ describe("simulated CloudWatch Logs delivery sources", () => {
 
     // Then the distribution has no delivery source left.
     assertUndefined(simAws.logs().findDeliverySource(sourceName));
+  });
+
+  it("takes a page of 50 and refuses one of 51", async () => {
+    // Given a delivery source.
+    const simAws = new SimAws();
+
+    await putSource(simAws);
+
+    // When the largest page CloudWatch Logs offers is asked for, and then one
+    // over it.
+    const largest = await simAws
+      .logs()
+      .describeDeliverySources(
+        new DescribeDeliverySourcesCommand({ limit: 50 }),
+      );
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .describeDeliverySources(
+          new DescribeDeliverySourcesCommand({ limit: 51 }),
+        );
+    });
+
+    // Then 50 is served and 51 is refused, as an account refuses it.
+    assertArrayLength(largest.deliverySources ?? [], 1);
+    assertStringIncludes(error.message, "limit");
   });
 });

--- a/src/service/logs/delivery/sim-logs-delivery-sources.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-sources.iso.test.ts
@@ -1,0 +1,165 @@
+import {
+  DeleteDeliverySourceCommand,
+  DescribeDeliverySourcesCommand,
+  PutDeliverySourceCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
+const sourceName = "site-access-logs";
+
+async function putSource(
+  simAws: SimAws,
+  name = sourceName,
+  resourceArn = distributionArn,
+): Promise<void> {
+  await simAws.logs().putDeliverySource(
+    new PutDeliverySourceCommand({
+      name,
+      resourceArn,
+      logType: "ACCESS_LOGS",
+    }),
+  );
+}
+
+describe("simulated CloudWatch Logs delivery sources", () => {
+  it("puts a delivery source over a distribution", async () => {
+    // Given a simulated account.
+    const simAws = new SimAws();
+
+    // When a delivery source is put over a distribution.
+    const put = await simAws.logs().putDeliverySource(
+      new PutDeliverySourceCommand({
+        name: sourceName,
+        resourceArn: distributionArn,
+        logType: "ACCESS_LOGS",
+      }),
+    );
+
+    // Then it comes back with the service CloudWatch Logs read off the ARN,
+    // which the caller never states.
+    const source = put.deliverySource;
+
+    assertNonNullable(source);
+    assertIdentical(source.name, sourceName);
+    assertIdentical(source.service, "cloudfront");
+    assertIdentical(source.logType, "ACCESS_LOGS");
+    assertArrayEquals(source.resourceArns, [distributionArn]);
+    assertStringIncludes(source.arn, ":us-east-1:");
+    assertStringIncludes(source.arn, `:delivery-source:${sourceName}`);
+  });
+
+  it("describes the delivery sources in the account", async () => {
+    // Given two delivery sources over different distributions.
+    const simAws = new SimAws();
+
+    await putSource(simAws);
+    await putSource(simAws, "other-access-logs", `${distributionArn}2`);
+
+    // When the delivery sources are described.
+    const described = await simAws
+      .logs()
+      .describeDeliverySources(new DescribeDeliverySourcesCommand({}));
+
+    // Then both are reported, in the order they were put.
+    assertArrayEquals(
+      (described.deliverySources ?? []).map((source) => source.name),
+      [sourceName, "other-access-logs"],
+    );
+    assertUndefined(described.nextToken);
+  });
+
+  it("pages the delivery sources it describes", async () => {
+    // Given two delivery sources.
+    const simAws = new SimAws();
+
+    await putSource(simAws);
+    await putSource(simAws, "other-access-logs", `${distributionArn}2`);
+
+    // When one is asked for at a time.
+    const first = await simAws
+      .logs()
+      .describeDeliverySources(
+        new DescribeDeliverySourcesCommand({ limit: 1 }),
+      );
+    const second = await simAws.logs().describeDeliverySources(
+      new DescribeDeliverySourcesCommand({
+        limit: 1,
+        nextToken: first.nextToken,
+      }),
+    );
+
+    // Then the token reaches the second, and the listing ends there.
+    assertArrayLength(first.deliverySources ?? [], 1);
+    assertNonNullable(first.nextToken);
+    assertArrayEquals(
+      (second.deliverySources ?? []).map((source) => source.name),
+      ["other-access-logs"],
+    );
+    assertUndefined(second.nextToken);
+  });
+
+  it("updates a delivery source put again under the same name", async () => {
+    // Given a delivery source over a distribution.
+    const simAws = new SimAws();
+
+    await putSource(simAws);
+
+    // When the same name is put again for the same distribution.
+    await simAws.logs().putDeliverySource(
+      new PutDeliverySourceCommand({
+        name: sourceName,
+        resourceArn: distributionArn,
+        logType: "ACCESS_LOGS",
+      }),
+    );
+
+    // Then there is still only the one source, as there is on real AWS.
+    assertArrayLength(simAws.logs().allDeliverySources(), 1);
+  });
+
+  it("takes a delivery source for a service outside us-east-1", async () => {
+    // Given a simulated account in another region.
+    const simAws = new SimAws();
+    const logs = simAws.account().region("eu-west-2").logs();
+
+    // When a delivery source is put over a resource in that region.
+    await logs.putDeliverySource(
+      new PutDeliverySourceCommand({
+        name: "model-invocation-logs",
+        resourceArn: "arn:aws:bedrock:eu-west-2:123456789012:model-invocation",
+        logType: "INVOCATION_LOGS",
+      }),
+    );
+
+    // Then it is created: only CloudFront delivery is pinned to one region.
+    assertNonNullable(logs.findDeliverySource("model-invocation-logs"));
+  });
+
+  it("deletes a delivery source", async () => {
+    // Given a delivery source.
+    const simAws = new SimAws();
+
+    await putSource(simAws);
+
+    // When it is deleted.
+    await simAws
+      .logs()
+      .deleteDeliverySource(
+        new DeleteDeliverySourceCommand({ name: sourceName }),
+      );
+
+    // Then the distribution has no delivery source left.
+    assertUndefined(simAws.logs().findDeliverySource(sourceName));
+  });
+});

--- a/src/service/logs/delivery/sim-logs-delivery-store.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-store.ts
@@ -1,0 +1,73 @@
+import {
+  SimLogsConflictException,
+  SimLogsResourceNotFoundException,
+} from "../error/sim-logs.error.js";
+import type { SimLogsDelivery } from "./sim-logs-delivery.js";
+
+/**
+ * The deliveries of one simulated CloudWatch Logs scope.
+ *
+ * Deliveries are keyed by the identifier CloudWatch Logs issued for them. One
+ * source and destination pair may be joined only once, so a second delivery
+ * for the same pair is refused rather than left duplicating the first.
+ */
+export class SimLogsDeliveryStore {
+  readonly #deliveries = new Map<string, SimLogsDelivery>();
+
+  /**
+   * Every delivery in this scope, in the order they were created.
+   */
+  get all(): readonly SimLogsDelivery[] {
+    return this.#deliveries.values().toArray();
+  }
+
+  /**
+   * Add a delivery, refusing a source and destination pair already joined.
+   */
+  add(delivery: SimLogsDelivery): void {
+    const joined = this.all.some(
+      (existing) =>
+        existing.deliverySourceName === delivery.deliverySourceName &&
+        existing.deliveryDestinationArn === delivery.deliveryDestinationArn,
+    );
+
+    if (joined) {
+      throw new SimLogsConflictException(
+        `Delivery source '${delivery.deliverySourceName}' already delivers ` +
+          `to '${delivery.deliveryDestinationArn}'`,
+      );
+    }
+
+    this.#deliveries.set(delivery.id, delivery);
+  }
+
+  /**
+   * Find a delivery by its identifier.
+   */
+  find(id: string): SimLogsDelivery | undefined {
+    return this.#deliveries.get(id);
+  }
+
+  /**
+   * Get a delivery by its identifier, refusing one that is not there.
+   */
+  require(id: string): SimLogsDelivery {
+    const delivery = this.find(id);
+
+    if (delivery === undefined) {
+      throw new SimLogsResourceNotFoundException(
+        `Delivery '${id}' does not exist`,
+      );
+    }
+
+    return delivery;
+  }
+
+  /**
+   * Remove a delivery, refusing one that is not there.
+   */
+  delete(id: string): void {
+    this.require(id);
+    this.#deliveries.delete(id);
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery.ts
+++ b/src/service/logs/delivery/sim-logs-delivery.ts
@@ -36,7 +36,12 @@ export class SimLogsDelivery {
     this.deliverySourceName = properties.deliverySourceName;
     this.deliveryDestinationArn = properties.deliveryDestinationArn;
     this.deliveryDestinationType = properties.deliveryDestinationType;
-    this.recordFields = properties.recordFields;
+    // Copied, because the list arrives from the caller's own command input and
+    // nothing stops them holding on to it and changing it afterwards.
+    this.recordFields =
+      properties.recordFields === undefined
+        ? undefined
+        : [...properties.recordFields];
     this.fieldDelimiter = properties.fieldDelimiter;
     this.s3DeliveryConfiguration = properties.s3DeliveryConfiguration;
     this.arn = simLogsDeliveryArn(properties.accountRegionScope, properties.id);

--- a/src/service/logs/delivery/sim-logs-delivery.ts
+++ b/src/service/logs/delivery/sim-logs-delivery.ts
@@ -1,0 +1,44 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simLogsDeliveryArn } from "./sim-logs-delivery-arn.js";
+import type { SimLogsDeliveryDestinationType } from "./sim-logs-delivery-destination-type.js";
+import type { SimLogsDeliveryS3Configuration } from "./sim-logs-delivery-s3-configuration.js";
+
+interface SimLogsDeliveryProperties {
+  readonly id: string;
+  readonly deliverySourceName: string;
+  readonly deliveryDestinationArn: string;
+  readonly deliveryDestinationType: SimLogsDeliveryDestinationType;
+  readonly recordFields: readonly string[] | undefined;
+  readonly fieldDelimiter: string | undefined;
+  readonly s3DeliveryConfiguration: SimLogsDeliveryS3Configuration | undefined;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * One delivery: the join between a source and a destination.
+ *
+ * Nothing here moves any logs. The delivery records that a source was joined
+ * to a destination and how the records would be written, which is what a test
+ * of a construct that sets logging up has to assert on.
+ */
+export class SimLogsDelivery {
+  readonly id: string;
+  readonly deliverySourceName: string;
+  readonly deliveryDestinationArn: string;
+  readonly deliveryDestinationType: SimLogsDeliveryDestinationType;
+  readonly recordFields: readonly string[] | undefined;
+  readonly fieldDelimiter: string | undefined;
+  readonly s3DeliveryConfiguration: SimLogsDeliveryS3Configuration | undefined;
+  readonly arn: string;
+
+  constructor(properties: SimLogsDeliveryProperties) {
+    this.id = properties.id;
+    this.deliverySourceName = properties.deliverySourceName;
+    this.deliveryDestinationArn = properties.deliveryDestinationArn;
+    this.deliveryDestinationType = properties.deliveryDestinationType;
+    this.recordFields = properties.recordFields;
+    this.fieldDelimiter = properties.fieldDelimiter;
+    this.s3DeliveryConfiguration = properties.s3DeliveryConfiguration;
+    this.arn = simLogsDeliveryArn(properties.accountRegionScope, properties.id);
+  }
+}

--- a/src/service/logs/error/sim-logs.error.ts
+++ b/src/service/logs/error/sim-logs.error.ts
@@ -93,3 +93,34 @@ export class SimLogsLimitExceededException extends SimLogsError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated CloudWatch Logs ValidationException error.
+ *
+ * The delivery operations report a bad input this way rather than as an
+ * `InvalidParameterException`. They were added to CloudWatch Logs long after
+ * the log group operations and carry the error shape AWS gives newer APIs, so
+ * a caller catching by name has to know which half of the service it is
+ * talking to.
+ */
+export class SimLogsValidationException extends SimLogsError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated CloudWatch Logs ConflictException error.
+ *
+ * This is what the delivery operations report when a resource is already in
+ * use, such as a distribution that already has a delivery source.
+ */
+export class SimLogsConflictException extends SimLogsError {
+  public override readonly name = "ConflictException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}

--- a/src/service/logs/index.ts
+++ b/src/service/logs/index.ts
@@ -25,11 +25,33 @@ export {
 export { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
 export { SimLogsFilterPattern } from "./event/sim-logs-filter-pattern.js";
 export { simLogsStandardLogGroupClass } from "./command/group/sim-logs-unsimulated-group-input.js";
+export { SimLogsDeliverySource } from "./delivery/sim-logs-delivery-source.js";
+export { SimLogsDeliveryDestination } from "./delivery/sim-logs-delivery-destination.js";
+export { SimLogsDelivery } from "./delivery/sim-logs-delivery.js";
+export { SimLogsDeliveryS3Configuration } from "./delivery/sim-logs-delivery-s3-configuration.js";
+export { simLogsDeliverySuffixPathVariables } from "./delivery/sim-logs-delivery-s3-configuration.js";
+export type { SimLogsDeliveryDestinationType } from "./delivery/sim-logs-delivery-destination-type.js";
 export {
+  simLogsDefaultDeliveryOutputFormat,
+  simLogsDeliveryOutputFormats,
+  type SimLogsDeliveryOutputFormat,
+} from "./delivery/sim-logs-delivery-output-format.js";
+export {
+  simLogsCloudFrontDeliveryRegion,
+  simLogsCloudFrontDeliveryService,
+} from "./delivery/sim-logs-delivery-source-service.js";
+export {
+  simLogsDeliveryArn,
+  simLogsDeliveryDestinationArn,
+  simLogsDeliverySourceArn,
+} from "./delivery/sim-logs-delivery-arn.js";
+export {
+  SimLogsConflictException,
   SimLogsError,
   type SimLogsErrorMetadata,
   SimLogsInvalidParameterException,
   SimLogsResourceAlreadyExistsException,
   SimLogsResourceNotFoundException,
   SimLogsUnsupportedOperationException,
+  SimLogsValidationException,
 } from "./error/sim-logs.error.js";

--- a/src/service/logs/index.ts
+++ b/src/service/logs/index.ts
@@ -39,6 +39,7 @@ export {
 export {
   simLogsCloudFrontDeliveryRegion,
   simLogsCloudFrontDeliveryService,
+  simLogsCloudFrontLogType,
 } from "./delivery/sim-logs-delivery-source-service.js";
 export {
   simLogsDeliveryArn,

--- a/src/service/logs/sdk/sim-logs-sdk-command-router.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-command-router.ts
@@ -20,6 +20,21 @@ import type {
   SimDescribeLogStreamsCommand,
 } from "../command/stream/stream.command.js";
 import type {
+  SimDeleteDeliveryDestinationCommand,
+  SimDescribeDeliveryDestinationsCommand,
+  SimPutDeliveryDestinationCommand,
+} from "../command/delivery/delivery-destination.command.js";
+import type {
+  SimDeleteDeliverySourceCommand,
+  SimDescribeDeliverySourcesCommand,
+  SimPutDeliverySourceCommand,
+} from "../command/delivery/delivery-source.command.js";
+import type {
+  SimCreateDeliveryCommand,
+  SimDeleteDeliveryCommand,
+  SimDescribeDeliveriesCommand,
+} from "../command/delivery/delivery.command.js";
+import type {
   SimDeleteSubscriptionFilterCommand,
   SimDescribeSubscriptionFiltersCommand,
   SimPutSubscriptionFilterCommand,
@@ -135,6 +150,78 @@ export class SimLogsSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simLogs.filterLogEvents(
             command as SimFilterLogEventsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutDeliverySourceCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.putDeliverySource(
+            command as SimPutDeliverySourceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeDeliverySourcesCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.describeDeliverySources(
+            command as SimDescribeDeliverySourcesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteDeliverySourceCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.deleteDeliverySource(
+            command as SimDeleteDeliverySourceCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutDeliveryDestinationCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.putDeliveryDestination(
+            command as SimPutDeliveryDestinationCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeDeliveryDestinationsCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.describeDeliveryDestinations(
+            command as SimDescribeDeliveryDestinationsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteDeliveryDestinationCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.deleteDeliveryDestination(
+            command as SimDeleteDeliveryDestinationCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateDeliveryCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.createDelivery(
+            command as SimCreateDeliveryCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeDeliveriesCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.describeDeliveries(
+            command as SimDescribeDeliveriesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteDeliveryCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.deleteDelivery(
+            command as SimDeleteDeliveryCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
@@ -13,6 +13,15 @@ import {
   PutSubscriptionFilterCommand,
   DescribeSubscriptionFiltersCommand,
   DeleteSubscriptionFilterCommand,
+  CreateDeliveryCommand,
+  DeleteDeliveryCommand,
+  DeleteDeliveryDestinationCommand,
+  DeleteDeliverySourceCommand,
+  DescribeDeliveriesCommand,
+  DescribeDeliveryDestinationsCommand,
+  DescribeDeliverySourcesCommand,
+  PutDeliveryDestinationCommand,
+  PutDeliverySourceCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
 import {
   AddPermissionCommand,
@@ -58,6 +67,15 @@ describe("SimLogsSdkCommandRouter", () => {
       "PutSubscriptionFilterCommand",
       "DescribeSubscriptionFiltersCommand",
       "DeleteSubscriptionFilterCommand",
+      "PutDeliverySourceCommand",
+      "DescribeDeliverySourcesCommand",
+      "DeleteDeliverySourceCommand",
+      "PutDeliveryDestinationCommand",
+      "DescribeDeliveryDestinationsCommand",
+      "DeleteDeliveryDestinationCommand",
+      "CreateDeliveryCommand",
+      "DescribeDeliveriesCommand",
+      "DeleteDeliveryCommand",
     ]);
   });
 
@@ -211,5 +229,68 @@ describe("CloudWatch Logs SDK interception", () => {
       ["starting"],
     );
     assertArrayLength(afterDelete.logGroups ?? [], 0);
+  });
+});
+
+describe("CloudWatch Logs delivery SDK interception", () => {
+  it("sets CloudFront logging up through the intercepted client", async () => {
+    // Given an intercepted client in the one Region CloudFront delivery is
+    // set up from.
+    using simSdk = new SimSdk();
+    simSdk.intercept(CloudWatchLogsClient);
+
+    const client = new CloudWatchLogsClient({ region: "us-east-1" });
+
+    // When ordinary SDK code sets up standard logging v2 for a distribution.
+    await client.send(
+      new PutDeliverySourceCommand({
+        name: "site-access-logs",
+        resourceArn: "arn:aws:cloudfront::123456789012:distribution/E1EX",
+        logType: "ACCESS_LOGS",
+      }),
+    );
+
+    const destination = await client.send(
+      new PutDeliveryDestinationCommand({
+        name: "site-access-logs",
+        outputFormat: "json",
+        deliveryDestinationConfiguration: {
+          destinationResourceArn: "arn:aws:s3:::example-access-logs",
+        },
+      }),
+    );
+
+    await client.send(
+      new CreateDeliveryCommand({
+        deliverySourceName: "site-access-logs",
+        deliveryDestinationArn: destination.deliveryDestination?.arn,
+      }),
+    );
+
+    // Then all three read back through the same client.
+    const sources = await client.send(new DescribeDeliverySourcesCommand({}));
+    const destinations = await client.send(
+      new DescribeDeliveryDestinationsCommand({}),
+    );
+    const deliveries = await client.send(new DescribeDeliveriesCommand({}));
+
+    assertArrayLength(sources.deliverySources ?? [], 1);
+    assertArrayLength(destinations.deliveryDestinations ?? [], 1);
+    assertArrayLength(deliveries.deliveries ?? [], 1);
+
+    // And each can be taken down again.
+    await client.send(
+      new DeleteDeliveryCommand({ id: deliveries.deliveries?.at(0)?.id }),
+    );
+    await client.send(
+      new DeleteDeliveryDestinationCommand({ name: "site-access-logs" }),
+    );
+    await client.send(
+      new DeleteDeliverySourceCommand({ name: "site-access-logs" }),
+    );
+
+    const remaining = await client.send(new DescribeDeliveriesCommand({}));
+
+    assertArrayLength(remaining.deliveries ?? [], 0);
   });
 });

--- a/src/service/logs/sim-logs-commands.ts
+++ b/src/service/logs/sim-logs-commands.ts
@@ -9,6 +9,12 @@ import {
   type SimIamInterServiceAuthZ,
 } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimLogsAuthorizer } from "./command/authorize/sim-logs-authorizer.js";
+import { SimLogsDeliveryCommands } from "./command/delivery/sim-logs-delivery-commands.js";
+import { SimLogsDeliveryDestinationCommands } from "./command/delivery/sim-logs-delivery-destination-commands.js";
+import { SimLogsDeliverySourceCommands } from "./command/delivery/sim-logs-delivery-source-commands.js";
+import { SimLogsDeliveryDestinationStore } from "./delivery/sim-logs-delivery-destination-store.js";
+import { SimLogsDeliverySourceStore } from "./delivery/sim-logs-delivery-source-store.js";
+import { SimLogsDeliveryStore } from "./delivery/sim-logs-delivery-store.js";
 import { SimLogsFilterLogEvents } from "./command/event/sim-logs-filter-log-events.js";
 import { SimLogsGetLogEvents } from "./command/event/sim-logs-get-log-events.js";
 import { SimLogsPutLogEvents } from "./command/event/sim-logs-put-log-events.js";
@@ -57,6 +63,12 @@ export class SimLogsCommands {
   readonly subscriptions: SimLogsSubscriptionCommands;
   readonly serviceWriter: SimLogsServiceWriter;
   readonly fanOut: SimLogsSubscriptionFanOut;
+  readonly deliverySourceStore: SimLogsDeliverySourceStore;
+  readonly deliveryDestinationStore: SimLogsDeliveryDestinationStore;
+  readonly deliveryStore: SimLogsDeliveryStore;
+  readonly deliverySources: SimLogsDeliverySourceCommands;
+  readonly deliveryDestinations: SimLogsDeliveryDestinationCommands;
+  readonly deliveries: SimLogsDeliveryCommands;
   readonly background: BackgroundScheduler;
 
   constructor(properties: SimLogsProperties = {}) {
@@ -110,6 +122,31 @@ export class SimLogsCommands {
       eventIds,
       clock: background,
       fanOut,
+    });
+
+    const deliverySources = new SimLogsDeliverySourceStore();
+    const deliveryDestinations = new SimLogsDeliveryDestinationStore();
+    const deliveries = new SimLogsDeliveryStore();
+
+    this.deliverySourceStore = deliverySources;
+    this.deliveryDestinationStore = deliveryDestinations;
+    this.deliveryStore = deliveries;
+    this.deliverySources = new SimLogsDeliverySourceCommands({
+      sources: deliverySources,
+      authorizer,
+      accountRegionScope,
+    });
+    this.deliveryDestinations = new SimLogsDeliveryDestinationCommands({
+      destinations: deliveryDestinations,
+      authorizer,
+      accountRegionScope,
+    });
+    this.deliveries = new SimLogsDeliveryCommands({
+      sources: deliverySources,
+      destinations: deliveryDestinations,
+      deliveries,
+      authorizer,
+      accountRegionScope,
     });
   }
 }

--- a/src/service/logs/sim-logs-commands.ts
+++ b/src/service/logs/sim-logs-commands.ts
@@ -133,11 +133,13 @@ export class SimLogsCommands {
     this.deliveryStore = deliveries;
     this.deliverySources = new SimLogsDeliverySourceCommands({
       sources: deliverySources,
+      deliveries,
       authorizer,
       accountRegionScope,
     });
     this.deliveryDestinations = new SimLogsDeliveryDestinationCommands({
       destinations: deliveryDestinations,
+      deliveries,
       authorizer,
       accountRegionScope,
     });

--- a/src/service/logs/sim-logs-delivery-inspection.ts
+++ b/src/service/logs/sim-logs-delivery-inspection.ts
@@ -1,0 +1,48 @@
+import type { SimLogsDeliveryDestination } from "./delivery/sim-logs-delivery-destination.js";
+import type { SimLogsDeliverySource } from "./delivery/sim-logs-delivery-source.js";
+import type { SimLogsDelivery } from "./delivery/sim-logs-delivery.js";
+import type { SimLogsCommands } from "./sim-logs-commands.js";
+
+/**
+ * What a test or another part of the simulation can ask a simulated CloudWatch
+ * Logs about the delivery resources it holds.
+ *
+ * These are the simulator's own accessors rather than simulated API
+ * operations. They go through no command and no authorization. That is what
+ * the CloudFormation Resource factory reads a created Resource back through.
+ */
+export abstract class SimLogsDeliveryInspection {
+  protected abstract readonly commands: SimLogsCommands;
+
+  /** Find a delivery source by name. */
+  findDeliverySource(name: string): SimLogsDeliverySource | undefined {
+    return this.commands.deliverySourceStore.find(name);
+  }
+
+  /** Every delivery source in this scope, in the order they were put. */
+  allDeliverySources(): readonly SimLogsDeliverySource[] {
+    return this.commands.deliverySourceStore.all;
+  }
+
+  /** Find a delivery destination by name. */
+  findDeliveryDestination(
+    name: string,
+  ): SimLogsDeliveryDestination | undefined {
+    return this.commands.deliveryDestinationStore.find(name);
+  }
+
+  /** Every delivery destination in this scope, in the order they were put. */
+  allDeliveryDestinations(): readonly SimLogsDeliveryDestination[] {
+    return this.commands.deliveryDestinationStore.all;
+  }
+
+  /** Find a delivery by the identifier CloudWatch Logs issued for it. */
+  findDelivery(id: string): SimLogsDelivery | undefined {
+    return this.commands.deliveryStore.find(id);
+  }
+
+  /** Every delivery in this scope, in the order they were created. */
+  allDeliveries(): readonly SimLogsDelivery[] {
+    return this.commands.deliveryStore.all;
+  }
+}

--- a/src/service/logs/sim-logs-delivery-operations.ts
+++ b/src/service/logs/sim-logs-delivery-operations.ts
@@ -1,0 +1,110 @@
+import type * as simLogsCommands from "./command/sim-logs-command.types.js";
+import type { SimLogsRequestOptions } from "./command/sim-logs-request-options.js";
+import type { SimLogsCommands } from "./sim-logs-commands.js";
+import { SimLogsDeliveryInspection } from "./sim-logs-delivery-inspection.js";
+
+/**
+ * The delivery commands of the simulated CloudWatch Logs facade.
+ *
+ * They sit here rather than on SimLogs itself because that file grows by one
+ * delegating method per simulated operation and is at the length this codebase
+ * allows. The nine belong together: they are the half of CloudWatch Logs that
+ * sets up delivery from another service, and they share no state with the log
+ * group operations at all.
+ */
+export abstract class SimLogsDeliveryOperations extends SimLogsDeliveryInspection {
+  protected abstract override readonly commands: SimLogsCommands;
+
+  /** Handle a PutDeliverySource Command from the SDK. */
+  async putDeliverySource(
+    command: simLogsCommands.SimPutDeliverySourceCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimPutDeliverySourceCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliverySources.putDeliverySource(command, options);
+  }
+
+  /** Handle a DescribeDeliverySources Command from the SDK. */
+  async describeDeliverySources(
+    command: simLogsCommands.SimDescribeDeliverySourcesCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDescribeDeliverySourcesCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliverySources.describeDeliverySources(
+      command,
+      options,
+    );
+  }
+
+  /** Handle a DeleteDeliverySource Command from the SDK. */
+  async deleteDeliverySource(
+    command: simLogsCommands.SimDeleteDeliverySourceCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDeleteDeliverySourceCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliverySources.deleteDeliverySource(command, options);
+  }
+
+  /** Handle a PutDeliveryDestination Command from the SDK. */
+  async putDeliveryDestination(
+    command: simLogsCommands.SimPutDeliveryDestinationCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimPutDeliveryDestinationCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliveryDestinations.putDeliveryDestination(
+      command,
+      options,
+    );
+  }
+
+  /** Handle a DescribeDeliveryDestinations Command from the SDK. */
+  async describeDeliveryDestinations(
+    command: simLogsCommands.SimDescribeDeliveryDestinationsCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDescribeDeliveryDestinationsCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliveryDestinations.describeDeliveryDestinations(
+      command,
+      options,
+    );
+  }
+
+  /** Handle a DeleteDeliveryDestination Command from the SDK. */
+  async deleteDeliveryDestination(
+    command: simLogsCommands.SimDeleteDeliveryDestinationCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDeleteDeliveryDestinationCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliveryDestinations.deleteDeliveryDestination(
+      command,
+      options,
+    );
+  }
+
+  /** Handle a CreateDelivery Command from the SDK. */
+  async createDelivery(
+    command: simLogsCommands.SimCreateDeliveryCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimCreateDeliveryCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliveries.createDelivery(command, options);
+  }
+
+  /** Handle a DescribeDeliveries Command from the SDK. */
+  async describeDeliveries(
+    command: simLogsCommands.SimDescribeDeliveriesCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDescribeDeliveriesCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliveries.describeDeliveries(command, options);
+  }
+
+  /** Handle a DeleteDelivery Command from the SDK. */
+  async deleteDelivery(
+    command: simLogsCommands.SimDeleteDeliveryCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDeleteDeliveryCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.deliveries.deleteDelivery(command, options);
+  }
+}

--- a/src/service/logs/sim-logs.ts
+++ b/src/service/logs/sim-logs.ts
@@ -8,6 +8,7 @@ import {
   SimLogsCommands,
   type SimLogsProperties,
 } from "./sim-logs-commands.js";
+import { SimLogsDeliveryOperations } from "./sim-logs-delivery-operations.js";
 import type { SimLogsSubscriptionFailure } from "./subscription/sim-logs-subscription-fan-out.js";
 import type { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
 
@@ -23,14 +24,20 @@ import type { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
  * than acted on, because a test would have to move the clock by months to see
  * an event expire, and what teams get wrong about retention is the value they
  * deployed rather than the deletion that eventually follows from it.
+ *
+ * The delivery operations are held apart in `SimLogsDeliveryOperations`, which
+ * this extends, because this file grows by one delegating method per simulated
+ * operation and is at the length this codebase allows.
  */
-export class SimLogs {
-  readonly #commands: SimLogsCommands;
+export class SimLogs extends SimLogsDeliveryOperations {
+  protected readonly commands: SimLogsCommands;
+
   readonly #sdkRouter = new SimLogsSdkCommandRouter(this);
   readonly #cfnFactory = new SimLogsCfnResourceFactory({ logs: this });
 
   constructor(properties: SimLogsProperties = {}) {
-    this.#commands = new SimLogsCommands(properties);
+    super();
+    this.commands = new SimLogsCommands(properties);
   }
 
   /**
@@ -40,14 +47,14 @@ export class SimLogs {
    * state without going through a Command and its authorization.
    */
   findLogGroup(logGroupName: string): SimLogsLogGroup | undefined {
-    return this.#commands.groups.find(logGroupName);
+    return this.commands.groups.find(logGroupName);
   }
 
   /**
    * Every log group in this scope, in creation order.
    */
   allLogGroups(): readonly SimLogsLogGroup[] {
-    return this.#commands.groups.all;
+    return this.commands.groups.all;
   }
 
   /**
@@ -61,7 +68,7 @@ export class SimLogs {
    * documented instead.
    */
   serviceWriter(): SimLogsServiceWriter {
-    return this.#commands.serviceWriter;
+    return this.commands.serviceWriter;
   }
 
   /**
@@ -71,8 +78,8 @@ export class SimLogs {
     command: simLogsCommands.SimCreateLogGroupCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimCreateLogGroupCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.logGroups.createLogGroup(command, options);
+    await this.commands.background.sequence();
+    return this.commands.logGroups.createLogGroup(command, options);
   }
 
   /**
@@ -82,8 +89,8 @@ export class SimLogs {
     command: simLogsCommands.SimDeleteLogGroupCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDeleteLogGroupCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.logGroups.deleteLogGroup(command, options);
+    await this.commands.background.sequence();
+    return this.commands.logGroups.deleteLogGroup(command, options);
   }
 
   /**
@@ -93,8 +100,8 @@ export class SimLogs {
     command: simLogsCommands.SimDescribeLogGroupsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDescribeLogGroupsCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.logGroups.describeLogGroups(command, options);
+    await this.commands.background.sequence();
+    return this.commands.logGroups.describeLogGroups(command, options);
   }
 
   /**
@@ -104,8 +111,8 @@ export class SimLogs {
     command: simLogsCommands.SimPutRetentionPolicyCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimPutRetentionPolicyCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.retention.putRetentionPolicy(command, options);
+    await this.commands.background.sequence();
+    return this.commands.retention.putRetentionPolicy(command, options);
   }
 
   /**
@@ -115,8 +122,8 @@ export class SimLogs {
     command: simLogsCommands.SimDeleteRetentionPolicyCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDeleteRetentionPolicyCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.retention.deleteRetentionPolicy(command, options);
+    await this.commands.background.sequence();
+    return this.commands.retention.deleteRetentionPolicy(command, options);
   }
 
   /**
@@ -126,8 +133,8 @@ export class SimLogs {
     command: simLogsCommands.SimCreateLogStreamCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimCreateLogStreamCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.streams.createLogStream(command, options);
+    await this.commands.background.sequence();
+    return this.commands.streams.createLogStream(command, options);
   }
 
   /**
@@ -137,8 +144,8 @@ export class SimLogs {
     command: simLogsCommands.SimDescribeLogStreamsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDescribeLogStreamsCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.streams.describeLogStreams(command, options);
+    await this.commands.background.sequence();
+    return this.commands.streams.describeLogStreams(command, options);
   }
 
   /**
@@ -148,8 +155,8 @@ export class SimLogs {
     command: simLogsCommands.SimPutLogEventsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimPutLogEventsCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.putLogEvents.handle(command, options);
+    await this.commands.background.sequence();
+    return this.commands.putLogEvents.handle(command, options);
   }
 
   /**
@@ -159,8 +166,8 @@ export class SimLogs {
     command: simLogsCommands.SimGetLogEventsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimGetLogEventsCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.getLogEvents.handle(command, options);
+    await this.commands.background.sequence();
+    return this.commands.getLogEvents.handle(command, options);
   }
 
   /**
@@ -170,8 +177,8 @@ export class SimLogs {
     command: simLogsCommands.SimFilterLogEventsCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimFilterLogEventsCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.filterLogEvents.handle(command, options);
+    await this.commands.background.sequence();
+    return this.commands.filterLogEvents.handle(command, options);
   }
 
   /**
@@ -182,7 +189,7 @@ export class SimLogs {
    * subscription it set up never reached anything.
    */
   get subscriptionFailures(): readonly SimLogsSubscriptionFailure[] {
-    return this.#commands.fanOut.failures;
+    return this.commands.fanOut.failures;
   }
 
   /**
@@ -192,8 +199,8 @@ export class SimLogs {
     command: simLogsCommands.SimPutSubscriptionFilterCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimPutSubscriptionFilterCommandOutput> {
-    await this.#commands.background.sequence();
-    return await this.#commands.subscriptions.putSubscriptionFilter(
+    await this.commands.background.sequence();
+    return await this.commands.subscriptions.putSubscriptionFilter(
       command,
       options,
     );
@@ -206,8 +213,8 @@ export class SimLogs {
     command: simLogsCommands.SimDescribeSubscriptionFiltersCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDescribeSubscriptionFiltersCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.subscriptions.describeSubscriptionFilters(
+    await this.commands.background.sequence();
+    return this.commands.subscriptions.describeSubscriptionFilters(
       command,
       options,
     );
@@ -220,8 +227,8 @@ export class SimLogs {
     command: simLogsCommands.SimDeleteSubscriptionFilterCommand,
     options?: SimLogsRequestOptions,
   ): Promise<simLogsCommands.SimDeleteSubscriptionFilterCommandOutput> {
-    await this.#commands.background.sequence();
-    return this.#commands.subscriptions.deleteSubscriptionFilter(
+    await this.commands.background.sequence();
+    return this.commands.subscriptions.deleteSubscriptionFilter(
       command,
       options,
     );


### PR DESCRIPTION
Simulated CloudWatch Logs now holds delivery sources, delivery destinations and deliveries, reachable through the nine SDK commands that manage them and through `AWS::Logs::DeliverySource`, `AWS::Logs::DeliveryDestination` and `AWS::Logs::Delivery` in a template. A distribution carries no logging property of its own, and a construct that turns CloudFront standard logging v2 on is made of those three resource types. A test of one used to deploy a stack where every resource was recorded as a skip, which proved nothing about the wiring. Four AWS rules are modelled alongside the resources, because each of them is a deploy that looks fine until it runs: one delivery source per distribution, CloudFront delivery only from us-east-1, an output format that is fixed once the destination exists, and Parquet on S3 only. A suffix path naming a partition variable delivery would never substitute is refused too.

Resolves https://github.com/KensioSoftware/yulin/issues/979

## Notes for the reviewer

This is a large one, around 4,400 lines. Folding the SDK commands in alongside the CloudFormation work roughly doubled it. The seam if you would rather take it in two passes is the `cfn/` directory plus the value adapters and the two CloudFormation test files, split off from the model and SDK work underneath, which stands alone.

Two things I could not settle against real AWS. The error name for a CloudFront delivery source created outside us-east-1 is `ValidationException` here, which is what the delivery API's model carries, with a message of Yulin's own wording. The one source per distribution message is the verbatim AWS text. And deleting a delivery source while a delivery still uses it is permitted here. Real CloudWatch Logs has its own rule about the order, guessing either way would be a divergence, and it is recorded under Limitations instead.

The delivery operations report a bad input as `ValidationException` and `ConflictException` rather than the `InvalidParameterException` the log group operations use. That is real: they were added to CloudWatch Logs long after the rest, and carry the error shape AWS gives newer APIs. `SimLogsPage` is shared with the older listings, so a bad `limit` on a `Describe` still raises `InvalidParameterException`, which is the one place the split leaks.

The CloudFormation creators go through the ordinary commands rather than writing to the stores, unlike `SimCfnLogGroupCreator`. There is no equivalent here of a log group a Lambda function already made for itself, so a template hits every refusal an SDK caller would, down to the region rule.

Three files went over the FTA threshold on the first pass. `simLogsCreatedDelivery`, `simCfnDeliveryInput` and `SimLogsCfnResourceDeleter` exist to carry tokens out of the files that were breaching, not because they were the natural shape to start with.

`SimLogs` gained `SimLogsDeliveryOperations` and `SimLogsDeliveryInspection` as bases, following `SimLambda`. The facade was at the line limit with nine delegating methods still to add. That is what turned `#commands` into a `protected commands`.

The branch is named `claude/confident-jang-379625` rather than `feat/hg/...`. Say the word and I will move it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudWatch Logs delivery sources, destinations, and deliveries.
  * Added support for creating, listing, describing, and deleting delivery resources through SDK and CloudFormation workflows.
  * Added CloudFront-to-S3 delivery configuration, including output formats and Hive-compatible partition paths.
  * Added validation, authorization, ARN generation, pagination, and lifecycle handling.
* **Documentation**
  * Added API, CloudFormation, limitations, and configuration examples.
* **Tests**
  * Added comprehensive coverage for delivery workflows, validation, authorization, routing, and resource lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->