### PR TITLE
feat: flatten an Athena array with UNNEST

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -336,6 +336,25 @@ Every ascending sort is emitted carrying `NULLS LAST`, because Trino orders null
 direction it sorts and SQLite orders them first ascending. Both were cases where a query answered
 differently while still succeeding, which is the failure that costs the most to find.
 
+### Flattening an array or a map
+
+`UNNEST` runs. An array or a map column is held as its JSON text, and SQLite reads that with
+`json_each`, so a statement flattening one returns a row per element the way Athena does.
+
+```sql
+SELECT e.id, t.tag
+FROM rainlytics.events e
+CROSS JOIN UNNEST(e.tags) AS t(tag)
+```
+
+An array gives one column per element and a map gives the key beside the value, as
+`UNNEST(e.attrs) AS t(attribute, value)`. `WITH ORDINALITY` adds the position, counted from one.
+The Glue schema is what says which of the two a column holds, and a column it calls anything else
+falls back rather than reading a scalar as a collection.
+
+One flattening per statement is what this covers, joined with `CROSS JOIN`. A second `UNNEST`, a
+`LEFT JOIN UNNEST`, a `SELECT *` beside one, and a position taken from a map all fall back.
+
 ## Tables a query names
 
 A query's `FROM` and `JOIN` clauses are read, and each table they name is looked for in the Glue
@@ -682,6 +701,7 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 - Query executions, moving through `QUEUED` and `RUNNING` to `SUCCEEDED`, `FAILED` or `CANCELLED`
 - `StartQueryExecution`, `GetQueryExecution`, `GetQueryResults` and `StopQueryExecution`
 - A `SELECT` run for real over JSON lines and CSV objects in simulated S3, answered by SQLite
+- `UNNEST` over an array or a map column, with `WITH ORDINALITY` where a query wants the position
 - Declared results, matched on the query text, ahead of the engine for one statement and behind it
   for everything else
 - Table names in `FROM` and `JOIN` resolved against the simulated Glue Data Catalog
@@ -707,7 +727,14 @@ Current documented limitations:
   accept a query real Athena would reject.
 - With the engine on, the statement is read as Athena by `node-sql-parser`, written back out for
   SQLite and run there. Around one query in twenty is turned down at one of those two steps and
-  falls back to its declared result. `UNNEST` and `GROUPING SETS` are the two measured cases.
+  falls back to its declared result. `GROUPING SETS` is the measured case, which the parser's
+  Athena grammar refuses outright.
+- One `UNNEST` per statement is rewritten onto `json_each`, and it has to be a `CROSS JOIN`. A
+  statement carrying two, one under a `LEFT JOIN`, one whose alias names no columns, and one
+  selecting every column all fall back. So does `WITH ORDINALITY` over a map, since `json_each`
+  gives a map's keys rather than its positions.
+- `UNNEST` over a `ROW` or a struct array falls back. The element needs field access and the
+  flattened column is JSON text here.
 - The Trino function library reaches as far as `date_trunc`, `date_format`, `from_unixtime`,
   `to_unixtime`, `from_iso8601_timestamp`, `from_iso8601_date`, `to_iso8601`,
   `json_extract_scalar`, `cardinality`, `element_at`, `regexp_like`, `split_part`, `strpos`,

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -347,7 +347,7 @@ FROM rainlytics.events e
 CROSS JOIN UNNEST(e.tags) AS t(tag)
 ```
 
-An array gives one column per element and a map gives the key beside the value, as
+An array flattens to one column and a map flattens to two, the key beside the value, as
 `UNNEST(e.attrs) AS t(attribute, value)`. `WITH ORDINALITY` adds the position, counted from one.
 The Glue schema is what says which of the two a column holds, and a column it calls anything else
 falls back rather than reading a scalar as a collection.

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -207,6 +207,29 @@ back a tick later, because `process.emitWarning` defers delivery and restoring s
 it. A project that installed a warning listener of its own keeps it, along with every other warning
 it would have printed.
 
+### Flattening with UNNEST
+
+`sim-athena-unnest-rewrite.ts` turns one `UNNEST` into a `json_each`. The rewrite happens on the
+tree between `astify` and `sqlify`, because `sqlify` writes the `UNNEST` back out unchanged and
+SQLite has no such clause.
+
+Three things made this more than a substitution.
+
+The parser's Athena grammar refuses `WITH ORDINALITY` outright, so
+`sim-athena-sql-rewrites.ts` takes those two words out before parsing and reports that they were
+there. Nothing else in Trino spells them, which is what makes a plain text removal safe.
+
+The alias names columns that `json_each` calls something else. An array's element is its `value`, a
+map's entry is a `key` beside a `value`, and a position is `key + 1`, since `json_each` counts an
+array from zero and Athena counts from one. `sim-athena-unnest-columns.ts` points every reference
+at the right one and keeps the name the statement wrote, so the result set reports `tag` rather
+than `value`. Every match is collected before any of them is rewritten, because reading a position
+writes a `key` into the tree and a walk still running would find it.
+
+Only the Glue schema says whether a column holds an array or a map, so `sim-athena-unnest-source.ts`
+resolves the `FROM` aliases back to catalog tables to read the type. A column the schema calls
+anything else falls back. That keeps a scalar from being read as a collection.
+
 ### Reading the answer back
 
 `sim-athena-engine-result.ts` reads rows as arrays through `setReturnArrays`, since a statement is

--- a/src/service/athena/engine/sim-athena-ast-nodes.ts
+++ b/src/service/athena/engine/sim-athena-ast-nodes.ts
@@ -1,0 +1,72 @@
+/**
+ * One node of the parser's syntax tree, as far as the engine reads it.
+ *
+ * The tree is the library's own and carries a node shape per dialect and per
+ * construct. Only the handful of properties the `UNNEST` rewrite needs are
+ * named, and everything else travels as an unknown value.
+ */
+export type SimAthenaAstNode = Record<string, unknown>;
+
+/** A reference to a column, qualified by a table or an alias where it has one. */
+export interface SimAthenaColumnRef extends SimAthenaAstNode {
+  type: "column_ref";
+  table: string | null;
+  column: string;
+}
+
+/** One entry of a `FROM` clause naming a catalog table. */
+export interface SimAthenaFromItem extends SimAthenaAstNode {
+  db?: string | null;
+  table: string;
+  as?: string | null;
+}
+
+/** Every node in the tree, the outermost first. */
+export function* simAthenaAstNodes(root: unknown): Generator<SimAthenaAstNode> {
+  if (Array.isArray(root)) {
+    for (const item of root) {
+      yield* simAthenaAstNodes(item);
+    }
+
+    return;
+  }
+
+  if (root === null || typeof root !== "object") {
+    return;
+  }
+
+  yield root as SimAthenaAstNode;
+
+  for (const value of Object.values(root)) {
+    yield* simAthenaAstNodes(value);
+  }
+}
+
+/** Whether this node references a column. */
+export function isColumnRef(
+  node: SimAthenaAstNode,
+): node is SimAthenaColumnRef {
+  return node["type"] === "column_ref" && typeof node["column"] === "string";
+}
+
+/**
+ * Whether this node names a catalog table in a `FROM` clause.
+ *
+ * A column reference carries a `table` of its own, and having no `column` is
+ * what tells the two apart.
+ */
+export function isFromItem(node: SimAthenaAstNode): node is SimAthenaFromItem {
+  return typeof node["table"] === "string" && node["column"] === undefined;
+}
+
+/** Replace everything one node holds, keeping the object the tree points at. */
+export function replaceNode(
+  node: SimAthenaAstNode,
+  replacement: SimAthenaAstNode,
+): void {
+  for (const key of Object.keys(node)) {
+    Reflect.deleteProperty(node, key);
+  }
+
+  Object.assign(node, replacement);
+}

--- a/src/service/athena/engine/sim-athena-query-engine.ts
+++ b/src/service/athena/engine/sim-athena-query-engine.ts
@@ -82,7 +82,11 @@ export class SimAthenaQueryEngine {
       return undefined;
     }
 
-    const sql = simAthenaSqliteSql(parser, request.queryString);
+    const sql = simAthenaSqliteSql({
+      parser,
+      athenaSql: request.queryString,
+      tables: request.tables.map((planned) => planned.table),
+    });
 
     return sql === undefined
       ? undefined

--- a/src/service/athena/engine/sim-athena-sql-rewrites.ts
+++ b/src/service/athena/engine/sim-athena-sql-rewrites.ts
@@ -1,20 +1,44 @@
+/** What a statement asks for, once the parser's grammar has been worked around. */
+export interface SimAthenaParserSql {
+  readonly sql: string;
+
+  /** Whether an `UNNEST` asked for the position of each element. */
+  readonly ordinality: boolean;
+}
+
+/**
+ * `WITH ORDINALITY`, which the parser's Athena grammar refuses outright.
+ *
+ * Nothing else in Trino spells it, so taking it out of the statement and
+ * remembering that it was there is enough to get the rest of the `UNNEST`
+ * through the grammar.
+ */
+const withOrdinality = /\s+WITH\s+ORDINALITY\b/giu;
+
 /**
  * The statement as the parser's Athena grammar will take it.
  *
- * Both rewrites close a gap in that grammar rather than a gap in SQLite.
+ * The two rewrites close a gap in that grammar rather than a gap in SQLite.
  * `try_cast` becomes a plain cast, which changes meaning in the forgiving
  * direction, since SQLite already answers with a value where a cast fails
- * rather than failing the query. Trino writes `OFFSET` before `LIMIT` and
- * every other dialect writes it after.
+ * rather than failing the query. Trino writes `OFFSET` before `LIMIT` and every
+ * other dialect writes it after.
  */
-export function simAthenaSqlForParser(sql: string): string {
-  return sql
+export function simAthenaSqlForParser(sql: string): SimAthenaParserSql {
+  const rewritten = sql
     .replaceAll(/\btry_cast\s*\(/giu, "CAST(")
     .replaceAll(
       /\bOFFSET\s+(\d+)\s+LIMIT\s+(\d+)/giu,
       (_match, offset: string, limit: string) =>
         `LIMIT ${limit} OFFSET ${offset}`,
     );
+
+  const forParser = rewritten.replaceAll(withOrdinality, "");
+
+  return {
+    sql: forParser,
+    ordinality: forParser.length !== rewritten.length,
+  };
 }
 
 /**

--- a/src/service/athena/engine/sim-athena-sql-translation.ts
+++ b/src/service/athena/engine/sim-athena-sql-translation.ts
@@ -1,27 +1,48 @@
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
 import type { SimAthenaSqlParser } from "./sim-athena-parser-module.js";
 import {
   simAthenaSqlForParser,
   simAthenaSqlForSqlite,
 } from "./sim-athena-sql-rewrites.js";
+import { simAthenaRewriteUnnest } from "./sim-athena-unnest-rewrite.js";
+
+interface SimAthenaSqlTranslationRequest {
+  readonly parser: SimAthenaSqlParser;
+  readonly athenaSql: string;
+
+  /** The catalog tables the statement reads, for the types it names. */
+  readonly tables: readonly SimAthenaCatalogTable[];
+}
 
 /**
  * One Athena statement written back out for SQLite, or nothing where it cannot
  * be.
  *
- * A statement the Athena grammar refuses and one the parser cannot write back
- * out both land the same way, because the engine has one answer to either:
- * turn the query down and let the declared result take it. Nothing is reported
- * from here, since a query the engine cannot run is an ordinary thing for a
- * test to write rather than a fault.
+ * A statement the Athena grammar refuses, one carrying an `UNNEST` that cannot
+ * become a `json_each`, and one the parser cannot write back out all land the
+ * same way. The engine has one answer to any of them, which is to turn the
+ * query down and let the declared result take it. Nothing is reported from
+ * here, since a query the engine cannot run is an ordinary thing for a test to
+ * write.
  */
 export function simAthenaSqliteSql(
-  parser: SimAthenaSqlParser,
-  athenaSql: string,
+  request: SimAthenaSqlTranslationRequest,
 ): string | undefined {
+  const { parser } = request;
+
   try {
-    const ast = parser.astify(simAthenaSqlForParser(athenaSql), {
-      database: "athena",
-    });
+    const read = simAthenaSqlForParser(request.athenaSql);
+    const ast = parser.astify(read.sql, { database: "athena" });
+
+    if (
+      !simAthenaRewriteUnnest({
+        ast,
+        ordinality: read.ordinality,
+        tables: request.tables,
+      })
+    ) {
+      return undefined;
+    }
 
     return simAthenaSqlForSqlite(parser.sqlify(ast, { database: "sqlite" }));
   } catch {

--- a/src/service/athena/engine/sim-athena-unnest-columns.ts
+++ b/src/service/athena/engine/sim-athena-unnest-columns.ts
@@ -1,0 +1,134 @@
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
+import {
+  isColumnRef,
+  replaceNode,
+  simAthenaAstNodes,
+  type SimAthenaAstNode,
+  type SimAthenaColumnRef,
+} from "./sim-athena-ast-nodes.js";
+import type { SimAthenaUnnestTarget } from "./sim-athena-unnest-targets.js";
+
+interface SimAthenaUnnestColumnsRequest {
+  readonly ast: unknown;
+  readonly alias: string;
+  readonly targets: readonly SimAthenaUnnestTarget[];
+  readonly reachable: ReadonlyMap<string, SimAthenaCatalogTable>;
+}
+
+/**
+ * Point every reference to an `UNNEST` alias at the column `json_each` answers
+ * with.
+ *
+ * A qualified reference is unambiguous and is always rewritten. An unqualified
+ * one is rewritten only where no table the statement reads declares a column of
+ * that name, since a statement writing one where both could answer is
+ * ambiguous on real Athena.
+ */
+export function simAthenaRewriteUnnestColumns(
+  request: SimAthenaUnnestColumnsRequest,
+): void {
+  const alias = request.alias.toLowerCase();
+  const matched: { node: SimAthenaAstNode; target: SimAthenaUnnestTarget }[] =
+    [];
+
+  // Every match is collected before any of them is rewritten. Reading the
+  // position writes a `key` of its own into the tree, and a walk still running
+  // would find that and read it as another reference to the alias.
+  for (const node of simAthenaAstNodes(request.ast)) {
+    const target = matchedTarget(node, alias, request);
+
+    if (target !== undefined) {
+      matched.push({ node, target });
+    }
+  }
+
+  for (const { node, target } of matched) {
+    nameSelectedColumn(node, request.ast);
+    readColumn(node, request.alias, target);
+  }
+}
+
+function matchedTarget(
+  node: SimAthenaAstNode,
+  alias: string,
+  request: SimAthenaUnnestColumnsRequest,
+): SimAthenaUnnestTarget | undefined {
+  if (!isColumnRef(node)) {
+    return undefined;
+  }
+
+  const qualifier = node.table?.toLowerCase();
+
+  if (qualifier !== undefined && qualifier !== alias) {
+    return undefined;
+  }
+
+  const target = request.targets.find(
+    (one) => one.from.toLowerCase() === node.column.toLowerCase(),
+  );
+
+  if (target === undefined || qualifier === alias) {
+    return target;
+  }
+
+  return declaredElsewhere(node.column, request.reachable) ? undefined : target;
+}
+
+/** Whether a table the statement reads carries a column of this name. */
+function declaredElsewhere(
+  column: string,
+  reachable: ReadonlyMap<string, SimAthenaCatalogTable>,
+): boolean {
+  return reachable
+    .values()
+    .some((table) =>
+      table.columns.some(
+        (one) => one.Name.toLowerCase() === column.toLowerCase(),
+      ),
+    );
+}
+
+/**
+ * Keep the name a selected column had.
+ *
+ * `SELECT t.tag` reads `t.value` once this is done, and the result set would
+ * report the column as `value`. Athena reports it as `tag`, so the name the
+ * statement wrote becomes the alias.
+ */
+function nameSelectedColumn(node: SimAthenaAstNode, ast: unknown): void {
+  for (const item of simAthenaAstNodes(ast)) {
+    if (
+      item["type"] === "expr" &&
+      item["expr"] === node &&
+      item["as"] === null
+    ) {
+      item["as"] = (node as SimAthenaColumnRef).column;
+    }
+  }
+}
+
+/** Read the `json_each` column, or the position Athena counts from one. */
+function readColumn(
+  node: SimAthenaAstNode,
+  alias: string,
+  target: SimAthenaUnnestTarget,
+): void {
+  if (target.reads !== "ordinality") {
+    replaceNode(node, {
+      type: "column_ref",
+      table: alias,
+      column: target.reads,
+      collate: null,
+    });
+
+    return;
+  }
+
+  replaceNode(node, {
+    type: "binary_expr",
+    operator: "+",
+    parentheses: true,
+    left: { type: "column_ref", table: alias, column: "key", collate: null },
+    right: { type: "number", value: 1 },
+  });
+}

--- a/src/service/athena/engine/sim-athena-unnest-item.ts
+++ b/src/service/athena/engine/sim-athena-unnest-item.ts
@@ -1,0 +1,105 @@
+import {
+  simAthenaAstNodes,
+  type SimAthenaAstNode,
+} from "./sim-athena-ast-nodes.js";
+
+/** The one `UNNEST` a statement carries, read off the tree. */
+export interface SimAthenaUnnestItem {
+  /** The `FROM` entry itself, which the rewrite replaces in place. */
+  readonly item: SimAthenaAstNode;
+
+  /** The name the flattened rows are reached through. */
+  readonly alias: string;
+
+  /** The names the alias gives the flattened columns, in order. */
+  readonly columns: readonly string[];
+
+  /** What is being flattened. */
+  readonly source: SimAthenaAstNode;
+}
+
+/** What looking for an `UNNEST` came to. */
+export type SimAthenaUnnestRead =
+  | { readonly kind: "absent" }
+  | { readonly kind: "unreadable" }
+  | ({ readonly kind: "found" } & SimAthenaUnnestItem);
+
+/**
+ * The `UNNEST` a statement flattens an array or a map with.
+ *
+ * A statement carrying more than one is reported unreadable, along with one
+ * whose `UNNEST` is joined any way other than a cross join and one that leaves
+ * the flattened columns unnamed. Each of those runs under real Athena and none
+ * of them survives the rewrite, so the query falls back to its declared result
+ * rather than answering differently.
+ */
+export function simAthenaUnnestItem(ast: unknown): SimAthenaUnnestRead {
+  const items = [...simAthenaAstNodes(ast)].filter(
+    (node) => node["type"] === "unnest",
+  );
+
+  if (items.length === 0) {
+    return { kind: "absent" };
+  }
+
+  const item = items[0];
+
+  if (item === undefined || items.length > 1 || !isCrossJoined(item)) {
+    return { kind: "unreadable" };
+  }
+
+  const alias = aliasOf(item);
+  const columns = aliasColumns(item);
+  const source = item["expr"];
+
+  if (alias === undefined || columns === undefined || !isNode(source)) {
+    return { kind: "unreadable" };
+  }
+
+  return { kind: "found", item, alias, columns, source };
+}
+
+/**
+ * Whether this `UNNEST` is cross joined.
+ *
+ * SQLite reads a comma in a `FROM` clause as a cross join and has no other way
+ * to reach a table valued function, so an `UNNEST` under a `LEFT JOIN` would
+ * come out meaning something else.
+ */
+const crossJoins = new Set([undefined, null, "CROSS JOIN"]);
+
+function isCrossJoined(item: SimAthenaAstNode): boolean {
+  return crossJoins.has(item["join"] as string | null | undefined);
+}
+
+/** The alias name, which the parser holds as a function's name. */
+function aliasOf(item: SimAthenaAstNode): string | undefined {
+  const parts = asNode(asNode(item["as"])?.["name"])?.["name"];
+  const first = Array.isArray(parts) ? asNode(parts[0]) : undefined;
+  const value = first?.["value"];
+
+  return typeof value === "string" ? value : undefined;
+}
+
+/** The names inside the alias, which the parser holds as a function's arguments. */
+function aliasColumns(item: SimAthenaAstNode): readonly string[] | undefined {
+  const values = asNode(asNode(item["as"])?.["args"])?.["value"];
+
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined;
+  }
+
+  const columns = values.map((value) => asNode(value)?.["column"]);
+
+  return columns.every((column) => typeof column === "string")
+    ? columns
+    : undefined;
+}
+
+function isNode(value: unknown): value is SimAthenaAstNode {
+  return typeof value === "object" && value !== null;
+}
+
+function asNode(value: unknown): SimAthenaAstNode | undefined {
+  return isNode(value) ? value : undefined;
+}

--- a/src/service/athena/engine/sim-athena-unnest-rewrite.ts
+++ b/src/service/athena/engine/sim-athena-unnest-rewrite.ts
@@ -1,0 +1,85 @@
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
+import {
+  isColumnRef,
+  replaceNode,
+  simAthenaAstNodes,
+  type SimAthenaAstNode,
+} from "./sim-athena-ast-nodes.js";
+import { simAthenaRewriteUnnestColumns } from "./sim-athena-unnest-columns.js";
+import { simAthenaUnnestItem } from "./sim-athena-unnest-item.js";
+import {
+  simAthenaQueryTables,
+  simAthenaUnnestKind,
+} from "./sim-athena-unnest-source.js";
+import { simAthenaUnnestTargets } from "./sim-athena-unnest-targets.js";
+
+interface SimAthenaUnnestRewriteRequest {
+  readonly ast: unknown;
+  readonly ordinality: boolean;
+  readonly tables: readonly SimAthenaCatalogTable[];
+}
+
+/**
+ * Turn an `UNNEST` into the `json_each` SQLite flattens JSON with.
+ *
+ * An array or a map column is held as its JSON text, and `json_each` reads that
+ * as one row per element with a `key` and a `value`. The `FROM` entry becomes a
+ * call to it and every reference to the alias is pointed at the column it
+ * answers with.
+ *
+ * Answers with whether the statement can run. A statement carrying no `UNNEST`
+ * runs untouched, and one carrying an `UNNEST` this cannot turn into
+ * `json_each` is left for the declared result to answer.
+ */
+export function simAthenaRewriteUnnest(
+  request: SimAthenaUnnestRewriteRequest,
+): boolean {
+  const read = simAthenaUnnestItem(request.ast);
+
+  if (read.kind !== "found") {
+    return read.kind === "absent";
+  }
+
+  const kind = simAthenaUnnestKind(read.source, request.ast, request.tables);
+  const targets =
+    kind === undefined
+      ? undefined
+      : simAthenaUnnestTargets(kind, read.columns, request.ordinality);
+
+  if (targets === undefined || selectsEverything(request.ast)) {
+    return false;
+  }
+
+  const source = { ...read.source };
+
+  replaceNode(read.item, {
+    expr: {
+      type: "function",
+      name: { name: [{ type: "default", value: "json_each" }] },
+      args: { type: "expr_list", value: [source] },
+    },
+    as: read.alias,
+  });
+
+  simAthenaRewriteUnnestColumns({
+    ast: request.ast,
+    alias: read.alias,
+    targets,
+    reachable: simAthenaQueryTables(request.ast, request.tables),
+  });
+
+  return true;
+}
+
+/**
+ * Whether the statement selects every column.
+ *
+ * `json_each` answers with eight columns of its own, and a `SELECT *` beside it
+ * would report all of them where Athena reports the flattened one. A result set
+ * carrying columns that were never asked for is worse than falling back.
+ */
+function selectsEverything(ast: unknown): boolean {
+  return [...simAthenaAstNodes(ast)].some(
+    (node: SimAthenaAstNode) => isColumnRef(node) && node.column === "*",
+  );
+}

--- a/src/service/athena/engine/sim-athena-unnest-source.ts
+++ b/src/service/athena/engine/sim-athena-unnest-source.ts
@@ -1,0 +1,121 @@
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
+import {
+  isColumnRef,
+  isFromItem,
+  simAthenaAstNodes,
+  type SimAthenaAstNode,
+} from "./sim-athena-ast-nodes.js";
+
+/** The two things Athena flattens with `UNNEST`. */
+export type SimAthenaUnnestKind = "array" | "map";
+
+/**
+ * What the statement is flattening, read off the Glue schema.
+ *
+ * The catalog is the only thing that says whether a column holds an array, a
+ * map or a scalar, and `json_each` answers with different columns for the first
+ * two. A column the schema calls anything else answers with nothing here, and
+ * the query falls back rather than reading a value as a collection it never
+ * was.
+ *
+ * An expression that is not a plain column reference answers with nothing too.
+ * `UNNEST(split(x, ','))` is a real Athena query and the schema says nothing
+ * about what it comes to.
+ */
+export function simAthenaUnnestKind(
+  source: SimAthenaAstNode,
+  ast: unknown,
+  tables: readonly SimAthenaCatalogTable[],
+): SimAthenaUnnestKind | undefined {
+  if (!isColumnRef(source)) {
+    return undefined;
+  }
+
+  const declared = declaredType(source, ast, tables);
+
+  if (declared === undefined) {
+    return undefined;
+  }
+
+  const type = declared.toLowerCase();
+
+  if (type.startsWith("array")) {
+    return "array";
+  }
+
+  return type.startsWith("map") ? "map" : undefined;
+}
+
+/** Every catalog table the statement reads, by the name it reaches each one by. */
+export function simAthenaQueryTables(
+  ast: unknown,
+  tables: readonly SimAthenaCatalogTable[],
+): ReadonlyMap<string, SimAthenaCatalogTable> {
+  const byName = new Map<string, SimAthenaCatalogTable>();
+
+  for (const node of simAthenaAstNodes(ast)) {
+    if (!isFromItem(node)) {
+      continue;
+    }
+
+    const found = tables.find(
+      (table) =>
+        table.name.toLowerCase() === node.table.toLowerCase() &&
+        matchesDatabase(table, node.db),
+    );
+
+    if (found !== undefined) {
+      byName.set((node.as ?? node.table).toLowerCase(), found);
+    }
+  }
+
+  return byName;
+}
+
+/** The Glue type of the column an `UNNEST` names. */
+function declaredType(
+  source: { table: string | null; column: string },
+  ast: unknown,
+  tables: readonly SimAthenaCatalogTable[],
+): string | undefined {
+  const reachable = simAthenaQueryTables(ast, tables);
+
+  if (source.table !== null) {
+    return columnType(reachable.get(source.table.toLowerCase()), source.column);
+  }
+
+  const declaring = [...new Set(reachable.values())].filter(
+    (table) => columnType(table, source.column) !== undefined,
+  );
+
+  return declaring.length === 1
+    ? columnType(declaring[0], source.column)
+    : undefined;
+}
+
+function columnType(
+  table: SimAthenaCatalogTable | undefined,
+  column: string,
+): string | undefined {
+  return table?.columns.find(
+    (one) => one.Name.toLowerCase() === column.toLowerCase(),
+  )?.Type;
+}
+
+/**
+ * Whether this table is the one a `FROM` entry names.
+ *
+ * An entry naming no database is resolved against the query's own, which the
+ * table resolution has already done, so the table name alone decides it.
+ */
+function matchesDatabase(
+  table: SimAthenaCatalogTable,
+  database: string | null | undefined,
+): boolean {
+  return (
+    database === undefined ||
+    database === null ||
+    database === "" ||
+    table.databaseName.toLowerCase() === database.toLowerCase()
+  );
+}

--- a/src/service/athena/engine/sim-athena-unnest-targets.ts
+++ b/src/service/athena/engine/sim-athena-unnest-targets.ts
@@ -1,0 +1,48 @@
+import type { SimAthenaUnnestKind } from "./sim-athena-unnest-source.js";
+
+/** What one name inside an `UNNEST` alias reads once the rewrite is done. */
+export interface SimAthenaUnnestTarget {
+  /** The name the statement wrote. */
+  readonly from: string;
+
+  /** The `json_each` column it reads, or the ordinal position. */
+  readonly reads: "key" | "value" | "ordinality";
+}
+
+/**
+ * The columns `json_each` answers an `UNNEST` alias with.
+ *
+ * An array gives one value per element and a map gives a key beside it, which
+ * is the same pair Athena hands back. `WITH ORDINALITY` adds the position, and
+ * `json_each` numbers an array's elements from zero where Athena numbers them
+ * from one.
+ *
+ * An alias naming a different number of columns from the ones available answers
+ * with nothing, and so does `WITH ORDINALITY` over a map. `json_each` gives a
+ * map's keys rather than its positions, and there is nothing to count from.
+ */
+export function simAthenaUnnestTargets(
+  kind: SimAthenaUnnestKind,
+  columns: readonly string[],
+  ordinality: boolean,
+): readonly SimAthenaUnnestTarget[] | undefined {
+  if (ordinality && kind === "map") {
+    return undefined;
+  }
+
+  const available: SimAthenaUnnestTarget["reads"][] =
+    kind === "array" ? ["value"] : ["key", "value"];
+
+  if (ordinality) {
+    available.push("ordinality");
+  }
+
+  if (columns.length !== available.length) {
+    return undefined;
+  }
+
+  return columns.map((from, index) => ({
+    from,
+    reads: available.at(index) ?? "value",
+  }));
+}

--- a/src/service/athena/sim-athena-engine-unnest.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-unnest.iso.test.ts
@@ -1,0 +1,312 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+const events = [
+  { id: 1, tags: ["red", "blue"], attrs: { size: "large" }, name: "one" },
+  { id: 2, tags: [], attrs: {}, name: "two" },
+  {
+    id: 3,
+    tags: ["green"],
+    attrs: { size: "small", colour: "green" },
+    name: "three",
+  },
+];
+
+/** A simulation holding the events, with the engine on. */
+async function anEventSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "events",
+    columns: [
+      { Name: "id", Type: "int" },
+      { Name: "tags", Type: "array<string>" },
+      { Name: "attrs", Type: "map<string,string>" },
+      { Name: "name", Type: "string" },
+    ],
+  });
+
+  await aSeededJson(simulation.simAws, "events/part-0.json", events);
+  await simulation.simAws.athena().engine().enable();
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["fallback"], rows: [["declared"]] });
+
+  return simulation;
+}
+
+describe("flattening an Athena array with UNNEST", () => {
+  it("returns one row per element", async () => {
+    // Given a table whose tags column holds an array.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT e.id, t.tag FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.tags) AS t(tag) ORDER BY e.id, t.tag",
+    );
+
+    // Then each element is a row of its own, the event holding none drops
+    // out, and the column keeps the name the statement gave it.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["1", "blue"],
+      ["1", "red"],
+      ["3", "green"],
+    ]);
+    assertObjectEquals(answered.columns, ["integer", "varchar"]);
+  });
+
+  it("reaches the flattened column without its alias", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query names the flattened column on its own in a filter and a
+    // sort as well as in the select list.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT e.id, tag FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.tags) AS t(tag) WHERE tag <> 'red' ORDER BY tag",
+    );
+
+    // Then every one of them reads the flattened value.
+    assertObjectEquals(answered.rows, [
+      ["1", "blue"],
+      ["3", "green"],
+    ]);
+  });
+
+  it("flattens a column the statement never qualified", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query names neither the table nor its alias.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT tag FROM rainlytics.events " +
+        "CROSS JOIN UNNEST(tags) AS t(tag) ORDER BY tag",
+    );
+
+    // Then the one table the statement reads is what the column is looked for
+    // on, the way Athena resolves it.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["blue"], ["green"], ["red"]]);
+  });
+
+  it("counts the elements from one with ORDINALITY", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query asks for each element's position.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT e.id, t.tag, t.place FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.tags) WITH ORDINALITY AS t(tag, place) " +
+        "ORDER BY e.id, t.place",
+    );
+
+    // Then the first element is one rather than zero, which is how Athena
+    // numbers it. SQLite numbers a JSON array's elements from zero.
+    assertObjectEquals(answered.rows, [
+      ["1", "red", "1"],
+      ["1", "blue", "2"],
+      ["3", "green", "1"],
+    ]);
+  });
+
+  it("rolls the flattened rows up like any others", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query groups on the flattened column.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.tag, count(*) AS seen FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.tags) AS t(tag) GROUP BY t.tag ORDER BY t.tag",
+    );
+
+    // Then the rollup is over the elements rather than over the rows.
+    assertObjectEquals(answered.rows, [
+      ["blue", "1"],
+      ["green", "1"],
+      ["red", "1"],
+    ]);
+  });
+});
+
+describe("flattening an Athena map with UNNEST", () => {
+  it("returns the key beside the value", async () => {
+    // Given a table whose attrs column holds a map.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens it into a pair.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT e.id, t.attribute, t.value FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.attrs) AS t(attribute, value) " +
+        "ORDER BY e.id, t.attribute",
+    );
+
+    // Then each entry is a row carrying both halves.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["1", "size", "large"],
+      ["3", "colour", "green"],
+      ["3", "size", "small"],
+    ]);
+  });
+});
+
+describe("an UNNEST the engine turns down", () => {
+  it("falls back over a column that is neither an array nor a map", async () => {
+    // Given a scalar column.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.letter FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.name) AS t(letter)",
+    );
+
+    // Then the declaration answers it. The Glue schema is what says a column
+    // holds a collection, and reading a scalar as one would answer with
+    // whatever SQLite made of the text.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("falls back over a statement selecting every column", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens an array and selects everything.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT * FROM rainlytics.events e CROSS JOIN UNNEST(e.tags) AS t(tag)",
+    );
+
+    // Then the declaration answers it. SQLite's own flattening carries eight
+    // columns, and a result set holding those is worse than falling back.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("falls back over a position taken from a map", async () => {
+    // Given a map column, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query asks a map for its positions.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.attribute FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.attrs) WITH ORDINALITY AS t(attribute, value, at)",
+    );
+
+    // Then the declaration answers it. SQLite gives a map's keys rather than
+    // its positions, so there is nothing to count from.
+    assertIdentical(answered.answeredBy, "declaration");
+  });
+
+  it("falls back over an expression the catalog says nothing about", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens something that is not a column.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.part FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(split_part(e.name, 'n', 1)) AS t(part)",
+    );
+
+    // Then the declaration answers it. Only the schema says what a value
+    // holds, and it says nothing about an expression.
+    assertIdentical(answered.answeredBy, "declaration");
+  });
+
+  it("falls back over two flattenings in one statement", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens twice.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT a.tag, b.attribute FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.tags) AS a(tag) " +
+        "CROSS JOIN UNNEST(e.attrs) AS b(attribute, value)",
+    );
+
+    // Then the declaration answers it. One flattening is what this rewrites.
+    assertIdentical(answered.answeredBy, "declaration");
+  });
+
+  it("falls back where the alias names no columns", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query gives the flattening an alias and no column name.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.tag FROM rainlytics.events e CROSS JOIN UNNEST(e.tags) AS t",
+    );
+
+    // Then the declaration answers it. Nothing says what to call the value.
+    assertIdentical(answered.answeredBy, "declaration");
+  });
+
+  it("falls back where the alias names too many columns", async () => {
+    // Given an array column, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query names two columns for it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.one, t.two FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(e.tags) AS t(one, two)",
+    );
+
+    // Then the declaration answers it. An array flattens to one column, and a
+    // map is what flattens to two.
+    assertIdentical(answered.answeredBy, "declaration");
+  });
+
+  it("falls back over a column the table never declared", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens a column the schema has never heard of.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.x FROM rainlytics.events e CROSS JOIN UNNEST(e.absent) AS t(x)",
+    );
+
+    // Then the declaration answers it.
+    assertIdentical(answered.answeredBy, "declaration");
+  });
+
+  it("falls back over a flattening that is not a cross join", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens under a left join.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT e.id, t.tag FROM rainlytics.events e " +
+        "LEFT JOIN UNNEST(e.tags) AS t(tag) ON TRUE",
+    );
+
+    // Then the declaration answers it. SQLite reaches a flattening through a
+    // comma, which is a cross join and keeps no unmatched row.
+    assertIdentical(answered.answeredBy, "declaration");
+  });
+});


### PR DESCRIPTION
A statement flattening an array or a map column runs under the engine. The rewrite happens on the parser's tree between reading the statement as Athena and writing it back out for SQLite, since `sqlify` writes the `UNNEST` back out unchanged and SQLite has no such clause. The `FROM` entry becomes a `json_each`, which is how SQLite reads JSON, and every reference to the alias is pointed at the column it answers with.

An array gives one value per element, a map gives the key beside it, and `WITH ORDINALITY` gives the position counted from one. Three things made this more than a substitution. The parser's Athena grammar refuses `WITH ORDINALITY` outright, so those two words come out before parsing and are remembered. The alias names columns `json_each` calls something else, and the name the statement wrote is kept as an alias so the result set still reports `tag` rather than `value`. And only the Glue schema says whether a column holds an array or a map, so the `FROM` aliases are resolved back to catalog tables to read the type.

A column the schema calls anything else falls back rather than reading a scalar as a collection, and so does a second `UNNEST` in one statement, a `LEFT JOIN UNNEST`, an alias naming no columns, a `SELECT *` beside one, and a position taken from a map.

Resolves https://github.com/KensioSoftware/yulin/issues/1012


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for flattening one array or map with `UNNEST` queries.
  * Added array ordinality support, including one-based position values.
  * Added map key and value expansion.
  * Preserved supported aliases and column references during query processing.

* **Bug Fixes**
  * Added graceful fallback for unsupported `UNNEST` patterns, including multiple sources, wildcard selections, and unsupported joins.

* **Documentation**
  * Documented supported `UNNEST` scenarios and current limitations.

* **Tests**
  * Added comprehensive coverage for arrays, maps, ordinality, grouping, and unsupported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->