### PR TITLE
fix: stop publishing maps that resolve nowhere

### DIFF
--- a/scripts/mts/verify-pack.mts
+++ b/scripts/mts/verify-pack.mts
@@ -42,6 +42,22 @@ const forbiddenTarballEntries = [
 ];
 
 /**
+ * What the tarball is allowed to weigh, unpacked and in files.
+ *
+ * Yulin gains about a megabyte and five hundred files a week, a simulated
+ * service at a time, so these are a ratchet rather than a fixed ceiling: raise
+ * them in the change that earns the growth. They sit far enough above the
+ * package to leave a couple of months of ordinary work alone, and close enough
+ * to catch a single change that alters what the build emits for every module.
+ *
+ * File count is the tighter of the two. Yulin is thousands of small modules
+ * rather than a few large ones, and a consumer feels that in how long an
+ * install takes to unpack far more than it feels the megabytes.
+ */
+const maximumUnpackedBytes = 20 * 1024 * 1024;
+const maximumFileCount = 12_000;
+
+/**
  * Exports a consumer imports by name, keyed by export subpath.
  *
  * A subpath resolving does not mean the export a consumer reaches for is in it,
@@ -74,7 +90,7 @@ async function main(): Promise<void> {
     const tarballPath = await pack(workDirectory);
 
     await assertTarballHygiene(tarballPath);
-    await reportTarballSize(tarballPath);
+    await assertTarballSize(tarballPath);
 
     const consumerDirectory = path.join(workDirectory, "consumer");
     await createConsumer(consumerDirectory, tarballPath, manifest);
@@ -159,20 +175,42 @@ async function assertTarballHygiene(tarballPath: string): Promise<void> {
 }
 
 /**
- * Reports what the tarball weighs, so a publish that suddenly ships far more
- * than the last one is visible before it goes out.
+ * Fails the verification when the tarball outgrows what the package is allowed
+ * to ship, and reports what it weighs either way.
+ *
+ * A publish that suddenly carries far more than the last one is worth seeing
+ * before it goes out, whether it came from a change to what the build emits or
+ * from a directory that should never have been packed.
  */
-async function reportTarballSize(tarballPath: string): Promise<void> {
+async function assertTarballSize(tarballPath: string): Promise<void> {
   const { size } = await stat(tarballPath);
   const { stdout } = await execa("tar", ["tzvf", tarballPath]);
 
-  const unpacked = stdout
-    .split("\n")
-    .reduce((total, entry) => total + entrySize(entry), 0);
+  const entries = stdout.split("\n");
+  const unpacked = entries.reduce(
+    (total, entry) => total + entrySize(entry),
+    0,
+  );
 
   console.log(
-    `Tarball is ${formatBytes(size)} packed, ${formatBytes(unpacked)} unpacked.`,
+    `Tarball is ${formatBytes(size)} packed, ${formatBytes(unpacked)} unpacked, in ${String(entries.length)} files.`,
   );
+
+  const breaches = [
+    unpacked > maximumUnpackedBytes
+      ? `unpacked size is ${formatBytes(unpacked)}, over the ${formatBytes(maximumUnpackedBytes)} limit`
+      : undefined,
+    entries.length > maximumFileCount
+      ? `file count is ${String(entries.length)}, over the ${String(maximumFileCount)} limit`
+      : undefined,
+  ].filter((breach) => breach !== undefined);
+
+  if (breaches.length > 0) {
+    throw new Error(
+      `Tarball is too large to publish:\n${breaches.join("\n")}\n` +
+        "Either stop shipping what it gained, or raise the limit in this script deliberately.",
+    );
+  }
 }
 
 /**

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,8 +5,12 @@
     "outDir": "dist",
     "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo",
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
+    // The published package carries dist, the readme and the licence, so a map
+    // emitted here resolves to a src directory the tarball does not have. Both
+    // kinds of map were a third of the package and half its file count, and
+    // neither of them loaded anywhere.
+    "declarationMap": false,
+    "sourceMap": false,
     "noEmitOnError": true
   },
   "include": ["src/**/*", "typings/**/*.d.ts"],


### PR DESCRIPTION
Brief, concise description of the change:

The build emitted a `.js.map` and a `.d.ts.map` for every module, while the package ships `dist`
alone. Both kinds of map pointed at a `src` directory the tarball has never carried, and nothing
ever loaded them. Between them they were a third of the package and half its file count. Turning
both off takes the tarball from 5.25 MiB to 3.62 MiB packed, 24.03 MiB to 15.00 MiB unpacked, and
17,676 files to 8,840, with all 40 export subpaths still importing from it with their declarations.
`tsconfig.json` keeps the maps on for local work, so editors and vitest still resolve into `src`.
`verify:pack` measured the tarball and printed the size without acting on it, and it now fails above
20 MiB unpacked or 12,000 files.

**Why those limits.** The registry carries every published version's size, and Yulin has gained
roughly a megabyte and 540 files a published day since 1.0.0 on 3 August. A limit set as far out as
the 124 MiB `aws-cdk-lib` weighs would fire months after the package was already oversized, and the
accidents it would catch (packing `node_modules`, a stray `dist-hidden`) are already named in
`assertTarballHygiene` directly above it. 20 MiB and 12,000 files sit about a third above the
package. That leaves a couple of months of ordinary service work alone and still catches a single
change that alters what the build emits for every module. Raise them in whichever change earns the
growth.

Two things worth knowing. `verify:pack` runs in both `pr.yml` and `release.yml`, so the limits guard
every pull request and every publish, though `pnpm check` does not reach them locally. And the guard
was checked by dropping the limits and watching it exit non-zero, not assumed from reading it.

- [x] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description` (branch was created as
      `claude/yulin-package-size-84282c`)
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/` (nothing in `docs/` mentions the published
      maps, so nothing needed changing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package verification now blocks releases when unpacked size exceeds 20 MiB or file count exceeds 12,000.
  * Verification reports packed size, unpacked size, and file count, including details when limits are exceeded.

* **Chores**
  * Published packages no longer include declaration maps or source maps, reducing package contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->