### PR TITLE
feat: evaluate Athena partition projection

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -253,6 +253,80 @@ Nothing here plans the query. Reading the table names is a scan, and a statement
 it cannot follow runs the way it always did. That covers a statement writing data, a query against a
 federated catalog, and anything the scan gets lost in.
 
+## Partition projection
+
+A table configuring [partition projection](https://docs.aws.amazon.com/athena/latest/ug/partition-projection.html "AWS partition projection docs") has that configuration read when a query runs against it. The four projection types are `enum`, `integer`, `date` and `injected`, and all four are expanded into the partition values the table projects.
+
+Projection lives entirely in a Glue table's `Parameters`, which Glue accepts whatever they say. Athena is what reads them, so a mistake in one shows up as a failed query rather than a failed deploy. That is where it shows up here too.
+
+```typescript sim-athena-partition-projection
+/**
+ * A table whose projected date range names a month that does not exist.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws.glue().createDatabase({
+  input: { DatabaseInput: { Name: "rainlytics" } },
+});
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [{ Name: "day", Type: "string" }],
+      StorageDescriptor: { Location: "s3://rainlytics-logs/cloudfront/" },
+      Parameters: {
+        "projection.enabled": "true",
+        "projection.day.type": "date",
+        "projection.day.format": "yyyy-MM-dd",
+        "projection.day.range": "2026-13-01,NOW",
+        // eslint-disable-next-line no-template-curly-in-string
+        "storage.location.template": "s3://rainlytics-logs/logs/${day}/",
+      },
+    },
+  },
+});
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString: "SELECT cs_uri_stem FROM rainlytics.access_logs",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const execution = await simAws.athena().getQueryExecution({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// "FAILED"
+console.log(execution.QueryExecution?.Status?.State);
+// INVALID_TABLE_PROPERTY, naming day and the bound it could not read
+console.log(execution.QueryExecution?.Status?.StateChangeReason);
+```
+
+A query fails where a partition key carries no `projection.<key>.type`, where a range fails to read, where an `integer` range carries `NOW`, where `storage.location.template` leaves out one of the projected keys, and where an `injected` column goes unconstrained.
+
+`NOW` is read against the simulated clock, along with an offset such as `NOW-3YEARS`. A test that froze time projects the same partitions on every run.
+
+The `WHERE` clause narrows what is projected. `day = '2026-08-25'` and `day IN ('a', 'b')` are the two forms read, and a query carrying `OR` anywhere is left unnarrowed. A filter left unread keeps every projected partition in. That is always the safe answer.
+
+A table with `projection.enabled` absent or false reads the location in its storage descriptor. A table with projection on and no `storage.location.template` gets the Hive layout under that same location, as `<location>/day=2026-08-25/`.
+
 ## The bytes scanned cutoff
 
 A query whose declared bytes scanned passes the workgroup's `BytesScannedCutoffPerQuery` reaches
@@ -378,6 +452,7 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 - Query executions, moving through `QUEUED` and `RUNNING` to `SUCCEEDED`, `FAILED` or `CANCELLED`
 - `StartQueryExecution`, `GetQueryExecution`, `GetQueryResults` and `StopQueryExecution`
 - Table names in `FROM` and `JOIN` resolved against the simulated Glue Data Catalog
+- Partition projection evaluated, covering `enum`, `integer`, `date` and `injected`
 - `BytesScannedCutoffPerQuery` enforced against what a declaration says a query scanned
 - Result sets written to the workgroup's output location as CSV, under the caller's own identity
 - Workgroups, scoped by account and region, with `primary` there from the start
@@ -403,6 +478,18 @@ Current documented limitations:
   out of reach.
 - Table resolution starts once the Data Catalog holds a database. Every query in a simulation
   holding none is answered from its declaration.
+- Partition projection is expanded and checked, and the objects under the prefixes it comes to stay
+  unread. A projection naming partitions the bucket never held still passes.
+- A projected date's format understands `y`, `M`, `d`, `H`, `m` and `s`, which covers the patterns a
+  partition path is written in. The wider `SimpleDateFormat` grammar stays out of reach.
+- The `WHERE` clause is read for `column = 'value'` and `column IN ('a', 'b')` only, and a query
+  carrying `OR` anywhere is left unnarrowed. A partition narrowed less than real Athena would narrow
+  it costs a wider scan here, and the answer stays the same.
+- A table projecting more than 20,000 partitions fails the query. Real Athena has a limit of its own
+  and this one is the simulation's.
+- Partitions registered through the Glue Partitions API are absent, along with `MSCK REPAIR TABLE`
+  and `ALTER TABLE ADD PARTITION`. A table without projection reads its storage descriptor location
+  as the one prefix it has.
 - A query naming a catalog other than `awsdatacatalog` runs with its tables never looked for.
   Federated catalogs and `AWS::Athena::DataCatalog` fall outside this simulation.
 - What a query scanned comes from that same declaration. The cutoff is enforced for real against

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -487,6 +487,12 @@ Current documented limitations:
   it costs a wider scan here, and the answer stays the same.
 - A table projecting more than 20,000 partitions fails the query. Real Athena has a limit of its own
   and this one is the simulation's.
+- An `enum` projection has the spaces around each of its values trimmed, so `a, b` is two values
+  rather than `a` and ` b`. Whether real Athena trims them is unverified.
+- An `integer` projection takes bounds inside JavaScript's safe integer range, and a bound beyond it
+  is refused. Athena's own range runs to the signed 64 bit limit.
+- `MILLISECONDS` is absent from the interval units, and a pattern carrying `S` is read as literal
+  text. A partition path written to the millisecond falls outside this.
 - Partitions registered through the Glue Partitions API are absent, along with `MSCK REPAIR TABLE`
   and `ALTER TABLE ADD PARTITION`. A table without projection reads its storage descriptor location
   as the one prefix it has.

--- a/docs/services/athena/sim-athena-partition-projection.example.ts
+++ b/docs/services/athena/sim-athena-partition-projection.example.ts
@@ -1,0 +1,57 @@
+/**
+ * A table whose projected date range names a month that does not exist.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws.glue().createDatabase({
+  input: { DatabaseInput: { Name: "rainlytics" } },
+});
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [{ Name: "day", Type: "string" }],
+      StorageDescriptor: { Location: "s3://rainlytics-logs/cloudfront/" },
+      Parameters: {
+        "projection.enabled": "true",
+        "projection.day.type": "date",
+        "projection.day.format": "yyyy-MM-dd",
+        "projection.day.range": "2026-13-01,NOW",
+        // eslint-disable-next-line no-template-curly-in-string
+        "storage.location.template": "s3://rainlytics-logs/logs/${day}/",
+      },
+    },
+  },
+});
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString: "SELECT cs_uri_stem FROM rainlytics.access_logs",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const execution = await simAws.athena().getQueryExecution({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// "FAILED"
+console.log(execution.QueryExecution?.Status?.State);
+// INVALID_TABLE_PROPERTY, naming day and the bound it could not read
+console.log(execution.QueryExecution?.Status?.StateChangeReason);

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -11,8 +11,8 @@ with what it was told to hold.
 Simulated [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") reads this
 catalog. A query naming a table no database here holds fails the way real Athena fails it, and a
 table's partition projection is evaluated when a query runs against it. All four projection types
-are covered, `enum`, `integer`, `date` and `injected`, so a projection with a mistake in its
-parameters fails the query that reads it.
+are covered, `enum`, `integer`, `date` and `injected`. A projection with a mistake in its parameters
+fails the query that reads it.
 
 Glue-specific types are imported from the `@kensio/yulin/glue` subpath.
 
@@ -85,8 +85,8 @@ console.log(Table.Parameters["projection.enabled"]);
 
 Partition projection lives entirely in `TableInput.Parameters`. Those parameters are read into the
 table, and never recorded as ignored. A table whose parameters were dropped on the way in deploys
-green while projecting none of them, and a broken projection then passes the test written to catch
-it.
+green while projecting none of them. Simulated Athena reads those same parameters when a query runs.
+A broken projection fails that query.
 
 `Ref` answers with the database name and with the table name.
 
@@ -240,9 +240,12 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
 
 ## Limitations
 
-- **Partition projection is held, never evaluated.** The parameters read back as they were declared,
-  and no partition follows from a value range.
-- **No query reads a table.** SQL goes unparsed, no S3 prefix is listed, and no object is opened.
+- **Partition projection is held here and evaluated by Athena.** The catalog stores the parameters
+  as they were declared and materializes no partition from them. Simulated
+  [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") expands them when a
+  query runs, which is where a broken projection is refused.
+- **The catalog reads no query and no object.** SQL reaches Athena rather than the catalog, no S3
+  prefix is listed here, and no object is opened.
 - **`AWS::Glue::Crawler` is absent.** A crawler fills a catalog by reading objects, and every object
   stays unread here. A template declaring one deploys, with the crawler recorded on the stack's
   `skippedResources`.

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -9,7 +9,10 @@ A table here is a definition. The data it describes stays in S3, unread, and the
 with what it was told to hold.
 
 Simulated [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") reads this
-catalog. A query naming a table no database here holds fails the way real Athena fails it.
+catalog. A query naming a table no database here holds fails the way real Athena fails it, and a
+table's partition projection is evaluated when a query runs against it. All four projection types
+are covered, `enum`, `integer`, `date` and `injected`, so a projection with a mistake in its
+parameters fails the query that reads it.
 
 Glue-specific types are imported from the `@kensio/yulin/glue` subpath.
 

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -91,6 +91,23 @@ entry per bracket level, and a subquery's own FROM then leaves the outer one sta
 `x AS (` is taken as a common table expression, since nothing else in a statement this scans puts a
 bracket straight after `AS`.
 
+`projection/` expands a table's partition projection into the S3 prefixes its partitions sit under.
+`sim-athena-projection-parameters.ts` reads the `projection.*` keys off the Glue table, and every
+partition key needs a type once projection is on, since Athena has no other way to know what a
+column's values are. `sim-athena-projection-values.ts` turns one column into its values, and
+`sim-athena-projection-location.ts` crosses those values into prefixes through
+`storage.location.template`, falling back to the Hive layout under the table's own location.
+
+Two decisions in there are worth knowing. A date bound is validated by writing it back out in its
+own format and comparing, because `Date.UTC` rolls a thirteenth month into the next January rather
+than refusing it. And a projection is capped at 20,000 partitions, which turns a runaway range into
+a named failure instead of a test that hangs.
+
+`sim-athena-partition-filters.ts` reads the `WHERE` clause for `column = 'value'` and
+`column IN (...)`. It reads nothing at all from a query carrying `OR`, since a value under one arm
+of an `OR` constrains nothing on its own. Failing to read a filter is always safe here, because it
+leaves every projected partition in.
+
 `sim-athena-table-resolution.ts` turns those names into a refusal. It skips a query against a
 catalog other than `awsdatacatalog`, and it skips everything while the Data Catalog holds no
 database at all. A simulation where nothing created a database is one where nothing asked for a

--- a/src/service/athena/execution/sim-athena-query-refusal.ts
+++ b/src/service/athena/execution/sim-athena-query-refusal.ts
@@ -1,6 +1,11 @@
 import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import { SimAthenaProjectionError } from "../projection/sim-athena-projection-error.js";
 import {
-  simAthenaTableRefusal,
+  simAthenaTablePartitions,
+  type SimAthenaPartitionedTable,
+} from "../projection/sim-athena-table-partitions.js";
+import {
+  simAthenaResolveTables,
   type SimAthenaCatalog,
 } from "../table/sim-athena-table-resolution.js";
 import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
@@ -11,17 +16,20 @@ interface SimAthenaQueryRefusalProperties {
   readonly result: SimAthenaResolvedResult;
   readonly workGroups: SimAthenaWorkGroupStore;
   readonly catalog: SimAthenaCatalog | undefined;
+
+  /** What the simulated clock reads, for a projection bound written `NOW`. */
+  readonly now: Date;
 }
 
 /**
  * Why a query cannot answer, where something says it cannot.
  *
- * Three things can refuse one, and they are asked in the order real Athena
+ * Four things can refuse one, and they are asked in the order real Athena
  * would reach them. A declaration saying the query fails wins, because that is
  * a test's own statement about the query. Then the tables it names are looked
- * for in the Data Catalog, the way Athena resolves them before running
- * anything. The cutoff is last, against what the declaration says the query
- * scanned.
+ * for in the Data Catalog, and each one's partition projection is expanded,
+ * both of which Athena does while planning. The cutoff is last, against what
+ * the declaration says the query scanned.
  */
 export function simAthenaQueryRefusal(
   properties: SimAthenaQueryRefusalProperties,
@@ -32,7 +40,7 @@ export function simAthenaQueryRefusal(
     return result.failsWith;
   }
 
-  const absentTable = simAthenaTableRefusal(
+  const resolved = simAthenaResolveTables(
     {
       queryString: execution.queryString,
       database: execution.database,
@@ -41,7 +49,42 @@ export function simAthenaQueryRefusal(
     properties.catalog,
   );
 
-  return absentTable ?? cutoffRefusal(properties);
+  if (resolved.refusal !== undefined) {
+    return resolved.refusal;
+  }
+
+  return (
+    projectionRefusal(properties, resolved.tables) ?? cutoffRefusal(properties)
+  );
+}
+
+/**
+ * Why a table's partition projection cannot be read.
+ *
+ * Glue accepts any parameters it is given, so a projection with a mistake in
+ * it is found here, when a query first asks what partitions the table has.
+ */
+function projectionRefusal(
+  properties: SimAthenaQueryRefusalProperties,
+  tables: readonly SimAthenaPartitionedTable[],
+): string | undefined {
+  for (const table of tables) {
+    try {
+      simAthenaTablePartitions({
+        table,
+        queryString: properties.execution.queryString,
+        now: properties.now,
+      });
+    } catch (error) {
+      if (error instanceof SimAthenaProjectionError) {
+        return error.message;
+      }
+
+      throw error;
+    }
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/service/athena/execution/sim-athena-query-runner.ts
+++ b/src/service/athena/execution/sim-athena-query-runner.ts
@@ -95,6 +95,7 @@ export class SimAthenaQueryRunner {
       result,
       workGroups: this.workGroups,
       catalog: this.catalog,
+      now: this.background.now(),
     });
 
     if (refusal !== undefined) {

--- a/src/service/athena/projection/sim-athena-date-arithmetic.ts
+++ b/src/service/athena/projection/sim-athena-date-arithmetic.ts
@@ -13,13 +13,19 @@ const unitMovers = new Map<
   [
     "YEARS",
     (date, amount): void => {
-      date.setUTCFullYear(date.getUTCFullYear() + amount);
+      moveMonths(date, amount * 12);
     },
   ],
   [
     "MONTHS",
     (date, amount): void => {
-      date.setUTCMonth(date.getUTCMonth() + amount);
+      moveMonths(date, amount);
+    },
+  ],
+  [
+    "WEEKS",
+    (date, amount): void => {
+      date.setUTCDate(date.getUTCDate() + amount * 7);
     },
   ],
   [
@@ -47,6 +53,27 @@ const unitMovers = new Map<
     },
   ],
 ]);
+
+/**
+ * Move a date by whole months, clamping the day rather than overflowing.
+ *
+ * The native setter rolls 31 January plus one month into 2 or 3 March. Java
+ * clamps it to the last day of February, and Athena projects dates through
+ * Java, so a table projecting month ends needs the clamp.
+ */
+function moveMonths(date: Date, months: number): void {
+  const day = date.getUTCDate();
+
+  date.setUTCDate(1);
+  date.setUTCMonth(date.getUTCMonth() + months);
+  date.setUTCDate(Math.min(day, lastDayOfMonth(date)));
+}
+
+function lastDayOfMonth(date: Date): number {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+}
 
 /** Move a date on by a whole number of one unit, in UTC. */
 export function simAthenaAddUnits(

--- a/src/service/athena/projection/sim-athena-date-arithmetic.ts
+++ b/src/service/athena/projection/sim-athena-date-arithmetic.ts
@@ -1,0 +1,62 @@
+import type { SimAthenaDateUnit } from "./sim-athena-date-pattern.js";
+
+/**
+ * How one unit moves a date, in UTC.
+ *
+ * A lookup keyed by the unit rather than a switch, so a unit added to
+ * `SimAthenaDateUnit` and left unhandled fails to compile.
+ */
+const unitMovers = new Map<
+  SimAthenaDateUnit,
+  (date: Date, amount: number) => void
+>([
+  [
+    "YEARS",
+    (date, amount): void => {
+      date.setUTCFullYear(date.getUTCFullYear() + amount);
+    },
+  ],
+  [
+    "MONTHS",
+    (date, amount): void => {
+      date.setUTCMonth(date.getUTCMonth() + amount);
+    },
+  ],
+  [
+    "DAYS",
+    (date, amount): void => {
+      date.setUTCDate(date.getUTCDate() + amount);
+    },
+  ],
+  [
+    "HOURS",
+    (date, amount): void => {
+      date.setUTCHours(date.getUTCHours() + amount);
+    },
+  ],
+  [
+    "MINUTES",
+    (date, amount): void => {
+      date.setUTCMinutes(date.getUTCMinutes() + amount);
+    },
+  ],
+  [
+    "SECONDS",
+    (date, amount): void => {
+      date.setUTCSeconds(date.getUTCSeconds() + amount);
+    },
+  ],
+]);
+
+/** Move a date on by a whole number of one unit, in UTC. */
+export function simAthenaAddUnits(
+  date: Date,
+  amount: number,
+  unit: SimAthenaDateUnit,
+): Date {
+  const moved = new Date(date);
+
+  unitMovers.get(unit)?.(moved, amount);
+
+  return moved;
+}

--- a/src/service/athena/projection/sim-athena-date-format.ts
+++ b/src/service/athena/projection/sim-athena-date-format.ts
@@ -1,0 +1,38 @@
+import { simAthenaDatePatternParts } from "./sim-athena-date-pattern.js";
+
+/** Write one date out in a pattern. */
+export function simAthenaFormatDate(date: Date, pattern: string): string {
+  return simAthenaDatePatternParts(pattern)
+    .map((part) =>
+      part.letter === undefined
+        ? part.text
+        : fieldText(date, part.letter, part.text.length),
+    )
+    .join("");
+}
+
+function fieldText(date: Date, letter: string, width: number): string {
+  const value = fieldValue(date, letter);
+  const text = String(value).padStart(width, "0");
+
+  return width === 2 && text.length > 2 ? text.slice(-2) : text;
+}
+
+/**
+ * What one pattern letter reads off a date.
+ *
+ * Held as a lookup so that a letter with no reader is a type error here rather
+ * than a wrong value in a partition path.
+ */
+const fieldReaders = new Map<string, (date: Date) => number>([
+  ["y", (date): number => date.getUTCFullYear()],
+  ["M", (date): number => date.getUTCMonth() + 1],
+  ["d", (date): number => date.getUTCDate()],
+  ["H", (date): number => date.getUTCHours()],
+  ["m", (date): number => date.getUTCMinutes()],
+  ["s", (date): number => date.getUTCSeconds()],
+]);
+
+function fieldValue(date: Date, letter: string): number {
+  return fieldReaders.get(letter)?.(date) ?? 0;
+}

--- a/src/service/athena/projection/sim-athena-date-format.ts
+++ b/src/service/athena/projection/sim-athena-date-format.ts
@@ -1,4 +1,4 @@
-import { simAthenaDatePatternParts } from "./sim-athena-date-pattern.js";
+import { simAthenaDatePatternParts } from "./sim-athena-date-pattern-parts.js";
 
 /** Write one date out in a pattern. */
 export function simAthenaFormatDate(date: Date, pattern: string): string {

--- a/src/service/athena/projection/sim-athena-date-parse.ts
+++ b/src/service/athena/projection/sim-athena-date-parse.ts
@@ -1,4 +1,4 @@
-import { simAthenaDatePatternParts } from "./sim-athena-date-pattern.js";
+import { simAthenaDatePatternParts } from "./sim-athena-date-pattern-parts.js";
 import { simAthenaFormatDate } from "./sim-athena-date-format.js";
 
 /**
@@ -28,13 +28,13 @@ export function simAthenaParseDate(
       continue;
     }
 
-    const digits = text.slice(cursor, cursor + part.text.length);
+    const digits = numberAt(text, cursor, part.text.length);
 
-    if (!/^\d+$/.test(digits) || digits.length !== part.text.length) {
+    if (digits === undefined) {
       return undefined;
     }
 
-    fields[part.letter] = Number(digits);
+    fields[part.letter] = yearValue(part.letter, part.text.length, digits);
     cursor += digits.length;
   }
 
@@ -45,6 +45,50 @@ export function simAthenaParseDate(
   const date = dateOfFields(fields);
 
   return simAthenaFormatDate(date, pattern) === text ? date : undefined;
+}
+
+/**
+ * The digits one field takes, or nothing where they are absent.
+ *
+ * A pattern letter written once takes as many digits as are there, the way
+ * Java reads one. `yyyy-M-d` writes October the fifth as `2026-10-5`, and a
+ * reader taking one digit for `M` would stop in the middle of the month.
+ */
+function numberAt(
+  text: string,
+  start: number,
+  width: number,
+): string | undefined {
+  if (width > 1) {
+    const fixed = text.slice(start, start + width);
+
+    return /^\d+$/.test(fixed) && fixed.length === width ? fixed : undefined;
+  }
+
+  let end = start;
+
+  while (
+    end < text.length &&
+    text.charAt(end) >= "0" &&
+    text.charAt(end) <= "9"
+  ) {
+    end += 1;
+  }
+
+  return end === start ? undefined : text.slice(start, end);
+}
+
+/**
+ * What a year field's digits come to.
+ *
+ * A two-letter year is the 2000s here. Java slides an eighty year window
+ * around the current date, and pinning it to one century keeps a projected
+ * range from starting in 1926 because a table wrote `26`.
+ */
+function yearValue(letter: string, width: number, digits: string): number {
+  const value = Number(digits);
+
+  return letter === "y" && width === 2 ? 2000 + value : value;
 }
 
 function dateOfFields(fields: Readonly<Record<string, number>>): Date {

--- a/src/service/athena/projection/sim-athena-date-parse.ts
+++ b/src/service/athena/projection/sim-athena-date-parse.ts
@@ -1,0 +1,61 @@
+import { simAthenaDatePatternParts } from "./sim-athena-date-pattern.js";
+import { simAthenaFormatDate } from "./sim-athena-date-format.js";
+
+/**
+ * Read a date written in one pattern, or nothing where it does not fit.
+ *
+ * Fields the pattern leaves out take their lowest value, which is what makes
+ * `2026` under `yyyy` the first instant of that year.
+ *
+ * The date is written back out and compared against the text it came from.
+ * `Date.UTC` rolls a thirteenth month into the next January rather than
+ * refusing it, and the round trip is what catches that.
+ */
+export function simAthenaParseDate(
+  text: string,
+  pattern: string,
+): Date | undefined {
+  const fields: Record<string, number> = {};
+  let cursor = 0;
+
+  for (const part of simAthenaDatePatternParts(pattern)) {
+    if (part.letter === undefined) {
+      if (!text.startsWith(part.text, cursor)) {
+        return undefined;
+      }
+
+      cursor += part.text.length;
+      continue;
+    }
+
+    const digits = text.slice(cursor, cursor + part.text.length);
+
+    if (!/^\d+$/.test(digits) || digits.length !== part.text.length) {
+      return undefined;
+    }
+
+    fields[part.letter] = Number(digits);
+    cursor += digits.length;
+  }
+
+  if (cursor !== text.length) {
+    return undefined;
+  }
+
+  const date = dateOfFields(fields);
+
+  return simAthenaFormatDate(date, pattern) === text ? date : undefined;
+}
+
+function dateOfFields(fields: Readonly<Record<string, number>>): Date {
+  return new Date(
+    Date.UTC(
+      fields["y"] ?? 1970,
+      (fields["M"] ?? 1) - 1,
+      fields["d"] ?? 1,
+      fields["H"] ?? 0,
+      fields["m"] ?? 0,
+      fields["s"] ?? 0,
+    ),
+  );
+}

--- a/src/service/athena/projection/sim-athena-date-pattern-parts.ts
+++ b/src/service/athena/projection/sim-athena-date-pattern-parts.ts
@@ -1,0 +1,98 @@
+import type { SimAthenaDatePatternPart } from "./sim-athena-date-pattern.js";
+
+/** Characters a date field is written with. */
+const patternLetters = new Set(["y", "M", "d", "H", "m", "s"]);
+
+/**
+ * Split a Java date pattern into runs of one letter and runs of literal text.
+ *
+ * Athena writes a projected date's format the way Java's `SimpleDateFormat`
+ * writes one, and `yyyy/MM/dd` is the shape nearly every table uses. Only the
+ * six letters that appear in a partition path are understood.
+ *
+ * Text in single quotes is literal, as Java has it, and `''` inside it is one
+ * quote. Without that a separator such as `'day='` would have its `d` read as
+ * a day field.
+ */
+export function simAthenaDatePatternParts(
+  pattern: string,
+): readonly SimAthenaDatePatternPart[] {
+  const parts: SimAthenaDatePatternPart[] = [];
+  let cursor = 0;
+
+  while (cursor < pattern.length) {
+    const character = pattern.charAt(cursor);
+
+    if (character === "'") {
+      const quoted = readQuoted(pattern, cursor);
+
+      parts.push({ letter: undefined, text: quoted.text });
+      cursor = quoted.next;
+      continue;
+    }
+
+    const letter = patternLetters.has(character) ? character : undefined;
+    let end = cursor + 1;
+
+    while (end < pattern.length && sameRun(pattern, character, end, letter)) {
+      end += 1;
+    }
+
+    parts.push({ letter, text: pattern.slice(cursor, end) });
+    cursor = end;
+  }
+
+  return parts;
+}
+
+/**
+ * Read a run of quoted literal text, starting at its opening quote.
+ *
+ * `''` is one quote, and a run that never closes takes the rest of the
+ * pattern.
+ */
+function readQuoted(
+  pattern: string,
+  start: number,
+): { text: string; next: number } {
+  // `''` on its own is one literal quote, which is how Java escapes it.
+  if (pattern.charAt(start + 1) === "'") {
+    return { text: "'", next: start + 2 };
+  }
+
+  let cursor = start + 1;
+  let text = "";
+
+  while (cursor < pattern.length) {
+    if (pattern.charAt(cursor) !== "'") {
+      text += pattern.charAt(cursor);
+      cursor += 1;
+      continue;
+    }
+
+    if (pattern.charAt(cursor + 1) === "'") {
+      text += "'";
+      cursor += 2;
+      continue;
+    }
+
+    return { text, next: cursor + 1 };
+  }
+
+  return { text, next: cursor };
+}
+
+function sameRun(
+  pattern: string,
+  character: string,
+  index: number,
+  letter: string | undefined,
+): boolean {
+  const next = pattern.charAt(index);
+
+  if (letter !== undefined) {
+    return next === character;
+  }
+
+  return !patternLetters.has(next) && next !== "'";
+}

--- a/src/service/athena/projection/sim-athena-date-pattern.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-date-pattern.iso.test.ts
@@ -1,0 +1,95 @@
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAthenaAddUnits } from "./sim-athena-date-arithmetic.js";
+import { simAthenaFormatDate } from "./sim-athena-date-format.js";
+import { simAthenaParseDate } from "./sim-athena-date-parse.js";
+import {
+  simAthenaDateUnit,
+  simAthenaPatternUnit,
+} from "./sim-athena-date-pattern.js";
+
+const instant = new Date("2026-08-26T09:07:05.000Z");
+
+describe("reading and writing a projected date", () => {
+  it("writes every field a partition path uses", () => {
+    // Given an instant and a pattern naming all six fields.
+    // When it is written out.
+    const text = simAthenaFormatDate(instant, "yyyy/MM/dd/HH-mm-ss");
+
+    // Then each field is padded to the width the pattern asked for.
+    assertIdentical(text, "2026/08/26/09-07-05");
+  });
+
+  it("takes text in single quotes as literal", () => {
+    // Given a pattern quoting a separator whose letters would otherwise read
+    // as date fields.
+    // When an instant is written out.
+    // Then the quoted text comes through as itself, quotes stripped, the way
+    // Java reads one.
+    assertIdentical(simAthenaFormatDate(instant, "'day='yyyy"), "day=2026");
+    assertIdentical(simAthenaFormatDate(instant, "yyyy''MM"), "2026'08");
+  });
+
+  it("takes the finest field of a pattern as its step", () => {
+    // Given patterns of different granularity.
+    // When each one's unit is read.
+    // Then the finest field it carries is what one step moves.
+    assertIdentical(simAthenaPatternUnit("yyyy"), "YEARS");
+    assertIdentical(simAthenaPatternUnit("yyyy-MM"), "MONTHS");
+    assertIdentical(simAthenaPatternUnit("yyyy-MM-dd"), "DAYS");
+    assertIdentical(simAthenaPatternUnit("yyyy-MM-dd-HH"), "HOURS");
+    assertIdentical(simAthenaPatternUnit("yyyy-MM-dd HH:mm"), "MINUTES");
+    assertIdentical(simAthenaPatternUnit("yyyyMMddHHmmss"), "SECONDS");
+    assertUndefined(simAthenaPatternUnit("'logs'"));
+  });
+
+  it("reads a unit named in the singular or the plural", () => {
+    // Given the two ways a table writes one.
+    // When each is read.
+    // Then both come to the same unit.
+    assertIdentical(simAthenaDateUnit("DAY"), "DAYS");
+    assertIdentical(simAthenaDateUnit("days"), "DAYS");
+    assertUndefined(simAthenaDateUnit("FORTNIGHTS"));
+    assertUndefined(simAthenaDateUnit(undefined));
+  });
+
+  it("moves an instant on by each unit it counts", () => {
+    // Given one instant.
+    // When it is moved by one of each unit.
+    // Then each lands where that unit takes it.
+    const moved = (unit: Parameters<typeof simAthenaAddUnits>[2]): string =>
+      simAthenaAddUnits(instant, 1, unit).toISOString();
+
+    assertIdentical(moved("YEARS"), "2027-08-26T09:07:05.000Z");
+    assertIdentical(moved("MONTHS"), "2026-09-26T09:07:05.000Z");
+    assertIdentical(moved("DAYS"), "2026-08-27T09:07:05.000Z");
+    assertIdentical(moved("HOURS"), "2026-08-26T10:07:05.000Z");
+    assertIdentical(moved("MINUTES"), "2026-08-26T09:08:05.000Z");
+    assertIdentical(moved("SECONDS"), "2026-08-26T09:07:06.000Z");
+  });
+
+  it("reads a date back out of the text a pattern wrote", () => {
+    // Given text written in a pattern.
+    // When it is read back.
+    const parsed = simAthenaParseDate("2026-08-26", "yyyy-MM-dd");
+
+    // Then it comes back as the first instant of that day, since the pattern
+    // says nothing about the time.
+    assertIdentical(parsed?.toISOString(), "2026-08-26T00:00:00.000Z");
+  });
+
+  it("refuses text that does not fit its pattern", () => {
+    // Given text that is the wrong shape, the wrong length, or names a month
+    // and a day that do not exist.
+    // When each is read against a pattern.
+    // Then none of them reads. A thirteenth month rolls into next January
+    // otherwise, and a wrong date is worse than a refused one.
+    assertUndefined(simAthenaParseDate("2026/08/26", "yyyy-MM-dd"));
+    assertUndefined(simAthenaParseDate("2026-8-26", "yyyy-MM-dd"));
+    assertUndefined(simAthenaParseDate("2026-08-26-01", "yyyy-MM-dd"));
+    assertUndefined(simAthenaParseDate("2026-13-01", "yyyy-MM-dd"));
+    assertUndefined(simAthenaParseDate("2026-02-30", "yyyy-MM-dd"));
+    assertUndefined(simAthenaParseDate("20xx-08-26", "yyyy-MM-dd"));
+  });
+});

--- a/src/service/athena/projection/sim-athena-date-pattern.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-date-pattern.iso.test.ts
@@ -69,6 +69,60 @@ describe("reading and writing a projected date", () => {
     assertIdentical(moved("SECONDS"), "2026-08-26T09:07:06.000Z");
   });
 
+  it("clamps a month end and a leap day rather than overflowing", () => {
+    // Given the last day of a long month and a leap day.
+    // When each is moved by a month and by a year.
+    const endOfJanuary = simAthenaAddUnits(
+      new Date("2024-01-31T00:00:00.000Z"),
+      1,
+      "MONTHS",
+    );
+    const leapDay = simAthenaAddUnits(
+      new Date("2024-02-29T00:00:00.000Z"),
+      1,
+      "YEARS",
+    );
+
+    // Then each lands on the last day of the month it reaches. The native
+    // setter rolls both into the month after, and Athena moves dates through
+    // Java, which clamps.
+    assertIdentical(endOfJanuary.toISOString(), "2024-02-29T00:00:00.000Z");
+    assertIdentical(leapDay.toISOString(), "2025-02-28T00:00:00.000Z");
+  });
+
+  it("counts a week as seven days", () => {
+    // Given a table stepping its projection weekly.
+    // When an instant is moved by two weeks.
+    // Then it lands fourteen days on. No pattern letter writes a week, so a
+    // table asks for one through its interval unit.
+    assertIdentical(simAthenaDateUnit("WEEKS"), "WEEKS");
+    assertIdentical(
+      simAthenaAddUnits(instant, 2, "WEEKS").toISOString(),
+      "2026-09-09T09:07:05.000Z",
+    );
+  });
+
+  it("reads a field written once as however many digits are there", () => {
+    // Given a pattern whose month and day are written once each, which is how
+    // Java says to take as many digits as the value needs.
+    // When a date with a two digit month is read back.
+    const parsed = simAthenaParseDate("2026-10-5", "yyyy-M-d");
+
+    // Then both fields read. A reader taking one digit stops mid-month.
+    assertIdentical(parsed?.toISOString(), "2026-10-05T00:00:00.000Z");
+    assertIdentical(simAthenaFormatDate(instant, "yyyy-M-d"), "2026-8-26");
+  });
+
+  it("reads a two digit year as this century", () => {
+    // Given a year written with two digits.
+    // When it is read.
+    const parsed = simAthenaParseDate("26-01", "yy-MM");
+
+    // Then it lands in the 2000s. Handing 26 straight to the calendar gives
+    // 1926, and the round trip hides it because the year writes back as 26.
+    assertIdentical(parsed?.toISOString(), "2026-01-01T00:00:00.000Z");
+  });
+
   it("reads a date back out of the text a pattern wrote", () => {
     // Given text written in a pattern.
     // When it is read back.

--- a/src/service/athena/projection/sim-athena-date-pattern.ts
+++ b/src/service/athena/projection/sim-athena-date-pattern.ts
@@ -1,0 +1,165 @@
+/** The date fields a projection pattern can carry, finest last. */
+export type SimAthenaDateUnit =
+  | "YEARS"
+  | "MONTHS"
+  | "DAYS"
+  | "HOURS"
+  | "MINUTES"
+  | "SECONDS";
+
+/** One run of the same letter in a pattern, or a run of literal text. */
+export interface SimAthenaDatePatternPart {
+  readonly letter: string | undefined;
+  readonly text: string;
+}
+
+const patternLetters = new Set(["y", "M", "d", "H", "m", "s"]);
+
+const unitOfLetter: Readonly<Record<string, SimAthenaDateUnit>> = {
+  y: "YEARS",
+  M: "MONTHS",
+  d: "DAYS",
+  H: "HOURS",
+  m: "MINUTES",
+  s: "SECONDS",
+};
+
+/** How fine each unit is, coarsest first. */
+const unitOrder: readonly SimAthenaDateUnit[] = [
+  "YEARS",
+  "MONTHS",
+  "DAYS",
+  "HOURS",
+  "MINUTES",
+  "SECONDS",
+];
+
+/**
+ * Split a Java date pattern into runs of one letter and runs of literal text.
+ *
+ * Athena writes a projected date's format the way Java's `SimpleDateFormat`
+ * writes one, and `yyyy/MM/dd` is the shape nearly every table uses. Only the
+ * six letters that appear in a partition path are understood.
+ *
+ * Text in single quotes is literal, as Java has it, and `''` inside it is one
+ * quote. Without that a separator such as `'day='` would have its `d` read as
+ * a day field.
+ */
+export function simAthenaDatePatternParts(
+  pattern: string,
+): readonly SimAthenaDatePatternPart[] {
+  const parts: SimAthenaDatePatternPart[] = [];
+  let cursor = 0;
+
+  while (cursor < pattern.length) {
+    const character = pattern.charAt(cursor);
+
+    if (character === "'") {
+      const quoted = readQuoted(pattern, cursor);
+
+      parts.push({ letter: undefined, text: quoted.text });
+      cursor = quoted.next;
+      continue;
+    }
+
+    const letter = patternLetters.has(character) ? character : undefined;
+    let end = cursor + 1;
+
+    while (end < pattern.length && sameRun(pattern, character, end, letter)) {
+      end += 1;
+    }
+
+    parts.push({ letter, text: pattern.slice(cursor, end) });
+    cursor = end;
+  }
+
+  return parts;
+}
+
+/**
+ * Read a run of quoted literal text, starting at its opening quote.
+ *
+ * `''` is one quote, and a run that never closes takes the rest of the
+ * pattern.
+ */
+function readQuoted(
+  pattern: string,
+  start: number,
+): { text: string; next: number } {
+  // `''` on its own is one literal quote, which is how Java escapes it.
+  if (pattern.charAt(start + 1) === "'") {
+    return { text: "'", next: start + 2 };
+  }
+
+  let cursor = start + 1;
+  let text = "";
+
+  while (cursor < pattern.length) {
+    if (pattern.charAt(cursor) !== "'") {
+      text += pattern.charAt(cursor);
+      cursor += 1;
+      continue;
+    }
+
+    if (pattern.charAt(cursor + 1) === "'") {
+      text += "'";
+      cursor += 2;
+      continue;
+    }
+
+    return { text, next: cursor + 1 };
+  }
+
+  return { text, next: cursor };
+}
+
+function sameRun(
+  pattern: string,
+  character: string,
+  index: number,
+  letter: string | undefined,
+): boolean {
+  const next = pattern.charAt(index);
+
+  if (letter !== undefined) {
+    return next === character;
+  }
+
+  return !patternLetters.has(next) && next !== "'";
+}
+
+/**
+ * The finest field a pattern carries, which is what one interval step moves.
+ *
+ * A table writing `yyyy/MM` projects a month at a time, and one writing
+ * `yyyy-MM-dd` projects a day at a time.
+ */
+export function simAthenaPatternUnit(
+  pattern: string,
+): SimAthenaDateUnit | undefined {
+  const units = simAthenaDatePatternParts(pattern)
+    .map((part) =>
+      part.letter === undefined ? undefined : unitOfLetter[part.letter],
+    )
+    .filter((unit) => unit !== undefined);
+
+  return units.length === 0
+    ? undefined
+    : units.reduce((finest, unit) =>
+        unitOrder.indexOf(unit) > unitOrder.indexOf(finest) ? unit : finest,
+      );
+}
+
+/** Read the unit a name like `DAYS` or `DAY` refers to. */
+export function simAthenaDateUnit(
+  name: string | undefined,
+): SimAthenaDateUnit | undefined {
+  if (name === undefined) {
+    return undefined;
+  }
+
+  const upper = name.toUpperCase();
+  const plural = upper.endsWith("S") ? upper : `${upper}S`;
+
+  return unitOrder.find((unit) => unit === plural);
+}

--- a/src/service/athena/projection/sim-athena-date-pattern.ts
+++ b/src/service/athena/projection/sim-athena-date-pattern.ts
@@ -1,7 +1,10 @@
+import { simAthenaDatePatternParts } from "./sim-athena-date-pattern-parts.js";
+
 /** The date fields a projection pattern can carry, finest last. */
 export type SimAthenaDateUnit =
   | "YEARS"
   | "MONTHS"
+  | "WEEKS"
   | "DAYS"
   | "HOURS"
   | "MINUTES"
@@ -13,8 +16,6 @@ export interface SimAthenaDatePatternPart {
   readonly text: string;
 }
 
-const patternLetters = new Set(["y", "M", "d", "H", "m", "s"]);
-
 const unitOfLetter: Readonly<Record<string, SimAthenaDateUnit>> = {
   y: "YEARS",
   M: "MONTHS",
@@ -24,7 +25,12 @@ const unitOfLetter: Readonly<Record<string, SimAthenaDateUnit>> = {
   s: "SECONDS",
 };
 
-/** How fine each unit is, coarsest first. */
+/**
+ * How fine each unit is, coarsest first.
+ *
+ * `WEEKS` is absent because no pattern letter writes one. A table asks for a
+ * weekly step through `interval.unit`, never through its format.
+ */
 const unitOrder: readonly SimAthenaDateUnit[] = [
   "YEARS",
   "MONTHS",
@@ -34,99 +40,8 @@ const unitOrder: readonly SimAthenaDateUnit[] = [
   "SECONDS",
 ];
 
-/**
- * Split a Java date pattern into runs of one letter and runs of literal text.
- *
- * Athena writes a projected date's format the way Java's `SimpleDateFormat`
- * writes one, and `yyyy/MM/dd` is the shape nearly every table uses. Only the
- * six letters that appear in a partition path are understood.
- *
- * Text in single quotes is literal, as Java has it, and `''` inside it is one
- * quote. Without that a separator such as `'day='` would have its `d` read as
- * a day field.
- */
-export function simAthenaDatePatternParts(
-  pattern: string,
-): readonly SimAthenaDatePatternPart[] {
-  const parts: SimAthenaDatePatternPart[] = [];
-  let cursor = 0;
-
-  while (cursor < pattern.length) {
-    const character = pattern.charAt(cursor);
-
-    if (character === "'") {
-      const quoted = readQuoted(pattern, cursor);
-
-      parts.push({ letter: undefined, text: quoted.text });
-      cursor = quoted.next;
-      continue;
-    }
-
-    const letter = patternLetters.has(character) ? character : undefined;
-    let end = cursor + 1;
-
-    while (end < pattern.length && sameRun(pattern, character, end, letter)) {
-      end += 1;
-    }
-
-    parts.push({ letter, text: pattern.slice(cursor, end) });
-    cursor = end;
-  }
-
-  return parts;
-}
-
-/**
- * Read a run of quoted literal text, starting at its opening quote.
- *
- * `''` is one quote, and a run that never closes takes the rest of the
- * pattern.
- */
-function readQuoted(
-  pattern: string,
-  start: number,
-): { text: string; next: number } {
-  // `''` on its own is one literal quote, which is how Java escapes it.
-  if (pattern.charAt(start + 1) === "'") {
-    return { text: "'", next: start + 2 };
-  }
-
-  let cursor = start + 1;
-  let text = "";
-
-  while (cursor < pattern.length) {
-    if (pattern.charAt(cursor) !== "'") {
-      text += pattern.charAt(cursor);
-      cursor += 1;
-      continue;
-    }
-
-    if (pattern.charAt(cursor + 1) === "'") {
-      text += "'";
-      cursor += 2;
-      continue;
-    }
-
-    return { text, next: cursor + 1 };
-  }
-
-  return { text, next: cursor };
-}
-
-function sameRun(
-  pattern: string,
-  character: string,
-  index: number,
-  letter: string | undefined,
-): boolean {
-  const next = pattern.charAt(index);
-
-  if (letter !== undefined) {
-    return next === character;
-  }
-
-  return !patternLetters.has(next) && next !== "'";
-}
+/** Every unit a table may name in `projection.<column>.interval.unit`. */
+const namedUnits: readonly SimAthenaDateUnit[] = [...unitOrder, "WEEKS"];
 
 /**
  * The finest field a pattern carries, which is what one interval step moves.
@@ -161,5 +76,5 @@ export function simAthenaDateUnit(
   const upper = name.toUpperCase();
   const plural = upper.endsWith("S") ? upper : `${upper}S`;
 
-  return unitOrder.find((unit) => unit === plural);
+  return namedUnits.find((unit) => unit === plural);
 }

--- a/src/service/athena/projection/sim-athena-projection-bound.ts
+++ b/src/service/athena/projection/sim-athena-projection-bound.ts
@@ -1,0 +1,110 @@
+import { simAthenaAddUnits } from "./sim-athena-date-arithmetic.js";
+import { simAthenaParseDate } from "./sim-athena-date-parse.js";
+import { simAthenaDateUnit } from "./sim-athena-date-pattern.js";
+import { SimAthenaProjectionError } from "./sim-athena-projection-error.js";
+
+/** `NOW` with an offset, split into its three pieces. */
+interface SimAthenaRelativeBound {
+  readonly sign: string | undefined;
+  readonly amount: string | undefined;
+  readonly unitName: string | undefined;
+}
+
+/**
+ * Read `NOW`, `NOW-3YEARS` or `NOW+1DAY`, or nothing where it is neither.
+ *
+ * Read by hand rather than by pattern, since a pattern with three groups in an
+ * optional block is the shape a scanner warns about.
+ */
+function relativeBound(bound: string): SimAthenaRelativeBound | undefined {
+  const text = bound.replaceAll(" ", "").toUpperCase();
+
+  if (text === "NOW") {
+    return { sign: undefined, amount: undefined, unitName: undefined };
+  }
+
+  if (!text.startsWith("NOW")) {
+    return undefined;
+  }
+
+  const sign = text.charAt(3);
+
+  if (sign !== "+" && sign !== "-") {
+    return undefined;
+  }
+
+  const rest = text.slice(4);
+  let digits = 0;
+
+  while (
+    digits < rest.length &&
+    rest.charAt(digits) >= "0" &&
+    rest.charAt(digits) <= "9"
+  ) {
+    digits += 1;
+  }
+
+  const amount = rest.slice(0, digits);
+  const unitName = rest.slice(digits);
+
+  return amount.length === 0 || unitName.length === 0
+    ? undefined
+    : { sign, amount, unitName };
+}
+
+/**
+ * Read one end of a `date` projection's range.
+ *
+ * A bound is either a date written in the column's own format or `NOW` with an
+ * optional offset, as `NOW-3YEARS`. The offset is read against the simulated
+ * clock, so a test that froze time projects the same partitions every run.
+ */
+export function simAthenaDateBound(
+  columnName: string,
+  bound: string,
+  pattern: string,
+  now: Date,
+): Date {
+  const relative = relativeBound(bound);
+
+  if (relative !== undefined) {
+    return offsetFrom(columnName, bound, relative, now);
+  }
+
+  const parsed = simAthenaParseDate(bound.trim(), pattern);
+
+  if (parsed === undefined) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${columnName} has range bound ${bound}, which does ` +
+        `not read as ${pattern} or as NOW`,
+    );
+  }
+
+  return parsed;
+}
+
+function offsetFrom(
+  columnName: string,
+  bound: string,
+  relative: SimAthenaRelativeBound,
+  now: Date,
+): Date {
+  const { sign, amount, unitName } = relative;
+
+  if (sign === undefined || amount === undefined || unitName === undefined) {
+    return new Date(now);
+  }
+
+  const unit = simAthenaDateUnit(unitName);
+
+  if (unit === undefined) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${columnName} has range bound ${bound}, and ` +
+        `${unitName} is no unit Athena counts`,
+    );
+  }
+
+  const steps = Number(amount);
+
+  return simAthenaAddUnits(now, sign === "-" ? -steps : steps, unit);
+}

--- a/src/service/athena/projection/sim-athena-projection-bound.ts
+++ b/src/service/athena/projection/sim-athena-projection-bound.ts
@@ -17,7 +17,8 @@ interface SimAthenaRelativeBound {
  * optional block is the shape a scanner warns about.
  */
 function relativeBound(bound: string): SimAthenaRelativeBound | undefined {
-  const text = bound.replaceAll(" ", "").toUpperCase();
+  // Trimmed rather than stripped, so `N O W` stays the malformed bound it is.
+  const text = bound.trim().toUpperCase();
 
   if (text === "NOW") {
     return { sign: undefined, amount: undefined, unitName: undefined };

--- a/src/service/athena/projection/sim-athena-projection-column-parameters.ts
+++ b/src/service/athena/projection/sim-athena-projection-column-parameters.ts
@@ -1,0 +1,83 @@
+import type {
+  SimAthenaProjectionColumn,
+  SimAthenaProjectionType,
+} from "./sim-athena-projection-column.js";
+import { SimAthenaProjectionError } from "./sim-athena-projection-error.js";
+
+const projectionTypes = new Set<string>([
+  "enum",
+  "integer",
+  "date",
+  "injected",
+]);
+
+/** Read how one partition column is projected. */
+export function simAthenaProjectionColumnOf(
+  name: string,
+  parameters: Readonly<Record<string, string>>,
+): SimAthenaProjectionColumn {
+  const declared = read(parameters, name, "type")?.toLowerCase();
+
+  if (declared === undefined) {
+    throw new SimAthenaProjectionError(
+      `Partition projection is enabled and partition column ${name} has no ` +
+        `projection.${name}.type`,
+    );
+  }
+
+  if (!projectionTypes.has(declared)) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${name} declares projection type ${declared}, and ` +
+        `Athena projects enum, integer, date and injected`,
+    );
+  }
+
+  return {
+    name,
+    type: declared as SimAthenaProjectionType,
+    values: splitValues(read(parameters, name, "values")),
+    range: read(parameters, name, "range"),
+    format: read(parameters, name, "format"),
+    interval: wholeNumber(name, "interval", read(parameters, name, "interval")),
+    intervalUnit: read(parameters, name, "interval.unit")?.toUpperCase(),
+    digits: wholeNumber(name, "digits", read(parameters, name, "digits")),
+  };
+}
+
+function read(
+  parameters: Readonly<Record<string, string>>,
+  name: string,
+  suffix: string,
+): string | undefined {
+  return parameters[`projection.${name}.${suffix}`];
+}
+
+function splitValues(
+  values: string | undefined,
+): readonly string[] | undefined {
+  return values
+    ?.split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function wholeNumber(
+  name: string,
+  suffix: string,
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value.trim());
+
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${name} has projection.${name}.${suffix} of ` +
+        `${value}, and it takes a whole number of 1 or more`,
+    );
+  }
+
+  return parsed;
+}

--- a/src/service/athena/projection/sim-athena-projection-column-parameters.ts
+++ b/src/service/athena/projection/sim-athena-projection-column-parameters.ts
@@ -16,7 +16,7 @@ export function simAthenaProjectionColumnOf(
   name: string,
   parameters: Readonly<Record<string, string>>,
 ): SimAthenaProjectionColumn {
-  const declared = read(parameters, name, "type")?.toLowerCase();
+  const declared = read(parameters, name, "type")?.trim().toLowerCase();
 
   if (declared === undefined) {
     throw new SimAthenaProjectionError(

--- a/src/service/athena/projection/sim-athena-projection-column.ts
+++ b/src/service/athena/projection/sim-athena-projection-column.ts
@@ -1,0 +1,36 @@
+/** The four ways Athena projects a partition column. */
+export type SimAthenaProjectionType = "enum" | "integer" | "date" | "injected";
+
+/** How one partition column is projected. */
+export interface SimAthenaProjectionColumn {
+  readonly name: string;
+  readonly type: SimAthenaProjectionType;
+
+  /** The values an `enum` column takes. */
+  readonly values: readonly string[] | undefined;
+
+  /** The bounds an `integer` or a `date` column runs between. */
+  readonly range: string | undefined;
+
+  /** The date pattern a `date` column's values are written in. */
+  readonly format: string | undefined;
+
+  /** How far apart two values sit. */
+  readonly interval: number | undefined;
+
+  /** What that interval counts, for a `date` column. */
+  readonly intervalUnit: string | undefined;
+
+  /** The width an `integer` column's values are zero padded to. */
+  readonly digits: number | undefined;
+}
+
+/** A table's whole partition projection configuration. */
+export interface SimAthenaProjection {
+  readonly enabled: boolean;
+
+  /** Where each projected partition's data sits, with `${key}` placeholders. */
+  readonly locationTemplate: string | undefined;
+
+  readonly columns: readonly SimAthenaProjectionColumn[];
+}

--- a/src/service/athena/projection/sim-athena-projection-date.ts
+++ b/src/service/athena/projection/sim-athena-projection-date.ts
@@ -29,8 +29,17 @@ export function simAthenaDateValues(
   }
 
   const [from, to] = simAthenaProjectionBounds(column);
-  const unit =
-    simAthenaDateUnit(column.intervalUnit) ?? simAthenaPatternUnit(pattern);
+  const declared = simAthenaDateUnit(column.intervalUnit);
+
+  if (declared === undefined && column.intervalUnit !== undefined) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${column.name} counts its interval in ` +
+        `${column.intervalUnit}, and Athena counts years, months, weeks, ` +
+        `days, hours, minutes and seconds`,
+    );
+  }
+
+  const unit = declared ?? simAthenaPatternUnit(pattern);
 
   if (unit === undefined) {
     throw new SimAthenaProjectionError(

--- a/src/service/athena/projection/sim-athena-projection-date.ts
+++ b/src/service/athena/projection/sim-athena-projection-date.ts
@@ -1,0 +1,54 @@
+import { simAthenaAddUnits } from "./sim-athena-date-arithmetic.js";
+import { simAthenaFormatDate } from "./sim-athena-date-format.js";
+import {
+  simAthenaDateUnit,
+  simAthenaPatternUnit,
+} from "./sim-athena-date-pattern.js";
+import { simAthenaDateBound } from "./sim-athena-projection-bound.js";
+import type { SimAthenaProjectionColumn } from "./sim-athena-projection-column.js";
+import { SimAthenaProjectionError } from "./sim-athena-projection-error.js";
+import {
+  simAthenaProjectionBounds,
+  simAthenaGuardProjectionSize,
+} from "./sim-athena-projection-range.js";
+
+/**
+ * The values a `date` column takes, walked from one bound to the other.
+ */
+export function simAthenaDateValues(
+  column: SimAthenaProjectionColumn,
+  now: Date,
+): readonly string[] {
+  const pattern = column.format;
+
+  if (pattern === undefined) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${column.name} is projected as a date and has no ` +
+        `projection.${column.name}.format`,
+    );
+  }
+
+  const [from, to] = simAthenaProjectionBounds(column);
+  const unit =
+    simAthenaDateUnit(column.intervalUnit) ?? simAthenaPatternUnit(pattern);
+
+  if (unit === undefined) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${column.name} has date format ${pattern}, which ` +
+        `carries no field to step through`,
+    );
+  }
+
+  const end = simAthenaDateBound(column.name, to, pattern, now);
+  const step = column.interval ?? 1;
+  const values: string[] = [];
+  let cursor = simAthenaDateBound(column.name, from, pattern, now);
+
+  while (cursor.getTime() <= end.getTime()) {
+    values.push(simAthenaFormatDate(cursor, pattern));
+    simAthenaGuardProjectionSize(column, values.length);
+    cursor = simAthenaAddUnits(cursor, step, unit);
+  }
+
+  return values;
+}

--- a/src/service/athena/projection/sim-athena-projection-error.ts
+++ b/src/service/athena/projection/sim-athena-projection-error.ts
@@ -1,0 +1,24 @@
+/**
+ * A projection configuration this simulation refuses.
+ *
+ * Athena reports a broken projection as a failed query rather than as a
+ * failure to create the table, because Glue accepts any parameters it is given
+ * and Athena is what reads them. The message shape follows Athena's
+ * `INVALID_TABLE_PROPERTY`, and the wording after that prefix is this
+ * simulation's own. Nothing has checked it against AWS.
+ */
+export class SimAthenaProjectionError extends Error {
+  constructor(message: string) {
+    super(`INVALID_TABLE_PROPERTY: ${message}`);
+    this.name = "SimAthenaProjectionError";
+  }
+}
+
+/**
+ * How many partitions one table may project.
+ *
+ * Real Athena caps this too, and a projection running to millions of values is
+ * a configuration mistake rather than a dataset. Failing says which column ran
+ * away, where generating them all would hang the test instead.
+ */
+export const simAthenaProjectionLimit = 20_000;

--- a/src/service/athena/projection/sim-athena-projection-integer.ts
+++ b/src/service/athena/projection/sim-athena-projection-integer.ts
@@ -1,0 +1,57 @@
+import type { SimAthenaProjectionColumn } from "./sim-athena-projection-column.js";
+import { SimAthenaProjectionError } from "./sim-athena-projection-error.js";
+import {
+  simAthenaProjectionBounds,
+  simAthenaGuardProjectionSize,
+} from "./sim-athena-projection-range.js";
+
+/**
+ * The values an `integer` column takes.
+ *
+ * `NOW` belongs to a date range, and an integer range carrying one is a
+ * configuration written against the wrong type.
+ */
+export function simAthenaIntegerValues(
+  column: SimAthenaProjectionColumn,
+): readonly string[] {
+  const [from, to] = simAthenaProjectionBounds(column);
+
+  if (/NOW/i.test(from) || /NOW/i.test(to)) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${column.name} is projected as an integer and its ` +
+        `range carries NOW, which belongs to a date projection`,
+    );
+  }
+
+  const start = wholeBound(column, from);
+  const end = wholeBound(column, to);
+  const step = column.interval ?? 1;
+  const values: string[] = [];
+
+  for (let value = start; value <= end; value += step) {
+    values.push(padded(value, column.digits));
+    simAthenaGuardProjectionSize(column, values.length);
+  }
+
+  return values;
+}
+
+function padded(value: number, digits: number | undefined): string {
+  const text = String(Math.abs(value));
+  const padding = digits === undefined ? text : text.padStart(digits, "0");
+
+  return value < 0 ? `-${padding}` : padding;
+}
+
+function wholeBound(column: SimAthenaProjectionColumn, bound: string): number {
+  const parsed = Number(bound.trim());
+
+  if (!Number.isSafeInteger(parsed)) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${column.name} is projected as an integer and its ` +
+        `range bound ${bound} is no whole number`,
+    );
+  }
+
+  return parsed;
+}

--- a/src/service/athena/projection/sim-athena-projection-location.ts
+++ b/src/service/athena/projection/sim-athena-projection-location.ts
@@ -1,0 +1,122 @@
+import type { SimAthenaProjection } from "./sim-athena-projection-column.js";
+import {
+  SimAthenaProjectionError,
+  simAthenaProjectionLimit,
+} from "./sim-athena-projection-error.js";
+
+/** The values each projected column takes, once a query has been read. */
+export type SimAthenaProjectedValues = ReadonlyMap<string, readonly string[]>;
+
+/**
+ * The S3 prefixes a table's projected partitions sit under.
+ *
+ * A `storage.location.template` says where each one goes and has to name every
+ * projected column, since a template leaving one out sends two partitions to
+ * the same prefix. A table with no template gets the Hive layout under its own
+ * location, which is what Athena falls back to.
+ */
+export function simAthenaProjectedPrefixes(
+  projection: SimAthenaProjection,
+  values: SimAthenaProjectedValues,
+  tableLocation: string | undefined,
+): readonly string[] {
+  const template = projection.locationTemplate;
+
+  if (template === undefined) {
+    return hivePrefixes(projection, values, tableLocation);
+  }
+
+  for (const column of projection.columns) {
+    if (!template.includes(placeholder(column.name))) {
+      throw new SimAthenaProjectionError(
+        `storage.location.template names no ${placeholder(column.name)}, and ` +
+          `every projected partition column has to appear in it`,
+      );
+    }
+  }
+
+  return combinations(projection, values).map((combination) =>
+    withTrailingSlash(fill(template, combination)),
+  );
+}
+
+function hivePrefixes(
+  projection: SimAthenaProjection,
+  values: SimAthenaProjectedValues,
+  tableLocation: string | undefined,
+): readonly string[] {
+  if (tableLocation === undefined) {
+    throw new SimAthenaProjectionError(
+      `Partition projection is enabled and the table has neither a ` +
+        `storage.location.template nor a location of its own`,
+    );
+  }
+
+  const base = withTrailingSlash(tableLocation);
+
+  return combinations(projection, values).map((combination) => {
+    const segments = projection.columns.map(
+      (column) => `${column.name}=${combination.get(column.name) ?? ""}`,
+    );
+
+    return `${base}${segments.join("/")}/`;
+  });
+}
+
+function placeholder(name: string): string {
+  return `\${${name}}`;
+}
+
+function fill(
+  template: string,
+  combination: ReadonlyMap<string, string>,
+): string {
+  let filled = template;
+
+  for (const [name, value] of combination) {
+    // A replacer function, because `$` in a projected value would be read
+    // as a capture group reference by the string form.
+    filled = filled.replaceAll(placeholder(name), () => value);
+  }
+
+  return filled;
+}
+
+function withTrailingSlash(location: string): string {
+  return location.endsWith("/") ? location : `${location}/`;
+}
+
+/**
+ * Every combination of one value from each projected column.
+ *
+ * A table projecting a region and a day has one partition per pair, which is
+ * what makes a projection over several columns grow as fast as it does.
+ */
+function combinations(
+  projection: SimAthenaProjection,
+  values: SimAthenaProjectedValues,
+): readonly ReadonlyMap<string, string>[] {
+  let built: ReadonlyMap<string, string>[] = [new Map<string, string>()];
+
+  for (const column of projection.columns) {
+    const columnValues = values.get(column.name) ?? [];
+    const grown: ReadonlyMap<string, string>[] = [];
+
+    for (const partial of built) {
+      for (const value of columnValues) {
+        grown.push(new Map([...partial, [column.name, value]]));
+      }
+    }
+
+    if (grown.length > simAthenaProjectionLimit) {
+      throw new SimAthenaProjectionError(
+        `The projected partition columns come to more than ` +
+          `${String(simAthenaProjectionLimit)} partitions between them`,
+      );
+    }
+
+    built = grown;
+  }
+
+  return built;
+}

--- a/src/service/athena/projection/sim-athena-projection-parameters.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-projection-parameters.iso.test.ts
@@ -1,0 +1,141 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorLike,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAthenaProjectionOf } from "./sim-athena-projection-parameters.js";
+
+function aTable(
+  parameters: Record<string, string>,
+  partitionKeys: readonly string[] = ["day"],
+): { parameters: Record<string, string>; partitionKeys: { Name: string }[] } {
+  return {
+    parameters,
+    partitionKeys: partitionKeys.map((Name) => ({ Name })),
+  };
+}
+
+describe("reading partition projection off a Glue table", () => {
+  it("reads nothing where projection is off", () => {
+    // Given a table with projection parameters and the switch left off.
+    const table = aTable({
+      "projection.enabled": "false",
+      "projection.day.type": "date",
+    });
+
+    // When its projection is read.
+    const projection = simAthenaProjectionOf(table);
+
+    // Then nothing is projected. The switch is what turns it on.
+    assertFalse(projection.enabled);
+    assertArrayLength(projection.columns, 0);
+  });
+
+  it("reads every parameter one column carries", () => {
+    // Given a column with each of its parameters set.
+    const table = aTable({
+      "projection.enabled": "TRUE",
+      "projection.day.type": "DATE",
+      "projection.day.format": "yyyy-MM-dd",
+      "projection.day.range": "2026-01-01,NOW",
+      "projection.day.interval": "7",
+      "projection.day.interval.unit": "days",
+      "storage.location.template": "s3://logs/x/",
+    });
+
+    // When its projection is read.
+    const projection = simAthenaProjectionOf(table);
+
+    // Then each one comes back, with the type and the unit folded to the case
+    // the rest of this works in.
+    assertTrue(projection.enabled);
+    assertIdentical(projection.locationTemplate, "s3://logs/x/");
+    assertArrayLength(projection.columns, 1);
+
+    const day = projection.columns[0];
+
+    assertIdentical(day.type, "date");
+    assertIdentical(day.format, "yyyy-MM-dd");
+    assertIdentical(day.interval, 7);
+    assertIdentical(day.intervalUnit, "DAYS");
+  });
+
+  it("splits an enum's values and drops the spaces around them", () => {
+    // Given an enum written with spaces after its commas.
+    const table = aTable({
+      "projection.enabled": "true",
+      "projection.day.type": "enum",
+      "projection.day.values": "mon, tue ,wed,",
+    });
+
+    // When its projection is read.
+    const projection = simAthenaProjectionOf(table);
+
+    // Then the values come back trimmed, and the trailing comma adds none.
+    assertArrayLength(projection.columns, 1);
+    assertArrayEquals(projection.columns[0].values, ["mon", "tue", "wed"]);
+  });
+
+  it("refuses a partition key with no projection type", () => {
+    // Given projection on and one of two keys left unconfigured.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.day.type": "enum",
+        "projection.day.values": "mon",
+      },
+      ["day", "region"],
+    );
+
+    // When its projection is read.
+    // Then it is refused, naming the key that has nothing said about it.
+    const error = assertThrowsErrorLike(() => simAthenaProjectionOf(table));
+    assertStringIncludes(error.message, "projection.region.type");
+  });
+
+  it("refuses a projection type Athena has never had", () => {
+    // Given a column declaring a type nobody projects.
+    const table = aTable({
+      "projection.enabled": "true",
+      "projection.day.type": "sequence",
+    });
+
+    // When its projection is read.
+    // Then it is refused, listing the four that exist.
+    const error = assertThrowsErrorLike(() => simAthenaProjectionOf(table));
+    assertStringIncludes(error.message, "sequence");
+    assertStringIncludes(error.message, "enum, integer, date and injected");
+  });
+
+  it("refuses an interval or a digit count that is no whole number", () => {
+    // Given a column whose interval is a fraction, and one whose digits are
+    // zero.
+    const fraction = aTable({
+      "projection.enabled": "true",
+      "projection.day.type": "integer",
+      "projection.day.interval": "1.5",
+    });
+    const zero = aTable({
+      "projection.enabled": "true",
+      "projection.day.type": "integer",
+      "projection.day.digits": "0",
+    });
+
+    // When each is read.
+    // Then both are refused, naming the parameter that is wrong.
+    assertStringIncludes(
+      assertThrowsErrorLike(() => simAthenaProjectionOf(fraction)).message,
+      "projection.day.interval",
+    );
+    assertStringIncludes(
+      assertThrowsErrorLike(() => simAthenaProjectionOf(zero)).message,
+      "projection.day.digits",
+    );
+  });
+});

--- a/src/service/athena/projection/sim-athena-projection-parameters.ts
+++ b/src/service/athena/projection/sim-athena-projection-parameters.ts
@@ -1,0 +1,34 @@
+import type { SimAthenaProjection } from "./sim-athena-projection-column.js";
+import { simAthenaProjectionColumnOf } from "./sim-athena-projection-column-parameters.js";
+
+/** What a table carries for reading a projection out of. */
+export interface SimAthenaProjectedTable {
+  readonly parameters: Readonly<Record<string, string>>;
+  readonly partitionKeys: readonly { Name: string }[];
+}
+
+/**
+ * Read a table's partition projection out of its Glue parameters.
+ *
+ * Every partition key needs a projection type once projection is enabled,
+ * since Athena has no other way to know what a column's values are. A key
+ * without one fails here, naming the key.
+ */
+export function simAthenaProjectionOf(
+  table: SimAthenaProjectedTable,
+): SimAthenaProjection {
+  const parameters = table.parameters;
+  const enabled = parameters["projection.enabled"]?.toLowerCase() === "true";
+
+  if (!enabled) {
+    return { enabled: false, locationTemplate: undefined, columns: [] };
+  }
+
+  return {
+    enabled: true,
+    locationTemplate: parameters["storage.location.template"],
+    columns: table.partitionKeys.map((key) =>
+      simAthenaProjectionColumnOf(key.Name, parameters),
+    ),
+  };
+}

--- a/src/service/athena/projection/sim-athena-projection-range.ts
+++ b/src/service/athena/projection/sim-athena-projection-range.ts
@@ -8,9 +8,15 @@ import {
 export function simAthenaProjectionBounds(
   column: SimAthenaProjectionColumn,
 ): readonly [string, string] {
-  const parts = column.range?.split(",");
+  const parts = column.range?.split(",").map((bound) => bound.trim());
 
-  if (parts?.length !== 2 || parts[0] === undefined || parts[1] === undefined) {
+  if (
+    parts?.length !== 2 ||
+    parts[0] === undefined ||
+    parts[1] === undefined ||
+    parts[0].length === 0 ||
+    parts[1].length === 0
+  ) {
     throw new SimAthenaProjectionError(
       `Partition column ${column.name} needs projection.${column.name}.range ` +
         `written as two bounds separated by a comma`,

--- a/src/service/athena/projection/sim-athena-projection-range.ts
+++ b/src/service/athena/projection/sim-athena-projection-range.ts
@@ -1,0 +1,34 @@
+import type { SimAthenaProjectionColumn } from "./sim-athena-projection-column.js";
+import {
+  SimAthenaProjectionError,
+  simAthenaProjectionLimit,
+} from "./sim-athena-projection-error.js";
+
+/** The two ends of a column's declared range. */
+export function simAthenaProjectionBounds(
+  column: SimAthenaProjectionColumn,
+): readonly [string, string] {
+  const parts = column.range?.split(",");
+
+  if (parts?.length !== 2 || parts[0] === undefined || parts[1] === undefined) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${column.name} needs projection.${column.name}.range ` +
+        `written as two bounds separated by a comma`,
+    );
+  }
+
+  return [parts[0], parts[1]];
+}
+
+/** Fail a column that runs away rather than generating for ever. */
+export function simAthenaGuardProjectionSize(
+  column: SimAthenaProjectionColumn,
+  count: number,
+): void {
+  if (count > simAthenaProjectionLimit) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${column.name} projects more than ` +
+        `${String(simAthenaProjectionLimit)} values`,
+    );
+  }
+}

--- a/src/service/athena/projection/sim-athena-projection-values.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-projection-values.iso.test.ts
@@ -148,6 +148,70 @@ describe("the values a projected partition column takes", () => {
     assertStringIncludes(error.message, "projection.day.format");
   });
 
+  it("refuses a range whose bounds are empty", () => {
+    // Given a range that is a comma and nothing else.
+    const column = aColumn({ type: "integer", range: "," });
+
+    // When its values are read.
+    // Then it is refused. Reading both bounds as zero projects one partition
+    // called 0 out of a configuration that says nothing.
+    const error = assertThrowsErrorLike(() =>
+      simAthenaProjectedValues(column, noon),
+    );
+    assertStringIncludes(error.message, "projection.day.range");
+  });
+
+  it("refuses an interval unit Athena does not count", () => {
+    // Given a date column counting its interval in fortnights.
+    const column = aColumn({
+      type: "date",
+      range: "2026-08-01,2026-08-26",
+      format: "yyyy-MM-dd",
+      intervalUnit: "FORTNIGHTS",
+    });
+
+    // When its values are read.
+    // Then it is refused. Falling back to the format's own unit would answer
+    // with a step nobody asked for.
+    const error = assertThrowsErrorLike(() =>
+      simAthenaProjectedValues(column, noon),
+    );
+    assertStringIncludes(error.message, "FORTNIGHTS");
+  });
+
+  it("refuses a bound with whitespace inside NOW", () => {
+    // Given a bound that reads as NOW only once its spaces are taken out.
+    const column = aColumn({
+      type: "date",
+      range: "2026-08-01,N OW",
+      format: "yyyy-MM-dd",
+    });
+
+    // When its values are read.
+    // Then it is refused, as the malformed bound it is.
+    const error = assertThrowsErrorLike(() =>
+      simAthenaProjectedValues(column, noon),
+    );
+    assertStringIncludes(error.message, "N OW");
+  });
+
+  it("steps a date column by weeks where its unit says so", () => {
+    // Given a column stepping a fortnight at a time.
+    const column = aColumn({
+      type: "date",
+      range: "2026-08-01,2026-08-26",
+      format: "yyyy-MM-dd",
+      interval: 2,
+      intervalUnit: "WEEKS",
+    });
+
+    // When its values are read.
+    const values = simAthenaProjectedValues(column, noon);
+
+    // Then each is fourteen days on from the last.
+    assertArrayEquals(values, ["2026-08-01", "2026-08-15"]);
+  });
+
   it("refuses a range that is not two bounds", () => {
     // Given a column whose range never got its second bound.
     const column = aColumn({ type: "integer", range: "1" });

--- a/src/service/athena/projection/sim-athena-projection-values.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-projection-values.iso.test.ts
@@ -1,0 +1,162 @@
+import {
+  assertArrayEquals,
+  assertUndefined,
+  assertStringIncludes,
+  assertThrowsErrorLike,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAthenaProjectionColumn } from "./sim-athena-projection-column.js";
+import { simAthenaProjectedValues } from "./sim-athena-projection-values.js";
+
+const noon = new Date("2026-08-26T12:00:00.000Z");
+
+function aColumn(
+  column: Partial<SimAthenaProjectionColumn> &
+    Pick<SimAthenaProjectionColumn, "type">,
+): SimAthenaProjectionColumn {
+  return {
+    name: "day",
+    values: undefined,
+    range: undefined,
+    format: undefined,
+    interval: undefined,
+    intervalUnit: undefined,
+    digits: undefined,
+    ...column,
+  };
+}
+
+describe("the values a projected partition column takes", () => {
+  it("takes an enum column's values as they were listed", () => {
+    // Given a column projected as an enum.
+    const column = aColumn({
+      type: "enum",
+      values: ["eu-west-2", "us-east-1"],
+    });
+
+    // When its values are read.
+    const values = simAthenaProjectedValues(column, noon);
+
+    // Then they come back in the order the table listed them.
+    assertArrayEquals(values, ["eu-west-2", "us-east-1"]);
+  });
+
+  it("counts an integer column through its range, padding to its digits", () => {
+    // Given a column projected as an integer over three values, zero padded.
+    const column = aColumn({ type: "integer", range: "1,3", digits: 2 });
+
+    // When its values are read.
+    const values = simAthenaProjectedValues(column, noon);
+
+    // Then each is padded to the declared width.
+    assertArrayEquals(values, ["01", "02", "03"]);
+  });
+
+  it("steps an integer column by its interval", () => {
+    // Given a column projected every five.
+    const column = aColumn({ type: "integer", range: "0,10", interval: 5 });
+
+    // When its values are read.
+    const values = simAthenaProjectedValues(column, noon);
+
+    // Then only the values on the step come back.
+    assertArrayEquals(values, ["0", "5", "10"]);
+  });
+
+  it("walks a date column a day at a time, taking the unit from its format", () => {
+    // Given a column projected across three days, with no interval unit set.
+    const column = aColumn({
+      type: "date",
+      range: "2026-08-24,2026-08-26",
+      format: "yyyy-MM-dd",
+    });
+
+    // When its values are read.
+    const values = simAthenaProjectedValues(column, noon);
+
+    // Then the format's finest field is what one step moves.
+    assertArrayEquals(values, ["2026-08-24", "2026-08-25", "2026-08-26"]);
+  });
+
+  it("reads NOW and an offset against the clock it was given", () => {
+    // Given a column running from two days ago to now.
+    const column = aColumn({
+      type: "date",
+      range: "NOW-2DAYS,NOW",
+      format: "yyyy-MM-dd",
+    });
+
+    // When its values are read at a fixed instant.
+    const values = simAthenaProjectedValues(column, noon);
+
+    // Then the range ends on that day. A frozen clock projects the same
+    // partitions every run.
+    assertArrayEquals(values, ["2026-08-24", "2026-08-25", "2026-08-26"]);
+  });
+
+  it("walks a month at a time where the format stops at months", () => {
+    // Given a column formatted to the month.
+    const column = aColumn({
+      type: "date",
+      range: "2026-06,2026-08",
+      format: "yyyy-MM",
+    });
+
+    // When its values are read.
+    const values = simAthenaProjectedValues(column, noon);
+
+    // Then one step is one month.
+    assertArrayEquals(values, ["2026-06", "2026-07", "2026-08"]);
+  });
+
+  it("answers with nothing for an injected column", () => {
+    // Given a column whose values the query supplies.
+    // When its values are read.
+    const values = simAthenaProjectedValues(
+      aColumn({ type: "injected" }),
+      noon,
+    );
+
+    // Then there are none to read. The query has to say.
+    assertUndefined(values);
+  });
+
+  it("refuses an integer range carrying NOW", () => {
+    // Given an integer column whose range was written for a date.
+    const column = aColumn({ type: "integer", range: "0,NOW" });
+
+    // When its values are read.
+    // Then it is refused, naming the column and what is wrong.
+    const error = assertThrowsErrorLike(() =>
+      simAthenaProjectedValues(column, noon),
+    );
+    assertStringIncludes(error.message, "INVALID_TABLE_PROPERTY");
+    assertStringIncludes(error.message, "Partition column day");
+    assertStringIncludes(error.message, "NOW");
+  });
+
+  it("refuses a date column with no format", () => {
+    // Given a date column that never said how its values are written.
+    const column = aColumn({ type: "date", range: "2026-01-01,NOW" });
+
+    // When its values are read.
+    // Then it is refused, naming the parameter that is missing.
+    const error = assertThrowsErrorLike(() =>
+      simAthenaProjectedValues(column, noon),
+    );
+    assertStringIncludes(error.message, "projection.day.format");
+  });
+
+  it("refuses a range that is not two bounds", () => {
+    // Given a column whose range never got its second bound.
+    const column = aColumn({ type: "integer", range: "1" });
+
+    // When its values are read.
+    // Then it is refused.
+    const error = assertThrowsErrorLike(() =>
+      simAthenaProjectedValues(column, noon),
+    );
+    assertStringIncludes(error.message, "projection.day.range");
+  });
+});

--- a/src/service/athena/projection/sim-athena-projection-values.ts
+++ b/src/service/athena/projection/sim-athena-projection-values.ts
@@ -1,0 +1,41 @@
+import type { SimAthenaProjectionColumn } from "./sim-athena-projection-column.js";
+import { SimAthenaProjectionError } from "./sim-athena-projection-error.js";
+import { simAthenaDateValues } from "./sim-athena-projection-date.js";
+import { simAthenaIntegerValues } from "./sim-athena-projection-integer.js";
+
+/**
+ * The values one projected column takes.
+ *
+ * An `injected` column has none of its own. Its value comes from the query's
+ * `WHERE` clause, which is what injecting one means, so this answers
+ * `undefined` for it and a caller supplies the value.
+ */
+export function simAthenaProjectedValues(
+  column: SimAthenaProjectionColumn,
+  now: Date,
+): readonly string[] | undefined {
+  if (column.type === "injected") {
+    return undefined;
+  }
+
+  if (column.type === "enum") {
+    return enumValues(column);
+  }
+
+  return column.type === "integer"
+    ? simAthenaIntegerValues(column)
+    : simAthenaDateValues(column, now);
+}
+
+function enumValues(column: SimAthenaProjectionColumn): readonly string[] {
+  const values = column.values;
+
+  if (values === undefined || values.length === 0) {
+    throw new SimAthenaProjectionError(
+      `Partition column ${column.name} is projected as an enum and has no ` +
+        `projection.${column.name}.values`,
+    );
+  }
+
+  return values;
+}

--- a/src/service/athena/projection/sim-athena-table-partitions.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-table-partitions.iso.test.ts
@@ -1,0 +1,258 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertStringIncludes,
+  assertThrowsErrorLike,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simAthenaTablePartitions,
+  type SimAthenaPartitionedTable,
+} from "./sim-athena-table-partitions.js";
+
+const noon = new Date("2026-08-26T12:00:00.000Z");
+
+function aTable(
+  parameters: Record<string, string>,
+  partitionKeys: readonly string[] = [],
+  location = "s3://rainlytics-logs/cloudfront/",
+): SimAthenaPartitionedTable {
+  return {
+    parameters,
+    partitionKeys: partitionKeys.map((Name) => ({ Name })),
+    storageDescriptor: { Location: location },
+  };
+}
+
+function partitionsOf(
+  table: SimAthenaPartitionedTable,
+  queryString = "SELECT * FROM rainlytics.access_logs",
+): readonly string[] {
+  return simAthenaTablePartitions({ table, queryString, now: noon });
+}
+
+describe("the S3 prefixes a query reads for one table", () => {
+  it("reads the table's own location where projection is off", () => {
+    // Given a table with no projection configured.
+    const table = aTable({}, ["day"]);
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table);
+
+    // Then the table's location is the whole of it.
+    assertArrayEquals(prefixes, ["s3://rainlytics-logs/cloudfront/"]);
+  });
+
+  it("fills the location template with each projected value", () => {
+    // Given a table projecting three days into a template of its own.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.day.type": "date",
+        "projection.day.format": "yyyy-MM-dd",
+        "projection.day.range": "2026-08-24,2026-08-26",
+        "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+      },
+      ["day"],
+    );
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table);
+
+    // Then there is one prefix per day.
+    assertArrayEquals(prefixes, [
+      "s3://rainlytics-logs/logs/2026-08-24/",
+      "s3://rainlytics-logs/logs/2026-08-25/",
+      "s3://rainlytics-logs/logs/2026-08-26/",
+    ]);
+  });
+
+  it("lays partitions out Hive style where no template was given", () => {
+    // Given a table projecting two regions and naming no template.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.region.type": "enum",
+        "projection.region.values": "eu-west-2,us-east-1",
+      },
+      ["region"],
+    );
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table);
+
+    // Then each sits under the table's own location, keyed the way Hive keys
+    // one, which is what Athena falls back to.
+    assertArrayEquals(prefixes, [
+      "s3://rainlytics-logs/cloudfront/region=eu-west-2/",
+      "s3://rainlytics-logs/cloudfront/region=us-east-1/",
+    ]);
+  });
+
+  it("takes one prefix per combination across two columns", () => {
+    // Given a table projecting two regions across two days.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.region.type": "enum",
+        "projection.region.values": "eu,us",
+        "projection.day.type": "date",
+        "projection.day.format": "yyyy-MM-dd",
+        "projection.day.range": "2026-08-25,2026-08-26",
+        "storage.location.template": `s3://rainlytics-logs/\${region}/\${day}/`,
+      },
+      ["region", "day"],
+    );
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table);
+
+    // Then there are four, one per pair.
+    assertArrayLength(prefixes, 4);
+    assertArrayEquals(prefixes, [
+      "s3://rainlytics-logs/eu/2026-08-25/",
+      "s3://rainlytics-logs/eu/2026-08-26/",
+      "s3://rainlytics-logs/us/2026-08-25/",
+      "s3://rainlytics-logs/us/2026-08-26/",
+    ]);
+  });
+
+  it("narrows to the partitions a WHERE clause pins down", () => {
+    // Given a table projecting three days.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.day.type": "date",
+        "projection.day.format": "yyyy-MM-dd",
+        "projection.day.range": "2026-08-24,2026-08-26",
+        "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+      },
+      ["day"],
+    );
+
+    // When a query filtering on one day reads them.
+    const prefixes = partitionsOf(
+      table,
+      "SELECT * FROM rainlytics.access_logs WHERE day = '2026-08-25'",
+    );
+
+    // Then only that day's prefix is read. This is the whole point of
+    // partitioning a table.
+    assertArrayEquals(prefixes, ["s3://rainlytics-logs/logs/2026-08-25/"]);
+  });
+
+  it("takes an injected column's values from the query", () => {
+    // Given a table with an injected column, and a query naming two of them.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.tenant.type": "injected",
+        "storage.location.template": `s3://rainlytics-logs/\${tenant}/`,
+      },
+      ["tenant"],
+    );
+
+    // When a query constraining it reads its partitions.
+    const prefixes = partitionsOf(
+      table,
+      "SELECT * FROM t WHERE tenant IN ('acme', 'globex')",
+    );
+
+    // Then the query's own values are what it projects.
+    assertArrayEquals(prefixes, [
+      "s3://rainlytics-logs/acme/",
+      "s3://rainlytics-logs/globex/",
+    ]);
+  });
+
+  it("gives a prefix its trailing slash where the template left one off", () => {
+    // Given a template that ends on the placeholder itself.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.day.type": "enum",
+        "projection.day.values": "2026-08-26",
+        "storage.location.template": `s3://rainlytics-logs/logs/\${day}`,
+      },
+      ["day"],
+    );
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table);
+
+    // Then the prefix ends in a slash. A prefix without one matches the keys
+    // of a sibling partition whose name starts the same way.
+    assertArrayEquals(prefixes, ["s3://rainlytics-logs/logs/2026-08-26/"]);
+  });
+
+  it("refuses a table projecting with neither a template nor a location", () => {
+    // Given a table with projection on and nowhere for its data to be.
+    const table: SimAthenaPartitionedTable = {
+      parameters: {
+        "projection.enabled": "true",
+        "projection.day.type": "enum",
+        "projection.day.values": "2026-08-26",
+      },
+      partitionKeys: [{ Name: "day" }],
+      storageDescriptor: undefined,
+    };
+
+    // When its partitions are read.
+    // Then it is refused. There is nothing to build a prefix out of.
+    const error = assertThrowsErrorLike(() => partitionsOf(table));
+    assertStringIncludes(error.message, "storage.location.template");
+  });
+
+  it("reads nothing for a table with neither projection nor a location", () => {
+    // Given a table with no projection and no location either.
+    const table: SimAthenaPartitionedTable = {
+      parameters: {},
+      partitionKeys: [],
+      storageDescriptor: undefined,
+    };
+
+    // When its partitions are read.
+    // Then there are none. Nothing said where the data is.
+    assertArrayLength(partitionsOf(table), 0);
+  });
+
+  it("refuses a query leaving an injected column unconstrained", () => {
+    // Given a table with an injected column.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.tenant.type": "injected",
+        "storage.location.template": `s3://rainlytics-logs/\${tenant}/`,
+      },
+      ["tenant"],
+    );
+
+    // When a query naming nothing about it reads its partitions.
+    // Then it is refused. An injected column has no values of its own.
+    const error = assertThrowsErrorLike(() => partitionsOf(table));
+    assertStringIncludes(error.message, "tenant");
+    assertStringIncludes(error.message, "injected");
+  });
+
+  it("refuses a template leaving out one of the projected columns", () => {
+    // Given a table projecting two columns and a template naming one.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.region.type": "enum",
+        "projection.region.values": "eu",
+        "projection.day.type": "enum",
+        "projection.day.values": "2026-08-26",
+        "storage.location.template": `s3://rainlytics-logs/\${region}/`,
+      },
+      ["region", "day"],
+    );
+
+    // When its partitions are read.
+    // Then it is refused, naming the placeholder that is missing. Two
+    // partitions would otherwise share one prefix.
+    const error = assertThrowsErrorLike(() => partitionsOf(table));
+    assertStringIncludes(error.message, `\${day}`);
+  });
+});

--- a/src/service/athena/projection/sim-athena-table-partitions.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-table-partitions.iso.test.ts
@@ -142,6 +142,55 @@ describe("the S3 prefixes a query reads for one table", () => {
     assertArrayEquals(prefixes, ["s3://rainlytics-logs/logs/2026-08-25/"]);
   });
 
+  it("leaves every partition in where the query negates its filter", () => {
+    // Given a table projecting three days, and a query excluding one of them.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.day.type": "date",
+        "projection.day.format": "yyyy-MM-dd",
+        "projection.day.range": "2026-08-24,2026-08-26",
+        "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+      },
+      ["day"],
+    );
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(
+      table,
+      "SELECT * FROM t WHERE NOT (day = '2026-08-25')",
+    );
+
+    // Then all three stay in. Reading the negated value as a constraint would
+    // answer from the one prefix the query asked to leave out.
+    assertArrayLength(prefixes, 3);
+  });
+
+  it("keeps what two filters on one column agree on", () => {
+    // Given a table projecting three days, and a query constraining the same
+    // column twice.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.day.type": "date",
+        "projection.day.format": "yyyy-MM-dd",
+        "projection.day.range": "2026-08-24,2026-08-26",
+        "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+      },
+      ["day"],
+    );
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(
+      table,
+      "SELECT * FROM t WHERE day IN ('2026-08-24', '2026-08-25') " +
+        "AND day IN ('2026-08-25', '2026-08-26')",
+    );
+
+    // Then only the day both terms allow is read.
+    assertArrayEquals(prefixes, ["s3://rainlytics-logs/logs/2026-08-25/"]);
+  });
+
   it("takes an injected column's values from the query", () => {
     // Given a table with an injected column, and a query naming two of them.
     const table = aTable(

--- a/src/service/athena/projection/sim-athena-table-partitions.ts
+++ b/src/service/athena/projection/sim-athena-table-partitions.ts
@@ -1,0 +1,90 @@
+import { simAthenaPartitionFilters } from "../table/sim-athena-partition-filters.js";
+import type { SimAthenaProjectionColumn } from "./sim-athena-projection-column.js";
+import { SimAthenaProjectionError } from "./sim-athena-projection-error.js";
+import { simAthenaProjectedPrefixes } from "./sim-athena-projection-location.js";
+import {
+  simAthenaProjectionOf,
+  type SimAthenaProjectedTable,
+} from "./sim-athena-projection-parameters.js";
+import { simAthenaProjectedValues } from "./sim-athena-projection-values.js";
+
+/** The table a query names, as reading its partitions needs it. */
+export interface SimAthenaPartitionedTable extends SimAthenaProjectedTable {
+  readonly storageDescriptor:
+    | { readonly Location?: string | undefined }
+    | undefined;
+}
+
+interface SimAthenaTablePartitionsRequest {
+  readonly table: SimAthenaPartitionedTable;
+  readonly queryString: string;
+  readonly now: Date;
+}
+
+/**
+ * The S3 prefixes one query reads for one table.
+ *
+ * A table with projection off reads its own location and nothing else, since
+ * the partitions it holds were registered rather than projected and simulated
+ * Glue has no commands for registering one.
+ *
+ * With projection on, every column is expanded and the query's own `WHERE`
+ * clause narrows what is left. A filter naming no projected column leaves
+ * every partition in, which is what a query scanning the whole table does.
+ */
+export function simAthenaTablePartitions(
+  request: SimAthenaTablePartitionsRequest,
+): readonly string[] {
+  const projection = simAthenaProjectionOf(request.table);
+  const location = request.table.storageDescriptor?.Location;
+
+  if (!projection.enabled) {
+    return location === undefined ? [] : [location];
+  }
+
+  const filters = simAthenaPartitionFilters(request.queryString);
+  const values = new Map<string, readonly string[]>();
+
+  for (const column of projection.columns) {
+    values.set(
+      column.name,
+      valuesFor(column, filters.valuesFor(column.name), request.now),
+    );
+  }
+
+  return simAthenaProjectedPrefixes(projection, values, location);
+}
+
+/**
+ * The values one column takes for this query.
+ *
+ * An injected column has no values of its own, so the query has to name them.
+ * Athena refuses a query that leaves one unconstrained, because projecting
+ * every possible value of an arbitrary string is no projection at all.
+ */
+function valuesFor(
+  column: SimAthenaProjectionColumn,
+  filtered: readonly string[] | undefined,
+  now: Date,
+): readonly string[] {
+  const projected = simAthenaProjectedValues(column, now);
+
+  if (projected === undefined) {
+    if (filtered === undefined) {
+      throw new SimAthenaProjectionError(
+        `Partition column ${column.name} is projected as injected, and a ` +
+          `query has to constrain it with an equality or an IN`,
+      );
+    }
+
+    return filtered;
+  }
+
+  if (filtered === undefined) {
+    return projected;
+  }
+
+  const wanted = new Set(filtered);
+
+  return projected.filter((value) => wanted.has(value));
+}

--- a/src/service/athena/sim-athena-partition-projection.iso.test.ts
+++ b/src/service/athena/sim-athena-partition-projection.iso.test.ts
@@ -1,0 +1,181 @@
+import { faker } from "@faker-js/faker";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+
+describe("evaluating an Athena table's partition projection", () => {
+  async function aQueryOver(
+    parameters: Record<string, string>,
+    queryString = "SELECT url FROM rainlytics.access_logs",
+  ): Promise<{ state: string | undefined; reason: string | undefined }> {
+    const simAws = new SimAws();
+    const workGroup = `analytics-${faker.string.uuid()}`;
+
+    await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+    await simAws.athena().createWorkGroup({
+      input: {
+        Name: workGroup,
+        Configuration: {
+          ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+        },
+      },
+    });
+
+    simAws.glue().createDatabase({
+      input: { DatabaseInput: { Name: "rainlytics" } },
+    });
+    simAws.glue().createTable({
+      input: {
+        DatabaseName: "rainlytics",
+        TableInput: {
+          Name: "access_logs",
+          PartitionKeys: [{ Name: "day", Type: "string" }],
+          StorageDescriptor: { Location: "s3://rainlytics-logs/cloudfront/" },
+          Parameters: parameters,
+        },
+      },
+    });
+
+    simAws
+      .athena()
+      .results()
+      .byDefault({ rows: [["/"]] });
+
+    const started = await simAws.athena().startQueryExecution({
+      input: { QueryString: queryString, WorkGroup: workGroup },
+    });
+
+    await simAws.backgroundTasksComplete();
+
+    const execution = await simAws.athena().getQueryExecution({
+      input: { QueryExecutionId: started.QueryExecutionId },
+    });
+
+    return {
+      state: execution.QueryExecution?.Status?.State,
+      reason: execution.QueryExecution?.Status?.StateChangeReason,
+    };
+  }
+
+  it("answers a query against a table whose projection reads", async () => {
+    // Given a table projecting a range of days.
+    // When a query runs against it.
+    const ran = await aQueryOver({
+      "projection.enabled": "true",
+      "projection.day.type": "date",
+      "projection.day.format": "yyyy-MM-dd",
+      "projection.day.range": "2026-08-01,NOW",
+      "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+    });
+
+    // Then it succeeds.
+    assertIdentical(ran.state, "SUCCEEDED");
+  });
+
+  it("answers a query against a table projecting nothing", async () => {
+    // Given a table with partition keys and no projection.
+    // When a query runs against it.
+    const ran = await aQueryOver({});
+
+    // Then it succeeds. A table without projection reads its own location.
+    assertIdentical(ran.state, "SUCCEEDED");
+  });
+
+  it("fails a query where a partition key has no projection type", async () => {
+    // Given a table with projection on and nothing said about its one key.
+    // When a query runs against it.
+    const ran = await aQueryOver({ "projection.enabled": "true" });
+
+    // Then it fails, naming the parameter the table is missing.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(ran.reason, "INVALID_TABLE_PROPERTY");
+    assertStringIncludes(ran.reason, "projection.day.type");
+  });
+
+  it("fails a query where a date range does not read", async () => {
+    // Given a table whose range names a month that does not exist.
+    // When a query runs against it.
+    const ran = await aQueryOver({
+      "projection.enabled": "true",
+      "projection.day.type": "date",
+      "projection.day.format": "yyyy-MM-dd",
+      "projection.day.range": "2026-13-01,NOW",
+      "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+    });
+
+    // Then it fails, naming the column and the bound it could not read.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(ran.reason, "day");
+    assertStringIncludes(ran.reason, "2026-13-01");
+  });
+
+  it("fails a query where an integer range carries NOW", async () => {
+    // Given a table projecting an integer with a date's bound.
+    // When a query runs against it.
+    const ran = await aQueryOver({
+      "projection.enabled": "true",
+      "projection.day.type": "integer",
+      "projection.day.range": "1,NOW",
+      "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+    });
+
+    // Then it fails. NOW belongs to a date projection.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(ran.reason, "NOW");
+  });
+
+  it("fails a query where the location template omits a projected key", async () => {
+    // Given a table whose template never names its projected column.
+    // When a query runs against it.
+    const ran = await aQueryOver({
+      "projection.enabled": "true",
+      "projection.day.type": "enum",
+      "projection.day.values": "2026-08-26",
+      "storage.location.template": "s3://rainlytics-logs/logs/",
+    });
+
+    // Then it fails, naming the placeholder that is missing.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(ran.reason, `\${day}`);
+  });
+
+  it("fails a query leaving an injected column unconstrained", async () => {
+    // Given a table with an injected partition column.
+    // When a query naming nothing about it runs.
+    const ran = await aQueryOver({
+      "projection.enabled": "true",
+      "projection.day.type": "injected",
+      "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+    });
+
+    // Then it fails. The query has to say which values it wants.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(ran.reason, "injected");
+  });
+
+  it("answers a query constraining an injected column", async () => {
+    // Given the same table, and a query naming the value it wants.
+    // When it runs.
+    const ran = await aQueryOver(
+      {
+        "projection.enabled": "true",
+        "projection.day.type": "injected",
+        "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+      },
+      "SELECT url FROM rainlytics.access_logs WHERE day = '2026-08-26'",
+    );
+
+    // Then it succeeds.
+    assertIdentical(ran.state, "SUCCEEDED");
+  });
+});

--- a/src/service/athena/table/sim-athena-partition-filters.ts
+++ b/src/service/athena/table/sim-athena-partition-filters.ts
@@ -1,0 +1,114 @@
+import { simAthenaSqlTokens } from "./sim-athena-sql-tokens.js";
+
+/**
+ * The partition values a query's `WHERE` clause pins down.
+ *
+ * Only two shapes are read, `column = 'value'` and `column IN ('a', 'b')`, and
+ * they are read wherever they appear. A query carrying `OR` anywhere is left
+ * unfiltered, since a value under one arm of an `OR` constrains nothing on its
+ * own and reading it as a constraint would drop partitions the query wants.
+ *
+ * Not reading a filter is always safe. It leaves every projected partition in,
+ * which is the answer a query with no filter gets anyway.
+ */
+export class SimAthenaPartitionFilters {
+  readonly #byColumn: ReadonlyMap<string, readonly string[]>;
+
+  constructor(byColumn: ReadonlyMap<string, readonly string[]>) {
+    this.#byColumn = byColumn;
+  }
+
+  /** The values this query pins one column to, where it pins any. */
+  valuesFor(columnName: string): readonly string[] | undefined {
+    return this.#byColumn.get(columnName.toLowerCase());
+  }
+}
+
+/**
+ * Read the partition filters out of one query.
+ */
+export function simAthenaPartitionFilters(
+  sql: string,
+): SimAthenaPartitionFilters {
+  const tokens = simAthenaSqlTokens(sql);
+  const byColumn = new Map<string, readonly string[]>();
+
+  if (tokens === undefined || tokens.some(isDisjunction)) {
+    return new SimAthenaPartitionFilters(byColumn);
+  }
+
+  for (const [position, token] of tokens.entries()) {
+    if (token.kind !== "word" && token.kind !== "quoted") {
+      continue;
+    }
+
+    const operator = tokens.at(position + 1);
+
+    if (operator?.kind === "symbol" && operator.text === "=") {
+      const value = tokens.at(position + 2);
+
+      if (value?.kind === "literal") {
+        byColumn.set(token.text.toLowerCase(), [value.text]);
+      }
+
+      continue;
+    }
+
+    if (operator?.kind === "word" && operator.text === "in") {
+      const values = literalList(tokens, position + 2);
+
+      if (values !== undefined) {
+        byColumn.set(token.text.toLowerCase(), values);
+      }
+    }
+  }
+
+  return new SimAthenaPartitionFilters(byColumn);
+}
+
+function isDisjunction(token: { kind: string; text: string }): boolean {
+  return token.kind === "word" && token.text === "or";
+}
+
+/**
+ * Read `('a', 'b')` starting at its opening bracket.
+ *
+ * Anything else in the brackets, such as a subquery, answers with nothing and
+ * leaves the column unfiltered.
+ */
+function literalList(
+  tokens: readonly { kind: string; text: string }[],
+  start: number,
+): readonly string[] | undefined {
+  if (tokens.at(start)?.text !== "(") {
+    return undefined;
+  }
+
+  const values: string[] = [];
+  let cursor = start + 1;
+
+  while (cursor < tokens.length) {
+    const value = tokens.at(cursor);
+
+    if (value?.kind !== "literal") {
+      return undefined;
+    }
+
+    values.push(value.text);
+    cursor += 1;
+
+    const separator = tokens.at(cursor);
+
+    if (separator?.text === ")") {
+      return values;
+    }
+
+    if (separator?.text !== ",") {
+      return undefined;
+    }
+
+    cursor += 1;
+  }
+
+  return undefined;
+}

--- a/src/service/athena/table/sim-athena-partition-filters.ts
+++ b/src/service/athena/table/sim-athena-partition-filters.ts
@@ -4,9 +4,13 @@ import { simAthenaSqlTokens } from "./sim-athena-sql-tokens.js";
  * The partition values a query's `WHERE` clause pins down.
  *
  * Only two shapes are read, `column = 'value'` and `column IN ('a', 'b')`, and
- * they are read wherever they appear. A query carrying `OR` anywhere is left
- * unfiltered, since a value under one arm of an `OR` constrains nothing on its
- * own and reading it as a constraint would drop partitions the query wants.
+ * they are read wherever they appear. A query carrying `OR` or `NOT` anywhere
+ * is left unfiltered. A value under one arm of an `OR` constrains nothing on
+ * its own, and a negated one names the partition the query does not want, so
+ * reading either as a constraint would answer from the wrong prefixes.
+ *
+ * Two constraints on one column are intersected, since a query carrying both
+ * wants the rows they agree on.
  *
  * Not reading a filter is always safe. It leaves every projected partition in,
  * which is the answer a query with no filter gets anyway.
@@ -33,7 +37,7 @@ export function simAthenaPartitionFilters(
   const tokens = simAthenaSqlTokens(sql);
   const byColumn = new Map<string, readonly string[]>();
 
-  if (tokens === undefined || tokens.some(isDisjunction)) {
+  if (tokens === undefined || tokens.some(isUnreadableTerm)) {
     return new SimAthenaPartitionFilters(byColumn);
   }
 
@@ -48,7 +52,7 @@ export function simAthenaPartitionFilters(
       const value = tokens.at(position + 2);
 
       if (value?.kind === "literal") {
-        byColumn.set(token.text.toLowerCase(), [value.text]);
+        narrow(byColumn, token.text, [value.text]);
       }
 
       continue;
@@ -58,7 +62,7 @@ export function simAthenaPartitionFilters(
       const values = literalList(tokens, position + 2);
 
       if (values !== undefined) {
-        byColumn.set(token.text.toLowerCase(), values);
+        narrow(byColumn, token.text, values);
       }
     }
   }
@@ -66,8 +70,33 @@ export function simAthenaPartitionFilters(
   return new SimAthenaPartitionFilters(byColumn);
 }
 
-function isDisjunction(token: { kind: string; text: string }): boolean {
-  return token.kind === "word" && token.text === "or";
+/**
+ * Add one constraint, keeping only what it and any earlier one agree on.
+ */
+function narrow(
+  byColumn: Map<string, readonly string[]>,
+  columnName: string,
+  values: readonly string[],
+): void {
+  const name = columnName.toLowerCase();
+  const already = byColumn.get(name);
+
+  if (already === undefined) {
+    byColumn.set(name, values);
+
+    return;
+  }
+
+  const wanted = new Set(values);
+
+  byColumn.set(
+    name,
+    already.filter((value) => wanted.has(value)),
+  );
+}
+
+function isUnreadableTerm(token: { kind: string; text: string }): boolean {
+  return token.kind === "word" && (token.text === "or" || token.text === "not");
 }
 
 /**

--- a/src/service/athena/table/sim-athena-table-resolution.ts
+++ b/src/service/athena/table/sim-athena-table-resolution.ts
@@ -5,6 +5,7 @@ import {
   simAthenaTableReferenceText,
   type SimAthenaTableReference,
 } from "./sim-athena-table-reference.js";
+import type { SimAthenaPartitionedTable } from "../projection/sim-athena-table-partitions.js";
 import { simAthenaTableReferences } from "./sim-athena-table-references.js";
 
 /**
@@ -16,7 +17,19 @@ import { simAthenaTableReferences } from "./sim-athena-table-references.js";
  */
 export interface SimAthenaCatalog {
   allDatabases(): readonly unknown[];
-  findTable(databaseName: string, name: string): unknown;
+  findTable(
+    databaseName: string,
+    name: string,
+  ): SimAthenaPartitionedTable | undefined;
+}
+
+/** What resolving a query's tables came to. */
+export interface SimAthenaResolvedTables {
+  /** Why the query cannot run, where a table it names is absent. */
+  readonly refusal: string | undefined;
+
+  /** The catalog entries the query reads, for whatever comes next. */
+  readonly tables: readonly SimAthenaPartitionedTable[];
 }
 
 /** What one query is resolved against. */
@@ -27,8 +40,7 @@ export interface SimAthenaTableResolutionRequest {
 }
 
 /**
- * Why a query cannot run against this catalog, where a table it names is
- * absent.
+ * Resolve the tables a query names against this catalog.
  *
  * Resolution is skipped altogether for a query the scanner cannot follow, for
  * a statement that writes data, and for a catalog other than
@@ -40,45 +52,52 @@ export interface SimAthenaTableResolutionRequest {
  * declaration the way it was before this existed. Deploying the first database
  * is what turns resolution on.
  */
-export function simAthenaTableRefusal(
+export function simAthenaResolveTables(
   request: SimAthenaTableResolutionRequest,
   catalog: SimAthenaCatalog | undefined,
-): string | undefined {
+): SimAthenaResolvedTables {
   if (
     catalog === undefined ||
     catalog.allDatabases().length === 0 ||
     isFederated(request.catalog)
   ) {
-    return undefined;
+    return { refusal: undefined, tables: [] };
   }
 
   const read = simAthenaTableReferences(request.queryString);
 
   if (!read.readable) {
-    return undefined;
+    return { refusal: undefined, tables: [] };
   }
+
+  const tables: SimAthenaPartitionedTable[] = [];
 
   for (const reference of read.references) {
-    const refusal = refusalFor(reference, request, catalog);
-
-    if (refusal !== undefined) {
-      return refusal;
+    if (isFederated(reference.catalog) || isInformationSchema(reference)) {
+      continue;
     }
+
+    const database = reference.database ?? request.database;
+    const found =
+      database === undefined
+        ? undefined
+        : catalog.findTable(database, reference.name);
+
+    if (found === undefined) {
+      return { refusal: refusalFor(reference, request, database), tables: [] };
+    }
+
+    tables.push(found);
   }
 
-  return undefined;
+  return { refusal: undefined, tables };
 }
 
 function refusalFor(
   reference: SimAthenaTableReference,
   request: SimAthenaTableResolutionRequest,
-  catalog: SimAthenaCatalog,
-): string | undefined {
-  if (isFederated(reference.catalog) || isInformationSchema(reference)) {
-    return undefined;
-  }
-
-  const database = reference.database ?? request.database;
+  database: string | undefined,
+): string {
   const position = simAthenaSqlPosition(request.queryString, reference.index);
   const at = `line ${String(position.line)}:${String(position.column)}`;
 
@@ -87,10 +106,6 @@ function refusalFor(
       `SYNTAX_ERROR: ${at}: Schema must be specified when session schema ` +
       `is not set`
     );
-  }
-
-  if (catalog.findTable(database, reference.name) !== undefined) {
-    return undefined;
   }
 
   return (


### PR DESCRIPTION
Simulated Athena reads a table's partition projection when a query runs against it and expands it into the S3 prefixes its partitions sit under. All four types are covered, `enum`, `integer`, `date` and `injected`. A projection Athena would refuse fails the query carrying `INVALID_TABLE_PROPERTY`, which is where a mistake in one shows up on AWS too, since Glue accepts whatever parameters it is given and Athena is what reads them.

Resolves https://github.com/KensioSoftware/yulin/issues/1006

Date bounds read `NOW` and an offset such as `NOW-3YEARS` against the simulated clock, so a frozen clock projects the same partitions on every run. The `WHERE` clause narrows what is projected where it pins a partition column down, through `column = 'value'` and `column IN (...)`. A query carrying `OR` anywhere is left unnarrowed, since a value under one arm of an `OR` constrains nothing on its own, and reading no filter is the safe direction.

Two things a reviewer might want to weigh. A projection is capped at 20,000 partitions, which turns a runaway range into a named failure rather than a test that hangs; the number is the simulation's own. And the prefixes themselves have no accessor yet, so they are reachable only through the failures they cause, since #1007 is what consumes them.

`src/service/athena/README.md` records the two decisions worth knowing, the sharpest being that a date bound is validated by writing it back out and comparing, because `Date.UTC` rolls a thirteenth month into next January rather than refusing it.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Athena partition projection support for enum, integer, date, and injected partition types.
  * Added query-time partition filtering and S3 location expansion, including `NOW` date bounds and Hive-style fallback paths.
  * Added validation for invalid projection settings, date ranges, location templates, and partition limits.
* **Documentation**
  * Expanded Athena and Glue documentation with configuration details, limitations, filtering behavior, and failure conditions.
  * Added an example demonstrating a failed query caused by invalid projection settings.
* **Tests**
  * Added comprehensive coverage for projection generation, filtering, validation, date handling, and query failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->