### PR TITLE
feat: measure Athena bytes scanned from S3

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -327,10 +327,86 @@ The `WHERE` clause narrows what is projected. `day = '2026-08-25'` and `day IN (
 
 A table with `projection.enabled` absent or false reads the location in its storage descriptor. A table with projection on and no `storage.location.template` gets the Hive layout under that same location, as `<location>/day=2026-08-25/`.
 
+## What a query scans
+
+A query's bytes scanned are measured from the objects it reads. The prefixes come from the table's
+partition projection, or from the location in its storage descriptor where a table projects nothing,
+and every object under each one counts.
+
+```typescript sim-athena-scanned-bytes
+/**
+ * A query measured against the objects a test seeded.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws.glue().createDatabase({
+  input: { DatabaseInput: { Name: "rainlytics" } },
+});
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "access_logs",
+      StorageDescriptor: { Location: "s3://rainlytics-logs/logs/" },
+    },
+  },
+});
+
+await simAws.s3().putObject({
+  input: {
+    Bucket: "rainlytics-logs",
+    Key: "logs/part-0.json",
+    Body: "x".repeat(1200),
+  },
+});
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString: "SELECT cs_uri_stem FROM rainlytics.access_logs",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const execution = await simAws.athena().getQueryExecution({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// 1200
+console.log(execution.QueryExecution?.Statistics?.DataScannedInBytes);
+```
+
+A query filtering on a projected partition key reads only the prefixes that filter allows. A
+partitioned table then scans less than an unpartitioned one, and a test can prove it.
+
+The listing goes through simulated S3 under the caller that started the query, as Athena reads a
+table's data under the identity that asked for it. A caller who cannot read the Bucket fails the
+query, and the reason names it. A table pointing at a Bucket the simulation never made scans
+nothing. A table nobody put data behind is one nobody set up to measure.
+
+A declared `bytesScanned` wins where a test writes one down. That keeps a test able to drive the
+guardrail without seeding an object.
+
 ## The bytes scanned cutoff
 
-A query whose declared bytes scanned passes the workgroup's `BytesScannedCutoffPerQuery` reaches
-`FAILED`. This is the one guardrail this simulation enforces for real.
+A query whose bytes scanned pass the workgroup's `BytesScannedCutoffPerQuery` reaches `FAILED`. This
+is the one guardrail this simulation enforces for real, and it is enforced against what the objects
+under the query's prefixes come to.
 
 ```typescript sim-athena-bytes-scanned-cutoff
 /**
@@ -453,6 +529,7 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 - `StartQueryExecution`, `GetQueryExecution`, `GetQueryResults` and `StopQueryExecution`
 - Table names in `FROM` and `JOIN` resolved against the simulated Glue Data Catalog
 - Partition projection evaluated, covering `enum`, `integer`, `date` and `injected`
+- Bytes scanned measured from the objects under the prefixes a query reads
 - `BytesScannedCutoffPerQuery` enforced against what a declaration says a query scanned
 - Result sets written to the workgroup's output location as CSV, under the caller's own identity
 - Workgroups, scoped by account and region, with `primary` there from the start
@@ -478,8 +555,9 @@ Current documented limitations:
   out of reach.
 - Table resolution starts once the Data Catalog holds a database. Every query in a simulation
   holding none is answered from its declaration.
-- Partition projection is expanded and checked, and the objects under the prefixes it comes to stay
-  unread. A projection naming partitions the bucket never held still passes.
+- Partition projection is expanded and checked. The objects under the prefixes it comes to are
+  listed for their sizes and never opened. A projection naming partitions the Bucket never held
+  scans nothing and passes.
 - A projected date's format understands `y`, `M`, `d`, `H`, `m` and `s`, which covers the patterns a
   partition path is written in. The wider `SimpleDateFormat` grammar stays out of reach.
 - The `WHERE` clause is read for `column = 'value'` and `column IN ('a', 'b')` only, and a query
@@ -498,8 +576,11 @@ Current documented limitations:
   as the one prefix it has.
 - A query naming a catalog other than `awsdatacatalog` runs with its tables never looked for.
   Federated catalogs and `AWS::Athena::DataCatalog` fall outside this simulation.
-- What a query scanned comes from that same declaration. The cutoff is enforced for real against
-  that figure, which is a test's own statement about the query.
+- Bytes scanned are the total size of every object under the prefixes a query reads. Real Athena
+  reads only the columns a query asks for and counts compressed bytes, so it reports a smaller
+  figure for the same data in a columnar format. A cutoff test written here therefore fires on less
+  data than production would need.
+- A declared `bytesScanned` overrides the measurement entirely.
 - A query that exceeds the cutoff reaches `FAILED` here. AWS documents the per-query data usage
   control as cancelling a query. So a client matching on `FAILED` passes here and misses the
   cancellation in production, and one matching on `CANCELLED` fails here while being right in

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -530,7 +530,7 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 - Table names in `FROM` and `JOIN` resolved against the simulated Glue Data Catalog
 - Partition projection evaluated, covering `enum`, `integer`, `date` and `injected`
 - Bytes scanned measured from the objects under the prefixes a query reads
-- `BytesScannedCutoffPerQuery` enforced against what a declaration says a query scanned
+- `BytesScannedCutoffPerQuery` enforced against that measurement, or against a declared figure
 - Result sets written to the workgroup's output location as CSV, under the caller's own identity
 - Workgroups, scoped by account and region, with `primary` there from the start
 - `CreateWorkGroup`, `GetWorkGroup`, `UpdateWorkGroup`, `DeleteWorkGroup` and `ListWorkGroups`

--- a/docs/services/athena/sim-athena-scanned-bytes.example.ts
+++ b/docs/services/athena/sim-athena-scanned-bytes.example.ts
@@ -1,0 +1,55 @@
+/**
+ * A query measured against the objects a test seeded.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws.glue().createDatabase({
+  input: { DatabaseInput: { Name: "rainlytics" } },
+});
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "access_logs",
+      StorageDescriptor: { Location: "s3://rainlytics-logs/logs/" },
+    },
+  },
+});
+
+await simAws.s3().putObject({
+  input: {
+    Bucket: "rainlytics-logs",
+    Key: "logs/part-0.json",
+    Body: "x".repeat(1200),
+  },
+});
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString: "SELECT cs_uri_stem FROM rainlytics.access_logs",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const execution = await simAws.athena().getQueryExecution({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// 1200
+console.log(execution.QueryExecution?.Statistics?.DataScannedInBytes);

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -74,9 +74,19 @@ text as the leading key and workgroup name as the trailing one, which puts the s
 the way Bedrock puts prompt before model. `SimAthenaResolvedResult` fills in what a declaration left
 out, and it is the only place that knows how.
 
-The cutoff is checked in the runner against what the declaration says the query scanned. That is the
-whole of the cost guardrail, and the one thing this simulation can enforce for real without an
-engine.
+`sim-athena-scanned-bytes.ts` measures what a query reads. It lists every prefix the plan came to
+through simulated S3, sums the object sizes, and counts a key reached twice once. An absent Bucket
+scans nothing. Every other listing failure raises, and that is how a caller refused by IAM fails the
+query.
+
+That split is the point of the file. A table whose Bucket is absent from the simulation is ordinary
+in a test, and refusing it would fail every query written before anything was measured. A caller
+refused permission on the data is the behaviour the measurement exists to expose.
+
+The cutoff is checked in the runner against that figure, or against a declaration where a test wrote
+one down. `SimAthenaResolvedResult.declaredBytesScanned` is what tells a declared zero from an
+absent one. That is the whole of the cost guardrail, and the one thing this simulation can enforce
+for real without an engine.
 
 `table/` reads the tables a query names. `sim-athena-sql-tokens.ts` tokenises and stops there, and
 `sim-athena-table-references.ts` walks those tokens looking only at what follows `FROM`, `JOIN` and a

--- a/src/service/athena/execution/sim-athena-query-outcome.ts
+++ b/src/service/athena/execution/sim-athena-query-outcome.ts
@@ -1,0 +1,66 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import type { SimAthenaCatalog } from "../table/sim-athena-table-resolution.js";
+import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
+import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
+import {
+  simAthenaCutoffRefusal,
+  simAthenaPlanQuery,
+} from "./sim-athena-query-refusal.js";
+import { simAthenaQueryScan } from "./sim-athena-query-scan.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-bytes.js";
+
+interface SimAthenaQueryOutcomeRequest {
+  readonly execution: SimAthenaQueryExecution;
+  readonly result: SimAthenaResolvedResult;
+  readonly workGroups: SimAthenaWorkGroupStore;
+  readonly catalog: SimAthenaCatalog | undefined;
+  readonly objects: SimAthenaScannedObjects | undefined;
+  readonly caller: SimAwsCaller | undefined;
+  readonly now: Date;
+}
+
+/** Whether one query can answer, and what it read to find out. */
+export interface SimAthenaQueryOutcome {
+  readonly refusal: string | undefined;
+  readonly bytesScanned: number;
+}
+
+/**
+ * Work out whether a query answers, in the order real Athena reaches each
+ * question.
+ *
+ * The query is planned, which resolves its tables and expands their partition
+ * projection. What it reads is then measured. The cutoff is checked last,
+ * against that figure.
+ */
+export async function simAthenaQueryOutcome(
+  request: SimAthenaQueryOutcomeRequest,
+): Promise<SimAthenaQueryOutcome> {
+  const declared = request.result.declaredBytesScanned ?? 0;
+  const plan = simAthenaPlanQuery(request);
+
+  if (plan.refusal !== undefined) {
+    return { refusal: plan.refusal, bytesScanned: declared };
+  }
+
+  const scanned = await simAthenaQueryScan({
+    prefixes: plan.prefixes,
+    result: request.result,
+    objects: request.objects,
+    caller: request.caller,
+  });
+
+  if (typeof scanned === "string") {
+    return { refusal: scanned, bytesScanned: declared };
+  }
+
+  return {
+    refusal: simAthenaCutoffRefusal(
+      request.execution,
+      scanned,
+      request.workGroups,
+    ),
+    bytesScanned: scanned,
+  };
+}

--- a/src/service/athena/execution/sim-athena-query-refusal.ts
+++ b/src/service/athena/execution/sim-athena-query-refusal.ts
@@ -11,6 +11,15 @@ import {
 import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
 import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
 
+/** What planning one query came to. */
+export interface SimAthenaQueryPlan {
+  /** Why the query cannot run, where something says it cannot. */
+  readonly refusal: string | undefined;
+
+  /** The S3 prefixes the query reads, for measuring what it scans. */
+  readonly prefixes: readonly string[];
+}
+
 interface SimAthenaQueryRefusalProperties {
   readonly execution: SimAthenaQueryExecution;
   readonly result: SimAthenaResolvedResult;
@@ -22,22 +31,22 @@ interface SimAthenaQueryRefusalProperties {
 }
 
 /**
- * Why a query cannot answer, where something says it cannot.
+ * Plan one query, the way Athena plans one before it runs.
  *
- * Four things can refuse one, and they are asked in the order real Athena
- * would reach them. A declaration saying the query fails wins, because that is
- * a test's own statement about the query. Then the tables it names are looked
- * for in the Data Catalog, and each one's partition projection is expanded,
- * both of which Athena does while planning. The cutoff is last, against what
- * the declaration says the query scanned.
+ * A declaration saying the query fails wins, because that is a test's own
+ * statement about the query. Then the tables it names are looked for in the
+ * Data Catalog and each one's partition projection is expanded, which is what
+ * produces the prefixes the query reads.
+ *
+ * The cutoff is checked after this, against what those prefixes hold.
  */
-export function simAthenaQueryRefusal(
+export function simAthenaPlanQuery(
   properties: SimAthenaQueryRefusalProperties,
-): string | undefined {
+): SimAthenaQueryPlan {
   const { execution, result } = properties;
 
   if (result.failsWith !== undefined) {
-    return result.failsWith;
+    return { refusal: result.failsWith, prefixes: [] };
   }
 
   const resolved = simAthenaResolveTables(
@@ -50,65 +59,68 @@ export function simAthenaQueryRefusal(
   );
 
   if (resolved.refusal !== undefined) {
-    return resolved.refusal;
+    return { refusal: resolved.refusal, prefixes: [] };
   }
 
-  return (
-    projectionRefusal(properties, resolved.tables) ?? cutoffRefusal(properties)
-  );
+  return partitionsOf(properties, resolved.tables);
 }
 
 /**
- * Why a table's partition projection cannot be read.
+ * The prefixes every table a query names comes to.
  *
- * Glue accepts any parameters it is given, so a projection with a mistake in
- * it is found here, when a query first asks what partitions the table has.
+ * Glue accepts any projection parameters it is given, so a projection with a
+ * mistake in it is found here, when a query first asks what partitions the
+ * table has.
  */
-function projectionRefusal(
+function partitionsOf(
   properties: SimAthenaQueryRefusalProperties,
   tables: readonly SimAthenaPartitionedTable[],
-): string | undefined {
+): SimAthenaQueryPlan {
+  const prefixes: string[] = [];
+
   for (const table of tables) {
     try {
-      simAthenaTablePartitions({
-        table,
-        queryString: properties.execution.queryString,
-        now: properties.now,
-      });
+      prefixes.push(
+        ...simAthenaTablePartitions({
+          table,
+          queryString: properties.execution.queryString,
+          now: properties.now,
+        }),
+      );
     } catch (error) {
       if (error instanceof SimAthenaProjectionError) {
-        return error.message;
+        return { refusal: error.message, prefixes: [] };
       }
 
       throw error;
     }
   }
 
-  return undefined;
+  return { refusal: undefined, prefixes };
 }
 
 /**
- * The cost guardrail, checked against what the declaration says the query
- * scanned.
+ * The cost guardrail, checked against what the query scanned.
  *
- * That is the whole of it, and the one thing this simulation can enforce for
- * real without a query engine.
+ * The figure comes from the objects under the prefixes the query reads, or
+ * from a declaration where a test wrote one down.
  */
-function cutoffRefusal(
-  properties: SimAthenaQueryRefusalProperties,
+export function simAthenaCutoffRefusal(
+  execution: SimAthenaQueryExecution,
+  bytesScanned: number,
+  workGroups: SimAthenaWorkGroupStore,
 ): string | undefined {
-  const { execution, result } = properties;
-  const cutoff = properties.workGroups.find(
+  const cutoff = workGroups.find(
     execution.workGroupName,
   )?.bytesScannedCutoffPerQuery;
 
-  if (cutoff === undefined || result.bytesScanned <= cutoff) {
+  if (cutoff === undefined || bytesScanned <= cutoff) {
     return undefined;
   }
 
   return (
     `Bytes scanned limit was exceeded. The query scanned ` +
-    `${String(result.bytesScanned)} bytes, and workgroup ` +
+    `${String(bytesScanned)} bytes, and workgroup ` +
     `${execution.workGroupName} allows ${String(cutoff)} per query.`
   );
 }

--- a/src/service/athena/execution/sim-athena-query-runner-properties.ts
+++ b/src/service/athena/execution/sim-athena-query-runner-properties.ts
@@ -1,0 +1,30 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAthenaQueryResults } from "../result/sim-athena-query-results.js";
+import type { SimAthenaCatalog } from "../table/sim-athena-table-resolution.js";
+import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
+import type { SimAthenaResultWriter } from "./sim-athena-result-writer.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-bytes.js";
+
+/** What one query runner is built from. */
+export interface SimAthenaQueryRunnerProperties {
+  readonly results: SimAthenaQueryResults;
+  readonly workGroups: SimAthenaWorkGroupStore;
+  readonly writer: SimAthenaResultWriter;
+  readonly background: BackgroundScheduler;
+
+  /**
+   * The Data Catalog a query's table names are resolved against.
+   *
+   * A SimAthena built on its own has none, and every query then runs without
+   * its tables being looked for.
+   */
+  readonly catalog?: SimAthenaCatalog | undefined;
+
+  /**
+   * Where the objects a query reads are listed from.
+   *
+   * A SimAthena built on its own has none, and a query then scans whatever a
+   * declaration says it scanned.
+   */
+  readonly objects?: SimAthenaScannedObjects | undefined;
+}

--- a/src/service/athena/execution/sim-athena-query-runner.ts
+++ b/src/service/athena/execution/sim-athena-query-runner.ts
@@ -4,25 +4,12 @@ import type { SimAthenaQueryResults } from "../result/sim-athena-query-results.j
 import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
 import type { SimAthenaCatalog } from "../table/sim-athena-table-resolution.js";
 import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
-import { simAthenaQueryRefusal } from "./sim-athena-query-refusal.js";
+import { simAthenaQueryOutcome } from "./sim-athena-query-outcome.js";
+import type { SimAthenaQueryRunnerProperties } from "./sim-athena-query-runner-properties.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-bytes.js";
 import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
 import type { SimAthenaResultWriter } from "./sim-athena-result-writer.js";
 import { simAthenaWriteFailureReason } from "./sim-athena-write-failure.js";
-
-interface SimAthenaQueryRunnerProperties {
-  readonly results: SimAthenaQueryResults;
-  readonly workGroups: SimAthenaWorkGroupStore;
-  readonly writer: SimAthenaResultWriter;
-  readonly background: BackgroundScheduler;
-
-  /**
-   * The Data Catalog a query's table names are resolved against.
-   *
-   * A SimAthena built on its own has none, and every query then runs without
-   * its tables being looked for.
-   */
-  readonly catalog?: SimAthenaCatalog | undefined;
-}
 
 /**
  * Moves a query execution through its states on the background scheduler.
@@ -42,6 +29,7 @@ export class SimAthenaQueryRunner {
   private readonly writer: SimAthenaResultWriter;
   private readonly background: BackgroundScheduler;
   private readonly catalog: SimAthenaCatalog | undefined;
+  private readonly objects: SimAthenaScannedObjects | undefined;
 
   constructor(properties: SimAthenaQueryRunnerProperties) {
     this.results = properties.results;
@@ -49,6 +37,7 @@ export class SimAthenaQueryRunner {
     this.writer = properties.writer;
     this.background = properties.background;
     this.catalog = properties.catalog;
+    this.objects = properties.objects;
   }
 
   /**
@@ -88,18 +77,20 @@ export class SimAthenaQueryRunner {
       workGroupName: execution.workGroupName,
     });
 
-    execution.recordBytesScanned(result.bytesScanned);
-
-    const refusal = simAthenaQueryRefusal({
+    const outcome = await simAthenaQueryOutcome({
       execution,
       result,
       workGroups: this.workGroups,
       catalog: this.catalog,
+      objects: this.objects,
+      caller,
       now: this.background.now(),
     });
 
-    if (refusal !== undefined) {
-      execution.fail(refusal, this.background.now());
+    execution.recordBytesScanned(outcome.bytesScanned);
+
+    if (outcome.refusal !== undefined) {
+      execution.fail(outcome.refusal, this.background.now());
 
       return;
     }

--- a/src/service/athena/execution/sim-athena-query-scan.ts
+++ b/src/service/athena/execution/sim-athena-query-scan.ts
@@ -1,0 +1,48 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import { simAthenaScanFailureReason } from "./sim-athena-scan-failure.js";
+import {
+  simAthenaScannedBytes,
+  type SimAthenaScannedObjects,
+} from "./sim-athena-scanned-bytes.js";
+
+interface SimAthenaQueryScanRequest {
+  readonly prefixes: readonly string[];
+  readonly result: SimAthenaResolvedResult;
+  readonly objects: SimAthenaScannedObjects | undefined;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * What one query scanned, or why it could not be measured.
+ *
+ * A declaration wins, so every test written before anything was measured keeps
+ * working and a test can still drive the cutoff without seeding an object.
+ * Listing goes under the caller that started the query, the way the result
+ * write does, and a caller who cannot read the data fails here.
+ *
+ * A string is the failure reason. A number is the figure.
+ */
+export async function simAthenaQueryScan(
+  request: SimAthenaQueryScanRequest,
+): Promise<number | string> {
+  const declared = request.result.declaredBytesScanned;
+
+  if (declared !== undefined) {
+    return declared;
+  }
+
+  if (request.objects === undefined || request.prefixes.length === 0) {
+    return 0;
+  }
+
+  try {
+    return await simAthenaScannedBytes({
+      prefixes: request.prefixes,
+      s3: request.objects,
+      caller: request.caller,
+    });
+  } catch (error) {
+    return simAthenaScanFailureReason(error, request.prefixes);
+  }
+}

--- a/src/service/athena/execution/sim-athena-scan-failure.ts
+++ b/src/service/athena/execution/sim-athena-scan-failure.ts
@@ -1,0 +1,29 @@
+import { simAthenaScannedLocation } from "./sim-athena-scanned-location.js";
+
+/**
+ * Why a query could not read what it was about to scan.
+ *
+ * Athena reads a table's data under the identity that asked for it. A caller
+ * without permission on the Bucket fails here rather than answering from an
+ * empty listing. Naming the Buckets is what makes that reachable, since a
+ * query may read several and only one of them refused.
+ *
+ * A Bucket that does not exist never reaches this. That one scans nothing and
+ * the query carries on.
+ */
+export function simAthenaScanFailureReason(
+  error: unknown,
+  prefixes: readonly string[],
+): string {
+  const buckets = [
+    ...new Set(
+      prefixes
+        .map((prefix) => simAthenaScannedLocation(prefix)?.bucket)
+        .filter((bucket) => bucket !== undefined),
+    ),
+  ];
+  const named = buckets.length === 0 ? "its data" : buckets.join(", ");
+  const cause = error instanceof Error ? error.message : String(error);
+
+  return `The query could not read ${named}. ${cause}`;
+}

--- a/src/service/athena/execution/sim-athena-scanned-bytes.ts
+++ b/src/service/athena/execution/sim-athena-scanned-bytes.ts
@@ -1,0 +1,135 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import {
+  simAthenaScannedLocation,
+  type SimAthenaScannedLocation,
+} from "./sim-athena-scanned-location.js";
+import { simAthenaScannedPage } from "./sim-athena-scanned-page.js";
+
+/**
+ * The narrow slice of simulated S3 that measuring a query needs.
+ *
+ * `SimS3` structurally implements this, the way it implements
+ * `SimAthenaResultDestination`.
+ */
+export interface SimAthenaScannedObjects {
+  listObjectsV2(
+    command: {
+      input: {
+        Bucket: string;
+        Prefix: string;
+        ContinuationToken?: string | undefined;
+      };
+    },
+    options?: { caller: SimAwsCaller },
+  ): Promise<{
+    Contents?: readonly { Key?: string; Size?: number }[] | undefined;
+    IsTruncated?: boolean | undefined;
+    NextContinuationToken?: string | undefined;
+  }>;
+}
+
+interface SimAthenaScannedBytesRequest {
+  readonly prefixes: readonly string[];
+  readonly s3: SimAthenaScannedObjects;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * How many bytes a query scans, measured from the objects it reads.
+ *
+ * Every object under every prefix counts, in full. Real Athena reads only the
+ * columns a query asks for and counts the compressed bytes, so this reports
+ * more than AWS would for the same data in a columnar format. The Athena docs
+ * page says so.
+ *
+ * A key reached through two prefixes is counted once. Two projected partitions
+ * never overlap, and a table location sitting above one of them can.
+ *
+ * A prefix whose Bucket does not exist scans nothing. A table pointing at a
+ * Bucket the simulation never made is one nobody set data up for, and refusing
+ * the query would fail every test written before anything was measured.
+ */
+export async function simAthenaScannedBytes(
+  request: SimAthenaScannedBytesRequest,
+): Promise<number> {
+  const locations = request.prefixes
+    .map((uri) => simAthenaScannedLocation(uri))
+    .filter((location) => location !== undefined);
+
+  const listed = await Promise.all(
+    locations.map(async (location) => objectsUnder(request, location)),
+  );
+
+  return distinctBytes(listed.flat());
+}
+
+/** One listed object, keyed so that two Buckets never collide. */
+interface SimAthenaScannedObject {
+  readonly key: string;
+  readonly size: number;
+}
+
+/**
+ * What every object under one prefix comes to, counting each key once.
+ */
+function distinctBytes(objects: readonly SimAthenaScannedObject[]): number {
+  const counted = new Set<string>();
+  let bytes = 0;
+
+  for (const object of objects) {
+    if (counted.has(object.key)) {
+      continue;
+    }
+
+    counted.add(object.key);
+    bytes += object.size;
+  }
+
+  return bytes;
+}
+
+/**
+ * Every object under one prefix, page by page.
+ *
+ * Written as a recursion because each page needs the token the one before it
+ * answered with, which no parallel form can give.
+ */
+async function objectsUnder(
+  request: SimAthenaScannedBytesRequest,
+  location: SimAthenaScannedLocation,
+  continuationToken?: string,
+): Promise<readonly SimAthenaScannedObject[]> {
+  const options =
+    request.caller === undefined ? undefined : { caller: request.caller };
+  const listed = await simAthenaScannedPage(
+    request.s3,
+    location,
+    continuationToken,
+    options,
+  );
+
+  if (listed === undefined) {
+    return [];
+  }
+
+  const contents = listed.Contents ?? [];
+  const objects = contents.map((object) => ({
+    key: `${location.bucket}/${object.Key ?? ""}`,
+    size: object.Size ?? 0,
+  }));
+
+  if (
+    listed.IsTruncated !== true ||
+    listed.NextContinuationToken === undefined
+  ) {
+    return objects;
+  }
+
+  const rest = await objectsUnder(
+    request,
+    location,
+    listed.NextContinuationToken,
+  );
+
+  return [...objects, ...rest];
+}

--- a/src/service/athena/execution/sim-athena-scanned-location.iso.test.ts
+++ b/src/service/athena/execution/sim-athena-scanned-location.iso.test.ts
@@ -1,0 +1,44 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAthenaScannedLocation } from "./sim-athena-scanned-location.js";
+
+describe("reading an S3 URI a query scans", () => {
+  it("reads the Bucket and the prefix apart", () => {
+    // Given a URI naming both.
+    // When it is read.
+    const location = simAthenaScannedLocation(
+      "s3://rainlytics-logs/logs/day=1/",
+    );
+
+    // Then each comes back on its own.
+    assertNonNullable(location);
+    assertIdentical(location.bucket, "rainlytics-logs");
+    assertIdentical(location.prefix, "logs/day=1/");
+  });
+
+  it("reads a Bucket named on its own", () => {
+    // Given a URI with no key prefix under it.
+    // When it is read.
+    const location = simAthenaScannedLocation("s3://rainlytics-logs");
+
+    // Then the prefix is empty, which lists the whole Bucket.
+    assertNonNullable(location);
+    assertIdentical(location.bucket, "rainlytics-logs");
+    assertIdentical(location.prefix, "");
+  });
+
+  it("answers with nothing for a URI it cannot read", () => {
+    // Given locations with the wrong scheme and with no Bucket.
+    // When each is read.
+    // Then none of them reads. A table location this cannot follow is skipped
+    // rather than refused.
+    assertUndefined(simAthenaScannedLocation("https://example.test/logs/"));
+    assertUndefined(simAthenaScannedLocation("s3:///logs/"));
+    assertUndefined(simAthenaScannedLocation("rainlytics-logs/logs/"));
+  });
+});

--- a/src/service/athena/execution/sim-athena-scanned-location.ts
+++ b/src/service/athena/execution/sim-athena-scanned-location.ts
@@ -1,0 +1,34 @@
+/** One S3 URI, read apart into the Bucket and the key prefix under it. */
+export interface SimAthenaScannedLocation {
+  readonly bucket: string;
+  readonly prefix: string;
+}
+
+/**
+ * Read an `s3://bucket/prefix` URI apart, or answer with nothing.
+ *
+ * A table location this cannot read is skipped rather than refused. Athena
+ * would refuse it, and a table nobody queries for its bytes is a poor place to
+ * start failing queries.
+ */
+export function simAthenaScannedLocation(
+  uri: string,
+): SimAthenaScannedLocation | undefined {
+  if (!uri.startsWith("s3://")) {
+    return undefined;
+  }
+
+  const withoutScheme = uri.slice("s3://".length);
+  const separator = withoutScheme.indexOf("/");
+  const bucket =
+    separator === -1 ? withoutScheme : withoutScheme.slice(0, separator);
+
+  if (bucket === "") {
+    return undefined;
+  }
+
+  return {
+    bucket,
+    prefix: separator === -1 ? "" : withoutScheme.slice(separator + 1),
+  };
+}

--- a/src/service/athena/execution/sim-athena-scanned-page.ts
+++ b/src/service/athena/execution/sim-athena-scanned-page.ts
@@ -1,0 +1,37 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-bytes.js";
+import type { SimAthenaScannedLocation } from "./sim-athena-scanned-location.js";
+
+/**
+ * One page of a listing, or nothing where the Bucket is absent.
+ *
+ * Every other failure is left to raise. A caller refused by IAM fails the
+ * query, which is what real Athena does when it cannot read a table's data.
+ */
+export async function simAthenaScannedPage(
+  s3: SimAthenaScannedObjects,
+  location: SimAthenaScannedLocation,
+  continuationToken: string | undefined,
+  options: { caller: SimAwsCaller } | undefined,
+): Promise<
+  Awaited<ReturnType<SimAthenaScannedObjects["listObjectsV2"]>> | undefined
+> {
+  try {
+    return await s3.listObjectsV2(
+      {
+        input: {
+          Bucket: location.bucket,
+          Prefix: location.prefix,
+          ContinuationToken: continuationToken,
+        },
+      },
+      options,
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === "NoSuchBucket") {
+      return undefined;
+    }
+
+    throw error;
+  }
+}

--- a/src/service/athena/result/sim-athena-resolved-result.ts
+++ b/src/service/athena/result/sim-athena-resolved-result.ts
@@ -19,12 +19,21 @@ export class SimAthenaResolvedResult {
   public readonly columns: readonly SimAthenaDeclaredColumn[];
   public readonly rows: readonly (readonly string[])[];
   public readonly bytesScanned: number;
+
+  /**
+   * What the declaration said the query scanned, where it said anything.
+   *
+   * A query with none of its own is measured against the objects it reads.
+   * Telling a declared zero from an absent one is what makes that possible.
+   */
+  public readonly declaredBytesScanned: number | undefined;
   public readonly failsWith: string | undefined;
 
   constructor(declared: SimAthenaDeclaredResult) {
     this.rows = declared.rows ?? [];
     this.columns = resolvedColumns(declared, this.rows);
     this.bytesScanned = declared.bytesScanned ?? 0;
+    this.declaredBytesScanned = declared.bytesScanned;
     this.failsWith = declared.failsWith;
   }
 

--- a/src/service/athena/sim-athena-executions.ts
+++ b/src/service/athena/sim-athena-executions.ts
@@ -15,6 +15,7 @@ import { SimAthenaQueryExecutionStore } from "./execution/sim-athena-query-execu
 import type { SimAthenaQueryExecution } from "./execution/sim-athena-query-execution.js";
 import { SimAthenaNoResultDestination } from "./execution/sim-athena-no-result-destination.js";
 import { SimAthenaQueryRunner } from "./execution/sim-athena-query-runner.js";
+import type { SimAthenaScannedObjects } from "./execution/sim-athena-scanned-bytes.js";
 import {
   SimAthenaResultWriter,
   type SimAthenaResultDestination,
@@ -37,7 +38,7 @@ interface SimAthenaProperties {
    * A SimAthena built on its own has none, and a query that would write
    * results fails saying so. A Bucket only exists inside a SimAws.
    */
-  readonly s3?: SimAthenaResultDestination;
+  readonly s3?: SimAthenaResultDestination & Partial<SimAthenaScannedObjects>;
 
   /**
    * The Data Catalog a query's table names are resolved against.
@@ -46,6 +47,22 @@ interface SimAthenaProperties {
    * its tables being looked for. A catalog only exists inside a SimAws.
    */
   readonly glue?: SimAthenaCatalog;
+}
+
+/**
+ * Whether this destination can also list what a query reads.
+ *
+ * `SimS3` can. The no-op destination a standalone `SimAthena` gets cannot, and
+ * a query there scans whatever a declaration says it scanned.
+ */
+function scannedObjects(
+  s3:
+    | (SimAthenaResultDestination & Partial<SimAthenaScannedObjects>)
+    | undefined,
+): SimAthenaScannedObjects | undefined {
+  return s3?.listObjectsV2 === undefined
+    ? undefined
+    : (s3 as SimAthenaScannedObjects);
 }
 
 /**
@@ -89,6 +106,7 @@ export class SimAthenaExecutions {
       writer,
       background,
       catalog: properties.glue,
+      objects: scannedObjects(properties.s3),
     });
 
     this.background = background;

--- a/src/service/athena/sim-athena-ran-query.fixture.ts
+++ b/src/service/athena/sim-athena-ran-query.fixture.ts
@@ -1,0 +1,35 @@
+import type { SimAws } from "../aws/sim-aws.js";
+
+/** What one query came to, as a test reads it back. */
+export interface SimAthenaRanQuery {
+  readonly state: string | undefined;
+  readonly reason: string | undefined;
+  readonly scanned: number | undefined;
+}
+
+/** Run one query to completion and read the execution back. */
+export async function aRanQuery(
+  simAws: SimAws,
+  workGroup: string,
+  queryString: string,
+  caller?: { kind: "arn"; arn: string },
+): Promise<SimAthenaRanQuery> {
+  const started = await simAws
+    .athena()
+    .startQueryExecution(
+      { input: { QueryString: queryString, WorkGroup: workGroup } },
+      caller === undefined ? undefined : { caller },
+    );
+
+  await simAws.backgroundTasksComplete();
+
+  const execution = await simAws.athena().getQueryExecution({
+    input: { QueryExecutionId: started.QueryExecutionId },
+  });
+
+  return {
+    state: execution.QueryExecution?.Status?.State,
+    reason: execution.QueryExecution?.Status?.StateChangeReason,
+    scanned: execution.QueryExecution?.Statistics?.DataScannedInBytes,
+  };
+}

--- a/src/service/athena/sim-athena-scanned-bytes.fixture.ts
+++ b/src/service/athena/sim-athena-scanned-bytes.fixture.ts
@@ -1,0 +1,68 @@
+import { faker } from "@faker-js/faker";
+
+import type { SimAws } from "../aws/sim-aws.js";
+import { SimAws as SimAwsClass } from "../aws/sim-aws.js";
+
+/** A table projecting one prefix per day across three days. */
+export const projectedDays = {
+  "projection.enabled": "true",
+  "projection.day.type": "date",
+  "projection.day.format": "yyyy-MM-dd",
+  "projection.day.range": "2026-08-24,2026-08-26",
+  "storage.location.template": `s3://rainlytics-logs/logs/\${day}/`,
+};
+
+/**
+ * A simulation holding a results Bucket, a logs Bucket, a workgroup and one
+ * catalog table over the logs.
+ */
+export async function aScannedSimulation(
+  parameters: Record<string, string> = {},
+  cutoff?: number,
+): Promise<{ simAws: SimAws; workGroup: string }> {
+  const simAws = new SimAwsClass();
+  const workGroup = `analytics-${faker.string.uuid()}`;
+
+  await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+  await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+  await simAws.athena().createWorkGroup({
+    input: {
+      Name: workGroup,
+      Configuration: {
+        ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+        ...(cutoff !== undefined && { BytesScannedCutoffPerQuery: cutoff }),
+      },
+    },
+  });
+
+  simAws.glue().createDatabase({
+    input: { DatabaseInput: { Name: "rainlytics" } },
+  });
+  simAws.glue().createTable({
+    input: {
+      DatabaseName: "rainlytics",
+      TableInput: {
+        Name: "access_logs",
+        PartitionKeys:
+          Object.keys(parameters).length === 0
+            ? []
+            : [{ Name: "day", Type: "string" }],
+        StorageDescriptor: { Location: "s3://rainlytics-logs/logs/" },
+        Parameters: parameters,
+      },
+    },
+  });
+
+  return { simAws, workGroup };
+}
+
+/** Put one object of a given size under the logs Bucket. */
+export async function aSeededObject(
+  simAws: SimAws,
+  key: string,
+  bytes: number,
+): Promise<void> {
+  await simAws.s3().putObject({
+    input: { Bucket: "rainlytics-logs", Key: key, Body: "x".repeat(bytes) },
+  });
+}

--- a/src/service/athena/sim-athena-scanned-bytes.iso.test.ts
+++ b/src/service/athena/sim-athena-scanned-bytes.iso.test.ts
@@ -1,0 +1,136 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { aRanQuery } from "./sim-athena-ran-query.fixture.js";
+import {
+  aScannedSimulation,
+  aSeededObject,
+  projectedDays,
+} from "./sim-athena-scanned-bytes.fixture.js";
+
+describe("measuring what an Athena query scans", () => {
+  it("counts the objects under the table's own location", async () => {
+    // Given a table with no projection and two objects under its location.
+    const { simAws, workGroup } = await aScannedSimulation();
+
+    await aSeededObject(simAws, "logs/part-0.json", 300);
+    await aSeededObject(simAws, "logs/part-1.json", 700);
+
+    // When a query runs against it.
+    const ran = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs",
+    );
+
+    // Then it reports what those objects come to.
+    assertIdentical(ran.state, "SUCCEEDED");
+    assertIdentical(ran.scanned, 1000);
+  });
+
+  it("counts only the partitions a filter allows", async () => {
+    // Given a table projecting three days, each holding an object.
+    const { simAws, workGroup } = await aScannedSimulation(projectedDays);
+
+    await aSeededObject(simAws, "logs/2026-08-24/part-0.json", 100);
+    await aSeededObject(simAws, "logs/2026-08-25/part-0.json", 200);
+    await aSeededObject(simAws, "logs/2026-08-26/part-0.json", 400);
+
+    // When a query naming one day runs.
+    const oneDay = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs WHERE day = '2026-08-25'",
+    );
+
+    // And when a query naming none of them runs.
+    const everyDay = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs",
+    );
+
+    // Then the filtered query reads one partition and the other reads all
+    // three. This is what partitioning a table is for.
+    assertIdentical(oneDay.scanned, 200);
+    assertIdentical(everyDay.scanned, 700);
+  });
+
+  it("scans nothing where the table points at a Bucket nobody made", async () => {
+    // Given a table whose location names a Bucket this simulation never had.
+    const { simAws, workGroup } = await aScannedSimulation();
+
+    simAws.glue().createTable({
+      input: {
+        DatabaseName: "rainlytics",
+        TableInput: {
+          Name: "elsewhere",
+          StorageDescriptor: { Location: "s3://somewhere-else/logs/" },
+        },
+      },
+    });
+
+    // When a query runs against it.
+    const ran = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.elsewhere",
+    );
+
+    // Then it succeeds having scanned nothing. A table nobody put data behind
+    // is one nobody set up to measure.
+    assertIdentical(ran.state, "SUCCEEDED");
+    assertIdentical(ran.scanned, 0);
+  });
+
+  it("counts a key once where two prefixes both reach it", async () => {
+    // Given a table whose location sits above a second table's, and one
+    // object under the deeper of the two.
+    const { simAws, workGroup } = await aScannedSimulation();
+
+    await aSeededObject(simAws, "logs/day=1/part-0.json", 250);
+
+    simAws.glue().createTable({
+      input: {
+        DatabaseName: "rainlytics",
+        TableInput: {
+          Name: "one_day",
+          StorageDescriptor: { Location: "s3://rainlytics-logs/logs/day=1/" },
+        },
+      },
+    });
+
+    // When a query reads both.
+    const ran = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs, rainlytics.one_day",
+    );
+
+    // Then the object counts once. Athena bills a byte it read once, however
+    // many prefixes reach it.
+    assertIdentical(ran.scanned, 250);
+  });
+
+  it("counts every object where a listing runs past one page", async () => {
+    // Given more objects under one prefix than a single S3 listing returns.
+    const { simAws, workGroup } = await aScannedSimulation();
+
+    await Promise.all(
+      Array.from({ length: 1001 }, async (_unused, index) =>
+        aSeededObject(simAws, `logs/part-${String(index)}.json`, 1),
+      ),
+    );
+
+    // When a query reads them.
+    const ran = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs",
+    );
+
+    // Then all of them count. A listing stops at 1000 keys and says so, and
+    // the measurement follows the continuation token.
+    assertIdentical(ran.scanned, 1001);
+  });
+});

--- a/src/service/athena/sim-athena-scanned-cutoff.iso.test.ts
+++ b/src/service/athena/sim-athena-scanned-cutoff.iso.test.ts
@@ -1,0 +1,103 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { faker } from "@faker-js/faker";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simIamPolicyDocumentFactory } from "../iam/policy/sim-iam-policy-document.factory.js";
+import { aRanQuery } from "./sim-athena-ran-query.fixture.js";
+import {
+  aScannedSimulation,
+  aSeededObject,
+} from "./sim-athena-scanned-bytes.fixture.js";
+
+describe("the Athena cutoff against what a query measured", () => {
+  it("fails a query whose measured bytes pass the cutoff", async () => {
+    // Given a workgroup allowing 500 bytes a query, and a table holding more.
+    const { simAws, workGroup } = await aScannedSimulation({}, 500);
+
+    await aSeededObject(simAws, "logs/part-0.json", 900);
+
+    // When a query runs against it.
+    const ran = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs",
+    );
+
+    // Then the guardrail refuses it against data the test seeded, naming both
+    // figures.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(ran.reason, "Bytes scanned limit was exceeded");
+    assertStringIncludes(ran.reason, "900");
+    assertIdentical(ran.scanned, 900);
+  });
+
+  it("takes a declared figure over the objects on the ground", async () => {
+    // Given a table holding one small object, and a test saying the query
+    // scans a great deal more.
+    const { simAws, workGroup } = await aScannedSimulation({}, 500);
+
+    await aSeededObject(simAws, "logs/part-0.json", 10);
+
+    const sql = "SELECT url FROM rainlytics.access_logs";
+    simAws.athena().results().onQuery(sql, { bytesScanned: 5000 });
+
+    // When the query runs.
+    const ran = await aRanQuery(simAws, workGroup, sql);
+
+    // Then the declaration answers, so a test can still drive the guardrail
+    // without seeding anything.
+    assertIdentical(ran.state, "FAILED");
+    assertIdentical(ran.scanned, 5000);
+  });
+
+  it("fails a caller who cannot read the data", async () => {
+    // Given a table with data, and a role allowed to run the query and
+    // nothing else.
+    const { simAws, workGroup } = await aScannedSimulation();
+
+    await aSeededObject(simAws, "logs/part-0.json", 100);
+
+    const roleName = `athena-caller-${faker.string.uuid()}`;
+    const role = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: roleName,
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: roleName,
+        PolicyName: "AthenaOnly",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: [{ Effect: "Allow", Action: "athena:*", Resource: "*" }],
+        }),
+      }),
+    );
+
+    // When that role runs the query.
+    const ran = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs",
+      { kind: "arn", arn: role.Role.Arn },
+    );
+
+    // Then the query fails naming the Bucket it could not read. Athena reads
+    // a table's data under the identity that asked for it.
+    assertIdentical(ran.state, "FAILED");
+    assertNonNullable(ran.reason);
+    assertStringIncludes(ran.reason, "rainlytics-logs");
+  });
+});


### PR DESCRIPTION
A query's bytes scanned come from the objects under the prefixes it reads, listed through simulated S3 under the caller that started it. The prefixes come from a table's partition projection, or from its storage descriptor location where a table projects nothing. The bytes-scanned cutoff is then enforced against data a test seeded rather than against a figure the test wrote down, which is what the guardrail exists to catch.

Resolves https://github.com/KensioSoftware/yulin/issues/1007

A query filtering on a projected partition key measures only the prefixes that filter allows, so a test can prove its partitioning works. A declared `bytesScanned` still wins where a test sets one, keeping every test written against #992 working.

Two behaviours worth a look. A caller who cannot read the data fails the query and the reason names the Bucket, since Athena reads a table's data under the identity that asked for it. A Bucket the simulation never made scans nothing instead of failing, because a table pointing at one is ordinary in a test and refusing it would break every query written before anything was measured. Those two are told apart by the S3 error name.

The honest divergence is in the docs Limitations. This sums whole objects, where real Athena reads only the columns a query asks for and counts compressed bytes, so it reports a larger figure than AWS would for the same data in a columnar format.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Athena simulations now measure scanned bytes from S3 object sizes.
  * Supports partition filtering, paginated listings, overlapping prefixes, and caller authorization.
  * Declared scan-byte values can override measured totals.
  * Workgroup scan cutoffs now use measured bytes when no override is provided.
  * Added an example demonstrating scanned-byte reporting.

* **Bug Fixes**
  * Missing buckets are treated as empty data, while other read failures are reported clearly.

* **Documentation**
  * Updated Athena documentation with measurement behavior, limitations, authorization, and cutoff details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->