### PR TITLE
feat: resolve Athena tables in the Glue catalog

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -9,6 +9,10 @@ refuses a query, that results land where the workgroup says, and that a client p
 correctly. Whether the SQL is valid stays out of reach. The [Limitations](#limitations) at the end
 say what that leaves out.
 
+One part of the SQL is read. The tables a query names are looked for in the simulated
+[Glue Data Catalog](https://yulinsim.dev/services/glue/ "Simulated Glue usage docs"), and a query
+naming one that is absent fails the way real Athena fails it.
+
 Athena-specific types are imported from the `@kensio/yulin/athena` subpath.
 
 ## Workgroups from a template
@@ -178,6 +182,77 @@ the SQL is never parsed, so two queries differing only in whitespace are two dif
 fail cannot be discovered on its own. Saying so is what makes a client's failure handling
 reachable.
 
+## Tables a query names
+
+A query's `FROM` and `JOIN` clauses are read, and each table they name is looked for in the Glue
+Data Catalog for the same account and region. A query naming a table the catalog has no entry for
+reaches `FAILED`, carrying Athena's own reason.
+
+That catches a stack whose table never deployed, a database renamed on one side only, and a typo.
+Each of them answers a declared result otherwise, and the test written to catch it passes.
+
+```typescript sim-athena-table-resolution
+/**
+ * A query naming a table the Data Catalog has never heard of.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws
+  .glue()
+  .createDatabase({ input: { DatabaseInput: { Name: "rainlytics" } } });
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: { Name: "access_logs" },
+  },
+});
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString: "SELECT cs_uri_stem FROM rainlytics.acess_logs",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const execution = await simAws.athena().getQueryExecution({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// "FAILED"
+console.log(execution.QueryExecution?.Status?.State);
+// names awsdatacatalog.rainlytics.acess_logs
+console.log(execution.QueryExecution?.Status?.StateChangeReason);
+```
+
+An unqualified name resolves against `QueryExecutionContext.Database`. A query naming neither fails
+saying a schema has to be specified, as Athena does.
+
+Resolution starts once the catalog holds a database. A simulation where nothing created one answers
+every query from its declaration. That is how simulated Athena behaved before this existed.
+
+A name a `WITH` clause defined is left alone, and so are a table alias, a subquery and whatever
+`UNNEST` produces. `information_schema` resolves without a catalog entry, because Athena serves that
+schema itself.
+
+Nothing here plans the query. Reading the table names is a scan, and a statement
+it cannot follow runs the way it always did. That covers a statement writing data, a query against a
+federated catalog, and anything the scan gets lost in.
+
 ## The bytes scanned cutoff
 
 A query whose declared bytes scanned passes the workgroup's `BytesScannedCutoffPerQuery` reaches
@@ -302,6 +377,7 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 
 - Query executions, moving through `QUEUED` and `RUNNING` to `SUCCEEDED`, `FAILED` or `CANCELLED`
 - `StartQueryExecution`, `GetQueryExecution`, `GetQueryResults` and `StopQueryExecution`
+- Table names in `FROM` and `JOIN` resolved against the simulated Glue Data Catalog
 - `BytesScannedCutoffPerQuery` enforced against what a declaration says a query scanned
 - Result sets written to the workgroup's output location as CSV, under the caller's own identity
 - Workgroups, scoped by account and region, with `primary` there from the start
@@ -317,9 +393,18 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 
 Current documented limitations:
 
-- No SQL is evaluated. Nothing parses, plans or runs a query, no Glue table or S3 object is read to
-  answer one, and every row comes from a declaration a test wrote. Simulated Athena will therefore
-  accept a query real Athena would reject.
+- No SQL is evaluated. Nothing plans or runs a query, no S3 object is read to answer one, and every
+  row comes from a declaration a test wrote. Simulated Athena will therefore accept a query real
+  Athena would reject.
+- The table names in `FROM` and `JOIN` are the one part of a query that is read, and they are found
+  by a scan. A statement the scan cannot follow runs with its tables never
+  looked for, which covers `CREATE TABLE AS SELECT`, `INSERT INTO`, `MSCK REPAIR TABLE`, `SHOW` and
+  `DESCRIBE`. Only the table is resolved. Columns, types and everything else a planner checks stay
+  out of reach.
+- Table resolution starts once the Data Catalog holds a database. Every query in a simulation
+  holding none is answered from its declaration.
+- A query naming a catalog other than `awsdatacatalog` runs with its tables never looked for.
+  Federated catalogs and `AWS::Athena::DataCatalog` fall outside this simulation.
 - What a query scanned comes from that same declaration. The cutoff is enforced for real against
   that figure, which is a test's own statement about the query.
 - A query that exceeds the cutoff reaches `FAILED` here. AWS documents the per-query data usage
@@ -348,9 +433,9 @@ Current documented limitations:
 - `AWS::Athena::DataCatalog`, `AWS::Athena::PreparedStatement` and
   `AWS::Athena::CapacityReservation` fall outside this simulation. A template declaring one is
   recorded on the stack's `skippedResources` and the rest of the stack deploys.
-- A named query's `Database` is a string simulated Athena leaves unresolved. Yulin does simulate the
-  [Glue Data Catalog](https://yulinsim.dev/services/glue/ "Simulated Glue usage docs"), and a saved
-  query naming a database that catalog has never heard of is stored all the same.
+- A named query's `Database` is a string simulated Athena leaves unresolved. A saved query naming a
+  database the Data Catalog has never heard of is stored all the same. Resolution happens when a
+  query runs rather than when one is saved.
 - Workgroup tags, prepared statements, capacity reservations, query result reuse and Athena for
   Spark are all absent.
 - A `WorkGroupConfiguration` setting this simulation has no answer for, such as `ExecutionRole`,

--- a/docs/services/athena/sim-athena-table-resolution.example.ts
+++ b/docs/services/athena/sim-athena-table-resolution.example.ts
@@ -1,0 +1,45 @@
+/**
+ * A query naming a table the Data Catalog has never heard of.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws
+  .glue()
+  .createDatabase({ input: { DatabaseInput: { Name: "rainlytics" } } });
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: { Name: "access_logs" },
+  },
+});
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString: "SELECT cs_uri_stem FROM rainlytics.acess_logs",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const execution = await simAws.athena().getQueryExecution({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// "FAILED"
+console.log(execution.QueryExecution?.Status?.State);
+// names awsdatacatalog.rainlytics.acess_logs
+console.log(execution.QueryExecution?.Status?.StateChangeReason);

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -8,6 +8,9 @@ to, including the Athena partition projection its parameters configure.
 A table here is a definition. The data it describes stays in S3, unread, and the catalog answers
 with what it was told to hold.
 
+Simulated [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") reads this
+catalog. A query naming a table no database here holds fails the way real Athena fails it.
+
 Glue-specific types are imported from the `@kensio/yulin/glue` subpath.
 
 ## Deploying a database and a table

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -1,8 +1,8 @@
 # Simulated Athena implementation
 
 This directory contains the simulated Athena implementation. Workgroups and named queries are
-deployable from a template and readable through the SDK, and a query runs through its states without
-anything reading the SQL.
+deployable from a template and readable through the SDK, and a query runs through its states with
+one part of its SQL read.
 
 The guiding decision is that no query is evaluated. Athena's own value is in the query engine, and a
 query engine over Parquet and JSON objects in S3 is a different order of magnitude from the rest of
@@ -11,9 +11,10 @@ on the query text. Simulated Bedrock answers a prompt the same way and simulated
 an image the same way, all three through `SimDeclaredResultRules`.
 
 What that leaves is worth having. The lifecycle a client polls is real, the bytes-scanned cutoff
-refuses a query for real, and a result set really is written to the workgroup's output location. The
-divergence to be honest about is that simulated Athena accepts a query real Athena would reject.
-`docs/services/athena/README.md` says so in its Limitations list.
+refuses a query for real, the tables a query names are looked for in the Data Catalog, and a result
+set really is written to the workgroup's output location. The divergence to be honest about is that
+simulated Athena accepts a query real Athena would reject. `docs/services/athena/README.md` says so
+in its Limitations list.
 
 ## Entry points
 
@@ -30,9 +31,9 @@ needs the shape a response comes back in. Each rule a write applies then sits in
 beside the handler, `sim-athena-work-group-creation.ts`, `-update.ts` and `-deletion.ts`. A create,
 an update and a delete share only the workgroup they name.
 
-The service is self-contained, and `SimAwsSelfContainedServiceBuilder` builds it for that reason.
-Writing to a Bucket and reading a catalog both belong to a running query. That is where the other
-services would come in.
+The service is self-contained, and `SimAwsSelfContainedServiceBuilder` builds it for that reason. It
+holds the same scope's simulated S3 to write a result into, and the same scope's simulated Glue to
+resolve a table name against. Both are services in the scope Athena already belongs to.
 
 ## The primary workgroup
 
@@ -76,6 +77,24 @@ out, and it is the only place that knows how.
 The cutoff is checked in the runner against what the declaration says the query scanned. That is the
 whole of the cost guardrail, and the one thing this simulation can enforce for real without an
 engine.
+
+`table/` reads the tables a query names. `sim-athena-sql-tokens.ts` tokenises and stops there, and
+`sim-athena-table-references.ts` walks those tokens looking only at what follows `FROM`, `JOIN` and a
+comma inside a FROM clause. Everything it does is conservative. A statement it cannot follow is
+reported unreadable and nothing is resolved for one, because refusing a query real Athena would run
+costs more than the check returns.
+
+Three things in that scanner are there for a reason a reader would otherwise undo. Parentheses carry
+a flag saying whether the word before them was a function name. That keeps `EXTRACT(hour FROM ts)`
+from naming a table called `ts`. The depths currently inside a FROM clause are held as a set, one
+entry per bracket level, and a subquery's own FROM then leaves the outer one standing. A name written
+`x AS (` is taken as a common table expression, since nothing else in a statement this scans puts a
+bracket straight after `AS`.
+
+`sim-athena-table-resolution.ts` turns those names into a refusal. It skips a query against a
+catalog other than `awsdatacatalog`, and it skips everything while the Data Catalog holds no
+database at all. A simulation where nothing created a database is one where nothing asked for a
+table to be looked for, and every test written before this existed stays working because of it.
 
 `SimAthenaResultWriter` writes the CSV through simulated S3 under the caller that started the query,
 because Athena writes a result under the identity that asked for it. Simulated Firehose does the

--- a/src/service/athena/execution/sim-athena-query-refusal.ts
+++ b/src/service/athena/execution/sim-athena-query-refusal.ts
@@ -1,0 +1,71 @@
+import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import {
+  simAthenaTableRefusal,
+  type SimAthenaCatalog,
+} from "../table/sim-athena-table-resolution.js";
+import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
+import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
+
+interface SimAthenaQueryRefusalProperties {
+  readonly execution: SimAthenaQueryExecution;
+  readonly result: SimAthenaResolvedResult;
+  readonly workGroups: SimAthenaWorkGroupStore;
+  readonly catalog: SimAthenaCatalog | undefined;
+}
+
+/**
+ * Why a query cannot answer, where something says it cannot.
+ *
+ * Three things can refuse one, and they are asked in the order real Athena
+ * would reach them. A declaration saying the query fails wins, because that is
+ * a test's own statement about the query. Then the tables it names are looked
+ * for in the Data Catalog, the way Athena resolves them before running
+ * anything. The cutoff is last, against what the declaration says the query
+ * scanned.
+ */
+export function simAthenaQueryRefusal(
+  properties: SimAthenaQueryRefusalProperties,
+): string | undefined {
+  const { execution, result } = properties;
+
+  if (result.failsWith !== undefined) {
+    return result.failsWith;
+  }
+
+  const absentTable = simAthenaTableRefusal(
+    {
+      queryString: execution.queryString,
+      database: execution.database,
+      catalog: execution.catalog,
+    },
+    properties.catalog,
+  );
+
+  return absentTable ?? cutoffRefusal(properties);
+}
+
+/**
+ * The cost guardrail, checked against what the declaration says the query
+ * scanned.
+ *
+ * That is the whole of it, and the one thing this simulation can enforce for
+ * real without a query engine.
+ */
+function cutoffRefusal(
+  properties: SimAthenaQueryRefusalProperties,
+): string | undefined {
+  const { execution, result } = properties;
+  const cutoff = properties.workGroups.find(
+    execution.workGroupName,
+  )?.bytesScannedCutoffPerQuery;
+
+  if (cutoff === undefined || result.bytesScanned <= cutoff) {
+    return undefined;
+  }
+
+  return (
+    `Bytes scanned limit was exceeded. The query scanned ` +
+    `${String(result.bytesScanned)} bytes, and workgroup ` +
+    `${execution.workGroupName} allows ${String(cutoff)} per query.`
+  );
+}

--- a/src/service/athena/execution/sim-athena-query-runner.ts
+++ b/src/service/athena/execution/sim-athena-query-runner.ts
@@ -2,7 +2,9 @@ import type { BackgroundScheduler } from "../../../util/background/background.js
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAthenaQueryResults } from "../result/sim-athena-query-results.js";
 import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import type { SimAthenaCatalog } from "../table/sim-athena-table-resolution.js";
 import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
+import { simAthenaQueryRefusal } from "./sim-athena-query-refusal.js";
 import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
 import type { SimAthenaResultWriter } from "./sim-athena-result-writer.js";
 import { simAthenaWriteFailureReason } from "./sim-athena-write-failure.js";
@@ -12,6 +14,14 @@ interface SimAthenaQueryRunnerProperties {
   readonly workGroups: SimAthenaWorkGroupStore;
   readonly writer: SimAthenaResultWriter;
   readonly background: BackgroundScheduler;
+
+  /**
+   * The Data Catalog a query's table names are resolved against.
+   *
+   * A SimAthena built on its own has none, and every query then runs without
+   * its tables being looked for.
+   */
+  readonly catalog?: SimAthenaCatalog | undefined;
 }
 
 /**
@@ -31,12 +41,14 @@ export class SimAthenaQueryRunner {
   private readonly workGroups: SimAthenaWorkGroupStore;
   private readonly writer: SimAthenaResultWriter;
   private readonly background: BackgroundScheduler;
+  private readonly catalog: SimAthenaCatalog | undefined;
 
   constructor(properties: SimAthenaQueryRunnerProperties) {
     this.results = properties.results;
     this.workGroups = properties.workGroups;
     this.writer = properties.writer;
     this.background = properties.background;
+    this.catalog = properties.catalog;
   }
 
   /**
@@ -78,7 +90,12 @@ export class SimAthenaQueryRunner {
 
     execution.recordBytesScanned(result.bytesScanned);
 
-    const refusal = this.refusalFor(execution, result);
+    const refusal = simAthenaQueryRefusal({
+      execution,
+      result,
+      workGroups: this.workGroups,
+      catalog: this.catalog,
+    });
 
     if (refusal !== undefined) {
       execution.fail(refusal, this.background.now());
@@ -87,36 +104,6 @@ export class SimAthenaQueryRunner {
     }
 
     await this.write(execution, result, caller);
-  }
-
-  /**
-   * Why this query cannot answer, where something says it cannot.
-   *
-   * The cutoff is checked against what the declaration says the query
-   * scanned. That is the whole of the cost guardrail here, and it is the one
-   * thing this simulation can enforce for real without a query engine.
-   */
-  private refusalFor(
-    execution: SimAthenaQueryExecution,
-    result: SimAthenaResolvedResult,
-  ): string | undefined {
-    if (result.failsWith !== undefined) {
-      return result.failsWith;
-    }
-
-    const cutoff = this.workGroups.find(
-      execution.workGroupName,
-    )?.bytesScannedCutoffPerQuery;
-
-    if (cutoff === undefined || result.bytesScanned <= cutoff) {
-      return undefined;
-    }
-
-    return (
-      `Bytes scanned limit was exceeded. The query scanned ` +
-      `${String(result.bytesScanned)} bytes, and workgroup ` +
-      `${execution.workGroupName} allows ${String(cutoff)} per query.`
-    );
   }
 
   private async write(

--- a/src/service/athena/sim-athena-executions.ts
+++ b/src/service/athena/sim-athena-executions.ts
@@ -21,6 +21,7 @@ import {
 } from "./execution/sim-athena-result-writer.js";
 import { SimAthenaNamedQueryStore } from "./named-query/sim-athena-named-query-store.js";
 import { SimAthenaQueryResults } from "./result/sim-athena-query-results.js";
+import type { SimAthenaCatalog } from "./table/sim-athena-table-resolution.js";
 import { SimAthenaWorkGroup } from "./workgroup/sim-athena-work-group.js";
 import { primaryWorkGroupName } from "./workgroup/sim-athena-work-group-name.js";
 import { SimAthenaWorkGroupStore } from "./workgroup/sim-athena-work-group-store.js";
@@ -37,6 +38,14 @@ interface SimAthenaProperties {
    * results fails saying so. A Bucket only exists inside a SimAws.
    */
   readonly s3?: SimAthenaResultDestination;
+
+  /**
+   * The Data Catalog a query's table names are resolved against.
+   *
+   * A SimAthena built on its own has none, and every query then runs without
+   * its tables being looked for. A catalog only exists inside a SimAws.
+   */
+  readonly glue?: SimAthenaCatalog;
 }
 
 /**
@@ -79,6 +88,7 @@ export class SimAthenaExecutions {
       workGroups: this.workGroupStore,
       writer,
       background,
+      catalog: properties.glue,
     });
 
     this.background = background;

--- a/src/service/athena/sim-athena-table-resolution.iso.test.ts
+++ b/src/service/athena/sim-athena-table-resolution.iso.test.ts
@@ -1,0 +1,229 @@
+import { faker } from "@faker-js/faker";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+
+interface RanQuery {
+  readonly state: string | undefined;
+  readonly reason: string | undefined;
+}
+
+describe("resolving an Athena query's tables against the Glue catalog", () => {
+  async function aWorkGroup(simAws: SimAws): Promise<string> {
+    const name = `analytics-${faker.string.uuid()}`;
+
+    await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+    await simAws.athena().createWorkGroup({
+      input: {
+        Name: name,
+        Configuration: {
+          ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+        },
+      },
+    });
+
+    return name;
+  }
+
+  function aCatalogTable(
+    simAws: SimAws,
+    databaseName: string,
+    tableName: string,
+  ): void {
+    simAws.glue().createDatabase({
+      input: { DatabaseInput: { Name: databaseName } },
+    });
+    simAws.glue().createTable({
+      input: {
+        DatabaseName: databaseName,
+        TableInput: {
+          Name: tableName,
+          StorageDescriptor: { Location: "s3://rainlytics-logs/cloudfront/" },
+        },
+      },
+    });
+  }
+
+  async function runQuery(
+    simAws: SimAws,
+    input: Record<string, unknown>,
+  ): Promise<RanQuery> {
+    const workGroup = await aWorkGroup(simAws);
+    const started = await simAws
+      .athena()
+      .startQueryExecution({ input: { WorkGroup: workGroup, ...input } });
+
+    await simAws.backgroundTasksComplete();
+
+    const execution = await simAws.athena().getQueryExecution({
+      input: { QueryExecutionId: started.QueryExecutionId },
+    });
+
+    return {
+      state: execution.QueryExecution?.Status?.State,
+      reason: execution.QueryExecution?.Status?.StateChangeReason,
+    };
+  }
+
+  it("answers a query naming a table the catalog holds", async () => {
+    // Given a catalog holding one table, and a query naming it.
+    const simAws = new SimAws();
+    aCatalogTable(simAws, "rainlytics", "access_logs");
+
+    simAws
+      .athena()
+      .results()
+      .byDefault({ columns: ["url"], rows: [["/"]] });
+
+    // When the query runs.
+    const ran = await runQuery(simAws, {
+      QueryString: "SELECT url FROM rainlytics.access_logs",
+    });
+
+    // Then it succeeds, the way it did before any table was looked for.
+    assertIdentical(ran.state, "SUCCEEDED");
+  });
+
+  it("fails a query naming a table the catalog has never heard of", async () => {
+    // Given a catalog holding one table, and a query with a typo in the name.
+    const simAws = new SimAws();
+    aCatalogTable(simAws, "rainlytics", "access_logs");
+
+    // When the query runs.
+    const ran = await runQuery(simAws, {
+      QueryString: "SELECT url FROM rainlytics.acess_logs",
+    });
+
+    // Then it fails, and the reason names the table the way Athena qualifies
+    // one, so a reader can see which part is wrong.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(
+      ran.reason,
+      "Table awsdatacatalog.rainlytics.acess_logs does not exist",
+    );
+  });
+
+  it("resolves an unqualified name against the request's database", async () => {
+    // Given a catalog holding one table, and a query naming it bare.
+    const simAws = new SimAws();
+    aCatalogTable(simAws, "rainlytics", "access_logs");
+
+    simAws
+      .athena()
+      .results()
+      .byDefault({ rows: [["1"]] });
+
+    // When the query runs carrying that database in its context.
+    const ran = await runQuery(simAws, {
+      QueryString: "SELECT url FROM access_logs",
+      QueryExecutionContext: { Database: "rainlytics" },
+    });
+
+    // Then the bare name resolves against it.
+    assertIdentical(ran.state, "SUCCEEDED");
+  });
+
+  it("fails a bare name where the request names no database", async () => {
+    // Given a catalog holding one table, and a query naming it bare with no
+    // database in its context.
+    const simAws = new SimAws();
+    aCatalogTable(simAws, "rainlytics", "access_logs");
+
+    // When the query runs.
+    const ran = await runQuery(simAws, {
+      QueryString: "SELECT url FROM access_logs",
+    });
+
+    // Then it fails saying so. There is nothing to resolve the name against.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(ran.reason, "Schema must be specified");
+  });
+
+  it("answers a query against information_schema with no catalog entry", async () => {
+    // Given a catalog holding one table, and a query reading Athena's own
+    // metadata schema.
+    const simAws = new SimAws();
+    aCatalogTable(simAws, "rainlytics", "access_logs");
+
+    simAws
+      .athena()
+      .results()
+      .byDefault({ rows: [["access_logs"]] });
+
+    // When the query runs.
+    const ran = await runQuery(simAws, {
+      QueryString: "SELECT table_name FROM information_schema.tables",
+    });
+
+    // Then it succeeds. Athena serves that schema rather than the catalog.
+    assertIdentical(ran.state, "SUCCEEDED");
+  });
+
+  it("leaves every query alone while the catalog holds nothing", async () => {
+    // Given a simulation where no database was ever created.
+    const simAws = new SimAws();
+
+    simAws
+      .athena()
+      .results()
+      .byDefault({ rows: [["4213"]] });
+
+    // When a query naming a table nothing declared runs.
+    const ran = await runQuery(simAws, {
+      QueryString: "SELECT count(*) FROM access_logs",
+    });
+
+    // Then it is answered from the declaration. A simulation holding no
+    // catalog is one where nothing asked for a table to be looked for.
+    assertIdentical(ran.state, "SUCCEEDED");
+  });
+
+  it("leaves a query against another catalog alone", async () => {
+    // Given a Data Catalog holding one table, and a query against a federated
+    // catalog this simulation has never seen.
+    const simAws = new SimAws();
+    aCatalogTable(simAws, "rainlytics", "access_logs");
+
+    simAws
+      .athena()
+      .results()
+      .byDefault({ rows: [["1"]] });
+
+    // When the query runs against that catalog.
+    const ran = await runQuery(simAws, {
+      QueryString: "SELECT id FROM postgres_source.public.orders",
+      QueryExecutionContext: { Catalog: "postgres_source" },
+    });
+
+    // Then it is answered from the declaration.
+    assertIdentical(ran.state, "SUCCEEDED");
+  });
+
+  it("lets a declared failure win over an absent table", async () => {
+    // Given a catalog holding one table, and a test saying a query against a
+    // different table fails for a reason of its own.
+    const simAws = new SimAws();
+    aCatalogTable(simAws, "rainlytics", "access_logs");
+
+    const sql = "SELECT url FROM rainlytics.sessions";
+    simAws
+      .athena()
+      .results()
+      .onQuery(sql, { failsWith: "Insufficient rights" });
+
+    // When the query runs.
+    const ran = await runQuery(simAws, { QueryString: sql });
+
+    // Then the declaration answers. It is a test's own statement about the
+    // query, and it stays the way out of anything decided here.
+    assertIdentical(ran.state, "FAILED");
+    assertIdentical(ran.reason, "Insufficient rights");
+  });
+});

--- a/src/service/athena/table/sim-athena-common-tables.ts
+++ b/src/service/athena/table/sim-athena-common-tables.ts
@@ -1,0 +1,52 @@
+import type { SimAthenaSqlToken } from "./sim-athena-sql-tokens.js";
+import type { SimAthenaTableReference } from "./sim-athena-table-reference.js";
+
+/**
+ * The names a `WITH` clause defines.
+ *
+ * A common table expression is written `name AS (`, and nothing else in a
+ * statement this scanner reads puts a bracket straight after `AS`.
+ */
+export function simAthenaCommonTableNames(
+  tokens: readonly SimAthenaSqlToken[],
+): ReadonlySet<string> {
+  const names = new Set<string>();
+
+  for (const [position, word] of tokens.entries()) {
+    if (word.kind !== "word" || word.text !== "as") {
+      continue;
+    }
+
+    const opening = tokens.at(position + 1);
+
+    if (opening?.kind !== "symbol" || opening.text !== "(") {
+      continue;
+    }
+
+    const name = position === 0 ? undefined : tokens.at(position - 1);
+
+    if (name?.kind === "word" || name?.kind === "quoted") {
+      names.add(name.text.toLowerCase());
+    }
+  }
+
+  return names;
+}
+
+/**
+ * Whether this reference names one of them.
+ *
+ * A common table expression is never qualified, so a name carrying a database
+ * or a catalog is a catalog entry whatever a `WITH` clause called something
+ * else.
+ */
+export function simAthenaIsCommonTable(
+  reference: SimAthenaTableReference,
+  names: ReadonlySet<string>,
+): boolean {
+  return (
+    reference.database === undefined &&
+    reference.catalog === undefined &&
+    names.has(reference.name.toLowerCase())
+  );
+}

--- a/src/service/athena/table/sim-athena-common-tables.ts
+++ b/src/service/athena/table/sim-athena-common-tables.ts
@@ -5,7 +5,9 @@ import type { SimAthenaTableReference } from "./sim-athena-table-reference.js";
  * The names a `WITH` clause defines.
  *
  * A common table expression is written `name AS (`, and nothing else in a
- * statement this scanner reads puts a bracket straight after `AS`.
+ * statement this scanner reads puts a bracket straight after `AS`. Athena also
+ * lets one name its output columns, as `name (a, b) AS (`, so the name is not
+ * always the token before the `AS`.
  */
 export function simAthenaCommonTableNames(
   tokens: readonly SimAthenaSqlToken[],
@@ -23,7 +25,7 @@ export function simAthenaCommonTableNames(
       continue;
     }
 
-    const name = position === 0 ? undefined : tokens.at(position - 1);
+    const name = nameBefore(tokens, position);
 
     if (name?.kind === "word" || name?.kind === "quoted") {
       names.add(name.text.toLowerCase());
@@ -31,6 +33,58 @@ export function simAthenaCommonTableNames(
   }
 
   return names;
+}
+
+/**
+ * The name a common table expression declares, reading back from its `AS`.
+ *
+ * A closing bracket there is the end of an output column list, and the name
+ * sits in front of the bracket that opened it.
+ */
+function nameBefore(
+  tokens: readonly SimAthenaSqlToken[],
+  position: number,
+): SimAthenaSqlToken | undefined {
+  const previous = position === 0 ? undefined : tokens.at(position - 1);
+
+  if (previous?.kind !== "symbol" || previous.text !== ")") {
+    return previous;
+  }
+
+  const opening = openingBracket(tokens, position - 1);
+
+  return opening === undefined || opening === 0
+    ? undefined
+    : tokens.at(opening - 1);
+}
+
+/** Where the bracket closing at this position was opened. */
+function openingBracket(
+  tokens: readonly SimAthenaSqlToken[],
+  closedAt: number,
+): number | undefined {
+  let cursor = closedAt;
+  let depth = 0;
+
+  while (cursor >= 0) {
+    const token = tokens.at(cursor);
+
+    if (token?.kind === "symbol" && token.text === ")") {
+      depth += 1;
+    }
+
+    if (token?.kind === "symbol" && token.text === "(") {
+      depth -= 1;
+
+      if (depth === 0) {
+        return cursor;
+      }
+    }
+
+    cursor -= 1;
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/service/athena/table/sim-athena-sql-keywords.ts
+++ b/src/service/athena/table/sim-athena-sql-keywords.ts
@@ -1,0 +1,84 @@
+/**
+ * The words that never start a table name.
+ *
+ * A scanner reading what follows `FROM` uses this to tell a table name from a
+ * query it has misread. The set is the keywords that can legally sit there in
+ * a statement this simulation resolves, plus the ones that mark the end of the
+ * clause.
+ */
+export const simAthenaClauseKeywords = new Set([
+  "as",
+  "cross",
+  "full",
+  "group",
+  "having",
+  "inner",
+  "join",
+  "lateral",
+  "left",
+  "limit",
+  "natural",
+  "offset",
+  "on",
+  "order",
+  "outer",
+  "right",
+  "select",
+  "union",
+  "unnest",
+  "using",
+  "where",
+  "window",
+  "with",
+]);
+
+/**
+ * The words a parenthesis may follow while still opening a subquery or a list.
+ *
+ * A parenthesis opening straight after any other word is a function call, and
+ * `FROM` inside one belongs to the function. `EXTRACT(hour FROM ts)` and
+ * `SUBSTRING(s FROM 2)` are the two that matter, and both would otherwise read
+ * as a table called `ts` or `2`.
+ */
+export const simAthenaSubqueryOpeners = new Set([
+  "and",
+  "as",
+  "exists",
+  "from",
+  "in",
+  "join",
+  "not",
+  "on",
+  "or",
+  "select",
+  "union",
+  "values",
+  "where",
+  "with",
+]);
+
+/** The statement kinds this simulation resolves table names for. */
+export const simAthenaResolvedStatements = new Set(["select", "with"]);
+
+/**
+ * The words that end a `FROM` clause.
+ *
+ * A comma before one of these separates two tables, and a comma after one
+ * belongs to something else. `AS` is left out on purpose, since an alias sits
+ * inside the clause it names a table in.
+ */
+export const simAthenaFromClauseEnders = new Set([
+  "except",
+  "group",
+  "having",
+  "intersect",
+  "limit",
+  "offset",
+  "on",
+  "order",
+  "select",
+  "union",
+  "using",
+  "where",
+  "window",
+]);

--- a/src/service/athena/table/sim-athena-sql-token-readers.ts
+++ b/src/service/athena/table/sim-athena-sql-token-readers.ts
@@ -1,0 +1,122 @@
+import type { SimAthenaSqlToken } from "./sim-athena-sql-tokens.js";
+
+/** Characters an unquoted identifier or a keyword is made of. */
+const wordCharacter = /[A-Za-z0-9_$]/;
+
+/** The quote characters Athena accepts around an identifier. */
+const identifierQuotes = new Set(['"', "`"]);
+
+/** One token, with where reading carries on from. */
+export interface SimAthenaSqlTokenRead {
+  readonly token: SimAthenaSqlToken;
+  readonly next: number;
+}
+
+/**
+ * Where a comment starting here ends, or `undefined` where none starts.
+ *
+ * An unterminated block comment answers -1, which a caller reads as a query it
+ * cannot make sense of.
+ */
+export function simAthenaCommentEnd(
+  sql: string,
+  index: number,
+): number | undefined {
+  if (sql.startsWith("--", index)) {
+    const newline = sql.indexOf("\n", index);
+
+    return newline === -1 ? sql.length : newline + 1;
+  }
+
+  if (!sql.startsWith("/*", index)) {
+    return undefined;
+  }
+
+  const close = sql.indexOf("*/", index + 2);
+
+  return close === -1 ? -1 : close + 2;
+}
+
+/** Read the one token starting here. */
+export function simAthenaReadToken(
+  sql: string,
+  index: number,
+): SimAthenaSqlTokenRead | undefined {
+  const character = sql.charAt(index);
+
+  if (character === "'") {
+    return readDelimited(sql, index, "'", "literal");
+  }
+
+  if (identifierQuotes.has(character)) {
+    return readDelimited(sql, index, character, "quoted");
+  }
+
+  if (wordCharacter.test(character)) {
+    return readWord(sql, index);
+  }
+
+  return {
+    token: { kind: "symbol", text: character, index },
+    next: index + 1,
+  };
+}
+
+/**
+ * Read a string literal or a quoted identifier.
+ *
+ * A doubled quote inside one is an escaped quote, which is how both Athena and
+ * ANSI SQL write it.
+ */
+function readDelimited(
+  sql: string,
+  index: number,
+  quote: string,
+  kind: "literal" | "quoted",
+): SimAthenaSqlTokenRead | undefined {
+  let cursor = index + 1;
+  let text = "";
+
+  while (cursor < sql.length) {
+    const character = sql.charAt(cursor);
+
+    if (character !== quote) {
+      text += character;
+      cursor += 1;
+      continue;
+    }
+
+    if (sql.charAt(cursor + 1) === quote) {
+      text += quote;
+      cursor += 2;
+      continue;
+    }
+
+    return { token: { kind, text, index }, next: cursor + 1 };
+  }
+
+  return undefined;
+}
+
+/**
+ * Read a keyword or an unquoted identifier.
+ *
+ * The text is lowercased, because Athena folds an unquoted identifier down and
+ * a keyword is matched however it was written.
+ */
+function readWord(sql: string, index: number): SimAthenaSqlTokenRead {
+  let cursor = index;
+
+  while (cursor < sql.length && wordCharacter.test(sql.charAt(cursor))) {
+    cursor += 1;
+  }
+
+  return {
+    token: {
+      kind: "word",
+      text: sql.slice(index, cursor).toLowerCase(),
+      index,
+    },
+    next: cursor,
+  };
+}

--- a/src/service/athena/table/sim-athena-sql-tokens.ts
+++ b/src/service/athena/table/sim-athena-sql-tokens.ts
@@ -1,0 +1,83 @@
+import {
+  simAthenaCommentEnd,
+  simAthenaReadToken,
+} from "./sim-athena-sql-token-readers.js";
+
+/**
+ * One token of a query, as much of one as finding table names needs.
+ *
+ * A word carries its text lowercased, because Athena folds an unquoted
+ * identifier to lower case and a keyword is matched however it was written. A
+ * quoted identifier keeps the case it was given, which is what quoting it
+ * means.
+ */
+export interface SimAthenaSqlToken {
+  readonly kind: "word" | "quoted" | "symbol" | "literal";
+  readonly text: string;
+  readonly index: number;
+}
+
+/**
+ * Read a query into tokens, or report that it cannot be read.
+ *
+ * Nothing here parses. The tokens exist so that a scanner can find what sits
+ * after `FROM` and `JOIN` without being confused by a keyword inside a string
+ * literal or a comment.
+ *
+ * An unterminated string, comment or quoted identifier answers `undefined`.
+ * That is a query this simulation has no opinion about, and a caller treats it
+ * as one to leave alone.
+ */
+export function simAthenaSqlTokens(
+  sql: string,
+): readonly SimAthenaSqlToken[] | undefined {
+  const tokens: SimAthenaSqlToken[] = [];
+  let index = 0;
+
+  while (index < sql.length) {
+    if (/\s/.test(sql.charAt(index))) {
+      index += 1;
+      continue;
+    }
+
+    const commentEnd = simAthenaCommentEnd(sql, index);
+
+    if (commentEnd === -1) {
+      return undefined;
+    }
+
+    if (commentEnd !== undefined) {
+      index = commentEnd;
+      continue;
+    }
+
+    const read = simAthenaReadToken(sql, index);
+
+    if (read === undefined) {
+      return undefined;
+    }
+
+    tokens.push(read.token);
+    index = read.next;
+  }
+
+  return tokens;
+}
+
+/**
+ * Where one token sits in the query, as Athena counts it.
+ *
+ * Athena reports a position with its errors and counts both from one, so an
+ * identifier at the very start of a query is at line 1 column 1.
+ */
+export function simAthenaSqlPosition(
+  sql: string,
+  index: number,
+): { line: number; column: number } {
+  const lines = sql.slice(0, index).split("\n");
+
+  return {
+    line: lines.length,
+    column: (lines.at(-1) ?? "").length + 1,
+  };
+}

--- a/src/service/athena/table/sim-athena-table-name.ts
+++ b/src/service/athena/table/sim-athena-table-name.ts
@@ -1,0 +1,93 @@
+import { simAthenaClauseKeywords } from "./sim-athena-sql-keywords.js";
+import type { SimAthenaSqlToken } from "./sim-athena-sql-tokens.js";
+import type { SimAthenaTableReference } from "./sim-athena-table-reference.js";
+
+/** What a table position came to, once it has been read. */
+export interface SimAthenaReferenceRead {
+  readonly reference: SimAthenaTableReference | undefined;
+}
+
+/**
+ * Read what follows a `FROM` or a `JOIN`.
+ *
+ * A parenthesis is a subquery and `UNNEST` produces rows of its own, so both
+ * answer with no reference. Anything the scanner cannot follow answers
+ * `undefined`, which fails the whole read.
+ */
+export function simAthenaReadReference(
+  tokens: readonly SimAthenaSqlToken[],
+  start: number,
+): SimAthenaReferenceRead | undefined {
+  const leading = tokens.at(start);
+
+  if (leading === undefined || leading.kind === "literal") {
+    return undefined;
+  }
+
+  if (leading.kind === "symbol") {
+    return leading.text === "(" ? { reference: undefined } : undefined;
+  }
+
+  if (leading.kind === "word" && simAthenaClauseKeywords.has(leading.text)) {
+    return leading.text === "unnest" || leading.text === "lateral"
+      ? { reference: undefined }
+      : undefined;
+  }
+
+  return { reference: qualifiedName(tokens, start) };
+}
+
+/**
+ * Read a name of one, two or three parts.
+ *
+ * Athena qualifies a table as `catalog.database.table`, and a query naming
+ * fewer parts leaves the outer ones to the request.
+ */
+function qualifiedName(
+  tokens: readonly SimAthenaSqlToken[],
+  start: number,
+): SimAthenaTableReference | undefined {
+  const parts = nameParts(tokens, start);
+  const name = parts?.at(-1);
+
+  if (parts === undefined || name === undefined) {
+    return undefined;
+  }
+
+  return {
+    catalog: parts.length === 3 ? parts.at(0) : undefined,
+    database: parts.length >= 2 ? parts.at(-2) : undefined,
+    name,
+    index: tokens.at(start)?.index ?? 0,
+  };
+}
+
+/** The dot-separated parts of one name, or nothing where it is not a name. */
+function nameParts(
+  tokens: readonly SimAthenaSqlToken[],
+  start: number,
+): readonly string[] | undefined {
+  const parts: string[] = [];
+  let cursor = start;
+
+  while (parts.length < 3) {
+    const part = tokens.at(cursor);
+
+    if (part?.kind !== "word" && part?.kind !== "quoted") {
+      return undefined;
+    }
+
+    parts.push(part.text);
+    cursor += 1;
+
+    const separator = tokens.at(cursor);
+
+    if (separator?.kind !== "symbol" || separator.text !== ".") {
+      break;
+    }
+
+    cursor += 1;
+  }
+
+  return parts;
+}

--- a/src/service/athena/table/sim-athena-table-position.ts
+++ b/src/service/athena/table/sim-athena-table-position.ts
@@ -1,0 +1,65 @@
+import { simAthenaSubqueryOpeners } from "./sim-athena-sql-keywords.js";
+import type { SimAthenaSqlToken } from "./sim-athena-sql-tokens.js";
+
+/**
+ * The token before this one, where there is one.
+ *
+ * `Array.prototype.at` would answer with the last token for position zero,
+ * which is why this guards rather than calling it directly.
+ */
+export function simAthenaTokenBefore(
+  tokens: readonly SimAthenaSqlToken[],
+  position: number,
+): SimAthenaSqlToken | undefined {
+  return position === 0 ? undefined : tokens.at(position - 1);
+}
+
+/**
+ * Whether a table name may follow this token.
+ *
+ * `FROM` and `JOIN` open one. So does a comma inside a FROM clause, which is
+ * how `FROM orders, customers` names two tables.
+ */
+export function simAthenaIsTablePosition(
+  token: SimAthenaSqlToken,
+  previous: SimAthenaSqlToken | undefined,
+  fromDepths: ReadonlySet<number>,
+  openers: readonly boolean[],
+): boolean {
+  if (token.kind === "symbol") {
+    return token.text === "," && fromDepths.has(openers.length);
+  }
+
+  return token.kind === "word" && isTableClause(token, previous);
+}
+
+/** Whether this word opens a table position rather than sitting inside one. */
+function isTableClause(
+  token: SimAthenaSqlToken,
+  previous: SimAthenaSqlToken | undefined,
+): boolean {
+  if (token.text !== "from" && token.text !== "join") {
+    return false;
+  }
+
+  // A qualified name never has a clause keyword as one of its parts, so a
+  // `from` straight after a dot is a column called from.
+  return !(previous?.kind === "symbol" && previous.text === ".");
+}
+
+/**
+ *
+ */
+export function simAthenaIsSubqueryOpener(
+  previous: SimAthenaSqlToken | undefined,
+): boolean {
+  if (previous === undefined) {
+    return true;
+  }
+
+  if (previous.kind === "word") {
+    return simAthenaSubqueryOpeners.has(previous.text);
+  }
+
+  return previous.kind !== "quoted";
+}

--- a/src/service/athena/table/sim-athena-table-position.ts
+++ b/src/service/athena/table/sim-athena-table-position.ts
@@ -48,7 +48,12 @@ function isTableClause(
 }
 
 /**
+ * Whether a bracket opening after this token holds a subquery or a list.
  *
+ * A bracket opening straight after any other word is a function call, and a
+ * `FROM` inside one belongs to the function. `EXTRACT(hour FROM ts)` and
+ * `SUBSTRING(s FROM 2)` are the two that matter, and both would otherwise name
+ * a table.
  */
 export function simAthenaIsSubqueryOpener(
   previous: SimAthenaSqlToken | undefined,

--- a/src/service/athena/table/sim-athena-table-reference.ts
+++ b/src/service/athena/table/sim-athena-table-reference.ts
@@ -1,0 +1,43 @@
+/**
+ * One table a query names, as the query wrote it.
+ *
+ * The catalog and the database are held only where the query qualified them.
+ * Resolving an unqualified name against the execution's database is the
+ * catalog's job rather than the scanner's.
+ */
+export interface SimAthenaTableReference {
+  readonly catalog: string | undefined;
+  readonly database: string | undefined;
+  readonly name: string;
+
+  /** Where the name starts in the query text, for the position in an error. */
+  readonly index: number;
+}
+
+/** The catalog Athena queries when a query names none. */
+export const defaultAthenaCatalog = "awsdatacatalog";
+
+/**
+ * The schema Athena answers about its own metadata from.
+ *
+ * A query against it resolves without the Data Catalog holding anything,
+ * because Athena serves it rather than the catalog.
+ */
+export const informationSchemaName = "information_schema";
+
+/**
+ * How a reference reads back in an error, qualified the way Athena qualifies
+ * one.
+ */
+export function simAthenaTableReferenceText(
+  reference: SimAthenaTableReference,
+  database: string | undefined,
+): string {
+  const parts = [
+    reference.catalog ?? defaultAthenaCatalog,
+    reference.database ?? database ?? "",
+    reference.name,
+  ];
+
+  return parts.join(".");
+}

--- a/src/service/athena/table/sim-athena-table-references.iso.test.ts
+++ b/src/service/athena/table/sim-athena-table-references.iso.test.ts
@@ -52,6 +52,20 @@ describe("reading the tables an Athena query names", () => {
     assertArrayEquals(names, ["rainlytics.access_logs"]);
   });
 
+  it("leaves out a WITH name that declares its own columns", () => {
+    // Given a common table expression naming its output columns, which Athena
+    // writes as `name (a, b) AS (`.
+    // When its table names are read.
+    const names = namesIn(
+      "WITH totals (id, spend) AS (SELECT customer_id, sum(total) " +
+        "FROM shop.orders GROUP BY 1) SELECT id FROM totals",
+    );
+
+    // Then only the catalog table is named. Reading `totals` as one would
+    // refuse a query real Athena runs.
+    assertArrayEquals(names, ["shop.orders"]);
+  });
+
   it("leaves an alias and a subquery out", () => {
     // Given a query aliasing a table and selecting from a subquery.
     // When its table names are read.

--- a/src/service/athena/table/sim-athena-table-references.iso.test.ts
+++ b/src/service/athena/table/sim-athena-table-references.iso.test.ts
@@ -1,0 +1,161 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAthenaTableReferences } from "./sim-athena-table-references.js";
+
+/** The table names one query comes to, qualified as the query wrote them. */
+function namesIn(sql: string): readonly string[] {
+  return simAthenaTableReferences(sql).references.map((reference) =>
+    [reference.catalog, reference.database, reference.name]
+      .filter((part) => part !== undefined)
+      .join("."),
+  );
+}
+
+describe("reading the tables an Athena query names", () => {
+  it("reads a qualified name and an unqualified one", () => {
+    // Given a query naming one table each way.
+    // When its table names are read.
+    const names = namesIn(
+      "SELECT * FROM rainlytics.access_logs JOIN sessions ON 1 = 1",
+    );
+
+    // Then both come back, each carrying only the parts the query wrote.
+    assertArrayEquals(names, ["rainlytics.access_logs", "sessions"]);
+  });
+
+  it("keeps the case a quoted identifier was given and folds an unquoted one", () => {
+    // Given a query naming one table quoted and one bare, both mixed case.
+    // When its table names are read.
+    const names = namesIn('SELECT * FROM "Rainlytics"."Access_Logs", Sessions');
+
+    // Then the quoted name keeps its case, as quoting it asks, and the bare
+    // one folds down the way Athena folds it.
+    assertArrayEquals(names, ["Rainlytics.Access_Logs", "sessions"]);
+  });
+
+  it("leaves a name a WITH clause defined out", () => {
+    // Given a query whose FROM names a common table expression.
+    // When its table names are read.
+    const names = namesIn(
+      "WITH errors AS (SELECT url FROM rainlytics.access_logs) " +
+        "SELECT count(*) FROM errors",
+    );
+
+    // Then only the catalog table is named. A CTE is no catalog entry.
+    assertArrayEquals(names, ["rainlytics.access_logs"]);
+  });
+
+  it("leaves an alias and a subquery out", () => {
+    // Given a query aliasing a table and selecting from a subquery.
+    // When its table names are read.
+    const names = namesIn(
+      "SELECT o.id FROM (SELECT id FROM shop.orders) o " +
+        "JOIN shop.customers AS c ON 1 = 1",
+    );
+
+    // Then the two real tables come back, and neither the alias nor the
+    // subquery does.
+    assertArrayEquals(names, ["shop.orders", "shop.customers"]);
+  });
+
+  it("reads two tables a comma separates, and none a subquery's commas hold", () => {
+    // Given a FROM naming two tables, one of them a subquery selecting several
+    // columns, and a WHERE clause with a comma of its own.
+    // When its table names are read.
+    const names = namesIn(
+      "SELECT * FROM (SELECT id, total FROM shop.orders) o, shop.customers c " +
+        "WHERE c.id IN (1, 2)",
+    );
+
+    // Then the two real tables come back. A comma inside brackets separates
+    // columns rather than tables.
+    assertArrayEquals(names, ["shop.orders", "shop.customers"]);
+  });
+
+  it("leaves the FROM inside a function call alone", () => {
+    // Given a query using EXTRACT, which writes FROM inside its own brackets.
+    // When its table names are read.
+    const names = namesIn(
+      "SELECT extract(hour FROM ts), substring(url FROM 2) " +
+        "FROM rainlytics.access_logs",
+    );
+
+    // Then only the table is named. Reading `ts` as a table would refuse a
+    // query real Athena runs.
+    assertArrayEquals(names, ["rainlytics.access_logs"]);
+  });
+
+  it("leaves what UNNEST produces out", () => {
+    // Given a query flattening an array column.
+    // When its table names are read.
+    const names = namesIn(
+      "SELECT t.tag FROM app.events CROSS JOIN UNNEST(tags) AS t(tag)",
+    );
+
+    // Then the events table is named on its own.
+    assertArrayEquals(names, ["app.events"]);
+  });
+
+  it("ignores a keyword sitting inside a string or a comment", () => {
+    // Given a query with FROM inside a literal and inside both comment forms.
+    // When its table names are read.
+    const names = namesIn(
+      "SELECT 'from nowhere' -- from a line comment\n" +
+        "/* from a block comment */ FROM rainlytics.access_logs",
+    );
+
+    // Then only the real table is named.
+    assertArrayEquals(names, ["rainlytics.access_logs"]);
+  });
+
+  it("reads a three part name as a catalog, a database and a table", () => {
+    // Given a query naming a federated catalog.
+    // When its table names are read.
+    const read = simAthenaTableReferences(
+      "SELECT * FROM hive.rainlytics.access_logs",
+    );
+
+    // Then all three parts are kept apart, so a caller can tell the Data
+    // Catalog from another one.
+    assertArrayLength(read.references, 1);
+    assertIdentical(read.references[0].catalog, "hive");
+    assertIdentical(read.references[0].database, "rainlytics");
+    assertIdentical(read.references[0].name, "access_logs");
+  });
+
+  it("reports a statement it cannot follow rather than guessing", () => {
+    // Given statements that write data, that are not SELECT at all, and one
+    // whose string literal never closes.
+    // When each is read.
+    const unreadable = [
+      "MSCK REPAIR TABLE rainlytics.access_logs",
+      "CREATE TABLE t AS SELECT * FROM rainlytics.access_logs",
+      "SHOW PARTITIONS rainlytics.access_logs",
+      "SELECT * FROM rainlytics.access_logs WHERE url = 'unclosed",
+      "SELECT * FROM",
+    ];
+
+    // Then none of them is readable, and nothing is resolved for one.
+    for (const sql of unreadable) {
+      assertFalse(simAthenaTableReferences(sql).readable, sql);
+      assertArrayLength(simAthenaTableReferences(sql).references, 0, sql);
+    }
+  });
+
+  it("reads a query naming no table at all", () => {
+    // Given a query with no FROM clause.
+    // When it is read.
+    const read = simAthenaTableReferences("SELECT 1");
+
+    // Then it is readable and names nothing.
+    assertTrue(read.readable);
+    assertArrayLength(read.references, 0);
+  });
+});

--- a/src/service/athena/table/sim-athena-table-references.ts
+++ b/src/service/athena/table/sim-athena-table-references.ts
@@ -1,0 +1,132 @@
+import {
+  simAthenaCommonTableNames,
+  simAthenaIsCommonTable,
+} from "./sim-athena-common-tables.js";
+import {
+  simAthenaFromClauseEnders,
+  simAthenaResolvedStatements,
+} from "./sim-athena-sql-keywords.js";
+import { simAthenaReadReference } from "./sim-athena-table-name.js";
+import {
+  simAthenaIsSubqueryOpener,
+  simAthenaIsTablePosition,
+  simAthenaTokenBefore,
+} from "./sim-athena-table-position.js";
+import {
+  simAthenaSqlTokens,
+  type SimAthenaSqlToken,
+} from "./sim-athena-sql-tokens.js";
+import type { SimAthenaTableReference } from "./sim-athena-table-reference.js";
+
+/**
+ * What a query's table names came to.
+ *
+ * `readable` false is a query this scanner could not make sense of. Nothing is
+ * resolved for one, since refusing a query real Athena would run costs more
+ * than the check returns.
+ */
+export interface SimAthenaTableReferences {
+  readonly readable: boolean;
+  readonly references: readonly SimAthenaTableReference[];
+}
+
+const unreadable: SimAthenaTableReferences = {
+  readable: false,
+  references: [],
+};
+
+/**
+ * The tables a query names, read out of the statement without planning it.
+ *
+ * Only `FROM` and `JOIN` positions are read, along with a comma separating two
+ * tables in a FROM clause. A name defined by a `WITH` clause is left out,
+ * because a common table expression is no catalog entry, and so is a subquery
+ * and anything `UNNEST` produces.
+ *
+ * Everything about this is deliberately conservative. A statement it cannot
+ * follow is reported as unreadable rather than guessed at, and a statement
+ * that writes data is left alone entirely.
+ */
+export function simAthenaTableReferences(
+  sql: string,
+): SimAthenaTableReferences {
+  const tokens = simAthenaSqlTokens(sql);
+
+  if (tokens === undefined || tokens.length === 0) {
+    return unreadable;
+  }
+
+  const first = tokens.at(0);
+
+  if (first?.kind !== "word" || !simAthenaResolvedStatements.has(first.text)) {
+    return unreadable;
+  }
+
+  return scan(tokens);
+}
+
+function scan(tokens: readonly SimAthenaSqlToken[]): SimAthenaTableReferences {
+  const commonTableNames = simAthenaCommonTableNames(tokens);
+  const references: SimAthenaTableReference[] = [];
+  const openers: boolean[] = [];
+
+  // The bracket depths currently inside a FROM clause. A comma separates two
+  // tables only at a depth in here, which is what tells it apart from a comma
+  // in a subquery's select list or in a function's arguments.
+  const fromDepths = new Set<number>();
+
+  for (const [position, token] of tokens.entries()) {
+    if (token.kind === "symbol" && token.text === "(") {
+      openers.push(
+        simAthenaIsSubqueryOpener(simAthenaTokenBefore(tokens, position)),
+      );
+      continue;
+    }
+
+    if (token.kind === "symbol" && token.text === ")") {
+      fromDepths.delete(openers.length);
+      openers.pop();
+      continue;
+    }
+
+    if (token.kind === "word" && simAthenaFromClauseEnders.has(token.text)) {
+      fromDepths.delete(openers.length);
+    }
+
+    if (
+      !simAthenaIsTablePosition(
+        token,
+        simAthenaTokenBefore(tokens, position),
+        fromDepths,
+        openers,
+      )
+    ) {
+      continue;
+    }
+
+    if (token.kind === "word" && token.text === "from") {
+      fromDepths.add(openers.length);
+    }
+
+    // Inside a function call, where `EXTRACT(hour FROM ts)` puts a `FROM`
+    // that names no table.
+    if (!(openers.at(-1) ?? true)) {
+      continue;
+    }
+
+    const read = simAthenaReadReference(tokens, position + 1);
+
+    if (read === undefined) {
+      return unreadable;
+    }
+
+    if (
+      read.reference !== undefined &&
+      !simAthenaIsCommonTable(read.reference, commonTableNames)
+    ) {
+      references.push(read.reference);
+    }
+  }
+
+  return { readable: true, references };
+}

--- a/src/service/athena/table/sim-athena-table-resolution.ts
+++ b/src/service/athena/table/sim-athena-table-resolution.ts
@@ -1,0 +1,116 @@
+import { simAthenaSqlPosition } from "./sim-athena-sql-tokens.js";
+import {
+  defaultAthenaCatalog,
+  informationSchemaName,
+  simAthenaTableReferenceText,
+  type SimAthenaTableReference,
+} from "./sim-athena-table-reference.js";
+import { simAthenaTableReferences } from "./sim-athena-table-references.js";
+
+/**
+ * The narrow slice of the simulated Glue Data Catalog that resolving a table
+ * needs.
+ *
+ * `SimGlue` structurally implements this, the way `SimS3` implements
+ * `SimAthenaResultDestination`.
+ */
+export interface SimAthenaCatalog {
+  allDatabases(): readonly unknown[];
+  findTable(databaseName: string, name: string): unknown;
+}
+
+/** What one query is resolved against. */
+export interface SimAthenaTableResolutionRequest {
+  readonly queryString: string;
+  readonly database: string | undefined;
+  readonly catalog: string | undefined;
+}
+
+/**
+ * Why a query cannot run against this catalog, where a table it names is
+ * absent.
+ *
+ * Resolution is skipped altogether for a query the scanner cannot follow, for
+ * a statement that writes data, and for a catalog other than
+ * `awsdatacatalog`. Simulated Athena answering a query real Athena would
+ * answer matters more here than catching every absent table.
+ *
+ * It is skipped for an empty catalog as well. A simulation holding no database
+ * is one where nothing declared a table, and a query there is answered from a
+ * declaration the way it was before this existed. Deploying the first database
+ * is what turns resolution on.
+ */
+export function simAthenaTableRefusal(
+  request: SimAthenaTableResolutionRequest,
+  catalog: SimAthenaCatalog | undefined,
+): string | undefined {
+  if (
+    catalog === undefined ||
+    catalog.allDatabases().length === 0 ||
+    isFederated(request.catalog)
+  ) {
+    return undefined;
+  }
+
+  const read = simAthenaTableReferences(request.queryString);
+
+  if (!read.readable) {
+    return undefined;
+  }
+
+  for (const reference of read.references) {
+    const refusal = refusalFor(reference, request, catalog);
+
+    if (refusal !== undefined) {
+      return refusal;
+    }
+  }
+
+  return undefined;
+}
+
+function refusalFor(
+  reference: SimAthenaTableReference,
+  request: SimAthenaTableResolutionRequest,
+  catalog: SimAthenaCatalog,
+): string | undefined {
+  if (isFederated(reference.catalog) || isInformationSchema(reference)) {
+    return undefined;
+  }
+
+  const database = reference.database ?? request.database;
+  const position = simAthenaSqlPosition(request.queryString, reference.index);
+  const at = `line ${String(position.line)}:${String(position.column)}`;
+
+  if (database === undefined) {
+    return (
+      `SYNTAX_ERROR: ${at}: Schema must be specified when session schema ` +
+      `is not set`
+    );
+  }
+
+  if (catalog.findTable(database, reference.name) !== undefined) {
+    return undefined;
+  }
+
+  return (
+    `SYNTAX_ERROR: ${at}: Table ` +
+    `${simAthenaTableReferenceText(reference, database)} does not exist`
+  );
+}
+
+/**
+ * Whether this names a catalog other than the Data Catalog.
+ *
+ * A federated catalog is somewhere this simulation has never looked, so a
+ * query against one is left to run.
+ */
+function isFederated(catalog: string | undefined): boolean {
+  return (
+    catalog !== undefined && catalog.toLowerCase() !== defaultAthenaCatalog
+  );
+}
+
+function isInformationSchema(reference: SimAthenaTableReference): boolean {
+  return reference.database?.toLowerCase() === informationSchemaName;
+}

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -42,10 +42,15 @@ export class SimAwsSelfContainedServiceBuilder {
    *
    * Workgroups, named queries and query executions are all Region-scoped on
    * real Athena. A query writes its result set into a Bucket through that same
-   * scope's simulated S3, which is the one service Athena reaches for.
+   * scope's simulated S3, and resolves the tables it names against that same
+   * scope's simulated Glue Data Catalog.
    */
   createAthena(scope: SimAwsAccountRegionContainer): SimAthena {
-    return new SimAthena({ ...this.scoped(scope), s3: scope.s3() });
+    return new SimAthena({
+      ...this.scoped(scope),
+      s3: scope.s3(),
+      glue: scope.glue(),
+    });
   }
 
   /**


### PR DESCRIPTION
Simulated Athena reads the tables a query names in its `FROM` and `JOIN` clauses and looks each one up in the same scope's Glue Data Catalog. A query naming a table with no entry there reaches `FAILED` carrying Athena's own reason, and an unqualified name resolves against `QueryExecutionContext.Database`. Reading the names is a scan rather than a parse, so a statement it cannot follow runs with its tables never looked for.

Resolves https://github.com/KensioSoftware/yulin/issues/1005

One decision to check. Resolution stays off entirely while the Data Catalog holds no database, which the issue did not ask for. Without it every existing Athena test breaks, including the one in the docs, since `SELECT ... FROM access_logs` with no database in context would start failing. A simulation where nothing created a database is one where nothing asked for a table to be looked for. The alternative is to accept the break and call it a major version.

The scanner is the part worth reading. `src/service/athena/README.md` records the three things in it that a reader would otherwise undo, the sharpest being that a bracket carries a flag saying whether the word before it was a function name, without which `EXTRACT(hour FROM ts)` names a table called `ts`.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Athena now resolves tables referenced in `FROM` and `JOIN` clauses using the simulated Glue Data Catalog.
  - Queries report Athena-style errors when databases or tables are missing.
  - Supports qualified and unqualified table names, common table expressions, nested queries, and `information_schema` handling.
  - Workgroup scan-limit failures now include clearer execution details.

- **Documentation**
  - Added guidance and an example demonstrating table resolution and failed query execution.

- **Tests**
  - Added coverage for table resolution, SQL parsing scenarios, missing resources, catalogs, and failure precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->