### PR TITLE
fix: refuse a lifecycle rule that does nothing

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1987,9 +1987,11 @@ carrying no rules answers `GetBucketLifecycleConfigurationCommand` with
 `NoSuchLifecycleConfiguration` rather than an empty list, which is how real S3 separates a Bucket
 nobody configured from one configured to do nothing.
 
-A configuration stating no rules at all is refused with `MalformedXML`, and so is a rule whose
-`Status` is anything but `Enabled` or `Disabled`. A rule stored under a status nothing recognises
-would read back looking configured.
+A configuration stating no rules at all is refused with `MalformedXML`. So is a rule whose `Status`
+is anything but `Enabled` or `Disabled`, and a rule stating no action to take, meaning none of
+`Expiration`, `Transitions`, `NoncurrentVersionExpiration`, `NoncurrentVersionTransitions` or
+`AbortIncompleteMultipartUpload`. An empty list of transitions counts as no action. Real S3 refuses
+all three, and a rule stored here that real S3 would have rejected reads back looking configured.
 
 ### From a CloudFormation template
 

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
@@ -19,10 +19,10 @@ interface SimS3LifecycleConfigurationProperties {
  * to add one rule without restating the others.
  */
 export class SimS3LifecycleConfiguration {
-  public readonly rules: readonly SimS3LifecycleRule[];
+  private readonly storedRules: readonly SimS3LifecycleRule[];
 
   constructor(properties: SimS3LifecycleConfigurationProperties = {}) {
-    this.rules = properties.rules ?? [];
+    this.storedRules = structuredClone(properties.rules ?? []);
   }
 
   /**
@@ -44,6 +44,17 @@ export class SimS3LifecycleConfiguration {
   }
 
   /**
+   * The rules this Bucket carries.
+   *
+   * Cloned on the way out as they were on the way in. A caller holding the
+   * objects it put, or the ones a read gave it, could otherwise change what
+   * the Bucket is configured with by mutating them.
+   */
+  get rules(): readonly SimS3LifecycleRule[] {
+    return structuredClone(this.storedRules);
+  }
+
+  /**
    * Whether the Bucket carries any rule at all.
    *
    * Real S3 distinguishes a Bucket with no configuration from one with an
@@ -51,6 +62,6 @@ export class SimS3LifecycleConfiguration {
    * unconfigured Bucket and a Bucket whose rules were all removed read alike.
    */
   get isEmpty(): boolean {
-    return this.rules.length === 0;
+    return this.storedRules.length === 0;
   }
 }

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle.iso.test.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle.iso.test.ts
@@ -155,19 +155,22 @@ describe("AWS::S3::Bucket LifecycleConfiguration", () => {
       {
         Id: "big-tagged-objects",
         Status: "Enabled",
+        ExpirationInDays: 30,
         ObjectSizeGreaterThan: 1024,
         TagFilters: [{ Key: "class", Value: "raw" }],
       },
     ]);
 
-    // Then both arrive as the template stated them. Dropping either would read
-    // back as a Bucket configured with less than the template asked for.
+    // Then both arrive as the template stated them, under the CloudFormation
+    // names. Dropping either would read back as a Bucket configured with less
+    // than the template asked for.
     const rules = await readRules(simAws);
 
     assertArrayLength(rules, 1);
     assertObjectEquals(rules[0], {
       ID: "big-tagged-objects",
       Status: "Enabled",
+      Expiration: { Days: 30 },
       ObjectSizeGreaterThan: 1024,
       TagFilters: [{ Key: "class", Value: "raw" }],
     });

--- a/src/service/s3/command/lifecycle/sim-s3-lifecycle-rules-validation.ts
+++ b/src/service/s3/command/lifecycle/sim-s3-lifecycle-rules-validation.ts
@@ -1,16 +1,42 @@
 import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
 import { SimS3MalformedXml } from "../../error/sim-s3.error.js";
-import type { SimS3LifecycleConfiguration } from "../put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+import type {
+  SimS3LifecycleConfiguration,
+  SimS3LifecycleRule,
+} from "../put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
 
 const ruleStatuses: ReadonlySet<string> = new Set(["Enabled", "Disabled"]);
 
 /**
+ * The fields that make a rule do something, for the refusal to name.
+ */
+const ruleActionNames =
+  "Expiration, Transitions, NoncurrentVersionExpiration, " +
+  "NoncurrentVersionTransitions or AbortIncompleteMultipartUpload";
+
+/**
+ * Whether a rule states an action to take on the Objects it selects.
+ *
+ * Real S3 refuses a rule stating none, because a rule that selects Objects and
+ * then does nothing with them is a configuration with no meaning.
+ */
+function statesAnAction(rule: SimS3LifecycleRule): boolean {
+  return [
+    rule.Expiration,
+    rule.Transitions,
+    rule.NoncurrentVersionExpiration,
+    rule.NoncurrentVersionTransitions,
+    rule.AbortIncompleteMultipartUpload,
+  ].some((action) => action !== undefined);
+}
+
+/**
  * Refuse a lifecycle configuration real S3 would refuse to store.
  *
- * Real S3 answers MalformedXML for a configuration carrying no rules and for a
- * rule whose Status is anything but Enabled or Disabled. Both are worth
- * keeping, because a rule stored under a status nothing recognises would read
- * back looking configured.
+ * Real S3 answers MalformedXML for a configuration carrying no rules, for a
+ * rule whose Status is anything but Enabled or Disabled, and for a rule
+ * stating no action at all. All three are worth keeping, because a rule real
+ * S3 would have rejected reads back here looking configured.
  */
 export function validateSimS3LifecycleRules(
   configuration: SimS3LifecycleConfiguration,
@@ -25,11 +51,27 @@ export function validateSimS3LifecycleRules(
   }
 
   for (const rule of rules) {
-    if (rule.Status === undefined || !ruleStatuses.has(rule.Status)) {
-      throw new SimS3MalformedXml(
-        `Lifecycle rule ${rule.ID ?? "(unnamed)"} for S3 Bucket ` +
-          `${bucketName} must state a Status of Enabled or Disabled`,
-      );
-    }
+    validateRule(rule, bucketName);
+  }
+}
+
+function validateRule(
+  rule: SimS3LifecycleRule,
+  bucketName: SimS3BucketName,
+): void {
+  const named = rule.ID ?? "(unnamed)";
+
+  if (rule.Status === undefined || !ruleStatuses.has(rule.Status)) {
+    throw new SimS3MalformedXml(
+      `Lifecycle rule ${named} for S3 Bucket ${bucketName} must state a ` +
+        `Status of Enabled or Disabled`,
+    );
+  }
+
+  if (!statesAnAction(rule)) {
+    throw new SimS3MalformedXml(
+      `Lifecycle rule ${named} for S3 Bucket ${bucketName} must state at ` +
+        `least one of ${ruleActionNames}`,
+    );
   }
 }

--- a/src/service/s3/command/lifecycle/sim-s3-lifecycle-rules-validation.ts
+++ b/src/service/s3/command/lifecycle/sim-s3-lifecycle-rules-validation.ts
@@ -18,16 +18,18 @@ const ruleActionNames =
  * Whether a rule states an action to take on the Objects it selects.
  *
  * Real S3 refuses a rule stating none, because a rule that selects Objects and
- * then does nothing with them is a configuration with no meaning.
+ * then does nothing with them is a configuration with no meaning. An empty
+ * list of transitions counts as none. The field is there and the rule still
+ * transitions nothing.
  */
 function statesAnAction(rule: SimS3LifecycleRule): boolean {
   return [
-    rule.Expiration,
-    rule.Transitions,
-    rule.NoncurrentVersionExpiration,
-    rule.NoncurrentVersionTransitions,
-    rule.AbortIncompleteMultipartUpload,
-  ].some((action) => action !== undefined);
+    rule.Expiration !== undefined,
+    rule.NoncurrentVersionExpiration !== undefined,
+    rule.AbortIncompleteMultipartUpload !== undefined,
+    (rule.Transitions ?? []).length > 0,
+    (rule.NoncurrentVersionTransitions ?? []).length > 0,
+  ].includes(true);
 }
 
 /**

--- a/src/service/s3/command/put-bucket-lifecycle-configuration/lifecycle-configuration-refusals.iso.test.ts
+++ b/src/service/s3/command/put-bucket-lifecycle-configuration/lifecycle-configuration-refusals.iso.test.ts
@@ -1,0 +1,123 @@
+import {
+  CreateBucketCommand,
+  PutBucketLifecycleConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3MalformedXml } from "../../error/sim-s3.error.js";
+
+describe("S3 lifecycle configurations simulated S3 refuses", () => {
+  it("refuses a configuration real S3 would refuse to store", async () => {
+    // Given a Bucket to configure.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "malformed" }));
+
+    // When a configuration states no rules, and one states a rule with a
+    // status S3 has no meaning for.
+    const emptyError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "malformed",
+          LifecycleConfiguration: { Rules: [] },
+        }),
+      ),
+    );
+    const statusError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "malformed",
+          // @ts-expect-error -- testing a status outside the two S3 accepts
+          LifecycleConfiguration: { Rules: [{ ID: "off", Status: "Off" }] },
+        }),
+      ),
+    );
+
+    // Then both are refused, so a rule nothing recognises cannot read back
+    // looking configured.
+    assertInstanceOf(emptyError, SimS3MalformedXml);
+    assertInstanceOf(statusError, SimS3MalformedXml);
+    assertStringIncludes(statusError.message, "Enabled or Disabled");
+  });
+
+  it("refuses a rule that would do nothing", async () => {
+    // Given a Bucket to configure.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "idle" }));
+
+    // When a rule states a status and no action to take.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "idle",
+          LifecycleConfiguration: {
+            Rules: [
+              {
+                ID: "does-nothing",
+                Status: "Enabled",
+                Filter: { Prefix: "raw/" },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, as real S3 refuses a rule carrying no expiry,
+    // transition or upload action.
+    assertInstanceOf(error, SimS3MalformedXml);
+    assertStringIncludes(error.message, "must state at least one of");
+  });
+
+  it("refuses a rule whose only action is an empty list", async () => {
+    // Given a Bucket to configure.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "empty" }));
+
+    // When a rule states its transitions, and states none of them.
+    const transitionsError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "empty",
+          LifecycleConfiguration: {
+            Rules: [
+              { ID: "no-transitions", Status: "Enabled", Transitions: [] },
+            ],
+          },
+        }),
+      ),
+    );
+    const noncurrentError = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "empty",
+          LifecycleConfiguration: {
+            Rules: [
+              {
+                ID: "no-noncurrent-transitions",
+                Status: "Enabled",
+                NoncurrentVersionTransitions: [],
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then both are refused. The field being there does not make the rule do
+    // anything, so neither counts as an action.
+    assertInstanceOf(transitionsError, SimS3MalformedXml);
+    assertInstanceOf(noncurrentError, SimS3MalformedXml);
+    assertStringIncludes(
+      transitionsError.message,
+      "must state at least one of",
+    );
+  });
+});

--- a/src/service/s3/command/put-bucket-lifecycle-configuration/lifecycle-configuration.iso.test.ts
+++ b/src/service/s3/command/put-bucket-lifecycle-configuration/lifecycle-configuration.iso.test.ts
@@ -9,6 +9,7 @@ import {
   assertArrayLength,
   assertIdentical,
   assertInstanceOf,
+  assertNonNullable,
   assertObjectEquals,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -172,6 +173,76 @@ describe("S3 lifecycle configuration commands", () => {
     assertInstanceOf(emptyError, SimS3MalformedXml);
     assertInstanceOf(statusError, SimS3MalformedXml);
     assertStringIncludes(statusError.message, "Enabled or Disabled");
+  });
+
+  it("refuses a rule that would do nothing", async () => {
+    // Given a Bucket to configure.
+    const simS3 = new SimAws().s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "idle" }));
+
+    // When a rule states a status and no action to take.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "idle",
+          LifecycleConfiguration: {
+            Rules: [
+              {
+                ID: "does-nothing",
+                Status: "Enabled",
+                Filter: { Prefix: "raw/" },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, as real S3 refuses a rule carrying no expiry,
+    // transition or upload action.
+    assertInstanceOf(error, SimS3MalformedXml);
+    assertStringIncludes(error.message, "must state at least one of");
+  });
+
+  it("keeps the caller's rules out of the Bucket's own state", async () => {
+    // Given a Bucket configured from a rule object the caller still holds.
+    const simS3 = new SimAws().s3();
+    const rule = {
+      ID: "expire-raw-logs",
+      Status: "Enabled" as const,
+      Expiration: { Days: 365 },
+    };
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "isolated" }));
+    await simS3.putBucketLifecycleConfiguration(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: "isolated",
+        LifecycleConfiguration: { Rules: [rule] },
+      }),
+    );
+
+    // When the caller mutates that object, and mutates what a read gives it.
+    rule.Expiration.Days = 1;
+    const firstRead = await simS3.getBucketLifecycleConfiguration(
+      new GetBucketLifecycleConfigurationCommand({ Bucket: "isolated" }),
+    );
+    assertNonNullable(firstRead.Rules[0]);
+    // A read result is readonly to a TypeScript caller, so this reaches past
+    // the type. The isolation being tested is in the value, not the type.
+    (firstRead.Rules[0] as { Status: string }).Status = "Disabled";
+
+    // Then the Bucket still reads back what it was configured with. Changing
+    // a Bucket's configuration takes another write.
+    const secondRead = await simS3.getBucketLifecycleConfiguration(
+      new GetBucketLifecycleConfigurationCommand({ Bucket: "isolated" }),
+    );
+
+    assertObjectEquals(secondRead.Rules[0], {
+      ID: "expire-raw-logs",
+      Status: "Enabled",
+      Expiration: { Days: 365 },
+    });
   });
 
   it("rejects a non-existent Bucket", async () => {

--- a/src/service/s3/command/put-bucket-lifecycle-configuration/lifecycle-configuration.iso.test.ts
+++ b/src/service/s3/command/put-bucket-lifecycle-configuration/lifecycle-configuration.iso.test.ts
@@ -19,7 +19,6 @@ import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import {
-  SimS3MalformedXml,
   SimS3NoSuchBucket,
   SimS3NoSuchLifecycleConfiguration,
 } from "../../error/sim-s3.error.js";
@@ -140,69 +139,6 @@ describe("S3 lifecycle configuration commands", () => {
     );
 
     assertInstanceOf(error, SimS3NoSuchLifecycleConfiguration);
-  });
-
-  it("refuses a configuration real S3 would refuse to store", async () => {
-    // Given a Bucket to configure.
-    const simS3 = new SimAws().s3();
-
-    await simS3.createBucket(new CreateBucketCommand({ Bucket: "malformed" }));
-
-    // When a configuration states no rules, and one states a rule with a
-    // status S3 has no meaning for.
-    const emptyError = await assertThrowsErrorAsync(async () =>
-      simS3.putBucketLifecycleConfiguration(
-        new PutBucketLifecycleConfigurationCommand({
-          Bucket: "malformed",
-          LifecycleConfiguration: { Rules: [] },
-        }),
-      ),
-    );
-    const statusError = await assertThrowsErrorAsync(async () =>
-      simS3.putBucketLifecycleConfiguration(
-        new PutBucketLifecycleConfigurationCommand({
-          Bucket: "malformed",
-          // @ts-expect-error -- testing a status outside the two S3 accepts
-          LifecycleConfiguration: { Rules: [{ ID: "off", Status: "Off" }] },
-        }),
-      ),
-    );
-
-    // Then both are refused, so a rule nothing recognises cannot read back
-    // looking configured.
-    assertInstanceOf(emptyError, SimS3MalformedXml);
-    assertInstanceOf(statusError, SimS3MalformedXml);
-    assertStringIncludes(statusError.message, "Enabled or Disabled");
-  });
-
-  it("refuses a rule that would do nothing", async () => {
-    // Given a Bucket to configure.
-    const simS3 = new SimAws().s3();
-
-    await simS3.createBucket(new CreateBucketCommand({ Bucket: "idle" }));
-
-    // When a rule states a status and no action to take.
-    const error = await assertThrowsErrorAsync(async () =>
-      simS3.putBucketLifecycleConfiguration(
-        new PutBucketLifecycleConfigurationCommand({
-          Bucket: "idle",
-          LifecycleConfiguration: {
-            Rules: [
-              {
-                ID: "does-nothing",
-                Status: "Enabled",
-                Filter: { Prefix: "raw/" },
-              },
-            ],
-          },
-        }),
-      ),
-    );
-
-    // Then it is refused, as real S3 refuses a rule carrying no expiry,
-    // transition or upload action.
-    assertInstanceOf(error, SimS3MalformedXml);
-    assertStringIncludes(error.message, "must state at least one of");
   });
 
   it("keeps the caller's rules out of the Bucket's own state", async () => {

--- a/src/service/s3/command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.ts
+++ b/src/service/s3/command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.ts
@@ -52,6 +52,9 @@ export interface SimS3LifecycleRule {
   readonly NoncurrentVersionExpiration?:
     | SimS3LifecycleNoncurrentVersionExpiration
     | undefined;
+  readonly NoncurrentVersionTransitions?:
+    | readonly SimS3LifecycleNoncurrentVersionTransition[]
+    | undefined;
 }
 
 /**
@@ -113,5 +116,14 @@ export interface SimS3LifecycleAbortIncompleteMultipartUpload {
  */
 export interface SimS3LifecycleNoncurrentVersionExpiration {
   readonly NoncurrentDays?: number | undefined;
+  readonly NewerNoncurrentVersions?: number | undefined;
+}
+
+/**
+ * Minimal structural sim S3 lifecycle noncurrent version transition.
+ */
+export interface SimS3LifecycleNoncurrentVersionTransition {
+  readonly NoncurrentDays?: number | undefined;
+  readonly StorageClass?: string | undefined;
   readonly NewerNoncurrentVersions?: number | undefined;
 }


### PR DESCRIPTION
Follow-up to #985, from the review on it.

A lifecycle rule stating a status and no expiry, transition or upload action is now refused with `MalformedXML`, as real S3 refuses one. `SimS3LifecycleRule` also gains `NoncurrentVersionTransitions`, which the SDK's `LifecycleRule` carries.

A Bucket's stored rules are cloned on the way in and on the way out. A caller holding the objects it put, or the ones a read gave it, could otherwise change what the Bucket is configured with by mutating them, the way `SimS3PublicAccessBlock` already guards against.

Two findings from that review are left alone and are worth a second opinion. Translating the CloudFormation-only rule fields (`TagFilters`, the object size bounds, the deprecated noncurrent forms) into their SDK shapes would be a real fidelity gain and reads as its own issue rather than a fix. Refusing a rule that states both `Transition` and `Transitions` is documented by AWS, and refusing it here would fail a Stack over a template shape the simulator can otherwise deploy.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for transitioning noncurrent object versions between storage classes.
  - Lifecycle expiration settings now support expiration after a specified number of days.

- **Bug Fixes**
  - Improved lifecycle rule validation, including clearer errors for missing actions or invalid statuses.
  - Lifecycle configurations are now protected from unintended changes after being submitted or retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->