### PR TITLE
fix: refuse a suffix path naming its Hive keys

### DIFF
--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -417,6 +417,9 @@ rules from real AWS are modelled here, each of them a deploy that looks fine unt
   refused.
 - **CloudFront delivery is set up from `us-east-1`**, whatever region the destination bucket is in.
   A CloudFront delivery source put from anywhere else is refused.
+- **Hive compatible paths write the `key=` half themselves.** A suffix path naming the partition
+  keys as well is refused. Delivery turns `{yyyy}` into `year=2026`, and `year={yyyy}` arrives
+  doubled, which an account answers with "Provided suffixPath is invalid".
 - **Output format is fixed once the destination exists.** A `PutDeliveryDestination` that would
   change it is refused. Changing a format means deleting the destination and making it again.
 - **Parquet is written to S3 only.** A log group or Firehose destination asking for it is refused.
@@ -425,6 +428,11 @@ The suffix path decides the key each log file lands under. `{DistributionId}`, `
 `{yyyy}`, `{MM}`, `{dd}`, `{HH}` and `{accountid}` are substituted, and a variable outside that set
 is refused. Delivery would write the text out literally, and the bucket would look partitioned when
 it was not. A path over the 256 characters CloudWatch Logs takes is refused too.
+
+Under `enableHiveCompatiblePath`, delivery writes each segment as `key=value` and supplies the key
+itself. `{yyyy}` lands as `year=2026` and `{distributionid}` as `distributionid=E1EXAMPLE1234`. A
+suffix path naming those keys is refused, because the key would arrive twice. Leave the segments as
+bare variables and let delivery name them.
 
 ### Declaring delivery in a template
 
@@ -844,6 +852,9 @@ console.log(described.logGroups?.[0]?.logGroupArn);
 - **Delivery resource tags and cross-account delivery.** `PutDeliverySource`,
   `PutDeliveryDestination` and `CreateDelivery` refuse tags outright. `DeliveryDestinationPolicy` in
   a template is recorded and acted on by nothing.
+- **An `=` in a suffix path with Hive compatible paths off.** Taken. Whether real CloudWatch Logs
+  takes one is unverified. A path hand-rolling its own partition keys without the option is left
+  alone here, and refused with the option on.
 - **Log types for services other than CloudFront.** Any `logType` is taken over a resource that is
   not a distribution, because the valid set varies by service and this simulation does not carry it.
 - **Logs Insights, export tasks, tags, encryption and data protection policies.** Absent. Tags and

--- a/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
@@ -152,6 +152,49 @@ describe("AWS::Logs delivery Resource refusals", () => {
     assertStringIncludes(error.message, "{DistributionID}");
   });
 
+  it("fails a delivery writing the Hive key= segments in its suffix path", async () => {
+    // Given a whole logging stack asking for Hive compatible paths and naming
+    // the partition keys in the suffix path as well. This is what a CloudFront
+    // analytics stack synthesises when it renders the keys by hand.
+    const error = await assertThrowsErrorAsync(async () => {
+      await new SimAws().cloudFormation().deployTemplate({
+        stackName: "site-logging",
+        template: {
+          Resources: {
+            [deliveryDistributionLogicalId]: deliveryDistributionResource,
+            AccessLogsSource: {
+              Type: "AWS::Logs::DeliverySource",
+              Properties: sourceProperties,
+            },
+            AccessLogsDestination: {
+              Type: "AWS::Logs::DeliveryDestination",
+              Properties: {
+                Name: sourceName,
+                DestinationResourceArn: bucketArn,
+              },
+            },
+            AccessLogsDelivery: {
+              Type: "AWS::Logs::Delivery",
+              Properties: {
+                DeliverySourceName: { Ref: "AccessLogsSource" },
+                DeliveryDestinationArn: {
+                  "Fn::GetAtt": ["AccessLogsDestination", "Arn"],
+                },
+                S3EnableHiveCompatiblePath: true,
+                S3SuffixPath: "year={yyyy}/month={MM}",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the deploy fails here rather than on a real account, where the
+    // doubled key comes back as "Provided suffixPath is invalid".
+    assertStringIncludes(error.message, "year={yyyy}");
+    assertStringIncludes(error.message, "enableHiveCompatiblePath");
+  });
+
   it("refuses a Resource property read back as an attribute", async () => {
     // Given a template reading DeliveryDestinationType off the delivery
     // destination, which carries it as a property and publishes it on the

--- a/src/service/logs/delivery/sim-logs-delivery-refusals.iso.test.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-refusals.iso.test.ts
@@ -264,4 +264,101 @@ describe("simulated CloudWatch Logs delivery refusals", () => {
     assertIdentical(empty.name, "ValidationException");
     assertStringIncludes(empty.message, "takes at least one character");
   });
+  it("refuses a suffix path spelling out its own Hive keys", async () => {
+    // Given a source and an S3 destination.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "site-access-logs",
+      bucketArn,
+    );
+
+    // When a delivery asks for Hive compatible paths and writes the `key=`
+    // half of every segment itself. This is the layout a CloudFront analytics
+    // stack reaches for, and the one real AWS refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.logs().createDelivery(
+        new CreateDeliveryCommand({
+          deliverySourceName: sourceName,
+          deliveryDestinationArn,
+          s3DeliveryConfiguration: {
+            suffixPath:
+              "distributionid={distributionid}/year={yyyy}/month={MM}/day={dd}/hour={HH}",
+            enableHiveCompatiblePath: true,
+          },
+        }),
+      );
+    });
+
+    // Then it is refused here rather than on a real deploy. Delivery writes
+    // the key itself under the option, so naming it doubles it.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "distributionid={distributionid}");
+    assertStringIncludes(error.message, "enableHiveCompatiblePath");
+  });
+
+  it("takes the same partition keys spelled as bare variables", async () => {
+    // Given a source and an S3 destination.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "site-access-logs",
+      bucketArn,
+    );
+
+    // When the delivery leaves the `key=` half to delivery and asks for Hive
+    // compatible paths.
+    const created = await simAws.logs().createDelivery(
+      new CreateDeliveryCommand({
+        deliverySourceName: sourceName,
+        deliveryDestinationArn,
+        s3DeliveryConfiguration: {
+          suffixPath: "{distributionid}/{yyyy}/{MM}/{dd}/{HH}",
+          enableHiveCompatiblePath: true,
+        },
+      }),
+    );
+
+    // Then it is created, because this is what the option is for.
+    assertIdentical(
+      created.delivery?.s3DeliveryConfiguration?.suffixPath,
+      "{distributionid}/{yyyy}/{MM}/{dd}/{HH}",
+    );
+  });
+
+  it("leaves a hand-rolled key alone with Hive compatible paths off", async () => {
+    // Given a source and an S3 destination.
+    const simAws = new SimAws();
+
+    await givenSource(simAws);
+
+    const deliveryDestinationArn = await givenDestination(
+      simAws,
+      "site-access-logs",
+      bucketArn,
+    );
+
+    // When a delivery writes its own partition keys and asks for no Hive
+    // compatible paths, so nothing doubles them.
+    const created = await simAws.logs().createDelivery(
+      new CreateDeliveryCommand({
+        deliverySourceName: sourceName,
+        deliveryDestinationArn,
+        s3DeliveryConfiguration: { suffixPath: "dt={yyyy}-{MM}-{dd}" },
+      }),
+    );
+
+    // Then it is created. Whether real CloudWatch Logs takes an `=` with the
+    // option off is unverified, and the Limitations in the logs docs say so.
+    assertIdentical(
+      created.delivery?.s3DeliveryConfiguration?.suffixPath,
+      "dt={yyyy}-{MM}-{dd}",
+    );
+  });
 });

--- a/src/service/logs/delivery/sim-logs-delivery-s3-configuration.ts
+++ b/src/service/logs/delivery/sim-logs-delivery-s3-configuration.ts
@@ -23,6 +23,9 @@ const suffixPathVariablePattern = /{([^{}]*)}/g;
 /** How long a suffix path real CloudWatch Logs accepts. */
 const maximumSuffixPathLength = 256;
 
+/** What separates the two halves of a Hive compatible path segment. */
+const hiveKeySeparator = "=";
+
 interface SimLogsDeliveryS3ConfigurationProperties {
   readonly suffixPath: string | undefined;
   readonly enableHiveCompatiblePath: boolean | undefined;
@@ -40,13 +43,19 @@ export class SimLogsDeliveryS3Configuration {
   readonly enableHiveCompatiblePath: boolean;
 
   constructor(properties: SimLogsDeliveryS3ConfigurationProperties) {
+    const enableHiveCompatiblePath =
+      properties.enableHiveCompatiblePath ?? false;
+
     if (properties.suffixPath !== undefined) {
       requireSimLogsDeliverySuffixPath(properties.suffixPath);
+
+      if (enableHiveCompatiblePath) {
+        requireSimLogsDeliveryHiveSuffixPath(properties.suffixPath);
+      }
     }
 
     this.suffixPath = properties.suffixPath;
-    this.enableHiveCompatiblePath =
-      properties.enableHiveCompatiblePath ?? false;
+    this.enableHiveCompatiblePath = enableHiveCompatiblePath;
   }
 }
 
@@ -80,6 +89,33 @@ export function requireSimLogsDeliverySuffixPath(suffixPath: string): void {
           `which delivery does not substitute. The ones it does are ${simLogsDeliverySuffixPathVariables
             .map((name) => `{${name}}`)
             .join(", ")}`,
+      );
+    }
+  }
+}
+
+/**
+ * Refuse a suffix path that spells out the Hive `key=` half itself.
+ *
+ * Delivery supplies that half under `enableHiveCompatiblePath`, turning
+ * `{yyyy}` into `year=2026`. A segment naming the key as well arrives
+ * doubled, and real CloudWatch Logs refuses the whole path with "Provided
+ * suffixPath is invalid".
+ *
+ * Only the Hive compatible case is refused. Whether real CloudWatch Logs
+ * takes an `=` in a suffix path with the option off is unverified. A path
+ * hand-rolling its own partition keys without the option is left alone, and
+ * the Limitations in docs/services/logs/README.md say so.
+ */
+export function requireSimLogsDeliveryHiveSuffixPath(suffixPath: string): void {
+  for (const segment of suffixPath.split("/")) {
+    if (segment.includes(hiveKeySeparator)) {
+      throw new SimLogsValidationException(
+        `suffixPath '${suffixPath}' spells out a Hive key in segment ` +
+          `'${segment}', and enableHiveCompatiblePath makes delivery write ` +
+          "the 'key=' half itself, so '{yyyy}' arrives as 'year=2026'. " +
+          `Naming it here doubles the key, and real CloudWatch Logs refuses ` +
+          `the path with "Provided suffixPath is invalid"`,
       );
     }
   }


### PR DESCRIPTION
`SimLogsDeliveryS3Configuration` validated the suffix path and never read `enableHiveCompatiblePath` beside it. Delivery supplies the `key=` half of each segment under that option, turning `{yyyy}` into `year=2026`. A suffix path naming those keys as well arrives doubled, and real CloudWatch Logs refuses the whole path with "Provided suffixPath is invalid". A template took the same route through the ordinary command. A CloudFront analytics stack rendering the Hive pairs by hand deployed clean here and failed on a real account. `CreateDelivery` now refuses a suffix path segment carrying an `=` while the option is on, and the refusal reaches `AWS::Logs::Delivery` in a template.

Resolves #1003

## Notes

Only the Hive compatible case is refused, because that is the case with evidence behind it. The deploy that failed had the option on. With it off, `dt={yyyy}` writes a literal `dt=2026` folder. That is a plausible way to hand-roll partition keys, and refusing it would be stricter than AWS. Whether an account takes an `=` there is unverified. A test pins the choice and the logs Limitations record it.

The generic wording of "Provided suffixPath is invalid" is the argument for widening this to any `=` in a suffix path, whatever the option says. One `create-delivery` against a real account with the option off would settle it, and I have not run one.

`requireSimLogsDeliverySuffixPath` keeps its three checks and their messages. The new check is a separate function, and the constructor reaches it only where the suffix path and the option are both set.

KensioSoftware/rainlytics#27 already moved the stack that hit this onto bare variables, so nothing downstream turns red when this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Hive-compatible CloudWatch Logs delivery paths.
  * Rejects manually specified `key=value` segments when Hive-compatible path generation is enabled.
  * Preserves custom key segments when Hive-compatible path generation is disabled.
  * Normalizes Hive-compatible path settings before validation.

* **Documentation**
  * Clarified supported suffix path formats and variable expansion behavior.
  * Documented limitations involving `=` in suffix paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->