### PR TITLE
feat: simulate the Glue Data Catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ npm i -D @kensio/yulin
 - [ECR](https://yulinsim.dev/services/ecr/ "Simulated ECR docs")
 - [ECS](https://yulinsim.dev/services/ecs/ "Simulated ECS docs")
 - [EventBridge](https://yulinsim.dev/services/eventbridge/ "Simulated EventBridge docs")
+- [Glue](https://yulinsim.dev/services/glue/ "Simulated Glue Data Catalog docs")
 - [IAM](https://yulinsim.dev/services/iam/ "Simulated IAM docs")
 - [KMS](https://yulinsim.dev/services/kms/ "Simulated KMS docs")
 - [Lambda](https://yulinsim.dev/services/lambda/ "Simulated Lambda docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [ECS](https://yulinsim.dev/services/ecs/ "Simulated ECS usage docs")
 - [Elastic Load Balancing](https://yulinsim.dev/services/elbv2/ "Simulated Application Load Balancer usage docs")
 - [EventBridge](https://yulinsim.dev/services/eventbridge/ "Simulated EventBridge usage docs")
+- [Glue](https://yulinsim.dev/services/glue/ "Simulated Glue Data Catalog usage docs")
 - [IAM](https://yulinsim.dev/services/iam/ "Simulated IAM usage docs")
 - [Kinesis Data Firehose](https://yulinsim.dev/services/firehose/ "Simulated Kinesis Data Firehose usage docs")
 - [Kinesis Data Streams](https://yulinsim.dev/services/kinesis/ "Simulated Kinesis Data Streams usage docs")

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -8,7 +8,7 @@ to, including the Athena partition projection its parameters configure.
 A table here is a definition. The data it describes stays in S3, unread, and the catalog answers
 with what it was told to hold.
 
-Glue specific types are imported from the `@kensio/yulin/glue` subpath.
+Glue-specific types are imported from the `@kensio/yulin/glue` subpath.
 
 ## Deploying a database and a table
 
@@ -138,21 +138,38 @@ console.log(TableList?.[0]?.Name);
 
 ## Permissions
 
-Every Command authorizes through simulated IAM. A database operation authorizes against the database
-ARN, a table operation against the table ARN, and an operation naming no database against the
-catalog ARN.
+Every Command authorizes through simulated IAM. Data Catalog resources are a hierarchy with the
+catalog at the root, and an operation on one needs permission on that resource and on every ancestor
+of it. Reading a table needs the table, the database and the catalog, and a policy naming only the
+table ARN is denied. Deleting a database needs permission on every table in it as well, since the
+tables go with it.
 
 ```typescript sim-glue-permissions
 /**
  * A Role that may read one table and nothing else in the catalog.
  */
 
-import { GetTableCommand } from "@aws-sdk/client-glue";
+import {
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetTableCommand,
+} from "@aws-sdk/client-glue";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 
 import { SimAws } from "@kensio/yulin";
 
 const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const glue = simAws.glue();
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+);
+glue.createTable(
+  new CreateTableCommand({
+    DatabaseName: "site_logs",
+    TableInput: { Name: "access_logs" },
+  }),
+);
 
 await simAws.iam().createRole(
   new CreateRoleCommand({
@@ -180,26 +197,32 @@ await simAws.iam().putRolePolicy(
         {
           Effect: "Allow",
           Action: "glue:GetTable",
-          Resource:
+          Resource: [
+            "arn:aws:glue:us-east-1:111111111111:catalog",
+            "arn:aws:glue:us-east-1:111111111111:database/site_logs",
             "arn:aws:glue:us-east-1:111111111111:table/site_logs/access_logs",
+          ],
         },
       ],
     }),
   }),
 );
 
-simAws
-  .glue()
-  .getTable(
-    new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
-    {
-      caller: {
-        kind: "arn",
-        arn: "arn:aws:iam::111111111111:role/ReportingRole",
-      },
+const { Table } = glue.getTable(
+  new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+  {
+    caller: {
+      kind: "arn",
+      arn: "arn:aws:iam::111111111111:role/ReportingRole",
     },
-  );
+  },
+);
+
+// access_logs
+console.log(Table.Name);
 ```
+
+A policy listing only the table ARN is refused here, and refused by real Glue for the same reason.
 
 ## Available functionality
 
@@ -207,7 +230,7 @@ simAws
 - `CreateTable`, `GetTable`, `GetTables` and `DeleteTable`.
 - `AWS::Glue::Database` and `AWS::Glue::Table`, deployed and deleted with the stack.
 - `TableInput.Parameters`, `PartitionKeys` and `StorageDescriptor`, held and read back as declared.
-- IAM authorization on every Command.
+- IAM authorization on every Command, over the resource and its ancestors.
 
 ## Limitations
 

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -1,0 +1,238 @@
+# Simulated Glue
+
+Yulin includes a simulated Glue Data Catalog for tests and local development. It holds databases and
+tables, deploys them from `AWS::Glue::Database` and `AWS::Glue::Table`, and hands them back through
+`GetDatabase` and `GetTable`. A test can assert that a stack declared the table definition it meant
+to, including the Athena partition projection its parameters configure.
+
+A table here is a definition. The data it describes stays in S3, unread, and the catalog answers
+with what it was told to hold.
+
+Glue specific types are imported from the `@kensio/yulin/glue` subpath.
+
+## Deploying a database and a table
+
+A stack declares the database, and the table names it through `Ref`. Both read back through the SDK
+once the deploy finishes.
+
+```typescript sim-glue-cloudformation
+/**
+ * Deploying a Glue database and a table, then reading the table back.
+ */
+
+import { GetTableCommand } from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "analytics-stack",
+  template: {
+    Resources: {
+      LogDatabase: {
+        Type: "AWS::Glue::Database",
+        Properties: {
+          CatalogId: { Ref: "AWS::AccountId" },
+          DatabaseInput: { Name: "site_logs" },
+        },
+      },
+      LogTable: {
+        Type: "AWS::Glue::Table",
+        Properties: {
+          CatalogId: { Ref: "AWS::AccountId" },
+          DatabaseName: { Ref: "LogDatabase" },
+          TableInput: {
+            Name: "access_logs",
+            TableType: "EXTERNAL_TABLE",
+            PartitionKeys: [{ Name: "year", Type: "string" }],
+            StorageDescriptor: {
+              Columns: [{ Name: "status", Type: "int" }],
+              Location: "s3://site-logs/cloudfront/",
+            },
+            Parameters: {
+              "projection.enabled": "true",
+              "projection.year.type": "date",
+              "projection.year.format": "yyyy",
+              "projection.year.range": "2026,NOW",
+              // eslint-disable-next-line no-template-curly-in-string
+              "storage.location.template": "s3://site-logs/cloudfront/${year}/",
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const { Table } = simAws
+  .glue()
+  .getTable(
+    new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+  );
+
+// true
+console.log(Table.Parameters["projection.enabled"]);
+```
+
+Partition projection lives entirely in `TableInput.Parameters`. Those parameters are read into the
+table, and never recorded as ignored. A table whose parameters were dropped on the way in deploys
+green while projecting none of them, and a broken projection then passes the test written to catch
+it.
+
+`Ref` answers with the database name and with the table name.
+
+## Reading the catalog back
+
+`GetDatabase`, `GetDatabases`, `GetTable` and `GetTables` answer through the SDK. A `SimGlue` also
+carries `findDatabase`, `findTable`, `allDatabases` and `tablesInDatabase`, which read the same
+state without going through a Command or its authorization.
+
+The storage descriptor keeps its columns in the order they were declared, and the partition keys
+keep theirs. The two stay apart, the way real Glue keeps them. A partition key repeated among the
+storage descriptor's columns gives a table Athena refuses to query.
+
+## Intercepting a GlueClient
+
+An intercepted `GlueClient` reaches the simulated catalog, so code under test builds its own client
+and sends its own Commands.
+
+```typescript sim-glue-sdk-interception
+/**
+ * Ordinary Glue SDK code reaching the simulated catalog.
+ */
+
+import {
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetTablesCommand,
+  GlueClient,
+} from "@aws-sdk/client-glue";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(GlueClient);
+
+const client = new GlueClient({ region: "eu-west-2" });
+
+await client.send(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+);
+await client.send(
+  new CreateTableCommand({
+    DatabaseName: "site_logs",
+    TableInput: { Name: "access_logs" },
+  }),
+);
+
+const { TableList } = await client.send(
+  new GetTablesCommand({ DatabaseName: "site_logs" }),
+);
+
+// access_logs
+console.log(TableList?.[0]?.Name);
+```
+
+## Permissions
+
+Every Command authorizes through simulated IAM. A database operation authorizes against the database
+ARN, a table operation against the table ARN, and an operation naming no database against the
+catalog ARN.
+
+```typescript sim-glue-permissions
+/**
+ * A Role that may read one table and nothing else in the catalog.
+ */
+
+import { GetTableCommand } from "@aws-sdk/client-glue";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ReportingRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ReportingRole",
+    PolicyName: "ReadAccessLogs",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "glue:GetTable",
+          Resource:
+            "arn:aws:glue:us-east-1:111111111111:table/site_logs/access_logs",
+        },
+      ],
+    }),
+  }),
+);
+
+simAws
+  .glue()
+  .getTable(
+    new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+    {
+      caller: {
+        kind: "arn",
+        arn: "arn:aws:iam::111111111111:role/ReportingRole",
+      },
+    },
+  );
+```
+
+## Available functionality
+
+- `CreateDatabase`, `GetDatabase`, `GetDatabases` and `DeleteDatabase`.
+- `CreateTable`, `GetTable`, `GetTables` and `DeleteTable`.
+- `AWS::Glue::Database` and `AWS::Glue::Table`, deployed and deleted with the stack.
+- `TableInput.Parameters`, `PartitionKeys` and `StorageDescriptor`, held and read back as declared.
+- IAM authorization on every Command.
+
+## Limitations
+
+- **Partition projection is held, never evaluated.** The parameters read back as they were declared,
+  and no partition follows from a value range.
+- **No query reads a table.** SQL goes unparsed, no S3 prefix is listed, and no object is opened.
+- **`AWS::Glue::Crawler` is absent.** A crawler fills a catalog by reading objects, and every object
+  stays unread here. A template declaring one deploys, with the crawler recorded on the stack's
+  `skippedResources`.
+- **Partitions are described by projection alone.** `CreatePartition`, `GetPartitions` and
+  `BatchCreatePartition` have no counterpart here.
+- **A table keeps the definition it was created with.** `UpdateTable` and `UpdateDatabase` are
+  absent, and `GetTable` reports the creation time as the update time.
+- **`Fn::GetAtt Id` on a table is refused.** CloudFormation documents the attribute without
+  documenting what its value contains. A stand-in would differ from the value a real deploy
+  resolves.
+- **Names keep the case they were given.** Real Glue lowercases a database or table name for Hive
+  compatibility. A name that differs only by case is a different name here.
+- **Cross-account catalogs are refused.** A `CatalogId` naming another account is refused, in a
+  Command and in a template.
+- **Versions, statistics and Lake Formation are absent.** A table has no version history and no
+  column statistics, and IAM is the whole of the permission model.
+- **Iceberg and other open table formats are recorded, never built.** `OpenTableFormatInput` is
+  reported as ignored and the table is created as an ordinary one.
+- **Listings come back whole.** `GetDatabases` and `GetTables` answer with everything in creation
+  order. `MaxResults` and `NextToken` are absent.
+- **Connections, jobs, triggers, workflows and the Schema Registry are absent.** The Data Catalog is
+  the whole of the simulated surface.

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -244,9 +244,12 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
   `BatchCreatePartition` have no counterpart here.
 - **A table keeps the definition it was created with.** `UpdateTable` and `UpdateDatabase` are
   absent, and `GetTable` reports the creation time as the update time.
-- **`Fn::GetAtt Id` on a table is refused.** CloudFormation documents the attribute without
-  documenting what its value contains. A stand-in would differ from the value a real deploy
-  resolves.
+- **`Fn::GetAtt Id` on a table answers with a guess.** It resolves to the catalog id, the database
+  name and the table name joined with `|`, as in `111111111111|site_logs|access_logs`. This is the
+  one piece of behaviour here that nothing has checked against AWS. CloudFormation documents that
+  the attribute exists and documents nothing about its value, so a template asserting on it agrees
+  with this simulation and may disagree with a real deploy. Confirming it takes one stack deployed
+  to an account with `!GetAtt Table.Id` as an output.
 - **Names keep the case they were given.** Real Glue lowercases a database or table name for Hive
   compatibility. A name that differs only by case is a different name here.
 - **Cross-account catalogs are refused.** A `CatalogId` naming another account is refused, in a

--- a/docs/services/glue/sim-glue-cloudformation.example.ts
+++ b/docs/services/glue/sim-glue-cloudformation.example.ts
@@ -1,0 +1,59 @@
+/**
+ * Deploying a Glue database and a table, then reading the table back.
+ */
+
+import { GetTableCommand } from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "analytics-stack",
+  template: {
+    Resources: {
+      LogDatabase: {
+        Type: "AWS::Glue::Database",
+        Properties: {
+          CatalogId: { Ref: "AWS::AccountId" },
+          DatabaseInput: { Name: "site_logs" },
+        },
+      },
+      LogTable: {
+        Type: "AWS::Glue::Table",
+        Properties: {
+          CatalogId: { Ref: "AWS::AccountId" },
+          DatabaseName: { Ref: "LogDatabase" },
+          TableInput: {
+            Name: "access_logs",
+            TableType: "EXTERNAL_TABLE",
+            PartitionKeys: [{ Name: "year", Type: "string" }],
+            StorageDescriptor: {
+              Columns: [{ Name: "status", Type: "int" }],
+              Location: "s3://site-logs/cloudfront/",
+            },
+            Parameters: {
+              "projection.enabled": "true",
+              "projection.year.type": "date",
+              "projection.year.format": "yyyy",
+              "projection.year.range": "2026,NOW",
+              // eslint-disable-next-line no-template-curly-in-string
+              "storage.location.template": "s3://site-logs/cloudfront/${year}/",
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const { Table } = simAws
+  .glue()
+  .getTable(
+    new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+  );
+
+// true
+console.log(Table.Parameters["projection.enabled"]);

--- a/docs/services/glue/sim-glue-permissions.example.ts
+++ b/docs/services/glue/sim-glue-permissions.example.ts
@@ -2,12 +2,27 @@
  * A Role that may read one table and nothing else in the catalog.
  */
 
-import { GetTableCommand } from "@aws-sdk/client-glue";
+import {
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetTableCommand,
+} from "@aws-sdk/client-glue";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 
 import { SimAws } from "@kensio/yulin";
 
 const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const glue = simAws.glue();
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+);
+glue.createTable(
+  new CreateTableCommand({
+    DatabaseName: "site_logs",
+    TableInput: { Name: "access_logs" },
+  }),
+);
 
 await simAws.iam().createRole(
   new CreateRoleCommand({
@@ -35,22 +50,26 @@ await simAws.iam().putRolePolicy(
         {
           Effect: "Allow",
           Action: "glue:GetTable",
-          Resource:
+          Resource: [
+            "arn:aws:glue:us-east-1:111111111111:catalog",
+            "arn:aws:glue:us-east-1:111111111111:database/site_logs",
             "arn:aws:glue:us-east-1:111111111111:table/site_logs/access_logs",
+          ],
         },
       ],
     }),
   }),
 );
 
-simAws
-  .glue()
-  .getTable(
-    new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
-    {
-      caller: {
-        kind: "arn",
-        arn: "arn:aws:iam::111111111111:role/ReportingRole",
-      },
+const { Table } = glue.getTable(
+  new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+  {
+    caller: {
+      kind: "arn",
+      arn: "arn:aws:iam::111111111111:role/ReportingRole",
     },
-  );
+  },
+);
+
+// access_logs
+console.log(Table.Name);

--- a/docs/services/glue/sim-glue-permissions.example.ts
+++ b/docs/services/glue/sim-glue-permissions.example.ts
@@ -1,0 +1,56 @@
+/**
+ * A Role that may read one table and nothing else in the catalog.
+ */
+
+import { GetTableCommand } from "@aws-sdk/client-glue";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+
+await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ReportingRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ReportingRole",
+    PolicyName: "ReadAccessLogs",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "glue:GetTable",
+          Resource:
+            "arn:aws:glue:us-east-1:111111111111:table/site_logs/access_logs",
+        },
+      ],
+    }),
+  }),
+);
+
+simAws
+  .glue()
+  .getTable(
+    new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+    {
+      caller: {
+        kind: "arn",
+        arn: "arn:aws:iam::111111111111:role/ReportingRole",
+      },
+    },
+  );

--- a/docs/services/glue/sim-glue-sdk-interception.example.ts
+++ b/docs/services/glue/sim-glue-sdk-interception.example.ts
@@ -1,0 +1,34 @@
+/**
+ * Ordinary Glue SDK code reaching the simulated catalog.
+ */
+
+import {
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetTablesCommand,
+  GlueClient,
+} from "@aws-sdk/client-glue";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+simSdk.intercept(GlueClient);
+
+const client = new GlueClient({ region: "eu-west-2" });
+
+await client.send(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+);
+await client.send(
+  new CreateTableCommand({
+    DatabaseName: "site_logs",
+    TableInput: { Name: "access_logs" },
+  }),
+);
+
+const { TableList } = await client.send(
+  new GetTablesCommand({ DatabaseName: "site_logs" }),
+);
+
+// access_logs
+console.log(TableList?.[0]?.Name);

--- a/package.json
+++ b/package.json
@@ -108,6 +108,10 @@
       "import": "./dist/service/eventbridge/index.js",
       "types": "./dist/service/eventbridge/index.d.ts"
     },
+    "./glue": {
+      "import": "./dist/service/glue/index.js",
+      "types": "./dist/service/glue/index.d.ts"
+    },
     "./iam": {
       "import": "./dist/service/iam/index.js",
       "types": "./dist/service/iam/index.d.ts"
@@ -227,6 +231,7 @@
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.1109.0",
     "@aws-sdk/client-eventbridge": "^3.1109.0",
     "@aws-sdk/client-firehose": "^3.1115.0",
+    "@aws-sdk/client-glue": "^3.1116.0",
     "@aws-sdk/client-iam": "^3.1101.0",
     "@aws-sdk/client-kinesis": "^3.1115.0",
     "@aws-sdk/client-kms": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@aws-sdk/client-firehose':
         specifier: ^3.1115.0
         version: 3.1115.0
+      '@aws-sdk/client-glue':
+        specifier: ^3.1116.0
+        version: 3.1116.0
       '@aws-sdk/client-iam':
         specifier: ^3.1101.0
         version: 3.1112.0
@@ -363,6 +366,10 @@ packages:
 
   '@aws-sdk/client-firehose@3.1115.0':
     resolution: {integrity: sha512-tgK3cwUN6LBOLZBZygICRJ4XkUvOhp3Nzd99Nz7NqsUnOgqSCtvMv5j+zJKG/eiEUDv7CeTUTkWRCEdyFZmFlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-glue@3.1116.0':
+    resolution: {integrity: sha512-tWlVsxEblM2a2pykQ1qLoEdTR+e49qUgtP2apoXIxnBUf/lHppdrgHN0tufCbsrmO2pCc2dy+yi5D6bytOZ/jg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-iam@3.1112.0':
@@ -3839,6 +3846,17 @@ snapshots:
       '@smithy/core': 3.33.2
       '@smithy/fetch-http-handler': 5.7.2
       '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-glue@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -80,6 +80,7 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     "EventBridge",
     (scoped): SimSdkCommandRouter => scoped.eventBridge().sdkCommandRouter(),
   ],
+  ["Glue", (scoped): SimSdkCommandRouter => scoped.glue().sdkCommandRouter()],
   ["IAM", (scoped): SimSdkCommandRouter => scoped.iam().sdkCommandRouter()],
   [
     "Firehose",

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -2,6 +2,7 @@ import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-sco
 import { SimBedrock } from "../../bedrock/index.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimFirehose } from "../../firehose/index.js";
+import { SimGlue } from "../../glue/index.js";
 import { SimKinesis } from "../../kinesis/index.js";
 import { SimSecretsManager } from "../../secretsmanager/index.js";
 import { SimSqs } from "../../sqs/index.js";
@@ -74,6 +75,17 @@ export class SimAwsSelfContainedServiceBuilder {
    */
   createKinesis(scope: SimAwsAccountRegionContainer): SimKinesis {
     return new SimKinesis(this.scoped(scope));
+  }
+
+  /**
+   * Create simulated Glue for an Account Region scope.
+   *
+   * A Data Catalog belongs to one account, and a database ARN names the
+   * region. Nothing here reads an S3 object or runs a query, so the catalog
+   * reaches no other simulated service.
+   */
+  createGlue(scope: SimAwsAccountRegionContainer): SimGlue {
+    return new SimGlue(this.scoped(scope));
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -25,6 +25,7 @@ import type { SimElbV2 } from "../../elbv2/index.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
 import type { SimFirehose } from "../../firehose/index.js";
+import type { SimGlue } from "../../glue/index.js";
 import type { SimKinesis } from "../../kinesis/index.js";
 import type { SimStepFunctions } from "../../stepfunctions/index.js";
 import type { SimKms } from "../../kms/index.js";
@@ -236,6 +237,11 @@ export class SimAwsServiceFactory {
   /** Create simulated Kinesis Data Firehose for an Account Region scope. */
   createFirehose(scope: SimAwsAccountRegionContainer): SimFirehose {
     return this.selfContainedServices.createFirehose(scope);
+  }
+
+  /** Create simulated Glue for an Account Region scope. */
+  createGlue(scope: SimAwsAccountRegionContainer): SimGlue {
+    return this.selfContainedServices.createGlue(scope);
   }
 
   /** Create simulated Kinesis Data Streams for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -31,6 +31,7 @@ import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimFirehose } from "../firehose/index.js";
+import type { SimGlue } from "../glue/index.js";
 import type { SimKinesis } from "../kinesis/index.js";
 import type { SimStepFunctions } from "../stepfunctions/index.js";
 import type { SimKms } from "../kms/index.js";
@@ -196,6 +197,11 @@ export class SimAwsAccountRegionContainer {
   /** Get simulated IAM for this account. */
   iam(): SimIam {
     return this.memo.getOrCreate("iam", () => this.factory.createIam(this));
+  }
+
+  /** Get simulated Glue for this account and region. */
+  glue(): SimGlue {
+    return this.memo.getOrCreate("glue", () => this.factory.createGlue(this));
   }
 
   /** Get simulated Kinesis Data Firehose for this account and region. */

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -17,6 +17,7 @@ import type { SimEcs } from "../ecs/index.js";
 import type { SimElbV2 } from "../elbv2/index.js";
 import type { SimIam } from "../iam/index.js";
 import type { SimFirehose } from "../firehose/index.js";
+import type { SimGlue } from "../glue/index.js";
 import type { SimKinesis } from "../kinesis/index.js";
 import type { SimStepFunctions } from "../stepfunctions/index.js";
 import type { SimKms } from "../kms/index.js";
@@ -139,6 +140,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated IAM in the default Account scope. */
   iam(): SimIam {
     return this.defaultAccountRegionScope().iam();
+  }
+
+  /** Get simulated Glue in the default Account Region scope. */
+  glue(): SimGlue {
+    return this.defaultAccountRegionScope().glue();
   }
 
   /** Get simulated Kinesis Data Firehose in the default Account Region scope. */

--- a/src/service/cloudformation/resource/cfn/glue/sim-glue-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/glue/sim-glue-cfn-value-adapter.ts
@@ -1,0 +1,31 @@
+import { SimGlueDatabase } from "../../../../glue/database/sim-glue-database.js";
+import { SimGlueTable } from "../../../../glue/table/sim-glue-table.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import { SimGlueDatabaseCfn } from "./sim-glue-database-cfn.js";
+import { SimGlueTableCfn } from "./sim-glue-table-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Glue Resource.
+ */
+export function glueValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (
+    properties.type === "AWS::Glue::Database" &&
+    properties.simResource instanceof SimGlueDatabase
+  ) {
+    return new SimGlueDatabaseCfn({ database: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Glue::Table" &&
+    properties.simResource instanceof SimGlueTable
+  ) {
+    return new SimGlueTableCfn({ table: properties.simResource });
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/glue/sim-glue-database-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/glue/sim-glue-database-cfn.ts
@@ -1,0 +1,39 @@
+import type { SimGlueDatabase } from "../../../../glue/database/sim-glue-database.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimGlueDatabaseCfnProperties {
+  readonly database: SimGlueDatabase;
+}
+
+/**
+ * CloudFormation-facing values for a simulated Glue database.
+ */
+export class SimGlueDatabaseCfn implements SimCfnResourceValueAdapter {
+  readonly #database: SimGlueDatabase;
+
+  constructor(properties: SimGlueDatabaseCfnProperties) {
+    this.#database = properties.database;
+  }
+
+  /**
+   * AWS::Glue::Database Ref returns the database name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#database.name;
+  }
+
+  /**
+   * AWS::Glue::Database has no Fn::GetAtt attributes.
+   *
+   * The CloudFormation reference lists none, and `CfnDatabase` in the CDK
+   * exposes none either, so an attribute asked for here is a mistake in the
+   * template rather than a gap in the simulation.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `AWS::Glue::Database has no attributes, and ${attributeName} was ` +
+        `asked for`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/glue/sim-glue-table-cfn-id.ts
+++ b/src/service/cloudformation/resource/cfn/glue/sim-glue-table-cfn-id.ts
@@ -1,0 +1,23 @@
+import type { SimGlueTable } from "../../../../glue/table/sim-glue-table.js";
+
+/**
+ * What `Fn::GetAtt Id` answers with for an AWS::Glue::Table.
+ *
+ * **This format is a guess, and nothing has checked it against AWS.**
+ * CloudFormation documents that the attribute exists and documents nothing
+ * about the value behind it, and the CDK's generated `CfnTable.attrId` carries
+ * no description either. A template asserting on this value will agree with
+ * this simulation and may disagree with a real deploy.
+ *
+ * The guess is the Data Catalog's own identity for a table, which is the
+ * catalog, the database and the name, joined the way Glue's CloudFormation
+ * handlers join a composite identifier. A table id leaving the catalog out
+ * would not tell two federated catalogs apart.
+ *
+ * Confirming it takes one stack deployed to a real account with
+ * `!GetAtt Table.Id` as an output. The format lives here alone, so correcting
+ * it is this function and the test naming it.
+ */
+export function simGlueTableCfnId(table: SimGlueTable): string {
+  return [table.catalogId, table.databaseName, table.name].join("|");
+}

--- a/src/service/cloudformation/resource/cfn/glue/sim-glue-table-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/glue/sim-glue-table-cfn.ts
@@ -1,0 +1,46 @@
+import type { SimGlueTable } from "../../../../glue/table/sim-glue-table.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimGlueTableCfnProperties {
+  readonly table: SimGlueTable;
+}
+
+/**
+ * CloudFormation-facing values for a simulated Glue table.
+ */
+export class SimGlueTableCfn implements SimCfnResourceValueAdapter {
+  readonly #table: SimGlueTable;
+
+  constructor(properties: SimGlueTableCfnProperties) {
+    this.#table = properties.table;
+  }
+
+  /**
+   * AWS::Glue::Table Ref returns the table name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#table.name;
+  }
+
+  /**
+   * AWS::Glue::Table attributes.
+   *
+   * `Id` is the one attribute CloudFormation documents, and it documents no
+   * format for its value. Answering with a plausible one would put a string in
+   * a template that a deploy to real AWS then disagrees with, so it is refused
+   * until the real value has been observed.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "Id") {
+      throw new Error(
+        `AWS::Glue::Table Fn::GetAtt Id is not simulated. CloudFormation ` +
+          `documents the attribute without documenting what its value ` +
+          `contains, and a stand-in would differ from the value a real ` +
+          `deploy resolves`,
+      );
+    }
+
+    throw new Error(`Unsupported AWS::Glue::Table attribute ${attributeName}`);
+  }
+}

--- a/src/service/cloudformation/resource/cfn/glue/sim-glue-table-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/glue/sim-glue-table-cfn.ts
@@ -1,6 +1,7 @@
 import type { SimGlueTable } from "../../../../glue/table/sim-glue-table.js";
 import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
 import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+import { simGlueTableCfnId } from "./sim-glue-table-cfn-id.js";
 
 interface SimGlueTableCfnProperties {
   readonly table: SimGlueTable;
@@ -27,18 +28,12 @@ export class SimGlueTableCfn implements SimCfnResourceValueAdapter {
    * AWS::Glue::Table attributes.
    *
    * `Id` is the one attribute CloudFormation documents, and it documents no
-   * format for its value. Answering with a plausible one would put a string in
-   * a template that a deploy to real AWS then disagrees with, so it is refused
-   * until the real value has been observed.
+   * format for its value. `simGlueTableCfnId` says what this answers with and
+   * why that value is a guess.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
     if (attributeName === "Id") {
-      throw new Error(
-        `AWS::Glue::Table Fn::GetAtt Id is not simulated. CloudFormation ` +
-          `documents the attribute without documenting what its value ` +
-          `contains, and a stand-in would differ from the value a real ` +
-          `deploy resolves`,
-      );
+      return simGlueTableCfnId(this.#table);
     }
 
     throw new Error(`Unsupported AWS::Glue::Table attribute ${attributeName}`);

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -12,6 +12,7 @@ import { ecsValueAdapter } from "./ecs/sim-ecs-cfn-value-adapter.js";
 import { elbV2ValueAdapter } from "./elasticloadbalancingv2/sim-elbv2-cfn-value-adapter.js";
 import { eventBridgeValueAdapter } from "./events/sim-event-bridge-cfn-value-adapter.js";
 import { firehoseValueAdapter } from "./firehose/sim-firehose-cfn-value-adapter.js";
+import { glueValueAdapter } from "./glue/sim-glue-cfn-value-adapter.js";
 import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kinesisValueAdapter } from "./kinesis/sim-kinesis-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
@@ -59,6 +60,7 @@ export const simCfnServiceValueAdapters: readonly ((
   elbV2ValueAdapter,
   eventBridgeValueAdapter,
   firehoseValueAdapter,
+  glueValueAdapter,
   iamValueAdapter,
   kinesisValueAdapter,
   kmsValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -85,6 +85,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.elbV2().cfnResourceFactory(),
   ],
   [
+    "Glue",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.glue().cfnResourceFactory(),
+  ],
+  [
     "IAM",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.iam().cfnResourceFactory(),

--- a/src/service/glue/README.md
+++ b/src/service/glue/README.md
@@ -45,9 +45,11 @@ behaviour for is reported through `ignoreProperty` and the resource is created a
 argument in issue #273. A property of the wrong type fails the deploy. A template declaring
 `TableInput` as a string is broken, and being ahead of the simulation is a different thing.
 
-**`Fn::GetAtt Id` on a table is refused.** CloudFormation documents the attribute and documents
-nothing about the value behind it. Answering with a plausible string would put a value in a template
-that a real deploy then disagrees with.
+**`Fn::GetAtt Id` on a table is a guess, and the only guess here.** CloudFormation documents the
+attribute and documents nothing about the value behind it, so `simGlueTableCfnId` joins the catalog
+id, the database name and the table name and says in its own comment that nothing has checked that
+against AWS. The format lives in that one function, so correcting it is that function and the test
+naming the value.
 
 **A `CatalogId` naming another account is refused.** Creating the resource in this account's catalog
 would give a template that deploys and a catalog holding something the template never asked for.

--- a/src/service/glue/README.md
+++ b/src/service/glue/README.md
@@ -1,0 +1,59 @@
+# Simulated Glue
+
+The Glue Data Catalog, holding databases and the table definitions inside them.
+
+Usage docs are at [docs/services/glue/](../../../docs/services/glue/README.md).
+
+## What this service is for
+
+A table is metadata about a dataset. The dataset stays in S3, unread, and no SQL is parsed or
+planned here. The whole of the observable behaviour is what the catalog was told to hold and what it
+hands back.
+
+That puts the weight on `TableInput.Parameters`. Athena partition projection is configured entirely
+through table parameters. A table created without them looks deployed while configuring none of it,
+and a projection with a mistake in it then passes the test written to catch it. The CloudFormation
+property reader treats those parameters as behaviour, alongside the storage descriptor and the
+partition keys.
+
+## Layout
+
+- `sim-glue.ts` is the facade. It holds the two stores, delegates each SDK Command to a command
+  class, and hands out the SDK router and the CloudFormation factory.
+- `database/` and `table/` hold the stored shapes and their stores. Tables are keyed by database
+  name and then by table name. A database's tables go with it when it is deleted, and two databases
+  may each hold a table of the same name.
+- `command/` is one directory per resource kind, holding the local structural command types, the
+  handler class, and the detail mapper deciding what a `Get` reports.
+- `cfn/` reads `AWS::Glue::Database` and `AWS::Glue::Table` properties and creates from them.
+- `write/sim-glue-catalog-writer.ts` is how CloudFormation writes to the catalog. A deploy happens
+  as CloudFormation, and never as the caller a later request carries, so a Resource creator goes
+  through here and skips the IAM authorization an SDK Command applies. The store refusals still
+  apply. A stack declaring two tables of one name in one database fails the way two `CreateTable`
+  calls would.
+- `arn/sim-glue-arn.ts` builds the three ARN forms IAM policies are written against.
+
+## Decisions worth knowing
+
+**A response leaves absent fields out.** The command detail mappers run their result through
+`definedEntries`. A table created without a description then carries no `Description` key at all.
+Real AWS responses are that shape, and an assertion comparing a response against what a caller
+declared trips over keys nobody set otherwise.
+
+**Unknown properties are recorded, malformed ones are refused.** A property this simulation has no
+behaviour for is reported through `ignoreProperty` and the resource is created anyway, which is what
+#273 argues for. A property of the wrong type fails the deploy. A template declaring `TableInput` as
+a string is broken, and being ahead of the simulation is a different thing.
+
+**`Fn::GetAtt Id` on a table is refused.** CloudFormation documents the attribute and documents
+nothing about the value behind it. Answering with a plausible string would put a value in a template
+that a real deploy then disagrees with.
+
+**A `CatalogId` naming another account is refused.** Creating the resource in this account's catalog
+would give a template that deploys and a catalog holding something the template never asked for.
+
+## What is deliberately absent
+
+Crawlers, partition registration, table versions, column statistics, Lake Formation, connections,
+jobs, triggers, workflows and the Schema Registry. Every one of them needs something outside the
+catalog, and most need data read back. The Limitations list in the usage docs is the full account.

--- a/src/service/glue/README.md
+++ b/src/service/glue/README.md
@@ -41,9 +41,9 @@ Real AWS responses are that shape, and an assertion comparing a response against
 declared trips over keys nobody set otherwise.
 
 **Unknown properties are recorded, malformed ones are refused.** A property this simulation has no
-behaviour for is reported through `ignoreProperty` and the resource is created anyway, which is what
-#273 argues for. A property of the wrong type fails the deploy. A template declaring `TableInput` as
-a string is broken, and being ahead of the simulation is a different thing.
+behaviour for is reported through `ignoreProperty` and the resource is created anyway, which is the
+argument in issue #273. A property of the wrong type fails the deploy. A template declaring
+`TableInput` as a string is broken, and being ahead of the simulation is a different thing.
 
 **`Fn::GetAtt Id` on a table is refused.** CloudFormation documents the attribute and documents
 nothing about the value behind it. Answering with a plausible string would put a value in a template

--- a/src/service/glue/arn/sim-glue-arn.ts
+++ b/src/service/glue/arn/sim-glue-arn.ts
@@ -1,0 +1,40 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The start of every Glue ARN in one account and region.
+ */
+export function simGlueArnPrefix(scope: SimAwsAccountRegionScope): string {
+  return `arn:aws:glue:${scope.regionName}:${scope.accountId}:`;
+}
+
+/**
+ * The ARN of the Data Catalog itself.
+ *
+ * An operation that names no particular database authorizes against this. Real
+ * Glue policies name the catalog alongside the databases and tables a
+ * principal may reach, so a policy written for real Glue already carries it.
+ */
+export function simGlueCatalogArn(scope: SimAwsAccountRegionScope): string {
+  return `${simGlueArnPrefix(scope)}catalog`;
+}
+
+/**
+ * The ARN of a database.
+ */
+export function simGlueDatabaseArn(
+  scope: SimAwsAccountRegionScope,
+  databaseName: string,
+): string {
+  return `${simGlueArnPrefix(scope)}database/${databaseName}`;
+}
+
+/**
+ * The ARN of a table, which names the database holding it.
+ */
+export function simGlueTableArn(
+  scope: SimAwsAccountRegionScope,
+  databaseName: string,
+  tableName: string,
+): string {
+  return `${simGlueArnPrefix(scope)}table/${databaseName}/${tableName}`;
+}

--- a/src/service/glue/arn/sim-glue-authorized-resources.ts
+++ b/src/service/glue/arn/sim-glue-authorized-resources.ts
@@ -1,0 +1,49 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  simGlueCatalogArn,
+  simGlueDatabaseArn,
+  simGlueTableArn,
+} from "./sim-glue-arn.js";
+
+/**
+ * Every ARN an operation on a Data Catalog resource has to be allowed on.
+ *
+ * A resource needs permission on itself and on all of its ancestors, and a
+ * delete needs permission on its children too. These build the list each
+ * operation authorizes against, outermost first, so a refusal names the
+ * outermost resource the policy left out.
+ *
+ * https://docs.aws.amazon.com/glue/latest/dg/glue-specifying-resource-arns.html
+ */
+export function simGlueDatabaseResources(
+  scope: SimAwsAccountRegionScope,
+  databaseName: string,
+): readonly string[] {
+  return [simGlueCatalogArn(scope), simGlueDatabaseArn(scope, databaseName)];
+}
+
+/** The catalog, the database and the table. */
+export function simGlueTableResources(
+  scope: SimAwsAccountRegionScope,
+  databaseName: string,
+  tableName: string,
+): readonly string[] {
+  return [
+    ...simGlueDatabaseResources(scope, databaseName),
+    simGlueTableArn(scope, databaseName, tableName),
+  ];
+}
+
+/** The catalog, the database, and every table going down with it. */
+export function simGlueDatabaseDeletionResources(
+  scope: SimAwsAccountRegionScope,
+  databaseName: string,
+  tableNames: readonly string[],
+): readonly string[] {
+  return [
+    ...simGlueDatabaseResources(scope, databaseName),
+    ...tableNames.map((tableName) =>
+      simGlueTableArn(scope, databaseName, tableName),
+    ),
+  ];
+}

--- a/src/service/glue/cfn/database/sim-cfn-glue-database-creator.ts
+++ b/src/service/glue/cfn/database/sim-cfn-glue-database-creator.ts
@@ -1,0 +1,62 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimGlueDatabase } from "../../database/sim-glue-database.js";
+import type { SimGlue } from "../../sim-glue.js";
+import { requireSimCfnGlueCatalogId } from "../sim-cfn-glue-catalog-id.js";
+import { SimCfnGlueDatabaseProperties } from "./sim-cfn-glue-database-properties.js";
+
+interface SimCfnGlueDatabaseCreatorProperties {
+  readonly glue: SimGlue;
+  readonly catalogId: string;
+}
+
+/**
+ * Creates simulated databases from AWS::Glue::Database Resources.
+ */
+export class SimCfnGlueDatabaseCreator {
+  readonly #glue: SimGlue;
+  readonly #catalogId: string;
+
+  constructor(properties: SimCfnGlueDatabaseCreatorProperties) {
+    this.#glue = properties.glue;
+    this.#catalogId = properties.catalogId;
+  }
+
+  /**
+   * Create a database from an AWS::Glue::Database Resource.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimGlueDatabase {
+    const databaseProperties = new SimCfnGlueDatabaseProperties({
+      resource,
+      properties,
+    });
+
+    requireSimCfnGlueCatalogId({
+      resourceType: "AWS::Glue::Database",
+      logicalId: resource.logicalId,
+      declared: databaseProperties.catalogId(),
+      simulated: this.#catalogId,
+    });
+
+    const databaseName = databaseProperties.databaseName();
+    const databaseInput = databaseProperties.databaseInput();
+
+    databaseProperties.recordIgnoredProperties();
+
+    return this.#glue
+      .catalogWriter()
+      .createDatabase(databaseName, databaseInput);
+  }
+
+  /**
+   * Delete a database created from an AWS::Glue::Database Resource.
+   *
+   * The tables in it go with it, as they do in an account.
+   */
+  delete(database: SimGlueDatabase): void {
+    this.#glue.catalogWriter().deleteDatabase(database.name);
+  }
+}

--- a/src/service/glue/cfn/database/sim-cfn-glue-database-properties.ts
+++ b/src/service/glue/cfn/database/sim-cfn-glue-database-properties.ts
@@ -1,0 +1,96 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimGlueDatabaseInput } from "../../database/sim-glue-database-store.js";
+import { glueCfnPropertyError } from "../sim-cfn-glue-property-error.js";
+import { SimCfnGlueValues } from "../sim-cfn-glue-values.js";
+import { SimCfnGlueDatabaseRules } from "./sim-cfn-glue-database-rules.js";
+
+const resourceType = "AWS::Glue::Database";
+
+interface SimCfnGlueDatabasePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Glue::Database CloudFormation properties.
+ */
+export class SimCfnGlueDatabaseProperties {
+  readonly #resource: SimCfnResource;
+  readonly #properties: SimCfnTemplateValueRecord;
+  readonly #values: SimCfnGlueValues;
+
+  constructor(properties: SimCfnGlueDatabasePropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#properties = properties.properties;
+    this.#values = new SimCfnGlueValues((reason) =>
+      glueCfnPropertyError(resourceType, properties.resource.logicalId, reason),
+    );
+  }
+
+  /** The catalog id the template names, when it names one. */
+  catalogId(): string | undefined {
+    return this.#values.optionalString(
+      this.#properties["CatalogId"],
+      "CatalogId",
+    );
+  }
+
+  /**
+   * The database name.
+   *
+   * `DatabaseInput.Name` is what CDK writes. A template may also carry a
+   * top-level `DatabaseName`, which is used when the input carries no name of
+   * its own. An unnamed database is named after the stack and the logical ID,
+   * lowercased, since Glue names are lowercase for Hive compatibility.
+   */
+  databaseName(): string {
+    const values = this.#values;
+    const stackName = this.#resource.stackName ?? "stack";
+
+    return (
+      values.optionalString(this.#input()["Name"], "DatabaseInput.Name") ??
+      values.optionalString(this.#properties["DatabaseName"], "DatabaseName") ??
+      `${stackName}-${this.#resource.logicalId}`.toLowerCase()
+    );
+  }
+
+  /** What the database is created with, beyond its name. */
+  databaseInput(): SimGlueDatabaseInput {
+    const input = this.#input();
+
+    return {
+      description: this.#values.optionalString(
+        input["Description"],
+        "DatabaseInput.Description",
+      ),
+      locationUri: this.#values.optionalString(
+        input["LocationUri"],
+        "DatabaseInput.LocationUri",
+      ),
+      parameters: this.#values.optionalParameters(
+        input["Parameters"],
+        "DatabaseInput.Parameters",
+      ),
+    };
+  }
+
+  /** Record the properties the database is created without acting on. */
+  recordIgnoredProperties(): void {
+    new SimCfnGlueDatabaseRules({
+      properties: this.#properties,
+      input: this.#input(),
+      ignorer: this.#resource,
+    }).apply();
+  }
+
+  #input(): SimCfnTemplateValueRecord {
+    const input = this.#properties["DatabaseInput"];
+
+    if (input === undefined) {
+      return {};
+    }
+
+    return this.#values.record(input, "DatabaseInput");
+  }
+}

--- a/src/service/glue/cfn/database/sim-cfn-glue-database-properties.ts
+++ b/src/service/glue/cfn/database/sim-cfn-glue-database-properties.ts
@@ -88,7 +88,7 @@ export class SimCfnGlueDatabaseProperties {
     const input = this.#properties["DatabaseInput"];
 
     if (input === undefined) {
-      return {};
+      throw this.#values.refuse("DatabaseInput is required");
     }
 
     return this.#values.record(input, "DatabaseInput");

--- a/src/service/glue/cfn/database/sim-cfn-glue-database-rules.ts
+++ b/src/service/glue/cfn/database/sim-cfn-glue-database-rules.ts
@@ -1,0 +1,61 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { unsimulatedDatabaseInputReasons } from "./sim-cfn-glue-database-unsimulated-properties.js";
+
+const readNames = new Set(["CatalogId", "DatabaseInput", "DatabaseName"]);
+
+const readInputNames = new Set([
+  "Name",
+  "Description",
+  "LocationUri",
+  "Parameters",
+]);
+
+interface SimCfnGlueDatabaseRulesProperties {
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly input: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}
+
+/**
+ * What a database Resource is created without acting on.
+ */
+export class SimCfnGlueDatabaseRules {
+  readonly #properties: SimCfnTemplateValueRecord;
+  readonly #input: SimCfnTemplateValueRecord;
+  readonly #ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnGlueDatabaseRulesProperties) {
+    this.#properties = properties.properties;
+    this.#input = properties.input;
+    this.#ignorer = properties.ignorer;
+  }
+
+  /** Record every property the database is created without. */
+  apply(): void {
+    for (const name of Object.keys(this.#properties)) {
+      if (!readNames.has(name)) {
+        this.#ignore(name, "AWS::Glue::Database");
+      }
+    }
+
+    for (const name of Object.keys(this.#input)) {
+      if (!readInputNames.has(name)) {
+        this.#ignore(`DatabaseInput.${name}`, "DatabaseInput", name);
+      }
+    }
+  }
+
+  #ignore(path: string, owner: string, name = path): void {
+    const reason = unsimulatedDatabaseInputReasons.get(name);
+
+    this.#ignorer.ignoreProperty(
+      path,
+      reason === undefined
+        ? `${path} is not a ${owner} property simulated Glue knows about, ` +
+            `so the database is created without it`
+        : `${path} is a real ${owner} property simulated Glue does not act ` +
+            `on: ${reason}`,
+    );
+  }
+}

--- a/src/service/glue/cfn/database/sim-cfn-glue-database-unsimulated-properties.ts
+++ b/src/service/glue/cfn/database/sim-cfn-glue-database-unsimulated-properties.ts
@@ -1,0 +1,25 @@
+/**
+ * The AWS::Glue::Database DatabaseInput properties this simulation has nothing
+ * to act on, and why.
+ *
+ * Each of them points the database somewhere outside this account's catalog,
+ * or grants something on it. Nothing here federates or authorizes at that
+ * level, so a database carrying one is created without it.
+ */
+export const unsimulatedDatabaseInputReasons: ReadonlyMap<string, string> =
+  new Map([
+    [
+      "CreateTableDefaultPermissions",
+      "Lake Formation permissions are not simulated, so nothing is granted " +
+        "on a table created in this database",
+    ],
+    [
+      "TargetDatabase",
+      "a database linking to another catalog's database is not simulated, so " +
+        "this one holds only the tables created in it",
+    ],
+    [
+      "FederatedDatabase",
+      "no federated source is reached, so a federated database holds nothing",
+    ],
+  ]);

--- a/src/service/glue/cfn/sim-cfn-glue-catalog-id.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-catalog-id.ts
@@ -1,0 +1,35 @@
+import { glueCfnPropertyError } from "./sim-cfn-glue-property-error.js";
+
+interface SimCfnGlueCatalogIdProperties {
+  readonly resourceType: string;
+  readonly logicalId: string;
+  readonly declared: string | undefined;
+  readonly simulated: string;
+}
+
+/**
+ * Check the catalog a Resource names is the one this simulation holds.
+ *
+ * `CatalogId` is the account whose Data Catalog the database or table belongs
+ * to, and CDK writes the deploying account into it. Nothing here crosses
+ * accounts, so a catalog id belonging to another account is refused. Creating
+ * the resource in this account instead would give a template that deploys and
+ * a catalog holding something the template never asked it to.
+ */
+export function requireSimCfnGlueCatalogId(
+  properties: SimCfnGlueCatalogIdProperties,
+): void {
+  const { declared, simulated } = properties;
+
+  if (declared === undefined || declared === simulated) {
+    return;
+  }
+
+  throw glueCfnPropertyError(
+    properties.resourceType,
+    properties.logicalId,
+    `CatalogId ${declared} names another account's Data Catalog, and this ` +
+      `simulated Glue holds the catalog of account ${simulated}. ` +
+      `Cross-account Data Catalog access is not simulated.`,
+  );
+}

--- a/src/service/glue/cfn/sim-cfn-glue-catalog.iso.test.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-catalog.iso.test.ts
@@ -1,0 +1,201 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * Where a projected partition's objects sit, written the way Athena reads it.
+ */
+// oxlint-disable-next-line no-template-curly-in-string -- Athena projection template, not a JavaScript template.
+const locationTemplate = "s3://site-logs/cloudfront/${year}/${month}/";
+
+/**
+ * A stack laying out CloudFront access logs the way a delivery writes them,
+ * read back with Athena partition projection rather than registered
+ * partitions.
+ */
+const catalogTemplate = {
+  Resources: {
+    LogDatabase: {
+      Type: "AWS::Glue::Database",
+      Properties: {
+        CatalogId: { Ref: "AWS::AccountId" },
+        DatabaseInput: {
+          Name: "site_logs",
+          Description: "CloudFront access logs",
+        },
+      },
+    },
+    LogTable: {
+      Type: "AWS::Glue::Table",
+      Properties: {
+        CatalogId: { Ref: "AWS::AccountId" },
+        DatabaseName: { Ref: "LogDatabase" },
+        TableInput: {
+          Name: "access_logs",
+          TableType: "EXTERNAL_TABLE",
+          PartitionKeys: [
+            { Name: "year", Type: "string" },
+            { Name: "month", Type: "string" },
+          ],
+          StorageDescriptor: {
+            Columns: [
+              { Name: "request_time", Type: "timestamp" },
+              { Name: "status", Type: "int" },
+            ],
+            Location: "s3://site-logs/cloudfront/",
+            InputFormat: "org.apache.hadoop.mapred.TextInputFormat",
+            OutputFormat:
+              "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+            SerdeInfo: {
+              SerializationLibrary:
+                "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+              Parameters: { "field.delim": "\t" },
+            },
+          },
+          Parameters: {
+            "projection.enabled": "true",
+            "projection.year.type": "date",
+            "projection.year.format": "yyyy",
+            "projection.year.range": "2026,NOW",
+            "projection.year.interval": "1",
+            "projection.year.interval.unit": "YEARS",
+            "projection.month.type": "integer",
+            "projection.month.range": "1,12",
+            "projection.month.digits": "2",
+            "storage.location.template": locationTemplate,
+          },
+        },
+      },
+    },
+  },
+  Outputs: {
+    DatabaseRef: { Value: { Ref: "LogDatabase" } },
+    TableRef: { Value: { Ref: "LogTable" } },
+  },
+};
+
+describe("AWS::Glue::Database and AWS::Glue::Table", () => {
+  it("creates the database and table a template declares", async () => {
+    // Given a template declaring a Glue database and a table in it.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: catalogTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then neither Resource was skipped, and both answer Ref with their name.
+    assertArrayLength(stack.skippedResources, 0);
+    assertIdentical(stack.outputs.get("DatabaseRef")?.value, "site_logs");
+    assertIdentical(stack.outputs.get("TableRef")?.value, "access_logs");
+
+    const database = simAws.glue().findDatabase("site_logs");
+
+    assertNonNullable(database);
+    assertIdentical(database.description, "CloudFront access logs");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("keeps the table parameters a projection is configured through", async () => {
+    // Given a deployed stack whose table carries Athena partition projection.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: catalogTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the table is read back through GetTable.
+    const { Table } = simAws.glue().getTable({
+      input: { DatabaseName: "site_logs", Name: "access_logs" },
+    });
+
+    // Then every projection parameter is there, entry for entry. A table that
+    // dropped them would look deployed while projecting nothing.
+    assertObjectEquals(Table.Parameters, {
+      "projection.enabled": "true",
+      "projection.year.type": "date",
+      "projection.year.format": "yyyy",
+      "projection.year.range": "2026,NOW",
+      "projection.year.interval": "1",
+      "projection.year.interval.unit": "YEARS",
+      "projection.month.type": "integer",
+      "projection.month.range": "1,12",
+      "projection.month.digits": "2",
+      "storage.location.template": locationTemplate,
+    });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("keeps the storage descriptor and partition keys in declared order", async () => {
+    // Given a deployed stack whose table declares columns and partition keys.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: catalogTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the table is read back.
+    const { Table } = simAws.glue().getTable({
+      input: { DatabaseName: "site_logs", Name: "access_logs" },
+    });
+
+    // Then the columns keep their order, the partition keys keep theirs, and
+    // the two stay apart the way real Glue keeps them.
+    assertObjectEquals(Table.StorageDescriptor?.Columns, [
+      { Name: "request_time", Type: "timestamp" },
+      { Name: "status", Type: "int" },
+    ]);
+    assertObjectEquals(Table.PartitionKeys, [
+      { Name: "year", Type: "string" },
+      { Name: "month", Type: "string" },
+    ]);
+    assertIdentical(
+      Table.StorageDescriptor.Location,
+      "s3://site-logs/cloudfront/",
+    );
+    assertIdentical(
+      Table.StorageDescriptor.SerdeInfo?.SerializationLibrary,
+      "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+    );
+    assertIdentical(Table.TableType, "EXTERNAL_TABLE");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deletes the database and table when the stack goes", async () => {
+    // Given a deployed stack holding a database and a table.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: catalogTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack({ input: { StackName: "analytics-stack" } });
+    await simAws.backgroundTasksComplete();
+
+    // Then the catalog holds neither.
+    assertUndefined(simAws.glue().findDatabase("site_logs"));
+    assertUndefined(simAws.glue().findTable("site_logs", "access_logs"));
+  });
+});

--- a/src/service/glue/cfn/sim-cfn-glue-ignored.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-ignored.ts
@@ -1,0 +1,40 @@
+import type { SimCfnPropertyIgnorer } from "../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnGlueRecord } from "./sim-cfn-glue-record.js";
+
+interface SimCfnGlueUnknownProperties {
+  readonly ignorer: SimCfnPropertyIgnorer;
+  readonly fields: SimCfnGlueRecord;
+  readonly known: ReadonlySet<string>;
+  readonly owner: string;
+  readonly reasons?: ReadonlyMap<string, string>;
+}
+
+/**
+ * Record every property of a nested Glue shape that is left unread.
+ *
+ * A name in the reasons map is a real AWS property this simulation has no
+ * behaviour for. Any other name is one it has never heard of, which is usually
+ * a typo in the template.
+ */
+export function recordUnreadGlueProperties(
+  properties: SimCfnGlueUnknownProperties,
+): void {
+  const { fields, known, owner, reasons } = properties;
+
+  for (const name of fields.keys()) {
+    if (known.has(name)) {
+      continue;
+    }
+
+    const reason = reasons?.get(name);
+
+    properties.ignorer.ignoreProperty(
+      `${fields.path}.${name}`,
+      reason === undefined
+        ? `${name} is not a ${owner} property simulated Glue knows about, ` +
+            `so it is left out`
+        : `${name} is a real ${owner} property simulated Glue does not act ` +
+            `on: ${reason}`,
+    );
+  }
+}

--- a/src/service/glue/cfn/sim-cfn-glue-properties.iso.test.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-properties.iso.test.ts
@@ -29,12 +29,16 @@ const database: SimCfnTemplateValueRecord = {
 
 describe("AWS::Glue::Database properties", () => {
   it("names an unnamed database after the stack and the logical ID", async () => {
-    // Given a template declaring a database with no name of its own.
+    // Given a template whose DatabaseInput carries no name of its own, which
+    // real Glue allows since only DatabaseInput itself is required.
     const simAws = new SimAws();
 
     // When it is deployed.
     await deploy(simAws, {
-      LogDatabase: { Type: "AWS::Glue::Database", Properties: {} },
+      LogDatabase: {
+        Type: "AWS::Glue::Database",
+        Properties: { DatabaseInput: {} },
+      },
     });
 
     // Then the name is built from the stack and the logical ID, lowercased,
@@ -44,6 +48,26 @@ describe("AWS::Glue::Database properties", () => {
     );
 
     await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a database with no DatabaseInput", async () => {
+    // Given a template leaving out the property real Glue requires.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: {
+            LogDatabase: { Type: "AWS::Glue::Database", Properties: {} },
+          },
+        },
+      });
+    });
+
+    // Then it is refused rather than deployed under a generated name.
+    assertStringIncludes(error.message, "DatabaseInput is required");
   });
 
   it("takes the name from a top-level DatabaseName", async () => {

--- a/src/service/glue/cfn/sim-cfn-glue-properties.iso.test.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-properties.iso.test.ts
@@ -1,0 +1,157 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+async function deploy(
+  simAws: SimAws,
+  resources: Record<string, SimCfnTemplateValueRecord>,
+): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "analytics-stack",
+    template: { Resources: resources },
+  });
+
+  await stack.waitForDeployComplete();
+}
+
+const database: SimCfnTemplateValueRecord = {
+  Type: "AWS::Glue::Database",
+  Properties: { DatabaseInput: { Name: "site_logs" } },
+};
+
+describe("AWS::Glue::Database properties", () => {
+  it("names an unnamed database after the stack and the logical ID", async () => {
+    // Given a template declaring a database with no name of its own.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      LogDatabase: { Type: "AWS::Glue::Database", Properties: {} },
+    });
+
+    // Then the name is built from the stack and the logical ID, lowercased,
+    // since Glue names are lowercase for Hive compatibility.
+    assertNonNullable(
+      simAws.glue().findDatabase("analytics-stack-logdatabase"),
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("takes the name from a top-level DatabaseName", async () => {
+    // Given a template naming the database outside its DatabaseInput, which
+    // AWS::Glue::Database also allows.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      LogDatabase: {
+        Type: "AWS::Glue::Database",
+        Properties: {
+          DatabaseName: "site_logs",
+          DatabaseInput: { Description: "CloudFront access logs" },
+        },
+      },
+    });
+
+    // Then that name is used.
+    assertNonNullable(simAws.glue().findDatabase("site_logs"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("keeps the location and parameters a database declares", async () => {
+    // Given a template declaring both.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      LogDatabase: {
+        Type: "AWS::Glue::Database",
+        Properties: {
+          DatabaseInput: {
+            Name: "site_logs",
+            LocationUri: "s3://site-logs/",
+            Parameters: { owner: "analytics" },
+          },
+        },
+      },
+    });
+
+    // Then both read back.
+    const found = simAws.glue().findDatabase("site_logs");
+
+    assertNonNullable(found);
+    assertIdentical(found.locationUri, "s3://site-logs/");
+    assertIdentical(found.parameters["owner"], "analytics");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("records the database properties it is created without", async () => {
+    // Given a template declaring a federated database and a Lake Formation
+    // grant, neither of which this simulation acts on.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: {
+        Resources: {
+          LogDatabase: {
+            Type: "AWS::Glue::Database",
+            Properties: {
+              Tags: [{ Key: "team", Value: "analytics" }],
+              DatabaseInput: {
+                Name: "site_logs",
+                FederatedDatabase: { Identifier: "elsewhere" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the database is created, and each unread property is reported.
+    assertNonNullable(simAws.glue().findDatabase("site_logs"));
+
+    const paths = stack.ignoredProperties.map((property) => property.path);
+
+    assertArrayLength(paths, 2);
+    assertStringIncludes(paths.join(" "), "Tags");
+    assertStringIncludes(paths.join(" "), "DatabaseInput.FederatedDatabase");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("has no Fn::GetAtt attribute at all", async () => {
+    // Given a template reading an attribute off a database.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: { LogDatabase: database },
+          Outputs: {
+            Anything: { Value: { "Fn::GetAtt": ["LogDatabase", "Arn"] } },
+          },
+        },
+      });
+    });
+
+    // Then it is refused, since CloudFormation gives this type none.
+    assertStringIncludes(error.message, "no attributes");
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/glue/cfn/sim-cfn-glue-property-error.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-property-error.ts
@@ -1,0 +1,13 @@
+/**
+ * A refusal naming the Glue Resource whose properties could not be read.
+ */
+export function glueCfnPropertyError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid sim Glue CloudFormation Resource ${logicalId} ` +
+      `(${resourceType}): ${reason}`,
+  );
+}

--- a/src/service/glue/cfn/sim-cfn-glue-record.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-record.ts
@@ -1,0 +1,96 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnGlueValues } from "./sim-cfn-glue-values.js";
+
+/**
+ * One object out of a template, read by property name.
+ *
+ * A reader working straight off the record repeats the key three times per
+ * property, once to index with and twice to build the path a refusal names.
+ * This holds the properties and the path so a property is its name and its
+ * type.
+ *
+ * The properties are held as a Map. A template is user input, so the key being
+ * looked up is user input too, and a Map has no prototype for one of them to
+ * reach.
+ */
+export class SimCfnGlueRecord {
+  readonly values: SimCfnGlueValues;
+  readonly path: string;
+
+  readonly #entries: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(
+    values: SimCfnGlueValues,
+    record: SimCfnTemplateValueRecord,
+    path: string,
+  ) {
+    this.values = values;
+    this.path = path;
+    this.#entries = new Map(Object.entries(record));
+  }
+
+  /** The property names this object carries. */
+  keys(): readonly string[] {
+    return this.#entries.keys().toArray();
+  }
+
+  /** A string property, absent when the template leaves it out. */
+  string(key: string): string | undefined {
+    return this.values.optionalString(this.#entries.get(key), this.#at(key));
+  }
+
+  /** A boolean property, absent when the template leaves it out. */
+  boolean(key: string): boolean | undefined {
+    return this.values.optionalBoolean(this.#entries.get(key), this.#at(key));
+  }
+
+  /** A number property, absent when the template leaves it out. */
+  number(key: string): number | undefined {
+    return this.values.optionalNumber(this.#entries.get(key), this.#at(key));
+  }
+
+  /** A string-to-string map, absent when the template leaves it out. */
+  parameters(key: string): Readonly<Record<string, string>> | undefined {
+    return this.values.optionalParameters(
+      this.#entries.get(key),
+      this.#at(key),
+    );
+  }
+
+  /** A property read by something else, absent when it is left out. */
+  read<T>(
+    key: string,
+    read: (value: SimCfnTemplateValue, path: string) => T,
+  ): T | undefined {
+    const value = this.#entries.get(key);
+
+    return value === undefined ? undefined : read(value, this.#at(key));
+  }
+
+  /** A property the Resource cannot be created without. */
+  required(key: string): SimCfnTemplateValue {
+    const value = this.#entries.get(key);
+
+    if (value === undefined) {
+      throw this.values.refuse(`${this.#at(key)} is required`);
+    }
+
+    return value;
+  }
+
+  /** A nested object, read by property name in its turn. */
+  nested(value: SimCfnTemplateValue, path: string): SimCfnGlueRecord {
+    return new SimCfnGlueRecord(
+      this.values,
+      this.values.record(value, path),
+      path,
+    );
+  }
+
+  #at(key: string): string {
+    return `${this.path}.${key}`;
+  }
+}

--- a/src/service/glue/cfn/sim-cfn-glue-refusals.iso.test.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-refusals.iso.test.ts
@@ -77,35 +77,40 @@ describe("AWS::Glue::Table refusals", () => {
     assertUndefined(simAws.glue().findDatabase("site_logs"));
   });
 
-  it("refuses Fn::GetAtt Id, whose value CloudFormation leaves undocumented", async () => {
+  it("answers Fn::GetAtt Id with a value AWS documents no format for", async () => {
     // Given a template reading the table's one documented attribute.
-    const simAws = new SimAws();
+    const simAws = new SimAws({ defaultAccountId: "111111111111" });
 
     // When it is deployed.
-    const error = await assertThrowsErrorAsync(async () => {
-      await simAws.cloudFormation().deployTemplate({
-        stackName: "analytics-stack",
-        template: {
-          Resources: {
-            LogDatabase: database,
-            LogTable: {
-              Type: "AWS::Glue::Table",
-              Properties: {
-                DatabaseName: { Ref: "LogDatabase" },
-                TableInput: { Name: "access_logs" },
-              },
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: {
+        Resources: {
+          LogDatabase: database,
+          LogTable: {
+            Type: "AWS::Glue::Table",
+            Properties: {
+              DatabaseName: { Ref: "LogDatabase" },
+              TableInput: { Name: "access_logs" },
             },
           },
-          Outputs: {
-            TableId: { Value: { "Fn::GetAtt": ["LogTable", "Id"] } },
-          },
         },
-      });
+        Outputs: {
+          TableId: { Value: { "Fn::GetAtt": ["LogTable", "Id"] } },
+        },
+      },
     });
 
-    // Then it is refused rather than answered with a stand-in a real deploy
-    // would disagree with.
-    assertStringIncludes(error.message, "Id is not simulated");
+    await stack.waitForDeployComplete();
+
+    // Then it resolves to the catalog, the database and the table joined.
+    // CloudFormation documents that this attribute exists and documents
+    // nothing about its value, so this format is a guess and a real deploy may
+    // disagree with it. `simGlueTableCfnId` is the one place to correct.
+    assertIdentical(
+      stack.outputs.get("TableId")?.value,
+      "111111111111|site_logs|access_logs",
+    );
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/glue/cfn/sim-cfn-glue-refusals.iso.test.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-refusals.iso.test.ts
@@ -1,0 +1,162 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const database = {
+  Type: "AWS::Glue::Database",
+  Properties: { DatabaseInput: { Name: "site_logs" } },
+};
+
+describe("AWS::Glue::Table refusals", () => {
+  it("fails a table whose database no stack created", async () => {
+    // Given a template declaring a table in a database nothing creates.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: {
+            LogTable: {
+              Type: "AWS::Glue::Table",
+              Properties: {
+                DatabaseName: "missing_logs",
+                TableInput: { Name: "access_logs" },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the deploy fails with the refusal CreateTable gives, because the
+    // Resource is created through the same store.
+    assertStringIncludes(error.message, "missing_logs");
+
+    const stack = simAws.cloudFormation().getStackByName("analytics-stack");
+
+    assertNonNullable(stack);
+    assertIdentical(stack.getResource("LogTable")?.status, "CREATE_FAILED");
+    assertUndefined(simAws.glue().findTable("missing_logs", "access_logs"));
+  });
+
+  it("refuses another account's Data Catalog", async () => {
+    // Given a template naming a CatalogId outside the simulated account.
+    const simAws = new SimAws({ defaultAccountId: "111111111111" });
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: {
+            LogDatabase: {
+              Type: "AWS::Glue::Database",
+              Properties: {
+                CatalogId: "222222222222",
+                DatabaseInput: { Name: "site_logs" },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the deploy fails rather than creating the database in this
+    // account's catalog, which the template never asked for.
+    assertStringIncludes(error.message, "Cross-account");
+    assertUndefined(simAws.glue().findDatabase("site_logs"));
+  });
+
+  it("refuses Fn::GetAtt Id, whose value CloudFormation leaves undocumented", async () => {
+    // Given a template reading the table's one documented attribute.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: {
+            LogDatabase: database,
+            LogTable: {
+              Type: "AWS::Glue::Table",
+              Properties: {
+                DatabaseName: { Ref: "LogDatabase" },
+                TableInput: { Name: "access_logs" },
+              },
+            },
+          },
+          Outputs: {
+            TableId: { Value: { "Fn::GetAtt": ["LogTable", "Id"] } },
+          },
+        },
+      });
+    });
+
+    // Then it is refused rather than answered with a stand-in a real deploy
+    // would disagree with.
+    assertStringIncludes(error.message, "Id is not simulated");
+
+    await simAws.backgroundTasksComplete();
+  });
+});
+
+describe("AWS::Glue::Table unsimulated properties", () => {
+  it("records what the table is created without, and creates it anyway", async () => {
+    // Given a template declaring a view and a sorted storage layout, neither
+    // of which this simulation acts on.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: {
+        Resources: {
+          LogDatabase: database,
+          LogTable: {
+            Type: "AWS::Glue::Table",
+            Properties: {
+              DatabaseName: { Ref: "LogDatabase" },
+              TableInput: {
+                Name: "access_logs",
+                ViewOriginalText: "SELECT 1",
+                StorageDescriptor: {
+                  Location: "s3://site-logs/",
+                  SortColumns: [{ Column: "status", SortOrder: 1 }],
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the table is there, and each unread property is reported.
+    assertNonNullable(simAws.glue().findTable("site_logs", "access_logs"));
+
+    const paths = stack.ignoredProperties
+      .filter((property) => property.logicalId === "LogTable")
+      .map((property) => property.path);
+
+    assertArrayLength(paths, 2);
+    assertStringIncludes(paths.join(" "), "TableInput.ViewOriginalText");
+    assertStringIncludes(
+      paths.join(" "),
+      "TableInput.StorageDescriptor.SortColumns",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/glue/cfn/sim-cfn-glue-table-properties.iso.test.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-table-properties.iso.test.ts
@@ -1,0 +1,296 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+async function deploy(
+  simAws: SimAws,
+  resources: Record<string, SimCfnTemplateValueRecord>,
+): Promise<void> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "analytics-stack",
+    template: { Resources: resources },
+  });
+
+  await stack.waitForDeployComplete();
+}
+
+const database: SimCfnTemplateValueRecord = {
+  Type: "AWS::Glue::Database",
+  Properties: { DatabaseInput: { Name: "site_logs" } },
+};
+
+describe("AWS::Glue::Table storage descriptor", () => {
+  it("reads the bucketing and compression a descriptor declares", async () => {
+    // Given a template declaring a bucketed, compressed layout.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      LogDatabase: database,
+      LogTable: {
+        Type: "AWS::Glue::Table",
+        Properties: {
+          DatabaseName: { Ref: "LogDatabase" },
+          TableInput: {
+            Name: "access_logs",
+            Description: "Delivered access logs",
+            Owner: "analytics",
+            Retention: 30,
+            StorageDescriptor: {
+              Columns: [
+                { Name: "status", Type: "int", Comment: "HTTP status" },
+              ],
+              Compressed: true,
+              NumberOfBuckets: 4,
+              BucketColumns: ["status"],
+              Parameters: { "skip.header.line.count": "1" },
+            },
+          },
+        },
+      },
+    });
+
+    // Then each field reads back as it was declared.
+    const table = simAws.glue().findTable("site_logs", "access_logs");
+
+    assertNonNullable(table);
+
+    const descriptor = table.storageDescriptor;
+
+    assertNonNullable(descriptor);
+    assertIdentical(table.description, "Delivered access logs");
+    assertIdentical(table.owner, "analytics");
+    assertIdentical(table.retention, 30);
+    assertTrue(descriptor.Compressed ?? false);
+    assertIdentical(descriptor.NumberOfBuckets, 4);
+    assertIdentical(descriptor.BucketColumns?.[0], "status");
+    assertIdentical(descriptor.Columns?.[0]?.Comment, "HTTP status");
+    assertIdentical(descriptor.Parameters?.["skip.header.line.count"], "1");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("writes a number or a boolean parameter out as its text", async () => {
+    // Given a template whose projection parameters were written unquoted, the
+    // way YAML leaves them.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      LogDatabase: database,
+      LogTable: {
+        Type: "AWS::Glue::Table",
+        Properties: {
+          DatabaseName: { Ref: "LogDatabase" },
+          TableInput: {
+            Name: "access_logs",
+            Parameters: { "projection.enabled": true, "retention.days": 30 },
+          },
+        },
+      },
+    });
+
+    // Then each becomes its text, which is what real Glue receives from
+    // CloudFormation.
+    const table = simAws.glue().findTable("site_logs", "access_logs");
+
+    assertNonNullable(table);
+    assertIdentical(table.parameters["projection.enabled"], "true");
+    assertIdentical(table.parameters["retention.days"], "30");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names the property whose type it refuses", async () => {
+    // Given a template declaring a descriptor field as the wrong type.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: {
+            LogDatabase: database,
+            LogTable: {
+              Type: "AWS::Glue::Table",
+              Properties: {
+                DatabaseName: { Ref: "LogDatabase" },
+                TableInput: {
+                  Name: "access_logs",
+                  StorageDescriptor: { Compressed: "yes" },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the refusal names the whole way to it.
+    assertStringIncludes(
+      error.message,
+      "TableInput.StorageDescriptor.Compressed must be a boolean",
+    );
+  });
+
+  it("records a table property outside the ones it reads", async () => {
+    // Given a template declaring an open table format and a property no Glue
+    // resource has, which is what a typo looks like.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: {
+        Resources: {
+          LogDatabase: database,
+          LogTable: {
+            Type: "AWS::Glue::Table",
+            Properties: {
+              DatabaseName: { Ref: "LogDatabase" },
+              OpenTableFormatInput: { IcebergInput: { Version: "2" } },
+              TabelInput: { Name: "typo" },
+              TableInput: { Name: "access_logs" },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the table is created, and both are reported.
+    assertNonNullable(simAws.glue().findTable("site_logs", "access_logs"));
+
+    const reasons = stack.ignoredProperties
+      .filter((property) => property.logicalId === "LogTable")
+      .map((property) => property.reason)
+      .join(" ");
+
+    assertStringIncludes(reasons, "no Iceberg metadata is written");
+    assertStringIncludes(reasons, "TabelInput is not a AWS::Glue::Table");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a Retention that is not a number", async () => {
+    // Given a template declaring one as text.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: {
+            LogDatabase: database,
+            LogTable: {
+              Type: "AWS::Glue::Table",
+              Properties: {
+                DatabaseName: { Ref: "LogDatabase" },
+                TableInput: { Name: "access_logs", Retention: "thirty" },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the refusal names the property.
+    assertStringIncludes(
+      error.message,
+      "TableInput.Retention must be a number",
+    );
+  });
+
+  it("refuses a second table of one name in one database", async () => {
+    // Given a template declaring the same table twice.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: {
+            LogDatabase: database,
+            LogTable: {
+              Type: "AWS::Glue::Table",
+              Properties: {
+                DatabaseName: { Ref: "LogDatabase" },
+                TableInput: { Name: "access_logs" },
+              },
+            },
+            OtherLogTable: {
+              Type: "AWS::Glue::Table",
+              Properties: {
+                DatabaseName: { Ref: "LogDatabase" },
+                TableInput: { Name: "access_logs" },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then it fails the way two CreateTable calls would.
+    assertStringIncludes(error.message, "Table already exists");
+  });
+
+  it("refuses a table with no TableInput", async () => {
+    // Given a template leaving out the property real Glue requires.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: {
+          Resources: {
+            LogDatabase: database,
+            LogTable: {
+              Type: "AWS::Glue::Table",
+              Properties: { DatabaseName: { Ref: "LogDatabase" } },
+            },
+          },
+        },
+      });
+    });
+
+    // Then it is refused.
+    assertStringIncludes(error.message, "TableInput is required");
+  });
+
+  it("names an unnamed table after the stack and the logical ID", async () => {
+    // Given a template declaring a table with no name in its TableInput.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    await deploy(simAws, {
+      LogDatabase: database,
+      LogTable: {
+        Type: "AWS::Glue::Table",
+        Properties: {
+          DatabaseName: { Ref: "LogDatabase" },
+          TableInput: { TableType: "EXTERNAL_TABLE" },
+        },
+      },
+    });
+
+    // Then the name is built from the stack and the logical ID.
+    assertNonNullable(
+      simAws.glue().findTable("site_logs", "analytics-stack-logtable"),
+    );
+    assertUndefined(simAws.glue().findTable("site_logs", "LogTable"));
+
+    await simAws.backgroundTasksComplete();
+  });
+});

--- a/src/service/glue/cfn/sim-cfn-glue-values.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-values.ts
@@ -1,0 +1,109 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnValueShape } from "../../cloudformation/template/value/sim-cfn-value-shape.js";
+
+/**
+ * The template values a Glue Resource is read out of.
+ *
+ * Wraps the shared shape checks with the ones every Glue property reader
+ * needs, so a reader is the properties it knows about rather than the type
+ * narrowing around them.
+ */
+export class SimCfnGlueValues {
+  readonly shape: SimCfnValueShape;
+  readonly refuse: (reason: string) => Error;
+
+  constructor(refuse: (reason: string) => Error) {
+    this.refuse = refuse;
+    this.shape = new SimCfnValueShape(refuse);
+  }
+
+  /** A value that has to be an object. */
+  record(
+    value: SimCfnTemplateValue | undefined,
+    path: string,
+  ): SimCfnTemplateValueRecord {
+    return this.shape.record(value, path);
+  }
+
+  /** A value that has to be a list. */
+  list(value: SimCfnTemplateValue, path: string): SimCfnTemplateValue[] {
+    return this.shape.list(value, path);
+  }
+
+  /** A value that has to be a string. */
+  string(value: SimCfnTemplateValue, path: string): string {
+    return this.shape.string(value, path);
+  }
+
+  /** A string the template need not carry. */
+  optionalString(
+    value: SimCfnTemplateValue | undefined,
+    path: string,
+  ): string | undefined {
+    return this.shape.present(value, (present) => this.string(present, path));
+  }
+
+  /** A boolean the template need not carry. */
+  optionalBoolean(
+    value: SimCfnTemplateValue | undefined,
+    path: string,
+  ): boolean | undefined {
+    return this.shape.present(value, (present) => {
+      if (typeof present !== "boolean") {
+        throw this.refuse(`${path} must be a boolean`);
+      }
+
+      return present;
+    });
+  }
+
+  /** A number the template need not carry. */
+  optionalNumber(
+    value: SimCfnTemplateValue | undefined,
+    path: string,
+  ): number | undefined {
+    return this.shape.present(value, (present) => {
+      if (typeof present !== "number") {
+        throw this.refuse(`${path} must be a number`);
+      }
+
+      return present;
+    });
+  }
+
+  /**
+   * A string-to-string map the template need not carry.
+   *
+   * Table parameters carry Athena partition projection, so this is the reader
+   * standing between a declared `projection.enabled` and a table that has one.
+   *
+   * A number or a boolean becomes its text, which is what CloudFormation does
+   * with a primitive bound to a String property. An unquoted
+   * `projection.enabled: true` in a YAML template is a boolean by the time it
+   * reaches here, and real Glue receives `"true"` from it.
+   */
+  optionalParameters(
+    value: SimCfnTemplateValue | undefined,
+    path: string,
+  ): Readonly<Record<string, string>> | undefined {
+    return this.shape.present(value, (present) =>
+      Object.fromEntries(
+        Object.entries(this.record(present, path)).map(([key, entry]) => [
+          key,
+          this.#parameter(entry, `${path}.${key}`),
+        ]),
+      ),
+    );
+  }
+
+  #parameter(value: SimCfnTemplateValue, path: string): string {
+    if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+
+    return this.string(value, path);
+  }
+}

--- a/src/service/glue/cfn/sim-glue-cfn-adapters.iso.test.ts
+++ b/src/service/glue/cfn/sim-glue-cfn-adapters.iso.test.ts
@@ -1,0 +1,184 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { glueValueAdapter } from "../../cloudformation/resource/cfn/glue/sim-glue-cfn-value-adapter.js";
+import { SimGlueTableCfn } from "../../cloudformation/resource/cfn/glue/sim-glue-table-cfn.js";
+import { SimGlueInvalidInputException } from "../error/sim-glue.error.js";
+import { SimGlueTable } from "../table/sim-glue-table.js";
+
+describe("glueValueAdapter", () => {
+  it("claims nothing for a Resource type Glue does not own", () => {
+    // Given a Resource of another service's type.
+    const simResource = new SimGlueTable({
+      name: "access_logs",
+      databaseName: "site_logs",
+      accountRegionScope: new SimAws().accountRegionScope().accountRegionScope,
+      createTime: new Date(0),
+    });
+
+    // When the adapter is asked for it.
+    const adapter = glueValueAdapter({
+      logicalId: "LogTable",
+      type: "AWS::S3::Bucket",
+      simResource,
+    });
+
+    // Then it claims nothing, leaving the next adapter to answer.
+    assertUndefined(adapter);
+  });
+
+  it("claims nothing for a Glue type holding another service's resource", () => {
+    // Given a Glue Resource type whose simulated resource is something else,
+    // which is what a partly deployed stack looks like.
+    const adapter = glueValueAdapter({
+      logicalId: "LogTable",
+      type: "AWS::Glue::Table",
+      simResource: { notATable: true },
+    });
+
+    // Then it claims nothing.
+    assertUndefined(adapter);
+  });
+});
+
+describe("SimGlueTableCfn attributes", () => {
+  it("refuses an attribute AWS::Glue::Table does not have", () => {
+    // Given the value adapter for a table.
+    const table = new SimGlueTable({
+      name: "access_logs",
+      databaseName: "site_logs",
+      accountRegionScope: new SimAws().accountRegionScope().accountRegionScope,
+      createTime: new Date(0),
+    });
+    const adapter = new SimGlueTableCfn({ table });
+
+    // When an attribute outside the one CloudFormation documents is read.
+    const error = assertThrowsError(() => {
+      adapter.attributeValue("Arn");
+    });
+
+    // Then it is refused by name.
+    assertStringIncludes(error.message, "Unsupported");
+    assertStringIncludes(error.message, "Arn");
+  });
+
+  it("reads no columns from a table with no storage descriptor", () => {
+    // Given a table declared without one.
+    const table = new SimGlueTable({
+      name: "access_logs",
+      databaseName: "site_logs",
+      accountRegionScope: new SimAws().accountRegionScope().accountRegionScope,
+      createTime: new Date(0),
+    });
+
+    // Then it has no columns, rather than failing to answer.
+    assertArrayLength(table.columns, 0);
+    assertArrayLength(table.partitionKeys, 0);
+  });
+});
+
+describe("SimGlueCfnResourceFactory", () => {
+  it("skips a Glue Resource type it has no creator for", async () => {
+    // Given a template declaring a crawler alongside a database, which is a
+    // stack half of this simulation can deploy.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: {
+        Resources: {
+          LogDatabase: {
+            Type: "AWS::Glue::Database",
+            Properties: { DatabaseInput: { Name: "site_logs" } },
+          },
+          LogCrawler: {
+            Type: "AWS::Glue::Crawler",
+            Properties: { Name: "site-logs", Role: "crawler" },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the crawler is recorded as skipped and the stack completes anyway,
+    // which is the behaviour argued for in #273. The database is there.
+    assertIdentical(stack.status, "CREATE_COMPLETE");
+    assertArrayLength(stack.skippedResources, 1);
+
+    const [skipped] = stack.skippedResources;
+
+    assertNonNullable(skipped);
+    assertIdentical(skipped.type, "AWS::Glue::Crawler");
+    assertNonNullable(simAws.glue().findDatabase("site_logs"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses deleting a Glue Resource type it has no creator for", async () => {
+    // Given the factory reached directly, since a skipped Resource never
+    // reaches deletion through a stack.
+    const factory = new SimAws().glue().cfnResourceFactory();
+
+    // When a type it has no creator for is deleted.
+    const error = await assertThrowsErrorAsync(async () => {
+      await factory.delete(
+        "Crawler",
+        { logicalId: "LogCrawler" } as never,
+        {} as never,
+      );
+    });
+
+    // Then it is refused by name, in the wording sim CloudFormation reads as
+    // an unsupported Resource rather than a failure.
+    assertStringIncludes(error.message, "Unsupported sim Glue CloudFormation");
+    assertStringIncludes(error.message, "Crawler");
+  });
+});
+
+describe("SimGlue command input defaults", () => {
+  it("refuses a database created with no DatabaseInput", () => {
+    // Given a catalog.
+    const glue = new SimAws().glue();
+
+    // When a database is created without the input naming it.
+    const error = assertThrowsError(() => {
+      glue.createDatabase({ input: {} });
+    });
+
+    // Then it is refused, since the name is a database's whole identity.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "DatabaseInput.Name");
+  });
+
+  it("takes a table name from the request when the input carries none", () => {
+    // Given a database to put a table in.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase({ input: { DatabaseInput: { Name: "site_logs" } } });
+
+    // When a table is created with the name outside its TableInput, which
+    // CreateTable also allows.
+    glue.createTable({
+      input: { DatabaseName: "site_logs", Name: "access_logs" },
+    });
+
+    // Then that name is used.
+    const { Table } = glue.getTable({
+      input: { DatabaseName: "site_logs", Name: "access_logs" },
+    });
+
+    assertIdentical(Table.Name, "access_logs");
+  });
+});

--- a/src/service/glue/cfn/sim-glue-cfn-adapters.iso.test.ts
+++ b/src/service/glue/cfn/sim-glue-cfn-adapters.iso.test.ts
@@ -70,6 +70,12 @@ describe("SimGlueTableCfn attributes", () => {
     // Then it is refused by name.
     assertStringIncludes(error.message, "Unsupported");
     assertStringIncludes(error.message, "Arn");
+
+    // And the one it does have answers with the guessed identifier.
+    assertIdentical(
+      adapter.attributeValue("Id"),
+      `${table.catalogId}|site_logs|access_logs`,
+    );
   });
 
   it("reads no columns from a table with no storage descriptor", () => {

--- a/src/service/glue/cfn/sim-glue-cfn-resource-factory.ts
+++ b/src/service/glue/cfn/sim-glue-cfn-resource-factory.ts
@@ -1,0 +1,99 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import { SimGlueDatabase } from "../database/sim-glue-database.js";
+import type { SimGlue } from "../sim-glue.js";
+import { SimGlueTable } from "../table/sim-glue-table.js";
+import { SimCfnGlueDatabaseCreator } from "./database/sim-cfn-glue-database-creator.js";
+import { SimCfnGlueTableCreator } from "./table/sim-cfn-glue-table-creator.js";
+
+interface SimGlueCfnResourceFactoryProperties {
+  readonly glue: SimGlue;
+  readonly catalogId: string;
+}
+
+/**
+ * CloudFormation Resource factory for simulated Glue resources.
+ *
+ * A database and a table are the two Data Catalog types a stack declares. A
+ * crawler is left out: it fills a catalog by reading objects, and nothing here
+ * reads one.
+ */
+export class SimGlueCfnResourceFactory implements SimCfnServiceResourceFactory {
+  readonly #databaseCreator: SimCfnGlueDatabaseCreator;
+  readonly #tableCreator: SimCfnGlueTableCreator;
+
+  constructor(properties: SimGlueCfnResourceFactoryProperties) {
+    this.#databaseCreator = new SimCfnGlueDatabaseCreator(properties);
+    this.#tableCreator = new SimCfnGlueTableCreator(properties);
+  }
+
+  /**
+   * Create a simulated Glue resource from a CloudFormation Resource.
+   */
+  create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+
+    if (resourceTypeName === "Database") {
+      return Promise.resolve(
+        this.#databaseCreator.create(resource, properties),
+      );
+    }
+
+    if (resourceTypeName === "Table") {
+      return Promise.resolve(this.#tableCreator.create(resource, properties));
+    }
+
+    throw new Error(
+      `Unsupported sim Glue CloudFormation Resource ${resourceTypeName}`,
+    );
+  }
+
+  /**
+   * Delete a simulated Glue resource created from a CloudFormation Resource.
+   */
+  delete(resourceTypeName: string, resource: SimCfnResource): Promise<void> {
+    if (resourceTypeName === "Database") {
+      this.#databaseCreator.delete(
+        this.#simResource(resource, SimGlueDatabase, "database"),
+      );
+
+      return Promise.resolve();
+    }
+
+    if (resourceTypeName === "Table") {
+      this.#tableCreator.delete(
+        this.#simResource(resource, SimGlueTable, "table"),
+      );
+
+      return Promise.resolve();
+    }
+
+    throw new Error(
+      `Unsupported sim Glue CloudFormation Resource ${resourceTypeName} ` +
+        `deletion`,
+    );
+  }
+
+  #simResource<T>(
+    resource: SimCfnResource,
+    kind: abstract new (...arguments_: never[]) => T,
+    label: string,
+  ): T {
+    const simResource = resource.simResource;
+
+    assertDefined(
+      simResource instanceof kind ? simResource : undefined,
+      `sim Glue ${label} for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    return simResource as T;
+  }
+}

--- a/src/service/glue/cfn/table/sim-cfn-glue-columns.ts
+++ b/src/service/glue/cfn/table/sim-cfn-glue-columns.ts
@@ -1,0 +1,80 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimGlueColumn,
+  SimGlueSerDeInfo,
+} from "../../table/sim-glue-table-schema.js";
+import { definedEntries } from "../../../../util/record/defined-entries.js";
+import { recordUnreadGlueProperties } from "../sim-cfn-glue-ignored.js";
+import { SimCfnGlueRecord } from "../sim-cfn-glue-record.js";
+import type { SimCfnGlueValues } from "../sim-cfn-glue-values.js";
+
+const readColumnNames = new Set(["Name", "Type", "Comment", "Parameters"]);
+const readSerdeNames = new Set(["Name", "SerializationLibrary", "Parameters"]);
+
+/**
+ * Reads the column lists and the SerDe out of a template.
+ *
+ * Real Glue uses one `Column` shape for data columns and for partition keys,
+ * so the same reader answers for both.
+ */
+export class SimCfnGlueColumns {
+  readonly #ignorer: SimCfnPropertyIgnorer;
+
+  constructor(ignorer: SimCfnPropertyIgnorer) {
+    this.#ignorer = ignorer;
+  }
+
+  /** Read a list of columns, in the order they were declared. */
+  list(
+    values: SimCfnGlueValues,
+    value: SimCfnTemplateValue,
+    path: string,
+  ): readonly SimGlueColumn[] {
+    return values.list(value, path).map((column, index) => {
+      const at = `${path}.${index}`;
+
+      return this.#column(
+        new SimCfnGlueRecord(values, values.record(column, at), at),
+      );
+    });
+  }
+
+  /** Read how rows are serialized and deserialized. */
+  serdeInfo(fields: SimCfnGlueRecord): SimGlueSerDeInfo {
+    this.#unread(fields, readSerdeNames, "SerdeInfo");
+
+    return definedEntries({
+      Name: fields.string("Name"),
+      SerializationLibrary: fields.string("SerializationLibrary"),
+      Parameters: fields.parameters("Parameters"),
+    });
+  }
+
+  #column(fields: SimCfnGlueRecord): SimGlueColumn {
+    this.#unread(fields, readColumnNames, "Column");
+
+    return definedEntries({
+      Name: fields.values.string(
+        fields.required("Name"),
+        `${fields.path}.Name`,
+      ),
+      Type: fields.string("Type"),
+      Comment: fields.string("Comment"),
+      Parameters: fields.parameters("Parameters"),
+    });
+  }
+
+  #unread(
+    fields: SimCfnGlueRecord,
+    known: ReadonlySet<string>,
+    owner: string,
+  ): void {
+    recordUnreadGlueProperties({
+      ignorer: this.#ignorer,
+      fields,
+      known,
+      owner,
+    });
+  }
+}

--- a/src/service/glue/cfn/table/sim-cfn-glue-storage-descriptor.ts
+++ b/src/service/glue/cfn/table/sim-cfn-glue-storage-descriptor.ts
@@ -1,0 +1,84 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimGlueStorageDescriptor } from "../../table/sim-glue-table-schema.js";
+import { definedEntries } from "../../../../util/record/defined-entries.js";
+import type { SimCfnGlueRecord } from "../sim-cfn-glue-record.js";
+import { recordUnreadGlueProperties } from "../sim-cfn-glue-ignored.js";
+import { SimCfnGlueColumns } from "./sim-cfn-glue-columns.js";
+import { unsimulatedStorageDescriptorReasons } from "./sim-cfn-glue-table-unsimulated-properties.js";
+
+const readNames = new Set([
+  "Columns",
+  "Location",
+  "InputFormat",
+  "OutputFormat",
+  "Compressed",
+  "NumberOfBuckets",
+  "SerdeInfo",
+  "BucketColumns",
+  "Parameters",
+]);
+
+/**
+ * Reads a table's StorageDescriptor out of a template.
+ *
+ * The columns keep the order they were declared in, which is the order a query
+ * over a delimited or a positional format reads them by.
+ */
+export class SimCfnGlueStorageDescriptor {
+  readonly #ignorer: SimCfnPropertyIgnorer;
+  readonly #columns: SimCfnGlueColumns;
+
+  constructor(ignorer: SimCfnPropertyIgnorer) {
+    this.#ignorer = ignorer;
+    this.#columns = new SimCfnGlueColumns(ignorer);
+  }
+
+  /** The column reader, which partition keys are read through too. */
+  get columns(): SimCfnGlueColumns {
+    return this.#columns;
+  }
+
+  /** Read the whole descriptor. */
+  read(fields: SimCfnGlueRecord): SimGlueStorageDescriptor {
+    this.#recordIgnored(fields);
+
+    return definedEntries({
+      Columns: fields.read("Columns", (value, path) =>
+        this.#columns.list(fields.values, value, path),
+      ),
+      Location: fields.string("Location"),
+      InputFormat: fields.string("InputFormat"),
+      OutputFormat: fields.string("OutputFormat"),
+      Compressed: fields.boolean("Compressed"),
+      NumberOfBuckets: fields.number("NumberOfBuckets"),
+      SerdeInfo: fields.read("SerdeInfo", (value, path) =>
+        this.#columns.serdeInfo(fields.nested(value, path)),
+      ),
+      BucketColumns: fields.read("BucketColumns", (value, path) =>
+        this.#bucketColumns(fields, value, path),
+      ),
+      Parameters: fields.parameters("Parameters"),
+    });
+  }
+
+  #bucketColumns(
+    fields: SimCfnGlueRecord,
+    value: SimCfnTemplateValue,
+    path: string,
+  ): readonly string[] {
+    return fields.values
+      .list(value, path)
+      .map((column, index) => fields.values.string(column, `${path}.${index}`));
+  }
+
+  #recordIgnored(fields: SimCfnGlueRecord): void {
+    recordUnreadGlueProperties({
+      ignorer: this.#ignorer,
+      fields,
+      known: readNames,
+      owner: "StorageDescriptor",
+      reasons: unsimulatedStorageDescriptorReasons,
+    });
+  }
+}

--- a/src/service/glue/cfn/table/sim-cfn-glue-table-creator.ts
+++ b/src/service/glue/cfn/table/sim-cfn-glue-table-creator.ts
@@ -1,0 +1,66 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimGlueTable } from "../../table/sim-glue-table.js";
+import type { SimGlue } from "../../sim-glue.js";
+import { requireSimCfnGlueCatalogId } from "../sim-cfn-glue-catalog-id.js";
+import { SimCfnGlueTableProperties } from "./sim-cfn-glue-table-properties.js";
+
+interface SimCfnGlueTableCreatorProperties {
+  readonly glue: SimGlue;
+  readonly catalogId: string;
+}
+
+/**
+ * Creates simulated tables from AWS::Glue::Table Resources.
+ *
+ * The database has to be there. A template declaring both usually leaves
+ * CloudFormation to work the order out from the `Ref` the table's
+ * `DatabaseName` carries, and one that names a database no stack creates fails
+ * here the way `CreateTable` fails.
+ */
+export class SimCfnGlueTableCreator {
+  readonly #glue: SimGlue;
+  readonly #catalogId: string;
+
+  constructor(properties: SimCfnGlueTableCreatorProperties) {
+    this.#glue = properties.glue;
+    this.#catalogId = properties.catalogId;
+  }
+
+  /**
+   * Create a table from an AWS::Glue::Table Resource.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimGlueTable {
+    const tableProperties = new SimCfnGlueTableProperties({
+      resource,
+      properties,
+    });
+
+    requireSimCfnGlueCatalogId({
+      resourceType: "AWS::Glue::Table",
+      logicalId: resource.logicalId,
+      declared: tableProperties.catalogId(),
+      simulated: this.#catalogId,
+    });
+
+    const databaseName = tableProperties.databaseName();
+    const tableName = tableProperties.tableName();
+    const tableInput = tableProperties.tableInput();
+
+    tableProperties.recordIgnoredProperties();
+
+    return this.#glue
+      .catalogWriter()
+      .createTable(databaseName, tableName, tableInput);
+  }
+
+  /**
+   * Delete a table created from an AWS::Glue::Table Resource.
+   */
+  delete(table: SimGlueTable): void {
+    this.#glue.catalogWriter().deleteTable(table.databaseName, table.name);
+  }
+}

--- a/src/service/glue/cfn/table/sim-cfn-glue-table-input.ts
+++ b/src/service/glue/cfn/table/sim-cfn-glue-table-input.ts
@@ -1,0 +1,35 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimGlueTableInput } from "../../table/sim-glue-table-schema.js";
+import type { SimCfnGlueRecord } from "../sim-cfn-glue-record.js";
+import { SimCfnGlueStorageDescriptor } from "./sim-cfn-glue-storage-descriptor.js";
+
+/**
+ * Reads a TableInput into what the table is created with.
+ *
+ * `Parameters` is read here rather than recorded as ignored, because Athena
+ * partition projection lives entirely in it.
+ */
+export class SimCfnGlueTableInputReader {
+  readonly #storage: SimCfnGlueStorageDescriptor;
+
+  constructor(ignorer: SimCfnPropertyIgnorer) {
+    this.#storage = new SimCfnGlueStorageDescriptor(ignorer);
+  }
+
+  /** Read the whole input. */
+  read(fields: SimCfnGlueRecord): SimGlueTableInput {
+    return {
+      description: fields.string("Description"),
+      owner: fields.string("Owner"),
+      retention: fields.number("Retention"),
+      tableType: fields.string("TableType"),
+      partitionKeys: fields.read("PartitionKeys", (value, path) =>
+        this.#storage.columns.list(fields.values, value, path),
+      ),
+      storageDescriptor: fields.read("StorageDescriptor", (value, path) =>
+        this.#storage.read(fields.nested(value, path)),
+      ),
+      parameters: fields.parameters("Parameters"),
+    };
+  }
+}

--- a/src/service/glue/cfn/table/sim-cfn-glue-table-properties.ts
+++ b/src/service/glue/cfn/table/sim-cfn-glue-table-properties.ts
@@ -1,0 +1,87 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimGlueTableInput } from "../../table/sim-glue-table-schema.js";
+import { glueCfnPropertyError } from "../sim-cfn-glue-property-error.js";
+import { SimCfnGlueRecord } from "../sim-cfn-glue-record.js";
+import { SimCfnGlueValues } from "../sim-cfn-glue-values.js";
+import { SimCfnGlueTableInputReader } from "./sim-cfn-glue-table-input.js";
+import { simCfnGlueTableIgnored } from "./sim-cfn-glue-table-rules.js";
+
+const resourceType = "AWS::Glue::Table";
+
+interface SimCfnGlueTablePropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Glue::Table CloudFormation properties.
+ */
+export class SimCfnGlueTableProperties {
+  readonly #resource: SimCfnResource;
+  readonly #fields: SimCfnGlueRecord;
+  readonly #reader: SimCfnGlueTableInputReader;
+
+  constructor(properties: SimCfnGlueTablePropertiesProperties) {
+    const values = new SimCfnGlueValues((reason) =>
+      glueCfnPropertyError(resourceType, properties.resource.logicalId, reason),
+    );
+
+    this.#resource = properties.resource;
+    this.#fields = new SimCfnGlueRecord(
+      values,
+      properties.properties,
+      resourceType,
+    );
+    this.#reader = new SimCfnGlueTableInputReader(properties.resource);
+  }
+
+  /** The catalog id the template names, when it names one. */
+  catalogId(): string | undefined {
+    return this.#fields.string("CatalogId");
+  }
+
+  /** The database the table belongs to, which real Glue requires. */
+  databaseName(): string {
+    return this.#fields.values.string(
+      this.#fields.required("DatabaseName"),
+      "DatabaseName",
+    );
+  }
+
+  /**
+   * The table name.
+   *
+   * An unnamed table is named after the stack and the logical ID, lowercased,
+   * since Glue names are lowercase for Hive compatibility.
+   */
+  tableName(): string {
+    const stackName = this.#resource.stackName ?? "stack";
+
+    return (
+      this.#input().string("Name") ??
+      `${stackName}-${this.#resource.logicalId}`.toLowerCase()
+    );
+  }
+
+  /** What the table is created with, beyond its name and its database. */
+  tableInput(): SimGlueTableInput {
+    return this.#reader.read(this.#input());
+  }
+
+  /** Record the properties the table is created without acting on. */
+  recordIgnoredProperties(): void {
+    simCfnGlueTableIgnored({
+      resource: this.#resource,
+      names: this.#fields.keys(),
+      inputNames: this.#input().keys(),
+    });
+  }
+
+  #input(): SimCfnGlueRecord {
+    return this.#fields.nested(
+      this.#fields.required("TableInput"),
+      "TableInput",
+    );
+  }
+}

--- a/src/service/glue/cfn/table/sim-cfn-glue-table-rules.ts
+++ b/src/service/glue/cfn/table/sim-cfn-glue-table-rules.ts
@@ -1,0 +1,70 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import {
+  unsimulatedTableInputReasons,
+  unsimulatedTableReasons,
+} from "./sim-cfn-glue-table-unsimulated-properties.js";
+
+const readNames = new Set(["CatalogId", "DatabaseName", "TableInput"]);
+
+const readInputNames = new Set([
+  "Name",
+  "Description",
+  "Owner",
+  "Retention",
+  "TableType",
+  "PartitionKeys",
+  "StorageDescriptor",
+  "Parameters",
+]);
+
+interface SimCfnGlueTableIgnoredProperties {
+  readonly resource: SimCfnPropertyIgnorer;
+  readonly names: readonly string[];
+  readonly inputNames: readonly string[];
+}
+
+/**
+ * Record every AWS::Glue::Table property the table is created without.
+ */
+export function simCfnGlueTableIgnored(
+  properties: SimCfnGlueTableIgnoredProperties,
+): void {
+  const { resource } = properties;
+
+  for (const name of properties.names) {
+    if (!readNames.has(name)) {
+      ignore(resource, name, "AWS::Glue::Table", unsimulatedTableReasons);
+    }
+  }
+
+  for (const name of properties.inputNames) {
+    if (!readInputNames.has(name)) {
+      ignore(
+        resource,
+        name,
+        "TableInput",
+        unsimulatedTableInputReasons,
+        `TableInput.${name}`,
+      );
+    }
+  }
+}
+
+function ignore(
+  resource: SimCfnPropertyIgnorer,
+  name: string,
+  owner: string,
+  reasons: ReadonlyMap<string, string>,
+  path = name,
+): void {
+  const reason = reasons.get(name);
+
+  resource.ignoreProperty(
+    path,
+    reason === undefined
+      ? `${path} is not a ${owner} property simulated Glue knows about, so ` +
+          `the table is created without it`
+      : `${path} is a real ${owner} property simulated Glue does not act ` +
+          `on: ${reason}`,
+  );
+}

--- a/src/service/glue/cfn/table/sim-cfn-glue-table-unsimulated-properties.ts
+++ b/src/service/glue/cfn/table/sim-cfn-glue-table-unsimulated-properties.ts
@@ -1,0 +1,78 @@
+/**
+ * The AWS::Glue::Table properties this simulation has nothing to act on, and
+ * why.
+ *
+ * A table here is a definition rather than a dataset, so anything describing
+ * how data would be read back or written is recorded and left out.
+ */
+export const unsimulatedTableReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "OpenTableFormatInput",
+    "no Iceberg metadata is written, so an open format table is created as " +
+      "an ordinary one",
+  ],
+]);
+
+/**
+ * The AWS::Glue::Table TableInput properties this simulation has nothing to
+ * act on, and why.
+ */
+export const unsimulatedTableInputReasons: ReadonlyMap<string, string> =
+  new Map([
+    [
+      "LastAccessTime",
+      "nothing reads the table, so the last access time is whatever a caller " +
+        "declared rather than something the simulation keeps",
+    ],
+    [
+      "LastAnalyzedTime",
+      "no statistics are gathered, so nothing analyses the table",
+    ],
+    [
+      "TargetTable",
+      "a table linking to another catalog's table is not simulated, so this " +
+        "one holds only its own definition",
+    ],
+    [
+      "ViewDefinition",
+      "no SQL is parsed or run, so a view resolves to nothing",
+    ],
+    [
+      "ViewExpandedText",
+      "no SQL is parsed or run, so a view resolves to nothing",
+    ],
+    [
+      "ViewOriginalText",
+      "no SQL is parsed or run, so a view resolves to nothing",
+    ],
+  ]);
+
+/**
+ * The StorageDescriptor properties this simulation has nothing to act on, and
+ * why.
+ */
+export const unsimulatedStorageDescriptorReasons: ReadonlyMap<string, string> =
+  new Map([
+    [
+      "AdditionalLocations",
+      "no object is read, so a table reads from none of its locations",
+    ],
+    [
+      "SchemaReference",
+      "the Schema Registry is not simulated, so a referenced schema resolves " +
+        "to nothing",
+    ],
+    [
+      "SkewedInfo",
+      "no query plan is built, so nothing takes a skewed value into account",
+    ],
+    [
+      "SortColumns",
+      "no data is read, so nothing relies on the order rows are stored in",
+    ],
+    [
+      "StoredAsSubDirectories",
+      "no object is listed, so nothing walks into a partition's " +
+        "subdirectories",
+    ],
+  ]);

--- a/src/service/glue/command/authorize/sim-glue-authorize-resources.ts
+++ b/src/service/glue/command/authorize/sim-glue-authorize-resources.ts
@@ -1,0 +1,43 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+interface SimGlueAuthorizeProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly action: string;
+  readonly resources: readonly string[];
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * Authorize every resource an operation reaches, outermost first.
+ *
+ * The first refusal names the resource the policy left out, so a policy
+ * carrying the table and missing the catalog says the catalog.
+ */
+export function authorizeSimGlueResources(
+  properties: SimGlueAuthorizeProperties,
+): SimAwsResolvedCaller {
+  const { iam, action, caller } = properties;
+  let resolved: SimAwsResolvedCaller | undefined;
+
+  for (const resource of properties.resources) {
+    const decision = iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    resolved = decision.caller;
+  }
+
+  assertDefined(resolved, `the caller a Glue ${action} authorized`);
+
+  return resolved;
+}

--- a/src/service/glue/command/authorize/sim-glue-authorizer.ts
+++ b/src/service/glue/command/authorize/sim-glue-authorizer.ts
@@ -1,0 +1,102 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import {
+  simGlueCatalogArn,
+  simGlueDatabaseArn,
+  simGlueTableArn,
+} from "../../arn/sim-glue-arn.js";
+
+interface SimGlueAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Applies simulated IAM authorization to Glue requests.
+ *
+ * An operation on one database or table authorizes against that resource's own
+ * ARN. Real Glue policies also name the catalog on most of these actions, and
+ * a policy written that way still passes here, since a policy granting more
+ * than the simulation checks is never the reason a request fails.
+ */
+export class SimGlueAuthorizer {
+  readonly #iam: SimIamInterServiceAuthZ;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimGlueAuthorizerProperties) {
+    this.#iam = properties.iam;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a database.
+   *
+   * The database need not exist. Real IAM evaluates a request before the
+   * service handles it, so a caller with no permission is refused whether or
+   * not the database is there.
+   */
+  authorizeDatabase(
+    action: string,
+    databaseName: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.#authorize(
+      action,
+      simGlueDatabaseArn(this.#accountRegionScope, databaseName),
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action on a table.
+   */
+  authorizeTable(
+    action: string,
+    databaseName: string,
+    tableName: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.#authorize(
+      action,
+      simGlueTableArn(this.#accountRegionScope, databaseName, tableName),
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action that names no particular database.
+   *
+   * The resource is the catalog, which is what such a request reaches.
+   */
+  authorizeCatalog(
+    action: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.#authorize(
+      action,
+      simGlueCatalogArn(this.#accountRegionScope),
+      caller,
+    );
+  }
+
+  #authorize(
+    action: string,
+    resource: string,
+    caller: SimAwsCaller | undefined,
+  ): SimAwsResolvedCaller {
+    const decision = this.#iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/glue/command/authorize/sim-glue-authorizer.ts
+++ b/src/service/glue/command/authorize/sim-glue-authorizer.ts
@@ -2,12 +2,13 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simGlueCatalogArn } from "../../arn/sim-glue-arn.js";
+import { authorizeSimGlueResources } from "./sim-glue-authorize-resources.js";
 import {
-  simGlueCatalogArn,
-  simGlueDatabaseArn,
-  simGlueTableArn,
-} from "../../arn/sim-glue-arn.js";
+  simGlueDatabaseDeletionResources,
+  simGlueDatabaseResources,
+  simGlueTableResources,
+} from "../../arn/sim-glue-authorized-resources.js";
 
 interface SimGlueAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -17,18 +18,23 @@ interface SimGlueAuthorizerProperties {
 /**
  * Applies simulated IAM authorization to Glue requests.
  *
- * An operation on one database or table authorizes against that resource's own
- * ARN. Real Glue policies also name the catalog on most of these actions, and
- * a policy written that way still passes here, since a policy granting more
- * than the simulation checks is never the reason a request fails.
+ * Data Catalog resources are a hierarchy with the catalog at the root, and an
+ * operation on one needs permission on that resource and on every ancestor of
+ * it. Reading a table needs the table, the database and the catalog, and a
+ * policy naming only the table ARN is denied. Deleting a database also needs
+ * permission on every table in it.
+ *
+ * That rule is why each method authorizes a list. A policy written for real
+ * Glue already names the ancestors, and one that names only the leaf fails the
+ * same way in both places.
  */
 export class SimGlueAuthorizer {
   readonly #iam: SimIamInterServiceAuthZ;
-  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #scope: SimAwsAccountRegionScope;
 
   constructor(properties: SimGlueAuthorizerProperties) {
     this.#iam = properties.iam;
-    this.#accountRegionScope = properties.accountRegionScope;
+    this.#scope = properties.accountRegionScope;
   }
 
   /**
@@ -45,14 +51,12 @@ export class SimGlueAuthorizer {
   ): SimAwsResolvedCaller {
     return this.#authorize(
       action,
-      simGlueDatabaseArn(this.#accountRegionScope, databaseName),
+      simGlueDatabaseResources(this.#scope, databaseName),
       caller,
     );
   }
 
-  /**
-   * Ensure the caller may perform an action on a table.
-   */
+  /** Ensure the caller may perform an action on a table. */
   authorizeTable(
     action: string,
     databaseName: string,
@@ -61,42 +65,46 @@ export class SimGlueAuthorizer {
   ): SimAwsResolvedCaller {
     return this.#authorize(
       action,
-      simGlueTableArn(this.#accountRegionScope, databaseName, tableName),
+      simGlueTableResources(this.#scope, databaseName, tableName),
+      caller,
+    );
+  }
+
+  /** Ensure the caller may delete a database holding these tables. */
+  authorizeDatabaseDeletion(
+    databaseName: string,
+    tableNames: readonly string[],
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.#authorize(
+      "glue:DeleteDatabase",
+      simGlueDatabaseDeletionResources(this.#scope, databaseName, tableNames),
       caller,
     );
   }
 
   /**
-   * Ensure the caller may perform an action that names no particular database.
+   * Ensure the caller may perform an action naming no particular database.
    *
-   * The resource is the catalog, which is what such a request reaches.
+   * The catalog has no ancestor, so it is the whole of the list.
    */
   authorizeCatalog(
     action: string,
     caller?: SimAwsCaller,
   ): SimAwsResolvedCaller {
-    return this.#authorize(
-      action,
-      simGlueCatalogArn(this.#accountRegionScope),
-      caller,
-    );
+    return this.#authorize(action, [simGlueCatalogArn(this.#scope)], caller);
   }
 
   #authorize(
     action: string,
-    resource: string,
+    resources: readonly string[],
     caller: SimAwsCaller | undefined,
   ): SimAwsResolvedCaller {
-    const decision = this.#iam.authorize({ action, resource, caller });
-
-    if (decision.isDenied) {
-      throw new SimIamAccessDenied({
-        principal: decision.caller.principal,
-        action,
-        resource,
-      });
-    }
-
-    return decision.caller;
+    return authorizeSimGlueResources({
+      iam: this.#iam,
+      action,
+      resources,
+      caller,
+    });
   }
 }

--- a/src/service/glue/command/database/database.command.ts
+++ b/src/service/glue/command/database/database.command.ts
@@ -1,0 +1,99 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * What a caller declares a database with.
+ *
+ * https://docs.aws.amazon.com/glue/latest/webapi/API_DatabaseInput.html
+ */
+export interface SimGlueDatabaseInputShape {
+  readonly Name?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly LocationUri?: string | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * What GetDatabase reports about one database.
+ */
+export interface SimGlueDatabaseDetail {
+  readonly Name: string;
+  readonly Description?: string | undefined;
+  readonly LocationUri?: string | undefined;
+  readonly Parameters: Readonly<Record<string, string>>;
+  readonly CreateTime: Date;
+  readonly CatalogId: string;
+}
+
+/**
+ * Minimal structural sim Glue CreateDatabase command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/CreateDatabaseCommand/
+ */
+export interface SimCreateDatabaseCommand {
+  readonly input: SimCreateDatabaseCommandInput;
+}
+
+export interface SimCreateDatabaseCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseInput?: SimGlueDatabaseInputShape | undefined;
+  readonly Tags?: Readonly<Record<string, string>> | undefined;
+}
+
+export interface SimCreateDatabaseCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue GetDatabase command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/GetDatabaseCommand/
+ */
+export interface SimGetDatabaseCommand {
+  readonly input: SimGetDatabaseCommandInput;
+}
+
+export interface SimGetDatabaseCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly Name?: string | undefined;
+}
+
+export interface SimGetDatabaseCommandOutput {
+  readonly Database: SimGlueDatabaseDetail;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue GetDatabases command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/GetDatabasesCommand/
+ */
+export interface SimGetDatabasesCommand {
+  readonly input: SimGetDatabasesCommandInput;
+}
+
+export interface SimGetDatabasesCommandInput {
+  readonly CatalogId?: string | undefined;
+}
+
+export interface SimGetDatabasesCommandOutput {
+  readonly DatabaseList: readonly SimGlueDatabaseDetail[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue DeleteDatabase command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/DeleteDatabaseCommand/
+ */
+export interface SimDeleteDatabaseCommand {
+  readonly input: SimDeleteDatabaseCommandInput;
+}
+
+export interface SimDeleteDatabaseCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly Name?: string | undefined;
+}
+
+export interface SimDeleteDatabaseCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/glue/command/database/sim-glue-database-commands.ts
+++ b/src/service/glue/command/database/sim-glue-database-commands.ts
@@ -1,0 +1,140 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
+import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
+import type { SimGlueTableStore } from "../../table/sim-glue-table-store.js";
+import type { SimGlueAuthorizer } from "../authorize/sim-glue-authorizer.js";
+import { requireSimGlueCatalogId } from "../sim-glue-catalog-id.js";
+import type { SimGlueRequestOptions } from "../sim-glue-request-options.js";
+import type {
+  SimCreateDatabaseCommand,
+  SimCreateDatabaseCommandOutput,
+  SimDeleteDatabaseCommand,
+  SimDeleteDatabaseCommandOutput,
+  SimGetDatabaseCommand,
+  SimGetDatabaseCommandOutput,
+  SimGetDatabasesCommand,
+  SimGetDatabasesCommandOutput,
+} from "./database.command.js";
+import { simGlueDatabaseDetail } from "./sim-glue-database-detail.js";
+
+interface SimGlueDatabaseCommandsProperties {
+  readonly databases: SimGlueDatabaseStore;
+  readonly tables: SimGlueTableStore;
+  readonly authorizer: SimGlueAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that make, read and remove Glue databases.
+ */
+export class SimGlueDatabaseCommands {
+  readonly #databases: SimGlueDatabaseStore;
+  readonly #tables: SimGlueTableStore;
+  readonly #authorizer: SimGlueAuthorizer;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimGlueDatabaseCommandsProperties) {
+    this.#databases = properties.databases;
+    this.#tables = properties.tables;
+    this.#authorizer = properties.authorizer;
+    this.#accountRegionScope = properties.accountRegionScope;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Make a database.
+   *
+   * Creation is not idempotent on real Glue, so a name already in use fails
+   * rather than answering with the database that is there.
+   */
+  createDatabase(
+    command: SimCreateDatabaseCommand,
+    options?: SimGlueRequestOptions,
+  ): SimCreateDatabaseCommandOutput {
+    requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
+
+    const input = command.input.DatabaseInput ?? {};
+    const name = requiredSimGlueName("DatabaseInput.Name", input.Name);
+
+    this.#authorizer.authorizeDatabase(
+      "glue:CreateDatabase",
+      name,
+      options?.caller,
+    );
+
+    this.#databases.create(name, this.#clock.now(), {
+      description: input.Description,
+      locationUri: input.LocationUri,
+      parameters: input.Parameters,
+    });
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Read a database back.
+   */
+  getDatabase(
+    command: SimGetDatabaseCommand,
+    options?: SimGlueRequestOptions,
+  ): SimGetDatabaseCommandOutput {
+    requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
+
+    const name = requiredSimGlueName("Name", command.input.Name);
+
+    this.#authorizer.authorizeDatabase(
+      "glue:GetDatabase",
+      name,
+      options?.caller,
+    );
+
+    return {
+      Database: simGlueDatabaseDetail(this.#databases.require(name)),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Read every database in this catalog, in creation order.
+   */
+  getDatabases(
+    command: SimGetDatabasesCommand,
+    options?: SimGlueRequestOptions,
+  ): SimGetDatabasesCommandOutput {
+    requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
+
+    this.#authorizer.authorizeCatalog("glue:GetDatabases", options?.caller);
+
+    return {
+      DatabaseList: this.#databases.all.map(simGlueDatabaseDetail),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Remove a database, and the tables it holds with it.
+   */
+  deleteDatabase(
+    command: SimDeleteDatabaseCommand,
+    options?: SimGlueRequestOptions,
+  ): SimDeleteDatabaseCommandOutput {
+    requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
+
+    const name = requiredSimGlueName("Name", command.input.Name);
+
+    this.#authorizer.authorizeDatabase(
+      "glue:DeleteDatabase",
+      name,
+      options?.caller,
+    );
+
+    this.#databases.require(name);
+    this.#databases.delete(name);
+    this.#tables.deleteDatabase(name);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/glue/command/database/sim-glue-database-commands.ts
+++ b/src/service/glue/command/database/sim-glue-database-commands.ts
@@ -125,9 +125,9 @@ export class SimGlueDatabaseCommands {
 
     const name = requiredSimGlueName("Name", command.input.Name);
 
-    this.#authorizer.authorizeDatabase(
-      "glue:DeleteDatabase",
+    this.#authorizer.authorizeDatabaseDeletion(
       name,
+      this.#tables.inDatabase(name).map((table) => table.name),
       options?.caller,
     );
 

--- a/src/service/glue/command/database/sim-glue-database-detail.ts
+++ b/src/service/glue/command/database/sim-glue-database-detail.ts
@@ -1,0 +1,19 @@
+import type { SimGlueDatabase } from "../../database/sim-glue-database.js";
+import { definedEntries } from "../../../../util/record/defined-entries.js";
+import type { SimGlueDatabaseDetail } from "./database.command.js";
+
+/**
+ * What GetDatabase and GetDatabases report about a database.
+ */
+export function simGlueDatabaseDetail(
+  database: SimGlueDatabase,
+): SimGlueDatabaseDetail {
+  return definedEntries({
+    Name: database.name,
+    Description: database.description,
+    LocationUri: database.locationUri,
+    Parameters: database.parameters,
+    CreateTime: database.createTime,
+    CatalogId: database.catalogId,
+  });
+}

--- a/src/service/glue/command/database/sim-glue-database-detail.ts
+++ b/src/service/glue/command/database/sim-glue-database-detail.ts
@@ -4,16 +4,21 @@ import type { SimGlueDatabaseDetail } from "./database.command.js";
 
 /**
  * What GetDatabase and GetDatabases report about a database.
+ *
+ * The result is detached from the stored database, for the reason
+ * `simGlueTableDetail` gives.
  */
 export function simGlueDatabaseDetail(
   database: SimGlueDatabase,
 ): SimGlueDatabaseDetail {
-  return definedEntries({
-    Name: database.name,
-    Description: database.description,
-    LocationUri: database.locationUri,
-    Parameters: database.parameters,
-    CreateTime: database.createTime,
-    CatalogId: database.catalogId,
-  });
+  return structuredClone(
+    definedEntries({
+      Name: database.name,
+      Description: database.description,
+      LocationUri: database.locationUri,
+      Parameters: database.parameters,
+      CreateTime: database.createTime,
+      CatalogId: database.catalogId,
+    }),
+  );
 }

--- a/src/service/glue/command/sim-glue-catalog-id.ts
+++ b/src/service/glue/command/sim-glue-catalog-id.ts
@@ -1,0 +1,25 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimGlueInvalidInputException } from "../error/sim-glue.error.js";
+
+/**
+ * Check the catalog a request names is the one this simulation holds.
+ *
+ * `CatalogId` defaults to the caller's own account on real Glue, and naming
+ * another account's catalog reaches that account's Data Catalog through a
+ * resource policy. Nothing here crosses accounts, so a catalog id belonging to
+ * another account is refused rather than quietly answered from this one.
+ */
+export function requireSimGlueCatalogId(
+  accountRegionScope: SimAwsAccountRegionScope,
+  catalogId: string | undefined,
+): void {
+  if (catalogId === undefined || catalogId === accountRegionScope.accountId) {
+    return;
+  }
+
+  throw new SimGlueInvalidInputException(
+    `Simulated Glue holds the Data Catalog of account ` +
+      `${accountRegionScope.accountId}, and CatalogId ${catalogId} names ` +
+      `another account. Cross-account Data Catalog access is not simulated.`,
+  );
+}

--- a/src/service/glue/command/sim-glue-request-options.ts
+++ b/src/service/glue/command/sim-glue-request-options.ts
@@ -1,0 +1,12 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * What a simulated Glue request carries besides its command input.
+ */
+export interface SimGlueRequestOptions {
+  /**
+   * Who is making the request. An omitted caller is the Account root, as it is
+   * everywhere else in the simulation.
+   */
+  readonly caller?: SimAwsCaller;
+}

--- a/src/service/glue/command/table/sim-glue-table-commands.ts
+++ b/src/service/glue/command/table/sim-glue-table-commands.ts
@@ -1,0 +1,186 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
+import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
+import type { SimGlueTableStore } from "../../table/sim-glue-table-store.js";
+import {
+  requiredSimGlueColumns,
+  requiredSimGlueStorageDescriptor,
+} from "../../table/sim-glue-table-input-shape.js";
+import type { SimGlueAuthorizer } from "../authorize/sim-glue-authorizer.js";
+import { requireSimGlueCatalogId } from "../sim-glue-catalog-id.js";
+import type { SimGlueRequestOptions } from "../sim-glue-request-options.js";
+import type {
+  SimCreateTableCommand,
+  SimCreateTableCommandOutput,
+  SimDeleteTableCommand,
+  SimDeleteTableCommandOutput,
+  SimGetTableCommand,
+  SimGetTableCommandOutput,
+  SimGetTablesCommand,
+  SimGetTablesCommandOutput,
+} from "./table.command.js";
+import { simGlueTableDetail } from "./sim-glue-table-detail.js";
+
+interface SimGlueTableCommandsProperties {
+  readonly databases: SimGlueDatabaseStore;
+  readonly tables: SimGlueTableStore;
+  readonly authorizer: SimGlueAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that make, read and remove Glue tables.
+ */
+export class SimGlueTableCommands {
+  readonly #databases: SimGlueDatabaseStore;
+  readonly #tables: SimGlueTableStore;
+  readonly #authorizer: SimGlueAuthorizer;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimGlueTableCommandsProperties) {
+    this.#databases = properties.databases;
+    this.#tables = properties.tables;
+    this.#authorizer = properties.authorizer;
+    this.#accountRegionScope = properties.accountRegionScope;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Make a table in a database.
+   *
+   * The database has to be there. Real Glue answers `EntityNotFoundException`
+   * for one that is absent rather than creating it on the way past.
+   */
+  createTable(
+    command: SimCreateTableCommand,
+    options?: SimGlueRequestOptions,
+  ): SimCreateTableCommandOutput {
+    requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
+
+    const databaseName = requiredSimGlueName(
+      "DatabaseName",
+      command.input.DatabaseName,
+    );
+    const input = command.input.TableInput ?? {};
+    const name = requiredSimGlueName(
+      "TableInput.Name",
+      input.Name ?? command.input.Name,
+    );
+
+    this.#authorizer.authorizeTable(
+      "glue:CreateTable",
+      databaseName,
+      name,
+      options?.caller,
+    );
+
+    this.#databases.require(databaseName);
+    this.#tables.create(databaseName, name, this.#clock.now(), {
+      description: input.Description,
+      owner: input.Owner,
+      retention: input.Retention,
+      tableType: input.TableType,
+      partitionKeys: requiredSimGlueColumns(
+        "TableInput.PartitionKeys",
+        input.PartitionKeys,
+      ),
+      storageDescriptor: requiredSimGlueStorageDescriptor(
+        "TableInput.StorageDescriptor",
+        input.StorageDescriptor,
+      ),
+      parameters: input.Parameters,
+    });
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Read a table back, with its storage descriptor, partition keys and
+   * parameters as they were declared.
+   */
+  getTable(
+    command: SimGetTableCommand,
+    options?: SimGlueRequestOptions,
+  ): SimGetTableCommandOutput {
+    requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
+
+    const databaseName = requiredSimGlueName(
+      "DatabaseName",
+      command.input.DatabaseName,
+    );
+    const name = requiredSimGlueName("Name", command.input.Name);
+
+    this.#authorizer.authorizeTable(
+      "glue:GetTable",
+      databaseName,
+      name,
+      options?.caller,
+    );
+
+    this.#databases.require(databaseName);
+
+    return {
+      Table: simGlueTableDetail(this.#tables.require(databaseName, name)),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Read every table in one database, in creation order.
+   */
+  getTables(
+    command: SimGetTablesCommand,
+    options?: SimGlueRequestOptions,
+  ): SimGetTablesCommandOutput {
+    requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
+
+    const databaseName = requiredSimGlueName(
+      "DatabaseName",
+      command.input.DatabaseName,
+    );
+
+    this.#authorizer.authorizeDatabase(
+      "glue:GetTables",
+      databaseName,
+      options?.caller,
+    );
+
+    this.#databases.require(databaseName);
+
+    return {
+      TableList: this.#tables.inDatabase(databaseName).map(simGlueTableDetail),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Remove a table.
+   */
+  deleteTable(
+    command: SimDeleteTableCommand,
+    options?: SimGlueRequestOptions,
+  ): SimDeleteTableCommandOutput {
+    requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
+
+    const databaseName = requiredSimGlueName(
+      "DatabaseName",
+      command.input.DatabaseName,
+    );
+    const name = requiredSimGlueName("Name", command.input.Name);
+
+    this.#authorizer.authorizeTable(
+      "glue:DeleteTable",
+      databaseName,
+      name,
+      options?.caller,
+    );
+
+    this.#tables.require(databaseName, name);
+    this.#tables.delete(databaseName, name);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/glue/command/table/sim-glue-table-detail.ts
+++ b/src/service/glue/command/table/sim-glue-table-detail.ts
@@ -6,20 +6,27 @@ import type { SimGlueTableDetail } from "./table.command.js";
  * What GetTable and GetTables report about a table.
  *
  * Nothing updates a table yet, so the update time is the creation time.
+ *
+ * The result is detached from the stored table. Real Glue answers each request
+ * with its own object, and a caller holding a reference into the catalog could
+ * otherwise change a definition without a command or the permission to make
+ * one.
  */
 export function simGlueTableDetail(table: SimGlueTable): SimGlueTableDetail {
-  return definedEntries({
-    Name: table.name,
-    DatabaseName: table.databaseName,
-    Description: table.description,
-    Owner: table.owner,
-    Retention: table.retention,
-    TableType: table.tableType,
-    PartitionKeys: table.partitionKeys,
-    StorageDescriptor: table.storageDescriptor,
-    Parameters: table.parameters,
-    CreateTime: table.createTime,
-    UpdateTime: table.createTime,
-    CatalogId: table.catalogId,
-  });
+  return structuredClone(
+    definedEntries({
+      Name: table.name,
+      DatabaseName: table.databaseName,
+      Description: table.description,
+      Owner: table.owner,
+      Retention: table.retention,
+      TableType: table.tableType,
+      PartitionKeys: table.partitionKeys,
+      StorageDescriptor: table.storageDescriptor,
+      Parameters: table.parameters,
+      CreateTime: table.createTime,
+      UpdateTime: table.createTime,
+      CatalogId: table.catalogId,
+    }),
+  );
 }

--- a/src/service/glue/command/table/sim-glue-table-detail.ts
+++ b/src/service/glue/command/table/sim-glue-table-detail.ts
@@ -1,0 +1,25 @@
+import type { SimGlueTable } from "../../table/sim-glue-table.js";
+import { definedEntries } from "../../../../util/record/defined-entries.js";
+import type { SimGlueTableDetail } from "./table.command.js";
+
+/**
+ * What GetTable and GetTables report about a table.
+ *
+ * Nothing updates a table yet, so the update time is the creation time.
+ */
+export function simGlueTableDetail(table: SimGlueTable): SimGlueTableDetail {
+  return definedEntries({
+    Name: table.name,
+    DatabaseName: table.databaseName,
+    Description: table.description,
+    Owner: table.owner,
+    Retention: table.retention,
+    TableType: table.tableType,
+    PartitionKeys: table.partitionKeys,
+    StorageDescriptor: table.storageDescriptor,
+    Parameters: table.parameters,
+    CreateTime: table.createTime,
+    UpdateTime: table.createTime,
+    CatalogId: table.catalogId,
+  });
+}

--- a/src/service/glue/command/table/table.command.ts
+++ b/src/service/glue/command/table/table.command.ts
@@ -1,0 +1,124 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimGlueColumn,
+  SimGlueStorageDescriptor,
+} from "../../table/sim-glue-table-schema.js";
+import type {
+  SimGlueColumnInput,
+  SimGlueStorageDescriptorInput,
+} from "../../table/sim-glue-table-input-shape.js";
+
+/**
+ * What a caller declares a table with.
+ *
+ * `Parameters` is where Athena partition projection lives, so it is the field
+ * a caller is most likely to be asserting on.
+ *
+ * https://docs.aws.amazon.com/glue/latest/webapi/API_TableInput.html
+ */
+export interface SimGlueTableInputShape {
+  readonly Name?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly Owner?: string | undefined;
+  readonly Retention?: number | undefined;
+  readonly TableType?: string | undefined;
+  readonly PartitionKeys?: readonly SimGlueColumnInput[] | undefined;
+  readonly StorageDescriptor?: SimGlueStorageDescriptorInput | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * What GetTable reports about one table.
+ */
+export interface SimGlueTableDetail {
+  readonly Name: string;
+  readonly DatabaseName: string;
+  readonly Description?: string | undefined;
+  readonly Owner?: string | undefined;
+  readonly Retention?: number | undefined;
+  readonly TableType?: string | undefined;
+  readonly PartitionKeys: readonly SimGlueColumn[];
+  readonly StorageDescriptor?: SimGlueStorageDescriptor | undefined;
+  readonly Parameters: Readonly<Record<string, string>>;
+  readonly CreateTime: Date;
+  readonly UpdateTime: Date;
+  readonly CatalogId: string;
+}
+
+/**
+ * Minimal structural sim Glue CreateTable command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/CreateTableCommand/
+ */
+export interface SimCreateTableCommand {
+  readonly input: SimCreateTableCommandInput;
+}
+
+export interface SimCreateTableCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly TableInput?: SimGlueTableInputShape | undefined;
+}
+
+export interface SimCreateTableCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue GetTable command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/GetTableCommand/
+ */
+export interface SimGetTableCommand {
+  readonly input: SimGetTableCommandInput;
+}
+
+export interface SimGetTableCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly Name?: string | undefined;
+}
+
+export interface SimGetTableCommandOutput {
+  readonly Table: SimGlueTableDetail;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue GetTables command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/GetTablesCommand/
+ */
+export interface SimGetTablesCommand {
+  readonly input: SimGetTablesCommandInput;
+}
+
+export interface SimGetTablesCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+}
+
+export interface SimGetTablesCommandOutput {
+  readonly TableList: readonly SimGlueTableDetail[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue DeleteTable command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/DeleteTableCommand/
+ */
+export interface SimDeleteTableCommand {
+  readonly input: SimDeleteTableCommandInput;
+}
+
+export interface SimDeleteTableCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly Name?: string | undefined;
+}
+
+export interface SimDeleteTableCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/glue/database/sim-glue-catalog-name.ts
+++ b/src/service/glue/database/sim-glue-catalog-name.ts
@@ -1,10 +1,18 @@
 import { SimGlueInvalidInputException } from "../error/sim-glue.error.js";
 
-/** How long a name real Glue accepts for a database or a table. */
-const maximumNameLength = 255;
+/**
+ * How long a name real Glue accepts for a database, a table or a column.
+ *
+ * Measured in UTF-8 bytes rather than characters, which is how the Data
+ * Catalog states the limit. A 255 character name of three-byte characters is
+ * three times over it.
+ */
+const maximumNameBytes = 255;
+
+const nameEncoder = new TextEncoder();
 
 /**
- * Read a database or table name, refusing one real Glue would refuse.
+ * Read a Data Catalog name, refusing one real Glue would refuse.
  *
  * Real Glue lowercases these names for Hive compatibility. This keeps the
  * name as it was given, which is recorded in the docs page's Limitations list.
@@ -17,9 +25,9 @@ export function requiredSimGlueName(
     throw new SimGlueInvalidInputException(`${label} is required`);
   }
 
-  if (value.length > maximumNameLength) {
+  if (nameEncoder.encode(value).length > maximumNameBytes) {
     throw new SimGlueInvalidInputException(
-      `${label} must be at most ${maximumNameLength} characters`,
+      `${label} must be at most ${maximumNameBytes} UTF-8 bytes`,
     );
   }
 

--- a/src/service/glue/database/sim-glue-catalog-name.ts
+++ b/src/service/glue/database/sim-glue-catalog-name.ts
@@ -1,0 +1,27 @@
+import { SimGlueInvalidInputException } from "../error/sim-glue.error.js";
+
+/** How long a name real Glue accepts for a database or a table. */
+const maximumNameLength = 255;
+
+/**
+ * Read a database or table name, refusing one real Glue would refuse.
+ *
+ * Real Glue lowercases these names for Hive compatibility. This keeps the
+ * name as it was given, which is recorded in the docs page's Limitations list.
+ */
+export function requiredSimGlueName(
+  label: string,
+  value: string | undefined,
+): string {
+  if (value === undefined || value === "") {
+    throw new SimGlueInvalidInputException(`${label} is required`);
+  }
+
+  if (value.length > maximumNameLength) {
+    throw new SimGlueInvalidInputException(
+      `${label} must be at most ${maximumNameLength} characters`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/glue/database/sim-glue-database-store.ts
+++ b/src/service/glue/database/sim-glue-database-store.ts
@@ -1,0 +1,86 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimGlueAlreadyExistsException,
+  SimGlueEntityNotFoundException,
+} from "../error/sim-glue.error.js";
+import { SimGlueDatabase } from "./sim-glue-database.js";
+
+interface SimGlueDatabaseStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/** What a database is created with, beyond its name. */
+export interface SimGlueDatabaseInput {
+  readonly description?: string | undefined;
+  readonly locationUri?: string | undefined;
+  readonly parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * The databases of one simulated Glue catalog.
+ *
+ * Keyed by name, which is the whole of a database's identity within one
+ * account and region.
+ */
+export class SimGlueDatabaseStore {
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #databases = new Map<string, SimGlueDatabase>();
+
+  constructor(properties: SimGlueDatabaseStoreProperties) {
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /** Every database in this catalog, in creation order. */
+  get all(): readonly SimGlueDatabase[] {
+    return this.#databases.values().toArray();
+  }
+
+  /**
+   * Make a database, refusing a name that is taken.
+   */
+  create(
+    name: string,
+    createTime: Date,
+    input: SimGlueDatabaseInput = {},
+  ): SimGlueDatabase {
+    if (this.#databases.has(name)) {
+      throw new SimGlueAlreadyExistsException(
+        `Database already exists: ${name}`,
+      );
+    }
+
+    const database = new SimGlueDatabase({
+      name,
+      accountRegionScope: this.#accountRegionScope,
+      createTime,
+      ...input,
+    });
+
+    this.#databases.set(name, database);
+
+    return database;
+  }
+
+  /** Find a database by name. */
+  find(name: string): SimGlueDatabase | undefined {
+    return this.#databases.get(name);
+  }
+
+  /**
+   * Get a database by name, refusing one that is absent.
+   */
+  require(name: string): SimGlueDatabase {
+    const database = this.find(name);
+
+    if (database === undefined) {
+      throw new SimGlueEntityNotFoundException(`Database not found: ${name}`);
+    }
+
+    return database;
+  }
+
+  /** Remove a database. */
+  delete(name: string): void {
+    this.#databases.delete(name);
+  }
+}

--- a/src/service/glue/database/sim-glue-database.ts
+++ b/src/service/glue/database/sim-glue-database.ts
@@ -14,7 +14,8 @@ interface SimGlueDatabaseProperties {
  * A simulated Glue database, which is the grouping a table lives in.
  *
  * A database holds no data of its own. What it carries is a name, somewhere
- * for a table to belong, and the parameters a caller put on it.
+ * for a table to belong, and the parameters a caller put on it, copied on the
+ * way in so a caller reusing its input cannot change what is stored.
  */
 export class SimGlueDatabase {
   readonly name: string;
@@ -27,10 +28,10 @@ export class SimGlueDatabase {
 
   constructor(properties: SimGlueDatabaseProperties) {
     this.name = properties.name;
-    this.createTime = properties.createTime;
+    this.createTime = new Date(properties.createTime);
     this.description = properties.description;
     this.locationUri = properties.locationUri;
-    this.parameters = { ...properties.parameters };
+    this.parameters = structuredClone(properties.parameters) ?? {};
     this.#accountRegionScope = properties.accountRegionScope;
   }
 

--- a/src/service/glue/database/sim-glue-database.ts
+++ b/src/service/glue/database/sim-glue-database.ts
@@ -1,0 +1,46 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simGlueDatabaseArn } from "../arn/sim-glue-arn.js";
+
+interface SimGlueDatabaseProperties {
+  readonly name: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly createTime: Date;
+  readonly description?: string | undefined;
+  readonly locationUri?: string | undefined;
+  readonly parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * A simulated Glue database, which is the grouping a table lives in.
+ *
+ * A database holds no data of its own. What it carries is a name, somewhere
+ * for a table to belong, and the parameters a caller put on it.
+ */
+export class SimGlueDatabase {
+  readonly name: string;
+  readonly createTime: Date;
+  readonly description: string | undefined;
+  readonly locationUri: string | undefined;
+  readonly parameters: Readonly<Record<string, string>>;
+
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimGlueDatabaseProperties) {
+    this.name = properties.name;
+    this.createTime = properties.createTime;
+    this.description = properties.description;
+    this.locationUri = properties.locationUri;
+    this.parameters = { ...properties.parameters };
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /** The catalog holding this database, which is the account id. */
+  get catalogId(): string {
+    return this.#accountRegionScope.accountId;
+  }
+
+  /** This database's ARN. */
+  get arn(): string {
+    return simGlueDatabaseArn(this.#accountRegionScope, this.name);
+  }
+}

--- a/src/service/glue/error/sim-glue.error.ts
+++ b/src/service/glue/error/sim-glue.error.ts
@@ -1,0 +1,54 @@
+/**
+ * Minimal metadata shape for simulated Glue errors.
+ */
+export interface SimGlueErrorMetadata {
+  readonly httpStatusCode?: number;
+}
+
+/**
+ * Base class for simulated Glue errors.
+ */
+export class SimGlueError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimGlueErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Simulated Glue EntityNotFoundException.
+ *
+ * Real Glue answers with this for a database or table that is absent, and for
+ * a `CreateTable` naming a database that is absent.
+ */
+export class SimGlueEntityNotFoundException extends SimGlueError {
+  public override readonly name = "EntityNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Glue AlreadyExistsException.
+ */
+export class SimGlueAlreadyExistsException extends SimGlueError {
+  public override readonly name = "AlreadyExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated Glue InvalidInputException.
+ */
+export class SimGlueInvalidInputException extends SimGlueError {
+  public override readonly name = "InvalidInputException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/glue/index.ts
+++ b/src/service/glue/index.ts
@@ -1,0 +1,66 @@
+export { SimGlue, type SimGlueProperties } from "./sim-glue.js";
+export { SimGlueDatabase } from "./database/sim-glue-database.js";
+export {
+  SimGlueDatabaseStore,
+  type SimGlueDatabaseInput,
+} from "./database/sim-glue-database-store.js";
+export { SimGlueTable } from "./table/sim-glue-table.js";
+export {
+  SimGlueTableStore,
+  type SimGlueTableInput,
+} from "./table/sim-glue-table-store.js";
+export type {
+  SimGlueColumn,
+  SimGlueSerDeInfo,
+  SimGlueStorageDescriptor,
+} from "./table/sim-glue-table-schema.js";
+export type {
+  SimGlueColumnInput,
+  SimGlueStorageDescriptorInput,
+} from "./table/sim-glue-table-input-shape.js";
+export { SimGlueCatalogWriter } from "./write/sim-glue-catalog-writer.js";
+export type { SimGlueRequestOptions } from "./command/sim-glue-request-options.js";
+export type {
+  SimCreateDatabaseCommand,
+  SimCreateDatabaseCommandInput,
+  SimCreateDatabaseCommandOutput,
+  SimDeleteDatabaseCommand,
+  SimDeleteDatabaseCommandInput,
+  SimDeleteDatabaseCommandOutput,
+  SimGetDatabaseCommand,
+  SimGetDatabaseCommandInput,
+  SimGetDatabaseCommandOutput,
+  SimGetDatabasesCommand,
+  SimGetDatabasesCommandInput,
+  SimGetDatabasesCommandOutput,
+  SimGlueDatabaseDetail,
+  SimGlueDatabaseInputShape,
+} from "./command/database/database.command.js";
+export type {
+  SimCreateTableCommand,
+  SimCreateTableCommandInput,
+  SimCreateTableCommandOutput,
+  SimDeleteTableCommand,
+  SimDeleteTableCommandInput,
+  SimDeleteTableCommandOutput,
+  SimGetTableCommand,
+  SimGetTableCommandInput,
+  SimGetTableCommandOutput,
+  SimGetTablesCommand,
+  SimGetTablesCommandInput,
+  SimGetTablesCommandOutput,
+  SimGlueTableDetail,
+  SimGlueTableInputShape,
+} from "./command/table/table.command.js";
+export {
+  simGlueCatalogArn,
+  simGlueDatabaseArn,
+  simGlueTableArn,
+} from "./arn/sim-glue-arn.js";
+export {
+  SimGlueAlreadyExistsException,
+  SimGlueEntityNotFoundException,
+  SimGlueError,
+  type SimGlueErrorMetadata,
+  SimGlueInvalidInputException,
+} from "./error/sim-glue.error.js";

--- a/src/service/glue/sdk/sim-glue-sdk-command-router.ts
+++ b/src/service/glue/sdk/sim-glue-sdk-command-router.ts
@@ -1,0 +1,120 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type {
+  SimCreateDatabaseCommand,
+  SimDeleteDatabaseCommand,
+  SimGetDatabaseCommand,
+  SimGetDatabasesCommand,
+} from "../command/database/database.command.js";
+import type {
+  SimCreateTableCommand,
+  SimDeleteTableCommand,
+  SimGetTableCommand,
+  SimGetTablesCommand,
+} from "../command/table/table.command.js";
+import type { SimGlue } from "../sim-glue.js";
+
+/**
+ * Routes intercepted SDK Commands to one scoped simulated Glue.
+ */
+export class SimGlueSdkCommandRouter implements SimSdkCommandRouter {
+  readonly #routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(simGlue: SimGlue) {
+    this.#routes = new Map<string, SimSdkCommandRoute>([
+      [
+        "CreateDatabaseCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.createDatabase(
+              command as SimCreateDatabaseCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "GetDatabaseCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.getDatabase(
+              command as SimGetDatabaseCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "GetDatabasesCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.getDatabases(
+              command as SimGetDatabasesCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "DeleteDatabaseCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.deleteDatabase(
+              command as SimDeleteDatabaseCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "CreateTableCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.createTable(
+              command as SimCreateTableCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "GetTableCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.getTable(
+              command as SimGetTableCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "GetTablesCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.getTables(
+              command as SimGetTablesCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "DeleteTableCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.deleteTable(
+              command as SimDeleteTableCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+    ]);
+  }
+
+  /** The SDK Command names simulated Glue can handle. */
+  supportedCommandNames(): readonly string[] {
+    return this.#routes.keys().toArray();
+  }
+
+  /** The simulated Glue operation behind one SDK Command name. */
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.#routes.get(commandName);
+  }
+}

--- a/src/service/glue/sdk/sim-glue-sdk-routing.iso.test.ts
+++ b/src/service/glue/sdk/sim-glue-sdk-routing.iso.test.ts
@@ -1,0 +1,156 @@
+import {
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  DeleteDatabaseCommand,
+  DeleteTableCommand,
+  GetDatabaseCommand,
+  GetDatabasesCommand,
+  GetTableCommand,
+  GetTablesCommand,
+  GlueClient,
+} from "@aws-sdk/client-glue";
+import {
+  assertArrayEquals,
+  assertArrayIncludesAll,
+  assertArrayLength,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("SimGlueSdkCommandRouter", () => {
+  it("names every Command simulated Glue handles", () => {
+    // Given a scoped simulated Glue.
+    const simAws = new SimAws();
+
+    // When its supported Command names are asked for.
+    const names = simAws.glue().sdkCommandRouter().supportedCommandNames();
+
+    // Then each simulated operation is routable by SDK Command name.
+    assertArrayIncludesAll(names, [
+      "CreateDatabaseCommand",
+      "GetDatabaseCommand",
+      "GetDatabasesCommand",
+      "DeleteDatabaseCommand",
+      "CreateTableCommand",
+      "GetTableCommand",
+      "GetTablesCommand",
+      "DeleteTableCommand",
+    ]);
+  });
+
+  it("has no route for a Command simulated Glue does not handle", () => {
+    // Given a scoped simulated Glue.
+    const simAws = new SimAws();
+
+    // When a Command outside the simulated surface is asked for.
+    const route = simAws
+      .glue()
+      .sdkCommandRouter()
+      .route("CreateCrawlerCommand");
+
+    // Then there is no route for it.
+    assertUndefined(route);
+  });
+});
+
+describe("Glue SDK interception", () => {
+  it("routes an intercepted GlueClient to simulated Glue", async () => {
+    // Given an intercepted Glue SDK client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(GlueClient);
+
+    const client = new GlueClient({ region: "eu-west-2" });
+
+    // When ordinary SDK code creates a database and a table in it.
+    await client.send(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    await client.send(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: {
+          Name: "access_logs",
+          Parameters: { "projection.enabled": "true" },
+        },
+      }),
+    );
+
+    const database = await client.send(
+      new GetDatabaseCommand({ Name: "site_logs" }),
+    );
+    const table = await client.send(
+      new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+    );
+
+    // Then both come back from the simulation.
+    assertIdentical(database.Database?.Name, "site_logs");
+    assertIdentical(table.Table?.Name, "access_logs");
+    assertIdentical(table.Table.Parameters?.["projection.enabled"], "true");
+  });
+
+  it("lists and deletes through an intercepted client", async () => {
+    // Given an intercepted client holding a database and two tables.
+    using simSdk = new SimSdk();
+    simSdk.intercept(GlueClient);
+
+    const client = new GlueClient({ region: "eu-west-2" });
+
+    await client.send(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    await client.send(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: { Name: "access_logs" },
+      }),
+    );
+    await client.send(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: { Name: "error_logs" },
+      }),
+    );
+
+    // When they are listed and one table is deleted.
+    const databases = await client.send(new GetDatabasesCommand({}));
+    const before = await client.send(
+      new GetTablesCommand({ DatabaseName: "site_logs" }),
+    );
+
+    await client.send(
+      new DeleteTableCommand({
+        DatabaseName: "site_logs",
+        Name: "error_logs",
+      }),
+    );
+
+    const after = await client.send(
+      new GetTablesCommand({ DatabaseName: "site_logs" }),
+    );
+
+    // Then the listings report what the catalog holds at each point.
+    assertArrayEquals(
+      databases.DatabaseList?.map((database) => database.Name),
+      ["site_logs"],
+    );
+    assertArrayEquals(
+      before.TableList?.map((table) => table.Name),
+      ["access_logs", "error_logs"],
+    );
+    assertArrayEquals(
+      after.TableList?.map((table) => table.Name),
+      ["access_logs"],
+    );
+
+    // And deleting the database takes its remaining table with it.
+    await client.send(new DeleteDatabaseCommand({ Name: "site_logs" }));
+
+    const remaining = await client.send(new GetDatabasesCommand({}));
+
+    assertArrayLength(remaining.DatabaseList ?? [], 0);
+  });
+});

--- a/src/service/glue/sim-glue-authorization.iso.test.ts
+++ b/src/service/glue/sim-glue-authorization.iso.test.ts
@@ -2,9 +2,11 @@ import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   CreateDatabaseCommand,
   CreateTableCommand,
+  DeleteDatabaseCommand,
   GetTableCommand,
 } from "@aws-sdk/client-glue";
 import {
+  assertArrayLength,
   assertIdentical,
   assertInstanceOf,
   assertStringIncludes,
@@ -21,10 +23,31 @@ const caller = {
   arn: `arn:aws:iam::${accountId}:role/ReportingRole`,
 };
 
-/**
- * A Role that may read one table and nothing else in the catalog.
- */
-async function reportingRole(simAws: SimAws): Promise<void> {
+const catalogArn = `arn:aws:glue:us-east-1:${accountId}:catalog`;
+const databaseArn = `arn:aws:glue:us-east-1:${accountId}:database/site_logs`;
+const tableArn = `arn:aws:glue:us-east-1:${accountId}:table/site_logs/access_logs`;
+
+/** A catalog holding one table, which is what the policies below name. */
+function catalogWithTable(simAws: SimAws): void {
+  const glue = simAws.glue();
+
+  glue.createDatabase(
+    new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+  );
+  glue.createTable(
+    new CreateTableCommand({
+      DatabaseName: "site_logs",
+      TableInput: { Name: "access_logs" },
+    }),
+  );
+}
+
+/** A Role allowed one action over the resources named. */
+async function roleAllowing(
+  simAws: SimAws,
+  action: string,
+  resource: readonly string[],
+): Promise<void> {
   await simAws.iam().createRole(
     new CreateRoleCommand({
       RoleName: "ReportingRole",
@@ -47,63 +70,99 @@ async function reportingRole(simAws: SimAws): Promise<void> {
       PolicyName: "ReadAccessLogs",
       PolicyDocument: JSON.stringify({
         Version: "2012-10-17",
-        Statement: [
-          {
-            Effect: "Allow",
-            Action: "glue:GetTable",
-            Resource: `arn:aws:glue:us-east-1:${accountId}:table/site_logs/access_logs`,
-          },
-        ],
+        Statement: [{ Effect: "Allow", Action: action, Resource: resource }],
       }),
     }),
   );
 }
 
 describe("SimGlue authorization", () => {
-  it("lets a caller read the table its policy names", async () => {
-    // Given a catalog holding a table, and a role allowed to read that table.
+  it("lets a caller whose policy names the table and its ancestors read it", async () => {
+    // Given a role allowed to read one table, over the catalog, the database
+    // and the table, which is what real Glue needs.
     const simAws = new SimAws({ defaultAccountId: accountId });
-    const glue = simAws.glue();
 
-    glue.createDatabase(
-      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
-    );
-    glue.createTable(
-      new CreateTableCommand({
-        DatabaseName: "site_logs",
-        TableInput: { Name: "access_logs" },
-      }),
-    );
-
-    await reportingRole(simAws);
+    catalogWithTable(simAws);
+    await roleAllowing(simAws, "glue:GetTable", [
+      catalogArn,
+      databaseArn,
+      tableArn,
+    ]);
 
     // When the role reads that table.
-    const { Table } = glue.getTable(
-      new GetTableCommand({
-        DatabaseName: "site_logs",
-        Name: "access_logs",
-      }),
-      { caller },
-    );
+    const { Table } = simAws
+      .glue()
+      .getTable(
+        new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+        { caller },
+      );
 
     // Then it comes back.
     assertIdentical(Table.Name, "access_logs");
   });
 
-  it("refuses a caller whose policy leaves the action out", async () => {
-    // Given the same role, which may read a table and nothing else.
+  it("refuses a policy naming the table without its ancestors", async () => {
+    // Given a role allowed to read the table ARN alone. Real Glue denies this,
+    // because an operation on a Data Catalog resource needs permission on the
+    // resource and on every ancestor of it.
     const simAws = new SimAws({ defaultAccountId: accountId });
-    const glue = simAws.glue();
 
-    glue.createDatabase(
-      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
-    );
+    catalogWithTable(simAws);
+    await roleAllowing(simAws, "glue:GetTable", [tableArn]);
 
-    await reportingRole(simAws);
+    // When the role reads that table.
+    const error = assertThrowsError(() => {
+      simAws.glue().getTable(
+        new GetTableCommand({
+          DatabaseName: "site_logs",
+          Name: "access_logs",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is refused, naming the outermost resource the policy left out.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, catalogArn);
+  });
+
+  it("refuses a policy naming the catalog without the database", async () => {
+    // Given a role allowed the action over the catalog alone.
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    catalogWithTable(simAws);
+    await roleAllowing(simAws, "glue:GetTable", [catalogArn]);
+
+    // When the role reads a table.
+    const error = assertThrowsError(() => {
+      simAws.glue().getTable(
+        new GetTableCommand({
+          DatabaseName: "site_logs",
+          Name: "access_logs",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is refused at the database, which is the next resource down.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, databaseArn);
+  });
+
+  it("refuses a caller whose policy leaves the action out", async () => {
+    // Given a role that may read a table and nothing else.
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    catalogWithTable(simAws);
+    await roleAllowing(simAws, "glue:GetTable", [
+      catalogArn,
+      databaseArn,
+      tableArn,
+    ]);
 
     // When it creates a table.
     const error = assertThrowsError(() => {
-      glue.createTable(
+      simAws.glue().createTable(
         new CreateTableCommand({
           DatabaseName: "site_logs",
           TableInput: { Name: "error_logs" },
@@ -117,35 +176,50 @@ describe("SimGlue authorization", () => {
     assertStringIncludes(error.message, "glue:CreateTable");
   });
 
-  it("refuses a caller reading a table outside its policy", async () => {
-    // Given a catalog holding a second table the role's policy leaves out.
+  it("refuses deleting a database the policy covers without its tables", async () => {
+    // Given a role allowed to delete the database and its ancestors, and
+    // nothing on the table inside it. A delete needs the children too.
     const simAws = new SimAws({ defaultAccountId: accountId });
-    const glue = simAws.glue();
 
-    glue.createDatabase(
-      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
-    );
-    glue.createTable(
-      new CreateTableCommand({
-        DatabaseName: "site_logs",
-        TableInput: { Name: "error_logs" },
-      }),
-    );
+    catalogWithTable(simAws);
+    await roleAllowing(simAws, "glue:DeleteDatabase", [
+      catalogArn,
+      databaseArn,
+    ]);
 
-    await reportingRole(simAws);
-
-    // When the role reads that other table.
+    // When the role deletes the database.
     const error = assertThrowsError(() => {
-      glue.getTable(
-        new GetTableCommand({
-          DatabaseName: "site_logs",
-          Name: "error_logs",
-        }),
-        { caller },
-      );
+      simAws
+        .glue()
+        .deleteDatabase(new DeleteDatabaseCommand({ Name: "site_logs" }), {
+          caller,
+        });
     });
 
-    // Then it is refused, because a table ARN names the table.
+    // Then it is refused, naming the table that would have gone with it.
     assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, tableArn);
+  });
+
+  it("deletes a database when the policy covers its tables too", async () => {
+    // Given the same role, with the table added to its policy.
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    catalogWithTable(simAws);
+    await roleAllowing(simAws, "glue:DeleteDatabase", [
+      catalogArn,
+      databaseArn,
+      tableArn,
+    ]);
+
+    // When the role deletes the database.
+    simAws
+      .glue()
+      .deleteDatabase(new DeleteDatabaseCommand({ Name: "site_logs" }), {
+        caller,
+      });
+
+    // Then it goes, and takes its table with it.
+    assertArrayLength(simAws.glue().allDatabases(), 0);
   });
 });

--- a/src/service/glue/sim-glue-authorization.iso.test.ts
+++ b/src/service/glue/sim-glue-authorization.iso.test.ts
@@ -1,0 +1,151 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetTableCommand,
+} from "@aws-sdk/client-glue";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../iam/error/sim-iam.error.js";
+
+const accountId = "111111111111";
+const caller = {
+  kind: "arn" as const,
+  arn: `arn:aws:iam::${accountId}:role/ReportingRole`,
+};
+
+/**
+ * A Role that may read one table and nothing else in the catalog.
+ */
+async function reportingRole(simAws: SimAws): Promise<void> {
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "ReportingRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "ReportingRole",
+      PolicyName: "ReadAccessLogs",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: "glue:GetTable",
+            Resource: `arn:aws:glue:us-east-1:${accountId}:table/site_logs/access_logs`,
+          },
+        ],
+      }),
+    }),
+  );
+}
+
+describe("SimGlue authorization", () => {
+  it("lets a caller read the table its policy names", async () => {
+    // Given a catalog holding a table, and a role allowed to read that table.
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const glue = simAws.glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    glue.createTable(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: { Name: "access_logs" },
+      }),
+    );
+
+    await reportingRole(simAws);
+
+    // When the role reads that table.
+    const { Table } = glue.getTable(
+      new GetTableCommand({
+        DatabaseName: "site_logs",
+        Name: "access_logs",
+      }),
+      { caller },
+    );
+
+    // Then it comes back.
+    assertIdentical(Table.Name, "access_logs");
+  });
+
+  it("refuses a caller whose policy leaves the action out", async () => {
+    // Given the same role, which may read a table and nothing else.
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const glue = simAws.glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+
+    await reportingRole(simAws);
+
+    // When it creates a table.
+    const error = assertThrowsError(() => {
+      glue.createTable(
+        new CreateTableCommand({
+          DatabaseName: "site_logs",
+          TableInput: { Name: "error_logs" },
+        }),
+        { caller },
+      );
+    });
+
+    // Then IAM refuses it, before the catalog is reached.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, "glue:CreateTable");
+  });
+
+  it("refuses a caller reading a table outside its policy", async () => {
+    // Given a catalog holding a second table the role's policy leaves out.
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const glue = simAws.glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    glue.createTable(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: { Name: "error_logs" },
+      }),
+    );
+
+    await reportingRole(simAws);
+
+    // When the role reads that other table.
+    const error = assertThrowsError(() => {
+      glue.getTable(
+        new GetTableCommand({
+          DatabaseName: "site_logs",
+          Name: "error_logs",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is refused, because a table ARN names the table.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+});

--- a/src/service/glue/sim-glue-catalog-listing.iso.test.ts
+++ b/src/service/glue/sim-glue-catalog-listing.iso.test.ts
@@ -4,6 +4,7 @@ import {
   DeleteDatabaseCommand,
   DeleteTableCommand,
   GetDatabasesCommand,
+  GetTableCommand,
   GetTablesCommand,
 } from "@aws-sdk/client-glue";
 import {
@@ -165,22 +166,62 @@ describe("SimGlue names and ARNs", () => {
     assertArrayLength(table.columns, 1);
   });
 
-  it("refuses a name longer than real Glue accepts", () => {
+  it("caps a name at 255 UTF-8 bytes rather than 255 characters", () => {
     // Given a catalog.
     const glue = new SimAws().glue();
 
-    // When a database is created with a 256 character name.
-    const error = assertThrowsError(() => {
+    // When a database is created at the limit, one byte over it, and once
+    // with 128 two-byte characters, which is 256 bytes in 128 characters.
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "a".repeat(255) } }),
+    );
+
+    const tooLong = assertThrowsError(() => {
       glue.createDatabase(
         new CreateDatabaseCommand({
           DatabaseInput: { Name: "a".repeat(256) },
         }),
       );
     });
+    const tooManyBytes = assertThrowsError(() => {
+      glue.createDatabase(
+        new CreateDatabaseCommand({
+          DatabaseInput: { Name: "é".repeat(128) },
+        }),
+      );
+    });
 
-    // Then it is refused, as real Glue caps these names at 255.
+    // Then the byte count is what decides it, which is how the Data Catalog
+    // states the limit.
+    assertInstanceOf(tooLong, SimGlueInvalidInputException);
+    assertInstanceOf(tooManyBytes, SimGlueInvalidInputException);
+    assertStringIncludes(tooManyBytes.message, "255 UTF-8 bytes");
+  });
+
+  it("holds a column name to the same limit", () => {
+    // Given a database to put a table in.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+
+    // When a column is declared with a name over the limit.
+    const error = assertThrowsError(() => {
+      glue.createTable(
+        new CreateTableCommand({
+          DatabaseName: "site_logs",
+          TableInput: {
+            Name: "access_logs",
+            StorageDescriptor: { Columns: [{ Name: "a".repeat(256) }] },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused, since the Data Catalog caps all three the same way.
     assertInstanceOf(error, SimGlueInvalidInputException);
-    assertStringIncludes(error.message, "255");
+    assertStringIncludes(error.message, "Columns.0.Name");
   });
 
   it("refuses a column declared without a name", () => {
@@ -218,5 +259,83 @@ describe("SimGlue names and ARNs", () => {
     assertStringIncludes(partitionKeyError.message, "PartitionKeys.0.Name");
     assertInstanceOf(columnError, SimGlueInvalidInputException);
     assertStringIncludes(columnError.message, "Columns.0.Name");
+  });
+});
+
+describe("SimGlue catalog state", () => {
+  it("hands back a table detached from the one it holds", () => {
+    // Given a table with parameters and partition keys.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    glue.createTable(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: {
+          Name: "access_logs",
+          PartitionKeys: [{ Name: "year", Type: "string" }],
+          StorageDescriptor: { Location: "s3://site-logs/" },
+          Parameters: { "projection.enabled": "true" },
+        },
+      }),
+    );
+
+    // When a caller mutates what GetTable answered with.
+    const first = glue.getTable(
+      new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+    );
+
+    (first.Table.Parameters as Record<string, string>)["projection.enabled"] =
+      "false";
+    (first.Table.StorageDescriptor as { Location?: string }).Location =
+      "s3://elsewhere/";
+
+    // Then the catalog is unchanged, since real Glue answers each request with
+    // its own object rather than a handle on the stored definition.
+    const second = glue.getTable(
+      new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+    );
+
+    assertIdentical(second.Table.Parameters["projection.enabled"], "true");
+    assertIdentical(
+      second.Table.StorageDescriptor?.Location,
+      "s3://site-logs/",
+    );
+  });
+
+  it("keeps a table declared with input the caller then reuses", () => {
+    // Given a TableInput a caller holds on to, which is the ordinary case when
+    // a helper builds one and creates two tables from it.
+    const glue = new SimAws().glue();
+    const columns = [{ Name: "status", Type: "int" }];
+    const parameters: Record<string, string> = { "projection.enabled": "true" };
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    glue.createTable(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: {
+          Name: "access_logs",
+          StorageDescriptor: { Columns: columns },
+          Parameters: parameters,
+        },
+      }),
+    );
+
+    // When the caller changes that input afterwards.
+    columns[0] = { Name: "status", Type: "string" };
+    parameters["projection.enabled"] = "false";
+
+    // Then the stored table keeps what it was created with.
+    const { Table } = glue.getTable(
+      new GetTableCommand({ DatabaseName: "site_logs", Name: "access_logs" }),
+    );
+
+    assertIdentical(Table.StorageDescriptor?.Columns?.[0]?.Type, "int");
+    assertIdentical(Table.Parameters["projection.enabled"], "true");
   });
 });

--- a/src/service/glue/sim-glue-catalog-listing.iso.test.ts
+++ b/src/service/glue/sim-glue-catalog-listing.iso.test.ts
@@ -1,0 +1,222 @@
+import {
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  DeleteDatabaseCommand,
+  DeleteTableCommand,
+  GetDatabasesCommand,
+  GetTablesCommand,
+} from "@aws-sdk/client-glue";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimGlueEntityNotFoundException,
+  SimGlueInvalidInputException,
+} from "./error/sim-glue.error.js";
+import type { SimGlue } from "./sim-glue.js";
+
+function catalogWithTables(glue: SimGlue): void {
+  glue.createDatabase(
+    new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+  );
+  glue.createDatabase(
+    new CreateDatabaseCommand({ DatabaseInput: { Name: "app_logs" } }),
+  );
+  glue.createTable(
+    new CreateTableCommand({
+      DatabaseName: "site_logs",
+      TableInput: { Name: "access_logs" },
+    }),
+  );
+  glue.createTable(
+    new CreateTableCommand({
+      DatabaseName: "app_logs",
+      TableInput: { Name: "access_logs" },
+    }),
+  );
+}
+
+describe("SimGlue listings", () => {
+  it("lists databases and tables in creation order", () => {
+    // Given two databases, each holding a table of the same name.
+    const glue = new SimAws().glue();
+
+    catalogWithTables(glue);
+
+    // When each listing is read.
+    const databases = glue.getDatabases(new GetDatabasesCommand({}));
+    const tables = glue.getTables(
+      new GetTablesCommand({ DatabaseName: "site_logs" }),
+    );
+
+    // Then they come back in creation order, and a table name is unique to
+    // the database holding it rather than to the catalog.
+    assertArrayEquals(
+      databases.DatabaseList.map((database) => database.Name),
+      ["site_logs", "app_logs"],
+    );
+    assertArrayEquals(
+      tables.TableList.map((table) => table.Name),
+      ["access_logs"],
+    );
+    assertArrayLength(glue.allDatabases(), 2);
+    assertArrayLength(glue.tablesInDatabase("app_logs"), 1);
+  });
+
+  it("takes a database's tables down with it", () => {
+    // Given two databases, each holding a table.
+    const glue = new SimAws().glue();
+
+    catalogWithTables(glue);
+
+    // When one database is deleted.
+    glue.deleteDatabase(new DeleteDatabaseCommand({ Name: "site_logs" }));
+
+    // Then its table goes with it, and the other database is untouched.
+    assertArrayLength(glue.tablesInDatabase("site_logs"), 0);
+    assertArrayLength(glue.tablesInDatabase("app_logs"), 1);
+  });
+
+  it("refuses deleting a database or table that is not there", () => {
+    // Given a catalog holding one database and no tables.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+
+    // When each is deleted by a name nobody created.
+    const databaseError = assertThrowsError(() => {
+      glue.deleteDatabase(new DeleteDatabaseCommand({ Name: "app_logs" }));
+    });
+    const tableError = assertThrowsError(() => {
+      glue.deleteTable(
+        new DeleteTableCommand({
+          DatabaseName: "site_logs",
+          Name: "access_logs",
+        }),
+      );
+    });
+
+    // Then both are refused the way real Glue refuses them.
+    assertInstanceOf(databaseError, SimGlueEntityNotFoundException);
+    assertInstanceOf(tableError, SimGlueEntityNotFoundException);
+  });
+
+  it("refuses listing tables in a database that is not there", () => {
+    // Given a catalog with nothing in it.
+    const glue = new SimAws().glue();
+
+    // When a database nobody created is listed.
+    const error = assertThrowsError(() => {
+      glue.getTables(new GetTablesCommand({ DatabaseName: "site_logs" }));
+    });
+
+    // Then it fails rather than answering with an empty list.
+    assertInstanceOf(error, SimGlueEntityNotFoundException);
+  });
+});
+
+describe("SimGlue names and ARNs", () => {
+  it("names a database and a table by ARN, as an IAM policy does", () => {
+    // Given a table in a database.
+    const simAws = new SimAws({ defaultAccountId: "111111111111" });
+    const glue = simAws.glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    glue.createTable(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: {
+          Name: "access_logs",
+          StorageDescriptor: { Columns: [{ Name: "status", Type: "int" }] },
+        },
+      }),
+    );
+
+    // When each ARN is read.
+    const database = glue.findDatabase("site_logs");
+    const table = glue.findTable("site_logs", "access_logs");
+
+    // Then a table ARN names the database holding it, which is what a policy
+    // scoped to one table has to write.
+    assertNonNullable(database);
+    assertNonNullable(table);
+    assertIdentical(
+      database.arn,
+      "arn:aws:glue:us-east-1:111111111111:database/site_logs",
+    );
+    assertIdentical(
+      table.arn,
+      "arn:aws:glue:us-east-1:111111111111:table/site_logs/access_logs",
+    );
+    assertIdentical(table.catalogId, "111111111111");
+    assertArrayLength(table.columns, 1);
+  });
+
+  it("refuses a name longer than real Glue accepts", () => {
+    // Given a catalog.
+    const glue = new SimAws().glue();
+
+    // When a database is created with a 256 character name.
+    const error = assertThrowsError(() => {
+      glue.createDatabase(
+        new CreateDatabaseCommand({
+          DatabaseInput: { Name: "a".repeat(256) },
+        }),
+      );
+    });
+
+    // Then it is refused, as real Glue caps these names at 255.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "255");
+  });
+
+  it("refuses a column declared without a name", () => {
+    // Given a database to put a table in.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+
+    // When a table declares a partition key and a column with no name. The SDK
+    // types the name as optional, so the check belongs here.
+    const partitionKeyError = assertThrowsError(() => {
+      glue.createTable({
+        input: {
+          DatabaseName: "site_logs",
+          TableInput: { Name: "access_logs", PartitionKeys: [{}] },
+        },
+      });
+    });
+    const columnError = assertThrowsError(() => {
+      glue.createTable(
+        new CreateTableCommand({
+          DatabaseName: "site_logs",
+          TableInput: {
+            Name: "access_logs",
+            StorageDescriptor: { Columns: [{ Name: "" }] },
+          },
+        }),
+      );
+    });
+
+    // Then both are refused, since a column is identified by its name.
+    assertInstanceOf(partitionKeyError, SimGlueInvalidInputException);
+    assertStringIncludes(partitionKeyError.message, "PartitionKeys.0.Name");
+    assertInstanceOf(columnError, SimGlueInvalidInputException);
+    assertStringIncludes(columnError.message, "Columns.0.Name");
+  });
+});

--- a/src/service/glue/sim-glue-catalog.iso.test.ts
+++ b/src/service/glue/sim-glue-catalog.iso.test.ts
@@ -1,0 +1,204 @@
+import {
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetDatabaseCommand,
+  GetTableCommand,
+} from "@aws-sdk/client-glue";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimGlueAlreadyExistsException,
+  SimGlueEntityNotFoundException,
+  SimGlueInvalidInputException,
+} from "./error/sim-glue.error.js";
+
+describe("SimGlue databases", () => {
+  it("reads a database back with what it was created with", () => {
+    // Given a database created with a description and parameters.
+    const glue = new SimAws({ defaultAccountId: "111111111111" }).glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({
+        DatabaseInput: {
+          Name: "site_logs",
+          Description: "CloudFront access logs",
+          LocationUri: "s3://site-logs/",
+          Parameters: { owner: "analytics" },
+        },
+      }),
+    );
+
+    // When it is read back.
+    const { Database } = glue.getDatabase(
+      new GetDatabaseCommand({ Name: "site_logs" }),
+    );
+
+    // Then every field comes back as it went in, under this account's catalog.
+    assertIdentical(Database.Name, "site_logs");
+    assertIdentical(Database.Description, "CloudFront access logs");
+    assertIdentical(Database.LocationUri, "s3://site-logs/");
+    assertObjectEquals(Database.Parameters, { owner: "analytics" });
+    assertIdentical(Database.CatalogId, "111111111111");
+  });
+
+  it("refuses a database name already in use", () => {
+    // Given a database that has been created.
+    const glue = new SimAws().glue();
+    const command = new CreateDatabaseCommand({
+      DatabaseInput: { Name: "site_logs" },
+    });
+
+    glue.createDatabase(command);
+
+    // When the same one is created again.
+    const error = assertThrowsError(() => {
+      glue.createDatabase(command);
+    });
+
+    // Then it fails, as creation is not idempotent on real Glue.
+    assertInstanceOf(error, SimGlueAlreadyExistsException);
+  });
+
+  it("refuses reading a database that is not there", () => {
+    // Given a catalog with nothing in it.
+    const glue = new SimAws().glue();
+
+    // When a database nobody created is read.
+    const error = assertThrowsError(() => {
+      glue.getDatabase(new GetDatabaseCommand({ Name: "site_logs" }));
+    });
+
+    // Then it fails the way real Glue fails it.
+    assertInstanceOf(error, SimGlueEntityNotFoundException);
+  });
+
+  it("refuses another account's Data Catalog", () => {
+    // Given a catalog belonging to one account.
+    const glue = new SimAws({ defaultAccountId: "111111111111" }).glue();
+
+    // When a request names another account's catalog.
+    const error = assertThrowsError(() => {
+      glue.getDatabase(
+        new GetDatabaseCommand({
+          CatalogId: "222222222222",
+          Name: "site_logs",
+        }),
+      );
+    });
+
+    // Then it is refused rather than answered from this one.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "222222222222");
+  });
+});
+
+describe("SimGlue tables", () => {
+  it("keeps partition keys out of the storage descriptor columns", () => {
+    // Given a table declaring both data columns and partition keys, which real
+    // Glue holds apart.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    glue.createTable(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: {
+          Name: "access_logs",
+          PartitionKeys: [{ Name: "year", Type: "string" }],
+          StorageDescriptor: {
+            Columns: [{ Name: "status", Type: "int" }],
+            Location: "s3://site-logs/",
+          },
+        },
+      }),
+    );
+
+    // When the table is read back.
+    const { Table } = glue.getTable(
+      new GetTableCommand({
+        DatabaseName: "site_logs",
+        Name: "access_logs",
+      }),
+    );
+
+    // Then the two stay apart. A partition key repeated among the columns is
+    // how a table ends up with a duplicate Athena then refuses to query.
+    assertObjectEquals(Table.PartitionKeys, [{ Name: "year", Type: "string" }]);
+    assertObjectEquals(Table.StorageDescriptor?.Columns, [
+      { Name: "status", Type: "int" },
+    ]);
+  });
+
+  it("refuses a table whose database is not there", () => {
+    // Given a catalog with no database in it.
+    const glue = new SimAws().glue();
+
+    // When a table is created in a database nobody made.
+    const error = assertThrowsError(() => {
+      glue.createTable(
+        new CreateTableCommand({
+          DatabaseName: "site_logs",
+          TableInput: { Name: "access_logs" },
+        }),
+      );
+    });
+
+    // Then it fails rather than creating the database on the way past.
+    assertInstanceOf(error, SimGlueEntityNotFoundException);
+  });
+
+  it("refuses reading a table that is not there", () => {
+    // Given a database holding no tables.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+
+    // When a table nobody created is read.
+    const error = assertThrowsError(() => {
+      glue.getTable(
+        new GetTableCommand({
+          DatabaseName: "site_logs",
+          Name: "access_logs",
+        }),
+      );
+    });
+
+    // Then it fails the way real Glue fails it.
+    assertInstanceOf(error, SimGlueEntityNotFoundException);
+  });
+
+  it("refuses a table with no name", () => {
+    // Given a database to put a table in.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+
+    // When a table is created without one. The SDK requires a name in its own
+    // types, so this is the request a caller reaching past them would make.
+    const error = assertThrowsError(() => {
+      glue.createTable({
+        input: {
+          DatabaseName: "site_logs",
+          TableInput: { Parameters: { "projection.enabled": "true" } },
+        },
+      });
+    });
+
+    // Then it is refused, since the name is a table's whole identity.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+  });
+});

--- a/src/service/glue/sim-glue.ts
+++ b/src/service/glue/sim-glue.ts
@@ -1,0 +1,197 @@
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimGlueAuthorizer } from "./command/authorize/sim-glue-authorizer.js";
+import { SimGlueDatabaseCommands } from "./command/database/sim-glue-database-commands.js";
+import type * as simGlueCommands from "./command/database/database.command.js";
+import type * as simGlueTableCommands from "./command/table/table.command.js";
+import { SimGlueTableCommands } from "./command/table/sim-glue-table-commands.js";
+import type { SimGlueRequestOptions } from "./command/sim-glue-request-options.js";
+import { SimGlueDatabaseStore } from "./database/sim-glue-database-store.js";
+import type { SimGlueDatabase } from "./database/sim-glue-database.js";
+import { SimGlueCfnResourceFactory } from "./cfn/sim-glue-cfn-resource-factory.js";
+import { SimGlueSdkCommandRouter } from "./sdk/sim-glue-sdk-command-router.js";
+import { SimGlueTableStore } from "./table/sim-glue-table-store.js";
+import { SimGlueCatalogWriter } from "./write/sim-glue-catalog-writer.js";
+import type { SimGlueTable } from "./table/sim-glue-table.js";
+
+export interface SimGlueProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated Glue Data Catalog. Handles SDK commands. Emulates AWS behaviour
+ * and state.
+ *
+ * A database and a table are metadata, so this holds definitions rather than
+ * data. Nothing here reads an S3 object, and nothing evaluates the Athena
+ * partition projection a table's parameters configure. What a table is for
+ * here is asserting that a stack declared the definition it meant to.
+ *
+ * Databases and tables are scoped to an account and region, as they are on
+ * real AWS: a catalog belongs to one account, and a database ARN names the
+ * region.
+ */
+export class SimGlue {
+  readonly #databases: SimGlueDatabaseStore;
+  readonly #tables: SimGlueTableStore;
+  readonly #databaseCommands: SimGlueDatabaseCommands;
+  readonly #tableCommands: SimGlueTableCommands;
+  readonly #catalogWriter: SimGlueCatalogWriter;
+
+  readonly #sdkRouter = new SimGlueSdkCommandRouter(this);
+  readonly #cfnFactory: SimGlueCfnResourceFactory;
+
+  constructor(properties: SimGlueProperties = {}) {
+    const {
+      accountRegionScope = simAwsAccountRegionScopeFactory.make(),
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    const authorizer = new SimGlueAuthorizer({ iam, accountRegionScope });
+
+    this.#databases = new SimGlueDatabaseStore({ accountRegionScope });
+    this.#tables = new SimGlueTableStore({ accountRegionScope });
+
+    const collaborators = {
+      databases: this.#databases,
+      tables: this.#tables,
+      authorizer,
+      accountRegionScope,
+      clock: background,
+    };
+
+    this.#databaseCommands = new SimGlueDatabaseCommands(collaborators);
+    this.#tableCommands = new SimGlueTableCommands(collaborators);
+    this.#catalogWriter = new SimGlueCatalogWriter({
+      databases: this.#databases,
+      tables: this.#tables,
+      clock: background,
+    });
+    this.#cfnFactory = new SimGlueCfnResourceFactory({
+      glue: this,
+      catalogId: accountRegionScope.accountId,
+    });
+  }
+
+  /**
+   * How CloudFormation writes to this catalog, skipping the IAM authorization
+   * an SDK Command goes through.
+   */
+  catalogWriter(): SimGlueCatalogWriter {
+    return this.#catalogWriter;
+  }
+
+  /**
+   * Find a database by name.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting
+   * catalog state without going through a Command and its authorization.
+   */
+  findDatabase(name: string): SimGlueDatabase | undefined {
+    return this.#databases.find(name);
+  }
+
+  /**
+   * Find a table by database and name, without going through a Command.
+   */
+  findTable(databaseName: string, name: string): SimGlueTable | undefined {
+    return this.#tables.find(databaseName, name);
+  }
+
+  /** Every database in this catalog, in creation order. */
+  allDatabases(): readonly SimGlueDatabase[] {
+    return this.#databases.all;
+  }
+
+  /** Every table in one database, in creation order. */
+  tablesInDatabase(databaseName: string): readonly SimGlueTable[] {
+    return this.#tables.inDatabase(databaseName);
+  }
+
+  /** Make a database. */
+  createDatabase(
+    command: simGlueCommands.SimCreateDatabaseCommand,
+    options?: SimGlueRequestOptions,
+  ): simGlueCommands.SimCreateDatabaseCommandOutput {
+    return this.#databaseCommands.createDatabase(command, options);
+  }
+
+  /** Read a database back. */
+  getDatabase(
+    command: simGlueCommands.SimGetDatabaseCommand,
+    options?: SimGlueRequestOptions,
+  ): simGlueCommands.SimGetDatabaseCommandOutput {
+    return this.#databaseCommands.getDatabase(command, options);
+  }
+
+  /** Read every database in this catalog. */
+  getDatabases(
+    command: simGlueCommands.SimGetDatabasesCommand,
+    options?: SimGlueRequestOptions,
+  ): simGlueCommands.SimGetDatabasesCommandOutput {
+    return this.#databaseCommands.getDatabases(command, options);
+  }
+
+  /** Remove a database, and the tables it holds with it. */
+  deleteDatabase(
+    command: simGlueCommands.SimDeleteDatabaseCommand,
+    options?: SimGlueRequestOptions,
+  ): simGlueCommands.SimDeleteDatabaseCommandOutput {
+    return this.#databaseCommands.deleteDatabase(command, options);
+  }
+
+  /** Make a table in a database. */
+  createTable(
+    command: simGlueTableCommands.SimCreateTableCommand,
+    options?: SimGlueRequestOptions,
+  ): simGlueTableCommands.SimCreateTableCommandOutput {
+    return this.#tableCommands.createTable(command, options);
+  }
+
+  /** Read a table back. */
+  getTable(
+    command: simGlueTableCommands.SimGetTableCommand,
+    options?: SimGlueRequestOptions,
+  ): simGlueTableCommands.SimGetTableCommandOutput {
+    return this.#tableCommands.getTable(command, options);
+  }
+
+  /** Read every table in one database. */
+  getTables(
+    command: simGlueTableCommands.SimGetTablesCommand,
+    options?: SimGlueRequestOptions,
+  ): simGlueTableCommands.SimGetTablesCommandOutput {
+    return this.#tableCommands.getTables(command, options);
+  }
+
+  /** Remove a table. */
+  deleteTable(
+    command: simGlueTableCommands.SimDeleteTableCommand,
+    options?: SimGlueRequestOptions,
+  ): simGlueTableCommands.SimDeleteTableCommandOutput {
+    return this.#tableCommands.deleteTable(command, options);
+  }
+
+  /** Route an intercepted SDK Command to this simulated Glue. */
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.#sdkRouter;
+  }
+
+  /** Get this service's CloudFormation Resource factory. */
+  cfnResourceFactory(): SimCfnServiceResourceFactory {
+    return this.#cfnFactory;
+  }
+}

--- a/src/service/glue/table/sim-glue-table-input-shape.ts
+++ b/src/service/glue/table/sim-glue-table-input-shape.ts
@@ -1,0 +1,67 @@
+import { SimGlueInvalidInputException } from "../error/sim-glue.error.js";
+import type {
+  SimGlueColumn,
+  SimGlueSerDeInfo,
+  SimGlueStorageDescriptor,
+} from "./sim-glue-table-schema.js";
+
+/**
+ * A column as a caller declares one.
+ *
+ * The name is required on real Glue and optional in the SDK's own types, so
+ * the shape a Command accepts follows the SDK and the check happens here.
+ */
+export interface SimGlueColumnInput {
+  readonly Name?: string | undefined;
+  readonly Type?: string | undefined;
+  readonly Comment?: string | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/** A storage descriptor as a caller declares one. */
+export interface SimGlueStorageDescriptorInput {
+  readonly Columns?: readonly SimGlueColumnInput[] | undefined;
+  readonly Location?: string | undefined;
+  readonly InputFormat?: string | undefined;
+  readonly OutputFormat?: string | undefined;
+  readonly Compressed?: boolean | undefined;
+  readonly NumberOfBuckets?: number | undefined;
+  readonly SerdeInfo?: SimGlueSerDeInfo | undefined;
+  readonly BucketColumns?: readonly string[] | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Read a declared column list, refusing one without a name.
+ */
+export function requiredSimGlueColumns(
+  label: string,
+  columns: readonly SimGlueColumnInput[] | undefined,
+): readonly SimGlueColumn[] | undefined {
+  return columns?.map((column, index) => {
+    if (column.Name === undefined || column.Name === "") {
+      throw new SimGlueInvalidInputException(
+        `${label}.${index}.Name is required`,
+      );
+    }
+
+    return { ...column, Name: column.Name };
+  });
+}
+
+/**
+ * Read a declared storage descriptor, refusing a column without a name.
+ */
+export function requiredSimGlueStorageDescriptor(
+  label: string,
+  descriptor: SimGlueStorageDescriptorInput | undefined,
+): SimGlueStorageDescriptor | undefined {
+  if (descriptor === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...descriptor,
+    Columns: requiredSimGlueColumns(`${label}.Columns`, descriptor.Columns),
+  };
+}

--- a/src/service/glue/table/sim-glue-table-input-shape.ts
+++ b/src/service/glue/table/sim-glue-table-input-shape.ts
@@ -1,4 +1,4 @@
-import { SimGlueInvalidInputException } from "../error/sim-glue.error.js";
+import { requiredSimGlueName } from "../database/sim-glue-catalog-name.js";
 import type {
   SimGlueColumn,
   SimGlueSerDeInfo,
@@ -32,21 +32,19 @@ export interface SimGlueStorageDescriptorInput {
 }
 
 /**
- * Read a declared column list, refusing one without a name.
+ * Read a declared column list, refusing a name real Glue would refuse.
+ *
+ * A column name is held to the same rule as a database or table name, since
+ * the Data Catalog caps all three the same way.
  */
 export function requiredSimGlueColumns(
   label: string,
   columns: readonly SimGlueColumnInput[] | undefined,
 ): readonly SimGlueColumn[] | undefined {
-  return columns?.map((column, index) => {
-    if (column.Name === undefined || column.Name === "") {
-      throw new SimGlueInvalidInputException(
-        `${label}.${index}.Name is required`,
-      );
-    }
-
-    return { ...column, Name: column.Name };
-  });
+  return columns?.map((column, index) => ({
+    ...column,
+    Name: requiredSimGlueName(`${label}.${index}.Name`, column.Name),
+  }));
 }
 
 /**

--- a/src/service/glue/table/sim-glue-table-schema.ts
+++ b/src/service/glue/table/sim-glue-table-schema.ts
@@ -1,0 +1,53 @@
+/**
+ * One column of a table, or one partition key.
+ *
+ * Real Glue uses the same `Column` shape for both, which is why a partition
+ * key carries a type and a comment the way an ordinary column does.
+ */
+export interface SimGlueColumn {
+  readonly Name: string;
+  readonly Type?: string | undefined;
+  readonly Comment?: string | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * How rows are serialized and deserialized.
+ *
+ * `SerializationLibrary` is the Java class name of the SerDe, which is how a
+ * table says whether it holds JSON, Parquet, or something else.
+ */
+export interface SimGlueSerDeInfo {
+  readonly Name?: string | undefined;
+  readonly SerializationLibrary?: string | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * Where a table's data lives and how it is read.
+ *
+ * The columns here are the data columns. Partition keys sit on the table
+ * rather than in here, and real Glue keeps them apart the same way.
+ */
+export interface SimGlueStorageDescriptor {
+  readonly Columns?: readonly SimGlueColumn[] | undefined;
+  readonly Location?: string | undefined;
+  readonly InputFormat?: string | undefined;
+  readonly OutputFormat?: string | undefined;
+  readonly Compressed?: boolean | undefined;
+  readonly NumberOfBuckets?: number | undefined;
+  readonly SerdeInfo?: SimGlueSerDeInfo | undefined;
+  readonly BucketColumns?: readonly string[] | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/** What a table is created with, beyond its name and its database. */
+export interface SimGlueTableInput {
+  readonly description?: string | undefined;
+  readonly owner?: string | undefined;
+  readonly retention?: number | undefined;
+  readonly tableType?: string | undefined;
+  readonly partitionKeys?: readonly SimGlueColumn[] | undefined;
+  readonly storageDescriptor?: SimGlueStorageDescriptor | undefined;
+  readonly parameters?: Readonly<Record<string, string>> | undefined;
+}

--- a/src/service/glue/table/sim-glue-table-store.ts
+++ b/src/service/glue/table/sim-glue-table-store.ts
@@ -1,0 +1,105 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  SimGlueAlreadyExistsException,
+  SimGlueEntityNotFoundException,
+} from "../error/sim-glue.error.js";
+import { SimGlueTable } from "./sim-glue-table.js";
+import type { SimGlueTableInput } from "./sim-glue-table-schema.js";
+
+interface SimGlueTableStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The tables of one simulated Glue catalog.
+ *
+ * Keyed by database name and then by table name, so a database's tables go
+ * with it when it is deleted, and so two databases may hold a table of the
+ * same name.
+ */
+export class SimGlueTableStore {
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #tables = new Map<string, Map<string, SimGlueTable>>();
+
+  constructor(properties: SimGlueTableStoreProperties) {
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Make a table, refusing a name already taken in the same database.
+   */
+  create(
+    databaseName: string,
+    name: string,
+    createTime: Date,
+    input: SimGlueTableInput = {},
+  ): SimGlueTable {
+    const inDatabase = this.#inDatabase(databaseName);
+
+    if (inDatabase.has(name)) {
+      throw new SimGlueAlreadyExistsException(`Table already exists: ${name}`);
+    }
+
+    const table = new SimGlueTable({
+      name,
+      databaseName,
+      accountRegionScope: this.#accountRegionScope,
+      createTime,
+      ...input,
+    });
+
+    inDatabase.set(name, table);
+
+    return table;
+  }
+
+  /** Find a table by database and name. */
+  find(databaseName: string, name: string): SimGlueTable | undefined {
+    return this.#tables.get(databaseName)?.get(name);
+  }
+
+  /**
+   * Get a table by database and name, refusing one that is absent.
+   */
+  require(databaseName: string, name: string): SimGlueTable {
+    const table = this.find(databaseName, name);
+
+    if (table === undefined) {
+      throw new SimGlueEntityNotFoundException(
+        `Table not found: ${databaseName}.${name}`,
+      );
+    }
+
+    return table;
+  }
+
+  /** Every table in one database, in creation order. */
+  inDatabase(databaseName: string): readonly SimGlueTable[] {
+    return this.#tables.get(databaseName)?.values().toArray() ?? [];
+  }
+
+  /** Remove a table. */
+  delete(databaseName: string, name: string): void {
+    this.#tables.get(databaseName)?.delete(name);
+  }
+
+  /** Remove every table in a database, as deleting the database does. */
+  deleteDatabase(databaseName: string): void {
+    this.#tables.delete(databaseName);
+  }
+
+  #inDatabase(databaseName: string): Map<string, SimGlueTable> {
+    const existing = this.#tables.get(databaseName);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const created = new Map<string, SimGlueTable>();
+    this.#tables.set(databaseName, created);
+
+    return created;
+  }
+}
+
+export { type SimGlueTableInput } from "./sim-glue-table-schema.js";

--- a/src/service/glue/table/sim-glue-table.ts
+++ b/src/service/glue/table/sim-glue-table.ts
@@ -26,6 +26,10 @@ interface SimGlueTableProperties {
  * The parameters are the part callers most often care about here. Athena
  * partition projection lives entirely in them, so a table whose parameters
  * were dropped on the way in looks created while configuring nothing.
+ *
+ * Everything a caller declared is copied on the way in. A `TableInput` the
+ * caller goes on to reuse or mutate would otherwise keep changing the stored
+ * definition, which no Glue command could account for.
  */
 export class SimGlueTable {
   readonly name: string;
@@ -44,14 +48,14 @@ export class SimGlueTable {
   constructor(properties: SimGlueTableProperties) {
     this.name = properties.name;
     this.databaseName = properties.databaseName;
-    this.createTime = properties.createTime;
+    this.createTime = new Date(properties.createTime);
     this.description = properties.description;
     this.owner = properties.owner;
     this.retention = properties.retention;
     this.tableType = properties.tableType;
-    this.partitionKeys = [...(properties.partitionKeys ?? [])];
-    this.storageDescriptor = properties.storageDescriptor;
-    this.parameters = { ...properties.parameters };
+    this.partitionKeys = structuredClone(properties.partitionKeys ?? []);
+    this.storageDescriptor = structuredClone(properties.storageDescriptor);
+    this.parameters = structuredClone(properties.parameters) ?? {};
     this.#accountRegionScope = properties.accountRegionScope;
   }
 

--- a/src/service/glue/table/sim-glue-table.ts
+++ b/src/service/glue/table/sim-glue-table.ts
@@ -1,0 +1,82 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simGlueTableArn } from "../arn/sim-glue-arn.js";
+import type {
+  SimGlueColumn,
+  SimGlueStorageDescriptor,
+} from "./sim-glue-table-schema.js";
+
+interface SimGlueTableProperties {
+  readonly name: string;
+  readonly databaseName: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly createTime: Date;
+  readonly description?: string | undefined;
+  readonly owner?: string | undefined;
+  readonly retention?: number | undefined;
+  readonly tableType?: string | undefined;
+  readonly partitionKeys?: readonly SimGlueColumn[] | undefined;
+  readonly storageDescriptor?: SimGlueStorageDescriptor | undefined;
+  readonly parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * A simulated Glue table, which is a definition of a dataset rather than the
+ * dataset itself.
+ *
+ * The parameters are the part callers most often care about here. Athena
+ * partition projection lives entirely in them, so a table whose parameters
+ * were dropped on the way in looks created while configuring nothing.
+ */
+export class SimGlueTable {
+  readonly name: string;
+  readonly databaseName: string;
+  readonly createTime: Date;
+  readonly description: string | undefined;
+  readonly owner: string | undefined;
+  readonly retention: number | undefined;
+  readonly tableType: string | undefined;
+  readonly partitionKeys: readonly SimGlueColumn[];
+  readonly storageDescriptor: SimGlueStorageDescriptor | undefined;
+  readonly parameters: Readonly<Record<string, string>>;
+
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimGlueTableProperties) {
+    this.name = properties.name;
+    this.databaseName = properties.databaseName;
+    this.createTime = properties.createTime;
+    this.description = properties.description;
+    this.owner = properties.owner;
+    this.retention = properties.retention;
+    this.tableType = properties.tableType;
+    this.partitionKeys = [...(properties.partitionKeys ?? [])];
+    this.storageDescriptor = properties.storageDescriptor;
+    this.parameters = { ...properties.parameters };
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /** The catalog holding this table, which is the account id. */
+  get catalogId(): string {
+    return this.#accountRegionScope.accountId;
+  }
+
+  /** This table's ARN, which names the database holding it. */
+  get arn(): string {
+    return simGlueTableArn(
+      this.#accountRegionScope,
+      this.databaseName,
+      this.name,
+    );
+  }
+
+  /**
+   * The data columns, which exclude the partition keys.
+   *
+   * Real Glue keeps the two apart, and a partition key repeated in the
+   * storage descriptor's columns is how a table ends up with a duplicate
+   * column that Athena then refuses to query.
+   */
+  get columns(): readonly SimGlueColumn[] {
+    return this.storageDescriptor?.Columns ?? [];
+  }
+}

--- a/src/service/glue/write/sim-glue-catalog-writer.ts
+++ b/src/service/glue/write/sim-glue-catalog-writer.ts
@@ -1,0 +1,67 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type {
+  SimGlueDatabaseInput,
+  SimGlueDatabaseStore,
+} from "../database/sim-glue-database-store.js";
+import type { SimGlueDatabase } from "../database/sim-glue-database.js";
+import type {
+  SimGlueTableInput,
+  SimGlueTableStore,
+} from "../table/sim-glue-table-store.js";
+import type { SimGlueTable } from "../table/sim-glue-table.js";
+
+interface SimGlueCatalogWriterProperties {
+  readonly databases: SimGlueDatabaseStore;
+  readonly tables: SimGlueTableStore;
+  readonly clock: SimClock;
+}
+
+/**
+ * How something other than an SDK caller writes to the catalog.
+ *
+ * CloudFormation deploys as itself rather than as the caller a later request
+ * carries, so a Resource creator writes through here and skips the IAM
+ * authorization an SDK Command goes through. The store refusals still apply,
+ * so a stack declaring two tables of one name in one database fails the way
+ * two `CreateTable` calls would.
+ */
+export class SimGlueCatalogWriter {
+  readonly #databases: SimGlueDatabaseStore;
+  readonly #tables: SimGlueTableStore;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimGlueCatalogWriterProperties) {
+    this.#databases = properties.databases;
+    this.#tables = properties.tables;
+    this.#clock = properties.clock;
+  }
+
+  /** Make a database. */
+  createDatabase(name: string, input: SimGlueDatabaseInput): SimGlueDatabase {
+    return this.#databases.create(name, this.#clock.now(), input);
+  }
+
+  /** Remove a database, and the tables it holds with it. */
+  deleteDatabase(name: string): void {
+    this.#databases.delete(name);
+    this.#tables.deleteDatabase(name);
+  }
+
+  /**
+   * Make a table in a database, refusing one whose database is absent.
+   */
+  createTable(
+    databaseName: string,
+    name: string,
+    input: SimGlueTableInput,
+  ): SimGlueTable {
+    this.#databases.require(databaseName);
+
+    return this.#tables.create(databaseName, name, this.#clock.now(), input);
+  }
+
+  /** Remove a table. */
+  deleteTable(databaseName: string, name: string): void {
+    this.#tables.delete(databaseName, name);
+  }
+}

--- a/src/util/record/defined-entries.ts
+++ b/src/util/record/defined-entries.ts
@@ -1,0 +1,13 @@
+/**
+ * The same object without the keys whose value is undefined.
+ *
+ * A response built by spreading optional fields carries a key for every one of
+ * them, and an assertion comparing it against what a caller declared then
+ * trips over keys nobody set. Real AWS responses leave an absent field out
+ * altogether, so this puts the response back to that shape.
+ */
+export function definedEntries<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+}


### PR DESCRIPTION
Simulated Glue holds databases and table definitions, deploys them from `AWS::Glue::Database` and `AWS::Glue::Table`, and hands them back through `GetDatabase` and `GetTable`. `TableInput.Parameters` is read into the table, and never recorded as ignored, because Athena partition projection is configured entirely through those parameters. A table that dropped them would deploy green while projecting none of it. `Fn::GetAtt Id` on a table is refused, because CloudFormation documents the attribute and documents nothing about the value behind it, so a stand-in would differ from what a real deploy resolves. A `CatalogId` naming another account is refused in a Command and in a template, since creating the resource in this account's catalog would give a catalog holding something the template never asked for.

Resolves https://github.com/KensioSoftware/yulin/issues/994

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS Glue Data Catalog support for databases and tables.
  * Added SDK interception for Glue database and table operations.
  * Added CloudFormation support for Glue databases and external tables.
  * Added IAM authorization, catalog and resource ARN handling, validation, and Glue-compatible errors.
  * Added support for schemas, partitions, storage descriptors, parameters, and metadata preservation.
* **Documentation**
  * Added Glue service documentation, usage examples, limitations, and service links.
* **Tests**
  * Added comprehensive coverage for SDK, CloudFormation, catalog, validation, and authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->