### PR TITLE
feat: shim more Trino functions in the engine

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -378,8 +378,13 @@ instant it froze, and the same test answers the same way on every machine. Athen
 instant the query started, which is what the execution records.
 
 A function that cannot answer faithfully raises rather than guessing, and the query falls back.
-`date_add` with a unit Trino does not name, `slice` starting at zero, and `array_join` over an array
-of objects all land there. A null answer would be a wrong answer wearing the shape of a right one.
+`date_add` with a unit Trino does not name, `slice` starting at zero, `array_join` over an array of
+objects, and `regexp_extract` naming a capture group the pattern has not got all land there. A null
+answer would be a wrong answer wearing the shape of a right one.
+
+A function answers null where any argument is null, the way Trino's do. An argument left out takes
+its default and an argument written as `NULL` does not, so `regexp_extract(url, 'a', NULL)` answers
+null where `regexp_extract(url, 'a')` reads the whole match.
 
 ## Tables a query names
 
@@ -778,8 +783,17 @@ Current documented limitations:
   text they cannot read. Trino fails the query.
 - `json_extract` answers with JSON, so a string comes back quoted. SQLite's own unwraps it, and a
   statement comparing the answer against a bare string matches on one and not the other.
-- A timestamp carrying a numeric UTC offset falls outside the date functions. A value written with
-  a `Z` or with no zone at all reads as UTC.
+- A timestamp carrying a numeric UTC offset falls outside the date functions, and so does one
+  written finer than the millisecond. A value written with a `Z` or with no zone at all reads as
+  UTC, and a value the date functions cannot read turns the query down.
+- A JSON number beyond about fifteen significant digits loses the digits past that, wherever the
+  engine reads JSON. An identifier of that size in a JSON lines object comes back rounded, and a
+  filter on it can then match the wrong row.
+- The `url_extract` family reads a URL the way a browser does, so a percent escape in the path, the
+  query or the fragment comes back still escaped and a parameter name is matched decoded. Trino
+  reads a URL the way Java does and decodes each of those.
+- `regexp_replace` takes Trino's own spelling for a named group and an escaped dollar, `${name}`
+  and `\$`. The rest of Java's replacement syntax is not translated.
 - The date and time functions work on the ISO-8601 text a JSON or CSV object carries. A column
   written any other way gets whatever slicing that text comes to.
 - `approx_distinct` and `approx_percentile` are computed exactly. The simulation is more accurate

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -355,6 +355,32 @@ falls back rather than reading a scalar as a collection.
 One flattening per statement is what this covers, joined with `CROSS JOIN`. A second `UNNEST`, a
 `LEFT JOIN UNNEST`, a `SELECT *` beside one, and a position taken from a map all fall back.
 
+### The functions a statement can call
+
+SQLite carries a much smaller function library than Trino, and the engine fills the gap for the ones
+a test reaches for. SQLite refuses a function absent from this list, and the query then falls back to
+its declared result.
+
+| Family        | Functions                                                                                                                                                                                             |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Date and time | `current_date`, `current_timestamp`, `date_add`, `date_diff`, `date_trunc`, `date_format`, `at_timezone`, `from_unixtime`, `to_unixtime`, `from_iso8601_timestamp`, `from_iso8601_date`, `to_iso8601` |
+| JSON          | `json_extract`, `json_extract_scalar`, `json_parse`, `json_size`                                                                                                                                      |
+| Array and map | `array_agg`, `cardinality`, `contains`, `element_at`, `array_join`, `slice`                                                                                                                           |
+| String        | `regexp_like`, `regexp_extract`, `regexp_replace`, `split_part`, `strpos`                                                                                                                             |
+| URL           | `url_extract_host`, `url_extract_path`, `url_extract_protocol`, `url_extract_port`, `url_extract_query`, `url_extract_fragment`, `url_extract_parameter`                                              |
+| Approximate   | `approx_distinct`, `approx_percentile`                                                                                                                                                                |
+
+`substr` and `format` are SQLite's own. Both count from one and take the same `%s` and `%d` a
+statement writes, so shadowing either would replace something that works.
+
+`current_date` and `current_timestamp` read the simulator's clock. A test that froze time gets the
+instant it froze, and the same test answers the same way on every machine. Athena reads both at the
+instant the query started, which is what the execution records.
+
+A function that cannot answer faithfully raises rather than guessing, and the query falls back.
+`date_add` with a unit Trino does not name, `slice` starting at zero, and `array_join` over an array
+of objects all land there. A null answer would be a wrong answer wearing the shape of a right one.
+
 ## Tables a query names
 
 A query's `FROM` and `JOIN` clauses are read, and each table they name is looked for in the Glue
@@ -702,6 +728,8 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 - `StartQueryExecution`, `GetQueryExecution`, `GetQueryResults` and `StopQueryExecution`
 - A `SELECT` run for real over JSON lines and CSV objects in simulated S3, answered by SQLite
 - `UNNEST` over an array or a map column, with `WITH ORDINALITY` where a query wants the position
+- Trino's date, JSON, array, string and URL functions, with `current_timestamp` reading the
+  simulated clock
 - Declared results, matched on the query text, ahead of the engine for one statement and behind it
   for everything else
 - Table names in `FROM` and `JOIN` resolved against the simulated Glue Data Catalog
@@ -735,11 +763,23 @@ Current documented limitations:
   gives a map's keys rather than its positions.
 - `UNNEST` over a `ROW` or a struct array falls back. The element needs field access and the
   flattened column is JSON text here.
-- The Trino function library reaches as far as `date_trunc`, `date_format`, `from_unixtime`,
-  `to_unixtime`, `from_iso8601_timestamp`, `from_iso8601_date`, `to_iso8601`,
-  `json_extract_scalar`, `cardinality`, `element_at`, `regexp_like`, `split_part`, `strpos`,
-  `approx_distinct` and `approx_percentile`. A query reaching for anything else Trino has and
-  SQLite lacks falls back.
+- The Trino function library reaches as far as the table under
+  [the functions a statement can call](#the-functions-a-statement-can-call). A query reaching for
+  anything else Trino has and SQLite lacks falls back.
+- `filter` and the other functions taking a lambda are absent, and deliberately unshimmed. SQLite
+  reads `->` as its own JSON operator. A name registered for one of them would leave the lambda to
+  be read as that operator and answer something, where an absent name fails and falls back.
+- `date_add` and `date_diff` count a calendar month by whether moving the first instant reached the
+  second. That is how `java.time` counts and so how Trino does. The thirty-first of January to the
+  twenty-eighth of February is a whole month.
+- `at_timezone` answers with the wall clock of the zone and no zone on it, since a timestamp here
+  carries none. Trino answers with a timestamp carrying the zone.
+- `json_parse`, `regexp_extract`, `regexp_replace` and the `url_extract` family answer null over
+  text they cannot read. Trino fails the query.
+- `json_extract` answers with JSON, so a string comes back quoted. SQLite's own unwraps it, and a
+  statement comparing the answer against a bare string matches on one and not the other.
+- A timestamp carrying a numeric UTC offset falls outside the date functions. A value written with
+  a `Z` or with no zone at all reads as UTC.
 - The date and time functions work on the ISO-8601 text a JSON or CSV object carries. A column
   written any other way gets whatever slicing that text comes to.
 - `approx_distinct` and `approx_percentile` are computed exactly. The simulation is more accurate

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -207,6 +207,38 @@ back a tick later, because `process.emitWarning` defers delivery and restoring s
 it. A project that installed a warning listener of its own keeps it, along with every other warning
 it would have printed.
 
+### The function library
+
+`sim-athena-shims.ts` installs every Trino function the engine carries, one file per family. The
+list grows as a query in a real test reaches for something absent from it, rather than by working
+through the Trino reference.
+
+Three rules shape what goes in.
+
+**A shim that cannot answer faithfully raises.** A thrown error reaches `simAthenaEngineRun`, which
+turns the query down and lets the declared result answer. A null would be a wrong answer wearing
+the shape of a right one, and that is the failure this engine can least afford. `date_add` with an
+unknown unit, `slice` starting at zero and `array_join` over objects all take that route.
+
+**A function SQLite already gets right is left alone.** `substr` and `format` both count from one
+and take the same format specifiers, and registering a name shadows the built-in, so a shim there
+would replace something that works. `json_extract` is the other way round: SQLite's unwraps a
+string where Trino answers with JSON, so that one is shadowed on purpose.
+
+**A function taking a lambda is left absent on purpose.** `filter` and its neighbours emit a `->`
+that SQLite reads as its own JSON operator. Registering the name would leave the lambda to be read
+as that operator and answer something. Leaving it absent makes SQLite refuse the statement, which
+is a refusal rather than a wrong answer.
+
+`sim-athena-timestamp-text.ts` is what keeps a timestamp's shape. A value arrives as text and has
+to leave as text written the same way, so an instant is rendered back through the value it came
+from. A value carrying a numeric UTC offset is refused for the same reason. Rendering
+the answer back into that offset is easy to get wrong and hard to notice.
+
+`sim-athena-clock-shims.ts` takes the execution's `submittedAt`, which is threaded from
+`SimAthenaQueryRunner` through the answer chain to the database. `current_timestamp` reading the
+host clock would make a frozen-clock test answer differently on every run.
+
 ### Flattening with UNNEST
 
 `sim-athena-unnest-rewrite.ts` turns one `UNNEST` into a `json_each`. The rewrite happens on the

--- a/src/service/athena/engine/sim-athena-array-shims.ts
+++ b/src/service/athena/engine/sim-athena-array-shims.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
 import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
 import { simAthenaJsonDocument } from "./sim-athena-json-path.js";
 import {
+  isExplicitNull,
   shimNumber,
   shimText,
   simAthenaScalarShim,
@@ -23,8 +24,14 @@ export function simAthenaInstallArrayShims(database: DatabaseSync): void {
     contains(arrayOf(value), element),
   );
 
-  simAthenaScalarShim(database, "array_join", (value, delimiter, absent) =>
-    joined(arrayOf(value), shimText(delimiter), shimText(absent)),
+  simAthenaScalarShim(database, "array_join", (...values) =>
+    isExplicitNull(values, 2)
+      ? null
+      : joined(
+          arrayOf(values.at(0)),
+          shimText(values.at(1)),
+          shimText(values.at(2)),
+        ),
   );
 
   simAthenaScalarShim(database, "slice", (value, start, length) =>

--- a/src/service/athena/engine/sim-athena-array-shims.ts
+++ b/src/service/athena/engine/sim-athena-array-shims.ts
@@ -1,0 +1,130 @@
+import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
+
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+import { simAthenaJsonDocument } from "./sim-athena-json-path.js";
+import {
+  shimNumber,
+  shimText,
+  simAthenaScalarShim,
+} from "./sim-athena-shim-registry.js";
+
+/**
+ * Trino's array functions, over the JSON text an array column is held as.
+ *
+ * `array_agg` collects into that same JSON text, so a rollup can be flattened
+ * again with `UNNEST` or read with `cardinality`.
+ *
+ * `filter` is deliberately absent. Its second argument is a lambda, which SQLite
+ * has no room for, and registering a name for it would leave the lambda to be
+ * read as SQLite's own JSON operator and answer something rather than failing.
+ */
+export function simAthenaInstallArrayShims(database: DatabaseSync): void {
+  simAthenaScalarShim(database, "contains", (value, element) =>
+    contains(arrayOf(value), element),
+  );
+
+  simAthenaScalarShim(database, "array_join", (value, delimiter, absent) =>
+    joined(arrayOf(value), shimText(delimiter), shimText(absent)),
+  );
+
+  simAthenaScalarShim(database, "slice", (value, start, length) =>
+    sliced(arrayOf(value), shimNumber(start), shimNumber(length)),
+  );
+
+  database.aggregate("array_agg", {
+    start: "[]",
+    step: (accumulator: string, value: SQLOutputValue) =>
+      JSON.stringify([
+        ...(JSON.parse(accumulator) as unknown[]),
+        typeof value === "bigint" ? Number(value) : value,
+      ]),
+    result: (accumulator: string) => accumulator,
+  });
+}
+
+function arrayOf(value: unknown): unknown[] | undefined {
+  const parsed = simAthenaJsonDocument(shimText(value as never));
+
+  return Array.isArray(parsed) ? parsed : undefined;
+}
+
+/** Whether an array holds this element, compared the way JSON writes it. */
+function contains(
+  array: unknown[] | undefined,
+  element: SQLOutputValue,
+): number | null {
+  if (array === undefined) {
+    return null;
+  }
+
+  const wanted = JSON.stringify(
+    typeof element === "bigint" ? Number(element) : element,
+  );
+
+  return array.some((one) => JSON.stringify(one) === wanted) ? 1 : 0;
+}
+
+/**
+ * One array written out as text.
+ *
+ * Trino leaves a null element out unless the call names what to write in its
+ * place, which is what the third argument is for.
+ */
+function joined(
+  array: unknown[] | undefined,
+  delimiter: string | undefined,
+  absent: string | undefined,
+): string | null {
+  if (array === undefined || delimiter === undefined) {
+    return null;
+  }
+
+  return array
+    .map((one) => (one === null ? absent : scalarText(one)))
+    .filter((one) => one !== undefined)
+    .join(delimiter);
+}
+
+/**
+ * One element written out.
+ *
+ * Trino refuses to join an array whose elements are not text, and raising here
+ * turns the query down to its declared result instead.
+ */
+function scalarText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  throw new SimAthenaSetUpError("array_join takes an array of scalars");
+}
+
+/**
+ * A run of one array, counted from one the way Trino counts.
+ *
+ * A negative start counts back from the end. A run reaching past the end stops
+ * there rather than failing.
+ */
+function sliced(
+  array: unknown[] | undefined,
+  start: number | undefined,
+  length: number | undefined,
+): string | null {
+  if (array === undefined || start === undefined || length === undefined) {
+    return null;
+  }
+
+  if (start === 0 || length < 0) {
+    throw new SimAthenaSetUpError(
+      "slice takes a start from one and a length from zero",
+    );
+  }
+
+  const from = start > 0 ? start - 1 : Math.max(array.length + start, 0);
+
+  return JSON.stringify(array.slice(from, from + length));
+}

--- a/src/service/athena/engine/sim-athena-clock-shims.ts
+++ b/src/service/athena/engine/sim-athena-clock-shims.ts
@@ -1,0 +1,26 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { simAthenaScalarShim } from "./sim-athena-shim-registry.js";
+
+/**
+ * The clock a query reads, which is the simulator's rather than the host's.
+ *
+ * `current_date` and `current_timestamp` are keywords in SQLite and answer from
+ * the machine the test runs on. Registering a function of each name shadows
+ * them, so a test that froze time gets the instant it froze and a test run
+ * twice answers the same way twice.
+ *
+ * Athena reads both at the instant the query started, which is what the
+ * execution records.
+ */
+export function simAthenaInstallClockShims(
+  database: DatabaseSync,
+  startedAt: Date,
+): void {
+  const started = startedAt.toISOString();
+
+  simAthenaScalarShim(database, "current_date", () => started.slice(0, 10));
+  simAthenaScalarShim(database, "current_timestamp", () =>
+    started.replace("T", " ").slice(0, 23),
+  );
+}

--- a/src/service/athena/engine/sim-athena-collection-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-collection-shims.iso.test.ts
@@ -42,6 +42,32 @@ describe("Trino's functions over a whole JSON document", () => {
     assertIdentical(await anAnsweredExpression("json_parse(NULL)"), null);
   });
 
+  it("reaches into an array by its index", async () => {
+    // Given a document holding an array of objects.
+    // When a path indexes into it.
+    // Then the bracketed index reads, counted from zero the way a JSON path
+    // counts. Reading it as a property name would answer null on a path a
+    // statement is likely to write.
+    assertIdentical(
+      await anAnsweredExpression(
+        `json_extract_scalar(${document}, '$.tags[1]')`,
+      ),
+      "b",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        `json_extract_scalar('{"a":[{"b":"z"}]}', '$.a[0].b')`,
+      ),
+      "z",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        `json_extract_scalar(${document}, '$.tags[9]')`,
+      ),
+      null,
+    );
+  });
+
   it("counts the entries at a path", async () => {
     // Given an array, an object and a scalar.
     // When each is sized.
@@ -106,6 +132,11 @@ describe("Trino's array functions on SQLite", () => {
       "1-true-2",
     );
     assertIdentical(await anAnsweredExpression("array_join('4', '-')"), null);
+    assertIdentical(
+      await anAnsweredExpression(`array_join('["a"]', '-', NULL)`),
+      null,
+      "an argument written as NULL is a null answer, not an absent argument",
+    );
   });
 
   it("takes a run out of an array, counted from one", async () => {

--- a/src/service/athena/engine/sim-athena-collection-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-collection-shims.iso.test.ts
@@ -1,0 +1,167 @@
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  anAggregatedExpression,
+  anAnsweredExpression,
+} from "./sim-athena-shim.fixture.js";
+
+const document = '\'{"tenant":{"name":"acme"},"tags":["a","b"],"n":4}\'';
+
+describe("Trino's functions over a whole JSON document", () => {
+  it("answers with JSON rather than with the value inside it", async () => {
+    // Given a document holding a string and an object.
+    // When each is extracted.
+    // Then a string comes back quoted, the way Trino answers with JSON.
+    // SQLite's own `json_extract` unwraps it, and a statement comparing the
+    // answer against a bare string matches on one and not the other.
+    assertIdentical(
+      await anAnsweredExpression(`json_extract(${document}, '$.tenant.name')`),
+      '"acme"',
+    );
+    assertIdentical(
+      await anAnsweredExpression(`json_extract(${document}, '$.tenant')`),
+      '{"name":"acme"}',
+    );
+    assertIdentical(
+      await anAnsweredExpression(`json_extract(${document}, '$.absent')`),
+      null,
+    );
+  });
+
+  it("reads text as a document and counts what it holds", async () => {
+    // Given text that is JSON and text that is not.
+    // When each is read.
+    // Then the text that is no JSON answers null, which is the forgiving
+    // direction the rest of the engine takes. Trino fails the query.
+    assertIdentical(
+      await anAnsweredExpression(`json_parse('{"b":2,"a":1}')`),
+      '{"b":2,"a":1}',
+    );
+    assertIdentical(await anAnsweredExpression("json_parse('nope')"), null);
+    assertIdentical(await anAnsweredExpression("json_parse(NULL)"), null);
+  });
+
+  it("counts the entries at a path", async () => {
+    // Given an array, an object and a scalar.
+    // When each is sized.
+    // Then a scalar holds no entries at all, which Trino counts as zero.
+    assertIdentical(
+      await anAnsweredExpression(`json_size(${document}, '$.tags')`),
+      2,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`json_size(${document}, '$.tenant')`),
+      1,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`json_size(${document}, '$.n')`),
+      0,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`json_size(${document}, '$.absent')`),
+      null,
+    );
+  });
+});
+
+describe("Trino's array functions on SQLite", () => {
+  it("says whether an array holds an element", async () => {
+    // Given an array of text and one of numbers.
+    // When each is asked about an element.
+    // Then it answers on the value rather than on its text, so a number is
+    // found as a number.
+    assertIdentical(
+      await anAnsweredExpression(`contains('["a","b"]', 'b')`),
+      1,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`contains('["a","b"]', 'z')`),
+      0,
+    );
+    assertIdentical(await anAnsweredExpression("contains('[1,2]', 2)"), 1);
+    assertIdentical(await anAnsweredExpression("contains('4', 4)"), null);
+    assertIdentical(await anAnsweredExpression("contains(NULL, 'a')"), null);
+  });
+
+  it("writes an array out as text", async () => {
+    // Given an array carrying a null.
+    // When it is joined with and without something to write in the null's
+    // place.
+    // Then the null is left out unless the call says what to put there.
+    assertIdentical(
+      await anAnsweredExpression(`array_join('["a",null,"b"]', '-')`),
+      "a-b",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`array_join('["a",null,"b"]', '-', 'X')`),
+      "a-X-b",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`array_join('["a"]', NULL)`),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("array_join('[1,true,2]', '-')"),
+      "1-true-2",
+    );
+    assertIdentical(await anAnsweredExpression("array_join('4', '-')"), null);
+  });
+
+  it("takes a run out of an array, counted from one", async () => {
+    // Given an array of four.
+    // When runs are taken from the front and from the end.
+    // Then Trino's one-based start is what answers, and a run reaching past
+    // the end stops there.
+    assertIdentical(
+      await anAnsweredExpression("slice('[1,2,3,4]', 2, 2)"),
+      "[2,3]",
+    );
+    assertIdentical(
+      await anAnsweredExpression("slice('[1,2,3,4]', -2, 2)"),
+      "[3,4]",
+    );
+    assertIdentical(
+      await anAnsweredExpression("slice('[1,2,3]', 2, 9)"),
+      "[2,3]",
+    );
+    assertIdentical(
+      await anAnsweredExpression("slice('[1,2]', NULL, 1)"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("slice('[1,2]', 1, NULL)"),
+      null,
+    );
+  });
+
+  it("collects a column into an array", async () => {
+    // Given two rows.
+    // When they are collected.
+    // Then the answer is the JSON text an array column is held as, so it can
+    // be flattened again or counted.
+    assertIdentical(
+      await anAggregatedExpression("array_agg(value)", [1, 2]),
+      "[1,2]",
+    );
+    assertIdentical(
+      await anAggregatedExpression("cardinality(array_agg(value))", ["a", "b"]),
+      2,
+    );
+  });
+
+  it("turns the query down rather than guessing", async () => {
+    // Given a run starting at zero and an array of objects.
+    // When each is used.
+    // Then the statement raises, which leaves the declared result to answer.
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("slice('[1,2,3]', 0, 1)"),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("slice('[1,2,3]', 1, -1)"),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression(`array_join('[{"a":1}]', '-')`),
+    );
+  });
+});

--- a/src/service/athena/engine/sim-athena-date-arithmetic-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-date-arithmetic-shims.iso.test.ts
@@ -114,6 +114,35 @@ describe("Trino's date arithmetic on SQLite", () => {
     );
   });
 
+  it("keeps the milliseconds a zone shift never moved", async () => {
+    // Given an instant written to the millisecond.
+    // When it is read in another zone.
+    // Then the milliseconds survive. The wall clock comes back to the second,
+    // and a zone shift moves whole minutes rather than fractions.
+    assertIdentical(
+      await anAnsweredExpression(
+        "at_timezone('2026-08-26T12:00:00.500Z', 'Asia/Tokyo')",
+      ),
+      "2026-08-26T21:00:00.500",
+    );
+  });
+
+  it("refuses a timestamp written finer than the millisecond", async () => {
+    // Given a value written to four fractional digits.
+    // When it is moved.
+    // Then the statement raises. An instant has no room for the fourth digit,
+    // and rendering the answer back would write a `Z` where that digit was.
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("date_add('day', 0, '2026-08-02T12:00:00.1234')"),
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "date_add('day', 0, '2026-08-02T12:00:00.123')",
+      ),
+      "2026-08-02T12:00:00.123",
+    );
+  });
+
   it("reads the clock the simulation is running on", async () => {
     // Given a simulation whose query started at a known instant.
     // When a statement asks for the date and the time.

--- a/src/service/athena/engine/sim-athena-date-arithmetic-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-date-arithmetic-shims.iso.test.ts
@@ -1,0 +1,173 @@
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  anAnsweredExpression,
+  shimStartedAt,
+} from "./sim-athena-shim.fixture.js";
+
+describe("Trino's date arithmetic on SQLite", () => {
+  it("moves an instant by a unit a clock counts", async () => {
+    // Given a timestamp and a date.
+    // When each is moved.
+    // Then the answer keeps the shape the value was written with, so a date
+    // comes back a date.
+    assertIdentical(
+      await anAnsweredExpression("date_add('day', 3, '2026-08-30T10:00:00Z')"),
+      "2026-09-02T10:00:00Z",
+    );
+    assertIdentical(
+      await anAnsweredExpression("date_add('hour', -2, '2026-08-30 10:00:00')"),
+      "2026-08-30 08:00:00",
+    );
+    assertIdentical(
+      await anAnsweredExpression("date_add('week', 1, '2026-08-30')"),
+      "2026-09-06",
+    );
+  });
+
+  it("lands on the last day of a month that is too short", async () => {
+    // Given the thirty-first of January.
+    // When a month is added.
+    // Then it lands on the last day of February rather than overflowing into
+    // March, which is what Trino does.
+    assertIdentical(
+      await anAnsweredExpression("date_add('month', 1, '2026-01-31')"),
+      "2026-02-28",
+    );
+    assertIdentical(
+      await anAnsweredExpression("date_add('year', -2, '2024-02-29')"),
+      "2022-02-28",
+    );
+  });
+
+  it("counts the whole units between two instants", async () => {
+    // Given pairs of instants.
+    // When the units between them are counted.
+    // Then a part of a unit does not count, whichever way the pair runs.
+    assertIdentical(
+      await anAnsweredExpression(
+        "date_diff('day', '2026-08-01', '2026-08-04T12:00:00Z')",
+      ),
+      3,
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "date_diff('day', '2026-08-04T12:00:00Z', '2026-08-01')",
+      ),
+      -3,
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "date_diff('quarter', '2026-01-01', '2026-07-01')",
+      ),
+      2,
+    );
+  });
+
+  it("counts a calendar month by whether moving reached it", async () => {
+    // Given a span ending on a month too short to hold the day it started on.
+    // When the months between them are counted.
+    // Then it counts as a whole month, because adding one to the start lands
+    // exactly on the end. That is how `java.time` counts and so how Trino
+    // does.
+    assertIdentical(
+      await anAnsweredExpression(
+        "date_diff('month', '2026-01-31', '2026-02-28')",
+      ),
+      1,
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "date_diff('month', '2026-01-15', '2026-02-10')",
+      ),
+      0,
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "date_diff('month', '2026-03-15', '2026-01-10')",
+      ),
+      -2,
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "date_diff('month', '2026-03-10', '2026-01-15')",
+      ),
+      -1,
+    );
+  });
+
+  it("reads a wall clock in another zone", async () => {
+    // Given an instant in UTC.
+    // When it is read in Tokyo.
+    // Then the wall clock moves and the `Z` comes off, since the answer is no
+    // longer in UTC and saying it was would be worse than saying nothing.
+    assertIdentical(
+      await anAnsweredExpression(
+        "at_timezone('2026-08-26T12:00:00Z', 'Asia/Tokyo')",
+      ),
+      "2026-08-26T21:00:00",
+    );
+    assertIdentical(
+      await anAnsweredExpression("at_timezone(NULL, 'Asia/Tokyo')"),
+      null,
+    );
+  });
+
+  it("reads the clock the simulation is running on", async () => {
+    // Given a simulation whose query started at a known instant.
+    // When a statement asks for the date and the time.
+    // Then both answer from that instant rather than from the host, so a test
+    // that froze time gets the instant it froze.
+    assertIdentical(await anAnsweredExpression("current_date"), "2026-08-26");
+    assertIdentical(
+      await anAnsweredExpression("current_timestamp"),
+      "2026-08-26 17:31:00.000",
+    );
+    assertIdentical(
+      shimStartedAt.toISOString(),
+      "2026-08-26T17:31:00.000Z",
+      "the fixture instant is what those two answers come from",
+    );
+  });
+
+  it("answers null where there is nothing to move", async () => {
+    // Given a null timestamp and a null distance.
+    // When each is moved or measured.
+    // Then the answer is null, the way every Trino scalar answers a null.
+    assertIdentical(
+      await anAnsweredExpression("date_add('day', 1, NULL)"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("date_add('day', NULL, '2026-08-30')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("date_diff('day', NULL, '2026-08-30')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("date_diff('day', '2026-08-30', NULL)"),
+      null,
+    );
+  });
+
+  it("turns the query down rather than guessing", async () => {
+    // Given a unit Trino does not name and text that is no timestamp.
+    // When each is used.
+    // Then the statement raises, which leaves the declared result to answer.
+    // A null would be a wrong answer wearing the shape of a right one.
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("date_add('fortnight', 1, '2026-08-30')"),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("date_add('day', 1, 'the other week')"),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression(
+        "at_timezone('2026-08-26T12:00:00Z', 'Mars/Olympus')",
+      ),
+    );
+  });
+});

--- a/src/service/athena/engine/sim-athena-date-arithmetic-shims.ts
+++ b/src/service/athena/engine/sim-athena-date-arithmetic-shims.ts
@@ -116,9 +116,10 @@ function inZone(
     timeZone: zone,
     hour12: false,
   });
+  // The wall clock comes back to the second, and the milliseconds the value
+  // arrived with go back on. A zone shift never moves them.
+  const wall = Date.parse(`${shifted.replace(" ", "T")}Z`);
+  const milliseconds = ((at.instant % 1000) + 1000) % 1000;
 
-  return simAthenaRenderLike(
-    Date.parse(`${shifted.replace(" ", "T")}Z`),
-    at.text.replace(/Z$/u, ""),
-  );
+  return simAthenaRenderLike(wall + milliseconds, at.text.replace(/Z$/u, ""));
 }

--- a/src/service/athena/engine/sim-athena-date-arithmetic-shims.ts
+++ b/src/service/athena/engine/sim-athena-date-arithmetic-shims.ts
@@ -1,0 +1,124 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+import {
+  isDateUnit,
+  simAthenaDateAdded,
+  simAthenaDateDifference,
+} from "./sim-athena-date-units.js";
+import {
+  shimNumber,
+  shimText,
+  simAthenaScalarShim,
+} from "./sim-athena-shim-registry.js";
+import {
+  simAthenaInstant,
+  simAthenaRenderLike,
+} from "./sim-athena-timestamp-text.js";
+
+/**
+ * Trino's date arithmetic, over ISO-8601 text.
+ *
+ * Each of these raises rather than guessing where it cannot answer faithfully.
+ * A unit outside the ones Trino names and a value that is no ISO-8601 timestamp
+ * both land there, and the engine turns the query down and lets the declared
+ * result answer. A shim answering a null instead would be a wrong answer
+ * wearing the shape of a right one.
+ */
+export function simAthenaInstallDateArithmeticShims(
+  database: DatabaseSync,
+): void {
+  simAthenaScalarShim(database, "date_add", (unit, value, timestamp) => {
+    const at = instantOf(timestamp);
+    const moved = shimNumber(value);
+
+    if (at === undefined || moved === undefined) {
+      return null;
+    }
+
+    return simAthenaRenderLike(
+      simAthenaDateAdded(unitOf(unit), moved, at.instant),
+      at.text,
+    );
+  });
+
+  simAthenaScalarShim(database, "date_diff", (unit, from, to) => {
+    const start = instantOf(from);
+    const end = instantOf(to);
+
+    if (start === undefined || end === undefined) {
+      return null;
+    }
+
+    return simAthenaDateDifference(unitOf(unit), start.instant, end.instant);
+  });
+
+  simAthenaScalarShim(database, "at_timezone", (timestamp, zone) =>
+    inZone(instantOf(timestamp), shimText(zone)),
+  );
+}
+
+/** One argument as an instant, with the text it was written as. */
+function instantOf(
+  value: unknown,
+): { instant: number; text: string } | undefined {
+  const text = shimText(value as never);
+
+  if (text === undefined) {
+    return undefined;
+  }
+
+  const instant = simAthenaInstant(text);
+
+  assertDefined(instant, `${text} is no ISO-8601 timestamp`);
+
+  return { instant, text };
+}
+
+function unitOf(value: unknown): string {
+  const unit = shimText(value as never)?.toLowerCase() ?? "";
+
+  return isDateUnit(unit)
+    ? unit
+    : raise(`${unit} is no date unit the engine reads`);
+}
+
+/**
+ * Turn the query down.
+ *
+ * A shim that cannot answer faithfully raises, and the engine catches it and
+ * lets the declared result answer. Answering a null instead would be a wrong
+ * answer wearing the shape of a right one.
+ */
+function raise(reason: string): never {
+  throw new SimAthenaSetUpError(reason);
+}
+
+/**
+ * One instant read as the wall clock of another zone.
+ *
+ * Trino answers with a timestamp carrying the zone. There is nowhere to put one
+ * here, so the answer is the wall clock alone, with any `Z` the value arrived
+ * with taken off. A `Z` left on would say UTC over a time that is no longer in
+ * it. A zone nobody has heard of raises out of `Intl`, and the query falls
+ * back.
+ */
+function inZone(
+  at: { instant: number; text: string } | undefined,
+  zone: string | undefined,
+): string | null {
+  if (at === undefined || zone === undefined) {
+    return null;
+  }
+
+  const shifted = new Date(at.instant).toLocaleString("sv-SE", {
+    timeZone: zone,
+    hour12: false,
+  });
+
+  return simAthenaRenderLike(
+    Date.parse(`${shifted.replace(" ", "T")}Z`),
+    at.text.replace(/Z$/u, ""),
+  );
+}

--- a/src/service/athena/engine/sim-athena-date-units.ts
+++ b/src/service/athena/engine/sim-athena-date-units.ts
@@ -1,0 +1,122 @@
+import { simAthenaDateParts } from "./sim-athena-timestamp-text.js";
+
+/** How long each unit a clock counts runs, in milliseconds. */
+const clockUnits: ReadonlyMap<string, number> = new Map([
+  ["millisecond", 1],
+  ["second", 1000],
+  ["minute", 60_000],
+  ["hour", 3_600_000],
+  ["day", 86_400_000],
+  ["week", 604_800_000],
+]);
+
+/** How many months each unit a calendar counts runs. */
+const calendarUnits: ReadonlyMap<string, number> = new Map([
+  ["month", 1],
+  ["quarter", 3],
+  ["year", 12],
+]);
+
+/**
+ * Whether this is a unit either kind of arithmetic knows.
+ *
+ * A shim answering a unit it does not know would be answering wrongly, so the
+ * ones here are the whole of what `date_add` and `date_diff` take. Anything
+ * else raises, and the engine turns the query down.
+ */
+export function isDateUnit(unit: string): boolean {
+  return clockUnits.has(unit) || calendarUnits.has(unit);
+}
+
+/**
+ * One instant moved by a whole number of units.
+ *
+ * A calendar unit lands on the same day of the month where the month has one,
+ * and on the last day of the month where it has not. Adding a month to the
+ * thirty-first of January gives the last day of February, which is what Trino
+ * does and what overflowing into March would not.
+ */
+export function simAthenaDateAdded(
+  unit: string,
+  value: number,
+  instant: number,
+): number {
+  const milliseconds = clockUnits.get(unit);
+
+  if (milliseconds !== undefined) {
+    return instant + value * milliseconds;
+  }
+
+  const months = calendarMonths(unit) * value;
+  const parts = simAthenaDateParts(instant);
+  const moved = parts.month + months;
+  const year = parts.year + Math.floor(moved / 12);
+  const month = ((moved % 12) + 12) % 12;
+
+  return (
+    Date.UTC(year, month, Math.min(parts.day, lastDayOf(year, month))) +
+    parts.time
+  );
+}
+
+/**
+ * How many whole units lie between two instants.
+ *
+ * A part of a unit does not count, whichever direction the pair runs in, which
+ * is the truncation Trino applies.
+ *
+ * A calendar unit is counted by moving the first instant and seeing whether it
+ * reached the second, which is how `java.time` counts and therefore how Trino
+ * does. It is the clamping that makes the difference. The thirty-first of
+ * January to the twenty-eighth of February is a whole month, because adding one
+ * month to the first lands exactly on the second.
+ */
+export function simAthenaDateDifference(
+  unit: string,
+  from: number,
+  to: number,
+): number {
+  const milliseconds = clockUnits.get(unit);
+
+  if (milliseconds !== undefined) {
+    return Math.trunc((to - from) / milliseconds);
+  }
+
+  return Math.trunc(reachedMonths(from, to) / calendarMonths(unit));
+}
+
+/**
+ * How many months of moving the first instant the second is worth.
+ *
+ * The calendar fields give the count to within one, and moving by that count
+ * says whether it overshot.
+ */
+function reachedMonths(from: number, to: number): number {
+  const start = simAthenaDateParts(from);
+  const end = simAthenaDateParts(to);
+  const months = (end.year - start.year) * 12 + (end.month - start.month);
+
+  if (months > 0 && simAthenaDateAdded("month", months, from) > to) {
+    return months - 1;
+  }
+
+  if (months < 0 && simAthenaDateAdded("month", months, from) < to) {
+    return months + 1;
+  }
+
+  return months;
+}
+
+/**
+ * How many months one calendar unit runs.
+ *
+ * Every caller has been past `isDateUnit`, so a unit that is neither a clock
+ * unit nor a calendar one never reaches here.
+ */
+function calendarMonths(unit: string): number {
+  return calendarUnits.get(unit) ?? 1;
+}
+
+function lastDayOf(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}

--- a/src/service/athena/engine/sim-athena-engine-run.ts
+++ b/src/service/athena/engine/sim-athena-engine-run.ts
@@ -19,6 +19,7 @@ export interface SimAthenaEngineRun {
   readonly tables: readonly SimAthenaPlannedTable[];
   readonly sessionDatabase: string | undefined;
   readonly caller: SimAwsCaller | undefined;
+  readonly startedAt: Date;
   readonly sql: string;
 }
 
@@ -45,6 +46,7 @@ export async function simAthenaEngineRun(
       sqlite: run.sqlite,
       loaded,
       sessionDatabase: run.sessionDatabase,
+      startedAt: run.startedAt,
     });
 
     try {

--- a/src/service/athena/engine/sim-athena-json-document-shims.ts
+++ b/src/service/athena/engine/sim-athena-json-document-shims.ts
@@ -1,0 +1,57 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { shimText, simAthenaScalarShim } from "./sim-athena-shim-registry.js";
+import {
+  simAthenaJsonAt,
+  simAthenaJsonDocument,
+} from "./sim-athena-json-path.js";
+
+/**
+ * Trino's functions over a whole JSON document.
+ *
+ * These answer with JSON text where Trino answers with a JSON value, which is
+ * the same thing here, because a structured column is held as its JSON text
+ * throughout the engine.
+ *
+ * `json_extract` shadows SQLite's own. SQLite's unwraps a string, so
+ * `json_extract('{"a":"x"}', '$.a')` answers `x` where Trino answers `"x"`. A
+ * statement comparing that against a bare string matches on one and not the
+ * other, and Trino is the one this follows.
+ */
+export function simAthenaInstallJsonDocumentShims(
+  database: DatabaseSync,
+): void {
+  simAthenaScalarShim(database, "json_extract", (json, path) => {
+    const found = simAthenaJsonAt(shimText(json), shimText(path));
+
+    return found === undefined ? null : JSON.stringify(found);
+  });
+
+  simAthenaScalarShim(database, "json_parse", (text) => {
+    const parsed = simAthenaJsonDocument(shimText(text));
+
+    return parsed === undefined ? null : JSON.stringify(parsed);
+  });
+
+  simAthenaScalarShim(database, "json_size", (json, path) =>
+    sizeOf(simAthenaJsonAt(shimText(json), shimText(path))),
+  );
+}
+
+/**
+ * How many entries a value holds.
+ *
+ * An array counts its elements and an object counts its keys. Trino answers
+ * zero for a scalar, since a scalar holds no entries at all.
+ */
+function sizeOf(value: unknown): number | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+
+  return typeof value === "object" ? Object.keys(value).length : 0;
+}

--- a/src/service/athena/engine/sim-athena-json-path.ts
+++ b/src/service/athena/engine/sim-athena-json-path.ts
@@ -20,8 +20,9 @@ export function simAthenaJsonDocument(text: string | undefined): unknown {
 /**
  * The value one `$.a.b` path reaches, or nothing where it reaches none.
  *
- * The path syntax read here is the dotted one Athena's own examples use. A
- * bracketed index and a filter expression both fall outside it.
+ * The path syntax read here is the dotted one Athena's own examples use, with
+ * a bracketed index into an array alongside it, as `$.tags[0]`. A filter
+ * expression falls outside it.
  */
 export function simAthenaJsonAt(
   json: string | undefined,
@@ -31,10 +32,7 @@ export function simAthenaJsonAt(
     return undefined;
   }
 
-  const keys = path
-    .replace(/^\$\.?/u, "")
-    .split(".")
-    .filter((key) => key.length > 0);
+  const keys = path.replace(/^\$\.?/u, "").match(/[^.[\]]+/gu) ?? [];
   let current = simAthenaJsonDocument(json);
 
   for (const key of keys) {
@@ -44,7 +42,13 @@ export function simAthenaJsonAt(
   return current;
 }
 
-/** One property of a JSON object, or nothing where it holds none. */
+/**
+ * One property of a JSON object, or one element of an array.
+ *
+ * An array carries its indexes as its own properties, so reading one by name
+ * is the same read either way. A JSON path counts an array from zero, unlike
+ * every Trino function that takes an index.
+ */
 export function simAthenaJsonProperty(value: unknown, key: string): unknown {
   if (
     typeof value !== "object" ||

--- a/src/service/athena/engine/sim-athena-json-path.ts
+++ b/src/service/athena/engine/sim-athena-json-path.ts
@@ -1,0 +1,60 @@
+/**
+ * One JSON document read out of text, or nothing where the text is no JSON.
+ *
+ * Trino fails a query over text that is no JSON and this answers null, which is
+ * the same forgiving direction the rest of the engine takes. The Athena docs
+ * page names it.
+ */
+export function simAthenaJsonDocument(text: string | undefined): unknown {
+  if (text === undefined) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The value one `$.a.b` path reaches, or nothing where it reaches none.
+ *
+ * The path syntax read here is the dotted one Athena's own examples use. A
+ * bracketed index and a filter expression both fall outside it.
+ */
+export function simAthenaJsonAt(
+  json: string | undefined,
+  path: string | undefined,
+): unknown {
+  if (path === undefined) {
+    return undefined;
+  }
+
+  const keys = path
+    .replace(/^\$\.?/u, "")
+    .split(".")
+    .filter((key) => key.length > 0);
+  let current = simAthenaJsonDocument(json);
+
+  for (const key of keys) {
+    current = simAthenaJsonProperty(current, key);
+  }
+
+  return current;
+}
+
+/** One property of a JSON object, or nothing where it holds none. */
+export function simAthenaJsonProperty(value: unknown, key: string): unknown {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !Object.hasOwn(value, key)
+  ) {
+    return undefined;
+  }
+
+  // The key comes out of the query's own JSON path, which is what this reads.
+  // oxlint-disable-next-line security/detect-object-injection
+  return (value as Record<string, unknown>)[key];
+}

--- a/src/service/athena/engine/sim-athena-json-shims.ts
+++ b/src/service/athena/engine/sim-athena-json-shims.ts
@@ -1,13 +1,18 @@
 import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
 
 import {
+  simAthenaJsonAt,
+  simAthenaJsonDocument,
+  simAthenaJsonProperty,
+} from "./sim-athena-json-path.js";
+import {
   shimNumber,
   shimText,
   simAthenaScalarShim,
 } from "./sim-athena-shim-registry.js";
 
 /**
- * Trino's JSON and array functions.
+ * Trino's functions over one value inside a JSON document.
  *
  * A structured column is held as its JSON text, so each of these parses before
  * it answers and a column holding something else answers null rather than
@@ -15,52 +20,16 @@ import {
  */
 export function simAthenaInstallJsonShims(database: DatabaseSync): void {
   simAthenaScalarShim(database, "json_extract_scalar", (json, path) =>
-    extractedScalar(shimText(json), shimText(path)),
+    scalarOf(simAthenaJsonAt(shimText(json), shimText(path))),
   );
   simAthenaScalarShim(database, "cardinality", (value) => {
-    const parsed = parsedJson(shimText(value));
+    const parsed = simAthenaJsonDocument(shimText(value));
 
     return Array.isArray(parsed) ? parsed.length : null;
   });
   simAthenaScalarShim(database, "element_at", (value, key) =>
-    elementAt(parsedJson(shimText(value)), key),
+    elementAt(simAthenaJsonDocument(shimText(value)), key),
   );
-}
-
-function parsedJson(text: string | undefined): unknown {
-  if (text === undefined) {
-    return undefined;
-  }
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * One scalar out of a JSON document, by a `$.a.b` path.
- *
- * Trino answers null for a path that reaches nothing and for a path that
- * reaches an object or an array rather than a scalar.
- */
-function extractedScalar(
-  json: string | undefined,
-  path: string | undefined,
-): string | number | null {
-  if (path === undefined) {
-    return null;
-  }
-
-  const keys = path.replace(/^\$\.?/u, "").split(".");
-  let current = parsedJson(json);
-
-  for (const key of keys) {
-    current = key.length === 0 ? current : propertyOf(current, key);
-  }
-
-  return scalarOf(current);
 }
 
 /**
@@ -75,7 +44,7 @@ function elementAt(
   key: SQLOutputValue,
 ): string | number | null {
   if (!Array.isArray(parsed)) {
-    return scalarOf(propertyOf(parsed, shimText(key) ?? ""));
+    return scalarOf(simAthenaJsonProperty(parsed, shimText(key) ?? ""));
   }
 
   const at = shimNumber(key);
@@ -87,20 +56,12 @@ function elementAt(
   return scalarOf(parsed.at(at > 0 ? at - 1 : at));
 }
 
-function propertyOf(value: unknown, key: string): unknown {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !Object.hasOwn(value, key)
-  ) {
-    return undefined;
-  }
-
-  // The key comes out of the query's own JSON path, which is what this reads.
-  // oxlint-disable-next-line security/detect-object-injection
-  return (value as Record<string, unknown>)[key];
-}
-
+/**
+ * One JSON value as SQLite will hold it.
+ *
+ * Trino answers null where a path reaches an object or an array rather than a
+ * scalar, since there is no scalar there to answer with.
+ */
 function scalarOf(value: unknown): string | number | null {
   if (typeof value === "number" || typeof value === "string") {
     return value;

--- a/src/service/athena/engine/sim-athena-query-engine.ts
+++ b/src/service/athena/engine/sim-athena-query-engine.ts
@@ -20,6 +20,9 @@ export interface SimAthenaEngineRequest {
   readonly sessionDatabase: string | undefined;
   readonly objects: SimAthenaTableObjects | undefined;
   readonly caller: SimAwsCaller | undefined;
+
+  /** When the query started, which `current_timestamp` answers with. */
+  readonly startedAt: Date;
 }
 
 /**

--- a/src/service/athena/engine/sim-athena-regexp-shims.ts
+++ b/src/service/athena/engine/sim-athena-regexp-shims.ts
@@ -1,0 +1,143 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+import {
+  isExplicitNull,
+  shimNumber,
+  shimText,
+  simAthenaScalarShim,
+} from "./sim-athena-shim-registry.js";
+
+/**
+ * Trino's regular expression functions.
+ *
+ * Each of these answers null over a pattern it cannot read, where Trino fails
+ * the query. That is the forgiving direction the rest of the engine takes.
+ */
+export function simAthenaInstallRegexpShims(database: DatabaseSync): void {
+  simAthenaScalarShim(database, "regexp_like", (value, pattern) =>
+    matches(shimText(value), shimText(pattern)),
+  );
+
+  simAthenaScalarShim(database, "regexp_extract", (...values) =>
+    isExplicitNull(values, 2)
+      ? null
+      : extracted(
+          shimText(values.at(0)),
+          shimText(values.at(1)),
+          shimNumber(values.at(2)) ?? 0,
+        ),
+  );
+
+  simAthenaScalarShim(database, "regexp_replace", (...values) =>
+    isExplicitNull(values, 2)
+      ? null
+      : replaced(
+          shimText(values.at(0)),
+          shimText(values.at(1)),
+          shimText(values.at(2)) ?? "",
+        ),
+  );
+}
+
+function matches(
+  value: string | undefined,
+  pattern: string | undefined,
+): number | null {
+  const expression = expressionFor(pattern);
+
+  if (value === undefined || expression === undefined) {
+    return null;
+  }
+
+  return expression.test(value) ? 1 : 0;
+}
+
+/**
+ * The first thing a pattern matches, or the capture group a call names.
+ *
+ * Trino counts the groups from one and calls the whole match zero, which is
+ * what a regular expression counts them as anywhere. Trino also refuses a group
+ * the pattern has not got, and raising here turns the query down rather than
+ * letting a negative index quietly count back from the end.
+ */
+function extracted(
+  value: string | undefined,
+  pattern: string | undefined,
+  group: number,
+): string | null {
+  if (!Number.isSafeInteger(group) || group < 0) {
+    throw new SimAthenaSetUpError(`${String(group)} is no capture group`);
+  }
+
+  const found = expressionFor(pattern)?.exec(value ?? "");
+
+  if (value === undefined || found === undefined || found === null) {
+    return null;
+  }
+
+  if (group >= found.length) {
+    throw new SimAthenaSetUpError(
+      `the pattern has no capture group ${String(group)}`,
+    );
+  }
+
+  return found.at(group) ?? null;
+}
+
+/**
+ * Every match replaced.
+ *
+ * A call naming no replacement takes the matches out.
+ */
+function replaced(
+  value: string | undefined,
+  pattern: string | undefined,
+  replacement: string,
+): string | null {
+  const expression = expressionFor(pattern, "gu");
+
+  if (value === undefined || expression === undefined) {
+    return null;
+  }
+
+  // The replacement is the statement's own, written the way Trino has it.
+  // oxlint-disable-next-line unicorn-js/no-unsafe-string-replacement
+  return value.replaceAll(expression, javaScriptReplacement(replacement));
+}
+
+/**
+ * One replacement written the way JavaScript reads it.
+ *
+ * Trino follows Java, which names a group `${name}` and escapes a literal
+ * dollar as `\$`. JavaScript writes those two `$<name>` and `$$`, and reads
+ * `${name}` as a dollar followed by braces. A numbered group is `$1` in both.
+ */
+function javaScriptReplacement(replacement: string): string {
+  return replacement
+    .replaceAll(String.raw`\$`, "$$$$")
+    .replaceAll(/\$\{(\w+)\}/gu, "$<$1>");
+}
+
+/**
+ * One pattern out of the statement, or nothing where it is no pattern at all.
+ *
+ * Trino fails a query carrying a pattern it cannot read, and answering null
+ * turns the query down to its declared result instead.
+ */
+function expressionFor(
+  pattern: string | undefined,
+  flags = "u",
+): RegExp | undefined {
+  if (pattern === undefined) {
+    return undefined;
+  }
+
+  try {
+    // The pattern is the query's own, which is the whole point of the function.
+    // oxlint-disable-next-line security/detect-non-literal-regexp
+    return new RegExp(pattern, flags);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/service/athena/engine/sim-athena-shim-registry.ts
+++ b/src/service/athena/engine/sim-athena-shim-registry.ts
@@ -24,6 +24,20 @@ export function simAthenaScalarShim(
   );
 }
 
+/**
+ * Whether an optional argument was written as an explicit `NULL`.
+ *
+ * A Trino function answers null when any argument is null, and a call that left
+ * the argument out gets the default instead. The two arrive here as the same
+ * value, and the count is what tells them apart.
+ */
+export function isExplicitNull(
+  values: readonly SQLOutputValue[],
+  index: number,
+): boolean {
+  return values.length > index && values.at(index) === null;
+}
+
 /** One argument as text, or nothing where it is null. */
 export function shimText(
   value: SQLOutputValue | undefined,

--- a/src/service/athena/engine/sim-athena-shim.fixture.ts
+++ b/src/service/athena/engine/sim-athena-shim.fixture.ts
@@ -1,6 +1,9 @@
 import { simAthenaSqliteDatabase } from "./sim-athena-sqlite-database.js";
 import { simAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
 
+/** The instant every query in these fixtures is taken to have started at. */
+export const shimStartedAt = new Date("2026-08-26T17:31:00.000Z");
+
 /**
  * What one expression comes to on the database the engine builds.
  *
@@ -15,6 +18,7 @@ export async function anAnsweredExpression(
     sqlite,
     loaded: [],
     sessionDatabase: undefined,
+    startedAt: shimStartedAt,
   });
 
   try {

--- a/src/service/athena/engine/sim-athena-shims.ts
+++ b/src/service/athena/engine/sim-athena-shims.ts
@@ -1,0 +1,34 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { simAthenaInstallAggregateShims } from "./sim-athena-aggregate-shims.js";
+import { simAthenaInstallArrayShims } from "./sim-athena-array-shims.js";
+import { simAthenaInstallClockShims } from "./sim-athena-clock-shims.js";
+import { simAthenaInstallDateArithmeticShims } from "./sim-athena-date-arithmetic-shims.js";
+import { simAthenaInstallDateShims } from "./sim-athena-date-shims.js";
+import { simAthenaInstallJsonDocumentShims } from "./sim-athena-json-document-shims.js";
+import { simAthenaInstallJsonShims } from "./sim-athena-json-shims.js";
+import { simAthenaInstallStringShims } from "./sim-athena-string-shims.js";
+import { simAthenaInstallUrlShims } from "./sim-athena-url-shims.js";
+
+/**
+ * Every Trino function the engine carries that SQLite does not.
+ *
+ * This is a list to extend as a query in a real test reaches for something
+ * absent from it. A function nobody has written a shim for is left absent, and
+ * SQLite refuses the statement rather than answering it, so the query falls
+ * back to its declared result.
+ */
+export function simAthenaInstallShims(
+  database: DatabaseSync,
+  startedAt: Date,
+): void {
+  simAthenaInstallClockShims(database, startedAt);
+  simAthenaInstallDateShims(database);
+  simAthenaInstallDateArithmeticShims(database);
+  simAthenaInstallJsonShims(database);
+  simAthenaInstallJsonDocumentShims(database);
+  simAthenaInstallArrayShims(database);
+  simAthenaInstallStringShims(database);
+  simAthenaInstallUrlShims(database);
+  simAthenaInstallAggregateShims(database);
+}

--- a/src/service/athena/engine/sim-athena-shims.ts
+++ b/src/service/athena/engine/sim-athena-shims.ts
@@ -7,6 +7,7 @@ import { simAthenaInstallDateArithmeticShims } from "./sim-athena-date-arithmeti
 import { simAthenaInstallDateShims } from "./sim-athena-date-shims.js";
 import { simAthenaInstallJsonDocumentShims } from "./sim-athena-json-document-shims.js";
 import { simAthenaInstallJsonShims } from "./sim-athena-json-shims.js";
+import { simAthenaInstallRegexpShims } from "./sim-athena-regexp-shims.js";
 import { simAthenaInstallStringShims } from "./sim-athena-string-shims.js";
 import { simAthenaInstallUrlShims } from "./sim-athena-url-shims.js";
 
@@ -29,6 +30,7 @@ export function simAthenaInstallShims(
   simAthenaInstallJsonDocumentShims(database);
   simAthenaInstallArrayShims(database);
   simAthenaInstallStringShims(database);
+  simAthenaInstallRegexpShims(database);
   simAthenaInstallUrlShims(database);
   simAthenaInstallAggregateShims(database);
 }

--- a/src/service/athena/engine/sim-athena-sqlite-database.ts
+++ b/src/service/athena/engine/sim-athena-sqlite-database.ts
@@ -1,9 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 
-import { simAthenaInstallAggregateShims } from "./sim-athena-aggregate-shims.js";
-import { simAthenaInstallDateShims } from "./sim-athena-date-shims.js";
-import { simAthenaInstallJsonShims } from "./sim-athena-json-shims.js";
-import { simAthenaInstallStringShims } from "./sim-athena-string-shims.js";
+import { simAthenaInstallShims } from "./sim-athena-shims.js";
 import type { SimAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
 import { simAthenaCreateTable } from "./sim-athena-sqlite-tables.js";
 import type { SimAthenaLoadedTable } from "./sim-athena-table-rows.js";
@@ -22,6 +19,14 @@ interface SimAthenaSqliteDatabaseRequest {
    * tables in it are created in SQLite's own `main` schema as well.
    */
   readonly sessionDatabase: string | undefined;
+
+  /**
+   * When the query started, which `current_timestamp` answers with.
+   *
+   * The simulator's clock rather than the host's, so a test that froze time
+   * gets the instant it froze.
+   */
+  readonly startedAt: Date;
 }
 
 /**
@@ -44,10 +49,7 @@ export function simAthenaSqliteDatabase(
   // a passing test and a wrong answer.
   database.exec("PRAGMA case_sensitive_like = ON");
 
-  simAthenaInstallDateShims(database);
-  simAthenaInstallJsonShims(database);
-  simAthenaInstallStringShims(database);
-  simAthenaInstallAggregateShims(database);
+  simAthenaInstallShims(database, request.startedAt);
 
   const attached = new Set<string>([mainSchema]);
 

--- a/src/service/athena/engine/sim-athena-string-shims.ts
+++ b/src/service/athena/engine/sim-athena-string-shims.ts
@@ -6,10 +6,23 @@ import {
   simAthenaScalarShim,
 } from "./sim-athena-shim-registry.js";
 
-/** Trino's string functions. */
+/**
+ * Trino's string functions.
+ *
+ * `substr` and `format` are deliberately absent. SQLite carries both, counts
+ * from one the way Trino does, and takes the same `%s` and `%d` a statement
+ * writes, so registering a name for either would replace something that works
+ * with something that works less well.
+ */
 export function simAthenaInstallStringShims(database: DatabaseSync): void {
   simAthenaScalarShim(database, "regexp_like", (value, pattern) =>
     matches(shimText(value), shimText(pattern)),
+  );
+  simAthenaScalarShim(database, "regexp_extract", (value, pattern, group) =>
+    extracted(shimText(value), shimText(pattern), shimNumber(group) ?? 0),
+  );
+  simAthenaScalarShim(database, "regexp_replace", (value, pattern, with_) =>
+    replaced(shimText(value), shimText(pattern), shimText(with_) ?? ""),
   );
   simAthenaScalarShim(database, "split_part", (value, delimiter, index) =>
     splitPart(shimText(value), shimText(delimiter), shimNumber(index)),
@@ -19,21 +32,79 @@ export function simAthenaInstallStringShims(database: DatabaseSync): void {
   );
 }
 
-function matches(
+/**
+ * The first thing a pattern matches, or the capture group a call names.
+ *
+ * Trino counts the groups from one and calls the whole match zero, which is
+ * what a regular expression counts them as anywhere.
+ */
+function extracted(
   value: string | undefined,
   pattern: string | undefined,
-): number | null {
-  if (value === undefined || pattern === undefined) {
+  group: number,
+): string | null {
+  const found = expressionFor(pattern)?.exec(value ?? "");
+
+  return value === undefined ? null : (found?.at(group) ?? null);
+}
+
+/**
+ * Every match replaced.
+ *
+ * Trino writes a capture group into the replacement as `$1`, which is what
+ * JavaScript writes too. A call naming no replacement takes the matches out.
+ */
+function replaced(
+  value: string | undefined,
+  pattern: string | undefined,
+  replacement: string,
+): string | null {
+  const expression = expressionFor(pattern, "gu");
+
+  if (value === undefined || expression === undefined) {
     return null;
+  }
+
+  // The replacement is the statement's own, and Trino writes a capture group
+  // into it the same way JavaScript does.
+  // oxlint-disable-next-line unicorn-js/no-unsafe-string-replacement
+  return value.replaceAll(expression, replacement);
+}
+
+/**
+ * One pattern out of the statement, or nothing where it is no pattern at all.
+ *
+ * Trino fails a query carrying a pattern it cannot read, and answering null
+ * turns the query down to its declared result instead.
+ */
+function expressionFor(
+  pattern: string | undefined,
+  flags = "u",
+): RegExp | undefined {
+  if (pattern === undefined) {
+    return undefined;
   }
 
   try {
     // The pattern is the query's own, which is the whole point of the function.
     // oxlint-disable-next-line security/detect-non-literal-regexp
-    return new RegExp(pattern, "u").test(value) ? 1 : 0;
+    return new RegExp(pattern, flags);
   } catch {
+    return undefined;
+  }
+}
+
+function matches(
+  value: string | undefined,
+  pattern: string | undefined,
+): number | null {
+  const expression = expressionFor(pattern);
+
+  if (value === undefined || expression === undefined) {
     return null;
   }
+
+  return expression.test(value) ? 1 : 0;
 }
 
 /** Trino counts the fields from one, and has no field below that. */

--- a/src/service/athena/engine/sim-athena-string-shims.ts
+++ b/src/service/athena/engine/sim-athena-string-shims.ts
@@ -15,96 +15,12 @@ import {
  * with something that works less well.
  */
 export function simAthenaInstallStringShims(database: DatabaseSync): void {
-  simAthenaScalarShim(database, "regexp_like", (value, pattern) =>
-    matches(shimText(value), shimText(pattern)),
-  );
-  simAthenaScalarShim(database, "regexp_extract", (value, pattern, group) =>
-    extracted(shimText(value), shimText(pattern), shimNumber(group) ?? 0),
-  );
-  simAthenaScalarShim(database, "regexp_replace", (value, pattern, with_) =>
-    replaced(shimText(value), shimText(pattern), shimText(with_) ?? ""),
-  );
   simAthenaScalarShim(database, "split_part", (value, delimiter, index) =>
     splitPart(shimText(value), shimText(delimiter), shimNumber(index)),
   );
   simAthenaScalarShim(database, "strpos", (value, search) =>
     position(shimText(value), shimText(search)),
   );
-}
-
-/**
- * The first thing a pattern matches, or the capture group a call names.
- *
- * Trino counts the groups from one and calls the whole match zero, which is
- * what a regular expression counts them as anywhere.
- */
-function extracted(
-  value: string | undefined,
-  pattern: string | undefined,
-  group: number,
-): string | null {
-  const found = expressionFor(pattern)?.exec(value ?? "");
-
-  return value === undefined ? null : (found?.at(group) ?? null);
-}
-
-/**
- * Every match replaced.
- *
- * Trino writes a capture group into the replacement as `$1`, which is what
- * JavaScript writes too. A call naming no replacement takes the matches out.
- */
-function replaced(
-  value: string | undefined,
-  pattern: string | undefined,
-  replacement: string,
-): string | null {
-  const expression = expressionFor(pattern, "gu");
-
-  if (value === undefined || expression === undefined) {
-    return null;
-  }
-
-  // The replacement is the statement's own, and Trino writes a capture group
-  // into it the same way JavaScript does.
-  // oxlint-disable-next-line unicorn-js/no-unsafe-string-replacement
-  return value.replaceAll(expression, replacement);
-}
-
-/**
- * One pattern out of the statement, or nothing where it is no pattern at all.
- *
- * Trino fails a query carrying a pattern it cannot read, and answering null
- * turns the query down to its declared result instead.
- */
-function expressionFor(
-  pattern: string | undefined,
-  flags = "u",
-): RegExp | undefined {
-  if (pattern === undefined) {
-    return undefined;
-  }
-
-  try {
-    // The pattern is the query's own, which is the whole point of the function.
-    // oxlint-disable-next-line security/detect-non-literal-regexp
-    return new RegExp(pattern, flags);
-  } catch {
-    return undefined;
-  }
-}
-
-function matches(
-  value: string | undefined,
-  pattern: string | undefined,
-): number | null {
-  const expression = expressionFor(pattern);
-
-  if (value === undefined || expression === undefined) {
-    return null;
-  }
-
-  return expression.test(value) ? 1 : 0;
 }
 
 /** Trino counts the fields from one, and has no field below that. */

--- a/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
@@ -1,4 +1,4 @@
-import { assertIdentical } from "@kensio/smartass";
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { anAnsweredExpression } from "./sim-athena-shim.fixture.js";
@@ -43,6 +43,66 @@ describe("Trino's regular expression functions on SQLite", () => {
     assertIdentical(
       await anAnsweredExpression(String.raw`regexp_replace('a1b2', '\d')`),
       "ab",
+    );
+  });
+
+  it("refuses a capture group the pattern has not got", async () => {
+    // Given a pattern with one group.
+    // When a group outside it is asked for.
+    // Then the statement raises, which leaves the declared result to answer.
+    // A negative index would otherwise count back from the end and answer.
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("regexp_extract('abc', '(a)', 5)"),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("regexp_extract('abc', '(a)(b)', -1)"),
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_extract('abc', '(a)(b)', 2)"),
+      "b",
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_extract('xyz', '(a)', 1)"),
+      null,
+    );
+  });
+
+  it("writes a replacement the way Trino writes one", async () => {
+    // Given replacements naming a group by name and escaping a dollar.
+    // When each is used.
+    // Then Trino's Java spelling is what reads, since a statement written for
+    // Athena carries that one. JavaScript spells both differently and would
+    // leave them as literal text.
+    // Written by hand rather than as a template, because `${` is Trino's own
+    // spelling here and a template literal would read it as an interpolation.
+    const reference = `$\u{7B}first}`;
+    const named = `regexp_replace('abc', '(?<first>a)', '[${reference}]')`;
+    const dollar = String.raw`regexp_replace('abc', 'a', '\$')`;
+
+    assertIdentical(await anAnsweredExpression(named), "[a]bc");
+    assertIdentical(await anAnsweredExpression(dollar), "$bc");
+  });
+
+  it("tells an argument left out from one written as NULL", async () => {
+    // Given calls leaving the last argument out and calls writing it as NULL.
+    // When each runs.
+    // Then the absent one takes the default and the NULL answers null, the
+    // way every Trino function answers a null argument.
+    assertIdentical(
+      await anAnsweredExpression("regexp_extract('abc', 'a')"),
+      "a",
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_extract('abc', 'a', NULL)"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_replace('abc', 'a')"),
+      "bc",
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_replace('abc', 'a', NULL)"),
+      null,
     );
   });
 
@@ -120,6 +180,20 @@ describe("Trino's URL functions on SQLite", () => {
     assertIdentical(
       await anAnsweredExpression("url_extract_port('https://rain.example/a')"),
       null,
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_extract_port('http://rain.example:80/a')",
+      ),
+      80,
+      "a port written out is a port, though it is the scheme's own default",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_extract_port('http://user:1234@rain.example/a')",
+      ),
+      null,
+      "the digits in a user's own credentials are no port",
     );
     assertIdentical(
       await anAnsweredExpression("url_extract_query('https://rain.example/a')"),

--- a/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
@@ -1,0 +1,175 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredExpression } from "./sim-athena-shim.fixture.js";
+
+const logLine = "'https://rain.example:8443/reports/august?tenant=acme#top'";
+
+describe("Trino's regular expression functions on SQLite", () => {
+  it("takes the first match or the group a call names", async () => {
+    // Given a value carrying letters and digits.
+    // When each is extracted.
+    // Then the groups count from one and the whole match is zero, which is
+    // what a regular expression counts them as anywhere.
+    assertIdentical(
+      await anAnsweredExpression(
+        String.raw`regexp_extract('abc123', '([a-z]+)(\d+)')`,
+      ),
+      "abc123",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        String.raw`regexp_extract('abc123', '([a-z]+)(\d+)', 2)`,
+      ),
+      "123",
+    );
+    assertIdentical(
+      await anAnsweredExpression(String.raw`regexp_extract('abc', '(\d+)', 1)`),
+      null,
+    );
+  });
+
+  it("replaces every match, writing the groups back in", async () => {
+    // Given a value with two matches in it.
+    // When each is replaced and then removed.
+    // Then `$1` reaches the capture group, and a call naming no replacement
+    // takes the matches out.
+    assertIdentical(
+      await anAnsweredExpression(
+        String.raw`regexp_replace('a1b2', '(\d)', '<$1>')`,
+      ),
+      "a<1>b<2>",
+    );
+    assertIdentical(
+      await anAnsweredExpression(String.raw`regexp_replace('a1b2', '\d')`),
+      "ab",
+    );
+  });
+
+  it("answers null over a pattern it cannot read", async () => {
+    // Given a pattern that is no pattern.
+    // When it is used.
+    // Then the answer is null rather than a failed query. Trino fails.
+    assertIdentical(
+      await anAnsweredExpression("regexp_extract('abc', '(')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_replace('abc', '(', 'x')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_replace(NULL, 'a')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_extract(NULL, 'a')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_extract('abc', NULL)"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('abc', NULL)"),
+      null,
+    );
+  });
+});
+
+describe("Trino's URL functions on SQLite", () => {
+  it("reads each part of a URL", async () => {
+    // Given one URL carrying every part.
+    // When each part is read.
+    // Then none of them keeps the punctuation that introduced it.
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_host(${logLine})`),
+      "rain.example",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_path(${logLine})`),
+      "/reports/august",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_protocol(${logLine})`),
+      "https",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_query(${logLine})`),
+      "tenant=acme",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_fragment(${logLine})`),
+      "top",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_port(${logLine})`),
+      8443,
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_parameter(${logLine}, 'tenant')`),
+      "acme",
+    );
+  });
+
+  it("answers nothing for a part the URL left out", async () => {
+    // Given a URL carrying no port, no query and no fragment.
+    // When each is read.
+    // Then the port answers null, since a port has no empty form, and the
+    // rest answer with the empty string Trino answers with.
+    assertIdentical(
+      await anAnsweredExpression("url_extract_port('https://rain.example/a')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_extract_query('https://rain.example/a')"),
+      "",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_extract_parameter('https://rain.example/a?x=1', 'y')",
+      ),
+      null,
+    );
+  });
+
+  it("answers null over text that is no URL", async () => {
+    // Given text nobody could read as a URL.
+    // When its host is read.
+    // Then the answer is null rather than a failed query. Trino fails.
+    assertIdentical(
+      await anAnsweredExpression("url_extract_host('rain dot example')"),
+      null,
+    );
+    assertIdentical(await anAnsweredExpression("url_extract_host(NULL)"), null);
+    assertIdentical(await anAnsweredExpression("url_extract_port(NULL)"), null);
+    assertIdentical(
+      await anAnsweredExpression("url_extract_parameter(NULL, 'x')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_extract_parameter('https://rain.example/a', NULL)",
+      ),
+      null,
+    );
+  });
+});
+
+describe("the string functions SQLite already carries", () => {
+  it("counts from one, as Trino does", async () => {
+    // Given a value and a format string.
+    // When `substr` and `format` are called.
+    // Then SQLite's own answer is Trino's answer, so neither is shimmed.
+    // Shadowing either would replace something that works.
+    assertIdentical(
+      await anAnsweredExpression("substr('abcdef', 2, 3)"),
+      "bcd",
+    );
+    assertIdentical(await anAnsweredExpression("substr('abcdef', -2)"), "ef");
+    assertIdentical(
+      await anAnsweredExpression("format('%s has %d', 'rain', 4)"),
+      "rain has 4",
+    );
+  });
+});

--- a/src/service/athena/engine/sim-athena-timestamp-text.ts
+++ b/src/service/athena/engine/sim-athena-timestamp-text.ts
@@ -5,14 +5,17 @@
 /**
  * The ISO-8601 shapes a table's timestamp column is written in.
  *
- * A date, or a date and a time joined by a `T` or a space, with optional
- * fractional seconds and an optional `Z`. A value carrying a numeric UTC offset
- * is deliberately left out. Reading one would mean rendering the answer back
- * into that offset, and getting that wrong is a wrong answer rather than a
- * refusal.
+ * A date, or a date and a time joined by a `T` or a space, with up to three
+ * fractional digits and an optional `Z`.
+ *
+ * Two shapes are deliberately left out. A value carrying a numeric UTC offset
+ * would mean rendering the answer back into that offset, and a value written
+ * finer than the millisecond has no room in the instant an answer is rendered
+ * from. Refusing either is better than answering with a timestamp that has been
+ * quietly cut about.
  */
 const isoDate = /^\d{4}-\d{2}-\d{2}$/u;
-const isoDateTime = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z?$/u;
+const isoDateTime = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z?$/u;
 
 /**
  * A value with no zone on it reads as UTC.

--- a/src/service/athena/engine/sim-athena-timestamp-text.ts
+++ b/src/service/athena/engine/sim-athena-timestamp-text.ts
@@ -1,0 +1,82 @@
+// Both patterns below are anchored at each end with every quantifier bounded,
+// so there is nothing in either to backtrack over.
+// oxlint-disable security/detect-unsafe-regex
+
+/**
+ * The ISO-8601 shapes a table's timestamp column is written in.
+ *
+ * A date, or a date and a time joined by a `T` or a space, with optional
+ * fractional seconds and an optional `Z`. A value carrying a numeric UTC offset
+ * is deliberately left out. Reading one would mean rendering the answer back
+ * into that offset, and getting that wrong is a wrong answer rather than a
+ * refusal.
+ */
+const isoDate = /^\d{4}-\d{2}-\d{2}$/u;
+const isoDateTime = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z?$/u;
+
+/**
+ * A value with no zone on it reads as UTC.
+ *
+ * `Date.parse` reads a space separated timestamp in the host's own zone, which
+ * would answer differently on two machines running the same test.
+ */
+function asUtc(text: string): string {
+  const joined = text.replace(" ", "T");
+
+  return joined.endsWith("Z") || joined.length <= 10 ? joined : `${joined}Z`;
+}
+
+/** The instant one ISO-8601 value names, or nothing where it names none. */
+export function simAthenaInstant(text: string): number | undefined {
+  if (!isoDate.test(text) && !isoDateTime.test(text)) {
+    return undefined;
+  }
+
+  const parsed = Date.parse(asUtc(text));
+
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Render an instant the way one value was written.
+ *
+ * The template says how long the answer is, where its separators go and whether
+ * it carries a `Z`, so a date comes back a date and a timestamp comes back
+ * carrying the same fields it arrived with.
+ */
+export function simAthenaRenderLike(instant: number, template: string): string {
+  const iso = new Date(instant).toISOString();
+  let rendered = "";
+
+  for (let index = 0; index < template.length; index += 1) {
+    const character = template.charAt(index);
+
+    rendered += /\d/u.test(character) ? iso.charAt(index) : character;
+  }
+
+  return rendered;
+}
+
+/** The calendar fields one instant reads in UTC. */
+export interface SimAthenaDateParts {
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+  readonly time: number;
+}
+
+/** One instant taken apart, for the units a calendar counts rather than a clock. */
+export function simAthenaDateParts(instant: number): SimAthenaDateParts {
+  const at = new Date(instant);
+
+  return {
+    year: at.getUTCFullYear(),
+    month: at.getUTCMonth(),
+    day: at.getUTCDate(),
+    time:
+      at.getUTCHours() * 3_600_000 +
+      at.getUTCMinutes() * 60_000 +
+      at.getUTCSeconds() * 1000 +
+      at.getUTCMilliseconds(),
+  };
+}

--- a/src/service/athena/engine/sim-athena-url-shims.ts
+++ b/src/service/athena/engine/sim-athena-url-shims.ts
@@ -1,0 +1,56 @@
+import type { DatabaseSync } from "node:sqlite";
+
+import { shimText, simAthenaScalarShim } from "./sim-athena-shim-registry.js";
+
+/** What each `url_extract` function reads off a parsed URL. */
+const parts: ReadonlyMap<string, (url: URL) => string | null> = new Map([
+  ["url_extract_host", (url: URL) => url.hostname],
+  ["url_extract_path", (url: URL) => url.pathname],
+  ["url_extract_protocol", (url: URL) => url.protocol.replace(":", "")],
+  ["url_extract_fragment", (url: URL) => url.hash.replace("#", "")],
+  ["url_extract_query", (url: URL) => url.search.replace("?", "")],
+]);
+
+/**
+ * Trino's URL functions, which a query over access logs reaches for.
+ *
+ * Trino fails a query over text that is no URL and these answer null, the same
+ * forgiving direction the rest of the engine takes.
+ *
+ * Trino answers with an empty string for a part the URL leaves out, apart from
+ * the port, which has no empty form and answers null.
+ */
+export function simAthenaInstallUrlShims(database: DatabaseSync): void {
+  for (const [name, read] of parts) {
+    simAthenaScalarShim(database, name, (value) => {
+      const url = parsedUrl(shimText(value));
+
+      return url === undefined ? null : read(url);
+    });
+  }
+
+  simAthenaScalarShim(database, "url_extract_port", (value) => {
+    const port = parsedUrl(shimText(value))?.port;
+
+    return port === undefined || port === "" ? null : Number(port);
+  });
+
+  simAthenaScalarShim(database, "url_extract_parameter", (value, name) => {
+    const wanted = shimText(name);
+    const url = parsedUrl(shimText(value));
+
+    if (url === undefined || wanted === undefined) {
+      return null;
+    }
+
+    return url.searchParams.get(wanted);
+  });
+}
+
+function parsedUrl(value: string | undefined): URL | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return URL.parse(value) ?? undefined;
+}

--- a/src/service/athena/engine/sim-athena-url-shims.ts
+++ b/src/service/athena/engine/sim-athena-url-shims.ts
@@ -29,11 +29,9 @@ export function simAthenaInstallUrlShims(database: DatabaseSync): void {
     });
   }
 
-  simAthenaScalarShim(database, "url_extract_port", (value) => {
-    const port = parsedUrl(shimText(value))?.port;
-
-    return port === undefined || port === "" ? null : Number(port);
-  });
+  simAthenaScalarShim(database, "url_extract_port", (value) =>
+    writtenPort(shimText(value)),
+  );
 
   simAthenaScalarShim(database, "url_extract_parameter", (value, name) => {
     const wanted = shimText(name);
@@ -45,6 +43,26 @@ export function simAthenaInstallUrlShims(database: DatabaseSync): void {
 
     return url.searchParams.get(wanted);
   });
+}
+
+/** Everything between the scheme and the path, which is where a port is written. */
+const authority = /^[A-Za-z][\w+.-]*:\/\/[^/?#]*/u;
+
+/**
+ * The port one URL names, or nothing where it names none.
+ *
+ * Read off the text rather than off the parsed URL, because the parser drops a
+ * port that is the scheme's own default. Trino answers with the port a URL was
+ * written with, so `http://rain.example:80/a` is eighty rather than nothing.
+ */
+function writtenPort(value: string | undefined): number | null {
+  if (value === undefined || parsedUrl(value) === undefined) {
+    return null;
+  }
+
+  const written = /:(\d+)$/u.exec(authority.exec(value)?.[0] ?? "")?.[1];
+
+  return written === undefined ? null : Number(written);
 }
 
 function parsedUrl(value: string | undefined): URL | undefined {

--- a/src/service/athena/execution/sim-athena-query-completion.ts
+++ b/src/service/athena/execution/sim-athena-query-completion.ts
@@ -57,6 +57,7 @@ export async function simAthenaCompleteQuery(
     tables: outcome.tables,
     objects: runner.tableObjects,
     caller,
+    startedAt: execution.submittedAt,
   });
 
   try {

--- a/src/service/athena/result/sim-athena-query-answer.ts
+++ b/src/service/athena/result/sim-athena-query-answer.ts
@@ -26,6 +26,9 @@ interface SimAthenaQueryAnswerRequest {
   readonly tables: readonly SimAthenaPlannedTable[];
   readonly objects: SimAthenaTableObjects | undefined;
   readonly caller: SimAwsCaller | undefined;
+
+  /** When the query started, which `current_timestamp` answers with. */
+  readonly startedAt: Date;
 }
 
 /**
@@ -56,6 +59,7 @@ export async function simAthenaQueryAnswer(
     sessionDatabase: request.sessionDatabase,
     objects: request.objects,
     caller: request.caller,
+    startedAt: request.startedAt,
   });
 
   return computed === undefined

--- a/src/service/athena/sim-athena-engine-functions.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-functions.iso.test.ts
@@ -1,0 +1,126 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+const frozen = new Date("2026-08-26T09:15:00.000Z");
+
+const requests = [
+  { at: "2026-08-24T10:00:00Z", url: "https://rain.example/a?tenant=acme" },
+  { at: "2026-08-26T11:00:00Z", url: "https://rain.example/b?tenant=zed" },
+];
+
+/** A simulation holding the requests, with time frozen and the engine on. */
+async function aRequestSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation(new SimFixedClock(frozen));
+
+  aCatalogTable(simulation.simAws, {
+    name: "requests",
+    columns: [
+      { Name: "at", Type: "timestamp" },
+      { Name: "url", Type: "string" },
+    ],
+  });
+
+  await aSeededJson(simulation.simAws, "requests/part-0.json", requests);
+  await simulation.simAws.athena().engine().enable();
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["fallback"], rows: [["declared"]] });
+
+  return simulation;
+}
+
+describe("the Trino functions a query reaches for", () => {
+  it("reads the clock the simulation froze rather than the host's", async () => {
+    // Given a simulation whose clock is frozen.
+    const simulation = await aRequestSimulation();
+
+    // When a query asks how old each request is.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT date_diff('day', at, current_timestamp) AS age " +
+        "FROM rainlytics.requests ORDER BY at",
+    );
+
+    // Then the answer is measured against the frozen instant, so the same
+    // test answers the same way on every run and on every machine.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["1"], ["0"]]);
+  });
+
+  it("reads a URL apart and rolls the parts up", async () => {
+    // Given the requests, with the engine on.
+    const simulation = await aRequestSimulation();
+
+    // When a query groups on a piece of the URL.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT url_extract_parameter(url, 'tenant') AS tenant, " +
+        "url_extract_path(url) AS path FROM rainlytics.requests " +
+        "WHERE url_extract_host(url) = 'rain.example' ORDER BY tenant",
+    );
+
+    // Then each part reads, and the filter on the host is real.
+    assertObjectEquals(answered.rows, [
+      ["acme", "/a"],
+      ["zed", "/b"],
+    ]);
+  });
+
+  it("collects a column into an array and flattens it again", async () => {
+    // Given the requests, with the engine on.
+    const simulation = await aRequestSimulation();
+
+    // When a query collects the paths and counts them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT cardinality(array_agg(url_extract_path(url))) AS paths " +
+        "FROM rainlytics.requests",
+    );
+
+    // Then the collected array is the JSON text an array column is held as,
+    // so the array functions reach into it.
+    assertObjectEquals(answered.rows, [["2"]]);
+  });
+
+  it("falls back where a function has no shim behind it", async () => {
+    // Given the requests, with the engine on.
+    const simulation = await aRequestSimulation();
+
+    // When a query reaches for a Trino function nobody has shimmed.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT word_stem(url) AS stem FROM rainlytics.requests",
+    );
+
+    // Then the declaration answers it. SQLite refuses a function it has never
+    // heard of, which is a refusal rather than a wrong answer.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("falls back where a shim will not guess", async () => {
+    // Given the requests, with the engine on.
+    const simulation = await aRequestSimulation();
+
+    // When a query names a unit Trino does not have.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT date_add('fortnight', 1, at) AS later FROM rainlytics.requests",
+    );
+
+    // Then the declaration answers it. A shim that cannot answer faithfully
+    // raises, and raising turns the query down.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+});

--- a/src/service/athena/sim-athena-engine.fixture.ts
+++ b/src/service/athena/sim-athena-engine.fixture.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 
+import type { SimClock } from "../../util/clock/sim-clock.js";
 import type { SimGlueColumn } from "../glue/table/sim-glue-table-schema.js";
 import { SimAws } from "../aws/sim-aws.js";
 
@@ -36,8 +37,10 @@ export interface SimAthenaEngineTableInput {
  * The engine is left off. A test that wants it turns it on, which is what a
  * reader of that test needs to see.
  */
-export async function anEngineSimulation(): Promise<SimAthenaEngineSimulation> {
-  const simAws = new SimAws();
+export async function anEngineSimulation(
+  clock?: SimClock,
+): Promise<SimAthenaEngineSimulation> {
+  const simAws = new SimAws(clock === undefined ? {} : { clock });
   const workGroup = `analytics-${faker.string.uuid()}`;
 
   await simAws.s3().createBucket({ input: { Bucket: logsBucket } });


### PR DESCRIPTION
Trino's date arithmetic, JSON, array, string and URL functions run under the engine, taking it from sixteen functions to thirty-seven. `current_date` and `current_timestamp` read the simulator's clock rather than the host's, threaded from the execution's `submittedAt` through the answer chain, so a test that froze time gets the instant it froze and answers the same way on every machine.

Three rules shaped what went in.

**A shim that cannot answer faithfully raises.** A thrown error reaches `simAthenaEngineRun`, which turns the query down and lets the declared result answer. `date_add` with a unit Trino does not name, `slice` starting at zero and `array_join` over objects all take that route. A null would be a wrong answer wearing the shape of a right one.

**A function SQLite already gets right is left alone.** `substr` and `format` both count from one and take the same format specifiers, and registering a name shadows the built-in, so a shim there would replace something that works. `json_extract` is the other way round, since SQLite's unwraps a string where Trino answers with JSON, so that one is shadowed on purpose.

**A function taking a lambda is left absent on purpose.** `filter` emits a `->` that SQLite reads as its own JSON operator, so a registered name would leave the lambda to be read as that and answer something. An absent name makes SQLite refuse the statement, which is a refusal rather than a wrong answer.

Two behaviours are worth reviewing. `date_add` and `date_diff` count a calendar month by whether moving the first instant reached the second, which is how `java.time` counts and so how Trino does, and which makes the thirty-first of January to the twenty-eighth of February a whole month. And `at_timezone` answers with the wall clock of the zone with any `Z` taken off, since a `Z` left on would claim UTC over a time no longer in it.

Resolves https://github.com/KensioSoftware/yulin/issues/1013


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded simulated Athena SQL support for date arithmetic, JSON, arrays, regular expressions, URLs, and clock functions.
  * Added deterministic `current_date` and `current_timestamp` behavior based on query start time.
  * Added support for URL component extraction, array operations, JSON inspection, and regex extraction and replacement.
  * Improved timestamp handling, including format preservation and timezone conversion.
* **Documentation**
  * Documented supported functions, limitations, fallback behavior, and simulator-clock semantics.
* **Tests**
  * Added comprehensive coverage for the new SQL function behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->