### PR TITLE
fix: measure a clock advance from a frozen instant

### DIFF
--- a/src/util/clock/sim-clock-control.iso.test.ts
+++ b/src/util/clock/sim-clock-control.iso.test.ts
@@ -3,9 +3,23 @@ import { describe, expect, it } from "vitest";
 import { BackgroundTasks } from "../background/background.js";
 import { SimClockControl } from "./sim-clock-control.js";
 import { SimControllableClock } from "./sim-controllable-clock.js";
-import { SimFixedClock } from "./sim-clock.js";
+import { SimFixedClock, type SimClock } from "./sim-clock.js";
 
 const start = new Date("2026-07-26T09:00:00.000Z");
+
+/**
+ * A host clock that reads a hundred milliseconds later every time it is asked,
+ * standing in for a machine busy enough to be preempted mid-advance.
+ */
+class DriftingClock implements SimClock {
+  private at = start.getTime();
+
+  now(): Date {
+    this.at += 100;
+
+    return new Date(this.at);
+  }
+}
 
 /**
  * A simulation's clock, its scheduler, and control over both, wired the way
@@ -49,6 +63,34 @@ describe("SimClockControl", () => {
     // Then simulated time has moved on, and stopped there
     expect(control.now()).toStrictEqual(new Date("2026-07-26T09:20:00.000Z"));
     expect(control.isFrozen).toBe(true);
+  });
+
+  it("measures an advance from where the clock stood when it started", async () => {
+    // Given a simulation on a host clock that moves while an advance runs, and
+    // work due now that buffers for an hour once it runs
+    const clock = new SimControllableClock({ base: new DriftingClock() });
+    const background = new BackgroundTasks({ clock });
+    const control = new SimClockControl({ clock, background });
+    let delivered = false;
+    background.scheduleAt(background.now(), async () => {
+      background.scheduleAt(
+        new Date(background.now().getTime() + 60 * 60 * 1000),
+        async () => {
+          delivered = true;
+
+          await Promise.resolve();
+        },
+      );
+
+      await Promise.resolve();
+    });
+
+    // When time is advanced by exactly that hour
+    await control.advanceBy({ hours: 1 });
+
+    // Then the hour reached the buffer's due instant. The host clock moving
+    // under the advance left the interval the length it was asked for.
+    expect(delivered).toBe(true);
   });
 
   it("runs work that falls due during the interval, at its own due time", async () => {

--- a/src/util/clock/sim-clock-control.ts
+++ b/src/util/clock/sim-clock-control.ts
@@ -87,8 +87,14 @@ export class SimClockControl implements SimClock {
    * due time rather than at the instant asked for. Simulated time got that far
    * and then something broke, and saying so is more use than claiming the whole
    * interval elapsed. Whatever was still queued stays queued.
+   *
+   * The clock freezes where it reads before any of that happens. Simulated time
+   * then moves only where this method moves it, and a task scheduling its own
+   * follow-up measures the delay from a still instant.
    */
   async setTo(instant: Date): Promise<void> {
+    this.clock.freeze();
+
     if (instant.getTime() >= this.now().getTime()) {
       await this.runDueTasksUpTo(instant);
     }
@@ -103,8 +109,14 @@ export class SimClockControl implements SimClock {
    *
    * Returns once the simulation has settled, so a test can advance and then
    * assert without waiting again.
+   *
+   * The duration is measured from a frozen instant. Advancing by exactly a
+   * buffering interval or a schedule period lands on the due instant every
+   * time, whatever the host clock does while the advance runs.
    */
   async advanceBy(duration: SimDuration | SimDurationInput): Promise<void> {
+    this.clock.freeze();
+
     const milliseconds = SimDuration.of(duration).toMilliseconds();
 
     await this.setTo(new Date(this.now().getTime() + milliseconds));


### PR DESCRIPTION
`src/service/firehose/source/sim-firehose-kinesis-source.iso.test.ts` had a test that failed once under a full parallel run and passed on every re-run. The cause is in `SimClockControl` rather than in the test. `advanceBy` read the running host clock for the instant it was heading for, and the first due task it ran read that clock again to freeze simulated time. Host time passing between those two readings shortened the advance by that much. A task that scheduled its own follow-up exactly one interval ahead then fell a millisecond or two past the target and never ran, which is what a Firehose delivery does when a record arrives during the advance and the buffer is due 60 seconds later. Advancing by exactly the 60 second buffering interval delivered nothing. The clock now freezes before the duration is measured, and every reading inside one advance sees the same instant.

The regression test drives a base clock that reads 100 milliseconds later on every call, which fails the assertion without the fix and passes with it. The Firehose tests are left alone. Two of them (`delivers a record put on the stream after it was created` and `reads once for records put before it got to them`) advance by exactly the buffering interval and were the exposed pair. The rest carry 30 seconds or more of slack, or assert that nothing was delivered. Both exposed tests now pass unchanged under the same 100 millisecond drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulated clock controls to ensure time adjustments are calculated from a stable starting instant.
  * Fixed timing behavior when host-clock drift or nested scheduled work occurs during time advancement.
  * Added coverage for clock adjustments under drifting host-time conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->