### PR TITLE
feat: expire an Object against a lifecycle rule

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -594,9 +594,9 @@ A completed upload raises `s3:ObjectCreated:CompleteMultipartUpload`. A single-r
   `EntityTooSmall` for one that is not. Sim S3 takes a part of any size.
 - A listing of uploads or of parts comes back on one page. `MaxUploads`, `MaxParts`, the markers that
   page them, and `Delimiter` are all left out.
-- An upload has no expiry, and nothing abandons one on its own. An
-  `AbortIncompleteMultipartUpload` lifecycle rule is stored and read back, and nothing acts on it.
-  See [Lifecycle configuration](#lifecycle-configuration).
+- No caller has to abort an upload. An `AbortIncompleteMultipartUpload` lifecycle rule abandons one
+  the clock has left unfinished for long enough, and takes its parts with it. See
+  [Lifecycle configuration](#lifecycle-configuration).
 
 ## Reading part of an Object
 
@@ -1694,13 +1694,11 @@ writes fall outside it. Without that, the simulation stops after a thousand deli
 
 ## Buckets from CloudFormation
 
-An `AWS::S3::Bucket` resource carries four properties simulated S3 acts on. Those are `BucketName`,
-`NotificationConfiguration`, `PublicAccessBlockConfiguration` and `WebsiteConfiguration`. A fifth,
-`LifecycleConfiguration`, is stored and readable while nothing acts on it, and is recorded alongside
-the properties below for that reason. See [Lifecycle configuration](#lifecycle-configuration).
-Without
-`BucketName` the Bucket is named after the resource's logical id, lowercased, where real
-CloudFormation invents a generated name.
+An `AWS::S3::Bucket` resource carries five properties simulated S3 acts on. Those are `BucketName`,
+`LifecycleConfiguration`, `NotificationConfiguration`, `PublicAccessBlockConfiguration` and
+`WebsiteConfiguration`. See [Lifecycle configuration](#lifecycle-configuration) for the parts of a
+rule that are read. Without `BucketName` the Bucket is named after the resource's logical id,
+lowercased, where real CloudFormation invents a generated name.
 
 Any other property is left out and recorded in
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without),
@@ -1914,13 +1912,87 @@ them disabled in favour of policies.
 
 ## Lifecycle configuration
 
-Sim S3 stores a Bucket's lifecycle rules and hands them back. Nothing expires or transitions an
-Object against them, so a rule here records what the Bucket was configured with rather than
-something that happens.
+Sim S3 stores a Bucket's lifecycle rules and acts on them. An `Expiration` rule removes the Objects
+it selects once simulated time passes the boundary, and an `AbortIncompleteMultipartUpload` rule
+discards uploads that were started and left unfinished.
 
-That is enough to test the configuration side of a construct or a template, which is otherwise
-only checkable by asserting on synthesized CloudFormation. Reading the rules off a deployed Bucket
-says the rules arrived, where a template assertion says only that CloudFormation was asked for them.
+Retention is otherwise the one property of a log or a backup Bucket a test cannot demonstrate.
+Reading the rules back off a deployed Bucket says the rules arrived. Putting an Object, moving the
+clock and finding the Object gone says the Bucket keeps what it was configured to keep.
+
+```typescript sim-s3-lifecycle-expiry
+/**
+ * Expiring simulated S3 Objects against a lifecycle rule.
+ */
+
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutBucketLifecycleConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+await simS3.putBucketLifecycleConfiguration(
+  new PutBucketLifecycleConfigurationCommand({
+    Bucket: "logs",
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: "expire-raw-logs",
+          Status: "Enabled",
+          Filter: { Prefix: "raw/" },
+          Expiration: { Days: 365 },
+        },
+      ],
+    },
+  }),
+);
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "logs",
+    Key: "raw/2026-08-24.gz",
+    Body: "one raw log line",
+  }),
+);
+
+await simAws.clock().advanceBy({ days: 366 });
+
+const listing = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "logs", Prefix: "raw/" }),
+);
+
+// The rule expired the Object, so the listing is empty.
+console.log(listing.Contents ?? []);
+```
+
+An Object goes the moment the clock reaches the boundary. Real S3 removes an expired Object some
+time after it and bills up to the removal, which a test would have to wait out. Expiring on the
+boundary is the answer a test can assert against.
+
+Expiry happens when the Bucket is read. What `ListObjectsV2`, `GetObject` and `HeadObject` find is
+what the rules leave at that instant, and a Bucket carrying no rules costs one comparison. Moving
+the clock backwards afterwards leaves an expired Object gone, because the rule deleted it on the way
+past.
+
+### What a rule selects
+
+A rule selects Objects by its `Filter`, or by the older top-level `Prefix`. A rule with no scope at
+all covers every key in the Bucket. `Filter.Prefix`, `Filter.And.Prefix`, `ObjectSizeGreaterThan` and
+`ObjectSizeLessThan` are all read. A `Disabled` rule is stored and skipped.
+
+A multipart upload is selected by its key alone. Half an upload has no size. A rule narrowed by an
+object size bound abandons no upload.
+
+Sim S3 holds no Object tags. A rule narrowed by `Filter.Tag`, `Filter.And.Tags` or a template's
+`TagFilters` selects no Object, and expires none.
+
+### Reading and replacing the rules
 
 ```typescript sim-s3-lifecycle-configuration
 import {
@@ -2001,23 +2073,26 @@ CloudFormation spells some rule fields differently from the request. `Id` become
 `Transitions` joins the list. Everything else, `Status`, `Prefix`, `AbortIncompleteMultipartUpload`,
 `TagFilters` and the object size bounds among them, is carried across as the template stated it.
 
-`LifecycleConfiguration` is still recorded in
-[`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without),
-under a reason saying the rules are readable and that nothing acts on them. A test reading the
-configuration back would otherwise take it for proof that retention works.
+`LifecycleConfiguration` is one of the properties simulated S3 acts on. It stays out of
+[`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without).
+The parts of a rule it acts on are the ones listed under
+[What a rule selects](#what-a-rule-selects).
 
 ### Limitations
 
-No Object is ever expired, and no Object moves between storage classes. Storage classes are left out
-of the simulator entirely, so a `Transitions` rule is stored and read back and goes no further. An
-incomplete multipart upload is never abandoned, whatever `AbortIncompleteMultipartUpload` says.
+No Object moves between storage classes. Storage classes are left out of the simulator entirely. A
+`Transitions` rule is stored and read back and goes no further.
 
-Nothing reads a rule's `Filter`, `Prefix`, `TagFilters` or object size bounds, since nothing selects
-Objects against a rule in the first place.
+Real S3 raises `s3:LifecycleExpiration:Delete` when a rule removes an Object. That event family is
+among the ones sim S3 leaves out. An expiry here is silent.
 
-The `s3:LifecycleExpiration:*` event notification family is left out along with the expiry that
-would raise it. `NoncurrentVersionExpiration` and `ExpiredObjectDeleteMarker` are stored and
-unread, because Object versions are left out.
+`NoncurrentVersionExpiration`, `NoncurrentVersionTransitions` and `ExpiredObjectDeleteMarker` are
+stored and unread, because Object versions are left out.
+
+A Bucket mounted on a filesystem directory refuses the deletion an expiry asks for, the way it
+refuses `DeleteObject`, and answers `NotImplemented`. Removing a real file off the mounted directory
+is worse than reporting that the rule cannot run. Use the default in-memory storage to test
+retention.
 
 `GetBucketLifecycleConfiguration` and its siblings are reachable through the SDK and not over the
 served S3 REST endpoint.
@@ -2935,8 +3010,9 @@ These apply across the page. The sections above each list what is specific to th
 - A listing reports `StorageClass` as `STANDARD` for every Object. Storage classes themselves are
   left out, and every Object is in that one.
 - `EncodingType` is ignored on a listing, and keys come back unencoded.
-- Object tags, ACLs, replication and server-side encryption are left out. Lifecycle rules are stored
-  and read back, and nothing expires or transitions an Object against them.
+- Object tags, ACLs, replication and server-side encryption are left out. A lifecycle rule expires
+  Objects and abandons uploads, and transitions nothing between storage classes. See
+  [Lifecycle configuration](#lifecycle-configuration).
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
   notifications, because it swaps the whole storage backend in place of putting Objects.
 - An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, leaving

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1703,12 +1703,12 @@ lowercased, where real CloudFormation invents a generated name.
 Any other property is left out and recorded in
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without),
 and the Bucket is created and the stack carries on. That matters because a Bucket deployed without
-the lifecycle rules, versioning or CORS configuration its template asked for looks configured and
+the versioning, replication or CORS configuration its template asked for looks configured and
 behaves as though it were bare, and the failure that causes turns up somewhere else entirely. The
 record is where a test checks which of those it is standing on. A property name `AWS::S3::Bucket`
 never had is recorded the same way, and a typo leaves the stack standing.
 
-One of the four given in the wrong shape still fails the stack, and so does a `BucketName` that is
+One of the five given in the wrong shape still fails the stack, and so does a `BucketName` that is
 something other than a string. There is no Bucket to create under a name nothing else in the
 template refers to.
 
@@ -2075,7 +2075,9 @@ CloudFormation spells some rule fields differently from the request. `Id` become
 
 `LifecycleConfiguration` is one of the properties simulated S3 acts on. It stays out of
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without).
-The parts of a rule it acts on are the ones listed under
+The two actions it enforces are `Expiration`, whether the template flattened it onto the rule or
+not, and `AbortIncompleteMultipartUpload`. A `Transitions` rule is stored and read back and goes no
+further. Which Objects an enforced action reaches is decided by the fields listed under
 [What a rule selects](#what-a-rule-selects).
 
 ### Limitations

--- a/docs/services/s3/sim-s3-lifecycle-expiry.example.ts
+++ b/docs/services/s3/sim-s3-lifecycle-expiry.example.ts
@@ -1,0 +1,48 @@
+/**
+ * Expiring simulated S3 Objects against a lifecycle rule.
+ */
+
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutBucketLifecycleConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+await simS3.putBucketLifecycleConfiguration(
+  new PutBucketLifecycleConfigurationCommand({
+    Bucket: "logs",
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: "expire-raw-logs",
+          Status: "Enabled",
+          Filter: { Prefix: "raw/" },
+          Expiration: { Days: 365 },
+        },
+      ],
+    },
+  }),
+);
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "logs",
+    Key: "raw/2026-08-24.gz",
+    Body: "one raw log line",
+  }),
+);
+
+await simAws.clock().advanceBy({ days: 366 });
+
+const listing = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "logs", Prefix: "raw/" }),
+);
+
+// The rule expired the Object, so the listing is empty.
+console.log(listing.Contents ?? []);

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-abandoned-uploads.iso.test.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-abandoned-uploads.iso.test.ts
@@ -102,14 +102,15 @@ describe("Simulated S3 lifecycle abandoned uploads", () => {
     assertIdentical(inProgress.join(","), "raw/big.gz");
   });
 
-  it("drops an upload the clock has carried past the abort", async () => {
+  it("drops an upload the moment the clock reaches the abort", async () => {
     // Given a Bucket abandoning uploads a week after they start.
     const { simAws } = await abandonedUpload([abortStaleUploads]);
 
-    // When simulated time moves past the week.
-    await simAws.clock().advanceBy({ days: 8 });
+    // When simulated time reaches the week exactly.
+    await simAws.clock().advanceBy({ days: 7 });
 
-    // Then nothing is in progress any more.
+    // Then the upload has already gone, because it is abandoned on the
+    // boundary rather than some time after it.
     assertArrayLength(await uploadsInProgress(simAws), 0);
   });
 

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-abandoned-uploads.iso.test.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-abandoned-uploads.iso.test.ts
@@ -1,0 +1,215 @@
+import {
+  CreateBucketCommand,
+  CreateMultipartUploadCommand,
+  ListMultipartUploadsCommand,
+  ListPartsCommand,
+  PutBucketLifecycleConfigurationCommand,
+  UploadPartCommand,
+  type LifecycleRule,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3NoSuchUpload } from "../../error/sim-s3.error.js";
+
+const startedAt = new Date("2026-08-24T09:00:00.000Z");
+
+interface StartedUpload {
+  readonly simAws: SimAws;
+  readonly uploadId: string;
+}
+
+/**
+ * A Bucket carrying the given rules, with one part of an upload sent under
+ * `raw/big.gz` and the rest never sent.
+ */
+async function abandonedUpload(
+  rules: readonly LifecycleRule[],
+): Promise<StartedUpload> {
+  const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+  const simS3 = simAws.region("eu-west-2").s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+  await simS3.putBucketLifecycleConfiguration(
+    new PutBucketLifecycleConfigurationCommand({
+      Bucket: "logs",
+      LifecycleConfiguration: { Rules: [...rules] },
+    }),
+  );
+
+  const started = await simS3.createMultipartUpload(
+    new CreateMultipartUploadCommand({ Bucket: "logs", Key: "raw/big.gz" }),
+  );
+  assertDefined(started.UploadId, "the issued upload id");
+
+  await simS3.uploadPart(
+    new UploadPartCommand({
+      Bucket: "logs",
+      Key: "raw/big.gz",
+      UploadId: started.UploadId,
+      PartNumber: 1,
+      Body: "the first part",
+    }),
+  );
+
+  return { simAws, uploadId: started.UploadId };
+}
+
+/**
+ * The keys the Bucket's uploads in progress are under.
+ */
+async function uploadsInProgress(simAws: SimAws): Promise<readonly string[]> {
+  const listing = await simAws
+    .region("eu-west-2")
+    .s3()
+    .listMultipartUploads(new ListMultipartUploadsCommand({ Bucket: "logs" }));
+
+  return (listing.Uploads ?? []).map((upload) => upload.Key ?? "");
+}
+
+const abortStaleUploads: LifecycleRule = {
+  ID: "abort-incomplete-uploads",
+  Status: "Enabled",
+  Filter: { Prefix: "" },
+  AbortIncompleteMultipartUpload: { DaysAfterInitiation: 7 },
+};
+
+/**
+ * Abandoning a simulated S3 multipart upload nobody finished.
+ *
+ * An upload holds its parts until something completes or aborts it. A rule
+ * stating `AbortIncompleteMultipartUpload` is the third way one ends, and the
+ * only one no caller asks for.
+ */
+describe("Simulated S3 lifecycle abandoned uploads", () => {
+  it("keeps an upload the clock has not carried to the abort", async () => {
+    // Given a Bucket abandoning uploads a week after they start.
+    const { simAws } = await abandonedUpload([abortStaleUploads]);
+
+    // When simulated time moves on by less than a week.
+    await simAws.clock().advanceBy({ days: 6 });
+
+    // Then the upload is still in progress.
+    const inProgress = await uploadsInProgress(simAws);
+    assertIdentical(inProgress.join(","), "raw/big.gz");
+  });
+
+  it("drops an upload the clock has carried past the abort", async () => {
+    // Given a Bucket abandoning uploads a week after they start.
+    const { simAws } = await abandonedUpload([abortStaleUploads]);
+
+    // When simulated time moves past the week.
+    await simAws.clock().advanceBy({ days: 8 });
+
+    // Then nothing is in progress any more.
+    assertArrayLength(await uploadsInProgress(simAws), 0);
+  });
+
+  it("takes the abandoned upload's parts with it", async () => {
+    // Given a Bucket whose upload the clock has carried past the abort.
+    const { simAws, uploadId } = await abandonedUpload([abortStaleUploads]);
+    await simAws.clock().advanceBy({ days: 8 });
+
+    // When the parts already sent are listed, and another is sent.
+    const listed = await assertThrowsErrorAsync(async () =>
+      simAws
+        .region("eu-west-2")
+        .s3()
+        .listParts(
+          new ListPartsCommand({
+            Bucket: "logs",
+            Key: "raw/big.gz",
+            UploadId: uploadId,
+          }),
+        ),
+    );
+    const sent = await assertThrowsErrorAsync(async () =>
+      simAws
+        .region("eu-west-2")
+        .s3()
+        .uploadPart(
+          new UploadPartCommand({
+            Bucket: "logs",
+            Key: "raw/big.gz",
+            UploadId: uploadId,
+            PartNumber: 2,
+            Body: "the second part",
+          }),
+        ),
+    );
+
+    // Then the upload id is as unknown as an aborted one, which is what real
+    // S3 leaves behind when it abandons an upload.
+    assertInstanceOf(listed, SimS3NoSuchUpload);
+    assertInstanceOf(sent, SimS3NoSuchUpload);
+  });
+
+  it("leaves an upload outside the rule's prefix in progress", async () => {
+    // Given a Bucket abandoning uploads under another prefix.
+    const { simAws } = await abandonedUpload([
+      { ...abortStaleUploads, Filter: { Prefix: "reports/" } },
+    ]);
+
+    // When simulated time moves past the week.
+    await simAws.clock().advanceBy({ days: 8 });
+
+    // Then the upload the rule does not select is still in progress.
+    const inProgress = await uploadsInProgress(simAws);
+    assertIdentical(inProgress.join(","), "raw/big.gz");
+  });
+
+  it("leaves an upload in progress for a Disabled rule", async () => {
+    // Given a Bucket carrying the same rule, switched off.
+    const { simAws } = await abandonedUpload([
+      { ...abortStaleUploads, Status: "Disabled" },
+    ]);
+
+    // When simulated time moves well past the week.
+    await simAws.clock().advanceBy({ days: 60 });
+
+    // Then the upload is still in progress.
+    const inProgress = await uploadsInProgress(simAws);
+    assertIdentical(inProgress.join(","), "raw/big.gz");
+  });
+
+  it("leaves an upload alone for an abort stating no days", async () => {
+    // Given a Bucket whose rule states the abort without a number of days.
+    const { simAws } = await abandonedUpload([
+      { ...abortStaleUploads, AbortIncompleteMultipartUpload: {} },
+    ]);
+
+    // When simulated time moves well past anything.
+    await simAws.clock().advanceBy({ days: 60 });
+
+    // Then the upload is still in progress. The rule states no boundary for
+    // the clock to pass.
+    const inProgress = await uploadsInProgress(simAws);
+    assertIdentical(inProgress.join(","), "raw/big.gz");
+  });
+
+  it("leaves an upload alone for a rule narrowed by object size", async () => {
+    // Given a Bucket abandoning uploads of Objects over a kilobyte.
+    const { simAws } = await abandonedUpload([
+      {
+        ...abortStaleUploads,
+        Filter: { ObjectSizeGreaterThan: 1024 },
+      },
+    ]);
+
+    // When simulated time moves past the week.
+    await simAws.clock().advanceBy({ days: 8 });
+
+    // Then the upload is still in progress. An upload has no size until its
+    // parts are joined, so a size bound selects none of them.
+    const inProgress = await uploadsInProgress(simAws);
+    assertIdentical(inProgress.join(","), "raw/big.gz");
+  });
+});

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
@@ -2,21 +2,46 @@ import type {
   SimS3LifecycleConfiguration as SimS3LifecycleConfigurationInput,
   SimS3LifecycleRule,
 } from "../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+import {
+  simS3LifecycleReached,
+  simS3ObjectExpiryInstant,
+  simS3UploadAbortInstant,
+} from "./sim-s3-lifecycle-expiry.js";
+import { simS3LifecycleRuleSelects } from "./sim-s3-lifecycle-selection.js";
 
 interface SimS3LifecycleConfigurationProperties {
   readonly rules?: readonly SimS3LifecycleRule[];
 }
 
 /**
+ * An Object as a lifecycle rule reads it.
+ */
+export interface SimS3LifecycleObject {
+  readonly key: string;
+  readonly size: number;
+  readonly lastModified: Date;
+}
+
+/**
+ * A multipart upload in progress as a lifecycle rule reads it.
+ */
+export interface SimS3LifecycleUpload {
+  readonly key: string;
+  readonly initiated: Date;
+}
+
+/**
  * The lifecycle configuration of one simulated S3 Bucket.
- *
- * Simulated S3 holds the rules and hands them back. Objects live for as long
- * as the simulation runs, whatever a rule says, so a rule here is a record of
- * what the Bucket was configured with. Expiring Objects against one is #984.
  *
  * A Bucket has one configuration rather than a list of them, which is why
  * PutBucketLifecycleConfiguration replaces the whole thing. Real S3 has no way
  * to add one rule without restating the others.
+ *
+ * The configuration also answers what its rules have expired. An Object goes
+ * once the clock passes the boundary of a rule that selects it, and a Bucket
+ * asks on the way to its storage. Nothing sweeps a Bucket on a schedule. See
+ * `simS3ObjectExpiryInstant` for why the boundary is a pure function of the
+ * current time.
  */
 export class SimS3LifecycleConfiguration {
   private readonly storedRules: readonly SimS3LifecycleRule[];
@@ -63,5 +88,54 @@ export class SimS3LifecycleConfiguration {
    */
   get isEmpty(): boolean {
     return this.storedRules.length === 0;
+  }
+
+  /**
+   * Whether an enabled rule has expired an Object by the given instant.
+   *
+   * One rule is enough. Real S3 applies the shortest expiry among the rules
+   * selecting a key, and an Object past any of the boundaries is past the
+   * shortest one.
+   */
+  expires(object: SimS3LifecycleObject, now: Date): boolean {
+    return this.enabledRules().some(
+      (rule) =>
+        rule.Expiration !== undefined &&
+        simS3LifecycleRuleSelects(rule, object) &&
+        simS3LifecycleReached(
+          simS3ObjectExpiryInstant(rule.Expiration, object.lastModified),
+          now,
+        ),
+    );
+  }
+
+  /**
+   * Whether an enabled rule has abandoned a multipart upload by the given
+   * instant.
+   */
+  abandons(upload: SimS3LifecycleUpload, now: Date): boolean {
+    return this.enabledRules().some(
+      (rule) =>
+        rule.AbortIncompleteMultipartUpload !== undefined &&
+        simS3LifecycleRuleSelects(rule, { key: upload.key }) &&
+        simS3LifecycleReached(
+          simS3UploadAbortInstant(
+            rule.AbortIncompleteMultipartUpload,
+            upload.initiated,
+          ),
+          now,
+        ),
+    );
+  }
+
+  /**
+   * The rules that act, which are the ones whose `Status` is `Enabled`.
+   *
+   * Read from the stored rules rather than from `rules`, because every read of
+   * a Bucket asks and cloning the whole configuration each time would be the
+   * cost of having one.
+   */
+  private enabledRules(): readonly SimS3LifecycleRule[] {
+    return this.storedRules.filter((rule) => rule.Status === "Enabled");
   }
 }

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.iso.test.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.iso.test.ts
@@ -95,15 +95,16 @@ describe("Simulated S3 lifecycle expiry", () => {
     assertIdentical(keys.join(","), "raw/2026-08-24.gz,reports/august.csv");
   });
 
-  it("drops an Object the clock has carried past the expiry", async () => {
+  it("drops an Object the moment the clock reaches the expiry", async () => {
     // Given a Bucket expiring raw logs after a year.
     const simAws = await loggingSimulation([expireRawLogs]);
 
-    // When simulated time moves past the year.
-    await simAws.clock().advanceBy({ days: 366 });
+    // When simulated time reaches the year exactly.
+    await simAws.clock().advanceBy({ days: 365 });
 
-    // Then the log has gone and the report the rule does not select is left
-    // where it is.
+    // Then the log has already gone, because an Object expires on the
+    // boundary rather than some time after it. The report the rule does not
+    // select is left where it is.
     const keys = await storedKeys(simAws);
     assertIdentical(keys.join(","), "reports/august.csv");
   });
@@ -147,10 +148,11 @@ describe("Simulated S3 lifecycle expiry", () => {
       },
     ]);
 
-    // When simulated time reaches the day before and then the day after.
+    // When simulated time reaches the second before, and then the instant
+    // itself.
     await simAws.clock().setTo(new Date("2026-12-31T23:59:59.000Z"));
     const beforeTheDate = await storedKeys(simAws);
-    await simAws.clock().setTo(new Date("2027-01-01T00:00:01.000Z"));
+    await simAws.clock().setTo(new Date("2027-01-01T00:00:00.000Z"));
 
     // Then the instant in the rule is what separates the two readings.
     const afterTheDate = await storedKeys(simAws);

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.iso.test.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.iso.test.ts
@@ -1,0 +1,358 @@
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutBucketLifecycleConfigurationCommand,
+  PutObjectCommand,
+  type LifecycleRule,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3NoSuchKey, SimS3NotFound } from "../../error/sim-s3.error.js";
+
+const startedAt = new Date("2026-08-24T09:00:00.000Z");
+
+/**
+ * A Bucket holding one raw log and one report, configured with the given
+ * rules.
+ */
+async function loggingSimulation(
+  rules: readonly LifecycleRule[],
+): Promise<SimAws> {
+  const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+  const simS3 = simAws.region("eu-west-2").s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+  await simS3.putBucketLifecycleConfiguration(
+    new PutBucketLifecycleConfigurationCommand({
+      Bucket: "logs",
+      LifecycleConfiguration: { Rules: [...rules] },
+    }),
+  );
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "logs",
+      Key: "raw/2026-08-24.gz",
+      Body: "one raw log line",
+    }),
+  );
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "logs",
+      Key: "reports/august.csv",
+      Body: "a,b",
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * The keys a listing of the whole Bucket answers with.
+ */
+async function storedKeys(simAws: SimAws): Promise<readonly string[]> {
+  const listing = await simAws
+    .region("eu-west-2")
+    .s3()
+    .listObjectsV2(new ListObjectsV2Command({ Bucket: "logs" }));
+
+  return (listing.Contents ?? []).map((entry) => entry.Key ?? "");
+}
+
+const expireRawLogs: LifecycleRule = {
+  ID: "expire-raw-logs",
+  Status: "Enabled",
+  Filter: { Prefix: "raw/" },
+  Expiration: { Days: 365 },
+};
+
+/**
+ * Expiring simulated S3 Objects against a Bucket's lifecycle rules.
+ *
+ * Expiry is applied when the Bucket is read, so what a read finds is what the
+ * rules leave at that instant. Moving the clock is all a test does to get
+ * there.
+ */
+describe("Simulated S3 lifecycle expiry", () => {
+  it("keeps an Object the clock has not carried to the expiry", async () => {
+    // Given a Bucket expiring raw logs after a year.
+    const simAws = await loggingSimulation([expireRawLogs]);
+
+    // When simulated time moves on by less than that.
+    await simAws.clock().advanceBy({ days: 364 });
+
+    // Then both Objects are still there.
+    const keys = await storedKeys(simAws);
+    assertIdentical(keys.join(","), "raw/2026-08-24.gz,reports/august.csv");
+  });
+
+  it("drops an Object the clock has carried past the expiry", async () => {
+    // Given a Bucket expiring raw logs after a year.
+    const simAws = await loggingSimulation([expireRawLogs]);
+
+    // When simulated time moves past the year.
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // Then the log has gone and the report the rule does not select is left
+    // where it is.
+    const keys = await storedKeys(simAws);
+    assertIdentical(keys.join(","), "reports/august.csv");
+  });
+
+  it("reports an expired Object as absent to a read and a head", async () => {
+    // Given a Bucket whose raw log the clock has carried past its expiry.
+    const simAws = await loggingSimulation([expireRawLogs]);
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // When the Object is read and asked about.
+    const read = await assertThrowsErrorAsync(async () =>
+      simAws
+        .region("eu-west-2")
+        .s3()
+        .getObject(
+          new GetObjectCommand({ Bucket: "logs", Key: "raw/2026-08-24.gz" }),
+        ),
+    );
+    const head = await assertThrowsErrorAsync(async () =>
+      simAws
+        .region("eu-west-2")
+        .s3()
+        .headObject(
+          new HeadObjectCommand({ Bucket: "logs", Key: "raw/2026-08-24.gz" }),
+        ),
+    );
+
+    // Then both answer as they would for a key nothing was ever written to.
+    assertInstanceOf(read, SimS3NoSuchKey);
+    assertInstanceOf(head, SimS3NotFound);
+  });
+
+  it("expires an Object once the clock passes an Expiration Date", async () => {
+    // Given a Bucket expiring raw logs at the turn of the year.
+    const simAws = await loggingSimulation([
+      {
+        ID: "expire-by-date",
+        Status: "Enabled",
+        Filter: { Prefix: "raw/" },
+        Expiration: { Date: new Date("2027-01-01T00:00:00.000Z") },
+      },
+    ]);
+
+    // When simulated time reaches the day before and then the day after.
+    await simAws.clock().setTo(new Date("2026-12-31T23:59:59.000Z"));
+    const beforeTheDate = await storedKeys(simAws);
+    await simAws.clock().setTo(new Date("2027-01-01T00:00:01.000Z"));
+
+    // Then the instant in the rule is what separates the two readings.
+    const afterTheDate = await storedKeys(simAws);
+    assertArrayLength(beforeTheDate, 2);
+    assertIdentical(afterTheDate.join(","), "reports/august.csv");
+  });
+
+  it("leaves every Object where it is for a Disabled rule", async () => {
+    // Given a Bucket carrying the same rule, switched off.
+    const simAws = await loggingSimulation([
+      { ...expireRawLogs, Status: "Disabled" },
+    ]);
+
+    // When simulated time moves well past the expiry the rule states.
+    await simAws.clock().advanceBy({ days: 800 });
+
+    // Then nothing has gone.
+    assertArrayLength(await storedKeys(simAws), 2);
+  });
+
+  it("selects by the older top-level Prefix as well as by a Filter", async () => {
+    // Given a Bucket whose rule states its scope the way the first version of
+    // the API did. The SDK marks that field deprecated, and real S3 still
+    // stores a rule using it.
+    const simAws = await loggingSimulation([
+      {
+        ID: "expire-raw-logs",
+        Status: "Enabled",
+        // oxlint-disable-next-line typescript/no-deprecated
+        Prefix: "raw/",
+        Expiration: { Days: 365 },
+      },
+    ]);
+
+    // When simulated time moves past the expiry.
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // Then the prefix selected the same Object a Filter would have.
+    const keys = await storedKeys(simAws);
+    assertIdentical(keys.join(","), "reports/august.csv");
+  });
+
+  it("selects by the object size bounds a filter states", async () => {
+    // Given a Bucket expiring whatever is larger than four bytes, which is
+    // the raw log and not the report.
+    const simAws = await loggingSimulation([
+      {
+        ID: "expire-large-objects",
+        Status: "Enabled",
+        Filter: { ObjectSizeGreaterThan: 4 },
+        Expiration: { Days: 1 },
+      },
+    ]);
+
+    // When simulated time moves past the expiry.
+    await simAws.clock().advanceBy({ days: 2 });
+
+    // Then only the Object inside the bound has gone.
+    const keys = await storedKeys(simAws);
+    assertIdentical(keys.join(","), "reports/august.csv");
+  });
+
+  it("expires nothing for a rule that only transitions", async () => {
+    // Given a Bucket whose only rule moves Objects between storage classes.
+    const simAws = await loggingSimulation([
+      {
+        ID: "archive-raw-logs",
+        Status: "Enabled",
+        Filter: { Prefix: "raw/" },
+        Transitions: [{ Days: 30, StorageClass: "GLACIER" }],
+      },
+    ]);
+
+    // When simulated time moves well past the transition.
+    await simAws.clock().advanceBy({ days: 800 });
+
+    // Then both Objects are still there. Storage classes are left out of the
+    // simulator, and a transition removes nothing.
+    assertArrayLength(await storedKeys(simAws), 2);
+  });
+
+  it("selects nothing for a rule filtered by an Object tag", async () => {
+    // Given a Bucket expiring raw logs carrying a tag.
+    const simAws = await loggingSimulation([
+      {
+        ID: "expire-tagged-logs",
+        Status: "Enabled",
+        Filter: {
+          And: { Prefix: "raw/", Tags: [{ Key: "class", Value: "raw" }] },
+        },
+        Expiration: { Days: 365 },
+      },
+    ]);
+
+    // When simulated time moves past the expiry.
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // Then both Objects are still there. Simulated S3 holds no Object tags,
+    // so a tag is a condition nothing meets.
+    assertArrayLength(await storedKeys(simAws), 2);
+  });
+
+  it("selects by a conjunction of a prefix and a size bound", async () => {
+    // Given a Bucket expiring raw logs larger than four bytes.
+    const simAws = await loggingSimulation([
+      {
+        ID: "expire-large-raw-logs",
+        Status: "Enabled",
+        Filter: { And: { Prefix: "raw/", ObjectSizeGreaterThan: 4 } },
+        Expiration: { Days: 365 },
+      },
+    ]);
+
+    // When simulated time moves past the expiry.
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // Then the Object meeting both halves of the conjunction has gone.
+    const keys = await storedKeys(simAws);
+    assertIdentical(keys.join(","), "reports/august.csv");
+  });
+
+  it("expires every Object for a rule stating no scope at all", async () => {
+    // Given a Bucket whose rule states neither a Prefix nor a Filter.
+    const simAws = await loggingSimulation([
+      { ID: "expire-everything", Status: "Enabled", Expiration: { Days: 365 } },
+    ]);
+
+    // When simulated time moves past the expiry.
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // Then the whole Bucket has gone, which is the scope such a rule covers.
+    assertArrayLength(await storedKeys(simAws), 0);
+  });
+
+  it("selects by both object size bounds at once", async () => {
+    // Given a Bucket expiring whatever is between four and a hundred bytes.
+    const simAws = await loggingSimulation([
+      {
+        ID: "expire-middling-objects",
+        Status: "Enabled",
+        Filter: { And: { ObjectSizeGreaterThan: 4, ObjectSizeLessThan: 100 } },
+        Expiration: { Days: 365 },
+      },
+    ]);
+
+    // When simulated time moves past the expiry.
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // Then the three byte report is under the lower bound and stays.
+    const keys = await storedKeys(simAws);
+    assertIdentical(keys.join(","), "reports/august.csv");
+  });
+
+  it("selects nothing for a rule filtered by a single tag", async () => {
+    // Given a Bucket expiring whatever carries a tag.
+    const simAws = await loggingSimulation([
+      {
+        ID: "expire-tagged",
+        Status: "Enabled",
+        Filter: { Tag: { Key: "class", Value: "raw" } },
+        Expiration: { Days: 365 },
+      },
+    ]);
+
+    // When simulated time moves past the expiry.
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // Then both Objects are still there, as for a tag inside an And.
+    assertArrayLength(await storedKeys(simAws), 2);
+  });
+
+  it("expires nothing for an Expiration stating no boundary", async () => {
+    // Given a Bucket whose rule expires only a delete marker.
+    const simAws = await loggingSimulation([
+      {
+        ID: "expire-delete-markers",
+        Status: "Enabled",
+        Filter: { Prefix: "raw/" },
+        Expiration: { ExpiredObjectDeleteMarker: true },
+      },
+    ]);
+
+    // When simulated time moves well past anything.
+    await simAws.clock().advanceBy({ days: 800 });
+
+    // Then both Objects are still there. Object versions are left out, so
+    // there is no delete marker for the rule to reach.
+    assertArrayLength(await storedKeys(simAws), 2);
+  });
+
+  it("leaves an expired Object gone once the clock moves back", async () => {
+    // Given a Bucket whose raw log expired while the clock was ahead.
+    const simAws = await loggingSimulation([expireRawLogs]);
+    await simAws.clock().advanceBy({ days: 366 });
+    await storedKeys(simAws);
+
+    // When simulated time moves back to before the Object was written.
+    await simAws.clock().setTo(startedAt);
+
+    // Then the Object stays gone. Expiry removed it, and moving the clock
+    // back moves the clock rather than restoring what a rule deleted.
+    const keys = await storedKeys(simAws);
+    assertIdentical(keys.join(","), "reports/august.csv");
+  });
+});

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.ts
@@ -1,0 +1,62 @@
+import type {
+  SimS3LifecycleAbortIncompleteMultipartUpload,
+  SimS3LifecycleExpiration,
+} from "../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+
+const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+/**
+ * The instant an `Expiration` puts an Object written at a given time past.
+ *
+ * Simulated S3 expires an Object the moment the boundary arrives. Real S3
+ * removes one some time after it and bills up to the removal, which a test
+ * would have to wait out. Exactly on the boundary is the answer a test can
+ * use.
+ *
+ * `Days` wins over `Date` when a rule carries both, though real S3 refuses to
+ * store such a rule. An `Expiration` carrying only `ExpiredObjectDeleteMarker`
+ * has no boundary at all, since Object versions are left out.
+ */
+export function simS3ObjectExpiryInstant(
+  expiration: SimS3LifecycleExpiration,
+  writtenAt: Date,
+): Date | undefined {
+  if (expiration.Days !== undefined) {
+    return afterDays(writtenAt, expiration.Days);
+  }
+
+  if (expiration.Date !== undefined) {
+    return new Date(expiration.Date);
+  }
+
+  return undefined;
+}
+
+/**
+ * The instant an `AbortIncompleteMultipartUpload` abandons an upload started
+ * at a given time.
+ */
+export function simS3UploadAbortInstant(
+  abort: SimS3LifecycleAbortIncompleteMultipartUpload,
+  initiated: Date,
+): Date | undefined {
+  if (abort.DaysAfterInitiation === undefined) {
+    return undefined;
+  }
+
+  return afterDays(initiated, abort.DaysAfterInitiation);
+}
+
+/**
+ * Whether simulated time has reached a boundary.
+ */
+export function simS3LifecycleReached(
+  boundary: Date | undefined,
+  now: Date,
+): boolean {
+  return boundary !== undefined && now.getTime() >= boundary.getTime();
+}
+
+function afterDays(from: Date, days: number): Date {
+  return new Date(from.getTime() + days * millisecondsPerDay);
+}

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-selection.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-selection.ts
@@ -1,0 +1,105 @@
+import type {
+  SimS3LifecycleRule,
+  SimS3LifecycleRuleAndOperator,
+  SimS3LifecycleRuleFilter,
+} from "../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+
+/**
+ * What a lifecycle rule looks at to decide whether it selects something.
+ *
+ * An Object states its size and a multipart upload leaves it out. Half an
+ * upload has no size for a rule to measure, and real S3 has no size to
+ * measure either until the parts are joined.
+ */
+export interface SimS3LifecycleSubject {
+  readonly key: string;
+  readonly size?: number | undefined;
+}
+
+/**
+ * The object size bounds a filter or its `And` operator can state.
+ */
+type SimS3LifecycleSizeBounds = Pick<
+  SimS3LifecycleRuleFilter,
+  "ObjectSizeGreaterThan" | "ObjectSizeLessThan"
+>;
+
+/**
+ * Whether a rule selects the Object or upload a key names.
+ *
+ * A rule states its scope either as the older top-level `Prefix` or as a
+ * `Filter`. A rule with no scope at all covers every key in the Bucket. Real
+ * S3 refuses a rule stating both.
+ *
+ * Simulated S3 has no Object tags. A `Tag` or a `TagFilters` entry names a
+ * condition the simulator has no answer for, and selects no key.
+ */
+export function simS3LifecycleRuleSelects(
+  rule: SimS3LifecycleRule,
+  subject: SimS3LifecycleSubject,
+): boolean {
+  if (rule.Filter === undefined) {
+    return subject.key.startsWith(rule.Prefix ?? "");
+  }
+
+  return filterSelects(rule.Filter, subject);
+}
+
+function filterSelects(
+  filter: SimS3LifecycleRuleFilter,
+  subject: SimS3LifecycleSubject,
+): boolean {
+  if (filter.And !== undefined) {
+    return conjunctionSelects(filter.And, subject);
+  }
+
+  if (filter.Tag !== undefined) {
+    return false;
+  }
+
+  return (
+    subject.key.startsWith(filter.Prefix ?? "") && sizeWithin(filter, subject)
+  );
+}
+
+function conjunctionSelects(
+  operator: SimS3LifecycleRuleAndOperator,
+  subject: SimS3LifecycleSubject,
+): boolean {
+  if ((operator.Tags ?? []).length > 0) {
+    return false;
+  }
+
+  return (
+    subject.key.startsWith(operator.Prefix ?? "") &&
+    sizeWithin(operator, subject)
+  );
+}
+
+/**
+ * Whether the subject's size falls inside the bounds a filter states.
+ *
+ * A subject with no size, meaning an upload still in progress, falls outside
+ * any stated bound. A rule narrowed to Objects of a certain size says nothing
+ * about parts on their way to becoming one.
+ */
+function sizeWithin(
+  bounds: SimS3LifecycleSizeBounds,
+  subject: SimS3LifecycleSubject,
+): boolean {
+  const { ObjectSizeGreaterThan: greaterThan, ObjectSizeLessThan: lessThan } =
+    bounds;
+
+  if (greaterThan === undefined && lessThan === undefined) {
+    return true;
+  }
+
+  if (subject.size === undefined) {
+    return false;
+  }
+
+  return (
+    (greaterThan === undefined || subject.size > greaterThan) &&
+    (lessThan === undefined || subject.size < lessThan)
+  );
+}

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-sweep.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-sweep.ts
@@ -1,0 +1,86 @@
+import type { SimS3Object } from "../../object/s3-object.js";
+import type { SimS3BucketStorage } from "../../storage/s3-bucket-storage.js";
+import type {
+  SimS3LifecycleConfiguration,
+  SimS3LifecycleObject,
+} from "./sim-s3-lifecycle-configuration.js";
+
+/**
+ * One pass over what a Bucket's lifecycle rules have expired.
+ *
+ * A Bucket makes one of these per read and throws it away, because both halves
+ * of it can be replaced while the Bucket is running. `configureSimStorage`
+ * swaps the storage, and PutBucketLifecycleConfiguration replaces the rules.
+ *
+ * Expiry happens here rather than on a schedule, which leaves a Bucket
+ * carrying no rules paying one comparison for the check. See
+ * `simS3ObjectExpiryInstant` for why the boundary is a pure function of the
+ * current time.
+ *
+ * Nothing is announced. Real S3 raises `s3:LifecycleExpiration:Delete` for an
+ * expiry, and that event family is among the ones simulated S3 leaves out.
+ */
+export class SimS3LifecycleSweep {
+  constructor(
+    private readonly storage: SimS3BucketStorage,
+    private readonly lifecycle: SimS3LifecycleConfiguration,
+    private readonly now: Date,
+  ) {}
+
+  /**
+   * Remove one Object if the rules have expired it.
+   *
+   * The Object is answered when it survives and nothing is when it does not,
+   * so a read hands on whatever it gets. A key holding nothing stays nothing.
+   */
+  async object(
+    object: SimS3Object | undefined,
+  ): Promise<SimS3Object | undefined> {
+    if (object === undefined || !this.expires(object)) {
+      return object;
+    }
+
+    await this.storage.deleteObject(object.key);
+
+    return undefined;
+  }
+
+  /**
+   * Remove the Objects among these the rules have expired, and answer with the
+   * ones still there.
+   */
+  async objects(objects: readonly SimS3Object[]): Promise<SimS3Object[]> {
+    if (this.lifecycle.isEmpty) {
+      return [...objects];
+    }
+
+    const expiredKeys = new Set(
+      objects.filter((object) => this.expires(object)).map(({ key }) => key),
+    );
+
+    await Promise.all(
+      expiredKeys.values().map(async (key) => this.storage.deleteObject(key)),
+    );
+
+    return objects.filter((object) => !expiredKeys.has(object.key));
+  }
+
+  private expires(object: SimS3Object): boolean {
+    return (
+      !this.lifecycle.isEmpty &&
+      this.lifecycle.expires(lifecycleObject(object), this.now)
+    );
+  }
+}
+
+/**
+ * An Object as a rule reads it. The size is the length of the bytes the
+ * Bucket holds, which is what `ContentLength` reports for the same Object.
+ */
+function lifecycleObject(object: SimS3Object): SimS3LifecycleObject {
+  return {
+    key: object.key,
+    size: object.body.length,
+    lastModified: object.lastModified,
+  };
+}

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -1,5 +1,5 @@
-import { BackgroundTasks } from "../../../util/background/background.js";
 import type { Brand } from "../../../util/brand.type.js";
+import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
 import type { SimS3BucketStorage } from "../storage/s3-bucket-storage.js";
 import type { SimS3Object } from "../object/s3-object.js";
 import { MemoryS3BucketStorage } from "../storage/s3-memory-storage.js";
@@ -7,6 +7,7 @@ import { SimS3BucketWebsite } from "./website/sim-s3-bucket-website.js";
 import { SimS3PublicAccessBlock } from "./public-access/sim-s3-public-access-block.js";
 import { SimS3NotificationConfiguration } from "./notification/sim-s3-notification-configuration.js";
 import { SimS3LifecycleConfiguration } from "./lifecycle/sim-s3-lifecycle-configuration.js";
+import { SimS3LifecycleSweep } from "./lifecycle/sim-s3-lifecycle-sweep.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
 import { simS3BucketWebsiteUrl } from "./website/sim-s3-bucket-website-url.js";
@@ -27,6 +28,12 @@ interface SimS3BucketProperties {
   readonly notifications?: SimS3NotificationConfiguration;
   readonly lifecycle?: SimS3LifecycleConfiguration;
   /**
+   * The simulation's sense of time, which is what a lifecycle rule is measured
+   * against. A Bucket made outside a simulated environment has none to be
+   * given, and runs on the host clock.
+   */
+  readonly clock?: SimClock;
+  /**
    * When the Bucket came into being, in simulated time.
    *
    * Real S3 reports this on every Bucket a listing returns, and the `aws` CLI
@@ -43,6 +50,7 @@ export class SimS3Bucket {
   public readonly creationDate: Date;
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clock: SimClock;
   private readonly systemMetadata = new SimS3BucketSystemMetadata();
   private readonly multipartUploads = new SimS3MultipartUploads();
   private storage: SimS3BucketStorage;
@@ -62,13 +70,15 @@ export class SimS3Bucket {
       publicAccessBlock = SimS3PublicAccessBlock.blockingAll(),
       notifications = SimS3NotificationConfiguration.empty(),
       lifecycle = SimS3LifecycleConfiguration.empty(),
-      creationDate = new BackgroundTasks().now(),
+      clock = new SimRealClock(),
+      creationDate = clock.now(),
     } = properties;
 
     validateS3BucketName(bucketName);
 
     this.bucketName = bucketName;
     this.accountRegionScope = accountRegionScope;
+    this.clock = clock;
     this.storage = storage;
     this.website = website;
     this.policy = policy;
@@ -87,16 +97,19 @@ export class SimS3Bucket {
 
   /**
    * Get a simulated S3 Object from storage.
+   *
+   * An Object a lifecycle rule has expired goes on the way past. Every read of
+   * it then finds the key empty.
    */
   async getObject(key: string): Promise<SimS3Object | undefined> {
-    return await this.storage.getObject(key);
+    return await this.sweep().object(await this.storage.getObject(key));
   }
 
   /**
    * List simulated S3 Objects from storage.
    */
   async listObjects(prefix?: string): Promise<SimS3Object[]> {
-    return await this.storage.listObjects(prefix);
+    return await this.sweep().objects(await this.storage.listObjects(prefix));
   }
 
   /**
@@ -120,6 +133,11 @@ export class SimS3Bucket {
    * completing the upload puts anything under a key.
    */
   getMultipartUploads(): SimS3MultipartUploads {
+    const now = this.clock.now();
+    this.multipartUploads.discardAbandoned((upload) =>
+      this.lifecycle.abandons(upload, now),
+    );
+
     return this.multipartUploads;
   }
 
@@ -263,6 +281,15 @@ export class SimS3Bucket {
       this.bucketName,
       this.accountRegionScope,
       this.website,
+    );
+  }
+
+  /** What this Bucket's rules have expired, as they stand at this moment. */
+  private sweep(): SimS3LifecycleSweep {
+    return new SimS3LifecycleSweep(
+      this.storage,
+      this.lifecycle,
+      this.clock.now(),
     );
   }
 }

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle.iso.test.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle.iso.test.ts
@@ -1,4 +1,8 @@
-import { GetBucketLifecycleConfigurationCommand } from "@aws-sdk/client-s3";
+import {
+  GetBucketLifecycleConfigurationCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
 import {
   assertArrayLength,
   assertFalse,
@@ -11,6 +15,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
 import { SimAws } from "../../../../aws/sim-aws.js";
 import type { SimCfnTemplateValue } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimS3NoSuchLifecycleConfiguration } from "../../../error/sim-s3.error.js";
@@ -176,7 +181,7 @@ describe("AWS::S3::Bucket LifecycleConfiguration", () => {
     });
   });
 
-  it("still records the property as one nothing acts on", async () => {
+  it("records nothing against a Resource whose rules are acted on", async () => {
     // Given a template expiring raw logs after a year.
     const simAws = new SimAws();
     const stack = await simAws.cloudFormation().deployTemplate({
@@ -201,16 +206,42 @@ describe("AWS::S3::Bucket LifecycleConfiguration", () => {
     // When the Stack has settled.
     await stack.waitForDeployComplete();
 
-    // Then the property is recorded against the Resource even though the rules
-    // are readable, because no Object expires against them. A test reading the
-    // configuration back would otherwise take it for proof that retention
-    // works.
-    assertArrayLength(stack.ignoredProperties, 1);
-    const ignored = stack.ignoredProperties[0];
-    assertNonNullable(ignored);
-    assertIdentical(ignored.path, "LifecycleConfiguration");
-    assertStringIncludes(ignored.reason, "hands them back");
-    assertStringIncludes(ignored.reason, "expires or transitions no Object");
+    // Then nothing is recorded against the Resource. The Bucket expires an
+    // Object once the clock passes the rule, so the deployed rules are the
+    // behaviour the template asked for.
+    assertArrayLength(stack.ignoredProperties, 0);
+  });
+
+  it("expires an Object against the rule the template declared", async () => {
+    // Given a deployed Bucket expiring raw logs after a year, holding one.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-08-24T09:00:00.000Z")),
+    });
+    await deployBucketWithRules(simAws, [
+      {
+        Id: "expire",
+        Status: "Enabled",
+        Prefix: "raw/",
+        ExpirationInDays: 365,
+      },
+    ]);
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "logs",
+        Key: "raw/2026-08-24.gz",
+        Body: "one raw log line",
+      }),
+    );
+
+    // When simulated time moves past the year.
+    await simAws.clock().advanceBy({ days: 366 });
+
+    // Then the Object has gone. The template asked for retention, and this is
+    // the retention rather than a record of the request for it.
+    const listing = await simAws
+      .s3()
+      .listObjectsV2(new ListObjectsV2Command({ Bucket: "logs" }));
+    assertArrayLength(listing.Contents ?? [], 0);
   });
 
   it("leaves a Bucket declaring no rules unconfigured", async () => {

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
@@ -3,6 +3,7 @@
  */
 export const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "BucketName",
+  "LifecycleConfiguration",
   "NotificationConfiguration",
   "PublicAccessBlockConfiguration",
   "WebsiteConfiguration",
@@ -52,11 +53,6 @@ export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
     "storage classes are not simulated, so nothing transitions between them",
   ],
   ["InventoryConfigurations", "Bucket inventory reports are not simulated"],
-  [
-    "LifecycleConfiguration",
-    "the rules are stored and GetBucketLifecycleConfiguration hands them " +
-      "back, and simulated S3 expires or transitions no Object against them",
-  ],
   ["LoggingConfiguration", "server access logging is not simulated"],
   ["MetadataConfiguration", "Bucket metadata tables are not simulated"],
   ["MetadataTableConfiguration", "Bucket metadata tables are not simulated"],

--- a/src/service/s3/command/create-bucket/create-bucket.handler.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.handler.ts
@@ -103,7 +103,7 @@ export class CreateBucketCommandHandler implements CommandHandler<
     const bucket = new SimS3Bucket({
       bucketName,
       accountRegionScope: this.accountRegionScope,
-      creationDate: this.background.now(),
+      clock: this.background,
     });
     this.buckets.set(bucketName, bucket);
     this.s3GlobalRegistry.registerBucket(bucketName, this.accountRegionScope);

--- a/src/service/s3/upload/sim-s3-multipart-uploads.ts
+++ b/src/service/s3/upload/sim-s3-multipart-uploads.ts
@@ -62,6 +62,24 @@ export class SimS3MultipartUploads {
   }
 
   /**
+   * Forget every upload a Bucket's lifecycle rules have abandoned.
+   *
+   * The Bucket asks before it hands the uploads to anything. An abandoned
+   * upload is then missing from a listing, and its id is as unknown as an
+   * aborted one. Real S3 does the same to an upload nobody finished, and keeps
+   * none of the parts.
+   */
+  discardAbandoned(
+    isAbandoned: (upload: SimS3MultipartUpload) => boolean,
+  ): void {
+    for (const [uploadId, upload] of this.uploads) {
+      if (isAbandoned(upload)) {
+        this.uploads.delete(uploadId);
+      }
+    }
+  }
+
+  /**
    * The uploads in progress, in the order real S3 lists them.
    *
    * S3 orders a multipart upload listing by key, and by when the upload was

--- a/src/terraform/map/sim-tf-map-s3-lifecycle.ts
+++ b/src/terraform/map/sim-tf-map-s3-lifecycle.ts
@@ -2,11 +2,10 @@
  * The bucket lifecycle configuration, which the provider declares as a
  * resource of its own and CloudFormation carries on the bucket.
  *
- * Simulated S3 expires and transitions nothing, and records the whole
- * `LifecycleConfiguration` property against the Resource as one it does not act
- * on. The rules are carried across so that record names what the bucket was
- * asked for, rather than the resource being skipped and the configuration
- * disappearing from the report.
+ * Simulated S3 expires an Object and abandons an upload against these rules,
+ * and transitions nothing between storage classes. The rules are carried
+ * across whole, transitions included, so that a bucket reads back configured
+ * as the plan asked for.
  *
  * Reading a plan means reading records whose keys come from the document
  * rather than from this code, so the object-injection rule fires on every


### PR DESCRIPTION
Resolves #984.

An `Expiration` rule removes the Objects it selects once simulated time passes the boundary, and an
`AbortIncompleteMultipartUpload` rule discards an upload left unfinished for long enough. Expiry is
applied when the Bucket is read, the way simulated Kinesis applies stream retention, and a Bucket
carrying no rules pays one comparison for the check. Every read goes through `SimS3Bucket`, so
`ListObjectsV2`, `GetObject`, `HeadObject`, a `CopyObject` source, the REST and website endpoints
and the emptiness check `DeleteBucket` makes all agree without a change to any handler. An Object
goes exactly on the boundary. Real S3 removes one some time after it and bills up to the removal,
which a test would have to wait out.

A rule selects by its top-level `Prefix`, by its `Filter`, by `Filter.And` and by the object size
bounds. A multipart upload is selected by its key alone, since half an upload has no size to
measure. A tag selects no key, because simulated S3 holds no Object tags, and a rule narrowed by
`Filter.Tag`, `Filter.And.Tags` or a template's `TagFilters` expires nothing. Refusing such a rule
would fail a Stack over a field the rest of the simulation is happy with, so it is stored, read back
and recorded in the Limitations.

`LifecycleConfiguration` moves from `unsimulatedPropertyReasons` into `simulatedPropertyNames`, so
it leaves `stack.ignoredProperties`. A Bucket mounted on a filesystem directory answers
`NotImplemented` for an expiry, the way it already answers `DeleteObject`, rather than removing a
real file off the mounted directory.

Out of scope, as the issue states: storage class transitions, the `s3:LifecycleExpiration:*`
notification events, `NoncurrentVersionExpiration` and `ExpiredObjectDeleteMarker`.

`pnpm check` passes. 26 new tests cover the two expiry paths, rule scope, a `Disabled` rule, a
backwards clock and the CloudFormation route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simulated S3 now expires objects according to lifecycle rules during bucket reads and listings.
  - Supports expiration by age or date, prefixes, object-size filters, and combined conditions.
  - Automatically aborts incomplete multipart uploads after configured thresholds.
  - CloudFormation `LifecycleConfiguration` rules are now actively simulated.
- **Documentation**
  - Added lifecycle expiration examples and clarified supported behavior and limitations.
- **Known Limitations**
  - Storage-class transitions, version-specific actions, tag-based filtering, and filesystem-backed expiry remain unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->