### PR TITLE
fix: keep the viewer's query string encoding

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1038,6 +1038,12 @@ A Function returning that response untouched leaves all three cookies on their w
 Function writing `multiValue` sends one header per value in it, and CloudFront ignores `value` while
 both are there. Writing `value` on its own sends a single header.
 
+A Function reads the query string as the viewer spelled it. `?q=%E5%AE%B6` arrives as
+`event.request.querystring.q.value === "%E5%AE%B6"`, `?q=a+b` keeps its plus, and a percent-encoded
+parameter name stays encoded. Whatever a Function leaves in `querystring` goes on to the Origin as
+it stands. A Function returning the request untouched forwards the query byte for byte, and one
+writing a value of its own encodes it (the same job it has on AWS).
+
 ```typescript sim-cloudfront-function
 /**
  * Simulated CloudFront Functions.

--- a/src/service/cloudfront/cff/adapter/sim-cff-query-string.iso.test.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-query-string.iso.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "vitest";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { SimCffEventAdapter } from "./sim-cff-event-adapter.js";
+import type { CloudFrontFunction } from "../../typings/cloudfront-functions.namespace.js";
+
+describe("query string spelling through a sim CloudFront Function", () => {
+  const adapter = new SimCffEventAdapter();
+
+  const viewerRequest = (search: string): Request =>
+    new Request(`https://example.test/liju/search${search}`);
+
+  const querystringSeenBy = (search: string): CloudFrontFunction.QueryString =>
+    adapter.toViewerRequestEvent(viewerRequest(search)).request.querystring;
+
+  const forwarded = (search: string): string => {
+    // Given a Function returning the request it was handed.
+    const request = viewerRequest(search);
+    const event = adapter.toViewerRequestEvent(request);
+
+    const result = adapter.fromViewerRequestResult(event.request, request);
+    assertInstanceOf(result, Request);
+
+    return new URL(result.url).search;
+  };
+
+  it("hands a Function the percent-encoding the viewer sent", () => {
+    assertObjectMatches(querystringSeenBy("?q=%E5%AE%B6"), {
+      q: { value: "%E5%AE%B6" },
+    });
+  });
+
+  it("tells a plus from an encoded space", () => {
+    assertObjectMatches(querystringSeenBy("?q=a+b"), { q: { value: "a+b" } });
+    assertObjectMatches(querystringSeenBy("?q=a%20b"), {
+      q: { value: "a%20b" },
+    });
+  });
+
+  it("leaves a percent-encoded parameter name encoded", () => {
+    assertObjectMatches(querystringSeenBy("?%E5%AE%B6=1"), {
+      "%E5%AE%B6": { value: "1" },
+    });
+  });
+
+  it("keeps every value of a repeated parameter as sent", () => {
+    assertObjectMatches(querystringSeenBy("?tag=a%20b&tag=c+d"), {
+      tag: {
+        value: "a%20b",
+        multiValue: [{ value: "a%20b" }, { value: "c+d" }],
+      },
+    });
+  });
+
+  it("reads a parameter with no value as an empty one", () => {
+    assertObjectMatches(querystringSeenBy("?draft"), { draft: { value: "" } });
+  });
+
+  it("forwards an untouched query string to the Origin byte for byte", () => {
+    assertIdentical(forwarded("?q=%E5%AE%B6"), "?q=%E5%AE%B6");
+    assertIdentical(forwarded("?q=a+b"), "?q=a+b");
+    assertIdentical(forwarded("?q=a%20b"), "?q=a%20b");
+    assertIdentical(forwarded("?tag=x&tag=y"), "?tag=x&tag=y");
+  });
+
+  it("sends the query a Function writes without encoding it again", () => {
+    // Given a Function replacing the query with one of its own.
+    const request = viewerRequest("?q=%E5%AE%B6");
+    const event = adapter.toViewerRequestEvent(request);
+    event.request.querystring = {
+      term: { value: "%E5%AE%B6" },
+      page: { value: "2" },
+    };
+
+    const result = adapter.fromViewerRequestResult(event.request, request);
+    assertInstanceOf(result, Request);
+
+    assertIdentical(new URL(result.url).search, "?term=%E5%AE%B6&page=2");
+  });
+
+  it("builds a redirect from a value the viewer encoded", () => {
+    // Given a Function redirecting to the encoded search it was handed.
+    const request = viewerRequest("?q=%E5%AE%B6");
+    const event = adapter.toViewerRequestEvent(request);
+    const term = event.request.querystring["q"];
+    assertObjectMatches(term, { value: "%E5%AE%B6" });
+
+    const result = adapter.fromViewerRequestResult(
+      {
+        statusCode: 308,
+        statusDescription: "Permanent Redirect",
+        headers: {
+          location: { value: `/liju/search/?q=${term.value}` },
+        },
+      },
+      request,
+    );
+    assertInstanceOf(result, Response);
+
+    assertIdentical(result.status, 308);
+    assertIdentical(
+      result.headers.get("location"),
+      "/liju/search/?q=%E5%AE%B6",
+    );
+  });
+});

--- a/src/service/cloudfront/cff/adapter/sim-cff-request-metadata-adapter.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-request-metadata-adapter.ts
@@ -1,4 +1,5 @@
 import type { CloudFrontFunction } from "../../typings/cloudfront-functions.namespace.js";
+import { fromCffValue, toCffValue } from "./sim-cff-value.js";
 
 /**
  * Converts request metadata between Fetch API and CloudFront Function shapes.
@@ -11,7 +12,7 @@ export class SimCffRequestMetadataAdapter {
     const cffHeaders = Object.create(null) as CloudFrontFunction.Headers;
 
     for (const [name, values] of this.headerValuesByName(headers)) {
-      const cffValue = this.toCffValue(values);
+      const cffValue = toCffValue(values);
       if (cffValue !== undefined) {
         // oxlint-disable-next-line security/detect-object-injection
         cffHeaders[name] = cffValue;
@@ -31,7 +32,7 @@ export class SimCffRequestMetadataAdapter {
     const nativeHeaders = new Headers();
 
     for (const [name, valueOrMultiValue] of Object.entries(headers)) {
-      for (const value of this.fromCffValue(valueOrMultiValue)) {
+      for (const value of fromCffValue(valueOrMultiValue)) {
         nativeHeaders.append(name, value);
       }
     }
@@ -45,38 +46,43 @@ export class SimCffRequestMetadataAdapter {
   }
 
   /**
-   * Convert Node URL search params to CFF QueryString.
+   * Convert a URL query string to CFF QueryString.
+   *
+   * CloudFront hands a Function the names and values the viewer sent.
+   * `?q=%E5%AE%B6` arrives percent-encoded, and `?q=a+b` keeps its plus.
+   * Decoding here would show a Function a spelling production never produces,
+   * and leave anything it writes out double-encoded.
    */
-  toCffQueryString(
-    searchParameters: URLSearchParams,
-  ): CloudFrontFunction.QueryString {
-    const queryString = Object.create(null) as CloudFrontFunction.QueryString;
+  toCffQueryString(search: string): CloudFrontFunction.QueryString {
+    const querystring = Object.create(null) as CloudFrontFunction.QueryString;
 
-    const searchParameterKeys = new Set(searchParameters.keys());
-    for (const key of searchParameterKeys) {
-      const cffValue = this.toCffValue(searchParameters.getAll(key));
+    for (const [name, values] of this.rawValuesByName(search)) {
+      const cffValue = toCffValue(values);
       if (cffValue !== undefined) {
         // oxlint-disable-next-line security/detect-object-injection
-        queryString[key] = cffValue;
+        querystring[name] = cffValue;
       }
     }
 
-    return queryString;
+    return querystring;
   }
 
   /**
-   * Convert CFF QueryString to Node URL search params.
+   * Convert CFF QueryString to a URL query string.
+   *
+   * Whatever a Function leaves behind goes to the Origin as it stands.
+   * Encoding is the Function's business, the same as on CloudFront.
    */
   fromCffQueryString(querystring: CloudFrontFunction.QueryString): string {
-    const searchParameters = new URLSearchParams();
+    const pairs: string[] = [];
 
-    for (const [key, valueOrMultiValue] of Object.entries(querystring)) {
-      for (const value of this.fromCffValue(valueOrMultiValue)) {
-        searchParameters.append(key, value);
+    for (const [name, valueOrMultiValue] of Object.entries(querystring)) {
+      for (const value of fromCffValue(valueOrMultiValue)) {
+        pairs.push(`${name}=${value}`);
       }
     }
 
-    return searchParameters.toString();
+    return pairs.join("&");
   }
 
   /**
@@ -107,6 +113,33 @@ export class SimCffRequestMetadataAdapter {
   }
 
   /**
+   * Group query string values under their name, both left as sent.
+   *
+   * A name repeated across pairs collects its values in the order they
+   * appeared, and a Function reads those as `multiValue`. A pair with no `=`
+   * is a name with an empty value.
+   */
+  private rawValuesByName(search: string): Map<string, string[]> {
+    const valuesByName = new Map<string, string[]>();
+
+    for (const pair of search.replace(/^\?/u, "").split("&")) {
+      if (pair === "") {
+        continue;
+      }
+
+      const separator = pair.indexOf("=");
+      const name = separator === -1 ? pair : pair.slice(0, separator);
+      const value = separator === -1 ? "" : pair.slice(separator + 1);
+
+      const values = valuesByName.get(name) ?? [];
+      values.push(value);
+      valuesByName.set(name, values);
+    }
+
+    return valuesByName;
+  }
+
+  /**
    * Group header values under their lowercased name.
    *
    * A `Set-Cookie` header repeated on a response is the case this exists for.
@@ -124,47 +157,6 @@ export class SimCffRequestMetadataAdapter {
     }
 
     return valuesByName;
-  }
-
-  /**
-   * Present values in the shape CloudFront gives a repeated name.
-   *
-   * A single value is `value` alone. Repeated values keep the first in `value`
-   * and all of them in `multiValue`. That is what a Function reads for a header
-   * or a query parameter appearing more than once.
-   */
-  private toCffValue(
-    values: readonly string[],
-  ): CloudFrontFunction.Value | CloudFrontFunction.MultiValue | undefined {
-    const [first] = values;
-    if (first === undefined) {
-      return undefined;
-    }
-
-    if (values.length === 1) {
-      return { value: first };
-    }
-
-    return {
-      value: first,
-      multiValue: values.map((value) => ({ value })),
-    };
-  }
-
-  /**
-   * Read back the values a Function left under one name.
-   *
-   * A Function that means to send several values sets `multiValue`, and
-   * CloudFront sends those in place of `value`.
-   */
-  private fromCffValue(
-    valueOrMultiValue: CloudFrontFunction.Value | CloudFrontFunction.MultiValue,
-  ): string[] {
-    if ("multiValue" in valueOrMultiValue) {
-      return valueOrMultiValue.multiValue.map(({ value }) => value);
-    }
-
-    return [valueOrMultiValue.value];
   }
 
   private fromCffCookies(

--- a/src/service/cloudfront/cff/adapter/sim-cff-request-response-adapter.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-request-response-adapter.ts
@@ -19,7 +19,7 @@ export class SimCffRequestResponseAdapter {
       method: request.method,
       uri: url.pathname,
       headers: this.viewerCffHeaders(request),
-      querystring: this.metadataAdapter.toCffQueryString(url.searchParams),
+      querystring: this.metadataAdapter.toCffQueryString(url.search),
       cookies: this.metadataAdapter.toCffCookies(request.headers),
     };
   }

--- a/src/service/cloudfront/cff/adapter/sim-cff-value.ts
+++ b/src/service/cloudfront/cff/adapter/sim-cff-value.ts
@@ -1,0 +1,42 @@
+import type { CloudFrontFunction } from "../../typings/cloudfront-functions.namespace.js";
+
+/**
+ * Present values in the shape CloudFront gives a repeated name.
+ *
+ * A single value is `value` alone. Repeated values keep the first in `value`
+ * and all of them in `multiValue`. That is what a Function reads for a header
+ * or a query parameter appearing more than once.
+ */
+export function toCffValue(
+  values: readonly string[],
+): CloudFrontFunction.Value | CloudFrontFunction.MultiValue | undefined {
+  const [first] = values;
+  if (first === undefined) {
+    return undefined;
+  }
+
+  if (values.length === 1) {
+    return { value: first };
+  }
+
+  return {
+    value: first,
+    multiValue: values.map((value) => ({ value })),
+  };
+}
+
+/**
+ * Read back the values a Function left under one name.
+ *
+ * A Function that means to send several values sets `multiValue`, and
+ * CloudFront sends those in place of `value`.
+ */
+export function fromCffValue(
+  valueOrMultiValue: CloudFrontFunction.Value | CloudFrontFunction.MultiValue,
+): string[] {
+  if ("multiValue" in valueOrMultiValue) {
+    return valueOrMultiValue.multiValue.map(({ value }) => value);
+  }
+
+  return [valueOrMultiValue.value];
+}

--- a/src/service/cloudfront/cff/sim-cff-query-string-viewer.iso.test.ts
+++ b/src/service/cloudfront/cff/sim-cff-query-string-viewer.iso.test.ts
@@ -1,0 +1,72 @@
+import {
+  assertIdentical,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { searchDistributionUrl } from "./sim-cff-search-distribution.fixture.js";
+import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
+
+/**
+ * A search Function reading a query parameter and sending the viewer somewhere
+ * with it. A decoded value goes wrong here.
+ */
+function searchHandler(event: CloudFrontFunction.ViewerRequestEvent) {
+  const term = event.request.querystring["q"];
+
+  if (term !== undefined && !event.request.uri.endsWith("/")) {
+    return {
+      statusCode: 308,
+      statusDescription: "Permanent Redirect",
+      headers: {
+        location: { value: `${event.request.uri}/?q=${term.value}` },
+      },
+    };
+  }
+
+  return event.request;
+}
+
+describe("query string encoding through a sim CloudFront Distribution", () => {
+  it("forwards the query the viewer sent to the Origin byte for byte", async () => {
+    // Given a search behind a Function passing the request through.
+    const simAws = new SimAws();
+    const url = await searchDistributionUrl(
+      simAws,
+      "/liju/search/?q=%E5%AE%B6&page=a%20b",
+      searchHandler,
+    );
+
+    // When the viewer searches with a percent-encoded term.
+    const response = await new SimAwsHttp({ simAws }).fetch(url);
+
+    // Then the Origin is sent the spelling the viewer used.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), '"q=%E5%AE%B6&page=a%20b"');
+  });
+
+  it("redirects with the encoded term rather than failing on it", async () => {
+    // Given the same search, reached without its trailing slash.
+    const simAws = new SimAws();
+    const url = await searchDistributionUrl(
+      simAws,
+      "/liju/search?q=%E5%AE%B6",
+      searchHandler,
+    );
+
+    // When the viewer searches with a term outside ASCII.
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      redirect: "manual",
+    });
+
+    // Then the Function's Location header carries the term as it arrived.
+    assertResponseStatus(response, 308, await describeResponse(response));
+    assertIdentical(
+      response.headers.get("location"),
+      "/liju/search/?q=%E5%AE%B6",
+    );
+  });
+});

--- a/src/service/cloudfront/cff/sim-cff-search-distribution.fixture.ts
+++ b/src/service/cloudfront/cff/sim-cff-search-distribution.fixture.ts
@@ -1,0 +1,70 @@
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { simHttpApiLambdaProxyFactory } from "../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { simCfDistroConfigFactory } from "../distribution/sim-cf-distro-config.factory.js";
+import { makeCffFunctionCodeInput } from "./function-code-input/cff-function-code-input.js";
+import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
+
+/**
+ * Put a viewer-request Function in front of an Origin echoing the query it is
+ * sent, and return the URL a viewer reaches the Distribution on.
+ */
+export async function searchDistributionUrl(
+  simAws: SimAws,
+  path: string,
+  handler: CloudFrontFunction.ViewerRequestHandler,
+): Promise<string> {
+  const api = await simHttpApiLambdaProxyFactory.make(
+    {
+      handler: (event: SimPayload2Event): unknown => event.rawQueryString,
+      routeKeys: ["GET /liju/search"],
+    },
+    simAws,
+  );
+
+  const cff = await simAws.cloudFront().createFunction({
+    input: {
+      Name: "search-redirect",
+      FunctionConfig: { Comment: "Search", Runtime: "cloudfront-js-2.0" },
+      FunctionCode: makeCffFunctionCodeInput(handler),
+    },
+  });
+
+  const originHostname = new URL(api.apiEndpoint).hostname;
+  const creation = await simAws.cloudFront().createDistribution({
+    input: {
+      DistributionConfig: simCfDistroConfigFactory.make({
+        CallerReference: "search-query-string",
+        Origins: {
+          Items: [
+            {
+              Id: "SiteOrigin",
+              DomainName: originHostname,
+              CustomOriginConfig: { OriginProtocolPolicy: "https-only" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "SiteOrigin",
+          ViewerProtocolPolicy: "allow-all",
+          FunctionAssociations: {
+            Items: [
+              {
+                EventType: "viewer-request",
+                FunctionARN: cff.FunctionMetadata.FunctionARN,
+              },
+            ],
+          },
+        },
+      }),
+    },
+  });
+
+  const hostname = creation.Distribution?.DomainName;
+  assertNonNullable(hostname);
+
+  return new SimAwsLocalUrl({ input: `https://${hostname}${path}` }).toString();
+}


### PR DESCRIPTION
CloudFront hands a Function the query string exactly as the viewer sent it. Yulin decoded on the way
in and re-encoded on the way out. The two cancel for a Function that passes the request through, and
anything else diverges. A viewer-request Function building a redirect from `?q=%E5%AE%B6` read `家`,
and putting that in a `Location` header threw a `TypeError` from Node's `Headers`. Names and values
now reach a Function undecoded, and what it leaves behind goes to the Origin unencoded.

Resolves #1024