### PR TITLE
feat: read back a Bucket's lifecycle rules

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -594,8 +594,9 @@ A completed upload raises `s3:ObjectCreated:CompleteMultipartUpload`. A single-r
   `EntityTooSmall` for one that is not. Sim S3 takes a part of any size.
 - A listing of uploads or of parts comes back on one page. `MaxUploads`, `MaxParts`, the markers that
   page them, and `Delimiter` are all left out.
-- An upload has no expiry, and nothing abandons one on its own. A lifecycle rule expiring incomplete
-  uploads is left out along with the rest of lifecycle configuration.
+- An upload has no expiry, and nothing abandons one on its own. An
+  `AbortIncompleteMultipartUpload` lifecycle rule is stored and read back, and nothing acts on it.
+  See [Lifecycle configuration](#lifecycle-configuration).
 
 ## Reading part of an Object
 
@@ -1694,7 +1695,10 @@ writes fall outside it. Without that, the simulation stops after a thousand deli
 ## Buckets from CloudFormation
 
 An `AWS::S3::Bucket` resource carries four properties simulated S3 acts on. Those are `BucketName`,
-`NotificationConfiguration`, `PublicAccessBlockConfiguration` and `WebsiteConfiguration`. Without
+`NotificationConfiguration`, `PublicAccessBlockConfiguration` and `WebsiteConfiguration`. A fifth,
+`LifecycleConfiguration`, is stored and readable while nothing acts on it, and is recorded alongside
+the properties below for that reason. See [Lifecycle configuration](#lifecycle-configuration).
+Without
 `BucketName` the Bucket is named after the resource's logical id, lowercased, where real
 CloudFormation invents a generated name.
 
@@ -1907,6 +1911,114 @@ the same way against real S3.
 Bucket ACLs and Object ownership settings are left out, and stay that way by choice. Object Ownership
 defaults to Bucket owner enforced on new Buckets, which disables ACLs, and AWS recommends keeping
 them disabled in favour of policies.
+
+## Lifecycle configuration
+
+Sim S3 stores a Bucket's lifecycle rules and hands them back. Nothing expires or transitions an
+Object against them, so a rule here records what the Bucket was configured with rather than
+something that happens.
+
+That is enough to test the configuration side of a construct or a template, which is otherwise
+only checkable by asserting on synthesized CloudFormation. Reading the rules off a deployed Bucket
+says the rules arrived, where a template assertion says only that CloudFormation was asked for them.
+
+```typescript sim-s3-lifecycle-configuration
+import {
+  GetBucketLifecycleConfigurationCommand,
+  PutBucketLifecycleConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "logs-stack",
+  template: {
+    Resources: {
+      LogBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "logs",
+          LifecycleConfiguration: {
+            Rules: [
+              {
+                Id: "expire-raw-logs",
+                Status: "Enabled",
+                Prefix: "raw/",
+                ExpirationInDays: 365,
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+
+// The template's rule reads back off the deployed Bucket, in the shape the SDK
+// states one in.
+const deployed = await simS3.getBucketLifecycleConfiguration(
+  new GetBucketLifecycleConfigurationCommand({ Bucket: "logs" }),
+);
+
+console.log(deployed.Rules);
+
+// A put replaces the whole configuration, so a rule it leaves out is gone.
+await simS3.putBucketLifecycleConfiguration(
+  new PutBucketLifecycleConfigurationCommand({
+    Bucket: "logs",
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: "abort-incomplete-uploads",
+          Status: "Enabled",
+          Filter: { Prefix: "" },
+          AbortIncompleteMultipartUpload: { DaysAfterInitiation: 7 },
+        },
+      ],
+    },
+  }),
+);
+```
+
+`DeleteBucketLifecycleCommand` removes the configuration, and is idempotent as in real S3. A Bucket
+carrying no rules answers `GetBucketLifecycleConfigurationCommand` with
+`NoSuchLifecycleConfiguration` rather than an empty list, which is how real S3 separates a Bucket
+nobody configured from one configured to do nothing.
+
+A configuration stating no rules at all is refused with `MalformedXML`, and so is a rule whose
+`Status` is anything but `Enabled` or `Disabled`. A rule stored under a status nothing recognises
+would read back looking configured.
+
+### From a CloudFormation template
+
+CloudFormation spells some rule fields differently from the request. `Id` becomes `ID`,
+`ExpirationInDays` and `ExpirationDate` are gathered under `Expiration`, and a transition's
+`TransitionInDays` becomes `Days`. The singular `Transition` a template may state alongside
+`Transitions` joins the list. Everything else, `Status`, `Prefix`, `AbortIncompleteMultipartUpload`,
+`TagFilters` and the object size bounds among them, is carried across as the template stated it.
+
+`LifecycleConfiguration` is still recorded in
+[`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without),
+under a reason saying the rules are readable and that nothing acts on them. A test reading the
+configuration back would otherwise take it for proof that retention works.
+
+### Limitations
+
+No Object is ever expired, and no Object moves between storage classes. Storage classes are left out
+of the simulator entirely, so a `Transitions` rule is stored and read back and goes no further. An
+incomplete multipart upload is never abandoned, whatever `AbortIncompleteMultipartUpload` says.
+
+Nothing reads a rule's `Filter`, `Prefix`, `TagFilters` or object size bounds, since nothing selects
+Objects against a rule in the first place.
+
+The `s3:LifecycleExpiration:*` event notification family is left out along with the expiry that
+would raise it. `NoncurrentVersionExpiration` and `ExpiredObjectDeleteMarker` are stored and
+unread, because Object versions are left out.
+
+`GetBucketLifecycleConfiguration` and its siblings are reachable through the SDK and not over the
+served S3 REST endpoint.
 
 ## Static website hosting
 
@@ -2785,6 +2897,9 @@ Sim S3 currently supports:
   Object events delivered to a simulated Lambda function, a simulated SQS queue or a simulated SNS
   topic
 - `PutBucketWebsiteCommand`, for static website hosting
+- `PutBucketLifecycleConfigurationCommand`, `GetBucketLifecycleConfigurationCommand` and
+  `DeleteBucketLifecycleCommand`, storing a Bucket's lifecycle rules and handing them back without
+  expiring or transitioning any Object against them
 - `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
   sim IAM alongside identity policies
 - The `AWS::S3::Bucket` and `AWS::S3::BucketPolicy` CloudFormation resources
@@ -2818,7 +2933,8 @@ These apply across the page. The sections above each list what is specific to th
 - A listing reports `StorageClass` as `STANDARD` for every Object. Storage classes themselves are
   left out, and every Object is in that one.
 - `EncodingType` is ignored on a listing, and keys come back unencoded.
-- Object tags, ACLs, lifecycle rules, replication and server-side encryption are left out.
+- Object tags, ACLs, replication and server-side encryption are left out. Lifecycle rules are stored
+  and read back, and nothing expires or transitions an Object against them.
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
   notifications, because it swaps the whole storage backend in place of putting Objects.
 - An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, leaving

--- a/docs/services/s3/sim-s3-lifecycle-configuration.example.ts
+++ b/docs/services/s3/sim-s3-lifecycle-configuration.example.ts
@@ -1,0 +1,57 @@
+import {
+  GetBucketLifecycleConfigurationCommand,
+  PutBucketLifecycleConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "logs-stack",
+  template: {
+    Resources: {
+      LogBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "logs",
+          LifecycleConfiguration: {
+            Rules: [
+              {
+                Id: "expire-raw-logs",
+                Status: "Enabled",
+                Prefix: "raw/",
+                ExpirationInDays: 365,
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+});
+
+// The template's rule reads back off the deployed Bucket, in the shape the SDK
+// states one in.
+const deployed = await simS3.getBucketLifecycleConfiguration(
+  new GetBucketLifecycleConfigurationCommand({ Bucket: "logs" }),
+);
+
+console.log(deployed.Rules);
+
+// A put replaces the whole configuration, so a rule it leaves out is gone.
+await simS3.putBucketLifecycleConfiguration(
+  new PutBucketLifecycleConfigurationCommand({
+    Bucket: "logs",
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: "abort-incomplete-uploads",
+          Status: "Enabled",
+          Filter: { Prefix: "" },
+          AbortIncompleteMultipartUpload: { DaysAfterInitiation: 7 },
+        },
+      ],
+    },
+  }),
+);

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
@@ -1,0 +1,56 @@
+import type {
+  SimS3LifecycleConfiguration as SimS3LifecycleConfigurationInput,
+  SimS3LifecycleRule,
+} from "../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+
+interface SimS3LifecycleConfigurationProperties {
+  readonly rules?: readonly SimS3LifecycleRule[];
+}
+
+/**
+ * The lifecycle configuration of one simulated S3 Bucket.
+ *
+ * Simulated S3 holds the rules and hands them back. Objects live for as long
+ * as the simulation runs, whatever a rule says, so a rule here is a record of
+ * what the Bucket was configured with. Expiring Objects against one is #984.
+ *
+ * A Bucket has one configuration rather than a list of them, which is why
+ * PutBucketLifecycleConfiguration replaces the whole thing. Real S3 has no way
+ * to add one rule without restating the others.
+ */
+export class SimS3LifecycleConfiguration {
+  public readonly rules: readonly SimS3LifecycleRule[];
+
+  constructor(properties: SimS3LifecycleConfigurationProperties = {}) {
+    this.rules = properties.rules ?? [];
+  }
+
+  /**
+   * The configuration a Bucket nobody has configured has.
+   */
+  static empty(): SimS3LifecycleConfiguration {
+    return new SimS3LifecycleConfiguration();
+  }
+
+  /**
+   * The configuration a PutBucketLifecycleConfiguration request asks for.
+   */
+  static fromConfiguration(
+    configuration: SimS3LifecycleConfigurationInput,
+  ): SimS3LifecycleConfiguration {
+    return new SimS3LifecycleConfiguration({
+      rules: [...(configuration.Rules ?? [])],
+    });
+  }
+
+  /**
+   * Whether the Bucket carries any rule at all.
+   *
+   * Real S3 distinguishes a Bucket with no configuration from one with an
+   * empty list of rules only in that it refuses to store the latter, so an
+   * unconfigured Bucket and a Bucket whose rules were all removed read alike.
+   */
+  get isEmpty(): boolean {
+    return this.rules.length === 0;
+  }
+}

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -6,6 +6,7 @@ import { MemoryS3BucketStorage } from "../storage/s3-memory-storage.js";
 import { SimS3BucketWebsite } from "./website/sim-s3-bucket-website.js";
 import { SimS3PublicAccessBlock } from "./public-access/sim-s3-public-access-block.js";
 import { SimS3NotificationConfiguration } from "./notification/sim-s3-notification-configuration.js";
+import { SimS3LifecycleConfiguration } from "./lifecycle/sim-s3-lifecycle-configuration.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
 import { simS3BucketWebsiteUrl } from "./website/sim-s3-bucket-website-url.js";
@@ -24,6 +25,7 @@ interface SimS3BucketProperties {
   readonly policy?: SimIamPolicyDocument | undefined;
   readonly publicAccessBlock?: SimS3PublicAccessBlock;
   readonly notifications?: SimS3NotificationConfiguration;
+  readonly lifecycle?: SimS3LifecycleConfiguration;
   /**
    * When the Bucket came into being, in simulated time.
    *
@@ -48,6 +50,7 @@ export class SimS3Bucket {
   private policy: SimIamPolicyDocument | undefined;
   private publicAccessBlock: SimS3PublicAccessBlock;
   private notifications: SimS3NotificationConfiguration;
+  private lifecycle: SimS3LifecycleConfiguration;
 
   constructor(properties: SimS3BucketProperties) {
     const {
@@ -58,6 +61,7 @@ export class SimS3Bucket {
       policy,
       publicAccessBlock = SimS3PublicAccessBlock.blockingAll(),
       notifications = SimS3NotificationConfiguration.empty(),
+      lifecycle = SimS3LifecycleConfiguration.empty(),
       creationDate = new BackgroundTasks().now(),
     } = properties;
 
@@ -70,6 +74,7 @@ export class SimS3Bucket {
     this.policy = policy;
     this.publicAccessBlock = publicAccessBlock;
     this.notifications = notifications;
+    this.lifecycle = lifecycle;
     this.creationDate = creationDate;
   }
 
@@ -214,6 +219,33 @@ export class SimS3Bucket {
    */
   getNotifications(): SimS3NotificationConfiguration {
     return this.notifications;
+  }
+
+  /**
+   * Replace this Bucket's lifecycle configuration.
+   *
+   * Real S3 holds one configuration per Bucket rather than a list of them, so
+   * this replaces what was there instead of adding to it.
+   */
+  configureLifecycle(lifecycle: SimS3LifecycleConfiguration): void {
+    this.lifecycle = lifecycle;
+  }
+
+  /**
+   * Get this Bucket's lifecycle configuration.
+   */
+  getLifecycle(): SimS3LifecycleConfiguration {
+    return this.lifecycle;
+  }
+
+  /**
+   * Remove this Bucket's lifecycle configuration.
+   *
+   * Real S3 DeleteBucketLifecycle is idempotent, so this reports nothing about
+   * whether there were rules to remove.
+   */
+  deleteLifecycle(): void {
+    this.lifecycle = SimS3LifecycleConfiguration.empty();
   }
 
   /**

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-configuration.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-configuration.ts
@@ -1,0 +1,100 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnValueShape } from "../../../../cloudformation/template/value/sim-cfn-value-shape.js";
+import type {
+  SimS3LifecycleConfiguration,
+  SimS3LifecycleRule,
+} from "../../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+import { s3BucketResourceError } from "../error/sim-cfn-s3-bucket-error.js";
+import {
+  simCfnS3CarriedRuleFields,
+  simCfnS3LifecycleDate,
+  simCfnS3StatedFields,
+} from "./sim-cfn-s3-bucket-lifecycle-fields.js";
+import { readSimCfnS3LifecycleTransitions } from "./sim-cfn-s3-bucket-lifecycle-transitions.js";
+
+/**
+ * Reads the `LifecycleConfiguration` property of an AWS::S3::Bucket Resource
+ * into a PutBucketLifecycleConfiguration request.
+ *
+ * A rule field this reader has no translation for is carried across unchanged
+ * rather than dropped or refused. Dropping it would deploy a Bucket whose
+ * rules read back shorter than the template asked for, and refusing it would
+ * fail a Stack over a field nothing in the simulation acts on anyway.
+ */
+export class SimCfnS3BucketLifecycleConfiguration {
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly shape: SimCfnValueShape;
+
+  constructor(logicalId: string, properties: SimCfnTemplateValueRecord) {
+    this.properties = properties;
+    this.shape = new SimCfnValueShape((reason) =>
+      s3BucketResourceError(logicalId, reason),
+    );
+  }
+
+  /**
+   * The configuration to apply, or nothing when the Resource declares none.
+   *
+   * A configuration that is there but is not the shape it should be fails the
+   * Resource. Read as nothing, it would deploy a Bucket whose rules a test
+   * then finds missing without being told why.
+   */
+  read(): SimS3LifecycleConfiguration | undefined {
+    const declared = this.properties["LifecycleConfiguration"];
+
+    if (declared === undefined) {
+      return undefined;
+    }
+
+    const configuration = this.shape.record(declared, "LifecycleConfiguration");
+    const rules = this.shape.list(
+      configuration["Rules"] ?? [],
+      "LifecycleConfiguration Rules",
+    );
+
+    return {
+      Rules: rules.map((rule, index) => this.readRule(rule, index)),
+    };
+  }
+
+  private readRule(
+    declared: SimCfnTemplateValue,
+    index: number,
+  ): SimS3LifecycleRule {
+    const path = `LifecycleConfiguration Rules[${index}]`;
+    const rule = this.shape.record(declared, path);
+
+    return {
+      ...simCfnS3CarriedRuleFields(rule),
+      ...simCfnS3StatedFields({
+        ID: rule["Id"],
+        Expiration: this.expiration(rule),
+        Transitions: readSimCfnS3LifecycleTransitions({
+          shape: this.shape,
+          listed: rule["Transitions"],
+          singular: rule["Transition"],
+          path,
+        }),
+      }),
+    };
+  }
+
+  /**
+   * The three flattened expiry fields, gathered under the one the request
+   * carries. A rule stating none of them keeps no `Expiration` at all.
+   */
+  private expiration(
+    rule: SimCfnTemplateValueRecord,
+  ): SimCfnTemplateValue | undefined {
+    const expiration = {
+      Date: simCfnS3LifecycleDate(rule["ExpirationDate"]),
+      Days: rule["ExpirationInDays"],
+      ExpiredObjectDeleteMarker: rule["ExpiredObjectDeleteMarker"],
+    };
+
+    return simCfnS3StatedFields(expiration);
+  }
+}

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-fields.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-fields.ts
@@ -1,0 +1,72 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The rule fields CloudFormation and the SDK spell differently.
+ *
+ * CloudFormation flattens an expiry onto the rule and names a transition's
+ * timing after it, where the request nests both. Everything absent from here,
+ * `Status`, `Prefix`, `AbortIncompleteMultipartUpload`, `TagFilters` and the
+ * object size bounds among them, is spelled the same way in both and goes
+ * through untouched.
+ */
+export const simCfnS3TranslatedLifecycleFields: ReadonlySet<string> = new Set([
+  "Id",
+  "ExpirationDate",
+  "ExpirationInDays",
+  "ExpiredObjectDeleteMarker",
+  "Transition",
+  "Transitions",
+]);
+
+/**
+ * A timestamp as the request wants it. CloudFormation states one as a string,
+ * and anything else is left as it came so the shape check that follows sees
+ * what the template actually said.
+ */
+export function simCfnS3LifecycleDate(
+  value: SimCfnTemplateValue | undefined,
+): SimCfnTemplateValue | undefined {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  return new Date(value) as unknown as SimCfnTemplateValue;
+}
+
+/**
+ * The fields that were stated, or nothing at all when none of them were.
+ */
+export function simCfnS3StatedFields(
+  fields: Record<string, SimCfnTemplateValue | undefined>,
+): SimCfnTemplateValueRecord | undefined {
+  const stated = Object.entries(fields).filter(
+    ([, value]) => value !== undefined,
+  );
+
+  if (stated.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(stated) as SimCfnTemplateValueRecord;
+}
+
+/**
+ * The fields of a rule this reader has no translation for.
+ *
+ * Carried across unchanged rather than dropped or refused. Dropping one would
+ * deploy a Bucket whose rules read back shorter than the template asked for,
+ * and refusing one would fail a Stack over a field nothing in the simulation
+ * acts on anyway.
+ */
+export function simCfnS3CarriedRuleFields(
+  rule: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return Object.fromEntries(
+    Object.entries(rule).filter(
+      ([name]) => !simCfnS3TranslatedLifecycleFields.has(name),
+    ),
+  );
+}

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-transitions.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-transitions.ts
@@ -1,0 +1,49 @@
+import type { SimCfnTemplateValue } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnValueShape } from "../../../../cloudformation/template/value/sim-cfn-value-shape.js";
+import {
+  simCfnS3LifecycleDate,
+  simCfnS3StatedFields,
+} from "./sim-cfn-s3-bucket-lifecycle-fields.js";
+
+interface SimCfnS3LifecycleTransitionsProperties {
+  readonly shape: SimCfnValueShape;
+  readonly listed: SimCfnTemplateValue | undefined;
+  readonly singular: SimCfnTemplateValue | undefined;
+  readonly path: string;
+}
+
+/**
+ * Reads the storage class transitions of one AWS::S3::Bucket lifecycle rule.
+ *
+ * A template may state them as a `Transitions` list, as a singular
+ * `Transition`, or as both, and CloudFormation accepts all three. They arrive
+ * as the one list the request carries. Each one is timed by `Days` or `Date`
+ * where the template says `TransitionInDays` or `TransitionDate`.
+ */
+export function readSimCfnS3LifecycleTransitions(
+  properties: SimCfnS3LifecycleTransitionsProperties,
+): SimCfnTemplateValue[] | undefined {
+  const { shape, listed, singular, path } = properties;
+  const declared =
+    listed === undefined ? [] : shape.list(listed, `${path} Transitions`);
+  const all = singular === undefined ? declared : [...declared, singular];
+
+  if (all.length === 0) {
+    return undefined;
+  }
+
+  return all.map((transition, position) => {
+    const { TransitionDate, TransitionInDays, ...carried } = shape.record(
+      transition,
+      `${path} Transitions[${position}]`,
+    );
+
+    return {
+      ...carried,
+      ...simCfnS3StatedFields({
+        Date: simCfnS3LifecycleDate(TransitionDate),
+        Days: TransitionInDays,
+      }),
+    };
+  });
+}

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle.iso.test.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle.iso.test.ts
@@ -1,0 +1,273 @@
+import { GetBucketLifecycleConfigurationCommand } from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimS3NoSuchLifecycleConfiguration } from "../../../error/sim-s3.error.js";
+import type { SimS3LifecycleRule } from "../../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+
+/**
+ * Deploy a log Bucket declaring the given lifecycle rules.
+ */
+async function deployBucketWithRules(
+  simAws: SimAws,
+  rules: SimCfnTemplateValue[],
+): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "logs-stack",
+    template: {
+      Resources: {
+        LogBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "logs",
+            LifecycleConfiguration: { Rules: rules },
+          },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+}
+
+/**
+ * The rules a deployed log Bucket reads back.
+ */
+async function readRules(
+  simAws: SimAws,
+): Promise<readonly SimS3LifecycleRule[]> {
+  const output = await simAws
+    .s3()
+    .getBucketLifecycleConfiguration(
+      new GetBucketLifecycleConfigurationCommand({ Bucket: "logs" }),
+    );
+
+  return output.Rules;
+}
+
+describe("AWS::S3::Bucket LifecycleConfiguration", () => {
+  it("reads a template's expiry rule back off the deployed Bucket", async () => {
+    // Given a template expiring raw logs after a year, as CDK synthesizes an
+    // expiration from a Duration.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    await deployBucketWithRules(simAws, [
+      {
+        Id: "expire-raw-logs",
+        Status: "Enabled",
+        Prefix: "raw/",
+        ExpirationInDays: 365,
+      },
+    ]);
+
+    // Then the rule reads back in the shape the SDK states one in, with the
+    // id renamed and the expiry gathered under the field the request carries.
+    const rules = await readRules(simAws);
+
+    assertArrayLength(rules, 1);
+    assertObjectEquals(rules[0], {
+      Status: "Enabled",
+      Prefix: "raw/",
+      ID: "expire-raw-logs",
+      Expiration: { Days: 365 },
+    });
+  });
+
+  it("gathers an expiry date and a delete marker under one field", async () => {
+    // Given a template stating an expiry as a date.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    await deployBucketWithRules(simAws, [
+      {
+        Id: "expire-on-a-date",
+        Status: "Enabled",
+        ExpirationDate: "2027-01-01T00:00:00Z",
+        ExpiredObjectDeleteMarker: false,
+      },
+    ]);
+
+    // Then the date arrives as a Date, because that is what the SDK hands a
+    // caller reading the configuration back.
+    const rules = await readRules(simAws);
+
+    assertArrayLength(rules, 1);
+    assertNonNullable(rules[0]);
+    const expiration = rules[0].Expiration;
+    assertNonNullable(expiration);
+    assertInstanceOf(expiration.Date, Date);
+    assertIdentical(expiration.Date.toISOString(), "2027-01-01T00:00:00.000Z");
+    assertFalse(expiration.ExpiredObjectDeleteMarker);
+  });
+
+  it("renames a transition's timing and takes the singular form too", async () => {
+    // Given a template stating one transition in the list and one on its own,
+    // both of which CloudFormation accepts.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    await deployBucketWithRules(simAws, [
+      {
+        Id: "tier-down",
+        Status: "Enabled",
+        Transitions: [{ StorageClass: "GLACIER", TransitionInDays: 90 }],
+        Transition: { StorageClass: "DEEP_ARCHIVE", TransitionInDays: 400 },
+      },
+    ]);
+
+    // Then both are read as transitions, each timed by the field the request
+    // names rather than the one the template does.
+    const rules = await readRules(simAws);
+
+    assertArrayLength(rules, 1);
+    assertNonNullable(rules[0]);
+    const transitions = rules[0].Transitions;
+    assertNonNullable(transitions);
+    assertArrayLength(transitions, 2);
+    assertObjectEquals(transitions[0], {
+      StorageClass: "GLACIER",
+      Days: 90,
+    });
+    assertObjectEquals(transitions[1], {
+      StorageClass: "DEEP_ARCHIVE",
+      Days: 400,
+    });
+  });
+
+  it("carries a rule field it has no translation for across unchanged", async () => {
+    // Given a template filtering by tag and object size, neither of which this
+    // simulation reads.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    await deployBucketWithRules(simAws, [
+      {
+        Id: "big-tagged-objects",
+        Status: "Enabled",
+        ObjectSizeGreaterThan: 1024,
+        TagFilters: [{ Key: "class", Value: "raw" }],
+      },
+    ]);
+
+    // Then both arrive as the template stated them. Dropping either would read
+    // back as a Bucket configured with less than the template asked for.
+    const rules = await readRules(simAws);
+
+    assertArrayLength(rules, 1);
+    assertObjectEquals(rules[0], {
+      ID: "big-tagged-objects",
+      Status: "Enabled",
+      ObjectSizeGreaterThan: 1024,
+      TagFilters: [{ Key: "class", Value: "raw" }],
+    });
+  });
+
+  it("still records the property as one nothing acts on", async () => {
+    // Given a template expiring raw logs after a year.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "logs-stack",
+      template: {
+        Resources: {
+          LogBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: "logs",
+              LifecycleConfiguration: {
+                Rules: [
+                  { Id: "expire", Status: "Enabled", ExpirationInDays: 365 },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // When the Stack has settled.
+    await stack.waitForDeployComplete();
+
+    // Then the property is recorded against the Resource even though the rules
+    // are readable, because no Object expires against them. A test reading the
+    // configuration back would otherwise take it for proof that retention
+    // works.
+    assertArrayLength(stack.ignoredProperties, 1);
+    const ignored = stack.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertIdentical(ignored.path, "LifecycleConfiguration");
+    assertStringIncludes(ignored.reason, "hands them back");
+    assertStringIncludes(ignored.reason, "expires or transitions no Object");
+  });
+
+  it("leaves a Bucket declaring no rules unconfigured", async () => {
+    // Given a template declaring a Bucket and nothing about its lifecycle.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "plain-stack",
+      template: {
+        Resources: {
+          LogBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "logs" },
+          },
+        },
+      },
+    });
+
+    // When the Stack has settled.
+    await stack.waitForDeployComplete();
+
+    // Then reading its configuration says there is none, and nothing was
+    // recorded against the Resource either.
+    const error = await assertThrowsErrorAsync(async () => readRules(simAws));
+
+    assertInstanceOf(error, SimS3NoSuchLifecycleConfiguration);
+    assertArrayLength(stack.ignoredProperties, 0);
+  });
+
+  it("fails the Resource over a configuration in the wrong shape", async () => {
+    // Given a template stating the rules as a string.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "broken-stack",
+        template: {
+          Resources: {
+            LogBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: {
+                BucketName: "logs",
+                LifecycleConfiguration: { Rules: "expire-everything" },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the Stack fails rather than deploying a Bucket whose rules a test
+    // then finds missing, and the refusal names the level that was wrong. The
+    // Bucket itself is created before its configurations are applied, so it is
+    // left behind carrying none of them.
+    assertStringIncludes(error.message, "LifecycleConfiguration Rules");
+    assertStringIncludes(error.message, "must be a list");
+
+    const readError = await assertThrowsErrorAsync(async () =>
+      readRules(simAws),
+    );
+    assertInstanceOf(readError, SimS3NoSuchLifecycleConfiguration);
+  });
+});

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-configurator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-configurator.ts
@@ -1,6 +1,7 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimS3 } from "../../sim-s3.js";
+import { SimCfnS3BucketLifecycleConfiguration } from "./lifecycle/sim-cfn-s3-bucket-lifecycle-configuration.js";
 import { SimCfnS3BucketNotificationConfiguration } from "./notification/sim-cfn-s3-bucket-notification-configuration.js";
 import { SimCfnS3BucketPublicAccessConfiguration } from "./public-access/sim-cfn-s3-bucket-public-access-configuration.js";
 import { SimCfnS3BucketWebsiteConfiguration } from "./website/sim-cfn-s3-bucket-website-configuration.js";
@@ -42,6 +43,7 @@ export class SimCfnS3BucketConfigurator {
   async configure(): Promise<void> {
     await this.configureWebsite();
     await this.configurePublicAccess();
+    await this.configureLifecycle();
     await this.configureNotifications();
   }
 
@@ -75,6 +77,21 @@ export class SimCfnS3BucketConfigurator {
         Bucket: this.bucketName,
         PublicAccessBlockConfiguration: config,
       },
+    });
+  }
+
+  private async configureLifecycle(): Promise<void> {
+    const config = new SimCfnS3BucketLifecycleConfiguration(
+      this.resource.logicalId,
+      this.properties,
+    ).read();
+
+    if (config === undefined) {
+      return;
+    }
+
+    await this.simS3.putBucketLifecycleConfiguration({
+      input: { Bucket: this.bucketName, LifecycleConfiguration: config },
     });
   }
 

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
@@ -54,7 +54,8 @@ export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
   ["InventoryConfigurations", "Bucket inventory reports are not simulated"],
   [
     "LifecycleConfiguration",
-    "simulated S3 does not expire or transition Objects on a schedule",
+    "the rules are stored and GetBucketLifecycleConfiguration hands them " +
+      "back, and simulated S3 expires or transitions no Object against them",
   ],
   ["LoggingConfiguration", "server access logging is not simulated"],
   ["MetadataConfiguration", "Bucket metadata tables are not simulated"],

--- a/src/service/s3/command/delete-bucket-lifecycle/delete-bucket-lifecycle.command.ts
+++ b/src/service/s3/command/delete-bucket-lifecycle/delete-bucket-lifecycle.command.ts
@@ -1,0 +1,22 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 DeleteBucketLifecycle command.
+ */
+export interface SimDeleteBucketLifecycleCommand {
+  readonly input: SimDeleteBucketLifecycleCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 DeleteBucketLifecycle input.
+ */
+export interface SimDeleteBucketLifecycleCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 DeleteBucketLifecycle output.
+ */
+export interface SimDeleteBucketLifecycleCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/delete-bucket-lifecycle/delete-bucket-lifecycle.handler.ts
+++ b/src/service/s3/command/delete-bucket-lifecycle/delete-bucket-lifecycle.handler.ts
@@ -1,0 +1,78 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3LifecycleAuthorizer } from "../lifecycle/sim-s3-lifecycle-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type {
+  SimDeleteBucketLifecycleCommand,
+  SimDeleteBucketLifecycleCommandOutput,
+} from "./delete-bucket-lifecycle.command.js";
+
+interface DeleteBucketLifecycleHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 DeleteBucketLifecycleCommand handler.
+ */
+export class DeleteBucketLifecycleCommandHandler implements CommandHandler<
+  SimDeleteBucketLifecycleCommand,
+  SimDeleteBucketLifecycleCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3LifecycleAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteBucketLifecycleHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3LifecycleAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and remove a Bucket's lifecycle rules.
+   *
+   * Real S3 DeleteBucketLifecycle is idempotent, so a Bucket that had no rules
+   * to remove is answered the same way as one that did.
+   */
+  async handle(
+    command: SimDeleteBucketLifecycleCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimDeleteBucketLifecycleCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "DeleteBucketLifecycleCommand.input.Bucket",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeWrite(bucket, options);
+
+    bucket.deleteLifecycle();
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/get-bucket-lifecycle-configuration/get-bucket-lifecycle-configuration.command.ts
+++ b/src/service/s3/command/get-bucket-lifecycle-configuration/get-bucket-lifecycle-configuration.command.ts
@@ -1,0 +1,28 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3LifecycleRule } from "../put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+
+/**
+ * Minimal structural sim S3 GetBucketLifecycleConfiguration command.
+ */
+export interface SimGetBucketLifecycleConfigurationCommand {
+  readonly input: SimGetBucketLifecycleConfigurationCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 GetBucketLifecycleConfiguration input.
+ */
+export interface SimGetBucketLifecycleConfigurationCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 GetBucketLifecycleConfiguration output.
+ *
+ * The rules come back at the top level rather than under a
+ * `LifecycleConfiguration`, which is the asymmetry real S3 has between putting
+ * a configuration and reading one.
+ */
+export interface SimGetBucketLifecycleConfigurationCommandOutput {
+  readonly Rules: readonly SimS3LifecycleRule[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/get-bucket-lifecycle-configuration/get-bucket-lifecycle-configuration.handler.ts
+++ b/src/service/s3/command/get-bucket-lifecycle-configuration/get-bucket-lifecycle-configuration.handler.ts
@@ -1,0 +1,86 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3NoSuchLifecycleConfiguration } from "../../error/sim-s3.error.js";
+import { SimS3LifecycleAuthorizer } from "../lifecycle/sim-s3-lifecycle-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type {
+  SimGetBucketLifecycleConfigurationCommand,
+  SimGetBucketLifecycleConfigurationCommandOutput,
+} from "./get-bucket-lifecycle-configuration.command.js";
+
+interface GetBucketLifecycleConfigurationHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 GetBucketLifecycleConfigurationCommand handler.
+ */
+export class GetBucketLifecycleConfigurationCommandHandler implements CommandHandler<
+  SimGetBucketLifecycleConfigurationCommand,
+  SimGetBucketLifecycleConfigurationCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3LifecycleAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: GetBucketLifecycleConfigurationHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3LifecycleAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and return a Bucket's lifecycle rules.
+   *
+   * A Bucket carrying no rules is reported as NoSuchLifecycleConfiguration
+   * rather than an empty list, which is how real S3 separates a Bucket nobody
+   * configured from one configured to do nothing.
+   */
+  async handle(
+    command: SimGetBucketLifecycleConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimGetBucketLifecycleConfigurationCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "GetBucketLifecycleConfigurationCommand.input.Bucket",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeRead(bucket, options);
+
+    const lifecycle = bucket.getLifecycle();
+    if (lifecycle.isEmpty) {
+      throw new SimS3NoSuchLifecycleConfiguration(
+        `No lifecycle configuration on S3 Bucket ${bucketName}`,
+      );
+    }
+
+    return {
+      Rules: lifecycle.rules,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/lifecycle/sim-s3-lifecycle-authorizer.ts
+++ b/src/service/s3/command/lifecycle/sim-s3-lifecycle-authorizer.ts
@@ -1,0 +1,68 @@
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+interface SimS3LifecycleAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to the S3 lifecycle configuration commands.
+ *
+ * Reading is governed by s3:GetLifecycleConfiguration. Both replacing and
+ * removing the configuration are governed by s3:PutLifecycleConfiguration:
+ * real S3 has no separate delete permission, so removing the rules needs
+ * exactly what setting them needs. Neither action name carries "Bucket", which
+ * is where they differ from the rest of the Bucket configuration actions.
+ */
+export class SimS3LifecycleAuthorizer {
+  private static readonly readAction = "s3:GetLifecycleConfiguration";
+  private static readonly writeAction = "s3:PutLifecycleConfiguration";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimS3LifecycleAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may read the Bucket's lifecycle rules.
+   */
+  authorizeRead(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
+    this.authorize(SimS3LifecycleAuthorizer.readAction, bucket, options);
+  }
+
+  /**
+   * Ensure the caller may replace or remove the Bucket's lifecycle rules.
+   */
+  authorizeWrite(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
+    this.authorize(SimS3LifecycleAuthorizer.writeAction, bucket, options);
+  }
+
+  private authorize(
+    action: string,
+    bucket: SimS3Bucket,
+    options?: SimS3RequestOptions,
+  ): void {
+    const resource = simS3BucketArn(bucket.bucketName);
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/lifecycle/sim-s3-lifecycle-commands.ts
+++ b/src/service/s3/command/lifecycle/sim-s3-lifecycle-commands.ts
@@ -1,0 +1,54 @@
+import { DeleteBucketLifecycleCommandHandler } from "../delete-bucket-lifecycle/delete-bucket-lifecycle.handler.js";
+import { GetBucketLifecycleConfigurationCommandHandler } from "../get-bucket-lifecycle-configuration/get-bucket-lifecycle-configuration.handler.js";
+import { PutBucketLifecycleConfigurationCommandHandler } from "../put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.handler.js";
+import type { SimS3BucketCommandState } from "../sim-s3-bucket-command-state.js";
+import type * as simS3Commands from "../sim-s3-command.types.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+/**
+ * The lifecycle configuration commands of one simulated S3 scope.
+ */
+export class SimS3LifecycleCommands {
+  private readonly state: SimS3BucketCommandState;
+
+  constructor(state: SimS3BucketCommandState) {
+    this.state = state;
+  }
+
+  /**
+   * Replace a Bucket's lifecycle rules.
+   */
+  async put(
+    command: simS3Commands.SimPutBucketLifecycleConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketLifecycleConfigurationCommandOutput> {
+    return await new PutBucketLifecycleConfigurationCommandHandler(
+      this.state,
+    ).handle(command, options);
+  }
+
+  /**
+   * Read a Bucket's lifecycle rules.
+   */
+  async get(
+    command: simS3Commands.SimGetBucketLifecycleConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketLifecycleConfigurationCommandOutput> {
+    return await new GetBucketLifecycleConfigurationCommandHandler(
+      this.state,
+    ).handle(command, options);
+  }
+
+  /**
+   * Remove a Bucket's lifecycle rules.
+   */
+  async delete(
+    command: simS3Commands.SimDeleteBucketLifecycleCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteBucketLifecycleCommandOutput> {
+    return await new DeleteBucketLifecycleCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+}

--- a/src/service/s3/command/lifecycle/sim-s3-lifecycle-rules-validation.ts
+++ b/src/service/s3/command/lifecycle/sim-s3-lifecycle-rules-validation.ts
@@ -1,0 +1,35 @@
+import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
+import { SimS3MalformedXml } from "../../error/sim-s3.error.js";
+import type { SimS3LifecycleConfiguration } from "../put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+
+const ruleStatuses: ReadonlySet<string> = new Set(["Enabled", "Disabled"]);
+
+/**
+ * Refuse a lifecycle configuration real S3 would refuse to store.
+ *
+ * Real S3 answers MalformedXML for a configuration carrying no rules and for a
+ * rule whose Status is anything but Enabled or Disabled. Both are worth
+ * keeping, because a rule stored under a status nothing recognises would read
+ * back looking configured.
+ */
+export function validateSimS3LifecycleRules(
+  configuration: SimS3LifecycleConfiguration,
+  bucketName: SimS3BucketName,
+): void {
+  const rules = configuration.Rules ?? [];
+
+  if (rules.length === 0) {
+    throw new SimS3MalformedXml(
+      `Lifecycle configuration for S3 Bucket ${bucketName} states no rules`,
+    );
+  }
+
+  for (const rule of rules) {
+    if (rule.Status === undefined || !ruleStatuses.has(rule.Status)) {
+      throw new SimS3MalformedXml(
+        `Lifecycle rule ${rule.ID ?? "(unnamed)"} for S3 Bucket ` +
+          `${bucketName} must state a Status of Enabled or Disabled`,
+      );
+    }
+  }
+}

--- a/src/service/s3/command/put-bucket-lifecycle-configuration/lifecycle-configuration.iso.test.ts
+++ b/src/service/s3/command/put-bucket-lifecycle-configuration/lifecycle-configuration.iso.test.ts
@@ -1,0 +1,319 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeleteBucketLifecycleCommand,
+  GetBucketLifecycleConfigurationCommand,
+  PutBucketLifecycleConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  SimS3MalformedXml,
+  SimS3NoSuchBucket,
+  SimS3NoSuchLifecycleConfiguration,
+} from "../../error/sim-s3.error.js";
+
+describe("S3 lifecycle configuration commands", () => {
+  const expireRawLogs = {
+    ID: "expire-raw-logs",
+    Status: "Enabled",
+    Filter: { Prefix: "raw/" },
+    Expiration: { Days: 365 },
+  } as const;
+
+  const abortUploads = {
+    ID: "abort-incomplete-uploads",
+    Status: "Enabled",
+    Filter: { Prefix: "" },
+    AbortIncompleteMultipartUpload: { DaysAfterInitiation: 7 },
+  } as const;
+
+  it("hands back the rules a Bucket was configured with", async () => {
+    // Given a Bucket carrying a retention rule and an upload rule.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+    await simS3.putBucketLifecycleConfiguration(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: "logs",
+        LifecycleConfiguration: { Rules: [expireRawLogs, abortUploads] },
+      }),
+    );
+
+    // When the configuration is read back.
+    const output = await simS3.getBucketLifecycleConfiguration(
+      new GetBucketLifecycleConfigurationCommand({ Bucket: "logs" }),
+    );
+
+    // Then every field of both rules survives the round trip. Nothing expires
+    // against them, so what they say is all a test can check.
+    assertArrayLength(output.Rules, 2);
+    assertObjectEquals(output.Rules[0], expireRawLogs);
+    assertObjectEquals(output.Rules[1], abortUploads);
+  });
+
+  it("replaces the whole configuration, dropping rules left out", async () => {
+    // Given a Bucket carrying two rules.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "replaced" }));
+    await simS3.putBucketLifecycleConfiguration(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: "replaced",
+        LifecycleConfiguration: { Rules: [expireRawLogs, abortUploads] },
+      }),
+    );
+
+    // When a configuration naming only one of them is applied.
+    await simS3.putBucketLifecycleConfiguration(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: "replaced",
+        LifecycleConfiguration: { Rules: [abortUploads] },
+      }),
+    );
+
+    // Then the rule it left out is gone, because a put replaces the previous
+    // configuration rather than merging into it.
+    const output = await simS3.getBucketLifecycleConfiguration(
+      new GetBucketLifecycleConfigurationCommand({ Bucket: "replaced" }),
+    );
+
+    assertArrayLength(output.Rules, 1);
+    assertObjectEquals(output.Rules[0], abortUploads);
+  });
+
+  it("reports a Bucket nobody configured rather than an empty list", async () => {
+    // Given a Bucket created with no lifecycle configuration.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "fresh" }));
+
+    // When its configuration is read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketLifecycleConfiguration(
+        new GetBucketLifecycleConfigurationCommand({ Bucket: "fresh" }),
+      ),
+    );
+
+    // Then S3 says there is none, which is how real S3 separates a Bucket
+    // nobody configured from one configured to do nothing.
+    assertInstanceOf(error, SimS3NoSuchLifecycleConfiguration);
+  });
+
+  it("leaves a Bucket unconfigured once its rules are deleted", async () => {
+    // Given a Bucket carrying a retention rule.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "cleared" }));
+    await simS3.putBucketLifecycleConfiguration(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: "cleared",
+        LifecycleConfiguration: { Rules: [expireRawLogs] },
+      }),
+    );
+
+    // When the configuration is deleted twice over.
+    await simS3.deleteBucketLifecycle(
+      new DeleteBucketLifecycleCommand({ Bucket: "cleared" }),
+    );
+    await simS3.deleteBucketLifecycle(
+      new DeleteBucketLifecycleCommand({ Bucket: "cleared" }),
+    );
+
+    // Then the Bucket reads as unconfigured, and the second deletion was as
+    // acceptable as the first because real S3 makes this idempotent.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketLifecycleConfiguration(
+        new GetBucketLifecycleConfigurationCommand({ Bucket: "cleared" }),
+      ),
+    );
+
+    assertInstanceOf(error, SimS3NoSuchLifecycleConfiguration);
+  });
+
+  it("refuses a configuration real S3 would refuse to store", async () => {
+    // Given a Bucket to configure.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "malformed" }));
+
+    // When a configuration states no rules, and one states a rule with a
+    // status S3 has no meaning for.
+    const emptyError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "malformed",
+          LifecycleConfiguration: { Rules: [] },
+        }),
+      ),
+    );
+    const statusError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "malformed",
+          // @ts-expect-error -- testing a status outside the two S3 accepts
+          LifecycleConfiguration: { Rules: [{ ID: "off", Status: "Off" }] },
+        }),
+      ),
+    );
+
+    // Then both are refused, so a rule nothing recognises cannot read back
+    // looking configured.
+    assertInstanceOf(emptyError, SimS3MalformedXml);
+    assertInstanceOf(statusError, SimS3MalformedXml);
+    assertStringIncludes(statusError.message, "Enabled or Disabled");
+  });
+
+  it("rejects a non-existent Bucket", async () => {
+    // Given simulated S3 without the requested Bucket.
+    const simS3 = new SimAws().s3();
+
+    // When each command targets the missing Bucket.
+    const readError = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketLifecycleConfiguration(
+        new GetBucketLifecycleConfigurationCommand({ Bucket: "absent" }),
+      ),
+    );
+    const writeError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "absent",
+          LifecycleConfiguration: { Rules: [expireRawLogs] },
+        }),
+      ),
+    );
+    const removalError = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucketLifecycle(
+        new DeleteBucketLifecycleCommand({ Bucket: "absent" }),
+      ),
+    );
+
+    // Then S3 returns its missing-Bucket error each time.
+    assertInstanceOf(readError, SimS3NoSuchBucket);
+    assertInstanceOf(writeError, SimS3NoSuchBucket);
+    assertInstanceOf(removalError, SimS3NoSuchBucket);
+  });
+
+  it("rejects missing required request inputs", async () => {
+    // Given a Bucket to send incomplete requests to.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "inputs" }));
+
+    // When the commands are called without their required inputs.
+    const bucketError = await assertThrowsErrorAsync(async () =>
+      simS3.getBucketLifecycleConfiguration(
+        // @ts-expect-error -- testing invalid input
+        new GetBucketLifecycleConfigurationCommand({}),
+      ),
+    );
+    const configError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({ Bucket: "inputs" }),
+      ),
+    );
+    const removalError = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucketLifecycle(
+        // @ts-expect-error -- testing invalid input
+        new DeleteBucketLifecycleCommand({}),
+      ),
+    );
+
+    // Then request validation names the missing input.
+    assertStringIncludes(
+      bucketError.message,
+      "GetBucketLifecycleConfigurationCommand.input.Bucket",
+    );
+    assertStringIncludes(
+      configError.message,
+      "PutBucketLifecycleConfigurationCommand.input.LifecycleConfiguration",
+    );
+    assertStringIncludes(
+      removalError.message,
+      "DeleteBucketLifecycleCommand.input.Bucket",
+    );
+  });
+
+  it("denies a caller granted only the read permission", async () => {
+    // Given a Role granted the read side of the configuration and no more.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const simS3 = simAws.s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "guarded" }));
+    await simS3.putBucketLifecycleConfiguration(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: "guarded",
+        LifecycleConfiguration: { Rules: [expireRawLogs] },
+      }),
+    );
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "LifecycleAuditor",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "LifecycleAuditor",
+        PolicyName: "ReadLifecycleConfiguration",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetLifecycleConfiguration",
+            Resource: "arn:aws:s3:::guarded",
+          },
+        }),
+      }),
+    );
+    const caller = { kind: "arn", arn: roleCreation.Role.Arn } as const;
+
+    // When the Role reads, then tries to change and to remove the rules.
+    const readOutput = await simS3.getBucketLifecycleConfiguration(
+      new GetBucketLifecycleConfigurationCommand({ Bucket: "guarded" }),
+      { caller },
+    );
+    const writeError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "guarded",
+          LifecycleConfiguration: { Rules: [abortUploads] },
+        }),
+        { caller },
+      ),
+    );
+    const removalError = await assertThrowsErrorAsync(async () =>
+      simS3.deleteBucketLifecycle(
+        new DeleteBucketLifecycleCommand({ Bucket: "guarded" }),
+        { caller },
+      ),
+    );
+
+    // Then the read succeeds and both writes are denied on the one action S3
+    // governs replacement and removal with.
+    assertArrayLength(readOutput.Rules, 1);
+    assertInstanceOf(writeError, SimIamAccessDenied);
+    assertIdentical(writeError.action, "s3:PutLifecycleConfiguration");
+    assertInstanceOf(removalError, SimIamAccessDenied);
+    assertIdentical(removalError.action, "s3:PutLifecycleConfiguration");
+  });
+});

--- a/src/service/s3/command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.ts
+++ b/src/service/s3/command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.ts
@@ -1,0 +1,117 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 PutBucketLifecycleConfiguration command.
+ */
+export interface SimPutBucketLifecycleConfigurationCommand {
+  readonly input: SimPutBucketLifecycleConfigurationCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 PutBucketLifecycleConfiguration input.
+ */
+export interface SimPutBucketLifecycleConfigurationCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly LifecycleConfiguration?: SimS3LifecycleConfiguration | undefined;
+}
+
+/**
+ * Minimal structural sim S3 PutBucketLifecycleConfiguration output.
+ */
+export interface SimPutBucketLifecycleConfigurationCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle configuration.
+ *
+ * A Bucket has one of these rather than a list of them, so a put replaces
+ * whatever was there instead of adding to it.
+ */
+export interface SimS3LifecycleConfiguration {
+  readonly Rules?: readonly SimS3LifecycleRule[] | undefined;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle rule.
+ *
+ * Simulated S3 holds a rule and hands it back. Nothing expires or transitions
+ * an Object, which is why the fields carry no more type than the SDK gives
+ * them.
+ */
+export interface SimS3LifecycleRule {
+  readonly ID?: string | undefined;
+  readonly Status?: string | undefined;
+  readonly Prefix?: string | undefined;
+  readonly Filter?: SimS3LifecycleRuleFilter | undefined;
+  readonly Expiration?: SimS3LifecycleExpiration | undefined;
+  readonly Transitions?: readonly SimS3LifecycleTransition[] | undefined;
+  readonly AbortIncompleteMultipartUpload?:
+    | SimS3LifecycleAbortIncompleteMultipartUpload
+    | undefined;
+  readonly NoncurrentVersionExpiration?:
+    | SimS3LifecycleNoncurrentVersionExpiration
+    | undefined;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle rule filter.
+ */
+export interface SimS3LifecycleRuleFilter {
+  readonly Prefix?: string | undefined;
+  readonly Tag?: SimS3LifecycleTag | undefined;
+  readonly And?: SimS3LifecycleRuleAndOperator | undefined;
+  readonly ObjectSizeGreaterThan?: number | undefined;
+  readonly ObjectSizeLessThan?: number | undefined;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle rule filter conjunction.
+ */
+export interface SimS3LifecycleRuleAndOperator {
+  readonly Prefix?: string | undefined;
+  readonly Tags?: readonly SimS3LifecycleTag[] | undefined;
+  readonly ObjectSizeGreaterThan?: number | undefined;
+  readonly ObjectSizeLessThan?: number | undefined;
+}
+
+/**
+ * Minimal structural sim S3 Object tag, as a lifecycle filter names one.
+ */
+export interface SimS3LifecycleTag {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle expiry.
+ */
+export interface SimS3LifecycleExpiration {
+  readonly Date?: Date | undefined;
+  readonly Days?: number | undefined;
+  readonly ExpiredObjectDeleteMarker?: boolean | undefined;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle storage class transition.
+ */
+export interface SimS3LifecycleTransition {
+  readonly Date?: Date | undefined;
+  readonly Days?: number | undefined;
+  readonly StorageClass?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle abandoned upload rule.
+ */
+export interface SimS3LifecycleAbortIncompleteMultipartUpload {
+  readonly DaysAfterInitiation?: number | undefined;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle noncurrent version expiry.
+ */
+export interface SimS3LifecycleNoncurrentVersionExpiration {
+  readonly NoncurrentDays?: number | undefined;
+  readonly NewerNoncurrentVersions?: number | undefined;
+}

--- a/src/service/s3/command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.handler.ts
+++ b/src/service/s3/command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.handler.ts
@@ -1,0 +1,90 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAllowAllAuth } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimS3LifecycleConfiguration } from "../../bucket/lifecycle/sim-s3-lifecycle-configuration.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3LifecycleAuthorizer } from "../lifecycle/sim-s3-lifecycle-authorizer.js";
+import { validateSimS3LifecycleRules } from "../lifecycle/sim-s3-lifecycle-rules-validation.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type {
+  SimPutBucketLifecycleConfigurationCommand,
+  SimPutBucketLifecycleConfigurationCommandOutput,
+} from "./put-bucket-lifecycle-configuration.command.js";
+
+interface PutBucketLifecycleConfigurationHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 PutBucketLifecycleConfigurationCommand handler.
+ */
+export class PutBucketLifecycleConfigurationCommandHandler implements CommandHandler<
+  SimPutBucketLifecycleConfigurationCommand,
+  SimPutBucketLifecycleConfigurationCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3LifecycleAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: PutBucketLifecycleConfigurationHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3LifecycleAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and replace a Bucket's lifecycle rules.
+   *
+   * The supplied configuration replaces the previous one wholesale, so a rule
+   * it leaves out is gone rather than kept from whatever the Bucket had
+   * before.
+   */
+  async handle(
+    command: SimPutBucketLifecycleConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutBucketLifecycleConfigurationCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "PutBucketLifecycleConfigurationCommand.input.Bucket",
+    );
+    assertDefined(
+      command.input.LifecycleConfiguration,
+      "PutBucketLifecycleConfigurationCommand.input.LifecycleConfiguration",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeWrite(bucket, options);
+
+    const configuration = command.input.LifecycleConfiguration;
+    validateSimS3LifecycleRules(configuration, bucketName);
+
+    bucket.configureLifecycle(
+      SimS3LifecycleConfiguration.fromConfiguration(configuration),
+    );
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -46,6 +46,20 @@ export type {
   SimDeletePublicAccessBlockCommandOutput,
 } from "./delete-public-access-block/delete-public-access-block.command.js";
 export type {
+  SimDeleteBucketLifecycleCommand,
+  SimDeleteBucketLifecycleCommandOutput,
+} from "./delete-bucket-lifecycle/delete-bucket-lifecycle.command.js";
+export type {
+  SimGetBucketLifecycleConfigurationCommand,
+  SimGetBucketLifecycleConfigurationCommandOutput,
+} from "./get-bucket-lifecycle-configuration/get-bucket-lifecycle-configuration.command.js";
+export type {
+  SimPutBucketLifecycleConfigurationCommand,
+  SimPutBucketLifecycleConfigurationCommandOutput,
+  SimS3LifecycleConfiguration,
+  SimS3LifecycleRule,
+} from "./put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+export type {
   SimGetBucketPolicyCommand,
   SimGetBucketPolicyCommandOutput,
 } from "./get-bucket-policy/get-bucket-policy.command.js";

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -70,6 +70,21 @@ export class SimS3NoSuchBucketPolicy extends SimS3Error {
 }
 
 /**
+ * Simulated S3 NoSuchLifecycleConfiguration error.
+ *
+ * Real S3 distinguishes a Bucket that does not exist from a Bucket that exists
+ * without lifecycle rules, so GetBucketLifecycleConfiguration answers this
+ * rather than an empty list of rules.
+ */
+export class SimS3NoSuchLifecycleConfiguration extends SimS3Error {
+  public override readonly name = "NoSuchLifecycleConfiguration";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
  * Simulated S3 AccessDenied error.
  *
  * This is S3 itself refusing a request, as Block Public Access does, rather

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -5,14 +5,17 @@ import {
   DeleteBucketPolicyCommand,
   DeleteObjectCommand,
   DeleteObjectsCommand,
+  DeleteBucketLifecycleCommand,
   DeletePublicAccessBlockCommand,
   GetBucketNotificationConfigurationCommand,
   GetBucketPolicyCommand,
+  GetBucketLifecycleConfigurationCommand,
   GetPublicAccessBlockCommand,
   ListObjectsCommand,
   ListObjectsV2Command,
   PutBucketNotificationConfigurationCommand,
   PutBucketPolicyCommand,
+  PutBucketLifecycleConfigurationCommand,
   PutBucketWebsiteCommand,
   PutObjectCommand,
   PutPublicAccessBlockCommand,
@@ -23,6 +26,7 @@ import {
   assertArrayLength,
   assertFalse,
   assertIdentical,
+  assertThrowsErrorAsync,
   assertObjectEquals,
   assertStringIncludes,
   assertTrue,
@@ -207,6 +211,41 @@ describe("simulated S3 SDK Command routing", () => {
     assertTrue(restoredOut.PublicAccessBlockConfiguration?.BlockPublicPolicy);
   });
 
+  it("routes the lifecycle configuration Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: "bucket-lc" }));
+
+    await client.send(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: "bucket-lc",
+        LifecycleConfiguration: {
+          Rules: [
+            { ID: "expire", Status: "Enabled", Expiration: { Days: 30 } },
+          ],
+        },
+      }),
+    );
+
+    const readOut = await client.send(
+      new GetBucketLifecycleConfigurationCommand({ Bucket: "bucket-lc" }),
+    );
+    assertArrayLength(readOut.Rules ?? [], 1);
+
+    // Removing the configuration leaves the Bucket with no rules to read.
+    await client.send(
+      new DeleteBucketLifecycleCommand({ Bucket: "bucket-lc" }),
+    );
+    const removalError = await assertThrowsErrorAsync(async () =>
+      client.send(
+        new GetBucketLifecycleConfigurationCommand({ Bucket: "bucket-lc" }),
+      ),
+    );
+    assertIdentical(removalError.name, "NoSuchLifecycleConfiguration");
+  });
+
   it("routes the Object deletion Commands through an intercepted client", async () => {
     using simSdk = new SimSdk();
     const client = new S3Client({ region: "us-east-1" });
@@ -273,7 +312,7 @@ describe("simulated S3 SDK Command routing", () => {
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 27);
+    assertArrayLength(supported, 30);
     assertArrayIncludes(supported, "CopyObjectCommand");
     assertArrayIncludes(supported, "GetObjectCommand");
     assertArrayIncludes(supported, "ListObjectsV2Command");
@@ -285,6 +324,9 @@ describe("simulated S3 SDK Command routing", () => {
     assertArrayIncludes(supported, "GetBucketPolicyCommand");
     assertArrayIncludes(supported, "DeleteBucketPolicyCommand");
     assertArrayIncludes(supported, "PutPublicAccessBlockCommand");
+    assertArrayIncludes(supported, "PutBucketLifecycleConfigurationCommand");
+    assertArrayIncludes(supported, "GetBucketLifecycleConfigurationCommand");
+    assertArrayIncludes(supported, "DeleteBucketLifecycleCommand");
     assertArrayIncludes(supported, "HeadObjectCommand");
     assertArrayIncludes(supported, "HeadBucketCommand");
     assertArrayIncludes(supported, "CreateMultipartUploadCommand");

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -4,36 +4,7 @@ import type {
   SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import { simSdkCallerOptions, simSdkStreamBody } from "../../../sdk/index.js";
-import type { SimAbortMultipartUploadCommand } from "../command/abort-multipart-upload/abort-multipart-upload.command.js";
-import type { SimCompleteMultipartUploadCommand } from "../command/complete-multipart-upload/complete-multipart-upload.command.js";
-import type { SimCopyObjectCommand } from "../command/copy-object/copy-object.command.js";
-import type { SimCreateBucketCommand } from "../command/create-bucket/create-bucket.command.js";
-import type { SimCreateMultipartUploadCommand } from "../command/create-multipart-upload/create-multipart-upload.command.js";
-import type { SimListMultipartUploadsCommand } from "../command/list-multipart-uploads/list-multipart-uploads.command.js";
-import type { SimListPartsCommand } from "../command/list-parts/list-parts.command.js";
-import type { SimUploadPartCommand } from "../command/upload-part/upload-part.command.js";
-import type {
-  SimGetObjectCommand,
-  SimGetObjectCommandOutput,
-} from "../command/get-object/get-object.command.js";
-import type { SimHeadBucketCommand } from "../command/head-bucket/head-bucket.command.js";
-import type { SimHeadObjectCommand } from "../command/head-object/head-object.command.js";
-import type { SimListBucketsCommand } from "../command/list-buckets/list-buckets.command.js";
-import type { SimListObjectsCommand } from "../command/list-objects/list-objects.command.js";
-import type { SimListObjectsV2Command } from "../command/list-objects-v2/list-objects-v2.command.js";
-import type { SimDeleteBucketCommand } from "../command/delete-bucket/delete-bucket.command.js";
-import type { SimDeleteBucketPolicyCommand } from "../command/delete-bucket-policy/delete-bucket-policy.command.js";
-import type { SimDeleteObjectCommand } from "../command/delete-object/delete-object.command.js";
-import type { SimDeleteObjectsCommand } from "../command/delete-objects/delete-objects.command.js";
-import type { SimGetBucketNotificationConfigurationCommand } from "../command/get-bucket-notification-configuration/get-bucket-notification-configuration.command.js";
-import type { SimGetBucketPolicyCommand } from "../command/get-bucket-policy/get-bucket-policy.command.js";
-import type { SimPutBucketNotificationConfigurationCommand } from "../command/put-bucket-notification-configuration/put-bucket-notification-configuration.command.js";
-import type { SimPutBucketPolicyCommand } from "../command/put-bucket-policy/put-bucket-policy.command.js";
-import type { SimPutBucketWebsiteCommand } from "../command/put-bucket-website/put-bucket-website.command.js";
-import type { SimPutObjectCommand } from "../command/put-object/put-object.command.js";
-import type { SimPutPublicAccessBlockCommand } from "../command/put-public-access-block/put-public-access-block.command.js";
-import type { SimGetPublicAccessBlockCommand } from "../command/get-public-access-block/get-public-access-block.command.js";
-import type { SimDeletePublicAccessBlockCommand } from "../command/delete-public-access-block/delete-public-access-block.command.js";
+import type * as simS3Commands from "../command/sim-s3-command.types.js";
 import type { SimS3 } from "../sim-s3.js";
 
 /**
@@ -48,7 +19,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "CreateBucketCommand",
         async (command, context): Promise<unknown> =>
           await simS3.createBucket(
-            command as SimCreateBucketCommand,
+            command as simS3Commands.SimCreateBucketCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -56,7 +27,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "CopyObjectCommand",
         async (command, context): Promise<unknown> =>
           await simS3.copyObject(
-            command as SimCopyObjectCommand,
+            command as simS3Commands.SimCopyObjectCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -64,7 +35,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "DeleteBucketCommand",
         async (command, context): Promise<unknown> =>
           await simS3.deleteBucket(
-            command as SimDeleteBucketCommand,
+            command as simS3Commands.SimDeleteBucketCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -72,7 +43,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "DeleteBucketPolicyCommand",
         async (command, context): Promise<unknown> =>
           await simS3.deleteBucketPolicy(
-            command as SimDeleteBucketPolicyCommand,
+            command as simS3Commands.SimDeleteBucketPolicyCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -80,7 +51,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "DeleteObjectCommand",
         async (command, context): Promise<unknown> =>
           await simS3.deleteObject(
-            command as SimDeleteObjectCommand,
+            command as simS3Commands.SimDeleteObjectCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -88,7 +59,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "DeleteObjectsCommand",
         async (command, context): Promise<unknown> =>
           await simS3.deleteObjects(
-            command as SimDeleteObjectsCommand,
+            command as simS3Commands.SimDeleteObjectsCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -96,7 +67,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "GetBucketPolicyCommand",
         async (command, context): Promise<unknown> =>
           await simS3.getBucketPolicy(
-            command as SimGetBucketPolicyCommand,
+            command as simS3Commands.SimGetBucketPolicyCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -104,7 +75,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "HeadBucketCommand",
         async (command, context): Promise<unknown> =>
           await simS3.headBucket(
-            command as SimHeadBucketCommand,
+            command as simS3Commands.SimHeadBucketCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -112,7 +83,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "HeadObjectCommand",
         async (command, context): Promise<unknown> =>
           await simS3.headObject(
-            command as SimHeadObjectCommand,
+            command as simS3Commands.SimHeadObjectCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -121,7 +92,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await getObjectWithSdkStreamBody(
             simS3,
-            command as SimGetObjectCommand,
+            command as simS3Commands.SimGetObjectCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -129,7 +100,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "ListBucketsCommand",
         async (command, context): Promise<unknown> =>
           await simS3.listBuckets(
-            command as SimListBucketsCommand,
+            command as simS3Commands.SimListBucketsCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -137,7 +108,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "ListObjectsCommand",
         async (command, context): Promise<unknown> =>
           await simS3.listObjects(
-            command as SimListObjectsCommand,
+            command as simS3Commands.SimListObjectsCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -145,7 +116,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "ListObjectsV2Command",
         async (command, context): Promise<unknown> =>
           await simS3.listObjectsV2(
-            command as SimListObjectsV2Command,
+            command as simS3Commands.SimListObjectsV2Command,
             simSdkCallerOptions(context),
           ),
       ],
@@ -153,7 +124,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "PutBucketPolicyCommand",
         async (command, context): Promise<unknown> =>
           await simS3.putBucketPolicy(
-            command as SimPutBucketPolicyCommand,
+            command as simS3Commands.SimPutBucketPolicyCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -161,7 +132,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "PutBucketNotificationConfigurationCommand",
         async (command, context): Promise<unknown> =>
           await simS3.putBucketNotificationConfiguration(
-            command as SimPutBucketNotificationConfigurationCommand,
+            command as simS3Commands.SimPutBucketNotificationConfigurationCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -169,7 +140,31 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "GetBucketNotificationConfigurationCommand",
         async (command, context): Promise<unknown> =>
           await simS3.getBucketNotificationConfiguration(
-            command as SimGetBucketNotificationConfigurationCommand,
+            command as simS3Commands.SimGetBucketNotificationConfigurationCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutBucketLifecycleConfigurationCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.putBucketLifecycleConfiguration(
+            command as simS3Commands.SimPutBucketLifecycleConfigurationCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetBucketLifecycleConfigurationCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.getBucketLifecycleConfiguration(
+            command as simS3Commands.SimGetBucketLifecycleConfigurationCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteBucketLifecycleCommand",
+        async (command, context): Promise<unknown> =>
+          await simS3.deleteBucketLifecycle(
+            command as simS3Commands.SimDeleteBucketLifecycleCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -177,7 +172,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "PutBucketWebsiteCommand",
         async (command, context): Promise<unknown> =>
           await simS3.putBucketWebsite(
-            command as SimPutBucketWebsiteCommand,
+            command as simS3Commands.SimPutBucketWebsiteCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -185,7 +180,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "PutPublicAccessBlockCommand",
         async (command, context): Promise<unknown> =>
           await simS3.putPublicAccessBlock(
-            command as SimPutPublicAccessBlockCommand,
+            command as simS3Commands.SimPutPublicAccessBlockCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -193,7 +188,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "GetPublicAccessBlockCommand",
         async (command, context): Promise<unknown> =>
           await simS3.getPublicAccessBlock(
-            command as SimGetPublicAccessBlockCommand,
+            command as simS3Commands.SimGetPublicAccessBlockCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -201,7 +196,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "DeletePublicAccessBlockCommand",
         async (command, context): Promise<unknown> =>
           await simS3.deletePublicAccessBlock(
-            command as SimDeletePublicAccessBlockCommand,
+            command as simS3Commands.SimDeletePublicAccessBlockCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -209,7 +204,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "PutObjectCommand",
         async (command, context): Promise<unknown> =>
           await simS3.putObject(
-            command as SimPutObjectCommand,
+            command as simS3Commands.SimPutObjectCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -217,7 +212,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "CreateMultipartUploadCommand",
         async (command, context): Promise<unknown> =>
           await simS3.createMultipartUpload(
-            command as SimCreateMultipartUploadCommand,
+            command as simS3Commands.SimCreateMultipartUploadCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -225,7 +220,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "UploadPartCommand",
         async (command, context): Promise<unknown> =>
           await simS3.uploadPart(
-            command as SimUploadPartCommand,
+            command as simS3Commands.SimUploadPartCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -233,7 +228,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "CompleteMultipartUploadCommand",
         async (command, context): Promise<unknown> =>
           await simS3.completeMultipartUpload(
-            command as SimCompleteMultipartUploadCommand,
+            command as simS3Commands.SimCompleteMultipartUploadCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -241,7 +236,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "AbortMultipartUploadCommand",
         async (command, context): Promise<unknown> =>
           await simS3.abortMultipartUpload(
-            command as SimAbortMultipartUploadCommand,
+            command as simS3Commands.SimAbortMultipartUploadCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -249,7 +244,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "ListMultipartUploadsCommand",
         async (command, context): Promise<unknown> =>
           await simS3.listMultipartUploads(
-            command as SimListMultipartUploadsCommand,
+            command as simS3Commands.SimListMultipartUploadsCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -257,7 +252,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
         "ListPartsCommand",
         async (command, context): Promise<unknown> =>
           await simS3.listParts(
-            command as SimListPartsCommand,
+            command as simS3Commands.SimListPartsCommand,
             simSdkCallerOptions(context),
           ),
       ],
@@ -285,9 +280,9 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
  */
 async function getObjectWithSdkStreamBody(
   simS3: SimS3,
-  command: SimGetObjectCommand,
+  command: simS3Commands.SimGetObjectCommand,
   options: SimSdkCallerOptions | undefined,
-): Promise<SimGetObjectCommandOutput> {
+): Promise<simS3Commands.SimGetObjectCommandOutput> {
   const output = await simS3.getObject(command, options);
   if (output.Body === undefined) {
     return output;

--- a/src/service/s3/sim-s3-commands.ts
+++ b/src/service/s3/sim-s3-commands.ts
@@ -10,6 +10,7 @@ import {
 import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
 import { SimS3BucketCommands } from "./command/bucket/sim-s3-bucket-commands.js";
 import { SimS3BucketPolicyCommands } from "./command/bucket-policy/sim-s3-bucket-policy-commands.js";
+import { SimS3LifecycleCommands } from "./command/lifecycle/sim-s3-lifecycle-commands.js";
 import { SimS3MultipartCommands } from "./command/multipart/sim-s3-multipart-commands.js";
 import { SimS3NotificationCommands } from "./command/notification/sim-s3-notification-commands.js";
 import { SimS3ObjectCommands } from "./command/object/sim-s3-object-commands.js";
@@ -62,6 +63,7 @@ export class SimS3Commands {
   public readonly bucketPolicies: SimS3BucketPolicyCommands;
   public readonly publicAccessBlocks: SimS3PublicAccessBlockCommands;
   public readonly notifications: SimS3NotificationCommands;
+  public readonly lifecycles: SimS3LifecycleCommands;
   public readonly objects: SimS3ObjectCommands;
   public readonly multipartUploads: SimS3MultipartCommands;
   public readonly objectNotifier: SimS3ObjectNotifier;
@@ -95,6 +97,7 @@ export class SimS3Commands {
     this.bucketPolicies = new SimS3BucketPolicyCommands(state);
     this.publicAccessBlocks = new SimS3PublicAccessBlockCommands(state);
     this.notifications = new SimS3NotificationCommands(state);
+    this.lifecycles = new SimS3LifecycleCommands(state);
     this.objects = new SimS3ObjectCommands(state);
     this.multipartUploads = new SimS3MultipartCommands(state);
   }

--- a/src/service/s3/sim-s3-operations.ts
+++ b/src/service/s3/sim-s3-operations.ts
@@ -124,6 +124,30 @@ export abstract class SimS3Operations {
     return await this.commands.notifications.get(command, options);
   }
 
+  /** Handle a Put Bucket Lifecycle Configuration Command from the SDK. */
+  async putBucketLifecycleConfiguration(
+    command: simS3Commands.SimPutBucketLifecycleConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketLifecycleConfigurationCommandOutput> {
+    return await this.commands.lifecycles.put(command, options);
+  }
+
+  /** Handle a Get Bucket Lifecycle Configuration Command from the SDK. */
+  async getBucketLifecycleConfiguration(
+    command: simS3Commands.SimGetBucketLifecycleConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketLifecycleConfigurationCommandOutput> {
+    return await this.commands.lifecycles.get(command, options);
+  }
+
+  /** Handle a Delete Bucket Lifecycle Command from the SDK. */
+  async deleteBucketLifecycle(
+    command: simS3Commands.SimDeleteBucketLifecycleCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteBucketLifecycleCommandOutput> {
+    return await this.commands.lifecycles.delete(command, options);
+  }
+
   /** Handle a List Buckets Command from the SDK. */
   async listBuckets(
     command: simS3Commands.SimListBucketsCommand,


### PR DESCRIPTION
Simulated S3 stores a Bucket's lifecycle rules and hands them back through `GetBucketLifecycleConfiguration`. An `AWS::S3::Bucket` Resource's `LifecycleConfiguration` reaches the Bucket through the same put an SDK caller reaches, alongside website, public access and notification configuration.

No Object expires or transitions against a rule, so `LifecycleConfiguration` stays recorded in `stack.ignoredProperties` under a reworded reason. Expiring Objects against one is #984.

The SDK command router passed the 300-line limit, so its per-command type imports collapsed to one namespace import from the command types barrel, as six other service routers already do.

Resolves https://github.com/KensioSoftware/yulin/issues/983

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulated S3 lifecycle configuration support for creating, retrieving, replacing, and deleting bucket rules.
  - Added CloudFormation support for lifecycle rules, including expiration, transitions, filters, and multipart-upload settings.
  - Added validation for missing rules and invalid statuses, with appropriate errors for absent configurations.
  - Added authorization checks for lifecycle reads and updates.
- **Documentation**
  - Documented supported lifecycle configuration behavior and limitations.
  - Added a CloudFormation and SDK usage example.
- **Tests**
  - Added comprehensive coverage for lifecycle operations, validation, authorization, and CloudFormation integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->