### PR TITLE
feat: register partitions in the Glue catalog

### DIFF
--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -1,9 +1,10 @@
 # Simulated Glue
 
-Yulin includes a simulated Glue Data Catalog for tests and local development. It holds databases and
-tables, deploys them from `AWS::Glue::Database` and `AWS::Glue::Table`, and hands them back through
-`GetDatabase` and `GetTable`. A test can assert that a stack declared the table definition it meant
-to, including the Athena partition projection its parameters configure.
+Yulin includes a simulated Glue Data Catalog for tests and local development. It holds databases,
+tables and the partitions registered against them, deploys databases and tables from
+`AWS::Glue::Database` and `AWS::Glue::Table`, and hands them back through `GetDatabase` and
+`GetTable`. A test can assert that a stack declared the table definition it meant to, including the
+Athena partition projection its parameters configure.
 
 A table here is a definition. The data it describes stays in S3, unread, and the catalog answers
 with what it was told to hold.
@@ -93,12 +94,98 @@ A broken projection fails that query.
 ## Reading the catalog back
 
 `GetDatabase`, `GetDatabases`, `GetTable` and `GetTables` answer through the SDK. A `SimGlue` also
-carries `findDatabase`, `findTable`, `allDatabases` and `tablesInDatabase`, which read the same
-state without going through a Command or its authorization.
+carries `findDatabase`, `findTable`, `allDatabases`, `tablesInDatabase`, `findPartition` and
+`partitionsInTable`. Those read the same state without going through a Command or its
+authorization.
 
 The storage descriptor keeps its columns in the order they were declared, and the partition keys
 keep theirs. The two stay apart, the way real Glue keeps them. A partition key repeated among the
 storage descriptor's columns gives a table Athena refuses to query.
+
+## Registering partitions
+
+A crawler, `MSCK REPAIR TABLE` or `ALTER TABLE ADD PARTITION` fills a real catalog's partition list.
+Here the six partition commands do it. A partition is keyed by its values in the order the table's
+`PartitionKeys` declares them, and carries a storage descriptor saying where its own data sits.
+
+```typescript sim-glue-partitions
+/**
+ * Registering two days of partitions against a table, then listing them.
+ */
+
+import {
+  BatchCreatePartitionCommand,
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetPartitionsCommand,
+} from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const glue = simAws.glue();
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+);
+glue.createTable(
+  new CreateTableCommand({
+    DatabaseName: "site_logs",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [{ Name: "day", Type: "string" }],
+      StorageDescriptor: { Location: "s3://site-logs/cloudfront/" },
+    },
+  }),
+);
+
+const { Errors } = glue.batchCreatePartition(
+  new BatchCreatePartitionCommand({
+    DatabaseName: "site_logs",
+    TableName: "access_logs",
+    PartitionInputList: [
+      {
+        Values: ["2026-08-25"],
+        StorageDescriptor: {
+          Location: "s3://site-logs/cloudfront/day=2026-08-25/",
+        },
+      },
+      {
+        Values: ["2026-08-26"],
+        StorageDescriptor: {
+          Location: "s3://site-logs/cloudfront/day=2026-08-26/",
+        },
+      },
+    ],
+  }),
+);
+
+const { Partitions } = glue.getPartitions(
+  new GetPartitionsCommand({
+    DatabaseName: "site_logs",
+    TableName: "access_logs",
+  }),
+);
+
+// 0
+console.log(Errors.length);
+// s3://site-logs/cloudfront/day=2026-08-26/
+console.log(Partitions[1]?.StorageDescriptor?.Location);
+```
+
+`CreatePartition` registers one partition and `BatchCreatePartition` registers a list of them.
+`GetPartition` reads one back by its values, and `GetPartitions` answers with a table's partitions in
+registration order. `DeletePartition` and `BatchDeletePartition` remove them.
+
+A batch reports what it could not do in `Errors` and carries on with the rest, the way real Glue
+does. Each entry there carries the values it was given and an `ErrorCode` naming the refusal, so a
+job re-run over a week of days learns which days were already registered and registers the others.
+
+Values are positional. A `Values` list of a different length from the table's `PartitionKeys` lines
+up with the wrong keys, and is refused with `InvalidInputException` naming both counts. Registering
+one day twice is an `AlreadyExistsException`, since registration is not idempotent on real Glue.
+Deleting a table removes the partitions registered against it, the way deleting a database removes
+its tables.
 
 ## Intercepting a GlueClient
 
@@ -234,6 +321,8 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
 
 - `CreateDatabase`, `GetDatabase`, `GetDatabases` and `DeleteDatabase`.
 - `CreateTable`, `GetTable`, `GetTables` and `DeleteTable`.
+- `CreatePartition`, `BatchCreatePartition`, `GetPartition`, `GetPartitions`, `DeletePartition` and
+  `BatchDeletePartition`.
 - `AWS::Glue::Database` and `AWS::Glue::Table`, deployed and deleted with the stack.
 - `TableInput.Parameters`, `PartitionKeys` and `StorageDescriptor`, held and read back as declared.
 - IAM authorization on every Command, over the resource and its ancestors.
@@ -249,8 +338,16 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
 - **`AWS::Glue::Crawler` is absent.** A crawler fills a catalog by reading objects, and every object
   stays unread here. A template declaring one deploys, with the crawler recorded on the stack's
   `skippedResources`.
-- **Partitions are described by projection alone.** `CreatePartition`, `GetPartitions` and
-  `BatchCreatePartition` have no counterpart here.
+- **Athena ignores a registered partition.** A query expands the table's projection parameters and
+  reads nothing the partition commands wrote. Registering partitions changes what the catalog
+  reports and leaves query planning alone.
+- **`GetPartitions` takes no `Expression`.** A filter is refused with `InvalidInputException`. An
+  ignored filter would answer with the partitions the caller asked to leave out.
+- **A partition keeps what it was registered with.** `UpdatePartition` and `BatchUpdatePartition`
+  are absent, along with `BatchGetPartition` and partition indexes.
+- **No template property registers a partition.** `AWS::Glue::Partition` is not a CloudFormation
+  resource type on real AWS either. A stack registers its partitions through the SDK after the
+  deploy.
 - **A table keeps the definition it was created with.** `UpdateTable` and `UpdateDatabase` are
   absent, and `GetTable` reports the creation time as the update time.
 - **`Fn::GetAtt Id` on a table answers with a guess.** It resolves to the catalog id, the database
@@ -267,7 +364,7 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
   column statistics, and IAM is the whole of the permission model.
 - **Iceberg and other open table formats are recorded, never built.** `OpenTableFormatInput` is
   reported as ignored and the table is created as an ordinary one.
-- **Listings come back whole.** `GetDatabases` and `GetTables` answer with everything in creation
-  order. `MaxResults` and `NextToken` are absent.
+- **Listings come back whole.** `GetDatabases`, `GetTables` and `GetPartitions` answer with
+  everything in creation order. `MaxResults` and `NextToken` are absent.
 - **Connections, jobs, triggers, workflows and the Schema Registry are absent.** The Data Catalog is
   the whole of the simulated surface.

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -345,9 +345,9 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
   ignored filter would answer with the partitions the caller asked to leave out.
 - **A partition keeps what it was registered with.** `UpdatePartition` and `BatchUpdatePartition`
   are absent, along with `BatchGetPartition` and partition indexes.
-- **No template property registers a partition.** `AWS::Glue::Partition` is not a CloudFormation
-  resource type on real AWS either. A stack registers its partitions through the SDK after the
-  deploy.
+- **`AWS::Glue::Partition` is absent.** Real CloudFormation has the resource type, and a template
+  declaring one deploys here with the partition recorded on the stack's `skippedResources`. A stack
+  that needs its partitions registered does it through the SDK once the deploy finishes.
 - **A table keeps the definition it was created with.** `UpdateTable` and `UpdateDatabase` are
   absent, and `GetTable` reports the creation time as the update time.
 - **`Fn::GetAtt Id` on a table answers with a guess.** It resolves to the catalog id, the database

--- a/docs/services/glue/sim-glue-partitions.example.ts
+++ b/docs/services/glue/sim-glue-partitions.example.ts
@@ -1,0 +1,62 @@
+/**
+ * Registering two days of partitions against a table, then listing them.
+ */
+
+import {
+  BatchCreatePartitionCommand,
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetPartitionsCommand,
+} from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const glue = simAws.glue();
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+);
+glue.createTable(
+  new CreateTableCommand({
+    DatabaseName: "site_logs",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [{ Name: "day", Type: "string" }],
+      StorageDescriptor: { Location: "s3://site-logs/cloudfront/" },
+    },
+  }),
+);
+
+const { Errors } = glue.batchCreatePartition(
+  new BatchCreatePartitionCommand({
+    DatabaseName: "site_logs",
+    TableName: "access_logs",
+    PartitionInputList: [
+      {
+        Values: ["2026-08-25"],
+        StorageDescriptor: {
+          Location: "s3://site-logs/cloudfront/day=2026-08-25/",
+        },
+      },
+      {
+        Values: ["2026-08-26"],
+        StorageDescriptor: {
+          Location: "s3://site-logs/cloudfront/day=2026-08-26/",
+        },
+      },
+    ],
+  }),
+);
+
+const { Partitions } = glue.getPartitions(
+  new GetPartitionsCommand({
+    DatabaseName: "site_logs",
+    TableName: "access_logs",
+  }),
+);
+
+// 0
+console.log(Errors.length);
+// s3://site-logs/cloudfront/day=2026-08-26/
+console.log(Partitions[1]?.StorageDescriptor?.Location);

--- a/src/service/glue/README.md
+++ b/src/service/glue/README.md
@@ -1,6 +1,7 @@
 # Simulated Glue
 
-The Glue Data Catalog, holding databases and the table definitions inside them.
+The Glue Data Catalog, holding databases, the table definitions inside them, and the partitions
+registered against those tables.
 
 Usage docs are at [docs/services/glue/](../../../docs/services/glue/README.md).
 
@@ -18,11 +19,14 @@ partition keys.
 
 ## Layout
 
-- `sim-glue.ts` is the facade. It holds the two stores, delegates each SDK Command to a command
+- `sim-glue.ts` is the facade. It holds the three stores, delegates each SDK Command to a command
   class, and hands out the SDK router and the CloudFormation factory.
 - `database/` and `table/` hold the stored shapes and their stores. Tables are keyed by database
   name and then by table name. A database's tables go with it when it is deleted, and two databases
   may each hold a table of the same name.
+- `partition/` follows that a level further down. `SimGluePartitionStore` is keyed by database name
+  and then table name, and each entry is a `SimGlueTablePartitions` holding one table's partitions
+  under their own values. A table's partitions go with it, and a database's go with the database.
 - `command/` is one directory per resource kind, holding the local structural command types, the
   handler class, and the detail mapper deciding what a `Get` reports.
 - `cfn/` reads `AWS::Glue::Database` and `AWS::Glue::Table` properties and creates from them.
@@ -51,11 +55,34 @@ id, the database name and the table name and says in its own comment that nothin
 against AWS. The format lives in that one function, so correcting it is that function and the test
 naming the value.
 
+**A partition is keyed by its values as JSON.** `simGluePartitionKey` runs the values through
+`JSON.stringify`. Joining them on a separator character gives one key for two different partitions
+whenever a value holds that character, and `["a", "b"]` then collides with `["a/b"]`.
+
+**A batch reports its refusals and keeps going.** `BatchCreatePartition` and `BatchDeletePartition`
+run each entry through the same path a single request takes, and collect the `SimGlueError` an entry
+raises into the `Errors` list. Any other error comes out of the batch. A fault in the simulation
+reported as a partition error would read as though the caller had asked for something invalid.
+
+**`Errors` is always there, empty when a batch had nothing to report.** The response mappers leave an
+absent field out, and this is the one exception. A caller checking a batch has one thing to check,
+and an optional empty list makes them reach through it first.
+
+**`GetPartitions` refuses an `Expression`.** Filtering is a separate issue. Ignoring the filter until
+it lands would answer with the partitions the caller asked to leave out, and the refusal names what
+is missing.
+
+**A partition authorizes against its table's ARN.** Partitions have no ARN of their own on real
+Glue, and a real policy grants `glue:CreatePartition` on the table. `SimGluePartitionRegistry`
+resolves the table first and every partition command goes through it.
+
 **A `CatalogId` naming another account is refused.** Creating the resource in this account's catalog
 would give a template that deploys and a catalog holding something the template never asked for.
 
 ## What is deliberately absent
 
-Crawlers, partition registration, table versions, column statistics, Lake Formation, connections,
-jobs, triggers, workflows and the Schema Registry. Every one of them needs something outside the
-catalog, and most need data read back. The Limitations list in the usage docs is the full account.
+Crawlers, partition updates, partition indexes, `BatchGetPartition`, table versions, column
+statistics, Lake Formation, connections, jobs, triggers, workflows and the Schema Registry. Every
+one of them needs something outside the catalog, or reads data back. Simulated Athena reads a
+table's projection parameters and none of its registered partitions, which is its own issue. The
+Limitations list in the usage docs is the full account.

--- a/src/service/glue/README.md
+++ b/src/service/glue/README.md
@@ -30,6 +30,8 @@ partition keys.
 - `command/` is one directory per resource kind, holding the local structural command types, the
   handler class, and the detail mapper deciding what a `Get` reports.
 - `cfn/` reads `AWS::Glue::Database` and `AWS::Glue::Table` properties and creates from them.
+  `AWS::Glue::Crawler` and `AWS::Glue::Partition` are real resource types with no creator here. A
+  template declaring either records that Resource as skipped.
 - `write/sim-glue-catalog-writer.ts` is how CloudFormation writes to the catalog. A deploy happens
   as CloudFormation, and never as the caller a later request carries, so a Resource creator goes
   through here and skips the IAM authorization an SDK Command applies. The store refusals still
@@ -64,9 +66,9 @@ run each entry through the same path a single request takes, and collect the `Si
 raises into the `Errors` list. Any other error comes out of the batch. A fault in the simulation
 reported as a partition error would read as though the caller had asked for something invalid.
 
-**`Errors` is always there, empty when a batch had nothing to report.** The response mappers leave an
-absent field out, and this is the one exception. A caller checking a batch has one thing to check,
-and an optional empty list makes them reach through it first.
+**`Errors` is always there, and empty when a batch had everything to do.** The response mappers
+leave an absent field out, and this is the one exception. A caller checking a batch has one thing to
+check, and an optional empty list makes them reach through it first.
 
 **`GetPartitions` refuses an `Expression`.** Filtering is a separate issue. Ignoring the filter until
 it lands would answer with the partitions the caller asked to leave out, and the refusal names what

--- a/src/service/glue/cfn/sim-glue-cfn-adapters.iso.test.ts
+++ b/src/service/glue/cfn/sim-glue-cfn-adapters.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  assertArrayEquals,
   assertArrayLength,
   assertIdentical,
   assertInstanceOf,
@@ -112,21 +113,27 @@ describe("SimGlueCfnResourceFactory", () => {
             Type: "AWS::Glue::Crawler",
             Properties: { Name: "site-logs", Role: "crawler" },
           },
+          LogPartition: {
+            Type: "AWS::Glue::Partition",
+            Properties: {
+              DatabaseName: "site_logs",
+              TableName: "access_logs",
+              PartitionInput: { Values: ["2026-08-26"] },
+            },
+          },
         },
       },
     });
 
     await stack.waitForDeployComplete();
 
-    // Then the crawler is recorded as skipped and the stack completes anyway,
-    // which is the behaviour argued for in #273. The database is there.
+    // Then both are recorded as skipped and the stack completes anyway, which
+    // is the behaviour argued for in #273. The database is there.
     assertIdentical(stack.status, "CREATE_COMPLETE");
-    assertArrayLength(stack.skippedResources, 1);
-
-    const [skipped] = stack.skippedResources;
-
-    assertNonNullable(skipped);
-    assertIdentical(skipped.type, "AWS::Glue::Crawler");
+    assertArrayEquals(
+      stack.skippedResources.map((skipped) => skipped.type),
+      ["AWS::Glue::Crawler", "AWS::Glue::Partition"],
+    );
     assertNonNullable(simAws.glue().findDatabase("site_logs"));
 
     await simAws.backgroundTasksComplete();

--- a/src/service/glue/cfn/sim-glue-cfn-resource-factory.ts
+++ b/src/service/glue/cfn/sim-glue-cfn-resource-factory.ts
@@ -18,9 +18,10 @@ interface SimGlueCfnResourceFactoryProperties {
 /**
  * CloudFormation Resource factory for simulated Glue resources.
  *
- * A database and a table are the two Data Catalog types a stack declares. A
- * crawler is left out: it fills a catalog by reading objects, and nothing here
- * reads one.
+ * A database and a table are the two Data Catalog types created from a
+ * template here. A crawler is left out, since it fills a catalog by reading
+ * objects and nothing here reads one. `AWS::Glue::Partition` is left out too,
+ * and a template declaring either is recorded as a skipped Resource.
  */
 export class SimGlueCfnResourceFactory implements SimCfnServiceResourceFactory {
   readonly #databaseCreator: SimCfnGlueDatabaseCreator;

--- a/src/service/glue/command/database/sim-glue-database-commands.ts
+++ b/src/service/glue/command/database/sim-glue-database-commands.ts
@@ -2,6 +2,7 @@ import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-regi
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
 import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
+import type { SimGluePartitionStore } from "../../partition/sim-glue-partition-store.js";
 import type { SimGlueTableStore } from "../../table/sim-glue-table-store.js";
 import type { SimGlueAuthorizer } from "../authorize/sim-glue-authorizer.js";
 import { requireSimGlueCatalogId } from "../sim-glue-catalog-id.js";
@@ -21,6 +22,7 @@ import { simGlueDatabaseDetail } from "./sim-glue-database-detail.js";
 interface SimGlueDatabaseCommandsProperties {
   readonly databases: SimGlueDatabaseStore;
   readonly tables: SimGlueTableStore;
+  readonly partitions: SimGluePartitionStore;
   readonly authorizer: SimGlueAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clock: SimClock;
@@ -32,6 +34,7 @@ interface SimGlueDatabaseCommandsProperties {
 export class SimGlueDatabaseCommands {
   readonly #databases: SimGlueDatabaseStore;
   readonly #tables: SimGlueTableStore;
+  readonly #partitions: SimGluePartitionStore;
   readonly #authorizer: SimGlueAuthorizer;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
   readonly #clock: SimClock;
@@ -39,6 +42,7 @@ export class SimGlueDatabaseCommands {
   constructor(properties: SimGlueDatabaseCommandsProperties) {
     this.#databases = properties.databases;
     this.#tables = properties.tables;
+    this.#partitions = properties.partitions;
     this.#authorizer = properties.authorizer;
     this.#accountRegionScope = properties.accountRegionScope;
     this.#clock = properties.clock;
@@ -115,7 +119,7 @@ export class SimGlueDatabaseCommands {
   }
 
   /**
-   * Remove a database, and the tables it holds with it.
+   * Remove a database, and the tables it holds and their partitions with it.
    */
   deleteDatabase(
     command: SimDeleteDatabaseCommand,
@@ -134,6 +138,7 @@ export class SimGlueDatabaseCommands {
     this.#databases.require(name);
     this.#databases.delete(name);
     this.#tables.deleteDatabase(name);
+    this.#partitions.deleteDatabase(name);
 
     return { $metadata: {} };
   }

--- a/src/service/glue/command/partition/partition.command.ts
+++ b/src/service/glue/command/partition/partition.command.ts
@@ -1,0 +1,185 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimGlueStorageDescriptor } from "../../table/sim-glue-table-schema.js";
+import type { SimGlueStorageDescriptorInput } from "../../table/sim-glue-table-input-shape.js";
+
+/**
+ * What a caller registers a partition with.
+ *
+ * `Values` lines up with the table's `PartitionKeys` in the order those were
+ * declared, and `StorageDescriptor.Location` is where this partition's own
+ * data sits.
+ *
+ * https://docs.aws.amazon.com/glue/latest/webapi/API_PartitionInput.html
+ */
+export interface SimGluePartitionInputShape {
+  readonly Values?: readonly string[] | undefined;
+  readonly LastAccessTime?: Date | undefined;
+  readonly LastAnalyzedTime?: Date | undefined;
+  readonly StorageDescriptor?: SimGlueStorageDescriptorInput | undefined;
+  readonly Parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/** The values naming one partition, as a batch delete lists them. */
+export interface SimGluePartitionValueListShape {
+  readonly Values?: readonly string[] | undefined;
+}
+
+/**
+ * What GetPartition reports about one partition.
+ */
+export interface SimGluePartitionDetail {
+  readonly Values: readonly string[];
+  readonly DatabaseName: string;
+  readonly TableName: string;
+  readonly CreationTime: Date;
+  readonly LastAccessTime?: Date | undefined;
+  readonly LastAnalyzedTime?: Date | undefined;
+  readonly StorageDescriptor?: SimGlueStorageDescriptor | undefined;
+  readonly Parameters: Readonly<Record<string, string>>;
+  readonly CatalogId: string;
+}
+
+/** Why one entry of a batch failed. */
+export interface SimGlueErrorDetail {
+  readonly ErrorCode: string;
+  readonly ErrorMessage: string;
+}
+
+/**
+ * One partition a batch could not make or remove, and why.
+ *
+ * A batch reports these rather than failing, so a caller registering a day's
+ * partitions learns which ones were already there without losing the rest.
+ */
+export interface SimGluePartitionError {
+  readonly PartitionValues: readonly string[];
+  readonly ErrorDetail: SimGlueErrorDetail;
+}
+
+/**
+ * Minimal structural sim Glue CreatePartition command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/CreatePartitionCommand/
+ */
+export interface SimCreatePartitionCommand {
+  readonly input: SimCreatePartitionCommandInput;
+}
+
+export interface SimCreatePartitionCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly TableName?: string | undefined;
+  readonly PartitionInput?: SimGluePartitionInputShape | undefined;
+}
+
+export interface SimCreatePartitionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue BatchCreatePartition command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/BatchCreatePartitionCommand/
+ */
+export interface SimBatchCreatePartitionCommand {
+  readonly input: SimBatchCreatePartitionCommandInput;
+}
+
+export interface SimBatchCreatePartitionCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly TableName?: string | undefined;
+  readonly PartitionInputList?:
+    | readonly SimGluePartitionInputShape[]
+    | undefined;
+}
+
+export interface SimBatchCreatePartitionCommandOutput {
+  readonly Errors: readonly SimGluePartitionError[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue GetPartition command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/GetPartitionCommand/
+ */
+export interface SimGetPartitionCommand {
+  readonly input: SimGetPartitionCommandInput;
+}
+
+export interface SimGetPartitionCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly TableName?: string | undefined;
+  readonly PartitionValues?: readonly string[] | undefined;
+}
+
+export interface SimGetPartitionCommandOutput {
+  readonly Partition: SimGluePartitionDetail;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue GetPartitions command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/GetPartitionsCommand/
+ */
+export interface SimGetPartitionsCommand {
+  readonly input: SimGetPartitionsCommandInput;
+}
+
+export interface SimGetPartitionsCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly TableName?: string | undefined;
+  readonly Expression?: string | undefined;
+}
+
+export interface SimGetPartitionsCommandOutput {
+  readonly Partitions: readonly SimGluePartitionDetail[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue DeletePartition command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/DeletePartitionCommand/
+ */
+export interface SimDeletePartitionCommand {
+  readonly input: SimDeletePartitionCommandInput;
+}
+
+export interface SimDeletePartitionCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly TableName?: string | undefined;
+  readonly PartitionValues?: readonly string[] | undefined;
+}
+
+export interface SimDeletePartitionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Glue BatchDeletePartition command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/glue/command/BatchDeletePartitionCommand/
+ */
+export interface SimBatchDeletePartitionCommand {
+  readonly input: SimBatchDeletePartitionCommandInput;
+}
+
+export interface SimBatchDeletePartitionCommandInput {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly TableName?: string | undefined;
+  readonly PartitionsToDelete?:
+    | readonly SimGluePartitionValueListShape[]
+    | undefined;
+}
+
+export interface SimBatchDeletePartitionCommandOutput {
+  readonly Errors: readonly SimGluePartitionError[];
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/glue/command/partition/sim-glue-partition-batch.ts
+++ b/src/service/glue/command/partition/sim-glue-partition-batch.ts
@@ -1,0 +1,46 @@
+import { SimGlueError } from "../../error/sim-glue.error.js";
+import type { SimGluePartitionError } from "./partition.command.js";
+
+/** What every entry of a partition batch names its partition with. */
+interface SimGluePartitionBatchEntry {
+  readonly Values?: readonly string[] | undefined;
+}
+
+/**
+ * Run each entry of a partition batch, collecting the refusals.
+ *
+ * A batch does not fail on one bad entry. Real Glue answers with the errors
+ * alongside the work it did do, so a caller registering a day's partitions
+ * learns which values were already there and keeps the rest.
+ *
+ * Only a Glue refusal is collected. Anything else is a fault in the simulation
+ * rather than something the caller asked for, and a batch that swallowed it
+ * would answer as though the entry had merely been rejected.
+ */
+export function simGluePartitionBatchErrors<
+  T extends SimGluePartitionBatchEntry,
+>(
+  label: string,
+  entries: readonly T[] | undefined,
+  handle: (entry: T, entryLabel: string) => void,
+): readonly SimGluePartitionError[] {
+  const errors: SimGluePartitionError[] = [];
+  const entered = entries ?? [];
+
+  for (const [index, entry] of entered.entries()) {
+    try {
+      handle(entry, `${label}.${index}`);
+    } catch (error) {
+      if (!(error instanceof SimGlueError)) {
+        throw error;
+      }
+
+      errors.push({
+        PartitionValues: [...(entry.Values ?? [])],
+        ErrorDetail: { ErrorCode: error.name, ErrorMessage: error.message },
+      });
+    }
+  }
+
+  return errors;
+}

--- a/src/service/glue/command/partition/sim-glue-partition-batch.ts
+++ b/src/service/glue/command/partition/sim-glue-partition-batch.ts
@@ -1,4 +1,7 @@
-import { SimGlueError } from "../../error/sim-glue.error.js";
+import {
+  SimGlueError,
+  SimGlueInvalidInputException,
+} from "../../error/sim-glue.error.js";
 import type { SimGluePartitionError } from "./partition.command.js";
 
 /** What every entry of a partition batch names its partition with. */
@@ -16,6 +19,10 @@ interface SimGluePartitionBatchEntry {
  * Only a Glue refusal is collected. Anything else is a fault in the simulation
  * rather than something the caller asked for, and a batch that swallowed it
  * would answer as though the entry had merely been rejected.
+ *
+ * The list itself is a required request member on real Glue. An empty one is
+ * within its stated bounds and does nothing. Leaving it out altogether is a
+ * malformed request.
  */
 export function simGluePartitionBatchErrors<
   T extends SimGluePartitionBatchEntry,
@@ -24,10 +31,13 @@ export function simGluePartitionBatchErrors<
   entries: readonly T[] | undefined,
   handle: (entry: T, entryLabel: string) => void,
 ): readonly SimGluePartitionError[] {
-  const errors: SimGluePartitionError[] = [];
-  const entered = entries ?? [];
+  if (entries === undefined) {
+    throw new SimGlueInvalidInputException(`${label} is required`);
+  }
 
-  for (const [index, entry] of entered.entries()) {
+  const errors: SimGluePartitionError[] = [];
+
+  for (const [index, entry] of entries.entries()) {
     try {
       handle(entry, `${label}.${index}`);
     } catch (error) {

--- a/src/service/glue/command/partition/sim-glue-partition-commands.ts
+++ b/src/service/glue/command/partition/sim-glue-partition-commands.ts
@@ -1,0 +1,184 @@
+import { SimGlueInvalidInputException } from "../../error/sim-glue.error.js";
+import type { SimGlueRequestOptions } from "../sim-glue-request-options.js";
+import { simGluePartitionDetail } from "./sim-glue-partition-detail.js";
+import { simGluePartitionBatchErrors } from "./sim-glue-partition-batch.js";
+import type { SimGluePartitionRegistry } from "./sim-glue-partition-registry.js";
+import type {
+  SimBatchCreatePartitionCommand,
+  SimBatchCreatePartitionCommandOutput,
+  SimBatchDeletePartitionCommand,
+  SimBatchDeletePartitionCommandOutput,
+  SimCreatePartitionCommand,
+  SimCreatePartitionCommandOutput,
+  SimDeletePartitionCommand,
+  SimDeletePartitionCommandOutput,
+  SimGetPartitionCommand,
+  SimGetPartitionCommandOutput,
+  SimGetPartitionsCommand,
+  SimGetPartitionsCommandOutput,
+} from "./partition.command.js";
+
+interface SimGluePartitionCommandsProperties {
+  readonly registry: SimGluePartitionRegistry;
+}
+
+/**
+ * The commands that register, read and remove Glue partitions.
+ */
+export class SimGluePartitionCommands {
+  readonly #registry: SimGluePartitionRegistry;
+
+  constructor(properties: SimGluePartitionCommandsProperties) {
+    this.#registry = properties.registry;
+  }
+
+  /**
+   * Register one partition against a table.
+   */
+  createPartition(
+    command: SimCreatePartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): SimCreatePartitionCommandOutput {
+    const table = this.#registry.requireTable(
+      "glue:CreatePartition",
+      command.input,
+      options,
+    );
+
+    this.#registry.create(
+      table,
+      "PartitionInput",
+      command.input.PartitionInput ?? {},
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Register several partitions at once, reporting the ones it could not make.
+   *
+   * A batch does not fail on one bad entry. Real Glue answers with the errors
+   * alongside the partitions it did register, so a caller adding a day's worth
+   * learns which values were already there and keeps the rest.
+   */
+  batchCreatePartition(
+    command: SimBatchCreatePartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): SimBatchCreatePartitionCommandOutput {
+    const table = this.#registry.requireTable(
+      "glue:BatchCreatePartition",
+      command.input,
+      options,
+    );
+
+    return {
+      Errors: simGluePartitionBatchErrors(
+        "PartitionInputList",
+        command.input.PartitionInputList,
+        (input, label) => {
+          this.#registry.create(table, label, input);
+        },
+      ),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Read one partition back by its values.
+   */
+  getPartition(
+    command: SimGetPartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): SimGetPartitionCommandOutput {
+    const table = this.#registry.requireTable(
+      "glue:GetPartition",
+      command.input,
+      options,
+    );
+
+    return {
+      Partition: simGluePartitionDetail(
+        this.#registry.require(
+          table,
+          "PartitionValues",
+          command.input.PartitionValues,
+        ),
+      ),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Read every partition of one table, in registration order.
+   */
+  getPartitions(
+    command: SimGetPartitionsCommand,
+    options?: SimGlueRequestOptions,
+  ): SimGetPartitionsCommandOutput {
+    const table = this.#registry.requireTable(
+      "glue:GetPartitions",
+      command.input,
+      options,
+    );
+
+    if (command.input.Expression !== undefined) {
+      throw new SimGlueInvalidInputException(
+        "GetPartitions Expression is not simulated, so it is refused rather " +
+          "than ignored. An ignored filter answers with the partitions the " +
+          "caller asked to leave out.",
+      );
+    }
+
+    return {
+      Partitions: this.#registry.inTable(table).map(simGluePartitionDetail),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Remove one partition, leaving the table and the data alone.
+   */
+  deletePartition(
+    command: SimDeletePartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): SimDeletePartitionCommandOutput {
+    const table = this.#registry.requireTable(
+      "glue:DeletePartition",
+      command.input,
+      options,
+    );
+
+    this.#registry.remove(
+      table,
+      "PartitionValues",
+      command.input.PartitionValues,
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Remove several partitions at once, reporting the ones it could not find.
+   */
+  batchDeletePartition(
+    command: SimBatchDeletePartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): SimBatchDeletePartitionCommandOutput {
+    const table = this.#registry.requireTable(
+      "glue:BatchDeletePartition",
+      command.input,
+      options,
+    );
+
+    return {
+      Errors: simGluePartitionBatchErrors(
+        "PartitionsToDelete",
+        command.input.PartitionsToDelete,
+        (entry, label) => {
+          this.#registry.remove(table, label, entry.Values);
+        },
+      ),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/glue/command/partition/sim-glue-partition-detail.ts
+++ b/src/service/glue/command/partition/sim-glue-partition-detail.ts
@@ -1,0 +1,29 @@
+import { definedEntries } from "../../../../util/record/defined-entries.js";
+import type { SimGluePartition } from "../../partition/sim-glue-partition.js";
+import type { SimGluePartitionDetail } from "./partition.command.js";
+
+/**
+ * What GetPartition and GetPartitions report about a partition.
+ *
+ * The result is detached from the stored partition, as a table's detail is.
+ * Real Glue answers each request with its own object, and a caller holding a
+ * reference into the catalog could otherwise change a registration without a
+ * command or the permission to make one.
+ */
+export function simGluePartitionDetail(
+  partition: SimGluePartition,
+): SimGluePartitionDetail {
+  return structuredClone(
+    definedEntries({
+      Values: partition.values,
+      DatabaseName: partition.databaseName,
+      TableName: partition.tableName,
+      CreationTime: partition.creationTime,
+      LastAccessTime: partition.lastAccessTime,
+      LastAnalyzedTime: partition.lastAnalyzedTime,
+      StorageDescriptor: partition.storageDescriptor,
+      Parameters: partition.parameters,
+      CatalogId: partition.catalogId,
+    }),
+  );
+}

--- a/src/service/glue/command/partition/sim-glue-partition-registry.ts
+++ b/src/service/glue/command/partition/sim-glue-partition-registry.ts
@@ -1,0 +1,147 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
+import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
+import type { SimGluePartition } from "../../partition/sim-glue-partition.js";
+import type { SimGluePartitionStore } from "../../partition/sim-glue-partition-store.js";
+import type { SimGlueTablePartitions } from "../../partition/sim-glue-table-partitions.js";
+import { requiredSimGluePartitionValues } from "../../partition/sim-glue-partition-values.js";
+import type { SimGlueTable } from "../../table/sim-glue-table.js";
+import type { SimGlueTableStore } from "../../table/sim-glue-table-store.js";
+import { requiredSimGlueStorageDescriptor } from "../../table/sim-glue-table-input-shape.js";
+import type { SimGlueAuthorizer } from "../authorize/sim-glue-authorizer.js";
+import { requireSimGlueCatalogId } from "../sim-glue-catalog-id.js";
+import type { SimGlueRequestOptions } from "../sim-glue-request-options.js";
+import type { SimGluePartitionInputShape } from "./partition.command.js";
+
+/** What every partition command names the table it works on with. */
+export interface SimGluePartitionTableRequest {
+  readonly CatalogId?: string | undefined;
+  readonly DatabaseName?: string | undefined;
+  readonly TableName?: string | undefined;
+}
+
+interface SimGluePartitionRegistryProperties {
+  readonly databases: SimGlueDatabaseStore;
+  readonly tables: SimGlueTableStore;
+  readonly partitions: SimGluePartitionStore;
+  readonly authorizer: SimGlueAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: SimClock;
+}
+
+/**
+ * The work every partition command does, whether it handles one partition or
+ * a batch of them.
+ *
+ * A batch entry has to fail the way a single request fails, since a batch
+ * reports the refusal it would otherwise have thrown. Keeping both on one path
+ * is what makes those two agree.
+ */
+export class SimGluePartitionRegistry {
+  readonly #databases: SimGlueDatabaseStore;
+  readonly #tables: SimGlueTableStore;
+  readonly #partitions: SimGluePartitionStore;
+  readonly #authorizer: SimGlueAuthorizer;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimGluePartitionRegistryProperties) {
+    this.#databases = properties.databases;
+    this.#tables = properties.tables;
+    this.#partitions = properties.partitions;
+    this.#authorizer = properties.authorizer;
+    this.#accountRegionScope = properties.accountRegionScope;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Authorize against the table a request names, and get it.
+   *
+   * The table has to be there. Real Glue answers `EntityNotFoundException` for
+   * a partition command naming a table that is absent, rather than making one.
+   *
+   * A partition has no ARN of its own, so the table ARN is what a real Glue
+   * policy grants partition actions on, and what this authorizes.
+   */
+  requireTable(
+    action: string,
+    input: SimGluePartitionTableRequest,
+    options: SimGlueRequestOptions | undefined,
+  ): SimGlueTable {
+    requireSimGlueCatalogId(this.#accountRegionScope, input.CatalogId);
+
+    const databaseName = requiredSimGlueName(
+      "DatabaseName",
+      input.DatabaseName,
+    );
+    const tableName = requiredSimGlueName("TableName", input.TableName);
+
+    this.#authorizer.authorizeTable(
+      action,
+      databaseName,
+      tableName,
+      options?.caller,
+    );
+
+    this.#databases.require(databaseName);
+
+    return this.#tables.require(databaseName, tableName);
+  }
+
+  /** Register one partition against a table. */
+  create(
+    table: SimGlueTable,
+    label: string,
+    input: SimGluePartitionInputShape,
+  ): void {
+    const values = requiredSimGluePartitionValues(
+      `${label}.Values`,
+      table,
+      input.Values,
+    );
+
+    this.#of(table).create(values, this.#clock.now(), {
+      lastAccessTime: input.LastAccessTime,
+      lastAnalyzedTime: input.LastAnalyzedTime,
+      storageDescriptor: requiredSimGlueStorageDescriptor(
+        `${label}.StorageDescriptor`,
+        input.StorageDescriptor,
+      ),
+      parameters: input.Parameters,
+    });
+  }
+
+  /** Remove one partition, refusing values nothing is registered under. */
+  remove(
+    table: SimGlueTable,
+    label: string,
+    declared: readonly string[] | undefined,
+  ): void {
+    const values = requiredSimGluePartitionValues(label, table, declared);
+    const partitions = this.#of(table);
+
+    partitions.require(values);
+    partitions.delete(values);
+  }
+
+  /** Get one partition by its values, refusing one that is absent. */
+  require(
+    table: SimGlueTable,
+    label: string,
+    declared: readonly string[] | undefined,
+  ): SimGluePartition {
+    return this.#of(table).require(
+      requiredSimGluePartitionValues(label, table, declared),
+    );
+  }
+
+  /** Every partition of one table, in registration order. */
+  inTable(table: SimGlueTable): readonly SimGluePartition[] {
+    return this.#of(table).all;
+  }
+
+  #of(table: SimGlueTable): SimGlueTablePartitions {
+    return this.#partitions.inTable(table.databaseName, table.name);
+  }
+}

--- a/src/service/glue/command/table/sim-glue-table-commands.ts
+++ b/src/service/glue/command/table/sim-glue-table-commands.ts
@@ -2,6 +2,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
 import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
+import type { SimGluePartitionStore } from "../../partition/sim-glue-partition-store.js";
 import type { SimGlueTableStore } from "../../table/sim-glue-table-store.js";
 import {
   requiredSimGlueColumns,
@@ -25,6 +26,7 @@ import { simGlueTableDetail } from "./sim-glue-table-detail.js";
 interface SimGlueTableCommandsProperties {
   readonly databases: SimGlueDatabaseStore;
   readonly tables: SimGlueTableStore;
+  readonly partitions: SimGluePartitionStore;
   readonly authorizer: SimGlueAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly clock: SimClock;
@@ -36,6 +38,7 @@ interface SimGlueTableCommandsProperties {
 export class SimGlueTableCommands {
   readonly #databases: SimGlueDatabaseStore;
   readonly #tables: SimGlueTableStore;
+  readonly #partitions: SimGluePartitionStore;
   readonly #authorizer: SimGlueAuthorizer;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
   readonly #clock: SimClock;
@@ -43,6 +46,7 @@ export class SimGlueTableCommands {
   constructor(properties: SimGlueTableCommandsProperties) {
     this.#databases = properties.databases;
     this.#tables = properties.tables;
+    this.#partitions = properties.partitions;
     this.#authorizer = properties.authorizer;
     this.#accountRegionScope = properties.accountRegionScope;
     this.#clock = properties.clock;
@@ -157,7 +161,7 @@ export class SimGlueTableCommands {
   }
 
   /**
-   * Remove a table.
+   * Remove a table, and the partitions registered against it with it.
    */
   deleteTable(
     command: SimDeleteTableCommand,
@@ -180,6 +184,7 @@ export class SimGlueTableCommands {
 
     this.#tables.require(databaseName, name);
     this.#tables.delete(databaseName, name);
+    this.#partitions.deleteTable(databaseName, name);
 
     return { $metadata: {} };
   }

--- a/src/service/glue/index.ts
+++ b/src/service/glue/index.ts
@@ -4,6 +4,12 @@ export {
   SimGlueDatabaseStore,
   type SimGlueDatabaseInput,
 } from "./database/sim-glue-database-store.js";
+export { SimGluePartition } from "./partition/sim-glue-partition.js";
+export {
+  SimGluePartitionStore,
+  type SimGluePartitionInput,
+} from "./partition/sim-glue-partition-store.js";
+export { SimGlueTablePartitions } from "./partition/sim-glue-table-partitions.js";
 export { SimGlueTable } from "./table/sim-glue-table.js";
 export {
   SimGlueTableStore,
@@ -52,6 +58,31 @@ export type {
   SimGlueTableDetail,
   SimGlueTableInputShape,
 } from "./command/table/table.command.js";
+export type {
+  SimBatchCreatePartitionCommand,
+  SimBatchCreatePartitionCommandInput,
+  SimBatchCreatePartitionCommandOutput,
+  SimBatchDeletePartitionCommand,
+  SimBatchDeletePartitionCommandInput,
+  SimBatchDeletePartitionCommandOutput,
+  SimCreatePartitionCommand,
+  SimCreatePartitionCommandInput,
+  SimCreatePartitionCommandOutput,
+  SimDeletePartitionCommand,
+  SimDeletePartitionCommandInput,
+  SimDeletePartitionCommandOutput,
+  SimGetPartitionCommand,
+  SimGetPartitionCommandInput,
+  SimGetPartitionCommandOutput,
+  SimGetPartitionsCommand,
+  SimGetPartitionsCommandInput,
+  SimGetPartitionsCommandOutput,
+  SimGlueErrorDetail,
+  SimGluePartitionDetail,
+  SimGluePartitionError,
+  SimGluePartitionInputShape,
+  SimGluePartitionValueListShape,
+} from "./command/partition/partition.command.js";
 export {
   simGlueCatalogArn,
   simGlueDatabaseArn,

--- a/src/service/glue/partition/sim-glue-partition-key.ts
+++ b/src/service/glue/partition/sim-glue-partition-key.ts
@@ -1,0 +1,12 @@
+/**
+ * The key one partition is held under within its table.
+ *
+ * A partition is identified by its values in the order the table's
+ * `PartitionKeys` declares them, so the values are the whole of the key. They
+ * are joined as JSON rather than with a separator character, since a value may
+ * hold any character a separator could use: joining `["a", "b"]` and `["a/b"]`
+ * on a slash gives one key for two different partitions.
+ */
+export function simGluePartitionKey(values: readonly string[]): string {
+  return JSON.stringify(values);
+}

--- a/src/service/glue/partition/sim-glue-partition-refusal.ts
+++ b/src/service/glue/partition/sim-glue-partition-refusal.ts
@@ -1,0 +1,35 @@
+import {
+  SimGlueAlreadyExistsException,
+  SimGlueEntityNotFoundException,
+} from "../error/sim-glue.error.js";
+import type { SimGluePartition } from "./sim-glue-partition.js";
+
+/**
+ * Refuse values a partition is already registered under.
+ *
+ * Registering is not idempotent on real Glue. A second `CreatePartition` for
+ * one day's values is an `AlreadyExistsException` rather than an overwrite,
+ * which is why a job re-run has to catch it.
+ */
+export function refuseSimGluePartitionInPlace(
+  existing: SimGluePartition | undefined,
+  label: string,
+): void {
+  if (existing !== undefined) {
+    throw new SimGlueAlreadyExistsException(
+      `Partition already exists: ${label}`,
+    );
+  }
+}
+
+/** Refuse values nothing is registered under. */
+export function requireSimGluePartitionFound(
+  found: SimGluePartition | undefined,
+  label: string,
+): SimGluePartition {
+  if (found === undefined) {
+    throw new SimGlueEntityNotFoundException(`Partition not found: ${label}`);
+  }
+
+  return found;
+}

--- a/src/service/glue/partition/sim-glue-partition-schema.ts
+++ b/src/service/glue/partition/sim-glue-partition-schema.ts
@@ -1,0 +1,9 @@
+import type { SimGlueStorageDescriptor } from "../table/sim-glue-table-schema.js";
+
+/** What a partition is created with, beyond its values. */
+export interface SimGluePartitionInput {
+  readonly lastAccessTime?: Date | undefined;
+  readonly lastAnalyzedTime?: Date | undefined;
+  readonly storageDescriptor?: SimGlueStorageDescriptor | undefined;
+  readonly parameters?: Readonly<Record<string, string>> | undefined;
+}

--- a/src/service/glue/partition/sim-glue-partition-store.ts
+++ b/src/service/glue/partition/sim-glue-partition-store.ts
@@ -1,0 +1,74 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimGlueTablePartitions } from "./sim-glue-table-partitions.js";
+
+interface SimGluePartitionStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The registered partitions of one simulated Glue catalog.
+ *
+ * Keyed by database name and then by table name, following the table store, so
+ * a table's partitions go with it when it is deleted and a database's go with
+ * the database.
+ *
+ * Each table's partitions are one object, which is what a partition command
+ * works through once it has resolved the table it was given.
+ */
+export class SimGluePartitionStore {
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #tables = new Map<string, Map<string, SimGlueTablePartitions>>();
+
+  constructor(properties: SimGluePartitionStoreProperties) {
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * The partitions of one table, empty until something registers one.
+   */
+  inTable(databaseName: string, tableName: string): SimGlueTablePartitions {
+    return mapEntry(
+      this.#inDatabase(databaseName),
+      tableName,
+      () =>
+        new SimGlueTablePartitions({
+          databaseName,
+          tableName,
+          accountRegionScope: this.#accountRegionScope,
+        }),
+    );
+  }
+
+  /** Remove every partition of a table, as deleting the table does. */
+  deleteTable(databaseName: string, tableName: string): void {
+    this.#tables.get(databaseName)?.delete(tableName);
+  }
+
+  /** Remove every partition in a database, as deleting the database does. */
+  deleteDatabase(databaseName: string): void {
+    this.#tables.delete(databaseName);
+  }
+
+  #inDatabase(databaseName: string): Map<string, SimGlueTablePartitions> {
+    return mapEntry(
+      this.#tables,
+      databaseName,
+      () => new Map<string, SimGlueTablePartitions>(),
+    );
+  }
+}
+
+function mapEntry<K, V>(map: Map<K, V>, key: K, make: () => V): V {
+  const existing = map.get(key);
+
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const created = make();
+  map.set(key, created);
+
+  return created;
+}
+
+export { type SimGluePartitionInput } from "./sim-glue-partition-schema.js";

--- a/src/service/glue/partition/sim-glue-partition-values.ts
+++ b/src/service/glue/partition/sim-glue-partition-values.ts
@@ -1,0 +1,35 @@
+import { SimGlueInvalidInputException } from "../error/sim-glue.error.js";
+import type { SimGlueTable } from "../table/sim-glue-table.js";
+
+/**
+ * Read a declared partition value list, refusing one the table has no keys
+ * for.
+ *
+ * A partition's values are positional, so a list of the wrong length lines up
+ * with the wrong keys and there is no way to tell which value was meant for
+ * which. Real Glue refuses it, and a table declaring no partition keys at all
+ * refuses every partition by the same count.
+ */
+export function requiredSimGluePartitionValues(
+  label: string,
+  table: SimGlueTable,
+  values: readonly string[] | undefined,
+): readonly string[] {
+  if (values === undefined) {
+    throw new SimGlueInvalidInputException(`${label} is required`);
+  }
+
+  const declared = table.partitionKeys.length;
+
+  if (values.length !== declared) {
+    throw new SimGlueInvalidInputException(
+      `${label} has ${counted(values.length, "value")}, and ${table.databaseName}.${table.name} declares ${counted(declared, "partition key")}`,
+    );
+  }
+
+  return [...values];
+}
+
+function counted(total: number, noun: string): string {
+  return `${total} ${noun}${total === 1 ? "" : "s"}`;
+}

--- a/src/service/glue/partition/sim-glue-partition.ts
+++ b/src/service/glue/partition/sim-glue-partition.ts
@@ -1,0 +1,69 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimGlueStorageDescriptor } from "../table/sim-glue-table-schema.js";
+import { simGluePartitionKey } from "./sim-glue-partition-key.js";
+
+interface SimGluePartitionProperties {
+  readonly values: readonly string[];
+  readonly databaseName: string;
+  readonly tableName: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly creationTime: Date;
+  readonly lastAccessTime?: Date | undefined;
+  readonly lastAnalyzedTime?: Date | undefined;
+  readonly storageDescriptor?: SimGlueStorageDescriptor | undefined;
+  readonly parameters?: Readonly<Record<string, string>> | undefined;
+}
+
+/**
+ * One registered partition of a simulated Glue table.
+ *
+ * The values are positional. They line up with the table's `PartitionKeys` in
+ * the order those were declared, which is why a partition carries no key names
+ * of its own.
+ *
+ * The storage descriptor is the part callers most often care about. A
+ * registered partition says where its own data sits, and that location need
+ * not sit under the table's.
+ *
+ * Everything a caller declared is copied on the way in, as a table's
+ * definition is, so a `PartitionInput` the caller goes on to reuse cannot keep
+ * changing what the catalog holds.
+ */
+export class SimGluePartition {
+  readonly values: readonly string[];
+  readonly databaseName: string;
+  readonly tableName: string;
+  readonly creationTime: Date;
+  readonly lastAccessTime: Date | undefined;
+  readonly lastAnalyzedTime: Date | undefined;
+  readonly storageDescriptor: SimGlueStorageDescriptor | undefined;
+  readonly parameters: Readonly<Record<string, string>>;
+
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimGluePartitionProperties) {
+    this.values = [...properties.values];
+    this.databaseName = properties.databaseName;
+    this.tableName = properties.tableName;
+    this.creationTime = new Date(properties.creationTime);
+    this.lastAccessTime = optionalDate(properties.lastAccessTime);
+    this.lastAnalyzedTime = optionalDate(properties.lastAnalyzedTime);
+    this.storageDescriptor = structuredClone(properties.storageDescriptor);
+    this.parameters = structuredClone(properties.parameters) ?? {};
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /** The catalog holding this partition, which is the account id. */
+  get catalogId(): string {
+    return this.#accountRegionScope.accountId;
+  }
+
+  /** The key this partition is held under within its table. */
+  get key(): string {
+    return simGluePartitionKey(this.values);
+  }
+}
+
+function optionalDate(value: Date | undefined): Date | undefined {
+  return value === undefined ? undefined : new Date(value);
+}

--- a/src/service/glue/partition/sim-glue-table-partitions.ts
+++ b/src/service/glue/partition/sim-glue-table-partitions.ts
@@ -1,0 +1,82 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimGluePartition } from "./sim-glue-partition.js";
+import { simGluePartitionKey } from "./sim-glue-partition-key.js";
+import {
+  refuseSimGluePartitionInPlace,
+  requireSimGluePartitionFound,
+} from "./sim-glue-partition-refusal.js";
+import type { SimGluePartitionInput } from "./sim-glue-partition-schema.js";
+
+interface SimGlueTablePartitionsProperties {
+  readonly databaseName: string;
+  readonly tableName: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The registered partitions of one simulated Glue table.
+ *
+ * Each is held under its own values, which are the whole of a partition's
+ * identity within its table. Two tables may each hold a partition of the same
+ * values, since each table has one of these to itself.
+ */
+export class SimGlueTablePartitions {
+  readonly #databaseName: string;
+  readonly #tableName: string;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #partitions = new Map<string, SimGluePartition>();
+
+  constructor(properties: SimGlueTablePartitionsProperties) {
+    this.#databaseName = properties.databaseName;
+    this.#tableName = properties.tableName;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /** Every partition of this table, in registration order. */
+  get all(): readonly SimGluePartition[] {
+    return this.#partitions.values().toArray();
+  }
+
+  /**
+   * Register a partition, refusing values already registered here.
+   */
+  create(
+    values: readonly string[],
+    creationTime: Date,
+    input: SimGluePartitionInput,
+  ): SimGluePartition {
+    refuseSimGluePartitionInPlace(this.find(values), this.#label(values));
+
+    const partition = new SimGluePartition({
+      values,
+      databaseName: this.#databaseName,
+      tableName: this.#tableName,
+      accountRegionScope: this.#accountRegionScope,
+      creationTime,
+      ...input,
+    });
+
+    this.#partitions.set(partition.key, partition);
+
+    return partition;
+  }
+
+  /** Find a partition by its values. */
+  find(values: readonly string[]): SimGluePartition | undefined {
+    return this.#partitions.get(simGluePartitionKey(values));
+  }
+
+  /** Get a partition by its values, refusing one that is absent. */
+  require(values: readonly string[]): SimGluePartition {
+    return requireSimGluePartitionFound(this.find(values), this.#label(values));
+  }
+
+  /** Remove a partition. */
+  delete(values: readonly string[]): void {
+    this.#partitions.delete(simGluePartitionKey(values));
+  }
+
+  #label(values: readonly string[]): string {
+    return `${this.#databaseName}.${this.#tableName} ${simGluePartitionKey(values)}`;
+  }
+}

--- a/src/service/glue/sdk/sim-glue-sdk-command-router.ts
+++ b/src/service/glue/sdk/sim-glue-sdk-command-router.ts
@@ -10,6 +10,14 @@ import type {
   SimGetDatabasesCommand,
 } from "../command/database/database.command.js";
 import type {
+  SimBatchCreatePartitionCommand,
+  SimBatchDeletePartitionCommand,
+  SimCreatePartitionCommand,
+  SimDeletePartitionCommand,
+  SimGetPartitionCommand,
+  SimGetPartitionsCommand,
+} from "../command/partition/partition.command.js";
+import type {
   SimCreateTableCommand,
   SimDeleteTableCommand,
   SimGetTableCommand,
@@ -101,6 +109,66 @@ export class SimGlueSdkCommandRouter implements SimSdkCommandRouter {
           Promise.resolve(
             simGlue.deleteTable(
               command as SimDeleteTableCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "CreatePartitionCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.createPartition(
+              command as SimCreatePartitionCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "BatchCreatePartitionCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.batchCreatePartition(
+              command as SimBatchCreatePartitionCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "GetPartitionCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.getPartition(
+              command as SimGetPartitionCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "GetPartitionsCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.getPartitions(
+              command as SimGetPartitionsCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "DeletePartitionCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.deletePartition(
+              command as SimDeletePartitionCommand,
+              simSdkCallerOptions(context),
+            ),
+          ),
+      ],
+      [
+        "BatchDeletePartitionCommand",
+        (command, context): Promise<unknown> =>
+          Promise.resolve(
+            simGlue.batchDeletePartition(
+              command as SimBatchDeletePartitionCommand,
               simSdkCallerOptions(context),
             ),
           ),

--- a/src/service/glue/sdk/sim-glue-sdk-routing.iso.test.ts
+++ b/src/service/glue/sdk/sim-glue-sdk-routing.iso.test.ts
@@ -1,10 +1,16 @@
 import {
+  BatchCreatePartitionCommand,
+  BatchDeletePartitionCommand,
   CreateDatabaseCommand,
+  CreatePartitionCommand,
   CreateTableCommand,
   DeleteDatabaseCommand,
+  DeletePartitionCommand,
   DeleteTableCommand,
   GetDatabaseCommand,
   GetDatabasesCommand,
+  GetPartitionCommand,
+  GetPartitionsCommand,
   GetTableCommand,
   GetTablesCommand,
   GlueClient,
@@ -39,6 +45,12 @@ describe("SimGlueSdkCommandRouter", () => {
       "GetTableCommand",
       "GetTablesCommand",
       "DeleteTableCommand",
+      "CreatePartitionCommand",
+      "BatchCreatePartitionCommand",
+      "GetPartitionCommand",
+      "GetPartitionsCommand",
+      "DeletePartitionCommand",
+      "BatchDeletePartitionCommand",
     ]);
   });
 
@@ -152,5 +164,89 @@ describe("Glue SDK interception", () => {
     const remaining = await client.send(new GetDatabasesCommand({}));
 
     assertArrayLength(remaining.DatabaseList ?? [], 0);
+  });
+
+  it("registers and reads partitions through an intercepted client", async () => {
+    // Given an intercepted client holding a table partitioned by day.
+    using simSdk = new SimSdk();
+    simSdk.intercept(GlueClient);
+
+    const client = new GlueClient({ region: "eu-west-2" });
+
+    await client.send(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+    );
+    await client.send(
+      new CreateTableCommand({
+        DatabaseName: "site_logs",
+        TableInput: {
+          Name: "access_logs",
+          PartitionKeys: [{ Name: "day", Type: "string" }],
+        },
+      }),
+    );
+
+    // When ordinary SDK code registers three days, reads one back and removes
+    // two of them.
+    await client.send(
+      new BatchCreatePartitionCommand({
+        DatabaseName: "site_logs",
+        TableName: "access_logs",
+        PartitionInputList: [
+          { Values: ["2026-08-24"] },
+          { Values: ["2026-08-25"] },
+        ],
+      }),
+    );
+    await client.send(
+      new CreatePartitionCommand({
+        DatabaseName: "site_logs",
+        TableName: "access_logs",
+        PartitionInput: {
+          Values: ["2026-08-26"],
+          StorageDescriptor: { Location: "s3://site-logs/day=2026-08-26/" },
+        },
+      }),
+    );
+
+    const one = await client.send(
+      new GetPartitionCommand({
+        DatabaseName: "site_logs",
+        TableName: "access_logs",
+        PartitionValues: ["2026-08-26"],
+      }),
+    );
+
+    await client.send(
+      new DeletePartitionCommand({
+        DatabaseName: "site_logs",
+        TableName: "access_logs",
+        PartitionValues: ["2026-08-24"],
+      }),
+    );
+    await client.send(
+      new BatchDeletePartitionCommand({
+        DatabaseName: "site_logs",
+        TableName: "access_logs",
+        PartitionsToDelete: [{ Values: ["2026-08-25"] }],
+      }),
+    );
+
+    const left = await client.send(
+      new GetPartitionsCommand({
+        DatabaseName: "site_logs",
+        TableName: "access_logs",
+      }),
+    );
+
+    // Then each command reached the simulation.
+    assertIdentical(
+      one.Partition?.StorageDescriptor?.Location,
+      "s3://site-logs/day=2026-08-26/",
+    );
+    assertArrayEquals(
+      left.Partitions?.map((partition) => partition.Values?.[0]),
+      ["2026-08-26"],
+    );
   });
 });

--- a/src/service/glue/sim-glue-authorization.iso.test.ts
+++ b/src/service/glue/sim-glue-authorization.iso.test.ts
@@ -1,8 +1,10 @@
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   CreateDatabaseCommand,
+  CreatePartitionCommand,
   CreateTableCommand,
   DeleteDatabaseCommand,
+  GetPartitionsCommand,
   GetTableCommand,
 } from "@aws-sdk/client-glue";
 import {
@@ -37,7 +39,10 @@ function catalogWithTable(simAws: SimAws): void {
   glue.createTable(
     new CreateTableCommand({
       DatabaseName: "site_logs",
-      TableInput: { Name: "access_logs" },
+      TableInput: {
+        Name: "access_logs",
+        PartitionKeys: [{ Name: "day", Type: "string" }],
+      },
     }),
   );
 }
@@ -221,5 +226,58 @@ describe("SimGlue authorization", () => {
 
     // Then it goes, and takes its table with it.
     assertArrayLength(simAws.glue().allDatabases(), 0);
+  });
+
+  it("lets a partition command through on the table's own ARN", async () => {
+    // Given a role allowed to register partitions over the catalog, the
+    // database and the table. A partition has no ARN of its own, so the table
+    // is what a real Glue policy grants this on.
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    catalogWithTable(simAws);
+    await roleAllowing(simAws, "glue:CreatePartition", [
+      catalogArn,
+      databaseArn,
+      tableArn,
+    ]);
+
+    // When the role registers a partition.
+    simAws.glue().createPartition(
+      new CreatePartitionCommand({
+        DatabaseName: "site_logs",
+        TableName: "access_logs",
+        PartitionInput: { Values: ["2026-08-26"] },
+      }),
+      { caller },
+    );
+
+    // Then it is registered.
+    assertArrayLength(
+      simAws.glue().partitionsInTable("site_logs", "access_logs"),
+      1,
+    );
+  });
+
+  it("refuses a partition command whose policy leaves the catalog out", async () => {
+    // Given a role allowed to list partitions on the table ARN alone.
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    catalogWithTable(simAws);
+    await roleAllowing(simAws, "glue:GetPartitions", [tableArn]);
+
+    // When the role lists the table's partitions.
+    const error = assertThrowsError(() => {
+      simAws.glue().getPartitions(
+        new GetPartitionsCommand({
+          DatabaseName: "site_logs",
+          TableName: "access_logs",
+        }),
+        { caller },
+      );
+    });
+
+    // Then it is refused at the catalog, as a table read is.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, catalogArn);
   });
 });

--- a/src/service/glue/sim-glue-partition-batches.iso.test.ts
+++ b/src/service/glue/sim-glue-partition-batches.iso.test.ts
@@ -7,12 +7,15 @@ import {
   assertArrayEquals,
   assertArrayLength,
   assertIdentical,
+  assertInstanceOf,
   assertObjectEquals,
   assertStringIncludes,
+  assertThrowsError,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../aws/sim-aws.js";
+import { SimGlueInvalidInputException } from "./error/sim-glue.error.js";
 import {
   createFixturePartition,
   createFixturePartitionedTable,
@@ -169,17 +172,18 @@ describe("SimGlue partition batches", () => {
     );
   });
 
-  it("answers a batch naming no entries with nothing to report", () => {
+  it("answers an empty batch with nothing to report", () => {
     // Given a table partitioned by day.
     const glue = new SimAws().glue();
     const table = createFixturePartitionedTable(glue);
 
-    // When a batch carries no list at all.
+    // When a batch carries an empty list, which is within the bounds real
+    // Glue states for it.
     const { Errors } = glue.batchCreatePartition(
       new BatchCreatePartitionCommand({
         DatabaseName: table.databaseName,
         TableName: table.tableName,
-        PartitionInputList: undefined,
+        PartitionInputList: [],
       }),
     );
 
@@ -189,6 +193,28 @@ describe("SimGlue partition batches", () => {
       glue.partitionsInTable(table.databaseName, table.tableName),
       0,
     );
+  });
+
+  it("refuses a batch leaving its list out altogether", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When a batch names no list at all.
+    const error = assertThrowsError(() => {
+      glue.batchDeletePartition(
+        new BatchDeletePartitionCommand({
+          DatabaseName: table.databaseName,
+          TableName: table.tableName,
+          PartitionsToDelete: undefined,
+        }),
+      );
+    });
+
+    // Then it is refused. The list is a required request member on real Glue,
+    // and an absent one is a malformed request rather than an empty batch.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "PartitionsToDelete is required");
   });
 
   it("reports a batch entry naming no values at all", () => {

--- a/src/service/glue/sim-glue-partition-batches.iso.test.ts
+++ b/src/service/glue/sim-glue-partition-batches.iso.test.ts
@@ -1,0 +1,214 @@
+import {
+  BatchCreatePartitionCommand,
+  BatchDeletePartitionCommand,
+  GetPartitionsCommand,
+} from "@aws-sdk/client-glue";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  createFixturePartition,
+  createFixturePartitionedTable,
+} from "./sim-glue-partitions.fixture.js";
+
+describe("SimGlue partition batches", () => {
+  it("registers a batch of partitions in one request", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When three days are registered at once.
+    const { Errors } = glue.batchCreatePartition(
+      new BatchCreatePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionInputList: [
+          { Values: ["2026-08-24"] },
+          { Values: ["2026-08-25"] },
+          { Values: ["2026-08-26"] },
+        ],
+      }),
+    );
+
+    // Then all three are there and nothing is reported.
+    assertArrayLength(Errors, 0);
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      3,
+    );
+  });
+
+  it("reports the entries it could not make and keeps the rest", () => {
+    // Given a day already registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, table, ["2026-08-25"]);
+
+    // When a batch repeats that day alongside a new one.
+    const { Errors } = glue.batchCreatePartition(
+      new BatchCreatePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionInputList: [
+          { Values: ["2026-08-25"] },
+          { Values: ["2026-08-26"] },
+        ],
+      }),
+    );
+
+    // Then the repeat is reported and the new day is registered, rather than
+    // the whole batch failing on the one entry.
+    assertArrayLength(Errors, 1);
+    assertArrayEquals(Errors[0].PartitionValues, ["2026-08-25"]);
+    assertIdentical(Errors[0].ErrorDetail.ErrorCode, "AlreadyExistsException");
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      2,
+    );
+  });
+
+  it("reports a batch entry whose values the table has no keys for", () => {
+    // Given a table partitioned by one key.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When a batch carries an entry of two values.
+    const { Errors } = glue.batchCreatePartition(
+      new BatchCreatePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionInputList: [
+          { Values: ["2026-08-26", "eu-west-2"] },
+          { Values: ["2026-08-25"] },
+        ],
+      }),
+    );
+
+    // Then that entry is reported the way a single request would have refused
+    // it, and the other is registered.
+    assertArrayLength(Errors, 1);
+    assertIdentical(Errors[0].ErrorDetail.ErrorCode, "InvalidInputException");
+    assertStringIncludes(Errors[0].ErrorDetail.ErrorMessage, "2 values");
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      1,
+    );
+  });
+
+  it("removes a batch of partitions in one request", () => {
+    // Given three days registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    for (const day of ["2026-08-24", "2026-08-25", "2026-08-26"]) {
+      createFixturePartition(glue, table, [day]);
+    }
+
+    // When two of them are deleted at once.
+    const { Errors } = glue.batchDeletePartition(
+      new BatchDeletePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionsToDelete: [
+          { Values: ["2026-08-24"] },
+          { Values: ["2026-08-25"] },
+        ],
+      }),
+    );
+
+    // Then only the third is left.
+    assertArrayLength(Errors, 0);
+
+    const { Partitions } = glue.getPartitions(
+      new GetPartitionsCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+      }),
+    );
+
+    assertObjectEquals(
+      Partitions.map((partition) => partition.Values),
+      [["2026-08-26"]],
+    );
+  });
+
+  it("reports the entries a batch delete could not find", () => {
+    // Given one day registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, table, ["2026-08-26"]);
+
+    // When a batch deletes it alongside a day nobody registered.
+    const { Errors } = glue.batchDeletePartition(
+      new BatchDeletePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionsToDelete: [
+          { Values: ["2026-08-25"] },
+          { Values: ["2026-08-26"] },
+        ],
+      }),
+    );
+
+    // Then the absent one is reported and the registered one is gone.
+    assertArrayLength(Errors, 1);
+    assertArrayEquals(Errors[0].PartitionValues, ["2026-08-25"]);
+    assertIdentical(Errors[0].ErrorDetail.ErrorCode, "EntityNotFoundException");
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      0,
+    );
+  });
+
+  it("answers a batch naming no entries with nothing to report", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When a batch carries no list at all.
+    const { Errors } = glue.batchCreatePartition(
+      new BatchCreatePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionInputList: undefined,
+      }),
+    );
+
+    // Then there is nothing to report and nothing was registered.
+    assertArrayLength(Errors, 0);
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      0,
+    );
+  });
+
+  it("reports a batch entry naming no values at all", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When a batch carries an entry with nothing in it.
+    const { Errors } = glue.batchCreatePartition(
+      new BatchCreatePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionInputList: [{}],
+      }),
+    );
+
+    // Then it is reported with the values it never gave, which is an empty
+    // list rather than an absent one.
+    assertArrayLength(Errors, 1);
+    assertArrayLength(Errors[0].PartitionValues, 0);
+    assertIdentical(Errors[0].ErrorDetail.ErrorCode, "InvalidInputException");
+  });
+});

--- a/src/service/glue/sim-glue-partition-registration.iso.test.ts
+++ b/src/service/glue/sim-glue-partition-registration.iso.test.ts
@@ -1,0 +1,200 @@
+import {
+  CreatePartitionCommand,
+  DeletePartitionCommand,
+  GetPartitionCommand,
+} from "@aws-sdk/client-glue";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { simGluePartitionBatchErrors } from "./command/partition/sim-glue-partition-batch.js";
+import { SimGlueInvalidInputException } from "./error/sim-glue.error.js";
+import {
+  createFixturePartition,
+  createFixturePartitionedTable,
+} from "./sim-glue-partitions.fixture.js";
+
+describe("SimGlue partition registration", () => {
+  it("reads back the access and analysis times a partition was given", () => {
+    // Given a partition registered with both timestamps a crawler sets.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+    const lastAccess = new Date("2026-08-26T09:00:00.000Z");
+    const lastAnalyzed = new Date("2026-08-26T10:30:00.000Z");
+
+    glue.createPartition(
+      new CreatePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionInput: {
+          Values: ["2026-08-26"],
+          LastAccessTime: lastAccess,
+          LastAnalyzedTime: lastAnalyzed,
+        },
+      }),
+    );
+
+    // When it is read back.
+    const { Partition } = glue.getPartition(
+      new GetPartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionValues: ["2026-08-26"],
+      }),
+    );
+
+    // Then both come back as they went in, and the parameters default to none
+    // rather than to nothing at all.
+    assertIdentical(
+      Partition.LastAccessTime?.toISOString(),
+      lastAccess.toISOString(),
+    );
+    assertIdentical(
+      Partition.LastAnalyzedTime?.toISOString(),
+      lastAnalyzed.toISOString(),
+    );
+    assertObjectEquals(Partition.Parameters, {});
+  });
+
+  it("tells a partition of two values apart from one holding a separator", () => {
+    // Given a table partitioned by two keys, with a partition whose first
+    // value carries the character a joined key would separate on.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["region", "day"]);
+
+    createFixturePartition(glue, table, ["eu-west-2/2026-08-26", "morning"]);
+
+    // When a partition is registered whose values join to the same string.
+    createFixturePartition(glue, table, ["eu-west-2", "2026-08-26/morning"]);
+
+    // Then both are held, rather than the second colliding with the first.
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      2,
+    );
+  });
+
+  it("refuses a CreatePartition carrying no partition input", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When a partition is registered with no input at all.
+    const error = assertThrowsError(() => {
+      glue.createPartition(
+        new CreatePartitionCommand({
+          DatabaseName: table.databaseName,
+          TableName: table.tableName,
+          PartitionInput: undefined,
+        }),
+      );
+    });
+
+    // Then it is refused for the values it never gave.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "PartitionInput.Values is required");
+  });
+
+  it("refuses a DeletePartition naming no values", () => {
+    // Given a table with one day registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, table, ["2026-08-26"]);
+
+    // When a delete names no values.
+    const error = assertThrowsError(() => {
+      glue.deletePartition(
+        new DeletePartitionCommand({
+          DatabaseName: table.databaseName,
+          TableName: table.tableName,
+          PartitionValues: undefined,
+        }),
+      );
+    });
+
+    // Then it is refused, and the day is still there.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      1,
+    );
+  });
+
+  it("registers a partition through the catalog writer", () => {
+    // Given a table, and the writer CloudFormation would deploy through.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+    const writer = glue.catalogWriter();
+
+    // When a partition is written and then removed through it.
+    writer.createPartition(
+      table.databaseName,
+      table.tableName,
+      ["2026-08-26"],
+      {
+        storageDescriptor: { Location: "s3://site-logs/day=2026-08-26/" },
+      },
+    );
+
+    const registered = glue.findPartition(table.databaseName, table.tableName, [
+      "2026-08-26",
+    ]);
+
+    writer.deletePartition(table.databaseName, table.tableName, ["2026-08-26"]);
+
+    // Then it was held without an SDK Command, and removing it took it away.
+    assertIdentical(
+      registered?.storageDescriptor?.Location,
+      "s3://site-logs/day=2026-08-26/",
+    );
+    assertUndefined(
+      glue.findPartition(table.databaseName, table.tableName, ["2026-08-26"]),
+    );
+  });
+
+  it("refuses a catalog writer partition whose table is absent", () => {
+    // Given a database holding no table of that name.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When a partition is written against a table nobody made.
+    const error = assertThrowsError(() => {
+      glue
+        .catalogWriter()
+        .createPartition(table.databaseName, "error_logs", ["2026-08-26"]);
+    });
+
+    // Then the deploy fails rather than holding a partition under no table.
+    assertStringIncludes(error.message, "error_logs");
+  });
+
+  it("lets a fault in the simulation out of a batch", () => {
+    // Given a batch entry whose handling fails for a reason no caller asked
+    // for.
+    const fault = new TypeError("the simulation is broken");
+
+    // When the batch runs.
+    const error = assertThrowsError(() => {
+      simGluePartitionBatchErrors(
+        "PartitionInputList",
+        [{ Values: ["2026-08-26"] }],
+        () => {
+          throw fault;
+        },
+      );
+    });
+
+    // Then it comes out rather than being reported as a refused entry, which
+    // would read as though the caller had asked for something invalid.
+    assertIdentical(error, fault);
+  });
+});

--- a/src/service/glue/sim-glue-partitions.fixture.ts
+++ b/src/service/glue/sim-glue-partitions.fixture.ts
@@ -1,0 +1,87 @@
+import { faker } from "@faker-js/faker";
+
+import type { SimGlue } from "./sim-glue.js";
+
+/**
+ * Test support for building a partitioned table to register partitions
+ * against.
+ *
+ * Every partition behaviour worth testing needs a database and a table with
+ * partition keys before it can be reached, so building those happens here
+ * rather than at the top of every test.
+ *
+ * These helpers drive the simulator through structural command shapes rather
+ * than real SDK command objects, because this is source rather than a test
+ * file. The colocated tests cover SDK-shaped input.
+ */
+
+/** A table name nothing else in the run will use. */
+export function fixtureTableName(): string {
+  return `access_logs_${faker.string.alphanumeric(8)}`;
+}
+
+/** A database name nothing else in the run will use. */
+export function fixtureDatabaseName(): string {
+  return `site_logs_${faker.string.alphanumeric(8)}`;
+}
+
+/**
+ * What a partitioned table is created with here.
+ */
+export interface FixturePartitionedTable {
+  readonly databaseName: string;
+  readonly tableName: string;
+}
+
+/**
+ * Create a database and a table partitioned by the named keys.
+ *
+ * The keys default to one `day`. That is the shape most of these tests want.
+ * One value per partition means a list of two values is refused by count.
+ */
+export function createFixturePartitionedTable(
+  glue: SimGlue,
+  partitionKeyNames: readonly string[] = ["day"],
+): FixturePartitionedTable {
+  const databaseName = fixtureDatabaseName();
+  const tableName = fixtureTableName();
+
+  glue.createDatabase({ input: { DatabaseInput: { Name: databaseName } } });
+  glue.createTable({
+    input: {
+      DatabaseName: databaseName,
+      TableInput: {
+        Name: tableName,
+        PartitionKeys: partitionKeyNames.map((Name) => ({
+          Name,
+          Type: "string",
+        })),
+        StorageDescriptor: { Location: `s3://${databaseName}/logs/` },
+      },
+    },
+  });
+
+  return { databaseName, tableName };
+}
+
+/**
+ * Register one partition against a fixture table.
+ */
+export function createFixturePartition(
+  glue: SimGlue,
+  table: FixturePartitionedTable,
+  values: readonly string[],
+): void {
+  glue.createPartition({
+    input: {
+      DatabaseName: table.databaseName,
+      TableName: table.tableName,
+      PartitionInput: {
+        Values: values,
+        StorageDescriptor: {
+          Location: `s3://${table.databaseName}/logs/day=${values.join("/")}/`,
+        },
+      },
+    },
+  });
+}

--- a/src/service/glue/sim-glue-partitions.iso.test.ts
+++ b/src/service/glue/sim-glue-partitions.iso.test.ts
@@ -1,0 +1,382 @@
+import {
+  CreatePartitionCommand,
+  CreateTableCommand,
+  DeleteDatabaseCommand,
+  DeletePartitionCommand,
+  DeleteTableCommand,
+  GetPartitionCommand,
+  GetPartitionsCommand,
+} from "@aws-sdk/client-glue";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertObjectHasProperty,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimGlueAlreadyExistsException,
+  SimGlueEntityNotFoundException,
+  SimGlueInvalidInputException,
+} from "./error/sim-glue.error.js";
+import {
+  createFixturePartition,
+  createFixturePartitionedTable,
+  fixtureTableName,
+} from "./sim-glue-partitions.fixture.js";
+
+describe("SimGlue partitions", () => {
+  it("reads a registered partition back with where its data sits", () => {
+    // Given a table partitioned by day, with one day registered.
+    const glue = new SimAws({ defaultAccountId: "111111111111" }).glue();
+    const table = createFixturePartitionedTable(glue);
+
+    glue.createPartition(
+      new CreatePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionInput: {
+          Values: ["2026-08-26"],
+          StorageDescriptor: { Location: "s3://rainlytics/day=2026-08-26/" },
+          Parameters: { compression: "gzip" },
+        },
+      }),
+    );
+
+    // When that partition is read back by its values.
+    const { Partition } = glue.getPartition(
+      new GetPartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionValues: ["2026-08-26"],
+      }),
+    );
+
+    // Then it carries the location and the parameters it was registered with,
+    // which is what tells a reader where this day's objects are.
+    assertArrayEquals(Partition.Values, ["2026-08-26"]);
+    assertIdentical(
+      Partition.StorageDescriptor?.Location,
+      "s3://rainlytics/day=2026-08-26/",
+    );
+    assertObjectEquals(Partition.Parameters, { compression: "gzip" });
+    assertIdentical(Partition.CatalogId, "111111111111");
+    assertIdentical(Partition.DatabaseName, table.databaseName);
+    assertIdentical(Partition.TableName, table.tableName);
+  });
+
+  it("leaves a field nobody set out of the response", () => {
+    // Given a partition registered with nothing but its values.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    glue.createPartition(
+      new CreatePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionInput: { Values: ["2026-08-26"] },
+      }),
+    );
+
+    // When it is read back.
+    const { Partition } = glue.getPartition(
+      new GetPartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionValues: ["2026-08-26"],
+      }),
+    );
+
+    // Then the response carries no key for the storage descriptor at all,
+    // which is the shape a real Glue response has.
+    assertObjectHasProperty(Partition, "CreationTime");
+    assertFalse(Object.hasOwn(Partition, "StorageDescriptor"));
+    assertFalse(Object.hasOwn(Partition, "LastAccessTime"));
+  });
+
+  it("lists every partition of one table in registration order", () => {
+    // Given three days registered against one table.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    for (const day of ["2026-08-24", "2026-08-25", "2026-08-26"]) {
+      createFixturePartition(glue, table, [day]);
+    }
+
+    // When the table's partitions are listed.
+    const { Partitions } = glue.getPartitions(
+      new GetPartitionsCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+      }),
+    );
+
+    // Then all three come back in the order they were registered.
+    assertObjectEquals(
+      Partitions.map((partition) => partition.Values),
+      [["2026-08-24"], ["2026-08-25"], ["2026-08-26"]],
+    );
+  });
+
+  it("keeps one table's partitions out of another's", () => {
+    // Given two tables, each with a partition of the same values.
+    const glue = new SimAws().glue();
+    const first = createFixturePartitionedTable(glue);
+    const second = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, first, ["2026-08-26"]);
+    createFixturePartition(glue, second, ["2026-08-26"]);
+
+    // When each table is listed.
+    const listed = [first, second].map(
+      (table) =>
+        glue.getPartitions(
+          new GetPartitionsCommand({
+            DatabaseName: table.databaseName,
+            TableName: table.tableName,
+          }),
+        ).Partitions,
+    );
+
+    // Then each holds its own, since values identify a partition only within
+    // the table registering them.
+    assertArrayLength(listed[0] ?? [], 1);
+    assertArrayLength(listed[1] ?? [], 1);
+    assertIdentical(listed[0]?.[0]?.TableName, first.tableName);
+    assertIdentical(listed[1]?.[0]?.TableName, second.tableName);
+  });
+
+  it("refuses values the table has no keys for, naming both counts", () => {
+    // Given a table partitioned by one key.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When a partition is registered with two values.
+    const error = assertThrowsError(() => {
+      glue.createPartition(
+        new CreatePartitionCommand({
+          DatabaseName: table.databaseName,
+          TableName: table.tableName,
+          PartitionInput: { Values: ["2026-08-26", "eu-west-2"] },
+        }),
+      );
+    });
+
+    // Then it is refused, and the message says how many of each there are.
+    // Values are positional, so a list of the wrong length lines up with the
+    // wrong keys.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "2 values");
+    assertStringIncludes(error.message, "1 partition key");
+  });
+
+  it("refuses a partition on a table declaring no partition keys", () => {
+    // Given a table with no partition keys at all.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, []);
+
+    // When a partition is registered against it.
+    const error = assertThrowsError(() => {
+      createFixturePartition(glue, table, ["2026-08-26"]);
+    });
+
+    // Then it is refused by the same count, since it declares none.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "0 partition keys");
+  });
+
+  it("refuses values already registered against the table", () => {
+    // Given a day already registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, table, ["2026-08-26"]);
+
+    // When the same day is registered again.
+    const error = assertThrowsError(() => {
+      createFixturePartition(glue, table, ["2026-08-26"]);
+    });
+
+    // Then it fails, as registering is not idempotent on real Glue.
+    assertInstanceOf(error, SimGlueAlreadyExistsException);
+  });
+
+  it("refuses reading a partition nothing registered", () => {
+    // Given a table with no partitions registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When a day nobody registered is read.
+    const error = assertThrowsError(() => {
+      glue.getPartition(
+        new GetPartitionCommand({
+          DatabaseName: table.databaseName,
+          TableName: table.tableName,
+          PartitionValues: ["2026-08-26"],
+        }),
+      );
+    });
+
+    // Then it fails the way real Glue fails it.
+    assertInstanceOf(error, SimGlueEntityNotFoundException);
+  });
+
+  it("refuses a partition command naming a table nobody made", () => {
+    // Given a database holding no such table.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When a partition is registered against a table that is absent.
+    const error = assertThrowsError(() => {
+      glue.createPartition(
+        new CreatePartitionCommand({
+          DatabaseName: table.databaseName,
+          TableName: fixtureTableName(),
+          PartitionInput: { Values: ["2026-08-26"] },
+        }),
+      );
+    });
+
+    // Then it is refused rather than making the table on the way past.
+    assertInstanceOf(error, SimGlueEntityNotFoundException);
+  });
+
+  it("refuses a GetPartitions Expression rather than ignoring it", () => {
+    // Given a table with two days registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, table, ["2026-08-25"]);
+    createFixturePartition(glue, table, ["2026-08-26"]);
+
+    // When they are listed through a filter.
+    const error = assertThrowsError(() => {
+      glue.getPartitions(
+        new GetPartitionsCommand({
+          DatabaseName: table.databaseName,
+          TableName: table.tableName,
+          Expression: "day = '2026-08-26'",
+        }),
+      );
+    });
+
+    // Then it is refused. An ignored filter would answer with the partition
+    // the caller asked to leave out.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "Expression");
+  });
+
+  it("removes a partition without touching the rest", () => {
+    // Given two days registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, table, ["2026-08-25"]);
+    createFixturePartition(glue, table, ["2026-08-26"]);
+
+    // When one of them is deleted.
+    glue.deletePartition(
+      new DeletePartitionCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        PartitionValues: ["2026-08-25"],
+      }),
+    );
+
+    // Then the other is still there.
+    const { Partitions } = glue.getPartitions(
+      new GetPartitionsCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+      }),
+    );
+
+    assertObjectEquals(
+      Partitions.map((partition) => partition.Values),
+      [["2026-08-26"]],
+    );
+  });
+
+  it("refuses deleting a partition nothing registered", () => {
+    // Given a table with no partitions registered.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    // When a day nobody registered is deleted.
+    const error = assertThrowsError(() => {
+      glue.deletePartition(
+        new DeletePartitionCommand({
+          DatabaseName: table.databaseName,
+          TableName: table.tableName,
+          PartitionValues: ["2026-08-26"],
+        }),
+      );
+    });
+
+    // Then it fails rather than reporting a deletion that never happened.
+    assertInstanceOf(error, SimGlueEntityNotFoundException);
+  });
+
+  it("takes a table's partitions with the table", () => {
+    // Given a table holding one partition.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, table, ["2026-08-26"]);
+
+    // When the table is deleted and a table of the same name is created
+    // again.
+    glue.deleteTable(
+      new DeleteTableCommand({
+        DatabaseName: table.databaseName,
+        Name: table.tableName,
+      }),
+    );
+    glue.createTable(
+      new CreateTableCommand({
+        DatabaseName: table.databaseName,
+        TableInput: {
+          Name: table.tableName,
+          PartitionKeys: [{ Name: "day", Type: "string" }],
+        },
+      }),
+    );
+
+    // Then the partition is gone, rather than reappearing under the new
+    // table.
+    assertUndefined(
+      glue.findPartition(table.databaseName, table.tableName, ["2026-08-26"]),
+    );
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      0,
+    );
+  });
+
+  it("takes a database's partitions with the database", () => {
+    // Given a database whose table holds a partition.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue);
+
+    createFixturePartition(glue, table, ["2026-08-26"]);
+
+    // When the database is deleted.
+    glue.deleteDatabase(
+      new DeleteDatabaseCommand({ Name: table.databaseName }),
+    );
+
+    // Then the partitions go with the tables that went with it.
+    assertArrayLength(
+      glue.partitionsInTable(table.databaseName, table.tableName),
+      0,
+    );
+  });
+});

--- a/src/service/glue/sim-glue.ts
+++ b/src/service/glue/sim-glue.ts
@@ -14,12 +14,17 @@ import { SimGlueAuthorizer } from "./command/authorize/sim-glue-authorizer.js";
 import { SimGlueDatabaseCommands } from "./command/database/sim-glue-database-commands.js";
 import type * as simGlueCommands from "./command/database/database.command.js";
 import type * as simGlueTableCommands from "./command/table/table.command.js";
+import type * as simGluePartitionCommands from "./command/partition/partition.command.js";
 import { SimGlueTableCommands } from "./command/table/sim-glue-table-commands.js";
+import { SimGluePartitionCommands } from "./command/partition/sim-glue-partition-commands.js";
+import { SimGluePartitionRegistry } from "./command/partition/sim-glue-partition-registry.js";
 import type { SimGlueRequestOptions } from "./command/sim-glue-request-options.js";
 import { SimGlueDatabaseStore } from "./database/sim-glue-database-store.js";
 import type { SimGlueDatabase } from "./database/sim-glue-database.js";
 import { SimGlueCfnResourceFactory } from "./cfn/sim-glue-cfn-resource-factory.js";
 import { SimGlueSdkCommandRouter } from "./sdk/sim-glue-sdk-command-router.js";
+import { SimGluePartitionStore } from "./partition/sim-glue-partition-store.js";
+import type { SimGluePartition } from "./partition/sim-glue-partition.js";
 import { SimGlueTableStore } from "./table/sim-glue-table-store.js";
 import { SimGlueCatalogWriter } from "./write/sim-glue-catalog-writer.js";
 import type { SimGlueTable } from "./table/sim-glue-table.js";
@@ -46,8 +51,10 @@ export interface SimGlueProperties {
 export class SimGlue {
   readonly #databases: SimGlueDatabaseStore;
   readonly #tables: SimGlueTableStore;
+  readonly #partitions: SimGluePartitionStore;
   readonly #databaseCommands: SimGlueDatabaseCommands;
   readonly #tableCommands: SimGlueTableCommands;
+  readonly #partitionCommands: SimGluePartitionCommands;
   readonly #catalogWriter: SimGlueCatalogWriter;
 
   readonly #sdkRouter = new SimGlueSdkCommandRouter(this);
@@ -64,10 +71,12 @@ export class SimGlue {
 
     this.#databases = new SimGlueDatabaseStore({ accountRegionScope });
     this.#tables = new SimGlueTableStore({ accountRegionScope });
+    this.#partitions = new SimGluePartitionStore({ accountRegionScope });
 
     const collaborators = {
       databases: this.#databases,
       tables: this.#tables,
+      partitions: this.#partitions,
       authorizer,
       accountRegionScope,
       clock: background,
@@ -75,9 +84,13 @@ export class SimGlue {
 
     this.#databaseCommands = new SimGlueDatabaseCommands(collaborators);
     this.#tableCommands = new SimGlueTableCommands(collaborators);
+    this.#partitionCommands = new SimGluePartitionCommands({
+      registry: new SimGluePartitionRegistry(collaborators),
+    });
     this.#catalogWriter = new SimGlueCatalogWriter({
       databases: this.#databases,
       tables: this.#tables,
+      partitions: this.#partitions,
       clock: background,
     });
     this.#cfnFactory = new SimGlueCfnResourceFactory({
@@ -119,6 +132,26 @@ export class SimGlue {
   /** Every table in one database, in creation order. */
   tablesInDatabase(databaseName: string): readonly SimGlueTable[] {
     return this.#tables.inDatabase(databaseName);
+  }
+
+  /**
+   * Find a partition by its table and its values, without going through a
+   * Command.
+   */
+  findPartition(
+    databaseName: string,
+    tableName: string,
+    values: readonly string[],
+  ): SimGluePartition | undefined {
+    return this.#partitions.inTable(databaseName, tableName).find(values);
+  }
+
+  /** Every partition registered against one table, in registration order. */
+  partitionsInTable(
+    databaseName: string,
+    tableName: string,
+  ): readonly SimGluePartition[] {
+    return this.#partitions.inTable(databaseName, tableName).all;
   }
 
   /** Make a database. */
@@ -177,12 +210,60 @@ export class SimGlue {
     return this.#tableCommands.getTables(command, options);
   }
 
-  /** Remove a table. */
+  /** Remove a table, and the partitions registered against it with it. */
   deleteTable(
     command: simGlueTableCommands.SimDeleteTableCommand,
     options?: SimGlueRequestOptions,
   ): simGlueTableCommands.SimDeleteTableCommandOutput {
     return this.#tableCommands.deleteTable(command, options);
+  }
+
+  /** Register one partition against a table. */
+  createPartition(
+    command: simGluePartitionCommands.SimCreatePartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): simGluePartitionCommands.SimCreatePartitionCommandOutput {
+    return this.#partitionCommands.createPartition(command, options);
+  }
+
+  /** Register several partitions at once. */
+  batchCreatePartition(
+    command: simGluePartitionCommands.SimBatchCreatePartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): simGluePartitionCommands.SimBatchCreatePartitionCommandOutput {
+    return this.#partitionCommands.batchCreatePartition(command, options);
+  }
+
+  /** Read one partition back by its values. */
+  getPartition(
+    command: simGluePartitionCommands.SimGetPartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): simGluePartitionCommands.SimGetPartitionCommandOutput {
+    return this.#partitionCommands.getPartition(command, options);
+  }
+
+  /** Read every partition registered against one table. */
+  getPartitions(
+    command: simGluePartitionCommands.SimGetPartitionsCommand,
+    options?: SimGlueRequestOptions,
+  ): simGluePartitionCommands.SimGetPartitionsCommandOutput {
+    return this.#partitionCommands.getPartitions(command, options);
+  }
+
+  /** Remove one partition. */
+  deletePartition(
+    command: simGluePartitionCommands.SimDeletePartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): simGluePartitionCommands.SimDeletePartitionCommandOutput {
+    return this.#partitionCommands.deletePartition(command, options);
+  }
+
+  /** Remove several partitions at once. */
+  batchDeletePartition(
+    command: simGluePartitionCommands.SimBatchDeletePartitionCommand,
+    options?: SimGlueRequestOptions,
+  ): simGluePartitionCommands.SimBatchDeletePartitionCommandOutput {
+    return this.#partitionCommands.batchDeletePartition(command, options);
   }
 
   /** Route an intercepted SDK Command to this simulated Glue. */

--- a/src/service/glue/write/sim-glue-catalog-writer.ts
+++ b/src/service/glue/write/sim-glue-catalog-writer.ts
@@ -4,6 +4,11 @@ import type {
   SimGlueDatabaseStore,
 } from "../database/sim-glue-database-store.js";
 import type { SimGlueDatabase } from "../database/sim-glue-database.js";
+import type { SimGluePartition } from "../partition/sim-glue-partition.js";
+import type {
+  SimGluePartitionInput,
+  SimGluePartitionStore,
+} from "../partition/sim-glue-partition-store.js";
 import type {
   SimGlueTableInput,
   SimGlueTableStore,
@@ -13,6 +18,7 @@ import type { SimGlueTable } from "../table/sim-glue-table.js";
 interface SimGlueCatalogWriterProperties {
   readonly databases: SimGlueDatabaseStore;
   readonly tables: SimGlueTableStore;
+  readonly partitions: SimGluePartitionStore;
   readonly clock: SimClock;
 }
 
@@ -28,11 +34,13 @@ interface SimGlueCatalogWriterProperties {
 export class SimGlueCatalogWriter {
   readonly #databases: SimGlueDatabaseStore;
   readonly #tables: SimGlueTableStore;
+  readonly #partitions: SimGluePartitionStore;
   readonly #clock: SimClock;
 
   constructor(properties: SimGlueCatalogWriterProperties) {
     this.#databases = properties.databases;
     this.#tables = properties.tables;
+    this.#partitions = properties.partitions;
     this.#clock = properties.clock;
   }
 
@@ -41,10 +49,11 @@ export class SimGlueCatalogWriter {
     return this.#databases.create(name, this.#clock.now(), input);
   }
 
-  /** Remove a database, and the tables it holds with it. */
+  /** Remove a database, and the tables and partitions it holds with it. */
   deleteDatabase(name: string): void {
     this.#databases.delete(name);
     this.#tables.deleteDatabase(name);
+    this.#partitions.deleteDatabase(name);
   }
 
   /**
@@ -60,8 +69,37 @@ export class SimGlueCatalogWriter {
     return this.#tables.create(databaseName, name, this.#clock.now(), input);
   }
 
-  /** Remove a table. */
+  /** Remove a table, and the partitions registered against it with it. */
   deleteTable(databaseName: string, name: string): void {
     this.#tables.delete(databaseName, name);
+    this.#partitions.deleteTable(databaseName, name);
+  }
+
+  /**
+   * Register a partition against a table, refusing one whose table is absent.
+   *
+   * The values are taken as given. Nothing here checks them against the
+   * table's partition keys, since a Command does that while reading its input.
+   */
+  createPartition(
+    databaseName: string,
+    tableName: string,
+    values: readonly string[],
+    input: SimGluePartitionInput = {},
+  ): SimGluePartition {
+    this.#tables.require(databaseName, tableName);
+
+    return this.#partitions
+      .inTable(databaseName, tableName)
+      .create(values, this.#clock.now(), input);
+  }
+
+  /** Remove a partition. */
+  deletePartition(
+    databaseName: string,
+    tableName: string,
+    values: readonly string[],
+  ): void {
+    this.#partitions.inTable(databaseName, tableName).delete(values);
   }
 }


### PR DESCRIPTION
A table in the simulated Glue Data Catalog now holds the partitions registered against it. Each is keyed by its values in the order the table's `PartitionKeys` declares them, and carries a storage descriptor saying where its own data sits. `CreatePartition`, `BatchCreatePartition`, `GetPartition`, `GetPartitions`, `DeletePartition` and `BatchDeletePartition` read and write them, through the SDK router and through `SimGlueCatalogWriter`. A batch reports the entries it could not handle in `Errors` and carries on with the rest, the way real Glue does. A `Values` list of a different length from the table's partition keys is refused naming both counts, values already registered are an `AlreadyExistsException`, and a `GetPartitions` `Expression` is refused while filtering is unsimulated, since ignoring the filter would answer with the partitions the caller asked to leave out. Deleting a table takes its partitions with it, the way deleting a database takes its tables.

Resolves https://github.com/KensioSoftware/yulin/issues/1020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS Glue partition support, including create, batch create, retrieve, list, delete, and batch delete operations.
  * Added partition validation, duplicate detection, authorization checks, and per-entry batch errors.
  * Partition metadata, storage locations, timestamps, and parameters are preserved.
  * Deleting a table or database now also removes its registered partitions.
  * Added direct partition lookup helpers and an executable usage example.

* **Documentation**
  * Expanded Glue documentation with partition behavior, limitations, command examples, and catalog listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->