### PR TITLE
fix: resolve a pseudo parameter beside a Ref in Fn::Sub

### DIFF
--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -9,6 +9,7 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../template/value/sim-cfn-template-value.js";
+import { SimCfnPseudoParameters } from "../parameters/pseudo/sim-cfn-pseudo-parameters.js";
 import { SimCfnResourcePropertyResolver } from "./resolve/property/sim-cfn-resource-property-resolver.js";
 import {
   type SimCfnResourceValueAdapter,
@@ -67,6 +68,14 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
       parameters,
       exports,
       accountRegionScope: this.accountRegionScope,
+      // The Resource pass needs these as well as the template-wide pass. An
+      // `Fn::Sub` naming a pseudo parameter beside a Ref to another Resource
+      // resolves in neither pass alone, because a value re-emitted for the
+      // next pass carries only the variables that pass was given.
+      pseudoParameters: new SimCfnPseudoParameters({
+        accountRegionScope: this.accountRegionScope,
+        stackName,
+      }),
       propertyIgnorer: this,
       resourceType: this.type,
     });

--- a/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/sub/sim-cfn-fn-sub-referential.iso.test.ts
@@ -217,6 +217,99 @@ describe("CloudFormation Fn::Sub Resource referential", () => {
     assertIdentical(derivedResource.simResource, derivedBucket);
   });
 
+  it("substitutes a pseudo parameter and a Resource Ref in the same string", async () => {
+    // Given a template naming a Bucket after both the Account it deploys into
+    // and another Resource. The pseudo parameter resolves in the template pass
+    // and the Ref in the Resource pass.
+    const mixedSubTemplate = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub": "${AWS::AccountId}-${SourceBucket}-derived",
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws({ defaultAccountId: "111111111111" });
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "test-stack",
+      template: mixedSubTemplate,
+    });
+
+    // Then both variables were substituted. Neither pass throws away what the
+    // other resolved.
+    const derivedBucket = simAws
+      .s3()
+      .getSimBucketByName("111111111111-source-bucket-derived");
+
+    assertNonNullable(derivedBucket);
+    assertInstanceOf(derivedBucket, SimS3Bucket);
+    assertIdentical(
+      stack.getResource("DerivedBucket")?.simResource,
+      derivedBucket,
+    );
+  });
+
+  it("substitutes a partition, a Region and an Account beside a Resource Ref", async () => {
+    // Given a template naming a Bucket from three pseudo parameters and a Ref,
+    // which is the shape of a hand-written ARN.
+    const arnSubTemplate = {
+      Resources: {
+        SourceBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: "source-bucket",
+          },
+        },
+        DerivedBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: {
+            BucketName: {
+              "Fn::Sub":
+                "${AWS::Partition}-${AWS::Region}-${AWS::AccountId}-${SourceBucket}",
+            },
+          },
+        },
+      },
+    };
+
+    // When the template is deployed into a Region of its own.
+    const simAws = new SimAws({ defaultAccountId: "111111111111" });
+    const stack = await simAws
+      .account()
+      .region("eu-west-2")
+      .cloudFormation()
+      .deployTemplate({
+        stackName: "test-stack",
+        template: arnSubTemplate,
+      });
+
+    // Then all four variables are read from the scope the Stack deployed into.
+    const derivedBucket = simAws
+      .account()
+      .region("eu-west-2")
+      .s3()
+      .getSimBucketByName("aws-eu-west-2-111111111111-source-bucket");
+
+    assertNonNullable(derivedBucket);
+    assertInstanceOf(derivedBucket, SimS3Bucket);
+    assertIdentical(
+      stack.getResource("DerivedBucket")?.simResource,
+      derivedBucket,
+    );
+  });
+
   it("throws when an explicit Fn::Sub variable is not resolved while preserving an unresolved Resource Ref", async () => {
     // Given a template where Fn::Sub has a deferred Resource Ref and an explicit
     // variable map entry that is not used by the template string.


### PR DESCRIPTION
A template is resolved in two passes. The template-wide pass held the pseudo parameters and no Resources, and the Resource pass held the Resources and no pseudo parameters. `Fn::Sub` re-emits itself whole whenever one of its variables is still unresolved, and re-emitting an expression with no explicit variables map drops everything the pass did resolve. An `Fn::Sub` naming both kinds of variable therefore lost the pseudo parameter in the first pass and the `Ref` in the second, and the property reached its service configurator holding the `Fn::Sub` object rather than a string. The Resource pass now carries the pseudo parameters too, built from the Account, Region and Stack name the Resource record already holds.

Resolves #996

## Notes

The issue offered two fixes and this takes the narrower one. Every implicit `Fn::Sub` variable is a Parameter, a pseudo parameter, a `Ref` or a `Fn::GetAtt`, and the Resource pass can now resolve all four on its own, so no implicit variable survives both passes for this reason any more. Carrying resolved implicit variables through `SimCfnFnSubUnresolvedValue` would be the wider change, and there is no failing case left behind it.

Deletion resolves its properties through the same resolver, so it is fixed with creation. Outputs already had the pseudo parameters and were never affected.

The issue's own repro now deploys all three queues as `a-888888888888`, `a-888888888888-probe-bucket` and `b-probe-bucket`. Two tests cover it: a pseudo parameter beside a `Ref`, and the partition, Region and Account together beside one, deployed into a Region of its own so the values are read from the Stack's scope rather than a default.

Nothing in `docs/` claimed the broken behaviour, so there is no stale limitation to remove.