### PR TITLE
fix: say when a Distribution repeats an Origin

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -732,6 +732,103 @@ An S3 Origin takes the headers and reaches nothing with them. Sim CloudFront rea
 `GetObject` and builds no HTTP request for a header to travel on, and real S3 ignores a header it
 has no use for.
 
+## An Origin declared twice
+
+Two Origins over one domain name are ordinary. They differ by `OriginPath`, by their custom headers
+or by how CloudFront connects, and a Behavior points at whichever one it wants.
+
+Two Origins that match in every property but the `Id` are one Origin written twice. Copying a
+Behavior and its Origin together, then editing the path pattern, leaves exactly that behind. Sim
+CloudFront keys an Origin by `Id`, as CloudFront does, and serves both Behaviors alike. An account
+has been seen to serve them differently, refusing every request on the second Behavior at the
+Origin. Why it did that is unconfirmed.
+
+The Distribution records each repeat as it is created or updated, and warns about it on the console.
+Each entry in `redundantOrigins` names the Origin, the earlier Origin it repeats and the domain both
+of them name. A test can assert the list is empty.
+
+```typescript sim-cloudfront-redundant-origins
+/**
+ * Catching an Origin a Distribution declares twice.
+ */
+
+import {
+  CreateDistributionCommand,
+  type Origin,
+} from "@aws-sdk/client-cloudfront";
+
+import { SimAws } from "@kensio/yulin";
+
+const simCloudFront = new SimAws().cloudFront();
+
+// The two Behaviors below were written by copying one of them, so the second
+// Origin says everything the first one says.
+const apiOrigin = (originId: string): Origin => ({
+  Id: originId,
+  DomainName: "api.example.test",
+  CustomOriginConfig: {
+    HTTPPort: 80,
+    HTTPSPort: 443,
+    OriginProtocolPolicy: "https-only",
+  },
+  CustomHeaders: {
+    Quantity: 1,
+    Items: [
+      {
+        HeaderName: "x-origin-secret",
+        HeaderValue: "5d6e2b0c6f564c1e9d5b2f1a5b8c9d70",
+      },
+    ],
+  },
+});
+
+const creation = await simCloudFront.createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "user-site",
+      Comment: "User API CDN",
+      Enabled: true,
+      Origins: {
+        Quantity: 2,
+        Items: [apiOrigin("live-origin"), apiOrigin("preview-origin")],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "live-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+      CacheBehaviors: {
+        Quantity: 1,
+        Items: [
+          {
+            PathPattern: "/preview/*",
+            TargetOriginId: "preview-origin",
+            ViewerProtocolPolicy: "allow-all",
+          },
+        ],
+      },
+    },
+  }),
+);
+
+const distribution = simCloudFront.getSimDistributionById(
+  creation.Distribution!.Id!,
+);
+
+// [
+//   {
+//     originId: "preview-origin",
+//     repeatsOriginId: "live-origin",
+//     domainName: "api.example.test",
+//   },
+// ]
+console.log(distribution?.redundantOrigins);
+```
+
+Sameness is every property the config declares apart from the `Id`, and not only the properties the
+simulation reads. An Origin differing by a connection setting sim CloudFront ignores is left alone.
+A property written as an empty string counts as one left out, and custom headers count by name and
+value however they were ordered or cased.
+
 ## Viewer certificates
 
 A Distribution with alternate domain names needs an ACM certificate, and CloudFront accepts only

--- a/docs/services/cloudfront/sim-cloudfront-redundant-origins.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-redundant-origins.example.ts
@@ -1,0 +1,74 @@
+/**
+ * Catching an Origin a Distribution declares twice.
+ */
+
+import {
+  CreateDistributionCommand,
+  type Origin,
+} from "@aws-sdk/client-cloudfront";
+
+import { SimAws } from "@kensio/yulin";
+
+const simCloudFront = new SimAws().cloudFront();
+
+// The two Behaviors below were written by copying one of them, so the second
+// Origin says everything the first one says.
+const apiOrigin = (originId: string): Origin => ({
+  Id: originId,
+  DomainName: "api.example.test",
+  CustomOriginConfig: {
+    HTTPPort: 80,
+    HTTPSPort: 443,
+    OriginProtocolPolicy: "https-only",
+  },
+  CustomHeaders: {
+    Quantity: 1,
+    Items: [
+      {
+        HeaderName: "x-origin-secret",
+        HeaderValue: "5d6e2b0c6f564c1e9d5b2f1a5b8c9d70",
+      },
+    ],
+  },
+});
+
+const creation = await simCloudFront.createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "user-site",
+      Comment: "User API CDN",
+      Enabled: true,
+      Origins: {
+        Quantity: 2,
+        Items: [apiOrigin("live-origin"), apiOrigin("preview-origin")],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "live-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+      CacheBehaviors: {
+        Quantity: 1,
+        Items: [
+          {
+            PathPattern: "/preview/*",
+            TargetOriginId: "preview-origin",
+            ViewerProtocolPolicy: "allow-all",
+          },
+        ],
+      },
+    },
+  }),
+);
+
+const distribution = simCloudFront.getSimDistributionById(
+  creation.Distribution!.Id!,
+);
+
+// [
+//   {
+//     originId: "preview-origin",
+//     repeatsOriginId: "live-origin",
+//     domainName: "api.example.test",
+//   },
+// ]
+console.log(distribution?.redundantOrigins);

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-redundant-origins.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-redundant-origins.iso.test.ts
@@ -1,0 +1,106 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import { simHttpApiLambdaProxyFactory } from "../../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+describe("CloudFormation CloudFront Distribution redundant Origins", () => {
+  it("says a template declared one Origin twice, and serves both", async () => {
+    // Given somewhere to catch what the deploy warns about, and an HTTP API
+    // that answers whichever path a request arrives on.
+    const warnings: string[] = [];
+    vi.spyOn(console, "warn").mockImplementation((...parts: unknown[]) => {
+      warnings.push(parts.map(String).join(" "));
+    });
+
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (event: SimPayload2Event): unknown => ({
+          path: event.rawPath,
+        }),
+        routeKeys: ["GET /live/things", "GET /preview/things"],
+      },
+      simAws,
+    );
+
+    // When a template declares two Origins over that API's domain, identical
+    // but for their Ids, with a Behavior pointing at each.
+    const apiOrigin = (originId: string): SimCfnTemplateValueRecord => ({
+      Id: originId,
+      DomainName: new URL(api.apiEndpoint).hostname,
+      CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
+      OriginCustomHeaders: [
+        { HeaderName: "x-origin-secret", HeaderValue: "shibboleth" },
+      ],
+    });
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "api-distribution-stack",
+      template: {
+        Resources: {
+          ApiDistribution: {
+            Type: "AWS::CloudFront::Distribution",
+            Properties: {
+              DistributionConfig: {
+                Enabled: true,
+                Origins: [apiOrigin("ApiOrigin"), apiOrigin("PreviewOrigin")],
+                DefaultCacheBehavior: {
+                  TargetOriginId: "ApiOrigin",
+                  ViewerProtocolPolicy: "redirect-to-https",
+                },
+                CacheBehaviors: [
+                  {
+                    PathPattern: "/preview/*",
+                    TargetOriginId: "PreviewOrigin",
+                    ViewerProtocolPolicy: "redirect-to-https",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Then the deploy said so, and the Distribution it deployed carries the
+    // record of it alongside the two Behaviors it serves alike.
+    const resource = stack.getResource("ApiDistribution");
+    assertInstanceOf(resource?.simResource, SimCloudFrontDistribution);
+
+    assertArrayLength(warnings, 1);
+    assertStringIncludes(String(warnings.at(0)), "PreviewOrigin");
+    assertArrayLength(resource.simResource.redundantOrigins, 1);
+    assertNonNullable(resource.simResource.redundantOrigins.at(0));
+    assertIdentical(
+      resource.simResource.redundantOrigins[0].repeatsOriginId,
+      "ApiOrigin",
+    );
+
+    const simAwsHttp = new SimAwsHttp({ simAws });
+    const distributionId = resource.simResource.distributionId.toLowerCase();
+    const live = await simAwsHttp.fetch(
+      new SimAwsLocalUrl({
+        input: `https://${distributionId}.cloudfront.net/live/things`,
+      }).toString(),
+    );
+    const preview = await simAwsHttp.fetch(
+      new SimAwsLocalUrl({
+        input: `https://${distributionId}.cloudfront.net/preview/things`,
+      }).toString(),
+    );
+
+    assertIdentical(await live.text(), '{"path":"/live/things"}');
+    assertIdentical(await preview.text(), '{"path":"/preview/things"}');
+  });
+});

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-distribution-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-distribution-configurator.ts
@@ -1,4 +1,7 @@
-import type { SimCloudFrontDistributionConfig } from "../../command/create-distribution/create-distribution.command.js";
+import type {
+  SimCloudFrontDistributionConfig,
+  SimCloudFrontOriginConfig,
+} from "../../command/create-distribution/create-distribution.command.js";
 import type { SimCloudFrontDistribution } from "../sim-cloudfront-distribution.js";
 import type { SimCloudFrontOriginConfigurator } from "./sim-cloud-front-origin-configurator.js";
 import type { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
@@ -9,6 +12,10 @@ import {
   type SimCfDistributionWebAcl,
   simCfWebAclArn,
 } from "../../web-acl/sim-cf-distribution-web-acl.js";
+import {
+  findSimCfRedundantOrigins,
+  warnSimCfRedundantOrigins,
+} from "../../origin/sim-cf-redundant-origins.js";
 
 /**
  * Applies top-level Distribution configuration to a sim CloudFront Distribution.
@@ -72,10 +79,10 @@ export class SimCloudFrontDistributionConfigurator {
       distribution.addAlternateDomainName(alias);
     }
 
-    const originItems = distributionConfig.Origins?.Items ?? [];
-    for (const origin of originItems) {
-      this.originConfigurator.configure(distribution, origin);
-    }
+    this.configureOrigins(
+      distribution,
+      distributionConfig.Origins?.Items ?? [],
+    );
 
     this.behaviorConfigurator.configureDefaultCacheBehavior(
       distribution,
@@ -99,6 +106,31 @@ export class SimCloudFrontDistributionConfigurator {
     for (const customErrorResponse of customErrorItems) {
       this.customErrorConfigurator.configure(distribution, customErrorResponse);
     }
+  }
+
+  /**
+   * Configure every Origin the config declares, saying so where it declares
+   * one of them twice.
+   *
+   * A repeat is recorded on the Distribution and warned about. CloudFront
+   * takes such a config, and this simulation has no account behaviour to hold
+   * it to. The reading comes after the Origins are configured, by which point
+   * each one is known to have the Id and the domain name a repeat is reported
+   * by.
+   */
+  private configureOrigins(
+    distribution: SimCloudFrontDistribution,
+    originItems: readonly SimCloudFrontOriginConfig[],
+  ): void {
+    for (const origin of originItems) {
+      this.originConfigurator.configure(distribution, origin);
+    }
+
+    distribution.redundantOrigins = findSimCfRedundantOrigins(originItems);
+    warnSimCfRedundantOrigins(
+      distribution.distributionId,
+      distribution.redundantOrigins,
+    );
   }
 
   /**

--- a/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
+++ b/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
@@ -1,5 +1,6 @@
 import type { Brand } from "../../../util/brand.type.js";
 import type { SimCloudFrontOrigin } from "../origin/sim-cloudfront-origin.js";
+import type { SimCfRedundantOrigin } from "../origin/sim-cf-redundant-origins.js";
 import type { SimCloudFrontBehavior } from "../behaviour/sim-cloud-front-behavior.js";
 import type { SimCloudFrontCustomErrorResponse } from "../custom-error/sim-cloudfront-custom-error-response.js";
 import { faker } from "@faker-js/faker";
@@ -45,6 +46,7 @@ export class SimCloudFrontDistribution {
   #enabled: boolean;
   #defaultRootObject: string | undefined;
   #webAclArn: string | undefined;
+  #redundantOrigins: readonly SimCfRedundantOrigin[] = [];
   private readonly alternateDomainNames = new Set<string>();
 
   private readonly origins = new Map<string, SimCloudFrontOrigin>();
@@ -120,6 +122,25 @@ export class SimCloudFrontDistribution {
   }
 
   /**
+   * The Origins of this sim Distribution that repeat another of its Origins.
+   *
+   * Each one is an Origin the config declared twice under two Ids. Both are
+   * served the same way here, whichever Behavior points at them. A test can
+   * assert this list is empty to say the Distribution declares each of its
+   * Origins once.
+   */
+  get redundantOrigins(): readonly SimCfRedundantOrigin[] {
+    return this.#redundantOrigins;
+  }
+
+  /**
+   * Record the Origins of this sim Distribution that repeat another of them.
+   */
+  set redundantOrigins(redundantOrigins: readonly SimCfRedundantOrigin[]) {
+    this.#redundantOrigins = redundantOrigins;
+  }
+
+  /**
    * Move the sim Distribution into Deployed status.
    */
   completeDeployment(): Promise<void> {
@@ -144,6 +165,7 @@ export class SimCloudFrontDistribution {
     this.#status = "Deploying";
     this.#defaultRootObject = undefined;
     this.#webAclArn = undefined;
+    this.#redundantOrigins = [];
     this.behaviors.length = 0;
     this.customErrorResponses.length = 0;
     this.alternateDomainNames.clear();

--- a/src/service/cloudfront/index.ts
+++ b/src/service/cloudfront/index.ts
@@ -6,6 +6,7 @@ export {
 export { cloudFrontFunctionSourceFromModule } from "./cff/function-code-module/cff-code-module-file.js";
 export type { CloudFrontFunction } from "./typings/cloudfront-functions.namespace.js";
 export type { LambdaAtEdge } from "./typings/lambda-at-edge.namespace.js";
+export type { SimCfRedundantOrigin } from "./origin/sim-cf-redundant-origins.js";
 export type { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.js";
 export type { SimCfKeyValueStoreCommands } from "./key-value-store/sim-cf-key-value-store-commands.js";
 export type {

--- a/src/service/cloudfront/origin/sim-cf-redundant-origins.iso.test.ts
+++ b/src/service/cloudfront/origin/sim-cf-redundant-origins.iso.test.ts
@@ -1,0 +1,244 @@
+import {
+  CreateDistributionCommand,
+  type DistributionConfig,
+  type Origin,
+  UpdateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import { faker } from "@faker-js/faker";
+import {
+  assertArrayLength,
+  assertNonNullable,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCloudFrontDistribution } from "../distribution/sim-cloudfront-distribution.js";
+
+describe("CloudFront redundant Origins", () => {
+  /**
+   * An Origin fronting one HTTP API, with the given properties written over
+   * whatever this says by default.
+   */
+  function apiOrigin(originId: string, origin: Partial<Origin> = {}): Origin {
+    return {
+      Id: originId,
+      DomainName: "api.example.test",
+      CustomOriginConfig: {
+        OriginProtocolPolicy: "https-only",
+        HTTPPort: 80,
+        HTTPSPort: 443,
+      },
+      CustomHeaders: {
+        Quantity: 1,
+        Items: [{ HeaderName: "x-origin-secret", HeaderValue: "shibboleth" }],
+      },
+      ...origin,
+    };
+  }
+
+  /**
+   * A DistributionConfig declaring the given Origins, with the first of them
+   * behind the default Behavior.
+   */
+  function distributionConfig(origins: readonly Origin[]): DistributionConfig {
+    return {
+      CallerReference: faker.string.uuid(),
+      Comment: "Distribution over one API",
+      Enabled: true,
+      Origins: { Quantity: origins.length, Items: [...origins] },
+      DefaultCacheBehavior: {
+        TargetOriginId: origins.at(0)?.Id,
+        ViewerProtocolPolicy: "redirect-to-https",
+      },
+    };
+  }
+
+  /**
+   * Create a Distribution over the given Origins, answering with the simulated
+   * Distribution itself, which is where a redundancy is recorded.
+   */
+  async function distributionOver(
+    origins: readonly Origin[],
+  ): Promise<SimCloudFrontDistribution> {
+    const simCloudFront = new SimAws().cloudFront();
+    const created = await simCloudFront.createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: distributionConfig(origins),
+      }),
+    );
+
+    assertNonNullable(created.Distribution?.Id);
+    const distribution = simCloudFront.getSimDistributionById(
+      created.Distribution.Id,
+    );
+    assertNonNullable(distribution);
+
+    return distribution;
+  }
+
+  /**
+   * Catch what the simulator warns about, so that a deploy which warns says so
+   * here rather than in the suite's own output.
+   */
+  function capturedWarnings(): string[] {
+    const warnings: string[] = [];
+
+    vi.spyOn(console, "warn").mockImplementation((...parts: unknown[]) => {
+      warnings.push(parts.map(String).join(" "));
+    });
+
+    return warnings;
+  }
+
+  it("records an Origin declared a second time under another Id", async () => {
+    // Given a Distribution whose second Origin repeats the first in every
+    // property but the Id. A Behavior added by copying the one above it leaves
+    // exactly that behind.
+    capturedWarnings();
+
+    // When it is created.
+    const distribution = await distributionOver([
+      apiOrigin("ApiOrigin"),
+      apiOrigin("ApiOriginTwo"),
+    ]);
+
+    // Then the repeat is recorded against the Origin it repeats.
+    assertArrayLength(distribution.redundantOrigins, 1);
+    assertObjectEquals(distribution.redundantOrigins[0], {
+      originId: "ApiOriginTwo",
+      repeatsOriginId: "ApiOrigin",
+      domainName: "api.example.test",
+    });
+  });
+
+  it("warns about the repeat as the Distribution is deployed", async () => {
+    // Given somewhere to catch what the simulator warns about.
+    const warnings = capturedWarnings();
+
+    // When a Distribution declaring the same Origin twice is created.
+    await distributionOver([apiOrigin("ApiOrigin"), apiOrigin("ApiOriginTwo")]);
+
+    // Then it was warned about once, naming both Origins.
+    assertArrayLength(warnings, 1);
+    assertStringIncludes(String(warnings.at(0)), "ApiOriginTwo");
+    assertStringIncludes(String(warnings.at(0)), "repeats Origin ApiOrigin");
+  });
+
+  it("leaves alone two Origins over one domain that differ", async () => {
+    // Given two Origins over one API, reaching different paths on it. That is
+    // what a second Origin over one domain is usually for.
+    // When the Distribution is created.
+    const distribution = await distributionOver([
+      apiOrigin("ApiOrigin", { OriginPath: "/live" }),
+      apiOrigin("PreviewOrigin", { OriginPath: "/preview" }),
+    ]);
+
+    // Then neither is called a repeat of the other.
+    assertArrayLength(distribution.redundantOrigins, 0);
+  });
+
+  it("reads an Origin path written empty as no Origin path", async () => {
+    // Given two Origins where one writes the empty Origin path CloudFront
+    // takes as none, and the other leaves it out.
+    capturedWarnings();
+
+    // When the Distribution is created.
+    const distribution = await distributionOver([
+      apiOrigin("ApiOrigin"),
+      apiOrigin("ApiOriginTwo", { OriginPath: "" }),
+    ]);
+
+    // Then they are still one Origin written twice.
+    assertArrayLength(distribution.redundantOrigins, 1);
+  });
+
+  it("counts custom headers however they were written", async () => {
+    // Given two Origins carrying the same two headers, written in a different
+    // order and a different case, which HTTP makes no distinction between.
+    capturedWarnings();
+    const headers = [
+      { HeaderName: "x-origin-secret", HeaderValue: "shibboleth" },
+      { HeaderName: "x-origin-tenant", HeaderValue: "kettle" },
+    ];
+
+    // When the Distribution is created.
+    const distribution = await distributionOver([
+      apiOrigin("ApiOrigin", {
+        CustomHeaders: { Quantity: 2, Items: headers },
+      }),
+      apiOrigin("ApiOriginTwo", {
+        CustomHeaders: {
+          Quantity: 2,
+          Items: [
+            { HeaderName: "X-Origin-Tenant", HeaderValue: "kettle" },
+            { HeaderName: "X-Origin-Secret", HeaderValue: "shibboleth" },
+          ],
+        },
+      }),
+    ]);
+
+    // Then they are one Origin written twice.
+    assertArrayLength(distribution.redundantOrigins, 1);
+  });
+
+  it("tells apart two Origins by a list only one of them declares", async () => {
+    // Given two Origins that differ by the protocols they accept, which is a
+    // list rather than a value.
+    // When the Distribution is created.
+    const distribution = await distributionOver([
+      apiOrigin("ApiOrigin", {
+        CustomOriginConfig: {
+          HTTPPort: 80,
+          HTTPSPort: 443,
+          OriginProtocolPolicy: "https-only",
+          OriginSslProtocols: { Quantity: 1, Items: ["TLSv1.2"] },
+        },
+      }),
+      apiOrigin("LegacyOrigin", {
+        CustomOriginConfig: {
+          HTTPPort: 80,
+          HTTPSPort: 443,
+          OriginProtocolPolicy: "https-only",
+          OriginSslProtocols: { Quantity: 2, Items: ["TLSv1.2", "TLSv1.1"] },
+        },
+      }),
+    ]);
+
+    // Then neither is called a repeat of the other.
+    assertArrayLength(distribution.redundantOrigins, 0);
+  });
+
+  it("forgets a repeat an update did away with", async () => {
+    // Given a Distribution created with the same Origin declared twice.
+    capturedWarnings();
+    const simCloudFront = new SimAws().cloudFront();
+    const declaredTwice = [apiOrigin("ApiOrigin"), apiOrigin("ApiOriginTwo")];
+    const created = await simCloudFront.createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: distributionConfig(declaredTwice),
+      }),
+    );
+    assertNonNullable(created.Distribution?.Id);
+
+    // When an update gives the second Origin a path of its own.
+    const eachOnce = [
+      apiOrigin("ApiOrigin"),
+      apiOrigin("ApiOriginTwo", { OriginPath: "/preview" }),
+    ];
+    await simCloudFront.updateDistribution(
+      new UpdateDistributionCommand({
+        Id: created.Distribution.Id,
+        DistributionConfig: distributionConfig(eachOnce),
+      }),
+    );
+
+    // Then the Distribution no longer holds the repeat it was created with.
+    const distribution = simCloudFront.getSimDistributionById(
+      created.Distribution.Id,
+    );
+    assertNonNullable(distribution);
+    assertArrayLength(distribution.redundantOrigins, 0);
+  });
+});

--- a/src/service/cloudfront/origin/sim-cf-redundant-origins.ts
+++ b/src/service/cloudfront/origin/sim-cf-redundant-origins.ts
@@ -1,0 +1,146 @@
+import type { SimCloudFrontOriginConfig } from "../command/create-distribution/create-distribution.command.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simCfOriginCustomHeaders } from "./sim-cf-origin-custom-headers.js";
+
+/**
+ * One Origin that repeats another Origin of the same Distribution.
+ */
+export interface SimCfRedundantOrigin {
+  /** The Id of the Origin that repeats an earlier one. */
+  readonly originId: string;
+
+  /** The Id of the earlier Origin it repeats. */
+  readonly repeatsOriginId: string;
+
+  /** The domain name both of them name. */
+  readonly domainName: string;
+}
+
+/**
+ * The Origins of a Distribution that repeat an earlier Origin of the same
+ * Distribution.
+ *
+ * Two Origins over one domain name are legal and useful where they differ, by
+ * `OriginPath`, by custom headers or by how CloudFront connects. Two that
+ * differ only by `Id` are one Origin written twice. Both are served the same
+ * way here, whichever Behavior points at them. One account served such a pair
+ * differently, refusing every request on the second Behavior at the Origin,
+ * for a reason CloudFront documents nowhere.
+ *
+ * Sameness is every property the config declares apart from the `Id`. An
+ * Origin differing by a connection setting this simulation ignores is left
+ * alone. A property written as an empty string counts as one left out (which
+ * is how CloudFront reads an Origin's optional strings), and custom headers
+ * count by name and value whatever order they were written in.
+ */
+export function findSimCfRedundantOrigins(
+  origins: readonly SimCloudFrontOriginConfig[],
+): readonly SimCfRedundantOrigin[] {
+  const redundant: SimCfRedundantOrigin[] = [];
+  const firstWithFingerprint = new Map<string, string>();
+
+  for (const origin of origins) {
+    assertDefined(origin.Id, "CloudFront Origin Id");
+    assertDefined(origin.DomainName, "CloudFront Origin DomainName");
+
+    const fingerprint = originFingerprint(origin, origin.Id);
+    const repeatsOriginId = firstWithFingerprint.get(fingerprint);
+
+    if (repeatsOriginId === undefined) {
+      firstWithFingerprint.set(fingerprint, origin.Id);
+      continue;
+    }
+
+    redundant.push({
+      originId: origin.Id,
+      repeatsOriginId,
+      domainName: origin.DomainName,
+    });
+  }
+
+  return redundant;
+}
+
+/**
+ * Warn that a Distribution declares the same Origin more than once.
+ *
+ * Warnings go to the console, where a test runner surfaces them next to the
+ * deploy that raised them. The simulator has no logger of its own to route
+ * them through. A test asserts on the Distribution's own record of them.
+ */
+export function warnSimCfRedundantOrigins(
+  distributionId: string,
+  redundantOrigins: readonly SimCfRedundantOrigin[],
+): void {
+  for (const redundant of redundantOrigins) {
+    // oxlint-disable-next-line no-console
+    console.warn(
+      `Simulated CloudFront Distribution ${distributionId} Origin ` +
+        `${redundant.originId} repeats Origin ${redundant.repeatsOriginId}. ` +
+        `Both name ${redundant.domainName} and match in every other ` +
+        `property, one Origin written twice. Both Behaviors are served the ` +
+        `same way here. One account served such a pair differently, refusing ` +
+        `every request on one of the two Behaviors at the Origin. Give one ` +
+        `Origin a difference, or point both Behaviors at the same Origin.`,
+    );
+  }
+}
+
+/**
+ * What makes one Origin the same as another, as a string two Origins can be
+ * compared by.
+ */
+function originFingerprint(
+  origin: SimCloudFrontOriginConfig,
+  originId: string,
+): string {
+  const {
+    Id: _id,
+    CustomHeaders: _customHeaders,
+    OriginCustomHeaders: _originCustomHeaders,
+    ...properties
+  } = origin;
+
+  return JSON.stringify([
+    canonicalValue(properties),
+    customHeaderPairs(origin, originId),
+  ]);
+}
+
+/**
+ * An Origin's custom headers as name and value pairs, in a settled order.
+ *
+ * These are the headers the Origin carries on a request it is sent, read the
+ * way the request reads them. Names arrive lower-cased and a name written
+ * twice keeps the value the Origin would send, whichever of the two field
+ * names the config wrote them under.
+ */
+function customHeaderPairs(
+  origin: SimCloudFrontOriginConfig,
+  originId: string,
+): readonly (readonly [string, string])[] {
+  return Object.entries(simCfOriginCustomHeaders(originId, origin)).toSorted(
+    ([left], [right]) => (left < right ? -1 : 1),
+  );
+}
+
+/**
+ * A value with its object keys in a settled order and everything unset left
+ * out. Two configs saying the same thing then serialize the same way.
+ */
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item: unknown) => canonicalValue(item));
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, property]) => property !== undefined && property !== "")
+      .toSorted(([left], [right]) => (left < right ? -1 : 1))
+      .map(([key, property]) => [key, canonicalValue(property)]),
+  );
+}


### PR DESCRIPTION
Two CloudFront Origins that differ only by their `Id` are one Origin written twice. A simulated Distribution served both of them alike and said nothing. That is how a site test on the second Behavior passed against a template an account then refused on every request.

A Distribution now records each repeat as `redundantOrigins` and warns about it on the console as it is created or updated, naming the Origin, the earlier Origin it repeats and the domain both of them name. A test can assert the list is empty to say a Distribution declares each of its Origins once. Sameness is every property the config declares apart from the `Id`. An Origin differing by a connection setting sim CloudFront ignores is left alone. A property written as an empty string counts as one left out, and custom headers count by the name and value the Origin would actually send. Nothing is refused. CloudFront takes such a config, and the account behaviour behind #1016 is unconfirmed.

Resolves #1016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CloudFront simulations now detect and record origins that are identical apart from their IDs.
  - Duplicate-origin relationships are exposed with the affected origin IDs and domain name.
  - Configuration updates refresh redundant-origin information automatically.

- **Bug Fixes**
  - Added warnings when redundant origins are detected.
  - Confirmed that duplicate origins continue serving correctly for default and path-specific behaviors.

- **Documentation**
  - Added guidance and examples for identifying and handling redundant CloudFront origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->