### PR TITLE
feat: run Athena queries with SQLite

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -3,15 +3,18 @@
 Yulin includes a simulated Amazon Athena for tests and local development. It holds workgroups and
 named queries, and hands both back through the SDK.
 
-No SQL is evaluated. A test declares what a query answers with, and the simulation reads the query
-text only as a key to match that declaration on. So a test can prove its bytes-scanned cutoff
-refuses a query, that results land where the workgroup says, and that a client polls the lifecycle
-correctly. Whether the SQL is valid stays out of reach. The [Limitations](#limitations) at the end
-say what that leaves out.
+A query is answered one of two ways. A test declares what it answers with, and the simulation
+matches that declaration on the query text. Or the
+[query engine](#running-a-query-for-real) runs the SQL for real over the objects a test seeded into
+simulated S3. The engine is off until a test turns it on, and it needs one package added to the
+project.
 
-One part of the SQL is read. The tables a query names are looked for in the simulated
+Either way the lifecycle around the query is real. A test can prove its bytes-scanned cutoff
+refuses a query, that results land where the workgroup says, and that a client polls the lifecycle
+correctly. The tables a query names are looked for in the simulated
 [Glue Data Catalog](https://yulinsim.dev/services/glue/ "Simulated Glue usage docs"), and a query
-naming one that is absent fails the way real Athena fails it.
+naming one that is absent fails the way real Athena fails it. The
+[Limitations](#limitations) at the end say what this leaves out.
 
 Athena-specific types are imported from the `@kensio/yulin/athena` subpath.
 
@@ -175,12 +178,163 @@ console.log(results.ResultSet?.Rows?.[1]?.Data?.[1]?.VarCharValue);
 ```
 
 A rule for an exact query wins, then a rule for a workgroup, then the default. `onWorkGroup` covers
-every query a stack's rollups run, and `byDefault` covers everything else. Matching is exact, and
-the SQL is never parsed, so two queries differing only in whitespace are two different keys.
+every query a stack's rollups run, and `byDefault` covers everything else. Matching is exact, on the
+query text as it was sent, so two queries differing only in whitespace are two different keys.
+
+The query engine sits between the two tiers. A rule for an exact query is ahead of it and the
+workgroup rule and the default are behind it.
 
 `failsWith` fails a query instead of answering it. Nothing here reads SQL, so a query that should
 fail cannot be discovered on its own. Saying so is what makes a client's failure handling
 reachable.
+
+## Running a query for real
+
+The query engine answers a `SELECT` from the objects a test seeded into simulated S3. It reads the
+table's schema out of the Glue Data Catalog, decodes each object with the SerDe the table declares,
+loads the rows into an in-memory SQLite database, and answers the statement from them. Roughly
+nineteen queries in twenty of the shapes a test writes run this way.
+
+The engine is off until a test turns it on, and it needs `node-sql-parser` in the project. The
+parser is an optional peer dependency, so a project that never runs a query never installs it.
+
+```bash
+pnpm add -D node-sql-parser
+```
+
+`engine().enable()` turns the engine on and loads the parser. It raises where the package is absent,
+naming what to add.
+
+```typescript sim-athena-query-engine
+/**
+ * A query answered from the objects a test seeded, rather than from a
+ * declaration.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws.glue().createDatabase({
+  input: { DatabaseInput: { Name: "rainlytics" } },
+});
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [{ Name: "day", Type: "string" }],
+      StorageDescriptor: {
+        Columns: [
+          { Name: "url", Type: "string" },
+          { Name: "status", Type: "int" },
+          { Name: "bytes", Type: "bigint" },
+        ],
+        Location: "s3://rainlytics-logs/cloudfront/",
+        SerdeInfo: {
+          SerializationLibrary: "org.openx.data.jsonserde.JsonSerDe",
+        },
+      },
+    },
+  },
+});
+
+await simAws.s3().putObject({
+  input: {
+    Bucket: "rainlytics-logs",
+    Key: "cloudfront/day=2026-08-01/part-0.json",
+    Body: [
+      '{"url":"/","status":200,"bytes":1200}',
+      '{"url":"/pricing","status":404,"bytes":310}',
+      '{"url":"/pricing","status":404,"bytes":305}',
+    ].join("\n"),
+  },
+});
+
+// node-sql-parser has to be in the project for this line to work.
+await simAws.athena().engine().enable();
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString:
+      "SELECT url, count(*) AS hits, sum(bytes) AS total " +
+      "FROM rainlytics.access_logs WHERE status >= 400 AND day = '2026-08-01' " +
+      "GROUP BY url ORDER BY hits DESC",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const results = await simAws.athena().getQueryResults({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// ["/pricing", "2", "615"], computed from the objects.
+console.log(
+  results.ResultSet?.Rows?.[1]?.Data?.map((cell) => cell.VarCharValue),
+);
+
+// "engine", which is how a test proves the rows came from the data.
+console.log(simAws.athena().queryExecutions()[0]?.answeredBy);
+```
+
+A declaration written against one exact query text still wins. That is the escape hatch for a
+statement the engine gets wrong, and it is why `results()` is unchanged. Everything the engine turns
+down falls back to the declarations, where a workgroup rule or the default answers it. `answeredBy`
+on the execution says which of the two answered, and a test that wants the engine can assert on it.
+
+The engine turns a query down where the parser refuses the statement, where SQLite refuses to run
+it, where a table declares a format it has no reader for, and where an object it needs cannot be
+opened. Every one of those ends the same way, with the declared result answering.
+
+### The objects it reads
+
+The SerDe class name in the table's storage descriptor says how its objects are decoded.
+
+- `org.openx.data.jsonserde.JsonSerDe`, `org.apache.hive.hcatalog.data.JsonSerDe` and
+  `org.apache.hadoop.hive.serde2.JsonSerDe` read JSON lines, one record per line.
+- `org.apache.hadoop.hive.serde2.OpenCSVSerde` reads comma separated text with `"` around a field
+  that needs it.
+- `org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe` reads the delimiter `field.delim` names,
+  which defaults to the control character Hive uses.
+
+`separatorChar`, `quoteChar` and `escapeChar` in the SerDe's parameters override those defaults, and
+`skip.header.line.count` on the table drops the first lines of every object. An empty field reads as
+null, along with Hive's `\N`. A boolean column reads `true`, `false`, `1` and `0`, and any other
+text in one reads as null.
+
+A nested object or array is kept as its JSON text, and `json_extract_scalar`, `cardinality` and
+`element_at` reach into it.
+
+A partition column's value comes from the partition the object sits in. A table projecting its
+partitions takes it from the projection, and a table laid out Hive style under its own location
+takes it from the `key=value` segments of the object's key. Either way the column reads on every
+row, though no object holds it.
+
+### What it answers with
+
+Column types come from the Glue schema, written the way Athena writes them, so Hive's `string`
+reports as `varchar` and its `int` as `integer`. A boolean column reads as `true` and `false`. A
+computed column has no schema entry behind it, and its type is read off the first value that is not
+null.
+
+Two rewrites keep an answer the same as Athena's. `PRAGMA case_sensitive_like` is set on the
+database, because SQLite matches `LIKE` without regard to case for ASCII and Athena matches it with.
+Every ascending sort is emitted carrying `NULLS LAST`, because Trino orders nulls last whichever
+direction it sorts and SQLite orders them first ascending. Both were cases where a query answered
+differently while still succeeding, which is the failure that costs the most to find.
 
 ## Tables a query names
 
@@ -527,6 +681,9 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 
 - Query executions, moving through `QUEUED` and `RUNNING` to `SUCCEEDED`, `FAILED` or `CANCELLED`
 - `StartQueryExecution`, `GetQueryExecution`, `GetQueryResults` and `StopQueryExecution`
+- A `SELECT` run for real over JSON lines and CSV objects in simulated S3, answered by SQLite
+- Declared results, matched on the query text, ahead of the engine for one statement and behind it
+  for everything else
 - Table names in `FROM` and `JOIN` resolved against the simulated Glue Data Catalog
 - Partition projection evaluated, covering `enum`, `integer`, `date` and `injected`
 - Bytes scanned measured from the objects under the prefixes a query reads
@@ -545,9 +702,35 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 
 Current documented limitations:
 
-- No SQL is evaluated. Nothing plans or runs a query, no S3 object is read to answer one, and every
-  row comes from a declaration a test wrote. Simulated Athena will therefore accept a query real
-  Athena would reject.
+- With the engine off, no SQL is evaluated. Nothing plans or runs a query, no S3 object is read to
+  answer one, and every row comes from a declaration a test wrote. Simulated Athena will therefore
+  accept a query real Athena would reject.
+- With the engine on, the statement is read as Athena by `node-sql-parser`, written back out for
+  SQLite and run there. Around one query in twenty is turned down at one of those two steps and
+  falls back to its declared result. `UNNEST` and `GROUPING SETS` are the two measured cases.
+- The Trino function library reaches as far as `date_trunc`, `date_format`, `from_unixtime`,
+  `to_unixtime`, `from_iso8601_timestamp`, `from_iso8601_date`, `to_iso8601`,
+  `json_extract_scalar`, `cardinality`, `element_at`, `regexp_like`, `split_part`, `strpos`,
+  `approx_distinct` and `approx_percentile`. A query reaching for anything else Trino has and
+  SQLite lacks falls back.
+- The date and time functions work on the ISO-8601 text a JSON or CSV object carries. A column
+  written any other way gets whatever slicing that text comes to.
+- `approx_distinct` and `approx_percentile` are computed exactly. The simulation is more accurate
+  than AWS here, and at the scale a test seeds the difference cannot show.
+- Three classes of expression the engine accepts are ones real Athena refuses. `1 / 0` answers
+  null, `CAST('abc' AS INTEGER)` answers 0, and `1 || 'x'` answers `'1x'`. Each of them fails a
+  real query.
+- Parquet and ORC are absent. A table declaring either falls back to its declared result, and so
+  does a table declaring no SerDe at all.
+- A null in a result row reads as an empty string. Real Athena leaves the value out of the row.
+- A computed boolean reads as `1` and `0`. The Glue column type is what makes a boolean column read
+  as `true` and `false`, and an expression has no column type behind it.
+- An expression nobody named is called `_col0` upward, as Athena calls one. An alias that needed
+  quotes around it is renamed the same way.
+- The engine reads every object under the prefixes a query reaches and holds the rows in memory.
+  That suits the fixture-sized data a test seeds and nothing larger.
+- A caller who can list a Bucket and cannot read its objects gets the declared result. A listing
+  refused by IAM fails the query, and that is what the bytes scanned measurement exposes.
 - The table names in `FROM` and `JOIN` are the one part of a query that is read, and they are found
   by a scan. A statement the scan cannot follow runs with its tables never
   looked for, which covers `CREATE TABLE AS SELECT`, `INSERT INTO`, `MSCK REPAIR TABLE`, `SHOW` and
@@ -588,7 +771,8 @@ Current documented limitations:
 - `GetQueryResults` pages up to 1000 rows, as Athena does. The listings of workgroups and named
   queries stop at 50, which is their own documented maximum.
 - `ListQueryExecutions`, `BatchGetQueryExecution` and `GetQueryRuntimeStatistics` are absent, along
-  with query result reuse, result encryption, `CREATE TABLE AS SELECT` and `INSERT INTO`.
+  with query result reuse, result encryption, `CREATE TABLE AS SELECT` and `INSERT INTO`. A
+  statement that writes data runs with its tables never looked for and answers from a declaration.
 - Real Athena's own floor for the bytes scanned cutoff is 10MB. This simulation takes any whole
   number of bytes from 1 up, putting the guardrail wherever the query a test is exercising needs
   it. A cutoff of zero or a fraction is still refused.

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -720,6 +720,15 @@ Current documented limitations:
 - Three classes of expression the engine accepts are ones real Athena refuses. `1 / 0` answers
   null, `CAST('abc' AS INTEGER)` answers 0, and `1 || 'x'` answers `'1x'`. Each of them fails a
   real query.
+- `try_cast` runs as a plain cast. `try_cast('abc' AS integer)` therefore answers 0 where real
+  Athena answers null, which is the same forgiving direction as the cast above. Reading the
+  statement without the rewrite would turn the whole query down.
+- A `decimal` column is held as a double. A value carrying more than about fifteen significant
+  digits loses the ones past that, and a filter, a sum or a group on it can then answer
+  differently from Athena's exact arithmetic.
+- A declaration that fails the query wins from any tier, the engine included. `failsWith` is a
+  statement about the query rather than about its rows, so a workgroup rule or a default carrying
+  one fails every query it covers whether or not the engine could have answered.
 - Parquet and ORC are absent. A table declaring either falls back to its declared result, and so
   does a table declaring no SerDe at all.
 - A null in a result row reads as an empty string. Real Athena leaves the value out of the row.

--- a/docs/services/athena/sim-athena-query-engine.example.ts
+++ b/docs/services/athena/sim-athena-query-engine.example.ts
@@ -1,0 +1,82 @@
+/**
+ * A query answered from the objects a test seeded, rather than from a
+ * declaration.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws.glue().createDatabase({
+  input: { DatabaseInput: { Name: "rainlytics" } },
+});
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [{ Name: "day", Type: "string" }],
+      StorageDescriptor: {
+        Columns: [
+          { Name: "url", Type: "string" },
+          { Name: "status", Type: "int" },
+          { Name: "bytes", Type: "bigint" },
+        ],
+        Location: "s3://rainlytics-logs/cloudfront/",
+        SerdeInfo: {
+          SerializationLibrary: "org.openx.data.jsonserde.JsonSerDe",
+        },
+      },
+    },
+  },
+});
+
+await simAws.s3().putObject({
+  input: {
+    Bucket: "rainlytics-logs",
+    Key: "cloudfront/day=2026-08-01/part-0.json",
+    Body: [
+      '{"url":"/","status":200,"bytes":1200}',
+      '{"url":"/pricing","status":404,"bytes":310}',
+      '{"url":"/pricing","status":404,"bytes":305}',
+    ].join("\n"),
+  },
+});
+
+// node-sql-parser has to be in the project for this line to work.
+await simAws.athena().engine().enable();
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString:
+      "SELECT url, count(*) AS hits, sum(bytes) AS total " +
+      "FROM rainlytics.access_logs WHERE status >= 400 AND day = '2026-08-01' " +
+      "GROUP BY url ORDER BY hits DESC",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const results = await simAws.athena().getQueryResults({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// ["/pricing", "2", "615"], computed from the objects.
+console.log(
+  results.ResultSet?.Rows?.[1]?.Data?.map((cell) => cell.VarCharValue),
+);
+
+// "engine", which is how a test proves the rows came from the data.
+console.log(simAws.athena().queryExecutions()[0]?.answeredBy);

--- a/package.json
+++ b/package.json
@@ -283,6 +283,7 @@
     "eslint-plugin-unicorn": "^72.0.0",
     "execa": "^10.0.0",
     "fta-cli": "^3.0.0",
+    "node-sql-parser": "^5.4.0",
     "oxfmt": "^0.64.0",
     "oxlint": "^1.77.0",
     "oxlint-tsgolint": "^7.0.2001",
@@ -300,10 +301,14 @@
   },
   "peerDependencies": {
     "eslint": "^10.4.1",
+    "node-sql-parser": "^5.4.0",
     "typescript-eslint": "^8.60.0"
   },
   "peerDependenciesMeta": {
     "eslint": {
+      "optional": true
+    },
+    "node-sql-parser": {
       "optional": true
     },
     "typescript-eslint": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       fta-cli:
         specifier: ^3.0.0
         version: 3.0.1
+      node-sql-parser:
+        specifier: ^5.4.0
+        version: 5.4.0
       oxfmt:
         specifier: ^0.64.0
         version: 0.64.0
@@ -1521,6 +1524,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/pegjs@0.10.6':
+    resolution: {integrity: sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==}
+
   '@types/sinon@17.0.4':
     resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
 
@@ -1869,6 +1875,10 @@ packages:
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
@@ -2759,6 +2769,10 @@ packages:
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
+
+  node-sql-parser@5.4.0:
+    resolution: {integrity: sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==}
+    engines: {node: '>=8'}
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -5158,6 +5172,8 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/pegjs@0.10.6': {}
+
   '@types/sinon@17.0.4':
     dependencies:
       '@types/sinonjs__fake-timers': 15.0.1
@@ -5461,6 +5477,8 @@ snapshots:
   baseline-browser-mapping@2.11.13: {}
 
   before-after-hook@4.0.0: {}
+
+  big-integer@1.6.52: {}
 
   bottleneck@2.19.5: {}
 
@@ -6342,6 +6360,11 @@ snapshots:
       skin-tone: 2.0.0
 
   node-releases@2.0.53: {}
+
+  node-sql-parser@5.4.0:
+    dependencies:
+      '@types/pegjs': 0.10.6
+      big-integer: 1.6.52
 
   normalize-package-data@6.0.2:
     dependencies:

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -1,20 +1,25 @@
 # Simulated Athena implementation
 
 This directory contains the simulated Athena implementation. Workgroups and named queries are
-deployable from a template and readable through the SDK, and a query runs through its states with
-one part of its SQL read.
+deployable from a template and readable through the SDK, and a query runs through its states over
+data a test seeded into simulated S3.
 
-The guiding decision is that no query is evaluated. Athena's own value is in the query engine, and a
-query engine over Parquet and JSON objects in S3 is a different order of magnitude from the rest of
-this. A test declares what a query answers with instead, and the simulation matches that declaration
-on the query text. Simulated Bedrock answers a prompt the same way and simulated Rekognition answers
-an image the same way, all three through `SimDeclaredResultRules`.
+A query is answered one of two ways. A test declares what it answers with and the simulation matches
+that declaration on the query text, the way simulated Bedrock answers a prompt and simulated
+Rekognition answers an image, all three through `SimDeclaredResultRules`. Or the query engine reads
+the objects a test seeded into simulated S3 and answers the statement under SQLite.
 
-What that leaves is worth having. The lifecycle a client polls is real, the bytes-scanned cutoff
-refuses a query for real, the tables a query names are looked for in the Data Catalog, and a result
-set really is written to the workgroup's output location. The divergence to be honest about is that
-simulated Athena accepts a query real Athena would reject. `docs/services/athena/README.md` says so
-in its Limitations list.
+The engine was the second answer to a question this service originally settled the other way.
+Writing a query engine over Parquet and JSON objects in S3 was sized at four to seven thousand lines
+and ruled out. Handing the SQL to `node-sql-parser` and the rows to `node:sqlite` came to a tenth of
+that, and it answers roughly nineteen queries in twenty of the shapes a test writes. The spike that
+measured it is on `#1004`.
+
+What the declarations give is still worth having on its own. The lifecycle a client polls is real,
+the bytes-scanned cutoff refuses a query for real, the tables a query names are looked for in the
+Data Catalog, and a result set really is written to the workgroup's output location. The divergence
+to be honest about is that simulated Athena accepts a query real Athena would reject.
+`docs/services/athena/README.md` says so in its Limitations list.
 
 ## Entry points
 
@@ -85,8 +90,8 @@ refused permission on the data is the behaviour the measurement exists to expose
 
 The cutoff is checked in the runner against that figure, or against a declaration where a test wrote
 one down. `SimAthenaResolvedResult.declaredBytesScanned` is what tells a declared zero from an
-absent one. That is the whole of the cost guardrail, and the one thing this simulation can enforce
-for real without an engine.
+absent one. That is the whole of the cost guardrail, and it is enforced whether or not the
+engine answers the query.
 
 `table/` reads the tables a query names. `sim-athena-sql-tokens.ts` tokenises and stops there, and
 `sim-athena-table-references.ts` walks those tokens looking only at what follows `FROM`, `JOIN` and a
@@ -127,6 +132,91 @@ table to be looked for, and every test written before this existed stays working
 because Athena writes a result under the identity that asked for it. Simulated Firehose does the
 same shape of thing under its delivery stream's role. A write that fails leaves the execution
 `FAILED` rather than raising at a caller who was answered long ago and has gone away to poll.
+
+## The query engine
+
+`engine/` holds it. `SimAthenaQueryEngine` is the whole of the public surface. A query it cannot run is turned down,
+and the declared result answers instead.
+
+Three decisions shape the rest of the directory.
+
+**It is opt-in.** A project holding `node-sql-parser` for a reason of its own would otherwise find
+simulated Athena answering differently from the version before it. `enable()` loads the parser there and then. A project without
+the package finds out at the line that asked for the engine.
+
+**The parser is an optional peer dependency.** It materialises 88MB in the pnpm store, and most
+users will never run a query. `sim-athena-parser-module.ts` loads it by a deep path,
+`node-sql-parser/build/athena.js`, which pulls one grammar at 192KB out of the twenty published. The
+specifier is held in a variable so that building this repository never turns the dependency into a
+required one, and a failure to resolve it is reported as something to go and add.
+`scripts/mts/verify-pack.mts` installs every declared peer into a throwaway consumer. The
+`package.json` entries had to land in the same change as the import.
+
+**Everything that can fail, turns the query down.** A statement the Athena grammar refuses, a table
+in a format there is no reader for, an object the caller cannot open and a statement SQLite will not
+run all end with no result and the declared result answering. `sim-athena-engine-run.ts` is where
+that catch sits.
+
+### The seam
+
+`sim-athena-query-answer.ts` is the chain. A declaration written against one exact query text wins,
+then the engine, then the declarations again for the workgroup tier and the default. That ordering
+is what keeps every test written before the engine existed working, and what gives a test an escape
+hatch for one statement the engine gets wrong.
+
+`SimDeclaredResultRules` had to learn to report a miss for it. `resultFor` always answered by
+falling back to the default, and `declaredFor` answers with `undefined` where every tier missed.
+Asking it for the leading key alone is what isolates the exact-query tier.
+
+`SimAthenaQueryExecution.answeredBy` records which of the two answered. Real Athena has no such
+field. It is a simulator accessor, read off `queryExecutions()`.
+
+### Reading the data
+
+`sim-athena-record-reader.ts` picks a reader off the SerDe class name in the table's storage
+descriptor. A table declaring Parquet lands in the same place as a table whose SerDe is absent.
+Guessing would answer a Parquet query with nonsense.
+
+`sim-athena-delimited-records.ts` reads a character at a time. A quoted CSV field carries both the
+delimiter and the line ending often enough to matter. An empty field reads as null, along with
+Hive's `\N`. Delimited text cannot tell an empty string from an absent value, and a numeric column
+is better served by the null than by text SQLite cannot convert.
+
+Partition values travel with the prefix. `simAthenaTablePartitions` used to answer with prefixes and
+now answers with a prefix and the values that produced it, because a `storage.location.template` can put a
+partition value nowhere in the key path. Reading the values back off the key would lose them for
+exactly the tables a template exists to serve. A table with no projection falls
+back to the Hive style `key=value` segments of the object's own key.
+
+### The database
+
+`sim-athena-sqlite-database.ts` builds one in-memory database per query. Each Glue database is
+attached as a SQLite schema of the same name, and `rainlytics.access_logs` in the statement resolves
+as it stands. SQLite refuses to reach across attached schemas from a view. A table the query context
+lets a statement name unqualified is created twice.
+
+Two settings keep an answer the same as Athena's, and both were found by measurement. `PRAGMA case_sensitive_like = ON` closes a filter that quietly takes in rows Athena
+excludes. Emitting `ASC NULLS LAST` closes a sort that comes back in a different order. Each of them
+was a query that succeeded and answered differently, which is the worst failure available here.
+
+`node:sqlite` prints an `ExperimentalWarning` on the first import under Node 24.
+`sim-athena-sqlite-module.ts` swaps the process warning listeners around that import and puts them
+back a tick later, because `process.emitWarning` defers delivery and restoring synchronously misses
+it. A project that installed a warning listener of its own keeps it, along with every other warning
+it would have printed.
+
+### Reading the answer back
+
+`sim-athena-engine-result.ts` reads rows as arrays through `setReturnArrays`, since a statement is
+free to answer with two columns of one name and an object would keep one of them.
+
+`sim-athena-result-columns.ts` types them. SQLite reports the origin table and column for anything
+traced back to a table, and that is what makes a boolean read as `true` and `false`. A computed
+column has no origin. Its type is read off the first value the column answered with.
+
+An expression nobody named is called `_col0` upward, the way Athena calls one. SQLite names it after
+the expression text instead, and a name that could not have been written as an identifier is how
+that is told apart from an alias a statement chose.
 
 ## The CloudFormation layer
 

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -160,7 +160,9 @@ that catch sits.
 ### The seam
 
 `sim-athena-query-answer.ts` is the chain. A declaration written against one exact query text wins,
-then the engine, then the declarations again for the workgroup tier and the default. That ordering
+then the engine, then the declarations again for the workgroup tier and the default. A declared
+`failsWith` is the exception and wins from any tier, because it is a statement about the query
+rather than about its rows. `simAthenaPlanQuery` reads it before anything is planned or measured. That ordering
 is what keeps every test written before the engine existed working, and what gives a test an escape
 hatch for one statement the engine gets wrong.
 

--- a/src/service/athena/engine/sim-athena-aggregate-shims.ts
+++ b/src/service/athena/engine/sim-athena-aggregate-shims.ts
@@ -1,0 +1,72 @@
+import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
+
+/** What `approx_percentile` carries between rows. */
+interface SimAthenaPercentileState {
+  readonly values: number[];
+  percentile: number;
+}
+
+/**
+ * Trino's two approximate aggregates, computed exactly.
+ *
+ * Real Athena answers both from a sketch and this answers from the values
+ * themselves, so the simulation is the more accurate of the two. At the scale
+ * a test seeds that difference cannot show, and the alternative is a query
+ * that refuses to run at all.
+ *
+ * The state travels as JSON because SQLite carries an aggregate's accumulator
+ * as one of its own values rather than as an object.
+ */
+export function simAthenaInstallAggregateShims(database: DatabaseSync): void {
+  database.aggregate("approx_distinct", {
+    start: "[]",
+    step: (accumulator: string, value: SQLOutputValue) => {
+      const seen = new Set(JSON.parse(accumulator) as unknown[]);
+
+      if (value !== null) {
+        seen.add(typeof value === "bigint" ? String(value) : value);
+      }
+
+      return JSON.stringify([...seen]);
+    },
+    result: (accumulator: string) =>
+      (JSON.parse(accumulator) as unknown[]).length,
+  });
+
+  database.aggregate("approx_percentile", {
+    start: () => JSON.stringify({ values: [], percentile: 0.5 }),
+    step: (accumulator: string, value: SQLOutputValue, at: SQLOutputValue) => {
+      const state = JSON.parse(accumulator) as SimAthenaPercentileState;
+
+      if (value !== null) {
+        state.values.push(Number(value));
+      }
+
+      if (at !== null) {
+        state.percentile = Number(at);
+      }
+
+      return JSON.stringify(state);
+    },
+    result: (accumulator: string) =>
+      percentileOf(JSON.parse(accumulator) as SimAthenaPercentileState),
+  });
+}
+
+/**
+ * The nearest rank percentile, which is what Trino documents its own
+ * approximation as converging on.
+ */
+function percentileOf(state: SimAthenaPercentileState): number | null {
+  if (state.values.length === 0) {
+    return null;
+  }
+
+  const sorted = state.values.toSorted((one, other) => one - other);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.floor(state.percentile * sorted.length),
+  );
+
+  return sorted.at(index) ?? null;
+}

--- a/src/service/athena/engine/sim-athena-column-types.ts
+++ b/src/service/athena/engine/sim-athena-column-types.ts
@@ -1,0 +1,85 @@
+/**
+ * The type a column reports when the schema says nothing and no value in the
+ * result gives it away.
+ */
+export const defaultAthenaResultType = "varchar";
+
+/**
+ * Hive type names, as a Glue column writes them, against the type name Athena
+ * reports for the same column in a result set.
+ *
+ * The two vocabularies differ in three places. Hive's `string` is Athena's
+ * `varchar`, Hive's `int` is Athena's `integer`, and Hive's `struct` is
+ * Athena's `row`. Everything else is written the same in both.
+ */
+const athenaResultTypes: ReadonlyMap<string, string> = new Map([
+  ["string", "varchar"],
+  ["char", "varchar"],
+  ["varchar", "varchar"],
+  ["int", "integer"],
+  ["integer", "integer"],
+  ["bigint", "bigint"],
+  ["tinyint", "tinyint"],
+  ["smallint", "smallint"],
+  ["float", "real"],
+  ["double", "double"],
+  ["decimal", "decimal"],
+  ["boolean", "boolean"],
+  ["date", "date"],
+  ["timestamp", "timestamp"],
+  ["binary", "varbinary"],
+  ["array", "array"],
+  ["map", "map"],
+  ["struct", "row"],
+]);
+
+/** The types SQLite should hold as whole numbers. */
+const integerTypes = new Set([
+  "tinyint",
+  "smallint",
+  "int",
+  "integer",
+  "bigint",
+  "boolean",
+]);
+
+/** The types SQLite should hold as floating point. */
+const realTypes = new Set(["float", "double", "real", "decimal"]);
+
+/**
+ * A Hive type name with its parameters and element types taken off.
+ *
+ * `decimal(10,2)` and `array<struct<a:int>>` both name their kind first, and
+ * that is the whole of what either mapping below needs.
+ */
+function baseType(glueType: string | undefined): string {
+  const named = /^\s*([\dA-Za-z_]+)/u.exec(glueType ?? "");
+
+  return (named?.[1] ?? "").toLowerCase();
+}
+
+/**
+ * The SQLite column affinity a Glue column type gets.
+ *
+ * A boolean is held as a whole number, which is the only thing SQLite has, and
+ * read back out as `true` or `false` by the type the Glue column declared.
+ */
+export function simAthenaSqliteAffinity(glueType: string | undefined): string {
+  const type = baseType(glueType);
+
+  if (integerTypes.has(type)) {
+    return "INTEGER";
+  }
+
+  return realTypes.has(type) ? "REAL" : "TEXT";
+}
+
+/** Whether a Glue column type holds a boolean. */
+export function simAthenaIsBooleanType(glueType: string | undefined): boolean {
+  return baseType(glueType) === "boolean";
+}
+
+/** The type name Athena reports for a Glue column type. */
+export function simAthenaResultType(glueType: string | undefined): string {
+  return athenaResultTypes.get(baseType(glueType)) ?? defaultAthenaResultType;
+}

--- a/src/service/athena/engine/sim-athena-date-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-date-shims.iso.test.ts
@@ -9,22 +9,36 @@ describe("Trino's date functions on SQLite", () => {
   it("truncates a timestamp to each unit it knows", async () => {
     // Given one timestamp.
     // When it is truncated to a year, a month, an hour and a minute.
-    // Then each answers with the text that unit leaves standing.
+    // Then the fields below the unit read zero and the ones above it stand.
     assertIdentical(
       await anAnsweredExpression(`date_trunc('year', '${noon}')`),
-      "2026-01-01",
+      "2026-01-01T00:00:00Z",
     );
     assertIdentical(
       await anAnsweredExpression(`date_trunc('MONTH', '${noon}')`),
-      "2026-08-01",
+      "2026-08-01T00:00:00Z",
     );
     assertIdentical(
       await anAnsweredExpression(`date_trunc('hour', '${noon}')`),
-      "2026-08-02T12:00:00",
+      "2026-08-02T12:00:00Z",
     );
     assertIdentical(
       await anAnsweredExpression(`date_trunc('minute', '${noon}')`),
-      "2026-08-02T12:34:00",
+      "2026-08-02T12:34:00Z",
+    );
+  });
+
+  it("keeps a date a date", async () => {
+    // Given a value written to the day.
+    // When it is truncated to a day and to a month.
+    // Then it stays written to the day, since there is nothing below to zero.
+    assertIdentical(
+      await anAnsweredExpression("date_trunc('day', '2026-08-02')"),
+      "2026-08-02",
+    );
+    assertIdentical(
+      await anAnsweredExpression("date_trunc('month', '2026-08-02')"),
+      "2026-08-01",
     );
   });
 

--- a/src/service/athena/engine/sim-athena-date-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-date-shims.iso.test.ts
@@ -1,0 +1,108 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredExpression } from "./sim-athena-shim.fixture.js";
+
+const noon = "2026-08-02T12:34:56Z";
+
+describe("Trino's date functions on SQLite", () => {
+  it("truncates a timestamp to each unit it knows", async () => {
+    // Given one timestamp.
+    // When it is truncated to a year, a month, an hour and a minute.
+    // Then each answers with the text that unit leaves standing.
+    assertIdentical(
+      await anAnsweredExpression(`date_trunc('year', '${noon}')`),
+      "2026-01-01",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`date_trunc('MONTH', '${noon}')`),
+      "2026-08-01",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`date_trunc('hour', '${noon}')`),
+      "2026-08-02T12:00:00",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`date_trunc('minute', '${noon}')`),
+      "2026-08-02T12:34:00",
+    );
+  });
+
+  it("leaves a timestamp alone for a unit it has no answer for", async () => {
+    // Given a unit outside the ones Trino names.
+    // When a timestamp is truncated to it.
+    // Then the timestamp comes back whole rather than as a fragment.
+    assertIdentical(
+      await anAnsweredExpression(`date_trunc('quarter', '${noon}')`),
+      noon,
+    );
+  });
+
+  it("answers null where there is no timestamp to truncate", async () => {
+    // Given a null.
+    // When it is truncated.
+    // Then the answer is null, the way every Trino scalar answers a null.
+    assertIdentical(
+      await anAnsweredExpression("date_trunc('day', NULL)"),
+      null,
+    );
+  });
+
+  it("formats a timestamp by the fields MySQL and Trino share", async () => {
+    // Given one timestamp.
+    // When it is written out through a format string.
+    // Then each field reads off the ISO-8601 text, and `%%` is a literal.
+    assertIdentical(
+      await anAnsweredExpression(`date_format('${noon}', '%d/%m/%Y %H:%i:%S')`),
+      "02/08/2026 12:34:56",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`date_format('${noon}', '%Y%% %q')`),
+      "2026% %q",
+    );
+    assertIdentical(
+      await anAnsweredExpression("date_format(NULL, '%Y')"),
+      null,
+    );
+  });
+
+  it("reads and writes ISO-8601 text", async () => {
+    // Given a timestamp and a date written as ISO-8601.
+    // When each conversion runs.
+    // Then the text is what a table holds, so each is close to a no-op.
+    assertIdentical(
+      await anAnsweredExpression(`from_iso8601_timestamp('${noon}')`),
+      noon,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`from_iso8601_date('${noon}')`),
+      "2026-08-02",
+    );
+    assertIdentical(await anAnsweredExpression(`to_iso8601('${noon}')`), noon);
+    assertIdentical(await anAnsweredExpression("to_iso8601(NULL)"), null);
+    assertIdentical(
+      await anAnsweredExpression("from_iso8601_timestamp(NULL)"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("from_iso8601_date(NULL)"),
+      null,
+    );
+  });
+
+  it("converts between an instant and a Unix time", async () => {
+    // Given a Unix time and a timestamp.
+    // When each is converted to the other.
+    // Then they agree, and text that is no timestamp answers null.
+    assertIdentical(
+      await anAnsweredExpression("from_unixtime(1785674400)"),
+      "2026-08-02 12:40:00.000",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_unixtime('2026-08-02T12:40:00Z')"),
+      1_785_674_400,
+    );
+    assertIdentical(await anAnsweredExpression("from_unixtime(NULL)"), null);
+    assertIdentical(await anAnsweredExpression("to_unixtime('never')"), null);
+  });
+});

--- a/src/service/athena/engine/sim-athena-date-shims.ts
+++ b/src/service/athena/engine/sim-athena-date-shims.ts
@@ -6,20 +6,21 @@ import {
   simAthenaScalarShim,
 } from "./sim-athena-shim-registry.js";
 
+/** How much of an ISO-8601 timestamp each unit keeps. */
+const truncations: ReadonlyMap<string, number> = new Map([
+  ["year", 4],
+  ["month", 7],
+  ["day", 10],
+  ["hour", 13],
+  ["minute", 16],
+  ["second", 19],
+]);
+
 /**
- * How much of an ISO-8601 timestamp each unit keeps, and what has to be put
- * back to leave a timestamp rather than a fragment.
+ * The start of the year, laid out so that every digit of an ISO-8601 timestamp
+ * has the value truncating to it leaves behind.
  */
-const truncations: ReadonlyMap<string, { keep: number; pad: string }> = new Map(
-  [
-    ["year", { keep: 4, pad: "-01-01" }],
-    ["month", { keep: 7, pad: "-01" }],
-    ["day", { keep: 10, pad: "" }],
-    ["hour", { keep: 13, pad: ":00:00" }],
-    ["minute", { keep: 16, pad: ":00" }],
-    ["second", { keep: 19, pad: "" }],
-  ],
-);
+const startOfYear = "0000-01-01T00:00:00.000";
 
 /** The `date_format` patterns Trino shares with MySQL. */
 const formatFields: ReadonlyMap<string, [number, number]> = new Map([
@@ -38,6 +39,10 @@ const formatFields: ReadonlyMap<string, [number, number]> = new Map([
  * because SQLite has no date type of its own. Every one of these therefore
  * works on the string rather than on an instant, which is exact for the
  * ISO-8601 a table holds and does nothing useful for anything else.
+ *
+ * `date_trunc` zeroes the fields below the unit and keeps the separators the
+ * value was written with. A date comes back as a date and a timestamp comes
+ * back as a timestamp at the start of the unit, which is what Trino does.
  */
 export function simAthenaInstallDateShims(database: DatabaseSync): void {
   simAthenaScalarShim(
@@ -83,11 +88,23 @@ function truncated(
     return null;
   }
 
-  const truncation = truncations.get(unit?.toLowerCase() ?? "");
+  const keep = truncations.get(unit?.toLowerCase() ?? "");
 
-  return truncation === undefined
-    ? value
-    : `${value.slice(0, truncation.keep)}${truncation.pad}`;
+  if (keep === undefined || value.length <= keep) {
+    return value;
+  }
+
+  let truncatedValue = value.slice(0, keep);
+
+  for (let index = keep; index < value.length; index += 1) {
+    const character = value.charAt(index);
+
+    truncatedValue += /\d/u.test(character)
+      ? startOfYear.charAt(index) || "0"
+      : character;
+  }
+
+  return truncatedValue;
 }
 
 function formatted(

--- a/src/service/athena/engine/sim-athena-date-shims.ts
+++ b/src/service/athena/engine/sim-athena-date-shims.ts
@@ -1,0 +1,110 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import {
+  shimNumber,
+  shimText,
+  simAthenaScalarShim,
+} from "./sim-athena-shim-registry.js";
+
+/**
+ * How much of an ISO-8601 timestamp each unit keeps, and what has to be put
+ * back to leave a timestamp rather than a fragment.
+ */
+const truncations: ReadonlyMap<string, { keep: number; pad: string }> = new Map(
+  [
+    ["year", { keep: 4, pad: "-01-01" }],
+    ["month", { keep: 7, pad: "-01" }],
+    ["day", { keep: 10, pad: "" }],
+    ["hour", { keep: 13, pad: ":00:00" }],
+    ["minute", { keep: 16, pad: ":00" }],
+    ["second", { keep: 19, pad: "" }],
+  ],
+);
+
+/** The `date_format` patterns Trino shares with MySQL. */
+const formatFields: ReadonlyMap<string, [number, number]> = new Map([
+  ["%Y", [0, 4]],
+  ["%m", [5, 7]],
+  ["%d", [8, 10]],
+  ["%H", [11, 13]],
+  ["%i", [14, 16]],
+  ["%S", [17, 19]],
+]);
+
+/**
+ * Trino's date and time functions, over ISO-8601 text.
+ *
+ * A timestamp is text here, because that is how JSON and CSV carry one and
+ * because SQLite has no date type of its own. Every one of these therefore
+ * works on the string rather than on an instant, which is exact for the
+ * ISO-8601 a table holds and does nothing useful for anything else.
+ */
+export function simAthenaInstallDateShims(database: DatabaseSync): void {
+  simAthenaScalarShim(
+    database,
+    "from_iso8601_timestamp",
+    (value) => shimText(value) ?? null,
+  );
+  simAthenaScalarShim(
+    database,
+    "from_iso8601_date",
+    (value) => shimText(value)?.slice(0, 10) ?? null,
+  );
+  simAthenaScalarShim(
+    database,
+    "to_iso8601",
+    (value) => shimText(value) ?? null,
+  );
+  simAthenaScalarShim(database, "date_trunc", (unit, value) =>
+    truncated(shimText(unit), shimText(value)),
+  );
+  simAthenaScalarShim(database, "date_format", (value, format) =>
+    formatted(shimText(value), shimText(format)),
+  );
+  simAthenaScalarShim(database, "from_unixtime", (seconds) => {
+    const epoch = shimNumber(seconds);
+
+    return epoch === undefined
+      ? null
+      : new Date(epoch * 1000).toISOString().replace("T", " ").slice(0, 23);
+  });
+  simAthenaScalarShim(database, "to_unixtime", (value) => {
+    const parsed = Date.parse(shimText(value) ?? "");
+
+    return Number.isNaN(parsed) ? null : Math.floor(parsed / 1000);
+  });
+}
+
+function truncated(
+  unit: string | undefined,
+  value: string | undefined,
+): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const truncation = truncations.get(unit?.toLowerCase() ?? "");
+
+  return truncation === undefined
+    ? value
+    : `${value.slice(0, truncation.keep)}${truncation.pad}`;
+}
+
+function formatted(
+  value: string | undefined,
+  format: string | undefined,
+): string | null {
+  if (value === undefined || format === undefined) {
+    return null;
+  }
+
+  return format.replaceAll(/%[A-Za-z%]/gu, (field) => {
+    if (field === "%%") {
+      return "%";
+    }
+
+    const range = formatFields.get(field);
+
+    return range === undefined ? field : value.slice(range[0], range[1]);
+  });
+}

--- a/src/service/athena/engine/sim-athena-delimited-records.ts
+++ b/src/service/athena/engine/sim-athena-delimited-records.ts
@@ -1,0 +1,119 @@
+// A record is keyed by the table's own column names, so every write of one is
+// by a name worked out at run time.
+// oxlint-disable security/detect-object-injection
+import type { SimAthenaEngineRow } from "./sim-athena-engine-row.js";
+
+/** How one table's delimited text is written. */
+export interface SimAthenaDelimitedFormat {
+  readonly delimiter: string;
+  readonly quote: string | undefined;
+  readonly escape: string | undefined;
+  readonly skipHeaderLines: number;
+}
+
+/**
+ * What Hive writes for a null in delimited text.
+ *
+ * An empty field reads as null too. Delimited text cannot tell an empty string
+ * from an absent value, and a query filtering or summing a numeric column is
+ * better served by a null than by a string SQLite cannot convert.
+ */
+const hiveNull = String.raw`\N`;
+
+/**
+ * One object of delimited text, read into rows.
+ *
+ * The columns are taken in the order the table declares them, since delimited
+ * text carries no names of its own. A record with more fields than the table
+ * has columns loses the surplus, and one with fewer leaves the rest null,
+ * which is what Hive does with a ragged file.
+ */
+export function simAthenaDelimitedRows(
+  text: string,
+  format: SimAthenaDelimitedFormat,
+  columns: readonly string[],
+): readonly SimAthenaEngineRow[] {
+  return delimitedRecords(text, format)
+    .slice(format.skipHeaderLines)
+    .map((fields) => rowOf(fields, columns));
+}
+
+function rowOf(
+  fields: readonly string[],
+  columns: readonly string[],
+): SimAthenaEngineRow {
+  const row: Record<string, unknown> = {};
+
+  for (const [index, column] of columns.entries()) {
+    const field = fields[index];
+
+    row[column] =
+      field === undefined || field === hiveNull || field.length === 0
+        ? null
+        : field;
+  }
+
+  return row;
+}
+
+/**
+ * The records one object holds, split on the delimiter and the line endings.
+ *
+ * Written as a scan rather than a split because a quoted field can carry both
+ * of those, and a CSV export of a URL or a log message routinely does.
+ */
+function delimitedRecords(
+  text: string,
+  format: SimAthenaDelimitedFormat,
+): readonly (readonly string[])[] {
+  const records: string[][] = [];
+  let record: string[] = [];
+  let field = "";
+  let quoted = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text.charAt(index);
+    const next = index + 1 < text.length ? text.charAt(index + 1) : undefined;
+
+    if (quoted) {
+      if (
+        next !== undefined &&
+        character === format.escape &&
+        format.escape !== format.quote
+      ) {
+        field += next;
+        index += 1;
+      } else if (character === format.quote && next === format.quote) {
+        field += format.quote;
+        index += 1;
+      } else if (character === format.quote) {
+        quoted = false;
+      } else {
+        field += character;
+      }
+
+      continue;
+    }
+
+    if (character === format.quote && field.length === 0) {
+      quoted = true;
+    } else if (character === format.delimiter) {
+      record.push(field);
+      field = "";
+    } else if (character === "\n") {
+      record.push(field);
+      records.push(record);
+      record = [];
+      field = "";
+    } else if (character !== "\r") {
+      field += character;
+    }
+  }
+
+  if (field.length > 0 || record.length > 0) {
+    record.push(field);
+    records.push(record);
+  }
+
+  return records;
+}

--- a/src/service/athena/engine/sim-athena-engine-modules.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-engine-modules.iso.test.ts
@@ -1,0 +1,62 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAthenaSqlParser } from "./sim-athena-parser-module.js";
+import { simAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
+
+describe("loading what the Athena query engine runs on", () => {
+  it("says what to add where the parser is not installed", async () => {
+    // Given a project without node-sql-parser.
+    // When the engine asks for its grammar.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAthenaSqlParser("node-sql-parser/build/absent.js"),
+    );
+
+    // Then it names the package to add and the alternative to it.
+    assertIdentical(error.name, "SimAthenaSetUpError");
+    assertStringIncludes(error.message, "node-sql-parser");
+    assertStringIncludes(error.message, "results()");
+  });
+
+  it("says the same where the grammar carries no parser", async () => {
+    // Given a module that resolves and is not the grammar.
+    // When the engine asks it for a parser.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAthenaSqlParser("node:util"),
+    );
+
+    // Then it says which module let it down.
+    assertStringIncludes(error.message, "node:util carries no Parser");
+  });
+
+  it("swallows SQLite's experimental warning and nothing else", async () => {
+    // Given a project handling its own process warnings.
+    const seen: string[] = [];
+    const listener = (warning: Error): void => {
+      seen.push(warning.message);
+    };
+
+    process.on("warning", listener);
+
+    try {
+      // When the engine loads node:sqlite and something else warns while it
+      // is loading, which is the window the swap is in place for.
+      const loading = simAthenaSqliteModule();
+
+      process.emitWarning("a warning the project should still see");
+      await loading;
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+    } finally {
+      process.removeListener("warning", listener);
+    }
+
+    // Then the project's own handling survived the swap.
+    assertIdentical(seen.at(-1), "a warning the project should still see");
+  });
+});

--- a/src/service/athena/engine/sim-athena-engine-result.ts
+++ b/src/service/athena/engine/sim-athena-engine-result.ts
@@ -1,0 +1,66 @@
+// A result row is an array in the statement's own column order, so every
+// read of one is by a position worked out at run time.
+// oxlint-disable security/detect-object-injection
+import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
+
+import type { SimAthenaDeclaredColumn } from "../result/sim-athena-declared-result.js";
+import { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import { simAthenaResultColumns } from "./sim-athena-result-columns.js";
+import type { SimAthenaLoadedTable } from "./sim-athena-table-rows.js";
+
+/**
+ * Run one translated statement and read its answer back as a result set.
+ *
+ * The rows come back as arrays rather than as objects, because a statement is
+ * free to answer with two columns of one name and an object would keep one of
+ * them.
+ */
+export function simAthenaEngineResult(
+  database: DatabaseSync,
+  sql: string,
+  loaded: readonly SimAthenaLoadedTable[],
+): SimAthenaResolvedResult {
+  const statement = database.prepare(sql);
+
+  statement.setReturnArrays(true);
+
+  const rows = statement.all() as unknown as readonly SQLOutputValue[][];
+  const columns = simAthenaResultColumns(statement.columns(), rows, loaded);
+
+  return new SimAthenaResolvedResult({
+    columns,
+    rows: rows.map((row) =>
+      columns.map((column, index) => rendered(row[index], column)),
+    ),
+  });
+}
+
+/**
+ * One value as `GetQueryResults` carries it.
+ *
+ * A boolean column is stored as a whole number, because SQLite has nothing
+ * else to store it as, and the Glue type is what says to write it back out as
+ * `true` or `false`. Real Athena leaves a null out of a result row altogether
+ * and this simulation has no way to say so, so a null reads as an empty
+ * string.
+ */
+function rendered(
+  value: SQLOutputValue | undefined,
+  column: SimAthenaDeclaredColumn,
+): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (column.type === "boolean") {
+    return value === 0 || value === 0n ? "false" : "true";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return value instanceof Uint8Array
+    ? new TextDecoder().decode(value)
+    : String(value);
+}

--- a/src/service/athena/engine/sim-athena-engine-row.ts
+++ b/src/service/athena/engine/sim-athena-engine-row.ts
@@ -1,0 +1,34 @@
+// A decoded record is keyed by whatever the object held, so every read of one
+// is by a name worked out at run time.
+// oxlint-disable security/detect-object-injection
+
+/** One decoded record, keyed by column name. */
+export type SimAthenaEngineRow = Readonly<Record<string, unknown>>;
+
+/**
+ * One value out of a decoded record, by column name.
+ *
+ * Hive column names are case insensitive and the JSON and CSV a table sits on
+ * need not agree with the case Glue holds. An exact match wins, and anything
+ * else is matched with the case taken off.
+ */
+export function simAthenaRowValue(
+  row: SimAthenaEngineRow,
+  name: string,
+): unknown {
+  const exact = row[name];
+
+  if (exact !== undefined) {
+    return exact;
+  }
+
+  const wanted = name.toLowerCase();
+
+  for (const [key, value] of Object.entries(row)) {
+    if (key.toLowerCase() === wanted) {
+      return value;
+    }
+  }
+
+  return undefined;
+}

--- a/src/service/athena/engine/sim-athena-engine-run.ts
+++ b/src/service/athena/engine/sim-athena-engine-run.ts
@@ -1,0 +1,97 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
+import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import { simAthenaEngineResult } from "./sim-athena-engine-result.js";
+import type { SimAthenaSqlParser } from "./sim-athena-parser-module.js";
+import { simAthenaSqliteDatabase } from "./sim-athena-sqlite-database.js";
+import type { SimAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
+import {
+  simAthenaTableRows,
+  type SimAthenaLoadedTable,
+} from "./sim-athena-table-rows.js";
+import type { SimAthenaTableObjects } from "./sim-athena-table-objects.js";
+
+/** What one query is run with, once the engine is on and has somewhere to read. */
+export interface SimAthenaEngineRun {
+  readonly parser: SimAthenaSqlParser;
+  readonly sqlite: SimAthenaSqliteModule;
+  readonly objects: SimAthenaTableObjects;
+  readonly tables: readonly SimAthenaPlannedTable[];
+  readonly sessionDatabase: string | undefined;
+  readonly caller: SimAwsCaller | undefined;
+  readonly sql: string;
+}
+
+/**
+ * Load the tables, build the database and run the statement.
+ *
+ * Every failure from here is the engine turning the query down. Loading a table
+ * can fail on an object the caller cannot open, building the database can fail
+ * on a schema SQLite refuses, and running the statement can fail on anything
+ * the parser wrote that SQLite does not have. All three leave the declared
+ * result to answer.
+ */
+export async function simAthenaEngineRun(
+  run: SimAthenaEngineRun,
+): Promise<SimAthenaResolvedResult | undefined> {
+  try {
+    const loaded = await loadedTables(run);
+
+    if (loaded === undefined) {
+      return undefined;
+    }
+
+    const database = simAthenaSqliteDatabase({
+      sqlite: run.sqlite,
+      loaded,
+      sessionDatabase: run.sessionDatabase,
+    });
+
+    try {
+      return simAthenaEngineResult(database, run.sql, loaded);
+    } finally {
+      database.close();
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Every table the query reads, loaded once each.
+ *
+ * A statement naming one table twice resolves to two entries, and loading each
+ * of them would read the objects twice and then fail to create the table.
+ */
+async function loadedTables(
+  run: SimAthenaEngineRun,
+): Promise<readonly SimAthenaLoadedTable[] | undefined> {
+  const loaded = await Promise.all(
+    distinctTables(run.tables).map(async (planned) =>
+      simAthenaTableRows({ planned, objects: run.objects, caller: run.caller }),
+    ),
+  );
+
+  return loaded.includes(undefined)
+    ? undefined
+    : (loaded as readonly SimAthenaLoadedTable[]);
+}
+
+function distinctTables(
+  tables: readonly SimAthenaPlannedTable[],
+): readonly SimAthenaPlannedTable[] {
+  const seen = new Set<string>();
+
+  return tables.filter((planned) => {
+    const identity =
+      `${planned.table.databaseName}.${planned.table.name}`.toLowerCase();
+
+    if (seen.has(identity)) {
+      return false;
+    }
+
+    seen.add(identity);
+
+    return true;
+  });
+}

--- a/src/service/athena/engine/sim-athena-hive-partitions.ts
+++ b/src/service/athena/engine/sim-athena-hive-partitions.ts
@@ -1,0 +1,42 @@
+/**
+ * The partition values one object key carries, Hive style.
+ *
+ * `cloudfront/day=2026-08-01/part-0.json` gives a `day` of `2026-08-01`. This
+ * is what a table laid out under its own location without a
+ * `storage.location.template` looks like, and it is the only place a partition
+ * column's value is written for a table nothing projects.
+ *
+ * A segment carrying a dot is left alone, so a file called `a=b.json` is a
+ * file rather than a partition.
+ */
+export function simAthenaHivePartitionValues(
+  key: string,
+): Readonly<Record<string, string>> {
+  const values: Record<string, string> = {};
+
+  for (const segment of key.split("/")) {
+    const equals = segment.indexOf("=");
+
+    if (equals > 0 && !segment.includes(".")) {
+      values[segment.slice(0, equals)] = decodeSegment(
+        segment.slice(equals + 1),
+      );
+    }
+  }
+
+  return values;
+}
+
+/**
+ * One partition value, with any percent encoding taken back off.
+ *
+ * Hive writes a value carrying a slash or a space percent encoded into the key
+ * path, and the value a query compares against is the decoded one.
+ */
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/src/service/athena/engine/sim-athena-hive-partitions.ts
+++ b/src/service/athena/engine/sim-athena-hive-partitions.ts
@@ -6,18 +6,20 @@
  * `storage.location.template` looks like, and it is the only place a partition
  * column's value is written for a table nothing projects.
  *
- * A segment carrying a dot is left alone, so a file called `a=b.json` is a
- * file rather than a partition.
+ * Only the directories count. The last segment is the object's own name, and a
+ * file called `a=b.json` is a file. A directory is read whatever it holds, so a
+ * partition on `version=1.2` reads as `1.2`.
  */
 export function simAthenaHivePartitionValues(
   key: string,
 ): Readonly<Record<string, string>> {
   const values: Record<string, string> = {};
+  const directories = key.split("/").slice(0, -1);
 
-  for (const segment of key.split("/")) {
+  for (const segment of directories) {
     const equals = segment.indexOf("=");
 
-    if (equals > 0 && !segment.includes(".")) {
+    if (equals > 0) {
       values[segment.slice(0, equals)] = decodeSegment(
         segment.slice(equals + 1),
       );

--- a/src/service/athena/engine/sim-athena-json-shims.ts
+++ b/src/service/athena/engine/sim-athena-json-shims.ts
@@ -1,0 +1,105 @@
+import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
+
+import {
+  shimNumber,
+  shimText,
+  simAthenaScalarShim,
+} from "./sim-athena-shim-registry.js";
+
+/**
+ * Trino's JSON and array functions.
+ *
+ * A structured column is held as its JSON text, so each of these parses before
+ * it answers and a column holding something else answers null rather than
+ * failing the query.
+ */
+export function simAthenaInstallJsonShims(database: DatabaseSync): void {
+  simAthenaScalarShim(database, "json_extract_scalar", (json, path) =>
+    extractedScalar(shimText(json), shimText(path)),
+  );
+  simAthenaScalarShim(database, "cardinality", (value) => {
+    const parsed = parsedJson(shimText(value));
+
+    return Array.isArray(parsed) ? parsed.length : null;
+  });
+  simAthenaScalarShim(database, "element_at", (value, key) =>
+    elementAt(parsedJson(shimText(value)), key),
+  );
+}
+
+function parsedJson(text: string | undefined): unknown {
+  if (text === undefined) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * One scalar out of a JSON document, by a `$.a.b` path.
+ *
+ * Trino answers null for a path that reaches nothing and for a path that
+ * reaches an object or an array rather than a scalar.
+ */
+function extractedScalar(
+  json: string | undefined,
+  path: string | undefined,
+): string | number | null {
+  if (path === undefined) {
+    return null;
+  }
+
+  const keys = path.replace(/^\$\.?/u, "").split(".");
+  let current = parsedJson(json);
+
+  for (const key of keys) {
+    current = key.length === 0 ? current : propertyOf(current, key);
+  }
+
+  return scalarOf(current);
+}
+
+/**
+ * One element of an array or one value of a map.
+ *
+ * Trino counts an array from one and reads a map by its key, and the JSON
+ * behind either one says which of the two this is.
+ */
+function elementAt(
+  parsed: unknown,
+  key: SQLOutputValue,
+): string | number | null {
+  if (!Array.isArray(parsed)) {
+    return scalarOf(propertyOf(parsed, shimText(key) ?? ""));
+  }
+
+  const at = shimNumber(key);
+
+  return at === undefined ? null : scalarOf(parsed.at(at - 1));
+}
+
+function propertyOf(value: unknown, key: string): unknown {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !Object.hasOwn(value, key)
+  ) {
+    return undefined;
+  }
+
+  // The key comes out of the query's own JSON path, which is what this reads.
+  // oxlint-disable-next-line security/detect-object-injection
+  return (value as Record<string, unknown>)[key];
+}
+
+function scalarOf(value: unknown): string | number | null {
+  if (typeof value === "number" || typeof value === "string") {
+    return value;
+  }
+
+  return typeof value === "boolean" ? String(value) : null;
+}

--- a/src/service/athena/engine/sim-athena-json-shims.ts
+++ b/src/service/athena/engine/sim-athena-json-shims.ts
@@ -66,8 +66,9 @@ function extractedScalar(
 /**
  * One element of an array or one value of a map.
  *
- * Trino counts an array from one and reads a map by its key, and the JSON
- * behind either one says which of the two this is.
+ * Trino counts an array from one, counts back from the end for a negative
+ * index, and has no element at zero. It reads a map by its key instead, and the
+ * JSON behind either one says which of the two this is.
  */
 function elementAt(
   parsed: unknown,
@@ -79,7 +80,11 @@ function elementAt(
 
   const at = shimNumber(key);
 
-  return at === undefined ? null : scalarOf(parsed.at(at - 1));
+  if (at === undefined || at === 0) {
+    return null;
+  }
+
+  return scalarOf(parsed.at(at > 0 ? at - 1 : at));
 }
 
 function propertyOf(value: unknown, key: string): unknown {

--- a/src/service/athena/engine/sim-athena-parser-module.ts
+++ b/src/service/athena/engine/sim-athena-parser-module.ts
@@ -1,0 +1,72 @@
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+
+/**
+ * The two things the engine needs out of `node-sql-parser`.
+ *
+ * `astify` reads Athena's dialect and `sqlify` writes the same statement back
+ * out for SQLite. The AST in between is the library's own and is never read
+ * here, so it stays opaque.
+ */
+export interface SimAthenaSqlParser {
+  astify(sql: string, options: { database: string }): unknown;
+  sqlify(ast: unknown, options: { database: string }): string;
+}
+
+interface SimAthenaParserModule {
+  readonly Parser?: new () => SimAthenaSqlParser;
+  readonly default?: { readonly Parser: new () => SimAthenaSqlParser };
+}
+
+/**
+ * Where the Athena grammar sits inside the package.
+ *
+ * The package publishes one build per dialect and no `exports` map, so this
+ * deep path pulls the Athena grammar alone rather than all twenty. It is held
+ * as a variable rather than written into the `import()` so that building this
+ * repository never turns an optional dependency into a required one.
+ */
+const athenaGrammar = "node-sql-parser/build/athena.js";
+
+const missingPackage =
+  `Simulated Athena needs node-sql-parser to run a query. Add it to your ` +
+  `project as a dev dependency, or leave the engine off and declare what ` +
+  `each query answers with through results().`;
+
+/**
+ * The SQL parser, loaded when a test turns the engine on.
+ *
+ * `node-sql-parser` is an optional peer dependency, so a project that never
+ * runs a query never installs it. That is why the import is dynamic and why a
+ * failure to resolve it is reported as something to go and add.
+ *
+ * The grammar is a parameter so that a test can ask for one that is not
+ * installed and read what a project without the package is told.
+ */
+export async function simAthenaSqlParser(
+  grammar: string = athenaGrammar,
+): Promise<SimAthenaSqlParser> {
+  const module = await importedGrammar(grammar);
+  const Parser = module.Parser ?? module.default?.Parser;
+
+  if (Parser === undefined) {
+    throw new SimAthenaSetUpError(
+      `${grammar} carries no Parser. ${missingPackage}`,
+    );
+  }
+
+  return new Parser();
+}
+
+async function importedGrammar(
+  grammar: string,
+): Promise<SimAthenaParserModule> {
+  try {
+    return (await import(grammar)) as SimAthenaParserModule;
+  } catch (error) {
+    const setUp = new SimAthenaSetUpError(missingPackage);
+
+    setUp.cause = error;
+
+    throw setUp;
+  }
+}

--- a/src/service/athena/engine/sim-athena-partitioned-objects.ts
+++ b/src/service/athena/engine/sim-athena-partitioned-objects.ts
@@ -1,0 +1,45 @@
+import { simAthenaObjectsUnder } from "../execution/sim-athena-listed-objects.js";
+import type {
+  SimAthenaListedObject,
+  SimAthenaListingRequest,
+} from "../execution/sim-athena-scanned-objects.js";
+import type { SimAthenaTablePartition } from "../projection/sim-athena-projection-location.js";
+
+/** One object to read, and the partition it was reached through. */
+export interface SimAthenaPartitionedObject {
+  readonly object: SimAthenaListedObject;
+  readonly values: ReadonlyMap<string, string>;
+}
+
+/**
+ * Every object one table's partitions reach, each one read once.
+ *
+ * A table location sitting above its own partitions reaches the same object
+ * twice, and its rows belong to whichever partition got there first.
+ */
+export async function simAthenaPartitionedObjects(
+  listing: SimAthenaListingRequest,
+  partitions: readonly SimAthenaTablePartition[],
+): Promise<readonly SimAthenaPartitionedObject[]> {
+  const listed = await Promise.all(
+    partitions.map(async (partition) => ({
+      values: partition.values,
+      objects: await simAthenaObjectsUnder(listing, partition.prefix),
+    })),
+  );
+  const seen = new Set<string>();
+  const objects: SimAthenaPartitionedObject[] = [];
+
+  for (const partition of listed) {
+    for (const object of partition.objects) {
+      const identity = `${object.bucket}/${object.key}`;
+
+      if (!seen.has(identity)) {
+        seen.add(identity);
+        objects.push({ object, values: partition.values });
+      }
+    }
+  }
+
+  return objects;
+}

--- a/src/service/athena/engine/sim-athena-query-engine.ts
+++ b/src/service/athena/engine/sim-athena-query-engine.ts
@@ -1,0 +1,91 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
+import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import { simAthenaEngineRun } from "./sim-athena-engine-run.js";
+import {
+  simAthenaSqlParser,
+  type SimAthenaSqlParser,
+} from "./sim-athena-parser-module.js";
+import {
+  simAthenaSqliteModule,
+  type SimAthenaSqliteModule,
+} from "./sim-athena-sqlite-module.js";
+import { simAthenaSqliteSql } from "./sim-athena-sql-translation.js";
+import type { SimAthenaTableObjects } from "./sim-athena-table-objects.js";
+
+/** What one query is run against. */
+export interface SimAthenaEngineRequest {
+  readonly queryString: string;
+  readonly tables: readonly SimAthenaPlannedTable[];
+  readonly sessionDatabase: string | undefined;
+  readonly objects: SimAthenaTableObjects | undefined;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * The query engine one simulated Athena scope answers with, when a test turns
+ * it on.
+ *
+ * It is off by default and `enable()` is what turns it on. A project holding
+ * `node-sql-parser` for a reason of its own would otherwise find simulated
+ * Athena answering differently from the version before it, and a query engine
+ * arriving unasked for is not a change a test suite should have to notice.
+ *
+ * Turning it on loads the parser, so a project that has not added the package
+ * finds out at the line that asked for the engine rather than inside a query
+ * that quietly fell back.
+ *
+ * Everything the engine cannot do, it turns down. A statement Athena's grammar
+ * refuses, a table in a format it has no reader for, an object it cannot open
+ * and a statement SQLite will not run all end the same way: no result, and the
+ * declaration a test wrote answers the query instead.
+ */
+export class SimAthenaQueryEngine {
+  #parser: SimAthenaSqlParser | undefined;
+  #sqlite: SimAthenaSqliteModule | undefined;
+
+  /** Whether this scope runs queries rather than answering from declarations. */
+  get isEnabled(): boolean {
+    return this.#parser !== undefined;
+  }
+
+  /**
+   * Run queries in this scope for real, loading the SQL parser.
+   *
+   * Raises where `node-sql-parser` is absent, naming what to add. It is an
+   * optional peer dependency, so a project that never runs a query never
+   * installs it.
+   */
+  async enable(): Promise<void> {
+    const parser = await simAthenaSqlParser();
+
+    this.#sqlite = await simAthenaSqliteModule();
+    this.#parser = parser;
+  }
+
+  /** Answer queries from declarations again. */
+  disable(): void {
+    this.#parser = undefined;
+  }
+
+  /**
+   * What one query answers with, or nothing where the engine turned it down.
+   */
+  async run(
+    request: SimAthenaEngineRequest,
+  ): Promise<SimAthenaResolvedResult | undefined> {
+    const parser = this.#parser;
+    const sqlite = this.#sqlite;
+    const { objects } = request;
+
+    if (parser === undefined || sqlite === undefined || objects === undefined) {
+      return undefined;
+    }
+
+    const sql = simAthenaSqliteSql(parser, request.queryString);
+
+    return sql === undefined
+      ? undefined
+      : simAthenaEngineRun({ ...request, parser, sqlite, objects, sql });
+  }
+}

--- a/src/service/athena/engine/sim-athena-record-reader.ts
+++ b/src/service/athena/engine/sim-athena-record-reader.ts
@@ -1,0 +1,126 @@
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
+import {
+  simAthenaDelimitedRows,
+  type SimAthenaDelimitedFormat,
+} from "./sim-athena-delimited-records.js";
+import type { SimAthenaEngineRow } from "./sim-athena-engine-row.js";
+
+/** One object's bytes, read into the rows it holds. */
+export type SimAthenaRecordReader = (
+  text: string,
+) => readonly SimAthenaEngineRow[];
+
+/** The SerDe class names that mean JSON lines. */
+const jsonSerDes = new Set([
+  "org.openx.data.jsonserde.jsonserde",
+  "org.apache.hive.hcatalog.data.jsonserde",
+  "org.apache.hadoop.hive.serde2.jsonserde",
+]);
+
+/** What one delimited SerDe reads before its parameters are applied. */
+interface SimAthenaSerDeDefaults {
+  readonly delimiter: string;
+  readonly quoted: boolean;
+}
+
+/**
+ * The SerDe class names that mean delimited text, and what each one reads
+ * before the table's own parameters are applied.
+ *
+ * `OpenCSVSerde` is comma separated and quoted. `LazySimpleSerDe` is what
+ * `ROW FORMAT DELIMITED` gives: it quotes nothing, and its own default
+ * delimiter is the control character Hive has always used rather than a comma.
+ */
+const delimitedSerDes: ReadonlyMap<string, SimAthenaSerDeDefaults> = new Map([
+  [
+    "org.apache.hadoop.hive.serde2.opencsvserde",
+    { delimiter: ",", quoted: true },
+  ],
+  [
+    "org.apache.hadoop.hive.serde2.lazy.lazysimpleserde",
+    { delimiter: "\u{1}", quoted: false },
+  ],
+]);
+
+/**
+ * How one table's objects are decoded, or nothing where this simulation has no
+ * reader for what the table declares.
+ *
+ * The SerDe is what says so, the way it says so on real Athena. A table
+ * holding Parquet or ORC lands here, and the query falls back to whatever a
+ * test declared. A table declaring no SerDe at all lands here too: nothing
+ * else in the catalog says what the bytes are, and guessing would answer a
+ * Parquet query with nonsense rather than turning it down.
+ */
+export function simAthenaRecordReader(
+  table: SimAthenaCatalogTable,
+): SimAthenaRecordReader | undefined {
+  const library =
+    table.storageDescriptor?.SerdeInfo?.SerializationLibrary?.toLowerCase();
+
+  if (library === undefined) {
+    return undefined;
+  }
+
+  if (jsonSerDes.has(library)) {
+    return jsonRows;
+  }
+
+  const defaults = delimitedSerDes.get(library);
+
+  if (defaults === undefined) {
+    return undefined;
+  }
+
+  const format = delimitedFormat(table, defaults);
+  const columns = table.columns.map((column) => column.Name);
+
+  return (text) => simAthenaDelimitedRows(text, format, columns);
+}
+
+/**
+ * JSON lines, one record per line.
+ *
+ * A nested object or array is kept as its JSON text, which is what makes
+ * `json_extract_scalar` and `cardinality` reach into it.
+ */
+function jsonRows(text: string): readonly SimAthenaEngineRow[] {
+  return text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as SimAthenaEngineRow);
+}
+
+function delimitedFormat(
+  table: SimAthenaCatalogTable,
+  defaults: SimAthenaSerDeDefaults,
+): SimAthenaDelimitedFormat {
+  const parameters = table.storageDescriptor?.SerdeInfo?.Parameters ?? {};
+  const quoted = defaults.quoted || parameters["quoteChar"] !== undefined;
+
+  return {
+    delimiter:
+      parameters["separatorChar"] ??
+      parameters["field.delim"] ??
+      defaults.delimiter,
+    quote: quoted ? (parameters["quoteChar"] ?? '"') : undefined,
+    escape: quoted ? (parameters["escapeChar"] ?? "\\") : undefined,
+    skipHeaderLines: skippedHeaderLines(table),
+  };
+}
+
+/**
+ * How many lines of every object are a header rather than a row.
+ *
+ * `skip.header.line.count` is a table property on real Athena, and the storage
+ * descriptor's own parameters are read as well because a template can put it
+ * in either place.
+ */
+function skippedHeaderLines(table: SimAthenaCatalogTable): number {
+  const declared =
+    table.parameters["skip.header.line.count"] ??
+    table.storageDescriptor?.Parameters?.["skip.header.line.count"];
+  const count = Math.trunc(Number(declared ?? ""));
+
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}

--- a/src/service/athena/engine/sim-athena-result-columns.ts
+++ b/src/service/athena/engine/sim-athena-result-columns.ts
@@ -1,0 +1,119 @@
+// A result row is an array in the statement's own column order, so every
+// read of one is by a position worked out at run time.
+// oxlint-disable security/detect-object-injection
+import type { SQLOutputValue, StatementColumnMetadata } from "node:sqlite";
+
+import type { SimAthenaDeclaredColumn } from "../result/sim-athena-declared-result.js";
+import {
+  defaultAthenaResultType,
+  simAthenaResultType,
+} from "./sim-athena-column-types.js";
+import type { SimAthenaLoadedTable } from "./sim-athena-table-rows.js";
+
+/** A name a statement could have written itself, rather than one SQLite made up. */
+const identifier = /^[A-Za-z_][\dA-Za-z_]*$/u;
+
+/**
+ * The columns a result set reports, named and typed as Athena names and types
+ * them.
+ *
+ * A column SQLite traces back to a table takes that table's Glue type, which
+ * is what makes a boolean read as `true` rather than as `1`. A computed column
+ * has no such origin, so its type is read off the first value that is not
+ * null.
+ *
+ * An expression nobody named is called `_col0` upward, which is what Athena
+ * calls one. SQLite names it after the expression instead, and a name that
+ * could not have been written as an identifier is how that is told apart from
+ * an alias a statement chose.
+ */
+export function simAthenaResultColumns(
+  metadata: readonly StatementColumnMetadata[],
+  rows: readonly (readonly SQLOutputValue[])[],
+  loaded: readonly SimAthenaLoadedTable[],
+): readonly SimAthenaDeclaredColumn[] {
+  const types = glueColumnTypes(loaded);
+
+  return metadata.map((column, index) => ({
+    name: nameOf(column, index),
+    type:
+      column.column === null
+        ? inferredType(rows, index)
+        : simAthenaResultType(types.get(originOf(column))),
+  }));
+}
+
+function nameOf(column: StatementColumnMetadata, index: number): string {
+  const { name } = column;
+
+  if (column.column !== null || identifier.test(name)) {
+    return name;
+  }
+
+  return `_col${String(index)}`;
+}
+
+function originOf(column: StatementColumnMetadata): string {
+  return [column.database, column.table, column.column]
+    .map((part) => (part ?? "").toLowerCase())
+    .join(".");
+}
+
+/**
+ * Every loaded column's Glue type, keyed the way SQLite reports a column's
+ * origin.
+ *
+ * A table the query context let a statement name unqualified is held in
+ * SQLite's `main` schema as well as its own, so both keys are written.
+ */
+function glueColumnTypes(
+  loaded: readonly SimAthenaLoadedTable[],
+): ReadonlyMap<string, string | undefined> {
+  const types = new Map<string, string | undefined>();
+
+  for (const one of loaded) {
+    for (const column of [...one.table.columns, ...one.table.partitionKeys]) {
+      const suffix = `${one.table.name}.${column.Name}`.toLowerCase();
+
+      types.set(
+        `${one.table.databaseName.toLowerCase()}.${suffix}`,
+        column.Type,
+      );
+      types.set(`main.${suffix}`, column.Type);
+    }
+  }
+
+  return types;
+}
+
+/**
+ * The type a computed column reports, taken from what it answered with.
+ *
+ * SQLite carries no type for an expression, and a column of nulls carries no
+ * value to read one off, so that falls back to `varchar` the way an
+ * undeclared column does.
+ */
+function inferredType(
+  rows: readonly (readonly SQLOutputValue[])[],
+  index: number,
+): string {
+  for (const row of rows) {
+    const value = row[index];
+
+    if (value === null || value === undefined) {
+      continue;
+    }
+
+    if (typeof value === "bigint") {
+      return "bigint";
+    }
+
+    if (typeof value === "number") {
+      return Number.isSafeInteger(value) ? "bigint" : "double";
+    }
+
+    return typeof value === "string" ? "varchar" : "varbinary";
+  }
+
+  return defaultAthenaResultType;
+}

--- a/src/service/athena/engine/sim-athena-shim-registry.ts
+++ b/src/service/athena/engine/sim-athena-shim-registry.ts
@@ -1,0 +1,45 @@
+import type { DatabaseSync, SQLInputValue, SQLOutputValue } from "node:sqlite";
+
+/** One Trino scalar function, as SQLite will call it. */
+export type SimAthenaScalarShim = (
+  ...values: SQLOutputValue[]
+) => SQLInputValue;
+
+/**
+ * Register one Trino scalar function on this database.
+ *
+ * Every shim takes any number of arguments, because SQLite checks the count
+ * against the JavaScript function's own arity otherwise and a Trino function
+ * with an optional argument would stop resolving.
+ */
+export function simAthenaScalarShim(
+  database: DatabaseSync,
+  name: string,
+  implementation: SimAthenaScalarShim,
+): void {
+  database.function(
+    name,
+    { varargs: true, deterministic: true },
+    implementation,
+  );
+}
+
+/** One argument as text, or nothing where it is null. */
+export function shimText(
+  value: SQLOutputValue | undefined,
+): string | undefined {
+  return value === null || value === undefined ? undefined : String(value);
+}
+
+/** One argument as a number, or nothing where it is not one. */
+export function shimNumber(
+  value: SQLOutputValue | undefined,
+): number | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/src/service/athena/engine/sim-athena-shim.fixture.ts
+++ b/src/service/athena/engine/sim-athena-shim.fixture.ts
@@ -1,0 +1,54 @@
+import { simAthenaSqliteDatabase } from "./sim-athena-sqlite-database.js";
+import { simAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
+
+/**
+ * What one expression comes to on the database the engine builds.
+ *
+ * The database is empty, since a Trino function shim answers from its
+ * arguments rather than from a table.
+ */
+export async function anAnsweredExpression(
+  expression: string,
+): Promise<unknown> {
+  const sqlite = await simAthenaSqliteModule();
+  const database = simAthenaSqliteDatabase({
+    sqlite,
+    loaded: [],
+    sessionDatabase: undefined,
+  });
+
+  try {
+    const answered = database
+      .prepare(`SELECT ${expression} AS answered`)
+      .get() as { answered: unknown } | undefined;
+
+    return answered?.answered;
+  } finally {
+    database.close();
+  }
+}
+
+/**
+ * What one aggregate comes to over a column of values.
+ *
+ * The values are written into the statement rather than into a table, because
+ * a table would need a catalog and a Bucket to sit behind it.
+ */
+export async function anAggregatedExpression(
+  expression: string,
+  values: readonly (string | number | null)[],
+): Promise<unknown> {
+  const rows = values
+    .map((value) => `SELECT ${literal(value)} AS value`)
+    .join(" UNION ALL ");
+
+  return anAnsweredExpression(`(SELECT ${expression} FROM (${rows}))`);
+}
+
+function literal(value: string | number | null): string {
+  if (value === null) {
+    return "NULL";
+  }
+
+  return typeof value === "number" ? String(value) : `'${value}'`;
+}

--- a/src/service/athena/engine/sim-athena-sql-rewrites.ts
+++ b/src/service/athena/engine/sim-athena-sql-rewrites.ts
@@ -20,9 +20,12 @@ export function simAthenaSqlForParser(sql: string): string {
 /**
  * An ascending sort, and what can follow the item it sorts once the parser has
  * written the statement back out.
+ *
+ * A window's own `ORDER BY` is followed by its frame, so `ROWS`, `RANGE` and
+ * `GROUPS` belong here alongside the ones that end a statement's.
  */
 const ascendingSort =
-  /\bASC\b(?=\s*(?:,|\)|$|LIMIT\b|OFFSET\b|UNION\b|EXCEPT\b|INTERSECT\b))/gu;
+  /\bASC\b(?=\s*(?:,|\)|$|LIMIT\b|OFFSET\b|UNION\b|EXCEPT\b|INTERSECT\b|ROWS\b|RANGE\b|GROUPS\b))/gu;
 
 /**
  * The statement as SQLite will take it.

--- a/src/service/athena/engine/sim-athena-sql-rewrites.ts
+++ b/src/service/athena/engine/sim-athena-sql-rewrites.ts
@@ -1,0 +1,43 @@
+/**
+ * The statement as the parser's Athena grammar will take it.
+ *
+ * Both rewrites close a gap in that grammar rather than a gap in SQLite.
+ * `try_cast` becomes a plain cast, which changes meaning in the forgiving
+ * direction, since SQLite already answers with a value where a cast fails
+ * rather than failing the query. Trino writes `OFFSET` before `LIMIT` and
+ * every other dialect writes it after.
+ */
+export function simAthenaSqlForParser(sql: string): string {
+  return sql
+    .replaceAll(/\btry_cast\s*\(/giu, "CAST(")
+    .replaceAll(
+      /\bOFFSET\s+(\d+)\s+LIMIT\s+(\d+)/giu,
+      (_match, offset: string, limit: string) =>
+        `LIMIT ${limit} OFFSET ${offset}`,
+    );
+}
+
+/**
+ * An ascending sort, and what can follow the item it sorts once the parser has
+ * written the statement back out.
+ */
+const ascendingSort =
+  /\bASC\b(?=\s*(?:,|\)|$|LIMIT\b|OFFSET\b|UNION\b|EXCEPT\b|INTERSECT\b))/gu;
+
+/**
+ * The statement as SQLite will take it.
+ *
+ * `ASC NULLS LAST` is the one that matters. Trino orders nulls last whichever
+ * direction it sorts, and SQLite orders them first ascending, so a query with
+ * a nullable sort column answers in a different order under each. Descending
+ * already agrees. The parser writes `ASC` out explicitly even where the
+ * statement left the direction off, so every ascending sort is reached here.
+ *
+ * A typed `DATE` or `TIMESTAMP` literal becomes the bare string it wraps,
+ * which is how the value was stored.
+ */
+export function simAthenaSqlForSqlite(sql: string): string {
+  return sql
+    .replaceAll(ascendingSort, "ASC NULLS LAST")
+    .replaceAll(/\b(?:DATE|TIMESTAMP)\s+'([^']*)'/giu, "'$1'");
+}

--- a/src/service/athena/engine/sim-athena-sql-translation.ts
+++ b/src/service/athena/engine/sim-athena-sql-translation.ts
@@ -1,0 +1,30 @@
+import type { SimAthenaSqlParser } from "./sim-athena-parser-module.js";
+import {
+  simAthenaSqlForParser,
+  simAthenaSqlForSqlite,
+} from "./sim-athena-sql-rewrites.js";
+
+/**
+ * One Athena statement written back out for SQLite, or nothing where it cannot
+ * be.
+ *
+ * A statement the Athena grammar refuses and one the parser cannot write back
+ * out both land the same way, because the engine has one answer to either:
+ * turn the query down and let the declared result take it. Nothing is reported
+ * from here, since a query the engine cannot run is an ordinary thing for a
+ * test to write rather than a fault.
+ */
+export function simAthenaSqliteSql(
+  parser: SimAthenaSqlParser,
+  athenaSql: string,
+): string | undefined {
+  try {
+    const ast = parser.astify(simAthenaSqlForParser(athenaSql), {
+      database: "athena",
+    });
+
+    return simAthenaSqlForSqlite(parser.sqlify(ast, { database: "sqlite" }));
+  } catch {
+    return undefined;
+  }
+}

--- a/src/service/athena/engine/sim-athena-sqlite-database.ts
+++ b/src/service/athena/engine/sim-athena-sqlite-database.ts
@@ -31,7 +31,8 @@ interface SimAthenaSqliteDatabaseRequest {
  * `rainlytics.access_logs` in the statement resolves with nothing renamed.
  * SQLite refuses to reach across attached schemas from a view, so a table the
  * query context lets a statement name unqualified is created twice rather than
- * aliased.
+ * aliased. A Glue database called `main` is already there, and creating it a
+ * second time would be the same table twice over.
  */
 export function simAthenaSqliteDatabase(
   request: SimAthenaSqliteDatabaseRequest,
@@ -60,7 +61,7 @@ export function simAthenaSqliteDatabase(
 
     simAthenaCreateTable(database, schema, loaded);
 
-    if (schema === request.sessionDatabase) {
+    if (schema !== mainSchema && schema === request.sessionDatabase) {
       simAthenaCreateTable(database, mainSchema, loaded);
     }
   }

--- a/src/service/athena/engine/sim-athena-sqlite-database.ts
+++ b/src/service/athena/engine/sim-athena-sqlite-database.ts
@@ -1,0 +1,69 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { simAthenaInstallAggregateShims } from "./sim-athena-aggregate-shims.js";
+import { simAthenaInstallDateShims } from "./sim-athena-date-shims.js";
+import { simAthenaInstallJsonShims } from "./sim-athena-json-shims.js";
+import { simAthenaInstallStringShims } from "./sim-athena-string-shims.js";
+import type { SimAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
+import { simAthenaCreateTable } from "./sim-athena-sqlite-tables.js";
+import type { SimAthenaLoadedTable } from "./sim-athena-table-rows.js";
+
+/** The SQLite schema an unqualified table name resolves in. */
+const mainSchema = "main";
+
+interface SimAthenaSqliteDatabaseRequest {
+  readonly sqlite: SimAthenaSqliteModule;
+  readonly loaded: readonly SimAthenaLoadedTable[];
+
+  /**
+   * The database a query runs in, where its context named one.
+   *
+   * A query naming its table unqualified is resolved against this, so the
+   * tables in it are created in SQLite's own `main` schema as well.
+   */
+  readonly sessionDatabase: string | undefined;
+}
+
+/**
+ * An in-memory SQLite database holding one query's tables.
+ *
+ * Each Glue database is attached as a SQLite schema of the same name, so
+ * `rainlytics.access_logs` in the statement resolves with nothing renamed.
+ * SQLite refuses to reach across attached schemas from a view, so a table the
+ * query context lets a statement name unqualified is created twice rather than
+ * aliased.
+ */
+export function simAthenaSqliteDatabase(
+  request: SimAthenaSqliteDatabaseRequest,
+): DatabaseSync {
+  const database = new request.sqlite.DatabaseSync(":memory:");
+
+  // SQLite matches LIKE without regard to case for ASCII and Athena matches it
+  // with. Without this a filter quietly takes in rows Athena excludes, which is
+  // a passing test and a wrong answer.
+  database.exec("PRAGMA case_sensitive_like = ON");
+
+  simAthenaInstallDateShims(database);
+  simAthenaInstallJsonShims(database);
+  simAthenaInstallStringShims(database);
+  simAthenaInstallAggregateShims(database);
+
+  const attached = new Set<string>([mainSchema]);
+
+  for (const loaded of request.loaded) {
+    const schema = loaded.table.databaseName;
+
+    if (!attached.has(schema)) {
+      database.exec(`ATTACH ':memory:' AS "${schema.replaceAll('"', '""')}"`);
+      attached.add(schema);
+    }
+
+    simAthenaCreateTable(database, schema, loaded);
+
+    if (schema === request.sessionDatabase) {
+      simAthenaCreateTable(database, mainSchema, loaded);
+    }
+  }
+
+  return database;
+}

--- a/src/service/athena/engine/sim-athena-sqlite-module.ts
+++ b/src/service/athena/engine/sim-athena-sqlite-module.ts
@@ -1,0 +1,56 @@
+import type { DatabaseSync } from "node:sqlite";
+
+/** The one thing the engine needs out of `node:sqlite`. */
+export interface SimAthenaSqliteModule {
+  readonly DatabaseSync: new (path: string) => DatabaseSync;
+}
+
+/**
+ * `node:sqlite`, loaded when a test turns the engine on.
+ *
+ * The import is dynamic so that the experimental warning Node prints on the
+ * first one stays out of a run that never asked for a query engine.
+ *
+ * Node's own warning listeners are taken off around the import and put back
+ * afterwards, so a project that installed one of its own keeps it, along with
+ * every other warning it would have printed. The swap outlives the import by a
+ * tick because `process.emitWarning` defers delivery, and restoring
+ * synchronously would put the listeners back before the warning arrives.
+ */
+export async function simAthenaSqliteModule(): Promise<SimAthenaSqliteModule> {
+  const listeners = process.listeners("warning");
+
+  process.removeAllListeners("warning");
+  process.on("warning", (warning) => {
+    if (isSqliteWarning(warning)) {
+      return;
+    }
+
+    for (const listener of listeners) {
+      listener(warning);
+    }
+  });
+
+  try {
+    return await import("node:sqlite");
+  } finally {
+    await deliveryTick();
+    process.removeAllListeners("warning");
+
+    for (const listener of listeners) {
+      process.on("warning", listener);
+    }
+  }
+}
+
+function deliveryTick(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+function isSqliteWarning(warning: Error): boolean {
+  return (
+    warning.name === "ExperimentalWarning" && warning.message.includes("SQLite")
+  );
+}

--- a/src/service/athena/engine/sim-athena-sqlite-tables.ts
+++ b/src/service/athena/engine/sim-athena-sqlite-tables.ts
@@ -1,0 +1,77 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import type { SimAthenaCatalogColumn } from "../table/sim-athena-catalog-table.js";
+import { simAthenaSqliteAffinity } from "./sim-athena-column-types.js";
+import { simAthenaRowValue } from "./sim-athena-engine-row.js";
+import type { SimAthenaLoadedTable } from "./sim-athena-table-rows.js";
+import { simAthenaSqliteValue } from "./sim-athena-sqlite-values.js";
+
+/**
+ * Every column one table's rows are held under.
+ *
+ * The partition keys come after the data columns, which is the order Athena
+ * itself puts them in and the order `SELECT *` answers with. A key repeating
+ * the name of a data column is dropped, since SQLite refuses a table with two
+ * columns of one name and a Glue table carrying that duplicate is one real
+ * Athena refuses to query anyway.
+ */
+export function simAthenaTableColumns(
+  table: SimAthenaLoadedTable["table"],
+): readonly SimAthenaCatalogColumn[] {
+  const seen = new Set<string>();
+
+  return [...table.columns, ...table.partitionKeys].filter((column) => {
+    const name = column.Name.toLowerCase();
+
+    if (seen.has(name)) {
+      return false;
+    }
+
+    seen.add(name);
+
+    return true;
+  });
+}
+
+/**
+ * Create one loaded table inside one SQLite schema and fill it.
+ *
+ * The schema is the Glue database, so `rainlytics.access_logs` in the query
+ * resolves without anything being renamed.
+ */
+export function simAthenaCreateTable(
+  database: DatabaseSync,
+  schema: string,
+  loaded: SimAthenaLoadedTable,
+): void {
+  const columns = simAthenaTableColumns(loaded.table);
+  const qualified = `${quoted(schema)}.${quoted(loaded.table.name)}`;
+  const declarations = columns
+    .map(
+      (column) =>
+        `${quoted(column.Name)} ${simAthenaSqliteAffinity(column.Type)}`,
+    )
+    .join(", ");
+
+  // A table declaring no columns is refused here, and the engine turns the
+  // query down. SQLite has no table without columns, and neither has Athena.
+  database.exec(`CREATE TABLE ${qualified} (${declarations})`);
+
+  const names = columns.map((column) => quoted(column.Name)).join(", ");
+  const holes = columns.map(() => "?").join(", ");
+  const insert = database.prepare(
+    `INSERT INTO ${qualified} (${names}) VALUES (${holes})`,
+  );
+
+  for (const row of loaded.rows) {
+    insert.run(
+      ...columns.map((column) =>
+        simAthenaSqliteValue(simAthenaRowValue(row, column.Name), column.Type),
+      ),
+    );
+  }
+}
+
+function quoted(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}

--- a/src/service/athena/engine/sim-athena-sqlite-values.ts
+++ b/src/service/athena/engine/sim-athena-sqlite-values.ts
@@ -1,0 +1,50 @@
+import { simAthenaIsBooleanType } from "./sim-athena-column-types.js";
+
+/** What SQLite will take as a bound parameter. */
+export type SimAthenaSqliteValue = string | number | bigint | null;
+
+/** How delimited text writes a boolean, which JSON writes as a keyword. */
+const booleanText: ReadonlyMap<string, number> = new Map([
+  ["true", 1],
+  ["false", 0],
+  ["1", 1],
+  ["0", 0],
+]);
+
+/**
+ * One decoded value, as SQLite will hold it.
+ *
+ * SQLite has no boolean and no structured types. A boolean is stored as a whole
+ * number and read back out by what the Glue column declared, and an object or
+ * an array is stored as its JSON text, which is what makes
+ * `json_extract_scalar` and `cardinality` reach into it.
+ *
+ * The Glue type is read for one reason. JSON carries a boolean as a keyword and
+ * delimited text carries it as the word `true`, and a column holding the word
+ * would otherwise compare against nothing and read back as `true` whichever
+ * value it held.
+ */
+export function simAthenaSqliteValue(
+  value: unknown,
+  glueType: string | undefined,
+): SimAthenaSqliteValue {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? 1 : 0;
+  }
+
+  if (typeof value === "string") {
+    return simAthenaIsBooleanType(glueType)
+      ? (booleanText.get(value.toLowerCase()) ?? null)
+      : value;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  return typeof value === "bigint" ? value : JSON.stringify(value);
+}

--- a/src/service/athena/engine/sim-athena-string-shims.ts
+++ b/src/service/athena/engine/sim-athena-string-shims.ts
@@ -1,0 +1,61 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import {
+  shimNumber,
+  shimText,
+  simAthenaScalarShim,
+} from "./sim-athena-shim-registry.js";
+
+/** Trino's string functions. */
+export function simAthenaInstallStringShims(database: DatabaseSync): void {
+  simAthenaScalarShim(database, "regexp_like", (value, pattern) =>
+    matches(shimText(value), shimText(pattern)),
+  );
+  simAthenaScalarShim(database, "split_part", (value, delimiter, index) =>
+    splitPart(shimText(value), shimText(delimiter), shimNumber(index)),
+  );
+  simAthenaScalarShim(database, "strpos", (value, search) =>
+    position(shimText(value), shimText(search)),
+  );
+}
+
+function matches(
+  value: string | undefined,
+  pattern: string | undefined,
+): number | null {
+  if (value === undefined || pattern === undefined) {
+    return null;
+  }
+
+  try {
+    // The pattern is the query's own, which is the whole point of the function.
+    // oxlint-disable-next-line security/detect-non-literal-regexp
+    return new RegExp(pattern, "u").test(value) ? 1 : 0;
+  } catch {
+    return null;
+  }
+}
+
+function splitPart(
+  value: string | undefined,
+  delimiter: string | undefined,
+  index: number | undefined,
+): string | null {
+  if (value === undefined || delimiter === undefined || index === undefined) {
+    return null;
+  }
+
+  return value.split(delimiter).at(index - 1) ?? null;
+}
+
+/** Trino counts the position of a substring from one, and zero for absent. */
+function position(
+  value: string | undefined,
+  search: string | undefined,
+): number | null {
+  if (value === undefined || search === undefined) {
+    return null;
+  }
+
+  return value.indexOf(search) + 1;
+}

--- a/src/service/athena/engine/sim-athena-string-shims.ts
+++ b/src/service/athena/engine/sim-athena-string-shims.ts
@@ -36,6 +36,7 @@ function matches(
   }
 }
 
+/** Trino counts the fields from one, and has no field below that. */
 function splitPart(
   value: string | undefined,
   delimiter: string | undefined,
@@ -45,7 +46,7 @@ function splitPart(
     return null;
   }
 
-  return value.split(delimiter).at(index - 1) ?? null;
+  return index < 1 ? null : (value.split(delimiter)[index - 1] ?? null);
 }
 
 /** Trino counts the position of a substring from one, and zero for absent. */

--- a/src/service/athena/engine/sim-athena-table-objects.ts
+++ b/src/service/athena/engine/sim-athena-table-objects.ts
@@ -1,0 +1,47 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAthenaScannedObjects } from "../execution/sim-athena-scanned-objects.js";
+
+/**
+ * The narrow slice of simulated S3 the query engine reads a table through.
+ *
+ * Listing is what measuring a query already needed. Opening an object is what
+ * the engine adds, since it answers from the rows rather than from the sizes.
+ * `SimS3` structurally implements both.
+ */
+export interface SimAthenaTableObjects extends SimAthenaScannedObjects {
+  getObject(
+    command: { input: { Bucket: string; Key: string } },
+    options?: { caller: SimAwsCaller },
+  ): Promise<{ Body?: AsyncIterable<Uint8Array> | undefined }>;
+}
+
+/**
+ * Whether this simulated S3 can open an object as well as list one.
+ *
+ * A standalone `SimAthena` has neither, and the engine turns every query down
+ * there because nothing holds the data it would answer from.
+ */
+export function simAthenaTableObjects(
+  s3: Partial<SimAthenaTableObjects> | undefined,
+): SimAthenaTableObjects | undefined {
+  return s3?.listObjectsV2 === undefined || s3.getObject === undefined
+    ? undefined
+    : (s3 as SimAthenaTableObjects);
+}
+
+/** One object's bytes, read as UTF-8 text. */
+export async function simAthenaObjectText(
+  objects: SimAthenaTableObjects,
+  bucket: string,
+  key: string,
+  caller: SimAwsCaller | undefined,
+): Promise<string> {
+  const got = await objects.getObject(
+    { input: { Bucket: bucket, Key: key } },
+    caller === undefined ? undefined : { caller },
+  );
+
+  const chunks = await Array.fromAsync(got.Body ?? []);
+
+  return new TextDecoder().decode(Buffer.concat(chunks));
+}

--- a/src/service/athena/engine/sim-athena-table-rows.ts
+++ b/src/service/athena/engine/sim-athena-table-rows.ts
@@ -1,0 +1,85 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
+import type { SimAthenaEngineRow } from "./sim-athena-engine-row.js";
+import { simAthenaHivePartitionValues } from "./sim-athena-hive-partitions.js";
+import {
+  simAthenaPartitionedObjects,
+  type SimAthenaPartitionedObject,
+} from "./sim-athena-partitioned-objects.js";
+import {
+  simAthenaRecordReader,
+  type SimAthenaRecordReader,
+} from "./sim-athena-record-reader.js";
+import {
+  simAthenaObjectText,
+  type SimAthenaTableObjects,
+} from "./sim-athena-table-objects.js";
+
+/** One table a query reads, with the rows the engine loaded for it. */
+export interface SimAthenaLoadedTable {
+  readonly table: SimAthenaCatalogTable;
+  readonly rows: readonly SimAthenaEngineRow[];
+}
+
+interface SimAthenaTableRowsRequest {
+  readonly planned: SimAthenaPlannedTable;
+  readonly objects: SimAthenaTableObjects;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * Every row one table holds for this query, or nothing where the engine has no
+ * reader for what the table declares.
+ *
+ * The rows come from the objects under the partitions the plan reached, so a
+ * query the partition filter narrowed reads only the partitions it left.
+ */
+export async function simAthenaTableRows(
+  request: SimAthenaTableRowsRequest,
+): Promise<SimAthenaLoadedTable | undefined> {
+  const { table } = request.planned;
+  const reader = simAthenaRecordReader(table);
+
+  if (reader === undefined) {
+    return undefined;
+  }
+
+  const objects = await simAthenaPartitionedObjects(
+    { s3: request.objects, caller: request.caller },
+    request.planned.partitions,
+  );
+  const rows = await Promise.all(
+    objects.map(async (one) => objectRows(request, reader, one)),
+  );
+
+  return { table, rows: rows.flat() };
+}
+
+/**
+ * One object's rows, each carrying the partition it sits in.
+ *
+ * A partition column is written into the key path rather than into the data,
+ * and with a `storage.location.template` it need not be written anywhere at
+ * all. The projection is what knows, so its values are laid down first and the
+ * Hive style `key=value` segments of the object's own key fill in behind them.
+ * A field the record itself carries wins over both.
+ */
+async function objectRows(
+  request: SimAthenaTableRowsRequest,
+  reader: SimAthenaRecordReader,
+  one: SimAthenaPartitionedObject,
+): Promise<readonly SimAthenaEngineRow[]> {
+  const text = await simAthenaObjectText(
+    request.objects,
+    one.object.bucket,
+    one.object.key,
+    request.caller,
+  );
+  const partition = {
+    ...simAthenaHivePartitionValues(one.object.key),
+    ...Object.fromEntries(one.values),
+  };
+
+  return reader(text).map((row) => ({ ...partition, ...row }));
+}

--- a/src/service/athena/engine/sim-athena-value-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-value-shims.iso.test.ts
@@ -1,0 +1,183 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  anAggregatedExpression,
+  anAnsweredExpression,
+} from "./sim-athena-shim.fixture.js";
+
+const document = '\'{"tenant":{"name":"acme","live":true},"tags":["a","b"]}\'';
+
+describe("Trino's JSON and array functions on SQLite", () => {
+  it("reads a scalar out of a JSON document by its path", async () => {
+    // Given a document with a nested object in it.
+    // When a path reaches a scalar, and when one reaches the object itself.
+    // Then the scalar comes back and the object answers null, as Trino has it.
+    assertIdentical(
+      await anAnsweredExpression(
+        `json_extract_scalar(${document}, '$.tenant.name')`,
+      ),
+      "acme",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        `json_extract_scalar(${document}, '$.tenant.live')`,
+      ),
+      "true",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        `json_extract_scalar(${document}, '$.tenant')`,
+      ),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        `json_extract_scalar(${document}, '$.absent')`,
+      ),
+      null,
+    );
+  });
+
+  it("answers null where there is nothing to read", async () => {
+    // Given a null document, text that is not JSON, and no path.
+    // When each is read.
+    // Then none of them fails the query.
+    assertIdentical(
+      await anAnsweredExpression("json_extract_scalar(NULL, '$.a')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("json_extract_scalar('not json', '$.a')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`json_extract_scalar(${document}, NULL)`),
+      null,
+    );
+  });
+
+  it("counts an array and reads an element of one", async () => {
+    // Given an array column held as JSON text.
+    // When it is counted and indexed.
+    // Then Trino's one-based indexing is what answers.
+    assertIdentical(
+      await anAnsweredExpression(`cardinality(json_extract(${document}, '$'))`),
+      null,
+    );
+    assertIdentical(await anAnsweredExpression(`cardinality('["a","b"]')`), 2);
+    assertIdentical(await anAnsweredExpression("cardinality('4')"), null);
+    assertIdentical(
+      await anAnsweredExpression(`element_at('["a","b"]', 2)`),
+      "b",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`element_at('["a","b"]', 9)`),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`element_at('["a"]', NULL)`),
+      null,
+    );
+  });
+
+  it("reads a map by its key", async () => {
+    // Given a map column held as JSON text.
+    // When it is read by a key it has and by one it has not.
+    // Then the value comes back, and the absent key answers null.
+    assertIdentical(
+      await anAnsweredExpression(`element_at('{"a":1}', 'a')`),
+      1,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`element_at('{"a":1}', 'b')`),
+      null,
+    );
+    assertIdentical(await anAnsweredExpression("element_at('4', 'a')"), null);
+  });
+});
+
+describe("Trino's string functions on SQLite", () => {
+  it("matches a regular expression", async () => {
+    // Given a value and three patterns.
+    // When each is matched.
+    // Then a pattern SQLite's own regular expressions cannot take answers
+    // null rather than failing the query.
+    assertIdentical(await anAnsweredExpression("regexp_like('abc', 'b+')"), 1);
+    assertIdentical(await anAnsweredExpression("regexp_like('abc', '^z')"), 0);
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('abc', '(')"),
+      null,
+    );
+    assertIdentical(await anAnsweredExpression("regexp_like(NULL, 'b')"), null);
+  });
+
+  it("splits a value and finds a substring in one", async () => {
+    // Given a path and a word inside it.
+    // When each function reads it.
+    // Then both count from one, and both answer nothing off the end.
+    assertIdentical(
+      await anAnsweredExpression("split_part('a/b/c', '/', 2)"),
+      "b",
+    );
+    assertIdentical(
+      await anAnsweredExpression("split_part('a/b', '/', 9)"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("split_part(NULL, '/', 1)"),
+      null,
+    );
+    assertIdentical(await anAnsweredExpression("strpos('abc', 'c')"), 3);
+    assertIdentical(await anAnsweredExpression("strpos('abc', 'z')"), 0);
+    assertIdentical(await anAnsweredExpression("strpos('abc', NULL)"), null);
+  });
+});
+
+describe("Trino's approximate aggregates on SQLite", () => {
+  it("counts distinct values exactly", async () => {
+    // Given four values, one of them repeated and one of them null.
+    // When they are counted.
+    // Then the count is exact rather than approximate, which is the
+    // simulation being more accurate than AWS.
+    assertIdentical(
+      await anAggregatedExpression("approx_distinct(value)", [
+        "a",
+        "b",
+        "a",
+        null,
+      ]),
+      2,
+    );
+    assertIdentical(
+      await anAggregatedExpression("approx_distinct(value)", [1, 2]),
+      2,
+    );
+  });
+
+  it("takes a percentile at the nearest rank", async () => {
+    // Given four numbers.
+    // When a percentile is taken, and when the percentile itself is null.
+    // Then the value at that rank answers, a null percentile falls back to
+    // the median, and a column of nulls answers null.
+    assertIdentical(
+      await anAggregatedExpression(
+        "approx_percentile(value, 0.5)",
+        [1, 2, 3, 4],
+      ),
+      3,
+    );
+    assertIdentical(
+      await anAggregatedExpression("approx_percentile(value, 1)", [1, 2, 3, 4]),
+      4,
+    );
+    assertIdentical(
+      await anAggregatedExpression("approx_percentile(value, NULL)", [10, 20]),
+      20,
+    );
+    assertIdentical(
+      await anAggregatedExpression("approx_percentile(value, 0.5)", [null]),
+      null,
+    );
+  });
+});

--- a/src/service/athena/engine/sim-athena-value-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-value-shims.iso.test.ts
@@ -60,7 +60,8 @@ describe("Trino's JSON and array functions on SQLite", () => {
   it("counts an array and reads an element of one", async () => {
     // Given an array column held as JSON text.
     // When it is counted and indexed.
-    // Then Trino's one-based indexing is what answers.
+    // Then Trino's indexing is what answers. It counts from one, counts back
+    // from the end for a negative index, and has no element at zero.
     assertIdentical(
       await anAnsweredExpression(`cardinality(json_extract(${document}, '$'))`),
       null,
@@ -115,7 +116,8 @@ describe("Trino's string functions on SQLite", () => {
   it("splits a value and finds a substring in one", async () => {
     // Given a path and a word inside it.
     // When each function reads it.
-    // Then both count from one, and both answer nothing off the end.
+    // Then both count from one. A field off either end answers nothing, and
+    // so does a field below the first.
     assertIdentical(
       await anAnsweredExpression("split_part('a/b/c', '/', 2)"),
       "b",

--- a/src/service/athena/error/sim-athena.error.ts
+++ b/src/service/athena/error/sim-athena.error.ts
@@ -43,3 +43,14 @@ export class SimAthenaAccessDeniedException extends SimAthenaError {
     super(message, { httpStatusCode: 403 });
   }
 }
+
+/**
+ * Simulated Athena refusing to do something the simulation was not set up for.
+ *
+ * This is the simulator talking rather than AWS. Nothing real Athena does
+ * raises it, and no SDK caller sees it: it reaches whoever configured the
+ * simulation, at the point they configured it.
+ */
+export class SimAthenaSetUpError extends SimAthenaError {
+  public override readonly name = "SimAthenaSetUpError";
+}

--- a/src/service/athena/execution/sim-athena-listed-objects.ts
+++ b/src/service/athena/execution/sim-athena-listed-objects.ts
@@ -1,0 +1,60 @@
+import type {
+  SimAthenaListedObject,
+  SimAthenaListingRequest,
+} from "./sim-athena-scanned-objects.js";
+import { simAthenaScannedLocation } from "./sim-athena-scanned-location.js";
+import { simAthenaObjectPages } from "./sim-athena-object-pages.js";
+
+/**
+ * Every object under one `s3://` prefix.
+ *
+ * A prefix whose Bucket does not exist lists nothing. A table pointing at a
+ * Bucket the simulation never made is one nobody set data up for, and refusing
+ * the query would fail every test written before anything was measured.
+ */
+export async function simAthenaObjectsUnder(
+  request: SimAthenaListingRequest,
+  prefix: string,
+): Promise<readonly SimAthenaListedObject[]> {
+  const location = simAthenaScannedLocation(prefix);
+
+  return location === undefined ? [] : simAthenaObjectPages(request, location);
+}
+
+/**
+ * Every object under every one of these prefixes, each key counted once.
+ */
+export async function simAthenaListedObjects(
+  request: SimAthenaListingRequest,
+  prefixes: readonly string[],
+): Promise<readonly SimAthenaListedObject[]> {
+  const listed = await Promise.all(
+    prefixes.map(async (prefix) => simAthenaObjectsUnder(request, prefix)),
+  );
+
+  return simAthenaDistinctObjects(listed.flat());
+}
+
+/**
+ * The same objects with any key reached more than once dropped.
+ *
+ * Two projected partitions never overlap, and a table location sitting above
+ * one of them can.
+ */
+export function simAthenaDistinctObjects(
+  objects: readonly SimAthenaListedObject[],
+): readonly SimAthenaListedObject[] {
+  const seen = new Set<string>();
+
+  return objects.filter((object) => {
+    const identity = `${object.bucket}/${object.key}`;
+
+    if (seen.has(identity)) {
+      return false;
+    }
+
+    seen.add(identity);
+
+    return true;
+  });
+}

--- a/src/service/athena/execution/sim-athena-object-pages.ts
+++ b/src/service/athena/execution/sim-athena-object-pages.ts
@@ -1,0 +1,52 @@
+import type {
+  SimAthenaListedObject,
+  SimAthenaListingRequest,
+} from "./sim-athena-scanned-objects.js";
+import type { SimAthenaScannedLocation } from "./sim-athena-scanned-location.js";
+import { simAthenaScannedPage } from "./sim-athena-scanned-page.js";
+
+/**
+ * Every object under one location, page by page.
+ *
+ * Written as a recursion because each page needs the token the one before it
+ * answered with, which no parallel form can give.
+ */
+export async function simAthenaObjectPages(
+  request: SimAthenaListingRequest,
+  location: SimAthenaScannedLocation,
+  continuationToken?: string,
+): Promise<readonly SimAthenaListedObject[]> {
+  const options =
+    request.caller === undefined ? undefined : { caller: request.caller };
+  const listed = await simAthenaScannedPage(
+    request.s3,
+    location,
+    continuationToken,
+    options,
+  );
+
+  if (listed === undefined) {
+    return [];
+  }
+
+  const objects = (listed.Contents ?? []).map((object) => ({
+    bucket: location.bucket,
+    key: object.Key ?? "",
+    size: object.Size ?? 0,
+  }));
+
+  if (
+    listed.IsTruncated !== true ||
+    listed.NextContinuationToken === undefined
+  ) {
+    return objects;
+  }
+
+  const rest = await simAthenaObjectPages(
+    request,
+    location,
+    listed.NextContinuationToken,
+  );
+
+  return [...objects, ...rest];
+}

--- a/src/service/athena/execution/sim-athena-query-completion.ts
+++ b/src/service/athena/execution/sim-athena-query-completion.ts
@@ -1,0 +1,71 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { simAthenaQueryAnswer } from "../result/sim-athena-query-answer.js";
+import { simAthenaQueryOutcome } from "./sim-athena-query-outcome.js";
+import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
+import type { SimAthenaQueryRunnerProperties } from "./sim-athena-query-runner-properties.js";
+import { simAthenaWriteFailureReason } from "./sim-athena-write-failure.js";
+
+interface SimAthenaQueryCompletionRequest {
+  readonly execution: SimAthenaQueryExecution;
+  readonly caller: SimAwsCaller | undefined;
+  readonly runner: SimAthenaQueryRunnerProperties;
+}
+
+/**
+ * Finish one running query.
+ *
+ * The order is the one real Athena reaches each question in. The query is
+ * planned and measured, the cutoff is checked against that measurement, and
+ * only a query that got past all three goes on to be answered and written.
+ *
+ * A write that fails leaves the execution `FAILED` rather than raising at a
+ * caller who was answered long ago and has gone away to poll.
+ */
+export async function simAthenaCompleteQuery(
+  request: SimAthenaQueryCompletionRequest,
+): Promise<void> {
+  const { execution, caller, runner } = request;
+  const declared = runner.results.resultFor({
+    queryString: execution.queryString,
+    workGroupName: execution.workGroupName,
+  });
+
+  const outcome = await simAthenaQueryOutcome({
+    execution,
+    result: declared,
+    workGroups: runner.workGroups,
+    catalog: runner.catalog,
+    objects: runner.objects,
+    caller,
+    now: runner.background.now(),
+  });
+
+  execution.recordBytesScanned(outcome.bytesScanned);
+
+  if (outcome.refusal !== undefined) {
+    execution.fail(outcome.refusal, runner.background.now());
+
+    return;
+  }
+
+  const answer = await simAthenaQueryAnswer({
+    queryString: execution.queryString,
+    sessionDatabase: execution.database,
+    declared,
+    results: runner.results,
+    engine: runner.engine,
+    tables: outcome.tables,
+    objects: runner.tableObjects,
+    caller,
+  });
+
+  try {
+    await runner.writer.write(execution, answer.result, caller);
+  } catch (error) {
+    execution.fail(simAthenaWriteFailureReason(error), runner.background.now());
+
+    return;
+  }
+
+  execution.succeed(answer.result, answer.source, runner.background.now());
+}

--- a/src/service/athena/execution/sim-athena-query-execution.ts
+++ b/src/service/athena/execution/sim-athena-query-execution.ts
@@ -1,3 +1,4 @@
+import type { SimAthenaAnswerSource } from "../result/sim-athena-query-answer.js";
 import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
 import type { SimAthenaQueryState } from "./sim-athena-query-state.js";
 import { SimAthenaQueryStatus } from "./sim-athena-query-status.js";
@@ -19,8 +20,8 @@ interface SimAthenaQueryExecutionProperties {
  * mutably and moved through its states by `SimAthenaQueryRunner`. Everything
  * else in simulated Athena is replaced rather than mutated.
  *
- * The result it settles with is a declaration, matched on the query text. No
- * SQL is read to produce it.
+ * The result it settles with comes either from the query engine or from a
+ * declaration matched on the query text, and `answeredBy` says which.
  */
 export class SimAthenaQueryExecution {
   public readonly queryExecutionId: string;
@@ -34,6 +35,7 @@ export class SimAthenaQueryExecution {
   readonly #status = new SimAthenaQueryStatus();
   #bytesScanned = 0;
   #result: SimAthenaResolvedResult | undefined;
+  #answeredBy: SimAthenaAnswerSource | undefined;
 
   constructor(properties: SimAthenaQueryExecutionProperties) {
     this.queryExecutionId = properties.queryExecutionId;
@@ -72,6 +74,16 @@ export class SimAthenaQueryExecution {
     return this.#result;
   }
 
+  /**
+   * Whether the query engine or a declaration answered this query.
+   *
+   * A test that turned the engine on reads this to prove it got the engine,
+   * since rows a declaration happens to agree with look the same either way.
+   */
+  get answeredBy(): SimAthenaAnswerSource | undefined {
+    return this.#answeredBy;
+  }
+
   /** Whether this query has finished. */
   get isSettled(): boolean {
     return this.#status.isSettled;
@@ -87,11 +99,18 @@ export class SimAthenaQueryExecution {
     this.#bytesScanned = bytesScanned;
   }
 
-  /** Finish the query with the rows it answered. */
-  succeed(result: SimAthenaResolvedResult, completedAt: Date): void {
-    if (this.#status.settle("SUCCEEDED", undefined, completedAt)) {
-      this.#result = result;
+  /** Finish the query with the rows it answered, and what answered it. */
+  succeed(
+    result: SimAthenaResolvedResult,
+    answeredBy: SimAthenaAnswerSource,
+    completedAt: Date,
+  ): void {
+    if (!this.#status.settle("SUCCEEDED", undefined, completedAt)) {
+      return;
     }
+
+    this.#result = result;
+    this.#answeredBy = answeredBy;
   }
 
   /** Finish the query without an answer, saying why. */

--- a/src/service/athena/execution/sim-athena-query-outcome.ts
+++ b/src/service/athena/execution/sim-athena-query-outcome.ts
@@ -6,9 +6,10 @@ import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
 import {
   simAthenaCutoffRefusal,
   simAthenaPlanQuery,
+  type SimAthenaPlannedTable,
 } from "./sim-athena-query-refusal.js";
 import { simAthenaQueryScan } from "./sim-athena-query-scan.js";
-import type { SimAthenaScannedObjects } from "./sim-athena-scanned-bytes.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-objects.js";
 
 interface SimAthenaQueryOutcomeRequest {
   readonly execution: SimAthenaQueryExecution;
@@ -24,6 +25,9 @@ interface SimAthenaQueryOutcomeRequest {
 export interface SimAthenaQueryOutcome {
   readonly refusal: string | undefined;
   readonly bytesScanned: number;
+
+  /** The tables the query reads, for whatever goes on to answer it. */
+  readonly tables: readonly SimAthenaPlannedTable[];
 }
 
 /**
@@ -41,7 +45,7 @@ export async function simAthenaQueryOutcome(
   const plan = simAthenaPlanQuery(request);
 
   if (plan.refusal !== undefined) {
-    return { refusal: plan.refusal, bytesScanned: declared };
+    return { refusal: plan.refusal, bytesScanned: declared, tables: [] };
   }
 
   const scanned = await simAthenaQueryScan({
@@ -52,7 +56,7 @@ export async function simAthenaQueryOutcome(
   });
 
   if (typeof scanned === "string") {
-    return { refusal: scanned, bytesScanned: declared };
+    return { refusal: scanned, bytesScanned: declared, tables: plan.tables };
   }
 
   return {
@@ -62,5 +66,6 @@ export async function simAthenaQueryOutcome(
       request.workGroups,
     ),
     bytesScanned: scanned,
+    tables: plan.tables,
   };
 }

--- a/src/service/athena/execution/sim-athena-query-refusal.ts
+++ b/src/service/athena/execution/sim-athena-query-refusal.ts
@@ -1,15 +1,20 @@
 import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
 import { SimAthenaProjectionError } from "../projection/sim-athena-projection-error.js";
-import {
-  simAthenaTablePartitions,
-  type SimAthenaPartitionedTable,
-} from "../projection/sim-athena-table-partitions.js";
+import type { SimAthenaTablePartition } from "../projection/sim-athena-projection-location.js";
+import { simAthenaTablePartitions } from "../projection/sim-athena-table-partitions.js";
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
 import {
   simAthenaResolveTables,
   type SimAthenaCatalog,
 } from "../table/sim-athena-table-resolution.js";
 import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
 import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
+
+/** One table a query reads, with the partitions of it the query reaches. */
+export interface SimAthenaPlannedTable {
+  readonly table: SimAthenaCatalogTable;
+  readonly partitions: readonly SimAthenaTablePartition[];
+}
 
 /** What planning one query came to. */
 export interface SimAthenaQueryPlan {
@@ -18,6 +23,9 @@ export interface SimAthenaQueryPlan {
 
   /** The S3 prefixes the query reads, for measuring what it scans. */
   readonly prefixes: readonly string[];
+
+  /** The tables the query reads, for the engine to load rows out of. */
+  readonly tables: readonly SimAthenaPlannedTable[];
 }
 
 interface SimAthenaQueryRefusalProperties {
@@ -46,7 +54,7 @@ export function simAthenaPlanQuery(
   const { execution, result } = properties;
 
   if (result.failsWith !== undefined) {
-    return { refusal: result.failsWith, prefixes: [] };
+    return { refusal: result.failsWith, prefixes: [], tables: [] };
   }
 
   const resolved = simAthenaResolveTables(
@@ -59,7 +67,7 @@ export function simAthenaPlanQuery(
   );
 
   if (resolved.refusal !== undefined) {
-    return { refusal: resolved.refusal, prefixes: [] };
+    return { refusal: resolved.refusal, prefixes: [], tables: [] };
   }
 
   return partitionsOf(properties, resolved.tables);
@@ -74,29 +82,36 @@ export function simAthenaPlanQuery(
  */
 function partitionsOf(
   properties: SimAthenaQueryRefusalProperties,
-  tables: readonly SimAthenaPartitionedTable[],
+  tables: readonly SimAthenaCatalogTable[],
 ): SimAthenaQueryPlan {
-  const prefixes: string[] = [];
+  const planned: SimAthenaPlannedTable[] = [];
 
   for (const table of tables) {
     try {
-      prefixes.push(
-        ...simAthenaTablePartitions({
+      planned.push({
+        table,
+        partitions: simAthenaTablePartitions({
           table,
           queryString: properties.execution.queryString,
           now: properties.now,
         }),
-      );
+      });
     } catch (error) {
       if (error instanceof SimAthenaProjectionError) {
-        return { refusal: error.message, prefixes: [] };
+        return { refusal: error.message, prefixes: [], tables: [] };
       }
 
       throw error;
     }
   }
 
-  return { refusal: undefined, prefixes };
+  return {
+    refusal: undefined,
+    prefixes: planned.flatMap((one) =>
+      one.partitions.map((partition) => partition.prefix),
+    ),
+    tables: planned,
+  };
 }
 
 /**

--- a/src/service/athena/execution/sim-athena-query-runner-properties.ts
+++ b/src/service/athena/execution/sim-athena-query-runner-properties.ts
@@ -1,13 +1,16 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAthenaQueryEngine } from "../engine/sim-athena-query-engine.js";
+import type { SimAthenaTableObjects } from "../engine/sim-athena-table-objects.js";
 import type { SimAthenaQueryResults } from "../result/sim-athena-query-results.js";
 import type { SimAthenaCatalog } from "../table/sim-athena-table-resolution.js";
 import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
 import type { SimAthenaResultWriter } from "./sim-athena-result-writer.js";
-import type { SimAthenaScannedObjects } from "./sim-athena-scanned-bytes.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-objects.js";
 
 /** What one query runner is built from. */
 export interface SimAthenaQueryRunnerProperties {
   readonly results: SimAthenaQueryResults;
+  readonly engine: SimAthenaQueryEngine;
   readonly workGroups: SimAthenaWorkGroupStore;
   readonly writer: SimAthenaResultWriter;
   readonly background: BackgroundScheduler;
@@ -27,4 +30,12 @@ export interface SimAthenaQueryRunnerProperties {
    * declaration says it scanned.
    */
   readonly objects?: SimAthenaScannedObjects | undefined;
+
+  /**
+   * Where the objects a query reads are opened from.
+   *
+   * Measuring a query needs only the listing. The engine needs the bytes, so
+   * it is turned down wherever this is absent.
+   */
+  readonly tableObjects?: SimAthenaTableObjects | undefined;
 }

--- a/src/service/athena/execution/sim-athena-query-runner.ts
+++ b/src/service/athena/execution/sim-athena-query-runner.ts
@@ -1,15 +1,7 @@
-import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
-import type { SimAthenaQueryResults } from "../result/sim-athena-query-results.js";
-import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
-import type { SimAthenaCatalog } from "../table/sim-athena-table-resolution.js";
-import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
-import { simAthenaQueryOutcome } from "./sim-athena-query-outcome.js";
-import type { SimAthenaQueryRunnerProperties } from "./sim-athena-query-runner-properties.js";
-import type { SimAthenaScannedObjects } from "./sim-athena-scanned-bytes.js";
+import { simAthenaCompleteQuery } from "./sim-athena-query-completion.js";
 import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
-import type { SimAthenaResultWriter } from "./sim-athena-result-writer.js";
-import { simAthenaWriteFailureReason } from "./sim-athena-write-failure.js";
+import type { SimAthenaQueryRunnerProperties } from "./sim-athena-query-runner-properties.js";
 
 /**
  * Moves a query execution through its states on the background scheduler.
@@ -17,27 +9,17 @@ import { simAthenaWriteFailureReason } from "./sim-athena-write-failure.js";
  * A query is queued as soon as `StartQueryExecution` is answered and reaches
  * `RUNNING` on the simulator's background work, the way
  * `SimEcsServiceTaskStarter` schedules a task to reach `RUNNING`. Finishing is
- * scheduled again from there, so a caller polling `GetQueryExecution` sees
- * each state rather than a query that was already over by the time it looked.
+ * scheduled again from there, so a caller polling `GetQueryExecution` sees each
+ * state rather than a query that was already over by the time it looked.
  *
  * A query somebody stopped in between is left where it is. Nothing here brings
  * a settled execution back.
  */
 export class SimAthenaQueryRunner {
-  private readonly results: SimAthenaQueryResults;
-  private readonly workGroups: SimAthenaWorkGroupStore;
-  private readonly writer: SimAthenaResultWriter;
-  private readonly background: BackgroundScheduler;
-  private readonly catalog: SimAthenaCatalog | undefined;
-  private readonly objects: SimAthenaScannedObjects | undefined;
+  readonly #properties: SimAthenaQueryRunnerProperties;
 
   constructor(properties: SimAthenaQueryRunnerProperties) {
-    this.results = properties.results;
-    this.workGroups = properties.workGroups;
-    this.writer = properties.writer;
-    this.background = properties.background;
-    this.catalog = properties.catalog;
-    this.objects = properties.objects;
+    this.#properties = properties;
   }
 
   /**
@@ -47,70 +29,28 @@ export class SimAthenaQueryRunner {
     execution: SimAthenaQueryExecution,
     caller: SimAwsCaller | undefined,
   ): void {
-    this.background.schedule(() => {
+    this.#properties.background.schedule(() => {
       if (!execution.isSettled) {
         execution.start();
-        this.scheduleFinish(execution, caller);
+        this.#scheduleFinish(execution, caller);
       }
 
       return Promise.resolve();
     });
   }
 
-  private scheduleFinish(
+  #scheduleFinish(
     execution: SimAthenaQueryExecution,
     caller: SimAwsCaller | undefined,
   ): void {
-    this.background.schedule(async () => {
+    this.#properties.background.schedule(async () => {
       if (!execution.isSettled) {
-        await this.finish(execution, caller);
+        await simAthenaCompleteQuery({
+          execution,
+          caller,
+          runner: this.#properties,
+        });
       }
     });
-  }
-
-  private async finish(
-    execution: SimAthenaQueryExecution,
-    caller: SimAwsCaller | undefined,
-  ): Promise<void> {
-    const result = this.results.resultFor({
-      queryString: execution.queryString,
-      workGroupName: execution.workGroupName,
-    });
-
-    const outcome = await simAthenaQueryOutcome({
-      execution,
-      result,
-      workGroups: this.workGroups,
-      catalog: this.catalog,
-      objects: this.objects,
-      caller,
-      now: this.background.now(),
-    });
-
-    execution.recordBytesScanned(outcome.bytesScanned);
-
-    if (outcome.refusal !== undefined) {
-      execution.fail(outcome.refusal, this.background.now());
-
-      return;
-    }
-
-    await this.write(execution, result, caller);
-  }
-
-  private async write(
-    execution: SimAthenaQueryExecution,
-    result: SimAthenaResolvedResult,
-    caller: SimAwsCaller | undefined,
-  ): Promise<void> {
-    try {
-      await this.writer.write(execution, result, caller);
-    } catch (error) {
-      execution.fail(simAthenaWriteFailureReason(error), this.background.now());
-
-      return;
-    }
-
-    execution.succeed(result, this.background.now());
   }
 }

--- a/src/service/athena/execution/sim-athena-query-scan.ts
+++ b/src/service/athena/execution/sim-athena-query-scan.ts
@@ -1,10 +1,8 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
 import { simAthenaScanFailureReason } from "./sim-athena-scan-failure.js";
-import {
-  simAthenaScannedBytes,
-  type SimAthenaScannedObjects,
-} from "./sim-athena-scanned-bytes.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-objects.js";
+import { simAthenaScannedBytes } from "./sim-athena-scanned-bytes.js";
 
 interface SimAthenaQueryScanRequest {
   readonly prefixes: readonly string[];

--- a/src/service/athena/execution/sim-athena-scanned-bytes.ts
+++ b/src/service/athena/execution/sim-athena-scanned-bytes.ts
@@ -1,32 +1,6 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
-import {
-  simAthenaScannedLocation,
-  type SimAthenaScannedLocation,
-} from "./sim-athena-scanned-location.js";
-import { simAthenaScannedPage } from "./sim-athena-scanned-page.js";
-
-/**
- * The narrow slice of simulated S3 that measuring a query needs.
- *
- * `SimS3` structurally implements this, the way it implements
- * `SimAthenaResultDestination`.
- */
-export interface SimAthenaScannedObjects {
-  listObjectsV2(
-    command: {
-      input: {
-        Bucket: string;
-        Prefix: string;
-        ContinuationToken?: string | undefined;
-      };
-    },
-    options?: { caller: SimAwsCaller },
-  ): Promise<{
-    Contents?: readonly { Key?: string; Size?: number }[] | undefined;
-    IsTruncated?: boolean | undefined;
-    NextContinuationToken?: string | undefined;
-  }>;
-}
+import { simAthenaListedObjects } from "./sim-athena-listed-objects.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-objects.js";
 
 interface SimAthenaScannedBytesRequest {
   readonly prefixes: readonly string[];
@@ -42,94 +16,16 @@ interface SimAthenaScannedBytesRequest {
  * more than AWS would for the same data in a columnar format. The Athena docs
  * page says so.
  *
- * A key reached through two prefixes is counted once. Two projected partitions
- * never overlap, and a table location sitting above one of them can.
- *
- * A prefix whose Bucket does not exist scans nothing. A table pointing at a
- * Bucket the simulation never made is one nobody set data up for, and refusing
- * the query would fail every test written before anything was measured.
+ * A key reached through two prefixes is counted once, and a prefix whose
+ * Bucket does not exist scans nothing. Both belong to the listing.
  */
 export async function simAthenaScannedBytes(
   request: SimAthenaScannedBytesRequest,
 ): Promise<number> {
-  const locations = request.prefixes
-    .map((uri) => simAthenaScannedLocation(uri))
-    .filter((location) => location !== undefined);
-
-  const listed = await Promise.all(
-    locations.map(async (location) => objectsUnder(request, location)),
+  const objects = await simAthenaListedObjects(
+    { s3: request.s3, caller: request.caller },
+    request.prefixes,
   );
 
-  return distinctBytes(listed.flat());
-}
-
-/** One listed object, keyed so that two Buckets never collide. */
-interface SimAthenaScannedObject {
-  readonly key: string;
-  readonly size: number;
-}
-
-/**
- * What every object under one prefix comes to, counting each key once.
- */
-function distinctBytes(objects: readonly SimAthenaScannedObject[]): number {
-  const counted = new Set<string>();
-  let bytes = 0;
-
-  for (const object of objects) {
-    if (counted.has(object.key)) {
-      continue;
-    }
-
-    counted.add(object.key);
-    bytes += object.size;
-  }
-
-  return bytes;
-}
-
-/**
- * Every object under one prefix, page by page.
- *
- * Written as a recursion because each page needs the token the one before it
- * answered with, which no parallel form can give.
- */
-async function objectsUnder(
-  request: SimAthenaScannedBytesRequest,
-  location: SimAthenaScannedLocation,
-  continuationToken?: string,
-): Promise<readonly SimAthenaScannedObject[]> {
-  const options =
-    request.caller === undefined ? undefined : { caller: request.caller };
-  const listed = await simAthenaScannedPage(
-    request.s3,
-    location,
-    continuationToken,
-    options,
-  );
-
-  if (listed === undefined) {
-    return [];
-  }
-
-  const contents = listed.Contents ?? [];
-  const objects = contents.map((object) => ({
-    key: `${location.bucket}/${object.Key ?? ""}`,
-    size: object.Size ?? 0,
-  }));
-
-  if (
-    listed.IsTruncated !== true ||
-    listed.NextContinuationToken === undefined
-  ) {
-    return objects;
-  }
-
-  const rest = await objectsUnder(
-    request,
-    location,
-    listed.NextContinuationToken,
-  );
-
-  return [...objects, ...rest];
+  return objects.reduce((bytes, object) => bytes + object.size, 0);
 }

--- a/src/service/athena/execution/sim-athena-scanned-objects.ts
+++ b/src/service/athena/execution/sim-athena-scanned-objects.ts
@@ -1,0 +1,37 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The narrow slice of simulated S3 that listing what a query reads needs.
+ *
+ * `SimS3` structurally implements this, the way it implements
+ * `SimAthenaResultDestination`.
+ */
+export interface SimAthenaScannedObjects {
+  listObjectsV2(
+    command: {
+      input: {
+        Bucket: string;
+        Prefix: string;
+        ContinuationToken?: string | undefined;
+      };
+    },
+    options?: { caller: SimAwsCaller },
+  ): Promise<{
+    Contents?: readonly { Key?: string; Size?: number }[] | undefined;
+    IsTruncated?: boolean | undefined;
+    NextContinuationToken?: string | undefined;
+  }>;
+}
+
+/** One object a query reads, named so that two Buckets never collide. */
+export interface SimAthenaListedObject {
+  readonly bucket: string;
+  readonly key: string;
+  readonly size: number;
+}
+
+/** What one listing goes through, and who it goes as. */
+export interface SimAthenaListingRequest {
+  readonly s3: SimAthenaScannedObjects;
+  readonly caller: SimAwsCaller | undefined;
+}

--- a/src/service/athena/execution/sim-athena-scanned-page.ts
+++ b/src/service/athena/execution/sim-athena-scanned-page.ts
@@ -1,5 +1,5 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
-import type { SimAthenaScannedObjects } from "./sim-athena-scanned-bytes.js";
+import type { SimAthenaScannedObjects } from "./sim-athena-scanned-objects.js";
 import type { SimAthenaScannedLocation } from "./sim-athena-scanned-location.js";
 
 /**

--- a/src/service/athena/index.ts
+++ b/src/service/athena/index.ts
@@ -26,6 +26,17 @@ export {
 export { SimAthenaWorkGroupStore } from "./workgroup/sim-athena-work-group-store.js";
 export { SimAthenaNamedQuery } from "./named-query/sim-athena-named-query.js";
 export { SimAthenaQueryExecution } from "./execution/sim-athena-query-execution.js";
+export { SimAthenaQueryEngine } from "./engine/sim-athena-query-engine.js";
+export type {
+  SimAthenaAnswerSource,
+  SimAthenaQueryAnswer,
+} from "./result/sim-athena-query-answer.js";
+export type {
+  SimAthenaCatalogColumn,
+  SimAthenaCatalogSerDe,
+  SimAthenaCatalogStorage,
+  SimAthenaCatalogTable,
+} from "./table/sim-athena-catalog-table.js";
 export { SimAthenaQueryExecutionStore } from "./execution/sim-athena-query-execution-store.js";
 export {
   isSettledQueryState,
@@ -51,4 +62,5 @@ export {
   SimAthenaError,
   type SimAthenaErrorMetadata,
   SimAthenaInvalidRequestException,
+  SimAthenaSetUpError,
 } from "./error/sim-athena.error.js";

--- a/src/service/athena/projection/sim-athena-projection-location.ts
+++ b/src/service/athena/projection/sim-athena-projection-location.ts
@@ -8,22 +8,36 @@ import {
 export type SimAthenaProjectedValues = ReadonlyMap<string, readonly string[]>;
 
 /**
- * The S3 prefixes a table's projected partitions sit under.
+ * One partition of a table: where its objects sit, and what its partition
+ * columns read for every row under that prefix.
+ *
+ * The values travel with the prefix because nothing in an object says which
+ * partition it belongs to. A Hive layout writes them into the key and a
+ * `storage.location.template` need not, so reading them back off a key would
+ * lose them for exactly the tables a template exists to serve.
+ */
+export interface SimAthenaTablePartition {
+  readonly prefix: string;
+  readonly values: ReadonlyMap<string, string>;
+}
+
+/**
+ * The partitions a table's projection comes to.
  *
  * A `storage.location.template` says where each one goes and has to name every
  * projected column, since a template leaving one out sends two partitions to
  * the same prefix. A table with no template gets the Hive layout under its own
  * location, which is what Athena falls back to.
  */
-export function simAthenaProjectedPrefixes(
+export function simAthenaProjectedPartitions(
   projection: SimAthenaProjection,
   values: SimAthenaProjectedValues,
   tableLocation: string | undefined,
-): readonly string[] {
+): readonly SimAthenaTablePartition[] {
   const template = projection.locationTemplate;
 
   if (template === undefined) {
-    return hivePrefixes(projection, values, tableLocation);
+    return hivePartitions(projection, values, tableLocation);
   }
 
   for (const column of projection.columns) {
@@ -35,16 +49,17 @@ export function simAthenaProjectedPrefixes(
     }
   }
 
-  return combinations(projection, values).map((combination) =>
-    withTrailingSlash(fill(template, combination)),
-  );
+  return combinations(projection, values).map((combination) => ({
+    prefix: withTrailingSlash(fill(template, combination)),
+    values: combination,
+  }));
 }
 
-function hivePrefixes(
+function hivePartitions(
   projection: SimAthenaProjection,
   values: SimAthenaProjectedValues,
   tableLocation: string | undefined,
-): readonly string[] {
+): readonly SimAthenaTablePartition[] {
   if (tableLocation === undefined) {
     throw new SimAthenaProjectionError(
       `Partition projection is enabled and the table has neither a ` +
@@ -59,7 +74,7 @@ function hivePrefixes(
       (column) => `${column.name}=${combination.get(column.name) ?? ""}`,
     );
 
-    return `${base}${segments.join("/")}/`;
+    return { prefix: `${base}${segments.join("/")}/`, values: combination };
   });
 }
 

--- a/src/service/athena/projection/sim-athena-table-partitions.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-table-partitions.iso.test.ts
@@ -29,7 +29,9 @@ function partitionsOf(
   table: SimAthenaPartitionedTable,
   queryString = "SELECT * FROM rainlytics.access_logs",
 ): readonly string[] {
-  return simAthenaTablePartitions({ table, queryString, now: noon });
+  return simAthenaTablePartitions({ table, queryString, now: noon }).map(
+    (partition) => partition.prefix,
+  );
 }
 
 describe("the S3 prefixes a query reads for one table", () => {

--- a/src/service/athena/projection/sim-athena-table-partitions.ts
+++ b/src/service/athena/projection/sim-athena-table-partitions.ts
@@ -1,7 +1,10 @@
 import { simAthenaPartitionFilters } from "../table/sim-athena-partition-filters.js";
 import type { SimAthenaProjectionColumn } from "./sim-athena-projection-column.js";
 import { SimAthenaProjectionError } from "./sim-athena-projection-error.js";
-import { simAthenaProjectedPrefixes } from "./sim-athena-projection-location.js";
+import {
+  simAthenaProjectedPartitions,
+  type SimAthenaTablePartition,
+} from "./sim-athena-projection-location.js";
 import {
   simAthenaProjectionOf,
   type SimAthenaProjectedTable,
@@ -22,11 +25,12 @@ interface SimAthenaTablePartitionsRequest {
 }
 
 /**
- * The S3 prefixes one query reads for one table.
+ * The partitions one query reads for one table.
  *
  * A table with projection off reads its own location and nothing else, since
  * the partitions it holds were registered rather than projected and simulated
- * Glue has no commands for registering one.
+ * Glue has no commands for registering one. Nothing then says what its
+ * partition columns read, so that partition carries no values.
  *
  * With projection on, every column is expanded and the query's own `WHERE`
  * clause narrows what is left. A filter naming no projected column leaves
@@ -34,12 +38,14 @@ interface SimAthenaTablePartitionsRequest {
  */
 export function simAthenaTablePartitions(
   request: SimAthenaTablePartitionsRequest,
-): readonly string[] {
+): readonly SimAthenaTablePartition[] {
   const projection = simAthenaProjectionOf(request.table);
   const location = request.table.storageDescriptor?.Location;
 
   if (!projection.enabled) {
-    return location === undefined ? [] : [location];
+    return location === undefined
+      ? []
+      : [{ prefix: location, values: new Map() }];
   }
 
   const filters = simAthenaPartitionFilters(request.queryString);
@@ -52,7 +58,7 @@ export function simAthenaTablePartitions(
     );
   }
 
-  return simAthenaProjectedPrefixes(projection, values, location);
+  return simAthenaProjectedPartitions(projection, values, location);
 }
 
 /**

--- a/src/service/athena/result/sim-athena-declared-result.ts
+++ b/src/service/athena/result/sim-athena-declared-result.ts
@@ -13,9 +13,11 @@ export interface SimAthenaDeclaredColumn {
 /**
  * What a test says one query answers with.
  *
- * Nothing here is derived from the SQL. The simulation reads a query only as a
- * key to match a declaration on, so the rows, the columns and the bytes
- * scanned are all a test's own statement about what the query did.
+ * A declaration is matched on the query text, and the rows, the columns and
+ * the bytes scanned are all a test's own statement about what the query did. A
+ * declaration written against one exact query wins over the query engine, and
+ * one written against a workgroup or the default answers whatever the engine
+ * turned down.
  */
 export interface SimAthenaDeclaredResult {
   /**
@@ -40,9 +42,9 @@ export interface SimAthenaDeclaredResult {
   /**
    * Fail the query with this reason rather than answering it.
    *
-   * Nothing here reads SQL, so a query that should fail cannot be discovered.
-   * A test says so instead, which is what makes a client's failure handling
-   * reachable.
+   * A declared failure wins over the engine, whichever tier declared it. That
+   * is what makes a client's failure handling reachable for a query the engine
+   * would otherwise answer.
    */
   readonly failsWith?: string | undefined;
 }

--- a/src/service/athena/result/sim-athena-query-answer.ts
+++ b/src/service/athena/result/sim-athena-query-answer.ts
@@ -1,0 +1,64 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAthenaTableObjects } from "../engine/sim-athena-table-objects.js";
+import type { SimAthenaQueryEngine } from "../engine/sim-athena-query-engine.js";
+import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
+import type { SimAthenaQueryResults } from "./sim-athena-query-results.js";
+import type { SimAthenaResolvedResult } from "./sim-athena-resolved-result.js";
+
+/** Which of the two things that can answer a query answered this one. */
+export type SimAthenaAnswerSource = "engine" | "declaration";
+
+/** One query's rows, and where they came from. */
+export interface SimAthenaQueryAnswer {
+  readonly result: SimAthenaResolvedResult;
+  readonly source: SimAthenaAnswerSource;
+}
+
+interface SimAthenaQueryAnswerRequest {
+  readonly queryString: string;
+  readonly sessionDatabase: string | undefined;
+
+  /** What the declarations answer this query with, default included. */
+  readonly declared: SimAthenaResolvedResult;
+
+  readonly results: SimAthenaQueryResults;
+  readonly engine: SimAthenaQueryEngine;
+  readonly tables: readonly SimAthenaPlannedTable[];
+  readonly objects: SimAthenaTableObjects | undefined;
+  readonly caller: SimAwsCaller | undefined;
+}
+
+/**
+ * What one query answers with, from the engine or from a declaration.
+ *
+ * A declaration written against this exact query text wins. That is a test
+ * saying what this one statement answers, which is more specific than anything
+ * the engine can work out and is the escape hatch for a query the engine
+ * cannot run correctly.
+ *
+ * The engine comes next, and a query it turns down falls back to the
+ * declarations again, where a workgroup rule or the default answers it. Every
+ * test written before the engine existed therefore keeps working, whether or
+ * not the engine is on.
+ */
+export async function simAthenaQueryAnswer(
+  request: SimAthenaQueryAnswerRequest,
+): Promise<SimAthenaQueryAnswer> {
+  const forQuery = request.results.declaredForQuery(request.queryString);
+
+  if (forQuery !== undefined) {
+    return { result: forQuery, source: "declaration" };
+  }
+
+  const computed = await request.engine.run({
+    queryString: request.queryString,
+    tables: request.tables,
+    sessionDatabase: request.sessionDatabase,
+    objects: request.objects,
+    caller: request.caller,
+  });
+
+  return computed === undefined
+    ? { result: request.declared, source: "declaration" }
+    : { result: computed, source: "engine" };
+}

--- a/src/service/athena/result/sim-athena-query-results.ts
+++ b/src/service/athena/result/sim-athena-query-results.ts
@@ -71,6 +71,19 @@ export class SimAthenaQueryResults {
       trailing: request.workGroupName,
     });
   }
+
+  /**
+   * The result declared for this exact query text, where a test wrote one.
+   *
+   * The workgroup tier and the default are left out, so this reports a miss
+   * rather than falling back. Nothing else can tell a query somebody wrote a
+   * rule for from one nobody did, and that is what puts a declaration for one
+   * statement ahead of the query engine while leaving the broader tiers
+   * behind it.
+   */
+  declaredForQuery(queryString: string): SimAthenaResolvedResult | undefined {
+    return this.#rules.declaredFor({ leading: queryString });
+  }
 }
 
 function requiredRuleKey(key: string, described: string): string {

--- a/src/service/athena/sim-athena-answered-query.fixture.ts
+++ b/src/service/athena/sim-athena-answered-query.fixture.ts
@@ -1,0 +1,58 @@
+import type { SimAthenaAnswerSource } from "./result/sim-athena-query-answer.js";
+import type { SimAthenaEngineSimulation } from "./sim-athena-engine.fixture.js";
+
+/** What one query came to, as a test reads it back. */
+export interface SimAthenaEngineQuery {
+  readonly state: string | undefined;
+  readonly answeredBy: SimAthenaAnswerSource | undefined;
+  readonly columns: readonly (string | undefined)[];
+  readonly rows: readonly (readonly (string | undefined)[])[];
+}
+
+/** Run one query to completion and read its result set back. */
+export async function anAnsweredQuery(
+  simulation: SimAthenaEngineSimulation,
+  queryString: string,
+  database?: string,
+): Promise<SimAthenaEngineQuery> {
+  const athena = simulation.simAws.athena();
+  const started = await athena.startQueryExecution({
+    input: {
+      QueryString: queryString,
+      WorkGroup: simulation.workGroup,
+      ...(database !== undefined && {
+        QueryExecutionContext: { Database: database },
+      }),
+    },
+  });
+
+  await simulation.simAws.backgroundTasksComplete();
+
+  const id = started.QueryExecutionId;
+  const execution = athena
+    .queryExecutions()
+    .find((one) => one.queryExecutionId === id);
+  const answered = {
+    state: execution?.state,
+    answeredBy: execution?.answeredBy,
+  };
+
+  if (execution?.state !== "SUCCEEDED") {
+    return { ...answered, columns: [], rows: [] };
+  }
+
+  const results = await athena.getQueryResults({
+    input: { QueryExecutionId: id },
+  });
+  const set = results.ResultSet;
+
+  return {
+    ...answered,
+    columns: (set?.ResultSetMetadata?.ColumnInfo ?? []).map(
+      (column) => column.Type,
+    ),
+    rows: (set?.Rows ?? [])
+      .slice(1)
+      .map((row) => (row.Data ?? []).map((cell) => cell.VarCharValue)),
+  };
+}

--- a/src/service/athena/sim-athena-engine-fallback.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-fallback.iso.test.ts
@@ -1,0 +1,204 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertObjectEquals,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+
+const oneOrder = [{ id: 1, customer: "ada" }];
+
+/** A simulation holding one order, with the engine left off. */
+async function anOrderSimulation(
+  serDe?: string,
+): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "orders",
+    columns: [
+      { Name: "id", Type: "int" },
+      { Name: "customer", Type: "string" },
+    ],
+    serDe,
+  });
+
+  await aSeededJson(simulation.simAws, "orders/part-0.json", oneOrder);
+
+  return simulation;
+}
+
+describe("what answers an Athena query", () => {
+  it("leaves the engine off until a test turns it on", async () => {
+    // Given a simulation with data behind its table and nothing turned on.
+    const simulation = await anOrderSimulation();
+
+    simulation.simAws
+      .athena()
+      .results()
+      .byDefault({ columns: ["id"], rows: [["declared"]] });
+
+    // When a query runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders",
+    );
+
+    // Then the declaration answers it, as it did before an engine existed.
+    assertFalse(simulation.simAws.athena().engine().isEnabled);
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("puts a declaration for one exact query ahead of the engine", async () => {
+    // Given the engine on, and a declaration written against one statement.
+    const simulation = await anOrderSimulation();
+    const sql = "SELECT id FROM rainlytics.orders";
+
+    await simulation.simAws.athena().engine().enable();
+    simulation.simAws
+      .athena()
+      .results()
+      .onQuery(sql, { columns: ["id"], rows: [["declared"]] });
+
+    // When that statement runs, and when a statement nobody declared runs.
+    const declared = await anAnsweredQuery(simulation, sql);
+    const computed = await anAnsweredQuery(
+      simulation,
+      "SELECT customer FROM rainlytics.orders",
+    );
+
+    // Then the declaration wins its own statement and the engine takes the
+    // rest. This is the escape hatch for a query the engine gets wrong.
+    assertIdentical(declared.answeredBy, "declaration");
+    assertObjectEquals(declared.rows, [["declared"]]);
+    assertIdentical(computed.answeredBy, "engine");
+    assertObjectEquals(computed.rows, [["ada"]]);
+  });
+
+  it("falls back where the parser turns the statement down", async () => {
+    // Given the engine on, and a workgroup rule to fall back to.
+    const simulation = await anOrderSimulation();
+
+    await simulation.simAws.athena().engine().enable();
+    simulation.simAws
+      .athena()
+      .results()
+      .onWorkGroup(simulation.workGroup, {
+        columns: ["id"],
+        rows: [["declared"]],
+      });
+
+    // When a query the Athena grammar refuses runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders GROUP BY GROUPING SETS ((id))",
+    );
+
+    // Then the workgroup rule answers it rather than the query failing.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("falls back where the table declares a SerDe with no reader", async () => {
+    // Given a Parquet table, with the engine on.
+    const simulation = await anOrderSimulation(
+      "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+    );
+
+    await simulation.simAws.athena().engine().enable();
+    simulation.simAws
+      .athena()
+      .results()
+      .byDefault({ columns: ["id"], rows: [["declared"]] });
+
+    // When a query against it runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders",
+    );
+
+    // Then the declaration answers it. Nothing here reads Parquet.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("falls back where SQLite refuses to run the statement", async () => {
+    // Given the engine on and a table nothing seeded data for.
+    const simulation = await anOrderSimulation();
+
+    await simulation.simAws.athena().engine().enable();
+    simulation.simAws
+      .athena()
+      .results()
+      .byDefault({ columns: ["n"], rows: [["declared"]] });
+
+    // When a query naming a column the table has not got runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT missing FROM rainlytics.orders",
+    );
+
+    // Then the declaration answers it. Simulated Athena has always accepted a
+    // query real Athena would reject, and the engine keeps that promise.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("stops running queries once the engine is turned off again", async () => {
+    // Given a simulation whose engine answered a query.
+    const simulation = await anOrderSimulation();
+    const sql = "SELECT customer FROM rainlytics.orders";
+
+    await simulation.simAws.athena().engine().enable();
+    simulation.simAws
+      .athena()
+      .results()
+      .byDefault({ columns: ["customer"], rows: [["declared"]] });
+
+    const computed = await anAnsweredQuery(simulation, sql);
+
+    // When the engine is turned off and the same query runs again.
+    simulation.simAws.athena().engine().disable();
+
+    const answered = await anAnsweredQuery(simulation, sql);
+
+    // Then the declaration takes it back.
+    assertTrue(computed.answeredBy === "engine");
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("keeps the cutoff ahead of the engine", async () => {
+    // Given a workgroup refusing a query that scans more than ten bytes.
+    const simulation = await anOrderSimulation();
+
+    await simulation.simAws.athena().engine().enable();
+    await simulation.simAws.athena().updateWorkGroup({
+      input: {
+        WorkGroup: simulation.workGroup,
+        ConfigurationUpdates: { BytesScannedCutoffPerQuery: 10 },
+      },
+    });
+
+    // When a query over more than that runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders",
+    );
+
+    // Then it fails on the cutoff, which is checked before anything answers.
+    assertIdentical(answered.state, "FAILED");
+    assertUndefined(answered.answeredBy);
+  });
+});

--- a/src/service/athena/sim-athena-engine-formats.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-formats.iso.test.ts
@@ -1,0 +1,263 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  aSeededObject,
+  csvSerDe,
+  logsBucket,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+
+const stockColumns = [
+  { Name: "sku", Type: "string" },
+  { Name: "held", Type: "int" },
+];
+
+/** A table projecting one prefix per day across two days. */
+const projectedDays = {
+  "projection.enabled": "true",
+  "projection.day.type": "date",
+  "projection.day.format": "yyyy-MM-dd",
+  "projection.day.range": "2026-08-01,2026-08-02",
+};
+
+async function aStockSimulation(
+  table: Partial<Parameters<typeof aCatalogTable>[1]> = {},
+): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "stock",
+    columns: stockColumns,
+    ...table,
+  });
+
+  await simulation.simAws.athena().engine().enable();
+
+  return simulation;
+}
+
+describe("the objects an Athena query reads", () => {
+  it("reads quoted CSV, skipping the header the table declares", async () => {
+    // Given a CSV table whose first line names its columns.
+    const simulation = await aStockSimulation({
+      serDe: csvSerDe,
+      parameters: { "skip.header.line.count": "1" },
+    });
+
+    await aSeededObject(
+      simulation.simAws,
+      "stock/all.csv",
+      'sku,held\n"widget, large",4\nbolt,9\n',
+    );
+
+    // When a query rolls the file up.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, held FROM rainlytics.stock ORDER BY held DESC",
+    );
+
+    // Then the header is not a row, and the comma inside the quoted field is
+    // part of the value rather than a column boundary.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["bolt", "9"],
+      ["widget, large", "4"],
+    ]);
+  });
+
+  it("takes the delimiter the table declares", async () => {
+    // Given a table declaring a pipe as its separator.
+    const simulation = await aStockSimulation({
+      serDe: csvSerDe,
+      serDeParameters: { separatorChar: "|" },
+    });
+
+    await aSeededObject(simulation.simAws, "stock/all.psv", "bolt|9\n");
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, held FROM rainlytics.stock",
+    );
+
+    // Then the fields split on the pipe.
+    assertObjectEquals(answered.rows, [["bolt", "9"]]);
+  });
+
+  it("reads an empty CSV field as a null", async () => {
+    // Given a row whose count was left blank.
+    const simulation = await aStockSimulation({ serDe: csvSerDe });
+
+    await aSeededObject(simulation.simAws, "stock/all.csv", "bolt,\n");
+
+    // When a query asks whether it is null.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku FROM rainlytics.stock WHERE held IS NULL",
+    );
+
+    // Then it is. Delimited text cannot tell an empty string from an absent
+    // value, and a numeric column is better served by the null.
+    assertObjectEquals(answered.rows, [["bolt"]]);
+  });
+
+  it("reads a partition column out of the key path", async () => {
+    // Given a table laid out Hive style under its own location.
+    const simulation = await aStockSimulation({
+      partitionKeys: [{ Name: "day", Type: "string" }],
+    });
+
+    await aSeededJson(simulation.simAws, "stock/day=2026-08-01/part-0.json", [
+      { sku: "bolt", held: 9 },
+    ]);
+    await aSeededJson(simulation.simAws, "stock/day=2026-08-02/part-0.json", [
+      { sku: "bolt", held: 4 },
+    ]);
+
+    // When a query groups on the partition column.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT day, sum(held) AS held FROM rainlytics.stock GROUP BY day ORDER BY day",
+    );
+
+    // Then the column reads, though no object holds it.
+    assertObjectEquals(answered.rows, [
+      ["2026-08-01", "9"],
+      ["2026-08-02", "4"],
+    ]);
+  });
+
+  it("reads a partition column a location template hides", async () => {
+    // Given a projected table whose prefixes carry no `key=value` segment.
+    const simulation = await aStockSimulation({
+      partitionKeys: [{ Name: "day", Type: "string" }],
+      parameters: {
+        ...projectedDays,
+        "storage.location.template": `s3://${logsBucket}/stock/\${day}/`,
+      },
+    });
+
+    await aSeededJson(simulation.simAws, "stock/2026-08-01/part-0.json", [
+      { sku: "bolt", held: 9 },
+    ]);
+    await aSeededJson(simulation.simAws, "stock/2026-08-02/part-0.json", [
+      { sku: "bolt", held: 4 },
+    ]);
+
+    // When a query filters on that column.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sum(held) AS held FROM rainlytics.stock WHERE day = '2026-08-02'",
+    );
+
+    // Then the projection is what says which partition a row belongs to. The
+    // key path could not, and the filter would answer nothing without it.
+    assertObjectEquals(answered.rows, [["4"]]);
+  });
+
+  it("reads an object one query names two partitions of once", async () => {
+    // Given a table whose tenant is injected, so the query supplies the
+    // partition values itself.
+    const simulation = await aStockSimulation({
+      partitionKeys: [{ Name: "tenant", Type: "string" }],
+      parameters: {
+        "projection.enabled": "true",
+        "projection.tenant.type": "injected",
+        "storage.location.template": `s3://${logsBucket}/stock/\${tenant}/`,
+      },
+    });
+
+    await aSeededJson(simulation.simAws, "stock/acme/part-0.json", [
+      { sku: "bolt", held: 9 },
+    ]);
+
+    // When a query names the same partition twice.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(*) AS seen FROM rainlytics.stock " +
+        "WHERE tenant IN ('acme', 'acme')",
+    );
+
+    // Then the object behind it is read once rather than twice.
+    assertObjectEquals(answered.rows, [["1"]]);
+  });
+
+  it("takes an escaped quote inside a quoted field", async () => {
+    // Given a CSV file whose quoted field carries a quote of its own, written
+    // both ways OpenCSVSerde takes it, and no newline at the end.
+    const simulation = await aStockSimulation({ serDe: csvSerDe });
+
+    await aSeededObject(
+      simulation.simAws,
+      "stock/all.csv",
+      `${String.raw`"5\" bolt",9`}\n"6"" bolt",4`,
+    );
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku FROM rainlytics.stock ORDER BY sku",
+    );
+
+    // Then both quotes are part of the value, and the last line is a row
+    // though nothing closed it.
+    assertObjectEquals(answered.rows, [['5" bolt'], ['6" bolt']]);
+  });
+
+  it("reads a file whose delimiter is quoted along with its fields", async () => {
+    // Given a quoted field carrying the delimiter and a line ending.
+    const simulation = await aStockSimulation({ serDe: csvSerDe });
+
+    await aSeededObject(
+      simulation.simAws,
+      "stock/all.csv",
+      '"bolt\r\nlong",9\r\n',
+    );
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, held FROM rainlytics.stock",
+    );
+
+    // Then the field survives whole, and the carriage return outside it does
+    // not become part of a value.
+    assertObjectEquals(answered.rows, [["bolt\r\nlong", "9"]]);
+  });
+
+  it("reads a boolean written as a word in delimited text", async () => {
+    // Given a CSV table with a boolean column.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "stock",
+      columns: [
+        { Name: "sku", Type: "string" },
+        { Name: "listed", Type: "boolean" },
+      ],
+      serDe: csvSerDe,
+    });
+
+    await aSeededObject(
+      simulation.simAws,
+      "stock/all.csv",
+      "bolt,TRUE\nnut,false\nwasher,maybe\n",
+    );
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query filters on it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, listed FROM rainlytics.stock WHERE listed = true",
+    );
+
+    // Then the word compares as a boolean and reads back as one. Anything
+    // that is no boolean at all reads as null and matches neither.
+    assertObjectEquals(answered.rows, [["bolt", "true"]]);
+  });
+});

--- a/src/service/athena/sim-athena-engine-results.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-results.iso.test.ts
@@ -86,6 +86,27 @@ describe("what a query the engine ran answers with", () => {
     assertObjectEquals(answered.rows, [["Alpha"], ["alpha"], [""]]);
   });
 
+  it("orders nulls last inside a window with a frame", async () => {
+    // Given a reading whose site is null.
+    const simulation = await aReadingSimulation();
+
+    // When a window function sorts on that column ascending and names a frame.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT site, sum(samples) OVER (ORDER BY site ASC " +
+        "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running " +
+        "FROM rainlytics.readings ORDER BY site",
+    );
+
+    // Then the null is last inside the window too. A frame follows the sort it
+    // is framing, and an ascending sort has to carry NULLS LAST past it.
+    assertObjectEquals(answered.rows, [
+      ["Alpha", "4"],
+      ["alpha", "11"],
+      ["", "13"],
+    ]);
+  });
+
   it("matches LIKE with regard to case, as Athena does", async () => {
     // Given two sites differing only in case.
     const simulation = await aReadingSimulation();

--- a/src/service/athena/sim-athena-engine-results.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-results.iso.test.ts
@@ -1,0 +1,222 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+
+const readings = [
+  { site: "Alpha", live: true, celsius: 20.5, samples: 4 },
+  { site: "alpha", live: false, celsius: 18, samples: 7 },
+  { site: null, live: true, celsius: 19.25, samples: 2 },
+];
+
+/** A simulation holding the readings, with the engine on. */
+async function aReadingSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "readings",
+    columns: [
+      { Name: "site", Type: "string" },
+      { Name: "live", Type: "boolean" },
+      { Name: "celsius", Type: "double" },
+      { Name: "samples", Type: "int" },
+    ],
+  });
+
+  await aSeededJson(simulation.simAws, "readings/part-0.json", readings);
+  await simulation.simAws.athena().engine().enable();
+
+  return simulation;
+}
+
+describe("what a query the engine ran answers with", () => {
+  it("reports Athena's own type names from the Glue schema", async () => {
+    // Given a table declaring four Hive types.
+    const simulation = await aReadingSimulation();
+
+    // When a query selects each of them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT site, live, celsius, samples FROM rainlytics.readings LIMIT 1",
+    );
+
+    // Then the metadata is written the way Athena writes it, so `string` is
+    // reported as `varchar` and `int` as `integer`.
+    assertObjectEquals(answered.columns, [
+      "varchar",
+      "boolean",
+      "double",
+      "integer",
+    ]);
+  });
+
+  it("renders a boolean column as true and false", async () => {
+    // Given the readings, whose `live` column is a Glue boolean.
+    const simulation = await aReadingSimulation();
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT live FROM rainlytics.readings ORDER BY samples",
+    );
+
+    // Then it reads as Athena writes it rather than as the 1 and 0 SQLite
+    // holds, because the Glue column type says which columns are boolean.
+    assertObjectEquals(answered.rows, [["true"], ["true"], ["false"]]);
+  });
+
+  it("orders nulls last ascending, as Trino does", async () => {
+    // Given a reading whose site is null.
+    const simulation = await aReadingSimulation();
+
+    // When a query sorts on that column ascending.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT site FROM rainlytics.readings ORDER BY site",
+    );
+
+    // Then the null sorts last. SQLite sorts it first, and a test whose
+    // expected order came from production would fail on that difference.
+    assertObjectEquals(answered.rows, [["Alpha"], ["alpha"], [""]]);
+  });
+
+  it("matches LIKE with regard to case, as Athena does", async () => {
+    // Given two sites differing only in case.
+    const simulation = await aReadingSimulation();
+
+    // When a query filters on one of them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(*) AS matched FROM rainlytics.readings WHERE site LIKE 'alpha'",
+    );
+
+    // Then it matches the one. SQLite matches both by default, which is a
+    // filter quietly taking in rows Athena excludes.
+    assertObjectEquals(answered.rows, [["1"]]);
+  });
+
+  it("names an expression nobody named the way Athena names it", async () => {
+    // Given the readings, with the engine on.
+    const simulation = await aReadingSimulation();
+
+    // When a query selects an aggregate with no alias on it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(*) FROM rainlytics.readings",
+    );
+
+    // Then the column is `_col0`, which is what Athena calls one.
+    const results = await simulation.simAws.athena().getQueryResults({
+      input: {
+        QueryExecutionId: simulation.simAws.athena().queryExecutions().at(-1)
+          ?.queryExecutionId,
+      },
+    });
+
+    assertIdentical(answered.answeredBy, "engine");
+    assertIdentical(
+      results.ResultSet?.Rows?.[0]?.Data?.[0]?.VarCharValue,
+      "_col0",
+    );
+  });
+
+  it("writes the rows it computed to the workgroup's output location", async () => {
+    // Given the readings, with the engine on.
+    const simulation = await aReadingSimulation();
+
+    // When a query runs.
+    await anAnsweredQuery(
+      simulation,
+      "SELECT site FROM rainlytics.readings WHERE live = true ORDER BY site",
+    );
+
+    // Then the CSV under the output location holds what the engine computed,
+    // rather than what any declaration said.
+    const written = await simulation.simAws.s3().listObjectsV2({
+      input: { Bucket: "rainlytics-results", Prefix: "q/" },
+    });
+    const object = await simulation.simAws.s3().getObject({
+      input: {
+        Bucket: "rainlytics-results",
+        Key: written.Contents?.[0]?.Key ?? "",
+      },
+    });
+    const body = Buffer.concat(await Array.fromAsync(object.Body ?? [])) as
+      | Buffer
+      | undefined;
+
+    assertIdentical(body?.toString("utf8"), '"site"\n"Alpha"\n""\n');
+  });
+
+  it("infers a computed column's type from what it answered with", async () => {
+    // Given the readings, with the engine on.
+    const simulation = await aReadingSimulation();
+
+    // When a query computes four columns the Glue schema says nothing about.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT max(site) AS latest, count(*) AS seen, " +
+        "avg(celsius) AS mean, NULL AS nothing FROM rainlytics.readings",
+    );
+
+    // Then each type comes off the value, and a column of nulls falls back to
+    // the type an undeclared column reports.
+    assertObjectEquals(answered.columns, [
+      "varchar",
+      "bigint",
+      "double",
+      "varchar",
+    ]);
+  });
+
+  it("takes the Trino spellings the parser will not read", async () => {
+    // Given the readings, with the engine on.
+    const simulation = await aReadingSimulation();
+
+    // When a query casts the forgiving way and pages the Trino way round.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT try_cast(samples AS varchar) AS samples " +
+        "FROM rainlytics.readings ORDER BY samples OFFSET 1 LIMIT 1",
+    );
+
+    // Then both are rewritten before the statement is parsed. Trino writes
+    // OFFSET before LIMIT and every other dialect writes it after.
+    assertObjectEquals(answered.rows, [["4"]]);
+  });
+
+  it("answers null for a column no object carried", async () => {
+    // Given a table declaring a column the data has never held.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "readings",
+      columns: [
+        { Name: "site", Type: "string" },
+        { Name: "humidity", Type: "double" },
+      ],
+    });
+
+    await aSeededJson(simulation.simAws, "readings/part-0.json", [
+      { site: "alpha" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query asks for it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT site FROM rainlytics.readings WHERE humidity IS NULL",
+    );
+
+    // Then it reads as null rather than failing the query. A table declaring
+    // more than its objects hold is ordinary.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["alpha"]]);
+  });
+});

--- a/src/service/athena/sim-athena-engine-schema.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-schema.iso.test.ts
@@ -175,6 +175,9 @@ describe("the schema an Athena query runs against", () => {
     await aSeededJson(simulation.simAws, "stock/site=%zz/b.json", [
       { sku: "nut" },
     ]);
+    await aSeededJson(simulation.simAws, "stock/site=yard 2.1/c.json", [
+      { sku: "screw" },
+    ]);
     await simulation.simAws.athena().engine().enable();
 
     // When a query reads the partition column.
@@ -183,8 +186,9 @@ describe("the schema an Athena query runs against", () => {
       "SELECT site FROM rainlytics.stock ORDER BY sku",
     );
 
-    // Then the encoding comes off, and a value that is no encoding at all is
-    // left as it was written.
-    assertObjectEquals(answered.rows, [["north yard"], ["%zz"]]);
+    // Then the encoding comes off, a value that is no encoding at all is left
+    // as it was written, and a value carrying a dot is a partition rather than
+    // a file name.
+    assertObjectEquals(answered.rows, [["north yard"], ["%zz"], ["yard 2.1"]]);
   });
 });

--- a/src/service/athena/sim-athena-engine-schema.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-schema.iso.test.ts
@@ -1,0 +1,190 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  logsBucket,
+} from "./sim-athena-engine.fixture.js";
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+
+describe("the schema an Athena query runs against", () => {
+  it("takes a column's case from Glue rather than from the data", async () => {
+    // Given a table whose column names are lower case and objects whose keys
+    // are not.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "readings",
+      columns: [{ Name: "site", Type: "string" }],
+    });
+
+    await aSeededJson(simulation.simAws, "readings/part-0.json", [
+      { Site: "alpha" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query reads the column.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT site FROM rainlytics.readings",
+    );
+
+    // Then it reads, because Hive column names are matched without regard to
+    // case and the JSON behind a table need not agree with the catalog.
+    assertObjectEquals(answered.rows, [["alpha"]]);
+  });
+
+  it("keeps a nested value as the JSON text a function can reach into", async () => {
+    // Given a column holding an object and one holding an array.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "events",
+      columns: [
+        { Name: "detail", Type: "struct<tenant:string>" },
+        { Name: "tags", Type: "array<string>" },
+        { Name: "cost", Type: "decimal(10,2)" },
+      ],
+    });
+
+    await aSeededJson(simulation.simAws, "events/part-0.json", [
+      { detail: { tenant: "acme" }, tags: ["a", "b"], cost: 1.5 },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query reaches into each of them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT json_extract_scalar(detail, '$.tenant') AS tenant, " +
+        "cardinality(tags) AS tag_count, cost FROM rainlytics.events",
+    );
+
+    // Then the structured columns read, and the decimal keeps its fraction.
+    assertObjectEquals(answered.rows, [["acme", "2", "1.5"]]);
+    assertObjectEquals(answered.columns, ["varchar", "bigint", "decimal"]);
+  });
+
+  it("drops a partition key repeating the name of a column", async () => {
+    // Given a table whose partition key is also one of its columns, which is
+    // a table real Athena refuses to query.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "stock",
+      columns: [
+        { Name: "sku", Type: "string" },
+        { Name: "day", Type: "string" },
+      ],
+      partitionKeys: [{ Name: "day", Type: "string" }],
+    });
+
+    await aSeededJson(simulation.simAws, "stock/day=2026-08-01/part-0.json", [
+      { sku: "bolt", day: "2026-08-01" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query reads both columns.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, day FROM rainlytics.stock",
+    );
+
+    // Then the duplicate is dropped rather than the query failing on a table
+    // SQLite would refuse to create.
+    assertObjectEquals(answered.rows, [["bolt", "2026-08-01"]]);
+  });
+
+  it("falls back where the table declares no columns", async () => {
+    // Given a table nobody gave a schema to.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, { name: "empty", columns: [] });
+
+    await aSeededJson(simulation.simAws, "empty/part-0.json", [{ a: 1 }]);
+    await simulation.simAws.athena().engine().enable();
+    simulation.simAws
+      .athena()
+      .results()
+      .byDefault({ columns: ["seen"], rows: [["declared"]] });
+
+    // When a query counts its rows.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(*) AS seen FROM rainlytics.empty",
+    );
+
+    // Then the declaration answers it. Neither SQLite nor Athena has a table
+    // without columns, so there is nothing for the engine to read.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("falls back where the table declares no SerDe at all", async () => {
+    // Given a table that never said what its objects hold.
+    const simulation = await anEngineSimulation();
+
+    simulation.simAws.glue().createTable({
+      input: {
+        DatabaseName: "rainlytics",
+        TableInput: {
+          Name: "unsaid",
+          StorageDescriptor: {
+            Columns: [{ Name: "sku", Type: "string" }],
+            Location: `s3://${logsBucket}/unsaid/`,
+          },
+        },
+      },
+    });
+
+    await aSeededJson(simulation.simAws, "unsaid/part-0.json", [
+      { sku: "bolt" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+    simulation.simAws
+      .athena()
+      .results()
+      .byDefault({ columns: ["sku"], rows: [["declared"]] });
+
+    // When a query runs against it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku FROM rainlytics.unsaid",
+    );
+
+    // Then the declaration answers it. Guessing would answer a Parquet query
+    // with nonsense rather than turning it down.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("reads a partition value written into the key path percent encoded", async () => {
+    // Given a partition value carrying a space.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "stock",
+      columns: [{ Name: "sku", Type: "string" }],
+      partitionKeys: [{ Name: "site", Type: "string" }],
+    });
+
+    await aSeededJson(simulation.simAws, "stock/site=north%20yard/a.json", [
+      { sku: "bolt" },
+    ]);
+    await aSeededJson(simulation.simAws, "stock/site=%zz/b.json", [
+      { sku: "nut" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query reads the partition column.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT site FROM rainlytics.stock ORDER BY sku",
+    );
+
+    // Then the encoding comes off, and a value that is no encoding at all is
+    // left as it was written.
+    assertObjectEquals(answered.rows, [["north yard"], ["%zz"]]);
+  });
+});

--- a/src/service/athena/sim-athena-engine.fixture.ts
+++ b/src/service/athena/sim-athena-engine.fixture.ts
@@ -1,0 +1,106 @@
+import { faker } from "@faker-js/faker";
+
+import type { SimGlueColumn } from "../glue/table/sim-glue-table-schema.js";
+import { SimAws } from "../aws/sim-aws.js";
+
+/** The SerDe class name a JSON lines table declares. */
+export const jsonSerDe = "org.openx.data.jsonserde.JsonSerDe";
+
+/** The SerDe class name a quoted CSV table declares. */
+export const csvSerDe = "org.apache.hadoop.hive.serde2.OpenCSVSerde";
+
+/** Where every table in these fixtures keeps its data. */
+export const logsBucket = "rainlytics-logs";
+
+/** A simulation holding both Buckets, a workgroup and a catalog database. */
+export interface SimAthenaEngineSimulation {
+  readonly simAws: SimAws;
+  readonly workGroup: string;
+}
+
+/** What one catalog table is declared with. */
+export interface SimAthenaEngineTableInput {
+  readonly name: string;
+  readonly columns: readonly SimGlueColumn[];
+  readonly partitionKeys?: readonly SimGlueColumn[];
+  readonly serDe?: string | undefined;
+  readonly serDeParameters?: Record<string, string>;
+  readonly parameters?: Record<string, string>;
+  readonly location?: string;
+}
+
+/**
+ * A simulation with somewhere to keep data, somewhere to write results, and a
+ * `rainlytics` database in the Data Catalog.
+ *
+ * The engine is left off. A test that wants it turns it on, which is what a
+ * reader of that test needs to see.
+ */
+export async function anEngineSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simAws = new SimAws();
+  const workGroup = `analytics-${faker.string.uuid()}`;
+
+  await simAws.s3().createBucket({ input: { Bucket: logsBucket } });
+  await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+  await simAws.athena().createWorkGroup({
+    input: {
+      Name: workGroup,
+      Configuration: {
+        ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+      },
+    },
+  });
+
+  simAws.glue().createDatabase({
+    input: { DatabaseInput: { Name: "rainlytics" } },
+  });
+
+  return { simAws, workGroup };
+}
+
+/** Declare one table in the `rainlytics` database. */
+export function aCatalogTable(
+  simAws: SimAws,
+  table: SimAthenaEngineTableInput,
+): void {
+  simAws.glue().createTable({
+    input: {
+      DatabaseName: "rainlytics",
+      TableInput: {
+        Name: table.name,
+        PartitionKeys: table.partitionKeys ?? [],
+        Parameters: table.parameters ?? {},
+        StorageDescriptor: {
+          Columns: table.columns,
+          Location: table.location ?? `s3://${logsBucket}/${table.name}/`,
+          SerdeInfo: {
+            SerializationLibrary: table.serDe ?? jsonSerDe,
+            Parameters: table.serDeParameters ?? {},
+          },
+        },
+      },
+    },
+  });
+}
+
+/** Put one object of literal text under the logs Bucket. */
+export async function aSeededObject(
+  simAws: SimAws,
+  key: string,
+  body: string,
+): Promise<void> {
+  await simAws
+    .s3()
+    .putObject({ input: { Bucket: logsBucket, Key: key, Body: body } });
+}
+
+/** Put one object of JSON lines under the logs Bucket. */
+export async function aSeededJson(
+  simAws: SimAws,
+  key: string,
+  records: readonly Record<string, unknown>[],
+): Promise<void> {
+  const lines = records.map((record) => JSON.stringify(record));
+
+  await aSeededObject(simAws, key, `${lines.join("\n")}\n`);
+}

--- a/src/service/athena/sim-athena-executions.ts
+++ b/src/service/athena/sim-athena-executions.ts
@@ -11,11 +11,16 @@ import {
 import type * as simAthenaCommands from "./command/sim-athena-command.types.js";
 import { SimAthenaCommands } from "./command/sim-athena-commands.js";
 import type { SimAthenaRequestOptions } from "./command/sim-athena-request-options.js";
+import { SimAthenaQueryEngine } from "./engine/sim-athena-query-engine.js";
+import {
+  simAthenaTableObjects,
+  type SimAthenaTableObjects,
+} from "./engine/sim-athena-table-objects.js";
 import { SimAthenaQueryExecutionStore } from "./execution/sim-athena-query-execution-store.js";
 import type { SimAthenaQueryExecution } from "./execution/sim-athena-query-execution.js";
 import { SimAthenaNoResultDestination } from "./execution/sim-athena-no-result-destination.js";
 import { SimAthenaQueryRunner } from "./execution/sim-athena-query-runner.js";
-import type { SimAthenaScannedObjects } from "./execution/sim-athena-scanned-bytes.js";
+import type { SimAthenaScannedObjects } from "./execution/sim-athena-scanned-objects.js";
 import {
   SimAthenaResultWriter,
   type SimAthenaResultDestination,
@@ -38,7 +43,7 @@ interface SimAthenaProperties {
    * A SimAthena built on its own has none, and a query that would write
    * results fails saying so. A Bucket only exists inside a SimAws.
    */
-  readonly s3?: SimAthenaResultDestination & Partial<SimAthenaScannedObjects>;
+  readonly s3?: SimAthenaResultDestination & Partial<SimAthenaTableObjects>;
 
   /**
    * The Data Catalog a query's table names are resolved against.
@@ -56,9 +61,7 @@ interface SimAthenaProperties {
  * a query there scans whatever a declaration says it scanned.
  */
 function scannedObjects(
-  s3:
-    | (SimAthenaResultDestination & Partial<SimAthenaScannedObjects>)
-    | undefined,
+  s3: (SimAthenaResultDestination & Partial<SimAthenaTableObjects>) | undefined,
 ): SimAthenaScannedObjects | undefined {
   return s3?.listObjectsV2 === undefined
     ? undefined
@@ -69,14 +72,13 @@ function scannedObjects(
  * Simulated Amazon Athena. Handles SDK commands. Emulates AWS behaviour and
  * state.
  *
- * Workgroups and named queries are what this models. A workgroup holds the
- * settings a query would run under, and a named query holds SQL under a name.
- * Nothing runs a query and nothing reads the SQL, so a named query here is the
- * text a caller saved and a workgroup is the configuration a stack set.
+ * Workgroups, named queries and query executions are what this models. A
+ * workgroup holds the settings a query runs under, a named query holds SQL
+ * under a name, and an execution is one run of a query.
  *
- * That is worth being plain about. A test can prove its stack configured the
- * bytes-scanned cutoff and its rollups were registered, and it cannot find out
- * whether the SQL is valid.
+ * A named query's SQL is stored and handed back exactly as it was sent. A
+ * running query is answered either from a declaration or by the query engine,
+ * and `engine()` is what turns the engine on.
  *
  * Both resources are scoped to an account and region, as they are on real
  * Athena. Every scope starts with the `primary` workgroup, which real Athena
@@ -89,6 +91,7 @@ export class SimAthenaExecutions {
   protected readonly background: BackgroundScheduler;
   readonly #executions = new SimAthenaQueryExecutionStore();
   readonly #results = new SimAthenaQueryResults();
+  readonly #engine = new SimAthenaQueryEngine();
 
   constructor(properties: SimAthenaProperties = {}) {
     const {
@@ -102,11 +105,13 @@ export class SimAthenaExecutions {
     });
     const runner = new SimAthenaQueryRunner({
       results: this.#results,
+      engine: this.#engine,
       workGroups: this.workGroupStore,
       writer,
       background,
       catalog: properties.glue,
       objects: scannedObjects(properties.s3),
+      tableObjects: simAthenaTableObjects(properties.s3),
     });
 
     this.background = background;
@@ -130,12 +135,23 @@ export class SimAthenaExecutions {
   /**
    * The results this scope answers queries with.
    *
-   * The simulator's own accessor rather than an Athena operation. No SQL is
-   * evaluated here, so a test says what a query answers with and the
-   * simulation matches on the query text.
+   * The simulator's own accessor rather than an Athena operation. A
+   * declaration written against one exact query text wins over the engine, and
+   * the broader tiers answer whatever the engine turned down.
    */
   results(): SimAthenaQueryResults {
     return this.#results;
+  }
+
+  /**
+   * The query engine this scope runs queries with.
+   *
+   * The simulator's own accessor rather than an Athena operation. It is off
+   * until a test turns it on, and every query is answered from a declaration
+   * until then.
+   */
+  engine(): SimAthenaQueryEngine {
+    return this.#engine;
   }
 
   /**

--- a/src/service/athena/sim-athena-query-engine.iso.test.ts
+++ b/src/service/athena/sim-athena-query-engine.iso.test.ts
@@ -180,6 +180,8 @@ describe("running an Athena query for real", () => {
     );
 
     // Then each one answers.
-    assertObjectEquals(answered.rows, [["2026-08-01", "a", "4", "acme"]]);
+    assertObjectEquals(answered.rows, [
+      ["2026-08-01T00:00:00Z", "a", "4", "acme"],
+    ]);
   });
 });

--- a/src/service/athena/sim-athena-query-engine.iso.test.ts
+++ b/src/service/athena/sim-athena-query-engine.iso.test.ts
@@ -1,0 +1,185 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+
+/** The orders one query in this file reads. */
+const orders = [
+  { id: 1, customer: "ada", amount: 10.5, refunded: false },
+  { id: 2, customer: "bob", amount: 4, refunded: true },
+  { id: 3, customer: "ada", amount: 7.25, refunded: false },
+  { id: 4, customer: "cyd", amount: 22, refunded: false },
+];
+
+/** A simulation holding the orders, with the engine turned on. */
+async function anOrderSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "orders",
+    columns: [
+      { Name: "id", Type: "int" },
+      { Name: "customer", Type: "string" },
+      { Name: "amount", Type: "double" },
+      { Name: "refunded", Type: "boolean" },
+    ],
+  });
+
+  await aSeededJson(simulation.simAws, "orders/part-0.json", orders);
+  await simulation.simAws.athena().engine().enable();
+
+  return simulation;
+}
+
+describe("running an Athena query for real", () => {
+  it("answers a filtered rollup from the objects a test seeded", async () => {
+    // Given a table over four orders, with the engine on.
+    const simulation = await anOrderSimulation();
+
+    // When a query rolls them up by customer.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT customer, count(*) AS orders, sum(amount) AS spend " +
+        "FROM rainlytics.orders WHERE refunded = false " +
+        "GROUP BY customer HAVING sum(amount) > 5 " +
+        "ORDER BY spend DESC LIMIT 2",
+    );
+
+    // Then the rows are what the data comes to, not what anybody declared.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["cyd", "1", "22"],
+      ["ada", "2", "17.75"],
+    ]);
+  });
+
+  it("joins two tables in the catalog", async () => {
+    // Given the orders and a second table naming each customer's tier.
+    const simulation = await anOrderSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "tiers",
+      columns: [
+        { Name: "customer", Type: "string" },
+        { Name: "tier", Type: "string" },
+      ],
+    });
+
+    await aSeededJson(simulation.simAws, "tiers/part-0.json", [
+      { customer: "ada", tier: "gold" },
+      { customer: "bob", tier: "silver" },
+    ]);
+
+    // When a query joins them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.tier, count(*) AS orders FROM rainlytics.orders o " +
+        "JOIN rainlytics.tiers t ON o.customer = t.customer " +
+        "GROUP BY t.tier ORDER BY t.tier",
+    );
+
+    // Then the join is real, and the customer in neither table is dropped.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["gold", "2"],
+      ["silver", "1"],
+    ]);
+  });
+
+  it("answers a common table expression and a window function", async () => {
+    // Given the orders, with the engine on.
+    const simulation = await anOrderSimulation();
+
+    // When a CTE feeds a window function.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "WITH kept AS (SELECT * FROM rainlytics.orders WHERE refunded = false) " +
+        "SELECT customer, amount, " +
+        "rank() OVER (PARTITION BY customer ORDER BY amount DESC) AS place " +
+        "FROM kept ORDER BY customer, place",
+    );
+
+    // Then each customer's orders are ranked within their own partition.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["ada", "10.5", "1"],
+      ["ada", "7.25", "2"],
+      ["cyd", "22", "1"],
+    ]);
+  });
+
+  it("resolves an unqualified table against the query's own database", async () => {
+    // Given the orders, with the engine on.
+    const simulation = await anOrderSimulation();
+
+    // When a query names the table without its database, saying which
+    // database it runs in.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(*) AS orders FROM orders",
+      "rainlytics",
+    );
+
+    // Then it resolves the way it resolves on real Athena.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["4"]]);
+  });
+
+  it("reads a table twice over without loading it twice", async () => {
+    // Given the orders, with the engine on.
+    const simulation = await anOrderSimulation();
+
+    // When a query names one table twice.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(*) AS pairs FROM rainlytics.orders a " +
+        "JOIN rainlytics.orders b ON a.customer = b.customer AND a.id < b.id",
+    );
+
+    // Then the self join is over the four rows rather than eight.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["1"]]);
+  });
+
+  it("shims the Trino functions SQLite does not have", async () => {
+    // Given a table holding a timestamp, a path and a JSON document.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "events",
+      columns: [
+        { Name: "at", Type: "timestamp" },
+        { Name: "path", Type: "string" },
+        { Name: "detail", Type: "string" },
+      ],
+    });
+
+    await aSeededJson(simulation.simAws, "events/part-0.json", [
+      {
+        at: "2026-08-02T09:30:00Z",
+        path: "/a/b/c",
+        detail: '{"tenant":"acme"}',
+      },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query reaches for four of them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT date_trunc('month', at) AS month, " +
+        "split_part(path, '/', 2) AS head, strpos(path, 'b') AS at_b, " +
+        "json_extract_scalar(detail, '$.tenant') AS tenant " +
+        "FROM rainlytics.events",
+    );
+
+    // Then each one answers.
+    assertObjectEquals(answered.rows, [["2026-08-01", "a", "4", "acme"]]);
+  });
+});

--- a/src/service/athena/sim-athena.ts
+++ b/src/service/athena/sim-athena.ts
@@ -15,12 +15,14 @@ import type { SimAthenaWorkGroup } from "./workgroup/sim-athena-work-group.js";
  * workgroup holds the settings a query runs under, a named query holds SQL
  * under a name, and an execution is one run of a query.
  *
- * No SQL is evaluated. A test declares what a query answers with through
- * `results()`, and the simulation reads the query text only as a key to match
- * that declaration on. So a test can prove its workgroup's bytes-scanned
- * cutoff refuses a query, that results land where the workgroup says, and that
- * a client polls the lifecycle correctly. Whether the SQL is valid stays out
- * of reach.
+ * A query is answered one of two ways. A test declares what it answers with
+ * through `results()` and the simulation matches that declaration on the query
+ * text, or the query engine runs the SQL over the objects a test seeded into
+ * simulated S3. The engine is off until `engine().enable()` turns it on.
+ *
+ * Either way the lifecycle around the query is real. A test can prove its
+ * workgroup's bytes-scanned cutoff refuses a query, that results land where
+ * the workgroup says, and that a client polls the lifecycle correctly.
  *
  * Everything here is scoped to an account and region, as it is on real Athena.
  * Every scope starts with the `primary` workgroup, which real Athena makes

--- a/src/service/athena/table/sim-athena-catalog-table.ts
+++ b/src/service/athena/table/sim-athena-catalog-table.ts
@@ -1,0 +1,42 @@
+import type { SimAthenaPartitionedTable } from "../projection/sim-athena-table-partitions.js";
+
+/**
+ * One column of a catalog table, or one partition key.
+ *
+ * Real Glue uses the same `Column` shape for both, and the type is written the
+ * way Hive writes it: `string`, `int`, `bigint`, `boolean` and so on.
+ */
+export interface SimAthenaCatalogColumn {
+  readonly Name: string;
+  readonly Type?: string | undefined;
+}
+
+/** How one table's rows are serialized, and where they sit. */
+export interface SimAthenaCatalogSerDe {
+  readonly SerializationLibrary?: string | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/** Where a catalog table's data lives and how it is read. */
+export interface SimAthenaCatalogStorage {
+  readonly Location?: string | undefined;
+  readonly SerdeInfo?: SimAthenaCatalogSerDe | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * One Glue table, as simulated Athena reads it.
+ *
+ * `SimGlueTable` structurally implements this, the way `SimS3` implements
+ * `SimAthenaResultDestination`. Partition projection needs the parameters, the
+ * partition keys and the location; the query engine needs the rest, since it
+ * builds a SQLite table out of the schema and decodes the objects with the
+ * SerDe.
+ */
+export interface SimAthenaCatalogTable extends SimAthenaPartitionedTable {
+  readonly name: string;
+  readonly databaseName: string;
+  readonly columns: readonly SimAthenaCatalogColumn[];
+  readonly partitionKeys: readonly SimAthenaCatalogColumn[];
+  readonly storageDescriptor: SimAthenaCatalogStorage | undefined;
+}

--- a/src/service/athena/table/sim-athena-table-resolution.ts
+++ b/src/service/athena/table/sim-athena-table-resolution.ts
@@ -5,7 +5,7 @@ import {
   simAthenaTableReferenceText,
   type SimAthenaTableReference,
 } from "./sim-athena-table-reference.js";
-import type { SimAthenaPartitionedTable } from "../projection/sim-athena-table-partitions.js";
+import type { SimAthenaCatalogTable } from "./sim-athena-catalog-table.js";
 import { simAthenaTableReferences } from "./sim-athena-table-references.js";
 
 /**
@@ -20,7 +20,7 @@ export interface SimAthenaCatalog {
   findTable(
     databaseName: string,
     name: string,
-  ): SimAthenaPartitionedTable | undefined;
+  ): SimAthenaCatalogTable | undefined;
 }
 
 /** What resolving a query's tables came to. */
@@ -29,7 +29,7 @@ export interface SimAthenaResolvedTables {
   readonly refusal: string | undefined;
 
   /** The catalog entries the query reads, for whatever comes next. */
-  readonly tables: readonly SimAthenaPartitionedTable[];
+  readonly tables: readonly SimAthenaCatalogTable[];
 }
 
 /** What one query is resolved against. */
@@ -70,7 +70,7 @@ export function simAthenaResolveTables(
     return { refusal: undefined, tables: [] };
   }
 
-  const tables: SimAthenaPartitionedTable[] = [];
+  const tables: SimAthenaCatalogTable[] = [];
 
   for (const reference of read.references) {
     if (isFederated(reference.catalog) || isInformationSchema(reference)) {

--- a/src/util/rule/sim-declared-result-rules.ts
+++ b/src/util/rule/sim-declared-result-rules.ts
@@ -64,14 +64,28 @@ export class SimDeclaredResultRules<TResult> {
    * The result for one request.
    */
   resultFor(keys: SimDeclaredResultKeys): TResult {
+    return this.declaredFor(keys) ?? this.defaultResult;
+  }
+
+  /**
+   * The result a rule declared for one request, where a rule matched it.
+   *
+   * The default is left out, so a caller can tell a request nobody wrote a
+   * rule for from one that matched. A service chaining declarations with
+   * something that computes an answer needs that distinction, and simulated
+   * Athena runs its query engine on the miss.
+   *
+   * A request carrying only the key of the tier it is asking about answers
+   * from that tier alone.
+   */
+  declaredFor(keys: SimDeclaredResultKeys): TResult | undefined {
     return (
-      this.declaredFor(this.byLeadingKey, keys.leading) ??
-      this.declaredFor(this.byTrailingKey, keys.trailing) ??
-      this.defaultResult
+      this.matched(this.byLeadingKey, keys.leading) ??
+      this.matched(this.byTrailingKey, keys.trailing)
     );
   }
 
-  private declaredFor(
+  private matched(
     rules: ReadonlyMap<string, TResult>,
     key: string | undefined,
   ): TResult | undefined {


### PR DESCRIPTION
Simulated Athena answers a `SELECT` from the objects a test seeded into simulated S3. It reads the table's schema out of the Glue Data Catalog, decodes each object with the SerDe the table declares, loads the rows into an in-memory SQLite database and answers the statement from them. The engine is off until `athena().engine().enable()` turns it on, and it needs `node-sql-parser` in the project as an optional peer dependency. A declaration written against one exact query text wins over the engine, and everything the engine turns down falls back to the declarations, so every test written before this keeps working. `answeredBy` on the execution reports which of the two answered.

JSON lines and CSV are the formats read, by the SerDe class name. Column types come from the Glue schema and are reported the way Athena reports them, so a boolean column reads as `true` and `false`. `PRAGMA case_sensitive_like` is set and every ascending sort is emitted carrying `NULLS LAST`, which were the two cases #1004 measured where a query succeeded and answered differently from Athena. A partition column's value travels with the prefix it was projected from, so `simAthenaTablePartitions` now answers with a prefix and its values rather than a prefix alone. Without that a table using `storage.location.template` would read every partition column as null.

Resolves https://github.com/KensioSoftware/yulin/issues/1008


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in simulated Athena SQL engine that executes supported queries against simulated S3 and Glue table data.
  * Added support for common filtering, joins, aggregations, window functions, date, JSON, string, and approximate aggregate operations.
  * Added CSV and JSON Lines ingestion, partition projection, schema-aware types, null handling, and query result metadata.
  * Added visibility into whether results came from SQL execution or declarations.
* **Documentation**
  * Expanded Athena guidance and added a complete working example.
* **Tests**
  * Added extensive coverage for query execution, formats, schemas, partitions, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->