### PR TITLE
feat: refuse a delivery source over an absent distribution

### DIFF
--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -315,6 +315,7 @@ where they land and in what form. A delivery joins one to the other.
  * Setting up CloudFront standard logging v2 delivery into a bucket.
  */
 
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
 import {
   CreateDeliveryCommand,
   DescribeDeliveriesCommand,
@@ -327,10 +328,38 @@ import { SimAws } from "@kensio/yulin";
 const simAws = new SimAws();
 const logs = simAws.logs();
 
+const distribution = await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "site",
+      Comment: "Static site distribution",
+      Enabled: true,
+      Origins: {
+        Quantity: 1,
+        Items: [
+          {
+            Id: "site-origin",
+            DomainName: "origin.example.com",
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "site-origin",
+        ViewerProtocolPolicy: "redirect-to-https",
+      },
+    },
+  }),
+);
+
 await logs.putDeliverySource(
   new PutDeliverySourceCommand({
     name: "site-access-logs",
-    resourceArn: "arn:aws:cloudfront::123456789012:distribution/E1EXAMPLE",
+    resourceArn: `arn:aws:cloudfront::${simAws.defaultAccountId}:distribution/${distribution.Distribution?.Id}`,
     logType: "ACCESS_LOGS",
   }),
 );
@@ -370,9 +399,14 @@ console.log(
 The delivery destination has an ARN of its own, and `CreateDelivery` names that one. The bucket
 behind it keeps its own ARN, and the two are easy to mix up.
 
-The service a delivery source is for is read off the resource ARN. A caller never states it. Four
+The service a delivery source is for is read off the resource ARN. A caller never states it. These
 rules from real AWS are modelled here, each of them a deploy that looks fine until it runs:
 
+- **The distribution has to be there.** A CloudFront delivery source over a distribution the
+  simulated account never created fails with `ResourceNotFoundException`, and so does one whose ARN
+  names another account. Pin a real distribution id in a template and the deploy fails here the way
+  it would in an account. A `SimLogs` built on its own has no CloudFront to look in and keeps taking
+  any ARN, so a test about delivery alone needs no distribution.
 - **One delivery source per resource.** A second source over a distribution that already has one
   fails with `ConflictException`, carrying the message an account gives, "This ResourceId has
   already been used in another Delivery Source in this account".
@@ -395,14 +429,25 @@ it was not. A path over the 256 characters CloudWatch Logs takes is refused too.
 ### Declaring delivery in a template
 
 The same three resources in a template, which is the whole of what a CDK construct for CloudFront
-logging synthesises.
+logging synthesises. The source's `ResourceArn` is built around a `Ref` to the distribution the
+template declares, the way CDK builds it. A pinned distribution id fails the deploy (see
+[the rules above](#delivering-logs-from-another-service)).
 
 ```yaml
 AccessLogsSource:
   Type: AWS::Logs::DeliverySource
   Properties:
     Name: site-access-logs
-    ResourceArn: arn:aws:cloudfront::123456789012:distribution/E1EXAMPLE
+    ResourceArn:
+      !Join [
+        "",
+        [
+          "arn:aws:cloudfront::",
+          !Ref "AWS::AccountId",
+          ":distribution/",
+          !Ref SiteDistribution,
+        ],
+      ]
     LogType: ACCESS_LOGS
 
 AccessLogsDestination:

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -429,11 +429,26 @@ it was not. A path over the 256 characters CloudWatch Logs takes is refused too.
 ### Declaring delivery in a template
 
 The same three resources in a template, which is the whole of what a CDK construct for CloudFront
-logging synthesises. The source's `ResourceArn` is built around a `Ref` to the distribution the
-template declares, the way CDK builds it. A pinned distribution id fails the deploy (see
-[the rules above](#delivering-logs-from-another-service)).
+logging synthesises, alongside the distribution they are for. The source's `ResourceArn` is built
+around a `Ref` to that distribution, the way CDK builds it. A pinned distribution id fails the
+deploy (see [the rules above](#delivering-logs-from-another-service)).
 
 ```yaml
+SiteDistribution:
+  Type: AWS::CloudFront::Distribution
+  Properties:
+    DistributionConfig:
+      Enabled: true
+      Origins:
+        Items:
+          - Id: site-origin
+            DomainName: origin.example.com
+            CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+      DefaultCacheBehavior:
+        TargetOriginId: site-origin
+        ViewerProtocolPolicy: redirect-to-https
+
 AccessLogsSource:
   Type: AWS::Logs::DeliverySource
   Properties:

--- a/docs/services/logs/sim-logs-delivery.example.ts
+++ b/docs/services/logs/sim-logs-delivery.example.ts
@@ -2,6 +2,7 @@
  * Setting up CloudFront standard logging v2 delivery into a bucket.
  */
 
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
 import {
   CreateDeliveryCommand,
   DescribeDeliveriesCommand,
@@ -14,10 +15,38 @@ import { SimAws } from "@kensio/yulin";
 const simAws = new SimAws();
 const logs = simAws.logs();
 
+const distribution = await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "site",
+      Comment: "Static site distribution",
+      Enabled: true,
+      Origins: {
+        Quantity: 1,
+        Items: [
+          {
+            Id: "site-origin",
+            DomainName: "origin.example.com",
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "site-origin",
+        ViewerProtocolPolicy: "redirect-to-https",
+      },
+    },
+  }),
+);
+
 await logs.putDeliverySource(
   new PutDeliverySourceCommand({
     name: "site-access-logs",
-    resourceArn: "arn:aws:cloudfront::123456789012:distribution/E1EXAMPLE",
+    resourceArn: `arn:aws:cloudfront::${simAws.defaultAccountId}:distribution/${distribution.Distribution?.Id}`,
     logType: "ACCESS_LOGS",
   }),
 );

--- a/src/service/aws/factory/sim-aws-logs-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-logs-collaborators.ts
@@ -1,3 +1,5 @@
+import { SimAwsLogsDeliveryDistributions } from "../../logs/delivery/cloudfront/sim-aws-logs-delivery-distributions.js";
+import type { SimLogsDeliverySourceResources } from "../../logs/delivery/sim-logs-delivery-source-resources.js";
 import { SimAwsLogsSubscriptionFunctions } from "../../logs/subscription/lambda/sim-aws-logs-subscription-functions.js";
 import type { SimLogsSubscriptionDestinations } from "../../logs/subscription/sim-logs-subscription-destinations.js";
 import type { SimAwsAccountRegionScope } from "../sim-aws-account-region-scope.js";
@@ -8,6 +10,7 @@ import type { SimAws } from "../sim-aws.js";
  */
 interface SimAwsLogsCollaborators {
   readonly subscriptionDestinations: SimLogsSubscriptionDestinations;
+  readonly deliverySourceResources: SimLogsDeliverySourceResources;
 }
 
 /**
@@ -20,6 +23,10 @@ interface SimAwsLogsCollaborators {
  * is looked up when an event is delivered rather than now: every Lambda
  * function records its output in simulated CloudWatch Logs, so reaching one
  * while this is being built would be a cycle with no bottom.
+ *
+ * A delivery source names the resource its logs come from by ARN. CloudFront
+ * is the one delivered service whose resources are resolved, and its resolver
+ * takes the same scope to read the account segment of that ARN against.
  */
 export function simAwsLogsCollaborators(
   simAws: SimAws,
@@ -27,6 +34,10 @@ export function simAwsLogsCollaborators(
 ): SimAwsLogsCollaborators {
   return {
     subscriptionDestinations: new SimAwsLogsSubscriptionFunctions({
+      simAws,
+      accountRegionScope,
+    }),
+    deliverySourceResources: new SimAwsLogsDeliveryDistributions({
       simAws,
       accountRegionScope,
     }),

--- a/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
@@ -8,8 +8,12 @@ import { describe, it } from "vitest";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimAws } from "../../aws/sim-aws.js";
+import {
+  deliveryDistributionLogicalId,
+  deliveryDistributionResource,
+  deliveryDistributionResourceArn,
+} from "../../../../test/logs/delivery-distribution-fixture.js";
 
-const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
 const bucketArn = "arn:aws:s3:::example-access-logs";
 const sourceName = "site-access-logs";
 
@@ -27,6 +31,7 @@ async function deploySource(
     stackName: "site-logging",
     template: {
       Resources: {
+        [deliveryDistributionLogicalId]: deliveryDistributionResource,
         AccessLogsSource: {
           Type: "AWS::Logs::DeliverySource",
           Properties: properties,
@@ -38,11 +43,39 @@ async function deploySource(
 
 const sourceProperties: SimCfnTemplateValueRecord = {
   Name: sourceName,
-  ResourceArn: distributionArn,
+  ResourceArn: deliveryDistributionResourceArn,
   LogType: "ACCESS_LOGS",
 };
 
 describe("AWS::Logs delivery Resource refusals", () => {
+  it("fails a stack whose delivery source names a distribution that is not there", async () => {
+    // Given a template pinning the distribution id of a real account, which
+    // is how a stack ends up naming one the simulation never created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await new SimAws().cloudFormation().deployTemplate({
+        stackName: "site-logging",
+        template: {
+          Resources: {
+            AccessLogsSource: {
+              Type: "AWS::Logs::DeliverySource",
+              Properties: {
+                Name: sourceName,
+                ResourceArn:
+                  "arn:aws:cloudfront::888888888888:distribution/E37CHA90H2SDED",
+                LogType: "ACCESS_LOGS",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the deploy fails. The stack would otherwise go up clean against a
+    // distribution that delivers nothing.
+    assertStringIncludes(error.message, "AccessLogsSource");
+    assertStringIncludes(error.message, "names no CloudFront distribution");
+  });
+
   it("fails a stack that sets CloudFront logging up outside us-east-1", async () => {
     // Given the delivery Resources declared in a stack in the region the rest
     // of an application lives in, which is the mistake worth catching.
@@ -87,6 +120,7 @@ describe("AWS::Logs delivery Resource refusals", () => {
         stackName: "site-logging",
         template: {
           Resources: {
+            [deliveryDistributionLogicalId]: deliveryDistributionResource,
             AccessLogsSource: {
               Type: "AWS::Logs::DeliverySource",
               Properties: sourceProperties,
@@ -167,6 +201,7 @@ describe("AWS::Logs delivery Resource refusals", () => {
         stackName: "site-logging",
         template: {
           Resources: {
+            [deliveryDistributionLogicalId]: deliveryDistributionResource,
             AccessLogsSource: {
               Type: "AWS::Logs::DeliverySource",
               Properties: sourceProperties,
@@ -196,6 +231,7 @@ describe("AWS::Logs delivery Resource refusals", () => {
       stackName: "site-logging",
       template: {
         Resources: {
+          [deliveryDistributionLogicalId]: deliveryDistributionResource,
           AccessLogsSource: {
             Type: "AWS::Logs::DeliverySource",
             Properties: sourceProperties,

--- a/src/service/logs/cfn/sim-cfn-delivery.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery.iso.test.ts
@@ -20,8 +20,12 @@ import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cf
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
+import {
+  deliveryDistributionLogicalId,
+  deliveryDistributionResource,
+  deliveryDistributionResourceArn,
+} from "../../../../test/logs/delivery-distribution-fixture.js";
 
-const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
 const bucketArn = "arn:aws:s3:::example-access-logs";
 const sourceName = "site-access-logs";
 const suffixPath = "{DistributionId}/{yyyy}/{MM}/{dd}/{HH}";
@@ -35,11 +39,12 @@ function loggingTemplate(
 ): CfnTemplateBodyRecord {
   return {
     Resources: {
+      [deliveryDistributionLogicalId]: deliveryDistributionResource,
       AccessLogsSource: {
         Type: "AWS::Logs::DeliverySource",
         Properties: {
           Name: sourceName,
-          ResourceArn: distributionArn,
+          ResourceArn: deliveryDistributionResourceArn,
           LogType: "ACCESS_LOGS",
         },
       },
@@ -205,6 +210,53 @@ describe("AWS::Logs delivery Resources", () => {
     assertArrayEquals(simAws.logs().allDeliverySources(), []);
     assertArrayEquals(simAws.logs().allDeliveryDestinations(), []);
     assertArrayEquals(simAws.logs().allDeliveries(), []);
+  });
+
+  it("takes a delivery source over a distribution another stack deployed", async () => {
+    // Given a stack holding the distribution and exporting its ARN, which is
+    // how an application splits its CDN from the analytics beside it.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.deployTemplate({
+      stackName: "site-cdn",
+      template: {
+        Resources: {
+          [deliveryDistributionLogicalId]: deliveryDistributionResource,
+        },
+        Outputs: {
+          DistributionArn: {
+            Value: deliveryDistributionResourceArn,
+            Export: { Name: "site-cdn:DistributionArn" },
+          },
+        },
+      },
+    });
+
+    // When a second stack puts a delivery source over the exported ARN.
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "site-analytics",
+      template: {
+        Resources: {
+          AccessLogsSource: {
+            Type: "AWS::Logs::DeliverySource",
+            Properties: {
+              Name: sourceName,
+              ResourceArn: { "Fn::ImportValue": "site-cdn:DistributionArn" },
+              LogType: "ACCESS_LOGS",
+            },
+          },
+        },
+      },
+    });
+
+    // Then it deploys, because the distribution the ARN names is one the
+    // account holds however many stacks away it was created.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertIdentical(
+      simAws.logs().findDeliverySource(sourceName)?.service,
+      "cloudfront",
+    );
   });
 
   it("records the delivery Resource properties it does not act on", async () => {

--- a/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
+++ b/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
@@ -19,6 +19,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simLogsDeliveryDistributionArn } from "../../../../../test/logs/delivery-distribution-fixture.js";
 
 const accountIdOneOnes = "111111111111";
 const logGroupName = "/aws/lambda/orders";
@@ -241,14 +242,23 @@ describe("CloudWatch Logs delivery IAM authorization", () => {
   });
 
   it("allows a delivery source a policy names", async () => {
-    // Given a Role allowed to put delivery sources.
+    // Given a Role allowed to put delivery sources, and a distribution for
+    // the source to be over.
     const simAws = await simAwsWithRole({
       Action: "logs:PutDeliverySource",
       Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:delivery-source:*`,
     });
+    const resourceArn = await simLogsDeliveryDistributionArn(simAws);
 
     // When it puts a delivery source.
-    await simAws.logs().putDeliverySource(putSource, asRole);
+    await simAws.logs().putDeliverySource(
+      new PutDeliverySourceCommand({
+        name: "site-access-logs",
+        resourceArn,
+        logType: "ACCESS_LOGS",
+      }),
+      asRole,
+    );
 
     // Then the source is there, so the ARN the policy names is the one the
     // request authorizes against.

--- a/src/service/logs/command/delivery/sim-logs-delivery-source-commands.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-source-commands.ts
@@ -3,6 +3,7 @@ import {
   simLogsAnyDeliverySourceArn,
   simLogsDeliverySourceArn,
 } from "../../delivery/sim-logs-delivery-arn.js";
+import type { SimLogsDeliverySourceResources } from "../../delivery/sim-logs-delivery-source-resources.js";
 import {
   requireSimLogsDeliverySource,
   requiredSimLogsDeliveredService,
@@ -10,6 +11,7 @@ import {
 import { SimLogsDeliverySource } from "../../delivery/sim-logs-delivery-source.js";
 import type { SimLogsDeliverySourceStore } from "../../delivery/sim-logs-delivery-source-store.js";
 import type { SimLogsDeliveryStore } from "../../delivery/sim-logs-delivery-store.js";
+import { SimLogsResourceNotFoundException } from "../../error/sim-logs.error.js";
 import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
 import { SimLogsPage } from "../sim-logs-page.js";
 import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
@@ -36,6 +38,7 @@ interface SimLogsDeliverySourceCommandsProperties {
   readonly deliveries: SimLogsDeliveryStore;
   readonly authorizer: SimLogsAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly resources: SimLogsDeliverySourceResources;
 }
 
 /**
@@ -46,12 +49,14 @@ export class SimLogsDeliverySourceCommands {
   readonly #deliveries: SimLogsDeliveryStore;
   readonly #authorizer: SimLogsAuthorizer;
   readonly #scope: SimAwsAccountRegionScope;
+  readonly #resources: SimLogsDeliverySourceResources;
 
   constructor(properties: SimLogsDeliverySourceCommandsProperties) {
     this.#sources = properties.sources;
     this.#deliveries = properties.deliveries;
     this.#authorizer = properties.authorizer;
     this.#scope = properties.accountRegionScope;
+    this.#resources = properties.resources;
   }
 
   /**
@@ -59,7 +64,9 @@ export class SimLogsDeliverySourceCommands {
    *
    * The service is read from the resource ARN, as real CloudWatch Logs reads
    * it, and the region the request was made in has to be one that service's
-   * delivery can be set up from.
+   * delivery can be set up from. The ARN is then resolved to a resource the
+   * account holds. A source over a distribution the account never created
+   * fails here, ahead of the delivery that would have carried nothing.
    */
   putDeliverySource(
     command: SimPutDeliverySourceCommand,
@@ -87,6 +94,12 @@ export class SimLogsDeliverySourceCommands {
       regionName: this.#scope.regionName,
       logType,
     });
+
+    const absent = this.#resources.refusalFor(resourceArn);
+
+    if (absent !== undefined) {
+      throw new SimLogsResourceNotFoundException(absent);
+    }
 
     const source = new SimLogsDeliverySource({
       name,

--- a/src/service/logs/delivery/cloudfront/sim-aws-logs-delivery-distributions.ts
+++ b/src/service/logs/delivery/cloudfront/sim-aws-logs-delivery-distributions.ts
@@ -1,0 +1,74 @@
+import { parseSimArn } from "../../../aws/arn.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimLogsDeliverySourceResources } from "../sim-logs-delivery-source-resources.js";
+import { simLogsCloudFrontDeliveryService } from "../sim-logs-delivery-source-service.js";
+
+interface SimAwsLogsDeliveryDistributionsProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The simulated CloudFront a delivery source's `resourceArn` is resolved in.
+ *
+ * CloudFront is the one delivered service resolved here, because it is the one
+ * whose delivery rules are modelled at all. An ARN of any other service is
+ * left alone, and a source over it is stored on the shape of the ARN alone, as
+ * it always was.
+ *
+ * The distribution is looked up as the source is put, and nothing holds onto
+ * it. A distribution deleted afterwards leaves the source standing, the way
+ * real CloudWatch Logs leaves it. CloudFront is account-scoped, and the lookup
+ * covers the whole account whichever region the request was made in.
+ */
+export class SimAwsLogsDeliveryDistributions implements SimLogsDeliverySourceResources {
+  readonly #simAws: SimAws;
+  readonly #scope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimAwsLogsDeliveryDistributionsProperties) {
+    this.#simAws = properties.simAws;
+    this.#scope = properties.accountRegionScope;
+  }
+
+  /**
+   * Why the account cannot deliver logs from the distribution an ARN names.
+   *
+   * The account segment is read before the distribution is looked up. An ARN
+   * naming another account is a mistake of its own, and an id that happens to
+   * match one this account holds would otherwise carry it through.
+   */
+  refusalFor(resourceArn: string): string | undefined {
+    const arn = parseSimArn(resourceArn);
+
+    if (arn === undefined || arn.service !== simLogsCloudFrontDeliveryService) {
+      return undefined;
+    }
+
+    const accountId = this.#scope.accountId;
+
+    if (arn.accountId !== accountId) {
+      return (
+        `resourceArn '${resourceArn}' names account ${arn.accountId}, and a ` +
+        `delivery source is over a resource of the account creating it, ` +
+        `which is ${accountId}`
+      );
+    }
+
+    const distribution = this.#simAws
+      .accountRegionScope(accountId, this.#scope.regionName)
+      .cloudFront()
+      .getSimDistributionById(arn.resourceId);
+
+    if (distribution !== undefined) {
+      return undefined;
+    }
+
+    return (
+      `resourceArn '${resourceArn}' names no CloudFront distribution in ` +
+      `account ${accountId}. Create the distribution before the delivery ` +
+      `source, or name it from the template so the id it was given is ` +
+      `substituted into the ARN`
+    );
+  }
+}

--- a/src/service/logs/delivery/sim-logs-deliveries.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-deliveries.iso.test.ts
@@ -16,8 +16,8 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
+import { simLogsDeliveryDistributionArn } from "../../../../test/logs/delivery-distribution-fixture.js";
 
-const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
 const bucketArn = "arn:aws:s3:::example-access-logs";
 const sourceName = "site-access-logs";
 const destinationName = "site-access-logs";
@@ -30,7 +30,7 @@ async function givenSourceAndDestination(simAws: SimAws): Promise<string> {
   await simAws.logs().putDeliverySource(
     new PutDeliverySourceCommand({
       name: sourceName,
-      resourceArn: distributionArn,
+      resourceArn: await simLogsDeliveryDistributionArn(simAws),
       logType: "ACCESS_LOGS",
     }),
   );

--- a/src/service/logs/delivery/sim-logs-delivery-refusals.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-refusals.iso.test.ts
@@ -13,8 +13,8 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
+import { simLogsDeliveryDistributionArn } from "../../../../test/logs/delivery-distribution-fixture.js";
 
-const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
 const bucketArn = "arn:aws:s3:::example-access-logs";
 const logGroupArn = "arn:aws:logs:us-east-1:123456789012:log-group:/site";
 const sourceName = "site-access-logs";
@@ -23,7 +23,7 @@ async function givenSource(simAws: SimAws): Promise<void> {
   await simAws.logs().putDeliverySource(
     new PutDeliverySourceCommand({
       name: sourceName,
-      resourceArn: distributionArn,
+      resourceArn: await simLogsDeliveryDistributionArn(simAws),
       logType: "ACCESS_LOGS",
     }),
   );

--- a/src/service/logs/delivery/sim-logs-delivery-source-refusals.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source-refusals.iso.test.ts
@@ -10,8 +10,12 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
+import {
+  simLogsDeliveryDistributionArn,
+  simLogsDistributionArn,
+} from "../../../../test/logs/delivery-distribution-fixture.js";
 
-const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
+const distributionArn = "arn:aws:cloudfront::888888888888:distribution/E1EX";
 const sourceName = "site-access-logs";
 
 function putSourceInput(
@@ -29,20 +33,24 @@ describe("simulated CloudWatch Logs delivery source refusals", () => {
   it("refuses a second delivery source over the same distribution", async () => {
     // Given a distribution that already has a delivery source.
     const simAws = new SimAws();
+    const resourceArn = await simLogsDeliveryDistributionArn(simAws);
 
     await simAws
       .logs()
-      .putDeliverySource(new PutDeliverySourceCommand(putSourceInput()));
+      .putDeliverySource(
+        new PutDeliverySourceCommand(putSourceInput({ resourceArn })),
+      );
 
     // When a second source is put over the same distribution.
     const error = await assertThrowsErrorAsync(async () => {
-      await simAws
-        .logs()
-        .putDeliverySource(
-          new PutDeliverySourceCommand(
-            putSourceInput({ name: "second-access-logs" }),
-          ),
-        );
+      await simAws.logs().putDeliverySource(
+        new PutDeliverySourceCommand(
+          putSourceInput({
+            name: "second-access-logs",
+            resourceArn,
+          }),
+        ),
+      );
     });
 
     // Then it is refused the way an account refuses it, which is what anyone
@@ -53,6 +61,50 @@ describe("simulated CloudWatch Logs delivery source refusals", () => {
       "This ResourceId has already been used in another Delivery Source in " +
         "this account",
     );
+  });
+
+  it("refuses a delivery source over a distribution that is not there", async () => {
+    // Given a simulated account holding no distributions.
+    const simAws = new SimAws();
+
+    // When a delivery source names one anyway, as a template pinning the
+    // distribution id of a real account does.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .logs()
+        .putDeliverySource(new PutDeliverySourceCommand(putSourceInput()));
+    });
+
+    // Then it is refused. An account does the same with a source over a
+    // resource it has never held.
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertStringIncludes(error.message, "names no CloudFront distribution");
+    assertStringIncludes(error.message, "888888888888");
+  });
+
+  it("refuses a delivery source over another account's distribution", async () => {
+    // Given a distribution in the simulated account, named by an ARN that
+    // says it belongs to another one.
+    const simAws = new SimAws();
+    const held = await simLogsDeliveryDistributionArn(simAws);
+    const distributionId = held.split("/").at(-1) ?? "";
+
+    // When a delivery source is put over that ARN.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().putDeliverySource(
+        new PutDeliverySourceCommand(
+          putSourceInput({
+            resourceArn: `arn:aws:cloudfront::207763040965:distribution/${distributionId}`,
+          }),
+        ),
+      );
+    });
+
+    // Then the account segment is read. An id that happens to match one this
+    // account holds carries a foreign ARN through without it.
+    assertIdentical(error.name, "ResourceNotFoundException");
+    assertStringIncludes(error.message, "names account 207763040965");
+    assertIdentical(simLogsDistributionArn(simAws, distributionId), held);
   });
 
   it("refuses a CloudFront delivery source outside us-east-1", async () => {

--- a/src/service/logs/delivery/sim-logs-delivery-source-resources.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-source-resources.ts
@@ -1,0 +1,30 @@
+/**
+ * The resources a delivery source's `resourceArn` is resolved against.
+ *
+ * Real CloudWatch Logs resolves that ARN to a resource of the account making
+ * the request, and refuses a source over one the account does not hold. A
+ * simulated CloudWatch Logs on its own has no other simulated service to
+ * resolve it in. A wired simulation supplies this, and a standalone SimLogs
+ * leaves it out.
+ */
+export interface SimLogsDeliverySourceResources {
+  /**
+   * Why the account cannot deliver logs from the resource an ARN names, or
+   * undefined where it can.
+   */
+  refusalFor(resourceArn: string): string | undefined;
+}
+
+/**
+ * The resources of a simulation holding nothing to resolve an ARN in.
+ *
+ * A SimLogs built on its own takes this. A test about delivery configuration
+ * alone names an ARN with no resource behind it, as it always could. A test
+ * that wants the refusal builds the simulated service the ARN names too.
+ */
+export class SimLogsUncheckedDeliverySourceResources implements SimLogsDeliverySourceResources {
+  /** Every ARN is taken, because there is nothing here to resolve one in. */
+  refusalFor(): undefined {
+    return;
+  }
+}

--- a/src/service/logs/delivery/sim-logs-delivery-sources.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-sources.iso.test.ts
@@ -15,15 +15,19 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
+import { SimLogs } from "../sim-logs.js";
+import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
+import { simLogsDeliveryDistributionArn } from "../../../../test/logs/delivery-distribution-fixture.js";
 
-const distributionArn = "arn:aws:cloudfront::123456789012:distribution/E1EX";
 const sourceName = "site-access-logs";
 
-async function putSource(
-  simAws: SimAws,
-  name = sourceName,
-  resourceArn = distributionArn,
-): Promise<void> {
+/**
+ * Put a delivery source over a distribution of its own, and report the ARN it
+ * was put over.
+ */
+async function putSource(simAws: SimAws, name = sourceName): Promise<string> {
+  const resourceArn = await simLogsDeliveryDistributionArn(simAws, name);
+
   await simAws.logs().putDeliverySource(
     new PutDeliverySourceCommand({
       name,
@@ -31,14 +35,17 @@ async function putSource(
       logType: "ACCESS_LOGS",
     }),
   );
+
+  return resourceArn;
 }
 
 describe("simulated CloudWatch Logs delivery sources", () => {
   it("puts a delivery source over a distribution", async () => {
-    // Given a simulated account.
+    // Given a distribution in the simulated account.
     const simAws = new SimAws();
+    const distributionArn = await simLogsDeliveryDistributionArn(simAws);
 
-    // When a delivery source is put over a distribution.
+    // When a delivery source is put over it.
     const put = await simAws.logs().putDeliverySource(
       new PutDeliverySourceCommand({
         name: sourceName,
@@ -65,7 +72,7 @@ describe("simulated CloudWatch Logs delivery sources", () => {
     const simAws = new SimAws();
 
     await putSource(simAws);
-    await putSource(simAws, "other-access-logs", `${distributionArn}2`);
+    await putSource(simAws, "other-access-logs");
 
     // When the delivery sources are described.
     const described = await simAws
@@ -85,7 +92,7 @@ describe("simulated CloudWatch Logs delivery sources", () => {
     const simAws = new SimAws();
 
     await putSource(simAws);
-    await putSource(simAws, "other-access-logs", `${distributionArn}2`);
+    await putSource(simAws, "other-access-logs");
 
     // When one is asked for at a time.
     const first = await simAws
@@ -113,8 +120,7 @@ describe("simulated CloudWatch Logs delivery sources", () => {
   it("updates a delivery source put again under the same name", async () => {
     // Given a delivery source over a distribution.
     const simAws = new SimAws();
-
-    await putSource(simAws);
+    const distributionArn = await putSource(simAws);
 
     // When the same name is put again for the same distribution.
     await simAws.logs().putDeliverySource(
@@ -145,6 +151,29 @@ describe("simulated CloudWatch Logs delivery sources", () => {
 
     // Then it is created: only CloudFront delivery is pinned to one region.
     assertNonNullable(logs.findDeliverySource("model-invocation-logs"));
+  });
+
+  it("takes a delivery source in a simulation with no CloudFront", async () => {
+    // Given simulated CloudWatch Logs on its own, which has no CloudFront to
+    // find a distribution in.
+    const logs = new SimLogs({
+      accountRegionScope: simAwsAccountRegionScopeFactory.make({
+        regionName: "us-east-1",
+      }),
+    });
+
+    // When a delivery source is put over a distribution ARN.
+    await logs.putDeliverySource({
+      input: {
+        name: sourceName,
+        resourceArn: "arn:aws:cloudfront::888888888888:distribution/E1EX",
+        logType: "ACCESS_LOGS",
+      },
+    });
+
+    // Then it is created. The account segment goes unread along with the
+    // distribution id, and a test about delivery alone needs neither.
+    assertNonNullable(logs.findDeliverySource(sourceName));
   });
 
   it("deletes a delivery source", async () => {

--- a/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
@@ -40,6 +40,7 @@ import { describe, it } from "vitest";
 import { SimSdk } from "../../../sdk/index.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import { simLogsDeliveryDistributionArn } from "../../../../test/logs/delivery-distribution-fixture.js";
 
 const logGroupName = "/aws/lambda/orders";
 const logStreamName = "2026/08/16/[$LATEST]abc";
@@ -235,17 +236,18 @@ describe("CloudWatch Logs SDK interception", () => {
 describe("CloudWatch Logs delivery SDK interception", () => {
   it("sets CloudFront logging up through the intercepted client", async () => {
     // Given an intercepted client in the one Region CloudFront delivery is
-    // set up from.
+    // set up from, and a distribution to deliver the logs of.
     using simSdk = new SimSdk();
     simSdk.intercept(CloudWatchLogsClient);
 
     const client = new CloudWatchLogsClient({ region: "us-east-1" });
+    const resourceArn = await simLogsDeliveryDistributionArn(simSdk.simAws);
 
     // When ordinary SDK code sets up standard logging v2 for a distribution.
     await client.send(
       new PutDeliverySourceCommand({
         name: "site-access-logs",
-        resourceArn: "arn:aws:cloudfront::123456789012:distribution/E1EX",
+        resourceArn,
         logType: "ACCESS_LOGS",
       }),
     );

--- a/src/service/logs/sim-logs-commands.ts
+++ b/src/service/logs/sim-logs-commands.ts
@@ -13,6 +13,10 @@ import { SimLogsDeliveryCommands } from "./command/delivery/sim-logs-delivery-co
 import { SimLogsDeliveryDestinationCommands } from "./command/delivery/sim-logs-delivery-destination-commands.js";
 import { SimLogsDeliverySourceCommands } from "./command/delivery/sim-logs-delivery-source-commands.js";
 import { SimLogsDeliveryDestinationStore } from "./delivery/sim-logs-delivery-destination-store.js";
+import {
+  type SimLogsDeliverySourceResources,
+  SimLogsUncheckedDeliverySourceResources,
+} from "./delivery/sim-logs-delivery-source-resources.js";
 import { SimLogsDeliverySourceStore } from "./delivery/sim-logs-delivery-source-store.js";
 import { SimLogsDeliveryStore } from "./delivery/sim-logs-delivery-store.js";
 import { SimLogsFilterLogEvents } from "./command/event/sim-logs-filter-log-events.js";
@@ -42,6 +46,13 @@ export interface SimLogsProperties {
    * none of them.
    */
   readonly subscriptionDestinations?: SimLogsSubscriptionDestinations;
+
+  /**
+   * What a delivery source's `resourceArn` is resolved against. A SimLogs
+   * built on its own has no simulated CloudFront to find a distribution in. It
+   * takes any ARN, the way it always did.
+   */
+  readonly deliverySourceResources?: SimLogsDeliverySourceResources;
 }
 
 /**
@@ -77,6 +88,7 @@ export class SimLogsCommands {
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       subscriptionDestinations = new SimLogsNoSubscriptionDestinations(),
+      deliverySourceResources = new SimLogsUncheckedDeliverySourceResources(),
     } = properties;
 
     const authorizer = new SimLogsAuthorizer({ iam, accountRegionScope });
@@ -136,6 +148,7 @@ export class SimLogsCommands {
       deliveries,
       authorizer,
       accountRegionScope,
+      resources: deliverySourceResources,
     });
     this.deliveryDestinations = new SimLogsDeliveryDestinationCommands({
       destinations: deliveryDestinations,

--- a/test/logs/delivery-distribution-fixture.ts
+++ b/test/logs/delivery-distribution-fixture.ts
@@ -1,0 +1,122 @@
+/**
+ * The CloudFront Distributions the delivery tests put delivery sources over.
+ *
+ * Simulated CloudWatch Logs resolves a delivery source's `resourceArn` in the
+ * account creating it. A test about delivery therefore needs a Distribution
+ * behind the ARN it names. Nothing is ever served from these, and the Origin
+ * is a custom one over a host name that answers nowhere. That spares every
+ * delivery test a Bucket it would never read.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { assertNonNullable } from "@kensio/smartass";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+
+/**
+ * Create a Distribution in the simulated account and return its ARN.
+ *
+ * The name separates one Distribution from another in a test that needs
+ * several, because a `CallerReference` belongs to one Distribution.
+ */
+export async function simLogsDeliveryDistributionArn(
+  simAws: SimAws,
+  name = "access-logs-site",
+): Promise<string> {
+  const created = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: name,
+        Comment: `Distribution for ${name}`,
+        Enabled: true,
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "delivery-origin",
+              DomainName: `${name}.example.test`,
+              CustomOriginConfig: {
+                HTTPPort: 80,
+                HTTPSPort: 443,
+                OriginProtocolPolicy: "https-only",
+              },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "delivery-origin",
+          ViewerProtocolPolicy: "allow-all",
+        },
+      },
+    }),
+  );
+
+  assertNonNullable(created.Distribution?.Id);
+
+  return simLogsDistributionArn(simAws, created.Distribution.Id);
+}
+
+/**
+ * The ARN of a Distribution id in the simulated account.
+ */
+export function simLogsDistributionArn(
+  simAws: SimAws,
+  distributionId: string,
+): string {
+  return `arn:aws:cloudfront::${simAws.account().accountId}:distribution/${distributionId}`;
+}
+
+/**
+ * The logical id of the Distribution a delivery template declares.
+ */
+export const deliveryDistributionLogicalId = "SiteDistribution";
+
+/**
+ * An `AWS::CloudFront::Distribution` for a delivery source to be over.
+ *
+ * A template that turns standard logging v2 on names a Distribution it
+ * declares itself. This is what goes in the template beside the three
+ * delivery Resources.
+ */
+export const deliveryDistributionResource = {
+  Type: "AWS::CloudFront::Distribution",
+  Properties: {
+    DistributionConfig: {
+      Enabled: true,
+      Origins: {
+        Items: [
+          {
+            Id: "delivery-origin",
+            DomainName: "site.example.test",
+            CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "delivery-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+    },
+  },
+};
+
+/**
+ * The `ResourceArn` of that Distribution, built the way CDK builds an ARN.
+ *
+ * `Ref` on an `AWS::CloudFront::Distribution` is the id it was given, and the
+ * ARN is assembled around that `Ref`. Reading one is also what makes the
+ * delivery source wait for the Distribution.
+ */
+export const deliveryDistributionResourceArn = {
+  "Fn::Join": [
+    "",
+    [
+      "arn:",
+      { Ref: "AWS::Partition" },
+      ":cloudfront::",
+      { Ref: "AWS::AccountId" },
+      ":distribution/",
+      { Ref: deliveryDistributionLogicalId },
+    ],
+  ],
+};


### PR DESCRIPTION
`PutDeliverySource` read the service segment of its `resourceArn` and stored the source without resolving the ARN to anything. A CloudFront delivery source over a distribution the simulated account never created was accepted, and so was one whose account segment named a different account. A template took the same path through `SimCfnDeliverySourceCreator`, so a stack that would fail in an account deployed clean here. The command now resolves a CloudFront `resourceArn` to a distribution of the account making the request and throws `ResourceNotFoundException` where there is none, which is the error the CloudWatch Logs API documents for a resource that does not exist. A `SimLogs` built on its own has no CloudFront to resolve in and keeps taking any ARN, so a test about delivery configuration alone still needs no distribution.

Resolves #993

## Notes

The resolver follows `SimCfViewerCertificateValidator`. `SimLogsDeliverySourceResources` is the collaborator, `SimAwsLogsDeliveryDistributions` is the wired implementation, and `SimLogsUncheckedDeliverySourceResources` is what a standalone `SimLogs` takes.

The account-segment check ships with the existence check because they are the same question. Both report `ResourceNotFoundException` with different messages.

The existing delivery tests all named a distribution that was never created, so they now build one. `test/logs/delivery-distribution-fixture.ts` holds both halves of that: an SDK helper returning a created Distribution's ARN, and the `AWS::CloudFront::Distribution` plus `Fn::Join` ARN that the template tests declare.

`Fn::Join` rather than `Fn::Sub` in the template fixture is deliberate. A resource property `Fn::Sub` mixing a pseudo parameter with a resource reference never resolves here, because `SimCfnResourceRecord` builds its property resolver without pseudo parameters and the template-wide pass discards the ones it resolved when it re-emits the unresolved expression. That is a separate bug and I will file it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CloudWatch Logs delivery sources now validate CloudFront distribution ARNs.
  - Delivery sources require an existing distribution in the same account.
  - Cross-stack references to valid distributions are supported.
  - Standalone log simulations continue accepting arbitrary resource ARNs.

- **Bug Fixes**
  - Clear resource-not-found errors are returned for missing or cross-account distributions.
  - Delivery examples and templates now use dynamically created distributions instead of fixed identifiers.

- **Documentation**
  - Updated delivery guidance and examples to reflect CloudFront distribution requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->