### PR TITLE
feat: filter Glue partitions with an Expression

### DIFF
--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -187,6 +187,86 @@ one day twice is an `AlreadyExistsException`, since registration is not idempote
 Deleting a table removes the partitions registered against it, the way deleting a database removes
 its tables.
 
+## Filtering partitions
+
+`GetPartitions` takes an `Expression` and answers with the partitions it matches. A request carrying
+none reads them all.
+
+```typescript sim-glue-partition-expressions
+/**
+ * Reading back the partitions an expression matches.
+ */
+
+import {
+  BatchCreatePartitionCommand,
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetPartitionsCommand,
+} from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const glue = simAws.glue();
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+);
+glue.createTable(
+  new CreateTableCommand({
+    DatabaseName: "site_logs",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [
+        { Name: "day", Type: "string" },
+        { Name: "region", Type: "string" },
+      ],
+    },
+  }),
+);
+
+glue.batchCreatePartition(
+  new BatchCreatePartitionCommand({
+    DatabaseName: "site_logs",
+    TableName: "access_logs",
+    PartitionInputList: [
+      { Values: ["2026-07-31", "eu-west-2"] },
+      { Values: ["2026-08-01", "eu-west-2"] },
+      { Values: ["2026-08-02", "us-east-1"] },
+    ],
+  }),
+);
+
+const { Partitions } = glue.getPartitions(
+  new GetPartitionsCommand({
+    DatabaseName: "site_logs",
+    TableName: "access_logs",
+    Expression: "day >= '2026-08-01' AND region IN ('eu-west-2', 'us-east-1')",
+  }),
+);
+
+// [["2026-08-01","eu-west-2"],["2026-08-02","us-east-1"]]
+console.log(JSON.stringify(Partitions.map((partition) => partition.Values)));
+```
+
+A term names a partition key, an operator, and whatever the operator takes. The operators are `=`,
+`<>` and `!=`, `>`, `<`, `>=`, `<=`, `LIKE`, `IN` and `BETWEEN`, and `BETWEEN` takes both of its
+ends. `AND`, `OR` and `NOT` combine terms and brackets group them, with the precedence SQL gives
+them (`NOT` binds tightest, then `AND`, then `OR`). `NOT` also sits in front of `LIKE`, `IN` and
+`BETWEEN` to reverse that one term.
+
+Comparison follows the type the table declares for the key. `tinyint`, `smallint`, `int`, `integer`,
+`bigint`, `float`, `double` and `decimal` compare as numbers, so `10` sorts above `9` rather than
+below it. Every other declared type compares as text, which is the order a date written the ISO way
+already has. A key declared as a number is held to a numeric literal, and `hour = 'noon'` is refused
+rather than matching nothing.
+
+`LIKE` matches the value's text whatever type the key is declared with, since that is what `LIKE`
+does. `%` stands for any run of characters and `_` for exactly one.
+
+An expression naming a column the table does not partition by is refused, naming the column and the
+keys the table does have. So is one that cannot be read, and the message says where reading stopped.
+
 ## Intercepting a GlueClient
 
 An intercepted `GlueClient` reaches the simulated catalog, so code under test builds its own client
@@ -323,6 +403,7 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
 - `CreateTable`, `GetTable`, `GetTables` and `DeleteTable`.
 - `CreatePartition`, `BatchCreatePartition`, `GetPartition`, `GetPartitions`, `DeletePartition` and
   `BatchDeletePartition`.
+- `GetPartitions` `Expression` filtering, over the SQL operators, `AND`, `OR`, `NOT` and brackets.
 - `AWS::Glue::Database` and `AWS::Glue::Table`, deployed and deleted with the stack.
 - `TableInput.Parameters`, `PartitionKeys` and `StorageDescriptor`, held and read back as declared.
 - IAM authorization on every Command, over the resource and its ancestors.
@@ -341,8 +422,12 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
 - **Athena ignores a registered partition.** A query expands the table's projection parameters and
   reads nothing the partition commands wrote. Registering partitions changes what the catalog
   reports and leaves query planning alone.
-- **`GetPartitions` takes no `Expression`.** A filter is refused with `InvalidInputException`. An
-  ignored filter would answer with the partitions the caller asked to leave out.
+- **A `GetPartitions` `Expression` is the whole of the filtering.** `Segment` and parallel listing,
+  `ExcludeColumnSchema` and `TransactionId` are absent, and so are partition indexes, which change
+  which expressions real Glue will serve rather than what any of them mean.
+- **An expression compares a partition key against a literal.** That is the whole grammar.
+  Functions, arithmetic and comparing one column against another sit outside it, and a column name
+  is written unquoted.
 - **A partition keeps what it was registered with.** `UpdatePartition` and `BatchUpdatePartition`
   are absent, along with `BatchGetPartition` and partition indexes.
 - **`AWS::Glue::Partition` is absent.** Real CloudFormation has the resource type, and a template

--- a/docs/services/glue/sim-glue-partition-expressions.example.ts
+++ b/docs/services/glue/sim-glue-partition-expressions.example.ts
@@ -1,0 +1,54 @@
+/**
+ * Reading back the partitions an expression matches.
+ */
+
+import {
+  BatchCreatePartitionCommand,
+  CreateDatabaseCommand,
+  CreateTableCommand,
+  GetPartitionsCommand,
+} from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const glue = simAws.glue();
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "site_logs" } }),
+);
+glue.createTable(
+  new CreateTableCommand({
+    DatabaseName: "site_logs",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [
+        { Name: "day", Type: "string" },
+        { Name: "region", Type: "string" },
+      ],
+    },
+  }),
+);
+
+glue.batchCreatePartition(
+  new BatchCreatePartitionCommand({
+    DatabaseName: "site_logs",
+    TableName: "access_logs",
+    PartitionInputList: [
+      { Values: ["2026-07-31", "eu-west-2"] },
+      { Values: ["2026-08-01", "eu-west-2"] },
+      { Values: ["2026-08-02", "us-east-1"] },
+    ],
+  }),
+);
+
+const { Partitions } = glue.getPartitions(
+  new GetPartitionsCommand({
+    DatabaseName: "site_logs",
+    TableName: "access_logs",
+    Expression: "day >= '2026-08-01' AND region IN ('eu-west-2', 'us-east-1')",
+  }),
+);
+
+// [["2026-08-01","eu-west-2"],["2026-08-02","us-east-1"]]
+console.log(JSON.stringify(Partitions.map((partition) => partition.Values)));

--- a/src/service/glue/README.md
+++ b/src/service/glue/README.md
@@ -29,6 +29,9 @@ partition keys.
   under their own values. A table's partitions go with it, and a database's go with the database.
 - `command/` is one directory per resource kind, holding the local structural command types, the
   handler class, and the detail mapper deciding what a `Get` reports.
+- `expression/` reads a `GetPartitions` `Expression`. A tokeniser, a cursor over the tokens, a
+  recursive descent parser and one small module per kind of term, following the DynamoDB key
+  condition parser in `src/service/dynamodb/expression/key-condition/`.
 - `cfn/` reads `AWS::Glue::Database` and `AWS::Glue::Table` properties and creates from them.
   `AWS::Glue::Crawler` and `AWS::Glue::Partition` are real resource types with no creator here. A
   template declaring either records that Resource as skipped.
@@ -70,9 +73,20 @@ reported as a partition error would read as though the caller had asked for some
 leave an absent field out, and this is the one exception. A caller checking a batch has one thing to
 check, and an optional empty list makes them reach through it first.
 
-**`GetPartitions` refuses an `Expression`.** Filtering is a separate issue. Ignoring the filter until
-it lands would answer with the partitions the caller asked to leave out, and the refusal names what
-is missing.
+**An expression is read into a predicate rather than an object tree.** Once a term has been read,
+the only thing left for it to do is answer for one partition's values. `SimGluePartitionFilter` is a
+function taking those values, and `AND`, `OR` and `NOT` are functions over the ones underneath them.
+Everything a refusal could catch is caught while the expression is read.
+
+**An expression is read against the table it filters.** Which names are partition keys, where each
+one's value sits in the positional list, and how that value is ordered are all properties of the
+table. Reading the expression without it would leave an unknown column matching nothing. That is a
+test passing here on a filter real Glue refuses.
+
+**A stored value with no place in the order matches nothing.** A key declared as a number can hold a
+partition registered with `noon`, since registering one takes the values it is given. The comparison
+answers false for that partition and the request still answers. Failing the whole read would make
+one bad registration hide every good one.
 
 **A partition authorizes against its table's ARN.** Partitions have no ARN of their own on real
 Glue, and a real policy grants `glue:CreatePartition` on the table. `SimGluePartitionRegistry`
@@ -86,5 +100,5 @@ would give a template that deploys and a catalog holding something the template 
 Crawlers, partition updates, partition indexes, `BatchGetPartition`, table versions, column
 statistics, Lake Formation, connections, jobs, triggers, workflows and the Schema Registry. Every
 one of them needs something outside the catalog, or reads data back. Simulated Athena reads a
-table's projection parameters and none of its registered partitions, which is its own issue. The
+table's projection parameters and none of its registered partitions. That gap is its own issue. The
 Limitations list in the usage docs is the full account.

--- a/src/service/glue/command/partition/sim-glue-partition-commands.ts
+++ b/src/service/glue/command/partition/sim-glue-partition-commands.ts
@@ -1,4 +1,3 @@
-import { SimGlueInvalidInputException } from "../../error/sim-glue.error.js";
 import type { SimGlueRequestOptions } from "../sim-glue-request-options.js";
 import { simGluePartitionDetail } from "./sim-glue-partition-detail.js";
 import { simGluePartitionBatchErrors } from "./sim-glue-partition-batch.js";
@@ -109,7 +108,9 @@ export class SimGluePartitionCommands {
   }
 
   /**
-   * Read every partition of one table, in registration order.
+   * Read the partitions of one table, in registration order.
+   *
+   * An `Expression` filters them. A request carrying none reads them all.
    */
   getPartitions(
     command: SimGetPartitionsCommand,
@@ -121,16 +122,10 @@ export class SimGluePartitionCommands {
       options,
     );
 
-    if (command.input.Expression !== undefined) {
-      throw new SimGlueInvalidInputException(
-        "GetPartitions Expression is not simulated, so it is refused rather " +
-          "than ignored. An ignored filter answers with the partitions the " +
-          "caller asked to leave out.",
-      );
-    }
-
     return {
-      Partitions: this.#registry.inTable(table).map(simGluePartitionDetail),
+      Partitions: this.#registry
+        .matching(table, command.input.Expression)
+        .map(simGluePartitionDetail),
       $metadata: {},
     };
   }

--- a/src/service/glue/command/partition/sim-glue-partition-registry.ts
+++ b/src/service/glue/command/partition/sim-glue-partition-registry.ts
@@ -2,6 +2,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
 import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
+import { simGluePartitionExpressionFilter } from "../../expression/sim-glue-partition-expression.js";
 import type { SimGluePartition } from "../../partition/sim-glue-partition.js";
 import type { SimGluePartitionStore } from "../../partition/sim-glue-partition-store.js";
 import type { SimGlueTablePartitions } from "../../partition/sim-glue-table-partitions.js";
@@ -139,6 +140,31 @@ export class SimGluePartitionRegistry {
   /** Every partition of one table, in registration order. */
   inTable(table: SimGlueTable): readonly SimGluePartition[] {
     return this.#of(table).all;
+  }
+
+  /**
+   * Every partition of one table an `Expression` matches.
+   *
+   * The expression is read against the table, since which names are partition
+   * keys and how each one's values are ordered are properties of the table
+   * rather than of the expression.
+   */
+  matching(
+    table: SimGlueTable,
+    expression: string | undefined,
+  ): readonly SimGluePartition[] {
+    const partitions = this.inTable(table);
+
+    if (expression === undefined) {
+      return partitions;
+    }
+
+    const holds = simGluePartitionExpressionFilter(
+      expression,
+      table.partitionKeys,
+    );
+
+    return partitions.filter((partition) => holds(partition.values));
   }
 
   #of(table: SimGlueTable): SimGlueTablePartitions {

--- a/src/service/glue/expression/sim-glue-decimal.ts
+++ b/src/service/glue/expression/sim-glue-decimal.ts
@@ -1,0 +1,100 @@
+/**
+ * A number written out, kept as the digits it was written with.
+ *
+ * Reading one through `Number` loses whatever will not fit in a double, so
+ * `9007199254740993` becomes `9007199254740992` and compares equal to it. A
+ * partition key declared `bigint` can hold either, and a catalog answering
+ * that they are the same partition is wrong in a way a test would trust.
+ */
+export interface SimGlueDecimal {
+  readonly negative: boolean;
+  readonly whole: string;
+  readonly fraction: string;
+}
+
+/** Read a number written out, or nothing where the text is not one. */
+export function simGlueDecimal(text: string): SimGlueDecimal | undefined {
+  const trimmed = text.trim();
+  const negative = trimmed.startsWith("-");
+  const digits = negative ? trimmed.slice(1) : trimmed;
+  const point = digits.indexOf(".");
+  const whole = point === -1 ? digits : digits.slice(0, point);
+  const fraction = point === -1 ? "" : digits.slice(point + 1);
+
+  if (!isDigits(whole) || (point !== -1 && !isDigits(fraction))) {
+    return undefined;
+  }
+
+  return { negative, whole, fraction };
+}
+
+/**
+ * How two numbers sit against each other, exactly.
+ *
+ * Negative, zero or positive, the way a sort comparator reports it. Zero has
+ * no sign here, so `-0` and `0` are the same number.
+ */
+export function simGlueCompareDecimals(
+  left: SimGlueDecimal,
+  right: SimGlueDecimal,
+): number {
+  const magnitude = compareMagnitudes(left, right);
+
+  if (magnitude === 0 && isZero(left)) {
+    return 0;
+  }
+
+  if (left.negative !== right.negative) {
+    return left.negative ? -1 : 1;
+  }
+
+  return left.negative ? -magnitude : magnitude;
+}
+
+/** How two numbers sit against each other with their signs set aside. */
+function compareMagnitudes(
+  left: SimGlueDecimal,
+  right: SimGlueDecimal,
+): number {
+  const whole = compareDigits(
+    stripLeadingZeros(left.whole),
+    stripLeadingZeros(right.whole),
+  );
+
+  if (whole !== 0) {
+    return whole;
+  }
+
+  const width = Math.max(left.fraction.length, right.fraction.length);
+
+  return compareDigits(
+    left.fraction.padEnd(width, "0"),
+    right.fraction.padEnd(width, "0"),
+  );
+}
+
+/**
+ * Two runs of digits compared as numbers.
+ *
+ * The longer run is the larger number once leading zeros are gone, and two of
+ * the same length compare character by character.
+ */
+function compareDigits(left: string, right: string): number {
+  if (left.length !== right.length) {
+    return left.length - right.length;
+  }
+
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function stripLeadingZeros(digits: string): string {
+  return digits.replace(/^0+(?=.)/, "");
+}
+
+function isZero(value: SimGlueDecimal): boolean {
+  return !/[1-9]/.test(value.whole + value.fraction);
+}
+
+function isDigits(text: string): boolean {
+  return text.length > 0 && !/\D/.test(text);
+}

--- a/src/service/glue/expression/sim-glue-expression-cursor.ts
+++ b/src/service/glue/expression/sim-glue-expression-cursor.ts
@@ -1,0 +1,96 @@
+import {
+  simGlueExpressionAt,
+  simGlueExpressionError,
+} from "./sim-glue-expression-error.js";
+import type { SimGlueExpressionToken } from "./sim-glue-expression-token.js";
+import { simGlueExpressionTokens } from "./sim-glue-expression-tokeniser.js";
+
+/**
+ * A parser's place in the tokens of one expression.
+ *
+ * The parser reads forwards and never goes back, so how far along it is, and
+ * what happens when it runs out, live here.
+ */
+export class SimGlueExpressionCursor {
+  readonly #tokens: readonly SimGlueExpressionToken[];
+  #position = 0;
+
+  constructor(expression: string) {
+    this.#tokens = simGlueExpressionTokens(expression);
+  }
+
+  /** Whether every token has been read. */
+  get atEnd(): boolean {
+    return this.#position >= this.#tokens.length;
+  }
+
+  /** The next token, without reading it. */
+  peek(): SimGlueExpressionToken | undefined {
+    return this.#tokens.at(this.#position);
+  }
+
+  /** Read the next token, refusing an expression that has run out. */
+  next(expected: string): SimGlueExpressionToken {
+    const upcoming = this.peek();
+
+    if (upcoming === undefined) {
+      throw this.error(`${expected} was expected`);
+    }
+
+    this.#position += 1;
+
+    return upcoming;
+  }
+
+  /** Read the next token when it is this symbol, and leave it otherwise. */
+  takeSymbol(text: string): boolean {
+    return this.#take("symbol", text, false);
+  }
+
+  /**
+   * Read the next token when it is this keyword, and leave it otherwise.
+   *
+   * A keyword arrives as a name, since that is what it looks like. Glue reads
+   * them whatever case they are written in, and so does this.
+   */
+  takeKeyword(word: string): boolean {
+    return this.#take("name", word, true);
+  }
+
+  /** Read a symbol the expression has to carry here. */
+  expectSymbol(text: string): void {
+    if (!this.takeSymbol(text)) {
+      throw this.error(`'${text}' was expected`);
+    }
+  }
+
+  /** Read a keyword the expression has to carry here. */
+  expectKeyword(word: string): void {
+    if (!this.takeKeyword(word)) {
+      throw this.error(`${word} was expected`);
+    }
+  }
+
+  /** Build the error this expression is refused with, saying where it is. */
+  error(reason: string): Error {
+    return simGlueExpressionError(reason, simGlueExpressionAt(this.peek()));
+  }
+
+  #take(kind: "name" | "symbol", text: string, fold: boolean): boolean {
+    const candidate = this.peek();
+
+    if (candidate?.kind !== kind) {
+      return false;
+    }
+
+    const written = fold ? candidate.text.toUpperCase() : candidate.text;
+
+    if (written !== text) {
+      return false;
+    }
+
+    this.#position += 1;
+
+    return true;
+  }
+}

--- a/src/service/glue/expression/sim-glue-expression-error.ts
+++ b/src/service/glue/expression/sim-glue-expression-error.ts
@@ -1,0 +1,32 @@
+import { SimGlueInvalidInputException } from "../error/sim-glue.error.js";
+import type { SimGlueExpressionToken } from "./sim-glue-expression-token.js";
+
+/**
+ * Build the error a `GetPartitions` `Expression` is refused with.
+ *
+ * Every refusal says where reading stopped. An expression is written by hand
+ * far more often than a partition is, and a message naming only the problem
+ * leaves the caller counting brackets.
+ */
+export function simGlueExpressionError(
+  reason: string,
+  where: string,
+): SimGlueInvalidInputException {
+  return new SimGlueInvalidInputException(
+    `Invalid Expression: ${reason}, ${where}`,
+  );
+}
+
+/** Where a token sits, as a refusal says it. */
+export function simGlueExpressionAt(
+  token: SimGlueExpressionToken | undefined,
+): string {
+  return token === undefined
+    ? "at the end of the expression"
+    : simGlueExpressionAtPosition(token.position);
+}
+
+/** Where reading stopped, as a refusal says it. */
+export function simGlueExpressionAtPosition(position: number): string {
+  return `at position ${String(position)}`;
+}

--- a/src/service/glue/expression/sim-glue-expression-literal-reader.ts
+++ b/src/service/glue/expression/sim-glue-expression-literal-reader.ts
@@ -1,0 +1,104 @@
+import {
+  simGlueExpressionAtPosition,
+  simGlueExpressionError,
+} from "./sim-glue-expression-error.js";
+import type { SimGlueExpressionTokenRead } from "./sim-glue-expression-token-reader.js";
+
+/**
+ * Read a string literal.
+ *
+ * A doubled quote inside one is an escaped quote, which is how both Glue and
+ * ANSI SQL write it.
+ */
+export function simGlueReadExpressionString(
+  expression: string,
+  position: number,
+): SimGlueExpressionTokenRead {
+  let cursor = position + 1;
+  let text = "";
+
+  while (cursor < expression.length) {
+    const character = expression.charAt(cursor);
+
+    if (character !== "'") {
+      text += character;
+      cursor += 1;
+      continue;
+    }
+
+    if (expression.charAt(cursor + 1) === "'") {
+      text += "'";
+      cursor += 2;
+      continue;
+    }
+
+    return { token: { kind: "string", text, position }, next: cursor + 1 };
+  }
+
+  throw simGlueExpressionError(
+    "a string literal was opened and never closed",
+    simGlueExpressionAtPosition(position),
+  );
+}
+
+/**
+ * Whether a number starts here.
+ *
+ * A minus sign begins one when a digit follows it. This grammar has no
+ * arithmetic, so a minus anywhere else is a character it cannot read.
+ */
+export function simGlueExpressionStartsNumber(
+  expression: string,
+  position: number,
+): boolean {
+  const character = expression.charAt(position);
+
+  if (isDigit(expression, position)) {
+    return true;
+  }
+
+  return character === "-" && isDigit(expression, position + 1);
+}
+
+/**
+ * Read a number literal, which may be negative and may have a fraction.
+ *
+ * A dot is part of the number only where a digit follows it, so `1.` reads as
+ * the number 1 and then a character this grammar refuses.
+ */
+export function simGlueReadExpressionNumber(
+  expression: string,
+  position: number,
+): SimGlueExpressionTokenRead {
+  const signed = expression.charAt(position) === "-" ? position + 1 : position;
+  let cursor = digitsEnd(expression, signed);
+
+  if (expression.charAt(cursor) === "." && isDigit(expression, cursor + 1)) {
+    cursor = digitsEnd(expression, cursor + 1);
+  }
+
+  return {
+    token: {
+      kind: "number",
+      text: expression.slice(position, cursor),
+      position,
+    },
+    next: cursor,
+  };
+}
+
+/** Where the run of digits starting here ends. */
+function digitsEnd(expression: string, from: number): number {
+  let cursor = from;
+
+  while (isDigit(expression, cursor)) {
+    cursor += 1;
+  }
+
+  return cursor;
+}
+
+/** Whether the character here is a digit. */
+function isDigit(expression: string, position: number): boolean {
+  return /[0-9]/.test(expression.charAt(position));
+}

--- a/src/service/glue/expression/sim-glue-expression-symbol-reader.ts
+++ b/src/service/glue/expression/sim-glue-expression-symbol-reader.ts
@@ -1,0 +1,47 @@
+import {
+  simGlueExpressionAtPosition,
+  simGlueExpressionError,
+} from "./sim-glue-expression-error.js";
+import type { SimGlueExpressionTokenRead } from "./sim-glue-expression-token-reader.js";
+
+/** The two-character operators, read before the one-character ones. */
+const longSymbols = ["<>", "!=", "<=", ">="];
+
+/** The one-character symbols this grammar uses. */
+const shortSymbols = new Set(["=", "<", ">", "(", ")", ","]);
+
+/**
+ * Read a comparison operator, a bracket or a comma.
+ *
+ * `<=` is read before `<`, since reading the shorter one first would leave an
+ * `=` behind and refuse the expression for holding one too many.
+ */
+export function simGlueReadExpressionSymbol(
+  expression: string,
+  position: number,
+): SimGlueExpressionTokenRead {
+  const long = longSymbols.find((symbol) =>
+    expression.startsWith(symbol, position),
+  );
+
+  if (long !== undefined) {
+    return {
+      token: { kind: "symbol", text: long, position },
+      next: position + long.length,
+    };
+  }
+
+  const character = expression.charAt(position);
+
+  if (shortSymbols.has(character)) {
+    return {
+      token: { kind: "symbol", text: character, position },
+      next: position + 1,
+    };
+  }
+
+  throw simGlueExpressionError(
+    `'${character}' is not something an expression can hold`,
+    simGlueExpressionAtPosition(position),
+  );
+}

--- a/src/service/glue/expression/sim-glue-expression-token-reader.ts
+++ b/src/service/glue/expression/sim-glue-expression-token-reader.ts
@@ -1,0 +1,60 @@
+import {
+  simGlueExpressionStartsNumber,
+  simGlueReadExpressionNumber,
+  simGlueReadExpressionString,
+} from "./sim-glue-expression-literal-reader.js";
+import { simGlueReadExpressionSymbol } from "./sim-glue-expression-symbol-reader.js";
+import type { SimGlueExpressionToken } from "./sim-glue-expression-token.js";
+
+/** Characters an unquoted column name or a keyword is made of. */
+const nameCharacter = /[A-Za-z0-9_]/;
+
+/** One token, with where reading carries on from. */
+export interface SimGlueExpressionTokenRead {
+  readonly token: SimGlueExpressionToken;
+  readonly next: number;
+}
+
+/**
+ * Read the one token starting here.
+ */
+export function simGlueReadExpressionToken(
+  expression: string,
+  position: number,
+): SimGlueExpressionTokenRead {
+  const character = expression.charAt(position);
+
+  if (character === "'") {
+    return simGlueReadExpressionString(expression, position);
+  }
+
+  if (simGlueExpressionStartsNumber(expression, position)) {
+    return simGlueReadExpressionNumber(expression, position);
+  }
+
+  if (nameCharacter.test(character)) {
+    return readName(expression, position);
+  }
+
+  return simGlueReadExpressionSymbol(expression, position);
+}
+
+/** Read a column name or a keyword, keeping the case it was written in. */
+function readName(
+  expression: string,
+  position: number,
+): SimGlueExpressionTokenRead {
+  let cursor = position;
+
+  while (
+    cursor < expression.length &&
+    nameCharacter.test(expression.charAt(cursor))
+  ) {
+    cursor += 1;
+  }
+
+  return {
+    token: { kind: "name", text: expression.slice(position, cursor), position },
+    next: cursor,
+  };
+}

--- a/src/service/glue/expression/sim-glue-expression-token.ts
+++ b/src/service/glue/expression/sim-glue-expression-token.ts
@@ -1,0 +1,23 @@
+/**
+ * What one piece of a `GetPartitions` `Expression` is.
+ *
+ * A string literal and a name are told apart here rather than by the parser,
+ * since `day` and `'day'` mean a column and a value.
+ */
+export type SimGlueExpressionTokenKind =
+  | "name"
+  | "string"
+  | "number"
+  | "symbol";
+
+/**
+ * One piece of a `GetPartitions` `Expression`.
+ *
+ * The position is where the token starts in the expression text, so a refusal
+ * can say where it stopped rather than only what was wrong.
+ */
+export interface SimGlueExpressionToken {
+  readonly kind: SimGlueExpressionTokenKind;
+  readonly text: string;
+  readonly position: number;
+}

--- a/src/service/glue/expression/sim-glue-expression-tokeniser.ts
+++ b/src/service/glue/expression/sim-glue-expression-tokeniser.ts
@@ -1,0 +1,37 @@
+import { simGlueExpressionError } from "./sim-glue-expression-error.js";
+import type { SimGlueExpressionToken } from "./sim-glue-expression-token.js";
+import { simGlueReadExpressionToken } from "./sim-glue-expression-token-reader.js";
+
+/**
+ * Read an `Expression` into the tokens a parser walks.
+ *
+ * Whitespace between tokens means nothing and is dropped here. Everything
+ * about what one token looks like belongs to the reader.
+ */
+export function simGlueExpressionTokens(
+  expression: string,
+): readonly SimGlueExpressionToken[] {
+  const tokens: SimGlueExpressionToken[] = [];
+  let position = 0;
+
+  while (position < expression.length) {
+    if (/\s/.test(expression.charAt(position))) {
+      position += 1;
+      continue;
+    }
+
+    const read = simGlueReadExpressionToken(expression, position);
+
+    tokens.push(read.token);
+    position = read.next;
+  }
+
+  if (tokens.length === 0) {
+    throw simGlueExpressionError(
+      "an expression with nothing in it filters nothing",
+      "at position 0",
+    );
+  }
+
+  return tokens;
+}

--- a/src/service/glue/expression/sim-glue-like-match.ts
+++ b/src/service/glue/expression/sim-glue-like-match.ts
@@ -1,0 +1,66 @@
+/**
+ * Whether a value matches a SQL `LIKE` pattern.
+ *
+ * `%` stands for any run of characters and `_` for exactly one. Everything
+ * else in the pattern matches itself.
+ *
+ * This walks both strings once, remembering where the last `%` was so it can
+ * come back and give it one more character. A regular expression built from
+ * the pattern would do the same job, and a pattern alternating wildcards with
+ * literals (`%a%a%a%ab`) would backtrack over every way of splitting the value
+ * between them. `GetPartitions` runs this against every partition of a table
+ * while the caller waits.
+ *
+ * Both are read as code points rather than as UTF-16 units, so `_` matches a
+ * character outside the basic plane whole rather than half of one.
+ */
+export function simGlueLikeMatches(value: string, pattern: string): boolean {
+  // A code point is the character SQL's `_` matches one of. Splitting further
+  // into grapheme clusters would make `_` match a family emoji, and splitting
+  // less would make it match half a character.
+  // oxlint-disable-next-line typescript/no-misused-spread
+  const text = [...value];
+  // oxlint-disable-next-line typescript/no-misused-spread
+  const wanted = [...pattern];
+
+  let read = 0;
+  let against = 0;
+  let wildcard = -1;
+  let resumed = 0;
+
+  while (read < text.length) {
+    if (matchesHere(text.at(read), wanted.at(against))) {
+      read += 1;
+      against += 1;
+    } else if (wanted.at(against) === "%") {
+      wildcard = against;
+      resumed = read;
+      against += 1;
+    } else if (wildcard === -1) {
+      return false;
+    } else {
+      resumed += 1;
+      read = resumed;
+      against = wildcard + 1;
+    }
+  }
+
+  return wanted.slice(against).every((character) => character === "%");
+}
+
+/**
+ * Whether the pattern character here takes the value character here.
+ *
+ * A pattern that has run out takes nothing, and the caller is still inside
+ * the value when it asks.
+ */
+function matchesHere(
+  character: string | undefined,
+  wanted: string | undefined,
+): boolean {
+  if (wanted === undefined) {
+    return false;
+  }
+
+  return wanted === "_" || wanted === character;
+}

--- a/src/service/glue/expression/sim-glue-partition-columns.ts
+++ b/src/service/glue/expression/sim-glue-partition-columns.ts
@@ -1,0 +1,86 @@
+import type { SimGlueColumn } from "../table/sim-glue-table-schema.js";
+
+/**
+ * How one partition key's values are put in order.
+ *
+ * A key typed as a number compares numerically, so `10` sorts above `9`.
+ * Everything else compares as text, which is what a date written the ISO way
+ * wants anyway.
+ */
+export type SimGluePartitionComparison = "number" | "text";
+
+/** The Glue column types whose values are ordered as numbers. */
+const numericTypes = new Set([
+  "byte",
+  "short",
+  "tinyint",
+  "smallint",
+  "int",
+  "integer",
+  "bigint",
+  "long",
+  "float",
+  "double",
+  "decimal",
+  "numeric",
+]);
+
+/** One partition key an expression may name. */
+export interface SimGluePartitionColumn {
+  readonly name: string;
+  readonly index: number;
+  readonly comparison: SimGluePartitionComparison;
+}
+
+/**
+ * The partition keys of one table, by the names an expression writes.
+ *
+ * A partition's values are positional, so what a column resolves to is the
+ * place its value sits in that list.
+ *
+ * Names are matched however they were written. Real Glue folds a column name
+ * to lower case when it stores one, and an expression naming `Day` reaches a
+ * key stored as `day`.
+ */
+export class SimGluePartitionColumns {
+  readonly #columns = new Map<string, SimGluePartitionColumn>();
+
+  constructor(partitionKeys: readonly SimGlueColumn[]) {
+    for (const [index, key] of partitionKeys.entries()) {
+      this.#columns.set(key.Name.toLowerCase(), {
+        name: key.Name,
+        index,
+        comparison: simGluePartitionComparison(key.Type),
+      });
+    }
+  }
+
+  /** Find a partition key by the name an expression wrote. */
+  find(name: string): SimGluePartitionColumn | undefined {
+    return this.#columns.get(name.toLowerCase());
+  }
+
+  /** Every partition key name, in the order the table declares them. */
+  get names(): readonly string[] {
+    return this.#columns
+      .values()
+      .map((column) => column.name)
+      .toArray();
+  }
+}
+
+/**
+ * How a column of this declared type compares.
+ *
+ * The type carries its parameters on real Glue, as `decimal(10,2)` does, so
+ * only the word in front of them is read.
+ */
+export function simGluePartitionComparison(
+  type: string | undefined,
+): SimGluePartitionComparison {
+  const declared = (type ?? "").trim().toLowerCase();
+  const bracket = declared.indexOf("(");
+  const named = bracket === -1 ? declared : declared.slice(0, bracket);
+
+  return numericTypes.has(named) ? "number" : "text";
+}

--- a/src/service/glue/expression/sim-glue-partition-comparisons.ts
+++ b/src/service/glue/expression/sim-glue-partition-comparisons.ts
@@ -1,0 +1,52 @@
+import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
+import type { SimGluePartitionFilter } from "./sim-glue-partition-filter.js";
+import type { SimGluePartitionLiteral } from "./sim-glue-partition-literal.js";
+import {
+  simGlueAtLeast,
+  simGlueAtMost,
+  simGlueColumnValue,
+  simGlueEqual,
+  simGluePartitionOrder,
+  type SimGlueOrderTest,
+} from "./sim-glue-partition-order.js";
+
+/** A filter putting one partition key against one literal. */
+export function simGlueComparisonFilter(
+  column: SimGluePartitionColumn,
+  holds: SimGlueOrderTest,
+  literal: SimGluePartitionLiteral,
+): SimGluePartitionFilter {
+  return (values): boolean => {
+    const placed = simGluePartitionOrder(
+      column,
+      simGlueColumnValue(column, values),
+      literal,
+    );
+
+    return placed === undefined ? false : holds(placed);
+  };
+}
+
+/** A filter holding for a key between two literals, both ends included. */
+export function simGlueBetweenFilter(
+  column: SimGluePartitionColumn,
+  lower: SimGluePartitionLiteral,
+  upper: SimGluePartitionLiteral,
+): SimGluePartitionFilter {
+  const atLeast = simGlueComparisonFilter(column, simGlueAtLeast, lower);
+  const atMost = simGlueComparisonFilter(column, simGlueAtMost, upper);
+
+  return (values): boolean => atLeast(values) && atMost(values);
+}
+
+/** A filter holding for a key equal to any one of these literals. */
+export function simGlueInFilter(
+  column: SimGluePartitionColumn,
+  literals: readonly SimGluePartitionLiteral[],
+): SimGluePartitionFilter {
+  const equals = literals.map((literal) =>
+    simGlueComparisonFilter(column, simGlueEqual, literal),
+  );
+
+  return (values): boolean => equals.some((holds) => holds(values));
+}

--- a/src/service/glue/expression/sim-glue-partition-expression-parser.ts
+++ b/src/service/glue/expression/sim-glue-partition-expression-parser.ts
@@ -1,0 +1,93 @@
+import { SimGlueExpressionCursor } from "./sim-glue-expression-cursor.js";
+import type { SimGluePartitionColumns } from "./sim-glue-partition-columns.js";
+import {
+  simGlueAllOf,
+  simGlueAnyOf,
+  simGlueNotFilter,
+  type SimGluePartitionFilter,
+} from "./sim-glue-partition-filter.js";
+import { SimGluePartitionOperands } from "./sim-glue-partition-operands.js";
+import { SimGluePartitionTermParser } from "./sim-glue-partition-term-parser.js";
+
+/**
+ * Reads a `GetPartitions` `Expression` into the filter it asks for.
+ *
+ * The grammar is the SQL one, with the precedence SQL gives it. `NOT` binds
+ * tightest, then `AND`, then `OR`, so `a = '1' OR b = '2' AND c = '3'` reads
+ * as `a = '1' OR (b = '2' AND c = '3')`. Brackets say something else.
+ */
+export class SimGluePartitionExpressionParser {
+  readonly #cursor: SimGlueExpressionCursor;
+  readonly #terms: SimGluePartitionTermParser;
+
+  constructor(expression: string, columns: SimGluePartitionColumns) {
+    const cursor = new SimGlueExpressionCursor(expression);
+
+    this.#cursor = cursor;
+    this.#terms = new SimGluePartitionTermParser({
+      cursor,
+      operands: new SimGluePartitionOperands({ cursor, columns }),
+    });
+  }
+
+  /** Read the whole expression, refusing anything left over after it. */
+  parse(): SimGluePartitionFilter {
+    const filter = this.#either();
+
+    this.#assertNothingFollows();
+
+    return filter;
+  }
+
+  /** Refuse an expression that was complete and then carried on. */
+  #assertNothingFollows(): void {
+    if (!this.#cursor.atEnd) {
+      throw this.#cursor.error(
+        "the expression was complete and then carried on",
+      );
+    }
+  }
+
+  /** Read one or more `AND` groups joined by `OR`. */
+  #either(): SimGluePartitionFilter {
+    const filters = [this.#both()];
+
+    while (this.#cursor.takeKeyword("OR")) {
+      filters.push(this.#both());
+    }
+
+    return simGlueAnyOf(filters);
+  }
+
+  /** Read one or more terms joined by `AND`. */
+  #both(): SimGluePartitionFilter {
+    const filters = [this.#negated()];
+
+    while (this.#cursor.takeKeyword("AND")) {
+      filters.push(this.#negated());
+    }
+
+    return simGlueAllOf(filters);
+  }
+
+  /** Read a term, or a `NOT` in front of one. */
+  #negated(): SimGluePartitionFilter {
+    if (this.#cursor.takeKeyword("NOT")) {
+      return simGlueNotFilter(this.#negated());
+    }
+
+    return this.#grouped();
+  }
+
+  /** Read a bracketed expression, or one plain term. */
+  #grouped(): SimGluePartitionFilter {
+    if (!this.#cursor.takeSymbol("(")) {
+      return this.#terms.parse();
+    }
+
+    const filter = this.#either();
+    this.#cursor.expectSymbol(")");
+
+    return filter;
+  }
+}

--- a/src/service/glue/expression/sim-glue-partition-expression.ts
+++ b/src/service/glue/expression/sim-glue-partition-expression.ts
@@ -1,0 +1,22 @@
+import type { SimGlueColumn } from "../table/sim-glue-table-schema.js";
+import { SimGluePartitionColumns } from "./sim-glue-partition-columns.js";
+import { SimGluePartitionExpressionParser } from "./sim-glue-partition-expression-parser.js";
+import type { SimGluePartitionFilter } from "./sim-glue-partition-filter.js";
+
+/**
+ * Read a `GetPartitions` `Expression` against the table it filters.
+ *
+ * The table is needed to read the expression at all. Which names are partition
+ * keys and how each one's values are ordered are both properties of the table,
+ * so an expression naming a column the table lacks is refused here rather than
+ * matching nothing.
+ */
+export function simGluePartitionExpressionFilter(
+  expression: string,
+  partitionKeys: readonly SimGlueColumn[],
+): SimGluePartitionFilter {
+  return new SimGluePartitionExpressionParser(
+    expression,
+    new SimGluePartitionColumns(partitionKeys),
+  ).parse();
+}

--- a/src/service/glue/expression/sim-glue-partition-filter.ts
+++ b/src/service/glue/expression/sim-glue-partition-filter.ts
@@ -1,0 +1,29 @@
+/**
+ * What a `GetPartitions` `Expression` comes to once it has been read.
+ *
+ * A filter answers for one partition's values, in the order the table declares
+ * its partition keys. Everything a refusal could catch is caught while the
+ * expression is read, so a filter only ever answers yes or no.
+ */
+export type SimGluePartitionFilter = (values: readonly string[]) => boolean;
+
+/** A filter holding only where every one of these holds. */
+export function simGlueAllOf(
+  filters: readonly SimGluePartitionFilter[],
+): SimGluePartitionFilter {
+  return (values): boolean => filters.every((filter) => filter(values));
+}
+
+/** A filter holding where any one of these holds. */
+export function simGlueAnyOf(
+  filters: readonly SimGluePartitionFilter[],
+): SimGluePartitionFilter {
+  return (values): boolean => filters.some((filter) => filter(values));
+}
+
+/** A filter holding exactly where this one does not. */
+export function simGlueNotFilter(
+  filter: SimGluePartitionFilter,
+): SimGluePartitionFilter {
+  return (values): boolean => !filter(values);
+}

--- a/src/service/glue/expression/sim-glue-partition-like.ts
+++ b/src/service/glue/expression/sim-glue-partition-like.ts
@@ -1,56 +1,20 @@
+import { simGlueLikeMatches } from "./sim-glue-like-match.js";
 import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
 import type { SimGluePartitionFilter } from "./sim-glue-partition-filter.js";
 import type { SimGluePartitionLiteral } from "./sim-glue-partition-literal.js";
 import { simGlueColumnValue } from "./sim-glue-partition-order.js";
 
 /**
- * The pattern characters, and the ones a regular expression would read as
- * something other than themselves.
- */
-const likeOrSpecial = /[%_]|[.*+?^${}()|[\]\\]/g;
-
-/**
  * A filter holding where a key matches a SQL `LIKE` pattern.
  *
- * `%` stands for any run of characters and `_` for exactly one, which is what
- * they mean in SQL. Everything else in the pattern matches itself.
- *
- * The pattern is matched against the value as it was stored, whatever type the
- * key is declared with. `LIKE` is a test on text, and a numeric key compared
- * this way is compared as the text it was registered as.
+ * The pattern is matched against the value as it was stored, whatever type
+ * the key is declared with. `LIKE` is a test on text, and a numeric key
+ * compared this way is compared as the text it was registered as.
  */
 export function simGlueLikeFilter(
   column: SimGluePartitionColumn,
   pattern: SimGluePartitionLiteral,
 ): SimGluePartitionFilter {
-  const matcher = simGlueLikePattern(pattern.text);
-
-  return (values): boolean => matcher.test(simGlueColumnValue(column, values));
-}
-
-/**
- * Turn a `LIKE` pattern into the expression that matches it.
- *
- * A run of `%` collapses to one. `%%%` asks the same thing as `%`, and the
- * expression it would otherwise build backtracks over every way of splitting
- * the value between them.
- */
-export function simGlueLikePattern(pattern: string): RegExp {
-  const source = pattern
-    .replaceAll(likeOrSpecial, (match) => simGlueLikeCharacter(match))
-    .replaceAll(/(?:\.\*)+/g, ".*");
-
-  // The pattern comes from the caller's expression, and this is what LIKE is.
-  // Every character that is not a wildcard has been escaped to match itself.
-  // oxlint-disable-next-line security/detect-non-literal-regexp
-  return new RegExp(`^${source}$`, "s");
-}
-
-/** What one pattern or special character becomes. */
-function simGlueLikeCharacter(character: string): string {
-  if (character === "%") {
-    return ".*";
-  }
-
-  return character === "_" ? "." : `\\${character}`;
+  return (values): boolean =>
+    simGlueLikeMatches(simGlueColumnValue(column, values), pattern.text);
 }

--- a/src/service/glue/expression/sim-glue-partition-like.ts
+++ b/src/service/glue/expression/sim-glue-partition-like.ts
@@ -1,0 +1,56 @@
+import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
+import type { SimGluePartitionFilter } from "./sim-glue-partition-filter.js";
+import type { SimGluePartitionLiteral } from "./sim-glue-partition-literal.js";
+import { simGlueColumnValue } from "./sim-glue-partition-order.js";
+
+/**
+ * The pattern characters, and the ones a regular expression would read as
+ * something other than themselves.
+ */
+const likeOrSpecial = /[%_]|[.*+?^${}()|[\]\\]/g;
+
+/**
+ * A filter holding where a key matches a SQL `LIKE` pattern.
+ *
+ * `%` stands for any run of characters and `_` for exactly one, which is what
+ * they mean in SQL. Everything else in the pattern matches itself.
+ *
+ * The pattern is matched against the value as it was stored, whatever type the
+ * key is declared with. `LIKE` is a test on text, and a numeric key compared
+ * this way is compared as the text it was registered as.
+ */
+export function simGlueLikeFilter(
+  column: SimGluePartitionColumn,
+  pattern: SimGluePartitionLiteral,
+): SimGluePartitionFilter {
+  const matcher = simGlueLikePattern(pattern.text);
+
+  return (values): boolean => matcher.test(simGlueColumnValue(column, values));
+}
+
+/**
+ * Turn a `LIKE` pattern into the expression that matches it.
+ *
+ * A run of `%` collapses to one. `%%%` asks the same thing as `%`, and the
+ * expression it would otherwise build backtracks over every way of splitting
+ * the value between them.
+ */
+export function simGlueLikePattern(pattern: string): RegExp {
+  const source = pattern
+    .replaceAll(likeOrSpecial, (match) => simGlueLikeCharacter(match))
+    .replaceAll(/(?:\.\*)+/g, ".*");
+
+  // The pattern comes from the caller's expression, and this is what LIKE is.
+  // Every character that is not a wildcard has been escaped to match itself.
+  // oxlint-disable-next-line security/detect-non-literal-regexp
+  return new RegExp(`^${source}$`, "s");
+}
+
+/** What one pattern or special character becomes. */
+function simGlueLikeCharacter(character: string): string {
+  if (character === "%") {
+    return ".*";
+  }
+
+  return character === "_" ? "." : `\\${character}`;
+}

--- a/src/service/glue/expression/sim-glue-partition-literal.ts
+++ b/src/service/glue/expression/sim-glue-partition-literal.ts
@@ -1,0 +1,54 @@
+import { simGlueExpressionError } from "./sim-glue-expression-error.js";
+import type { SimGlueExpressionToken } from "./sim-glue-expression-token.js";
+import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
+
+/**
+ * A literal an expression compares a partition key against.
+ *
+ * Both readings are kept. Which one a comparison uses follows the column's
+ * declared type, and `LIKE` matches the text of a value whatever that type is.
+ */
+export interface SimGluePartitionLiteral {
+  readonly text: string;
+  readonly numeric: number;
+}
+
+/**
+ * Read a literal an expression compares a column against.
+ *
+ * A column declared as a number is held to a literal that is one. Comparing it
+ * against `'today'` can hold for no partition, and answering with an empty
+ * list would read as a table that happens to have none.
+ */
+export function simGluePartitionLiteral(
+  column: SimGluePartitionColumn,
+  token: SimGlueExpressionToken,
+  where: string,
+): SimGluePartitionLiteral {
+  if (token.kind !== "string" && token.kind !== "number") {
+    throw simGlueExpressionError(
+      `a value was expected for ${column.name}, and '${token.text}' is not one`,
+      where,
+    );
+  }
+
+  const numeric = simGlueNumericValue(token.text);
+
+  if (column.comparison === "number" && Number.isNaN(numeric)) {
+    throw simGlueExpressionError(
+      `${column.name} is declared as a number, and '${token.text}' is not one`,
+      where,
+    );
+  }
+
+  return { text: token.text, numeric };
+}
+
+/**
+ * What a stored partition value reads as when its key is a number.
+ *
+ * An empty value is not a number, which `Number` alone reads as zero.
+ */
+export function simGlueNumericValue(text: string): number {
+  return text.trim() === "" ? NaN : Number(text);
+}

--- a/src/service/glue/expression/sim-glue-partition-literal.ts
+++ b/src/service/glue/expression/sim-glue-partition-literal.ts
@@ -1,3 +1,4 @@
+import { simGlueDecimal, type SimGlueDecimal } from "./sim-glue-decimal.js";
 import { simGlueExpressionError } from "./sim-glue-expression-error.js";
 import type { SimGlueExpressionToken } from "./sim-glue-expression-token.js";
 import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
@@ -10,7 +11,7 @@ import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
  */
 export interface SimGluePartitionLiteral {
   readonly text: string;
-  readonly numeric: number;
+  readonly decimal: SimGlueDecimal | undefined;
 }
 
 /**
@@ -32,23 +33,14 @@ export function simGluePartitionLiteral(
     );
   }
 
-  const numeric = simGlueNumericValue(token.text);
+  const decimal = simGlueDecimal(token.text);
 
-  if (column.comparison === "number" && Number.isNaN(numeric)) {
+  if (decimal === undefined && column.comparison === "number") {
     throw simGlueExpressionError(
       `${column.name} is declared as a number, and '${token.text}' is not one`,
       where,
     );
   }
 
-  return { text: token.text, numeric };
-}
-
-/**
- * What a stored partition value reads as when its key is a number.
- *
- * An empty value is not a number, which `Number` alone reads as zero.
- */
-export function simGlueNumericValue(text: string): number {
-  return text.trim() === "" ? NaN : Number(text);
+  return { text: token.text, decimal };
 }

--- a/src/service/glue/expression/sim-glue-partition-operands.ts
+++ b/src/service/glue/expression/sim-glue-partition-operands.ts
@@ -1,0 +1,98 @@
+import type { SimGlueExpressionCursor } from "./sim-glue-expression-cursor.js";
+import { simGlueExpressionAt } from "./sim-glue-expression-error.js";
+import type {
+  SimGluePartitionColumn,
+  SimGluePartitionColumns,
+} from "./sim-glue-partition-columns.js";
+import {
+  simGluePartitionLiteral,
+  type SimGluePartitionLiteral,
+} from "./sim-glue-partition-literal.js";
+import {
+  simGlueComparisonTest,
+  type SimGlueOrderTest,
+} from "./sim-glue-partition-order.js";
+
+interface SimGluePartitionOperandsProperties {
+  readonly cursor: SimGlueExpressionCursor;
+  readonly columns: SimGluePartitionColumns;
+}
+
+/**
+ * The pieces a term is written out of.
+ *
+ * A partition key, an operator and a literal are read the same way wherever
+ * they appear, and what a term does with them is the parser's business.
+ */
+export class SimGluePartitionOperands {
+  readonly #cursor: SimGlueExpressionCursor;
+  readonly #columns: SimGluePartitionColumns;
+
+  constructor(properties: SimGluePartitionOperandsProperties) {
+    this.#cursor = properties.cursor;
+    this.#columns = properties.columns;
+  }
+
+  /** Read a partition key, refusing one the table does not declare. */
+  column(): SimGluePartitionColumn {
+    const token = this.#cursor.next("a partition key");
+
+    if (token.kind !== "name") {
+      throw this.#cursor.error(
+        `a partition key was expected, and '${token.text}' is not a name`,
+      );
+    }
+
+    const column = this.#columns.find(token.text);
+
+    if (column === undefined) {
+      throw this.#cursor.error(
+        `${token.text} is not a partition key of this table, which is ` +
+          `partitioned by ${this.#columns.names.join(", ")}`,
+      );
+    }
+
+    return column;
+  }
+
+  /** Read one comparison operator, and the test it makes. */
+  comparator(): SimGlueOrderTest {
+    const token = this.#cursor.next("a comparison operator");
+    const holds =
+      token.kind === "symbol" ? simGlueComparisonTest(token.text) : undefined;
+
+    if (holds === undefined) {
+      throw this.#cursor.error(`'${token.text}' is not a comparison operator`);
+    }
+
+    return holds;
+  }
+
+  /** Read one literal, held to the type its column is declared with. */
+  literal(column: SimGluePartitionColumn): SimGluePartitionLiteral {
+    const token = this.#cursor.next(`a value for ${column.name}`);
+
+    return simGluePartitionLiteral(
+      column,
+      token,
+      simGlueExpressionAt(this.#cursor.peek()),
+    );
+  }
+
+  /** Read `(a, b, c)`, the values an `IN` accepts. */
+  literalList(
+    column: SimGluePartitionColumn,
+  ): readonly SimGluePartitionLiteral[] {
+    this.#cursor.expectSymbol("(");
+
+    const literals = [this.literal(column)];
+
+    while (this.#cursor.takeSymbol(",")) {
+      literals.push(this.literal(column));
+    }
+
+    this.#cursor.expectSymbol(")");
+
+    return literals;
+  }
+}

--- a/src/service/glue/expression/sim-glue-partition-order.ts
+++ b/src/service/glue/expression/sim-glue-partition-order.ts
@@ -1,0 +1,72 @@
+import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
+import {
+  simGlueNumericValue,
+  type SimGluePartitionLiteral,
+} from "./sim-glue-partition-literal.js";
+
+/**
+ * What one operator asks of the order between a stored value and a literal.
+ *
+ * The order is negative, zero or positive, the way a sort comparator reports
+ * one, and each operator is the question it asks about that number.
+ */
+export type SimGlueOrderTest = (placed: number) => boolean;
+
+/** The test `=` and an `IN` entry make. */
+export const simGlueEqual: SimGlueOrderTest = (placed): boolean => placed === 0;
+
+/** The test the lower end of a `BETWEEN` makes. */
+export const simGlueAtLeast: SimGlueOrderTest = (placed): boolean =>
+  placed >= 0;
+
+/** The test the upper end of a `BETWEEN` makes. */
+export const simGlueAtMost: SimGlueOrderTest = (placed): boolean => placed <= 0;
+
+/** The operator an expression writes, and the test it makes. */
+const comparisons = new Map<string, SimGlueOrderTest>([
+  ["=", simGlueEqual],
+  ["<>", (placed): boolean => placed !== 0],
+  ["!=", (placed): boolean => placed !== 0],
+  ["<", (placed): boolean => placed < 0],
+  ["<=", simGlueAtMost],
+  [">", (placed): boolean => placed > 0],
+  [">=", simGlueAtLeast],
+]);
+
+/** The test one written operator makes, or nothing where it is not one. */
+export function simGlueComparisonTest(
+  operator: string,
+): SimGlueOrderTest | undefined {
+  return comparisons.get(operator);
+}
+
+/** The value of one partition key, in a partition's positional values. */
+export function simGlueColumnValue(
+  column: SimGluePartitionColumn,
+  values: readonly string[],
+): string {
+  return values[column.index] ?? "";
+}
+
+/**
+ * How one stored value sits against a literal, or `undefined` where the two
+ * cannot be put in order.
+ *
+ * A key declared as a number whose stored value is not one has no place in a
+ * numeric order. It matches nothing rather than failing the request, since the
+ * partition was registered with that value and reading the table should still
+ * answer.
+ */
+export function simGluePartitionOrder(
+  column: SimGluePartitionColumn,
+  stored: string,
+  literal: SimGluePartitionLiteral,
+): number | undefined {
+  if (column.comparison === "text") {
+    return stored < literal.text ? -1 : stored > literal.text ? 1 : 0;
+  }
+
+  const value = simGlueNumericValue(stored);
+
+  return Number.isNaN(value) ? undefined : value - literal.numeric;
+}

--- a/src/service/glue/expression/sim-glue-partition-order.ts
+++ b/src/service/glue/expression/sim-glue-partition-order.ts
@@ -1,8 +1,6 @@
 import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
-import {
-  simGlueNumericValue,
-  type SimGluePartitionLiteral,
-} from "./sim-glue-partition-literal.js";
+import { simGlueCompareDecimals, simGlueDecimal } from "./sim-glue-decimal.js";
+import type { SimGluePartitionLiteral } from "./sim-glue-partition-literal.js";
 
 /**
  * What one operator asks of the order between a stored value and a literal.
@@ -66,7 +64,11 @@ export function simGluePartitionOrder(
     return stored < literal.text ? -1 : stored > literal.text ? 1 : 0;
   }
 
-  const value = simGlueNumericValue(stored);
+  const value = simGlueDecimal(stored);
 
-  return Number.isNaN(value) ? undefined : value - literal.numeric;
+  if (value === undefined || literal.decimal === undefined) {
+    return undefined;
+  }
+
+  return simGlueCompareDecimals(value, literal.decimal);
 }

--- a/src/service/glue/expression/sim-glue-partition-term-parser.ts
+++ b/src/service/glue/expression/sim-glue-partition-term-parser.ts
@@ -1,0 +1,81 @@
+import type { SimGlueExpressionCursor } from "./sim-glue-expression-cursor.js";
+import type { SimGluePartitionColumn } from "./sim-glue-partition-columns.js";
+import {
+  simGlueBetweenFilter,
+  simGlueComparisonFilter,
+  simGlueInFilter,
+} from "./sim-glue-partition-comparisons.js";
+import {
+  simGlueNotFilter,
+  type SimGluePartitionFilter,
+} from "./sim-glue-partition-filter.js";
+import { simGlueLikeFilter } from "./sim-glue-partition-like.js";
+import type { SimGluePartitionOperands } from "./sim-glue-partition-operands.js";
+
+interface SimGluePartitionTermParserProperties {
+  readonly cursor: SimGlueExpressionCursor;
+  readonly operands: SimGluePartitionOperands;
+}
+
+/**
+ * Reads one test an expression makes against one partition key.
+ *
+ * A term is a key, an operator and what the operator takes. `NOT` in front of
+ * `LIKE`, `IN` or `BETWEEN` reverses the term it belongs to. That is a
+ * different thing from the `NOT` reversing a whole bracketed group, which the
+ * expression parser reads.
+ */
+export class SimGluePartitionTermParser {
+  readonly #cursor: SimGlueExpressionCursor;
+  readonly #operands: SimGluePartitionOperands;
+
+  constructor(properties: SimGluePartitionTermParserProperties) {
+    this.#cursor = properties.cursor;
+    this.#operands = properties.operands;
+  }
+
+  /** Read one term. */
+  parse(): SimGluePartitionFilter {
+    const column = this.#operands.column();
+    const negated = this.#cursor.takeKeyword("NOT");
+    const filter = this.#operation(column, negated);
+
+    return negated ? simGlueNotFilter(filter) : filter;
+  }
+
+  /** Read the operator this term uses, and whatever it takes. */
+  #operation(
+    column: SimGluePartitionColumn,
+    negated: boolean,
+  ): SimGluePartitionFilter {
+    if (this.#cursor.takeKeyword("LIKE")) {
+      return simGlueLikeFilter(column, this.#operands.literal(column));
+    }
+
+    if (this.#cursor.takeKeyword("IN")) {
+      return simGlueInFilter(column, this.#operands.literalList(column));
+    }
+
+    if (this.#cursor.takeKeyword("BETWEEN")) {
+      return this.#between(column);
+    }
+
+    if (negated) {
+      throw this.#cursor.error("LIKE, IN or BETWEEN was expected after NOT");
+    }
+
+    return simGlueComparisonFilter(
+      column,
+      this.#operands.comparator(),
+      this.#operands.literal(column),
+    );
+  }
+
+  /** Read `key BETWEEN lower AND upper`, both ends included. */
+  #between(column: SimGluePartitionColumn): SimGluePartitionFilter {
+    const lower = this.#operands.literal(column);
+    this.#cursor.expectKeyword("AND");
+
+    return simGlueBetweenFilter(column, lower, this.#operands.literal(column));
+  }
+}

--- a/src/service/glue/sim-glue-partition-expression-grammar.iso.test.ts
+++ b/src/service/glue/sim-glue-partition-expression-grammar.iso.test.ts
@@ -1,0 +1,277 @@
+import { GetPartitionsCommand } from "@aws-sdk/client-glue";
+import {
+  assertArrayEquals,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  createFixturePartition,
+  createFixturePartitionedTable,
+  createFixtureTypedTable,
+  type FixturePartitionedTable,
+} from "./sim-glue-partitions.fixture.js";
+import type { SimGlue } from "./sim-glue.js";
+
+/** The values a filter answers with, flattened for a one-key table. */
+function matching(
+  glue: SimGlue,
+  table: FixturePartitionedTable,
+  Expression: string,
+): readonly string[] {
+  return glue
+    .getPartitions(
+      new GetPartitionsCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        Expression,
+      }),
+    )
+    .Partitions.flatMap((partition) => partition.Values);
+}
+
+describe("SimGlue partition expression literals", () => {
+  it("reads a quote doubled inside a string literal", () => {
+    // Given a partition whose value carries a quote.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["owner"]);
+
+    createFixturePartition(glue, table, ["it's"]);
+    createFixturePartition(glue, table, ["theirs"]);
+
+    // When it is asked for with the quote doubled, as SQL writes one.
+    const listed = matching(glue, table, "owner = 'it''s'");
+
+    // Then the doubled quote reads as one character in the value.
+    assertArrayEquals(listed, ["it's"]);
+  });
+
+  it("reads a negative number and a fraction", () => {
+    // Given a table partitioned by a number, holding values either side of
+    // zero.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "offset", Type: "double" },
+    ]);
+
+    for (const value of ["-3.5", "-1", "2.25"]) {
+      createFixturePartition(glue, table, [value]);
+    }
+
+    // When each kind of number literal is compared against.
+    const above = matching(glue, table, "offset > -2");
+    const below = matching(glue, table, "offset <= -3.5");
+
+    // Then both read as the numbers they are written as.
+    assertArrayEquals(above, ["-1", "2.25"]);
+    assertArrayEquals(below, ["-3.5"]);
+  });
+
+  it("refuses a dot that no digit follows", () => {
+    // Given a table partitioned by a number.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "offset", Type: "int" },
+    ]);
+
+    // When a literal ends at the dot.
+    const error = assertThrowsError(() => {
+      matching(glue, table, "offset = 1.");
+    });
+
+    // Then the number ends before it and the dot is refused on its own.
+    assertStringIncludes(error.message, "'.' is not something");
+  });
+
+  it("matches a pattern character that a regular expression would read", () => {
+    // Given two partitions differing only where a dot sits.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["host"]);
+
+    createFixturePartition(glue, table, ["a.example"]);
+    createFixturePartition(glue, table, ["axexample"]);
+
+    // When a LIKE pattern carries a literal dot.
+    const listed = matching(glue, table, "host LIKE 'a.exa%'");
+
+    // Then the dot matches itself rather than any character.
+    assertArrayEquals(listed, ["a.example"]);
+  });
+
+  it("collapses a run of LIKE wildcards", () => {
+    // Given one partition.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["host"]);
+
+    createFixturePartition(glue, table, ["shop.example.com"]);
+
+    // When a pattern repeats the wildcard.
+    const listed = matching(glue, table, "host LIKE '%%%example%%%'");
+
+    // Then it asks the same thing one wildcard would.
+    assertArrayEquals(listed, ["shop.example.com"]);
+  });
+
+  it("treats a key with no declared type as text", () => {
+    // Given a table whose partition key declares no type at all.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [{ Name: "day" }]);
+
+    createFixturePartition(glue, table, ["9"]);
+    createFixturePartition(glue, table, ["10"]);
+
+    // When the two are compared.
+    const listed = matching(glue, table, "day > '9'");
+
+    // Then they compare as text, which is what an unknown type falls back to.
+    assertArrayEquals(listed, []);
+  });
+
+  it("treats an empty stored value as no number at all", () => {
+    // Given a table partitioned by an int, holding a partition registered
+    // with an empty value.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "hour", Type: "int" },
+    ]);
+
+    createFixturePartition(glue, table, [""]);
+    createFixturePartition(glue, table, ["0"]);
+
+    // When a comparison that zero would satisfy is made.
+    const listed = matching(glue, table, "hour >= 0");
+
+    // Then the empty value is left out. Read as a number it would be zero,
+    // which is a value nobody registered.
+    assertArrayEquals(listed, ["0"]);
+  });
+
+  it("reads a missing value as empty where a partition is short", () => {
+    // Given a table partitioned by two keys, and a partition the catalog
+    // writer registered with one value. That path takes the values it is
+    // given rather than holding them to the table.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "day", Type: "string" },
+      { Name: "region", Type: "string" },
+    ]);
+
+    glue
+      .catalogWriter()
+      .createPartition(table.databaseName, table.tableName, ["2026-08-26"]);
+
+    // When the key it has no value for is filtered on.
+    const listed = matching(glue, table, "region = ''");
+
+    // Then the value it never got reads as empty.
+    assertArrayEquals(listed, ["2026-08-26"]);
+  });
+
+  it("leaves out a numeric key whose stored value is not a number", () => {
+    // Given a table partitioned by an int, holding a value that is not one.
+    // Registration takes the values it is given, so this is reachable.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "hour", Type: "int" },
+    ]);
+
+    createFixturePartition(glue, table, ["noon"]);
+    createFixturePartition(glue, table, ["11"]);
+
+    // When a numeric comparison is made.
+    const listed = matching(glue, table, "hour >= 0");
+
+    // Then the value with no place in a numeric order matches nothing, and
+    // the request still answers.
+    assertArrayEquals(listed, ["11"]);
+  });
+});
+
+describe("SimGlue partition expression grammar refusals", () => {
+  it("refuses a BETWEEN missing its AND", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When a range is written without the AND joining its ends.
+    const error = assertThrowsError(() => {
+      matching(glue, table, "day BETWEEN '1' '2'");
+    });
+
+    // Then it is refused for the keyword it wanted.
+    assertStringIncludes(error.message, "AND was expected");
+  });
+
+  it("refuses an IN list missing its closing bracket", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When the list is opened and never closed.
+    const error = assertThrowsError(() => {
+      matching(glue, table, "day IN ('1', '2'");
+    });
+
+    // Then it is refused for the bracket it wanted.
+    assertStringIncludes(error.message, "')' was expected");
+  });
+
+  it("refuses a term starting with something that is not a key", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When a term starts with a literal.
+    const error = assertThrowsError(() => {
+      matching(glue, table, "'2026-08-26' = day");
+    });
+
+    // Then it is refused, naming what was written where a key belongs.
+    assertStringIncludes(error.message, "is not a name");
+  });
+
+  it("refuses a key compared against another key", () => {
+    // Given a table partitioned by two keys.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day", "region"]);
+
+    // When one is compared against the other.
+    const error = assertThrowsError(() => {
+      matching(glue, table, "day = region");
+    });
+
+    // Then it is refused. A term compares a key against a value, and real
+    // Glue has no column-to-column comparison here either.
+    assertStringIncludes(error.message, "is not one");
+  });
+
+  it("refuses a value where a comparison operator belongs", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When a key is followed straight by a value.
+    const error = assertThrowsError(() => {
+      matching(glue, table, "day '2026-08-26'");
+    });
+
+    // Then it is refused, naming what was written where the operator belongs.
+    assertStringIncludes(error.message, "is not a comparison operator");
+  });
+
+  it("refuses an IN list that opens with no bracket", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When the values follow IN with no bracket around them.
+    const error = assertThrowsError(() => {
+      matching(glue, table, "day IN '1', '2'");
+    });
+
+    // Then it is refused for the bracket it wanted.
+    assertStringIncludes(error.message, "'(' was expected");
+  });
+});

--- a/src/service/glue/sim-glue-partition-expression-grammar.iso.test.ts
+++ b/src/service/glue/sim-glue-partition-expression-grammar.iso.test.ts
@@ -189,6 +189,98 @@ describe("SimGlue partition expression literals", () => {
   });
 });
 
+describe("SimGlue partition expression numbers", () => {
+  it("tells apart two numbers a double would round together", () => {
+    // Given a table partitioned by a bigint, holding two values a step apart
+    // above the point where a double stops counting in ones.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "id", Type: "bigint" },
+    ]);
+
+    createFixturePartition(glue, table, ["9007199254740992"]);
+    createFixturePartition(glue, table, ["9007199254740993"]);
+
+    // When one of them is asked for.
+    const listed = matching(glue, table, "id = 9007199254740993");
+
+    // Then only that one comes back. Read through a double both values are
+    // the same number, and this would answer with two partitions.
+    assertArrayEquals(listed, ["9007199254740993"]);
+  });
+
+  it("keeps a decimal exact past what a double holds", () => {
+    // Given a table partitioned by a decimal, holding two values that differ
+    // beyond a double's precision.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "amount", Type: "decimal(38,18)" },
+    ]);
+
+    createFixturePartition(glue, table, ["1.000000000000000001"]);
+    createFixturePartition(glue, table, ["1.000000000000000002"]);
+
+    // When the larger one is asked for.
+    const listed = matching(glue, table, "amount > 1.000000000000000001");
+
+    // Then the two are told apart.
+    assertArrayEquals(listed, ["1.000000000000000002"]);
+  });
+
+  it("reads trailing zeros and a signed zero as the same number", () => {
+    // Given a table partitioned by a decimal holding zero and a padded value.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "amount", Type: "decimal(10,2)" },
+    ]);
+
+    createFixturePartition(glue, table, ["-0"]);
+    createFixturePartition(glue, table, ["1.50"]);
+
+    // When each is asked for by an equal value written differently.
+    const zero = matching(glue, table, "amount = 0");
+    const padded = matching(glue, table, "amount = 1.5");
+
+    // Then the digits it was written with do not change the number it is.
+    assertArrayEquals(zero, ["-0"]);
+    assertArrayEquals(padded, ["1.50"]);
+  });
+});
+
+describe("SimGlue partition LIKE matching", () => {
+  it("matches a pattern whose wildcard has to give a character back", () => {
+    // Given values a greedy first attempt at the pattern would miss.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["host"]);
+
+    createFixturePartition(glue, table, ["aab"]);
+    createFixturePartition(glue, table, ["aba"]);
+
+    // When a pattern ends in a literal the wildcard first swallows.
+    const listed = matching(glue, table, "host LIKE '%ab'");
+
+    // Then the wildcard gives the characters back until the rest matches.
+    assertArrayEquals(listed, ["aab"]);
+  });
+
+  it("answers a pattern that alternates wildcards and literals", () => {
+    // Given a long value that misses the pattern only at its last character.
+    // Matching this by building a regular expression from the pattern takes
+    // time doubling with each wildcard, and this test would never finish.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["host"]);
+
+    createFixturePartition(glue, table, ["a".repeat(64)]);
+
+    // When a pattern alternates wildcards with literals and then asks for a
+    // character the value never holds.
+    const listed = matching(glue, table, `host LIKE '${"%a".repeat(20)}b'`);
+
+    // Then it answers, and answers with nothing.
+    assertArrayEquals(listed, []);
+  });
+});
+
 describe("SimGlue partition expression grammar refusals", () => {
   it("refuses a BETWEEN missing its AND", () => {
     // Given a table partitioned by day.

--- a/src/service/glue/sim-glue-partition-expression-refusals.iso.test.ts
+++ b/src/service/glue/sim-glue-partition-expression-refusals.iso.test.ts
@@ -1,0 +1,235 @@
+import { GetPartitionsCommand } from "@aws-sdk/client-glue";
+import {
+  assertArrayEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimGlueInvalidInputException } from "./error/sim-glue.error.js";
+import {
+  createFixturePartition,
+  createFixturePartitionedTable,
+  createFixtureTypedTable,
+  type FixturePartitionedTable,
+} from "./sim-glue-partitions.fixture.js";
+import type { SimGlue } from "./sim-glue.js";
+
+/** List a table's partitions through an expression. */
+function listWith(
+  glue: SimGlue,
+  table: FixturePartitionedTable,
+  Expression: string,
+): readonly (readonly string[])[] {
+  return glue
+    .getPartitions(
+      new GetPartitionsCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        Expression,
+      }),
+    )
+    .Partitions.map((partition) => partition.Values);
+}
+
+/** The error one expression is refused with. */
+function refusalFor(
+  glue: SimGlue,
+  table: FixturePartitionedTable,
+  expression: string,
+): Error {
+  return assertThrowsError(() => {
+    listWith(glue, table, expression);
+  });
+}
+
+describe("SimGlue partition expression types", () => {
+  it("compares a key declared as a number numerically", () => {
+    // Given a table partitioned by an int, holding a value either side of the
+    // point where text and number orders disagree.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "hour", Type: "int" },
+    ]);
+
+    createFixturePartition(glue, table, ["9"]);
+    createFixturePartition(glue, table, ["10"]);
+
+    // When the larger of the two is asked for.
+    const listed = listWith(glue, table, "hour > 9");
+
+    // Then 10 comes back. Compared as text it would sort below 9 and this
+    // would answer with nothing.
+    assertArrayEquals(listed.flat(), ["10"]);
+  });
+
+  it("compares a key declared as a string as text", () => {
+    // Given a table partitioned by a string holding the same two values.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["hour"]);
+
+    createFixturePartition(glue, table, ["9"]);
+    createFixturePartition(glue, table, ["10"]);
+
+    // When the same comparison is made.
+    const listed = listWith(glue, table, "hour > '9'");
+
+    // Then nothing comes back, since '10' sorts below '9' as text.
+    assertArrayEquals(listed.flat(), []);
+  });
+
+  it("reads a decimal type carrying its parameters as a number", () => {
+    // Given a table partitioned by a decimal declared the way real Glue
+    // writes one.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "amount", Type: "decimal(10,2)" },
+    ]);
+
+    createFixturePartition(glue, table, ["9.50"]);
+    createFixturePartition(glue, table, ["10.25"]);
+
+    // When a numeric comparison is made.
+    const listed = listWith(glue, table, "amount > 9.5");
+
+    // Then the parameters are read past and the values compare as numbers.
+    assertArrayEquals(listed.flat(), ["10.25"]);
+  });
+
+  it("refuses a value of the wrong type for a numeric key", () => {
+    // Given a table partitioned by an int.
+    const glue = new SimAws().glue();
+    const table = createFixtureTypedTable(glue, [
+      { Name: "hour", Type: "int" },
+    ]);
+
+    // When it is compared against something that is not a number.
+    const error = refusalFor(glue, table, "hour = 'noon'");
+
+    // Then it is refused rather than answering with nothing, which would read
+    // as a table that happens to hold no such partition.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "hour is declared as a number");
+  });
+});
+
+describe("SimGlue partition expression refusals", () => {
+  it("refuses a column the table does not partition by, naming it", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When an expression names a column that is not a partition key.
+    const error = refusalFor(glue, table, "status = '404'");
+
+    // Then it is refused, naming the column and the keys there are.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "status is not a partition key");
+    assertStringIncludes(error.message, "day");
+  });
+
+  it("refuses an expression that does not parse, saying where it stopped", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When an expression is missing the value its comparison needs.
+    const error = refusalFor(glue, table, "day =");
+
+    // Then it is refused, and the message says where reading stopped.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "at the end of the expression");
+  });
+
+  it("refuses an unclosed bracket at the position it was reached", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When a bracket is opened and never closed.
+    const error = refusalFor(glue, table, "(day = '2026-08-26'");
+
+    // Then it is refused for the bracket it wanted.
+    assertStringIncludes(error.message, "')' was expected");
+  });
+
+  it("refuses an expression carrying more after it is complete", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When two terms sit together with nothing joining them.
+    const error = refusalFor(glue, table, "day = '1' day = '2'");
+
+    // Then it is refused, at the token that carried on.
+    assertStringIncludes(error.message, "and then carried on");
+    assertStringIncludes(error.message, "at position 10");
+  });
+
+  it("refuses a string literal that is never closed", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When a quote is opened and never closed.
+    const error = refusalFor(glue, table, "day = '2026-08-26");
+
+    // Then it is refused at the quote that opened it.
+    assertStringIncludes(error.message, "opened and never closed");
+    assertStringIncludes(error.message, "at position 6");
+  });
+
+  it("refuses a character the grammar has no meaning for", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When an expression carries one.
+    const error = refusalFor(glue, table, "day + '1'");
+
+    // Then it is refused, naming the character and where it sits.
+    assertStringIncludes(error.message, "'+' is not something");
+    assertStringIncludes(error.message, "at position 4");
+  });
+
+  it("refuses an expression with nothing in it", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When the expression is blank.
+    const error = refusalFor(glue, table, " ".repeat(3));
+
+    // Then it is refused rather than read as no filter at all, which is what
+    // leaving the parameter out means.
+    assertInstanceOf(error, SimGlueInvalidInputException);
+    assertStringIncludes(error.message, "filters nothing");
+  });
+
+  it("refuses an operator this grammar does not have", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When a term uses something that is not a comparison.
+    const error = refusalFor(glue, table, "day ('1')");
+
+    // Then it is refused, naming what was written.
+    assertStringIncludes(error.message, "is not a comparison operator");
+  });
+
+  it("refuses NOT in front of a plain comparison", () => {
+    // Given a table partitioned by day.
+    const glue = new SimAws().glue();
+    const table = createFixturePartitionedTable(glue, ["day"]);
+
+    // When NOT sits between a key and a comparison, where SQL has no meaning
+    // for it.
+    const error = refusalFor(glue, table, "day NOT = '1'");
+
+    // Then it is refused, naming what may follow NOT there.
+    assertStringIncludes(error.message, "LIKE, IN or BETWEEN was expected");
+  });
+});

--- a/src/service/glue/sim-glue-partition-expressions.iso.test.ts
+++ b/src/service/glue/sim-glue-partition-expressions.iso.test.ts
@@ -1,0 +1,213 @@
+import { GetPartitionsCommand } from "@aws-sdk/client-glue";
+import { assertArrayEquals, assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  createFixturePartition,
+  createFixturePartitionedTable,
+  type FixturePartitionedTable,
+} from "./sim-glue-partitions.fixture.js";
+import type { SimGlue } from "./sim-glue.js";
+
+/** A table partitioned by day and region, holding four partitions. */
+function catalogWithDays(glue: SimGlue): FixturePartitionedTable {
+  const table = createFixturePartitionedTable(glue, ["day", "region"]);
+
+  for (const values of [
+    ["2026-08-24", "eu-west-2"],
+    ["2026-08-25", "eu-west-2"],
+    ["2026-08-26", "us-east-1"],
+    ["2026-08-27", "ap-south-1"],
+  ]) {
+    createFixturePartition(glue, table, values);
+  }
+
+  return table;
+}
+
+/** The days a filter answers with, in registration order. */
+function daysMatching(
+  glue: SimGlue,
+  table: FixturePartitionedTable,
+  Expression: string,
+): readonly string[] {
+  return glue
+    .getPartitions(
+      new GetPartitionsCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+        Expression,
+      }),
+    )
+    .Partitions.map((partition) => partition.Values[0] ?? "");
+}
+
+describe("SimGlue partition expressions", () => {
+  it("filters on an equality", () => {
+    // Given a table holding four days.
+    const glue = new SimAws().glue();
+    const table = catalogWithDays(glue);
+
+    // When one day is asked for.
+    const days = daysMatching(glue, table, "day = '2026-08-25'");
+
+    // Then only that day comes back.
+    assertArrayEquals(days, ["2026-08-25"]);
+  });
+
+  it("filters on each ordering operator", () => {
+    // Given a table holding four days.
+    const glue = new SimAws().glue();
+    const table = catalogWithDays(glue);
+
+    // When each ordering operator is used against the same day.
+    const results = [">", ">=", "<", "<=", "<>", "!="].map((operator) =>
+      daysMatching(glue, table, `day ${operator} '2026-08-25'`),
+    );
+
+    // Then each answers with the run of days it asks for.
+    assertArrayEquals(results[0] ?? [], ["2026-08-26", "2026-08-27"]);
+    assertArrayEquals(results[1] ?? [], [
+      "2026-08-25",
+      "2026-08-26",
+      "2026-08-27",
+    ]);
+    assertArrayEquals(results[2] ?? [], ["2026-08-24"]);
+    assertArrayEquals(results[3] ?? [], ["2026-08-24", "2026-08-25"]);
+    assertArrayEquals(results[4] ?? [], [
+      "2026-08-24",
+      "2026-08-26",
+      "2026-08-27",
+    ]);
+    assertArrayEquals(results[5] ?? [], [
+      "2026-08-24",
+      "2026-08-26",
+      "2026-08-27",
+    ]);
+  });
+
+  it("filters on LIKE, IN and BETWEEN", () => {
+    // Given a table holding four days across three regions.
+    const glue = new SimAws().glue();
+    const table = catalogWithDays(glue);
+
+    // When each of the three is used.
+    const like = daysMatching(glue, table, "region LIKE 'eu-%'");
+    const inList = daysMatching(
+      glue,
+      table,
+      "region IN ('us-east-1', 'ap-south-1')",
+    );
+    const between = daysMatching(
+      glue,
+      table,
+      "day BETWEEN '2026-08-25' AND '2026-08-26'",
+    );
+
+    // Then each answers with what it asks for, and BETWEEN takes both ends.
+    assertArrayEquals(like, ["2026-08-24", "2026-08-25"]);
+    assertArrayEquals(inList, ["2026-08-26", "2026-08-27"]);
+    assertArrayEquals(between, ["2026-08-25", "2026-08-26"]);
+  });
+
+  it("matches a single character with a LIKE underscore", () => {
+    // Given a table holding four regions.
+    const glue = new SimAws().glue();
+    const table = catalogWithDays(glue);
+
+    // When a pattern of one wildcard character is used.
+    const days = daysMatching(glue, table, "region LIKE 'us-east-_'");
+
+    // Then it matches one character rather than any run of them.
+    assertArrayEquals(days, ["2026-08-26"]);
+  });
+
+  it("combines terms with AND, OR and brackets", () => {
+    // Given a table holding four days.
+    const glue = new SimAws().glue();
+    const table = catalogWithDays(glue);
+
+    // When terms are combined each way.
+    const both = daysMatching(
+      glue,
+      table,
+      "day >= '2026-08-25' AND region = 'eu-west-2'",
+    );
+    const either = daysMatching(
+      glue,
+      table,
+      "day = '2026-08-24' OR day = '2026-08-27'",
+    );
+    const grouped = daysMatching(
+      glue,
+      table,
+      "(day = '2026-08-24' OR day = '2026-08-26') AND region = 'us-east-1'",
+    );
+
+    // Then each combination holds only where it should.
+    assertArrayEquals(both, ["2026-08-25"]);
+    assertArrayEquals(either, ["2026-08-24", "2026-08-27"]);
+    assertArrayEquals(grouped, ["2026-08-26"]);
+  });
+
+  it("binds AND tighter than OR", () => {
+    // Given a table holding four days.
+    const glue = new SimAws().glue();
+    const table = catalogWithDays(glue);
+
+    // When an unbracketed OR and AND are mixed.
+    const days = daysMatching(
+      glue,
+      table,
+      "day = '2026-08-24' OR day = '2026-08-26' AND region = 'nowhere'",
+    );
+
+    // Then the AND binds first, so the second half holds for nothing and the
+    // first day is the whole answer. Bracketing the OR would give two.
+    assertArrayEquals(days, ["2026-08-24"]);
+  });
+
+  it("reverses a term with NOT", () => {
+    // Given a table holding four days.
+    const glue = new SimAws().glue();
+    const table = catalogWithDays(glue);
+
+    // When NOT is put in front of a term, and inside one.
+    const prefix = daysMatching(glue, table, "NOT day = '2026-08-24'");
+    const grouped = daysMatching(
+      glue,
+      table,
+      "NOT (region = 'eu-west-2' OR region = 'us-east-1')",
+    );
+    const notIn = daysMatching(
+      glue,
+      table,
+      "region NOT IN ('eu-west-2', 'us-east-1')",
+    );
+    const notLike = daysMatching(glue, table, "region NOT LIKE 'eu-%'");
+
+    // Then each answers with everything the term leaves out.
+    assertArrayLength(prefix, 3);
+    assertArrayEquals(grouped, ["2026-08-27"]);
+    assertArrayEquals(notIn, ["2026-08-27"]);
+    assertArrayEquals(notLike, ["2026-08-26", "2026-08-27"]);
+  });
+
+  it("answers with every partition when there is no Expression", () => {
+    // Given a table holding four days.
+    const glue = new SimAws().glue();
+    const table = catalogWithDays(glue);
+
+    // When the partitions are listed with no filter.
+    const { Partitions } = glue.getPartitions(
+      new GetPartitionsCommand({
+        DatabaseName: table.databaseName,
+        TableName: table.tableName,
+      }),
+    );
+
+    // Then all four come back, as they did before filtering existed.
+    assertArrayLength(Partitions, 4);
+  });
+});

--- a/src/service/glue/sim-glue-partitions.fixture.ts
+++ b/src/service/glue/sim-glue-partitions.fixture.ts
@@ -34,7 +34,8 @@ export interface FixturePartitionedTable {
 }
 
 /**
- * Create a database and a table partitioned by the named keys.
+ * Create a database and a table partitioned by the named keys, all of them
+ * strings.
  *
  * The keys default to one `day`. That is the shape most of these tests want.
  * One value per partition means a list of two values is refused by count.
@@ -42,6 +43,25 @@ export interface FixturePartitionedTable {
 export function createFixturePartitionedTable(
   glue: SimGlue,
   partitionKeyNames: readonly string[] = ["day"],
+): FixturePartitionedTable {
+  return createFixtureTypedTable(
+    glue,
+    partitionKeyNames.map((Name) => ({ Name, Type: "string" })),
+  );
+}
+
+/**
+ * Create a database and a table partitioned by keys of the declared types.
+ *
+ * The type is what decides whether an expression compares a key numerically,
+ * so a test about that declares it here.
+ */
+export function createFixtureTypedTable(
+  glue: SimGlue,
+  partitionKeys: readonly {
+    readonly Name: string;
+    readonly Type?: string | undefined;
+  }[],
 ): FixturePartitionedTable {
   const databaseName = fixtureDatabaseName();
   const tableName = fixtureTableName();
@@ -52,10 +72,7 @@ export function createFixturePartitionedTable(
       DatabaseName: databaseName,
       TableInput: {
         Name: tableName,
-        PartitionKeys: partitionKeyNames.map((Name) => ({
-          Name,
-          Type: "string",
-        })),
+        PartitionKeys: partitionKeys,
         StorageDescriptor: { Location: `s3://${databaseName}/logs/` },
       },
     },

--- a/src/service/glue/sim-glue-partitions.iso.test.ts
+++ b/src/service/glue/sim-glue-partitions.iso.test.ts
@@ -249,31 +249,6 @@ describe("SimGlue partitions", () => {
     assertInstanceOf(error, SimGlueEntityNotFoundException);
   });
 
-  it("refuses a GetPartitions Expression rather than ignoring it", () => {
-    // Given a table with two days registered.
-    const glue = new SimAws().glue();
-    const table = createFixturePartitionedTable(glue);
-
-    createFixturePartition(glue, table, ["2026-08-25"]);
-    createFixturePartition(glue, table, ["2026-08-26"]);
-
-    // When they are listed through a filter.
-    const error = assertThrowsError(() => {
-      glue.getPartitions(
-        new GetPartitionsCommand({
-          DatabaseName: table.databaseName,
-          TableName: table.tableName,
-          Expression: "day = '2026-08-26'",
-        }),
-      );
-    });
-
-    // Then it is refused. An ignored filter would answer with the partition
-    // the caller asked to leave out.
-    assertInstanceOf(error, SimGlueInvalidInputException);
-    assertStringIncludes(error.message, "Expression");
-  });
-
   it("removes a partition without touching the rest", () => {
     // Given two days registered.
     const glue = new SimAws().glue();


### PR DESCRIPTION
`GetPartitions` reads its `Expression` and answers with the partitions it matches. A request carrying none still reads them all.

A term names a partition key against a literal through `=`, `<>` and `!=`, `>`, `<`, `>=`, `<=`, `LIKE`, `IN` or `BETWEEN`. `AND`, `OR` and `NOT` combine terms and brackets group them, with the precedence SQL gives them, and `NOT` also sits in front of `LIKE`, `IN` and `BETWEEN` to reverse one term. Comparison follows the type the table declares for the key, so a key typed `int` sorts `10` above `9` while a `string` key compares as text, and `LIKE` matches the value's text whatever the type is. A column the table does not partition by is refused naming the column and the keys it does have, and an expression that cannot be read is refused saying where reading stopped.

The grammar is read by a tokeniser and a recursive descent parser in `src/service/glue/expression/`, following the DynamoDB key condition parser the issue points at. A term comes out as a predicate over a partition's values rather than an object tree, since everything a refusal could catch is caught while the expression is read.

Resolves https://github.com/KensioSoftware/yulin/issues/1021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expression filtering for Glue `GetPartitions`.
  * Supports comparisons, `LIKE`, `IN`, `BETWEEN`, boolean operators, negation, and grouped conditions.
  * Applies type-aware comparisons for numeric and text partition keys.
  * Added an example demonstrating filtered partition queries.

* **Bug Fixes**
  * Invalid expressions, unknown keys, malformed literals, and unsupported syntax now return clear validation errors.

* **Documentation**
  * Updated Glue documentation with supported expression syntax, limitations, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->