### PR TITLE
feat: read registered partitions for an Athena query

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -529,13 +529,95 @@ A query fails where a partition key carries no `projection.<key>.type`, where a 
 
 The `WHERE` clause narrows what is projected. `day = '2026-08-25'` and `day IN ('a', 'b')` are the two forms read, and a query carrying `OR` anywhere is left unnarrowed. A filter left unread keeps every projected partition in. That is always the safe answer.
 
-A table with `projection.enabled` absent or false reads the location in its storage descriptor. A table with projection on and no `storage.location.template` gets the Hive layout under that same location, as `<location>/day=2026-08-25/`.
+A table with projection on and no `storage.location.template` gets the Hive layout under its own location, as `<location>/day=2026-08-25/`.
+
+## Registered partitions
+
+A table that registers its partitions rather than projecting them is read from the catalog. A query against one reads a prefix per registered partition, taken from that partition's own storage descriptor location, and the `WHERE` clause narrows them the way it narrows projected ones.
+
+```typescript sim-athena-registered-partitions
+/**
+ * A query over a table whose partitions the catalog holds.
+ */
+
+import {
+  CreateDatabaseCommand,
+  CreatePartitionCommand,
+  CreateTableCommand,
+} from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const glue = simAws.glue();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "rainlytics" } }),
+);
+glue.createTable(
+  new CreateTableCommand({
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [{ Name: "day", Type: "string" }],
+      StorageDescriptor: { Location: "s3://rainlytics-logs/logs/" },
+    },
+  }),
+);
+
+for (const day of ["2026-08-25", "2026-08-26"]) {
+  glue.createPartition(
+    new CreatePartitionCommand({
+      DatabaseName: "rainlytics",
+      TableName: "access_logs",
+      PartitionInput: {
+        Values: [day],
+        StorageDescriptor: { Location: `s3://rainlytics-logs/logs/${day}/` },
+      },
+    }),
+  );
+
+  await simAws.s3().putObject({
+    input: {
+      Bucket: "rainlytics-logs",
+      Key: `logs/${day}/part-0.json`,
+      Body: "x".repeat(1000),
+    },
+  });
+}
+
+const { QueryExecutionId } = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString:
+      "SELECT url FROM rainlytics.access_logs WHERE day = '2026-08-26'",
+    ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const execution = await simAws
+  .athena()
+  .getQueryExecution({ input: { QueryExecutionId } });
+
+// 1000
+console.log(execution.QueryExecution?.Statistics?.DataScannedInBytes);
+```
+
+A partition registered with no location of its own falls back to the Hive layout under the table's location, as `<location>/day=2026-08-26/`. A partition registered somewhere else entirely is read there, which is something a table location alone could never reach.
+
+Projection wins where a table carries both. Real Athena stops reading the catalog's partitions once `projection.enabled` is true, and that is the whole reason for turning it on.
+
+A table with neither reads the location in its storage descriptor, and the query reads everything under it.
 
 ## What a query scans
 
 A query's bytes scanned are measured from the objects it reads. The prefixes come from the table's
-partition projection, or from the location in its storage descriptor where a table projects nothing,
-and every object under each one counts.
+partition projection, from the partitions the catalog holds against it, or from the location in its
+storage descriptor where a table has neither. Every object under each one counts.
 
 ```typescript sim-athena-scanned-bytes
 /**
@@ -595,8 +677,9 @@ const execution = await simAws.athena().getQueryExecution({
 console.log(execution.QueryExecution?.Statistics?.DataScannedInBytes);
 ```
 
-A query filtering on a projected partition key reads only the prefixes that filter allows. A
-partitioned table then scans less than an unpartitioned one, and a test can prove it.
+A query filtering on a partition key reads only the prefixes that filter allows, whether the
+partitions were projected or registered. A partitioned table then scans less than an unpartitioned
+one, and a test can prove it.
 
 The listing goes through simulated S3 under the caller that started the query, as Athena reads a
 table's data under the identity that asked for it. A caller who cannot read the Bucket fails the
@@ -844,9 +927,14 @@ Current documented limitations:
   is refused. Athena's own range runs to the signed 64 bit limit.
 - `MILLISECONDS` is absent from the interval units, and a pattern carrying `S` is read as literal
   text. A partition path written to the millisecond falls outside this.
-- Partitions registered through the Glue Partitions API are absent, along with `MSCK REPAIR TABLE`
-  and `ALTER TABLE ADD PARTITION`. A table without projection reads its storage descriptor location
-  as the one prefix it has.
+- Partitions registered through the Glue Partitions API are read. Registering one from Athena is
+  absent, so `MSCK REPAIR TABLE` and `ALTER TABLE ADD PARTITION` register nothing and a test that
+  wants partitions puts them in the catalog through Glue.
+- A registered partition's own columns are ignored. The table's schema is what every partition is
+  read with, so a table whose schema changed part way through its life reads the newer columns for
+  the older partitions too.
+- A partition registered with no location, against a table with none either, is read as having
+  nowhere to look and contributes no prefix.
 - A query naming a catalog other than `awsdatacatalog` runs with its tables never looked for.
   Federated catalogs and `AWS::Athena::DataCatalog` fall outside this simulation.
 - Bytes scanned are the total size of every object under the prefixes a query reads. Real Athena

--- a/docs/services/athena/sim-athena-registered-partitions.example.ts
+++ b/docs/services/athena/sim-athena-registered-partitions.example.ts
@@ -1,0 +1,69 @@
+/**
+ * A query over a table whose partitions the catalog holds.
+ */
+
+import {
+  CreateDatabaseCommand,
+  CreatePartitionCommand,
+  CreateTableCommand,
+} from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const glue = simAws.glue();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "rainlytics" } }),
+);
+glue.createTable(
+  new CreateTableCommand({
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "access_logs",
+      PartitionKeys: [{ Name: "day", Type: "string" }],
+      StorageDescriptor: { Location: "s3://rainlytics-logs/logs/" },
+    },
+  }),
+);
+
+for (const day of ["2026-08-25", "2026-08-26"]) {
+  glue.createPartition(
+    new CreatePartitionCommand({
+      DatabaseName: "rainlytics",
+      TableName: "access_logs",
+      PartitionInput: {
+        Values: [day],
+        StorageDescriptor: { Location: `s3://rainlytics-logs/logs/${day}/` },
+      },
+    }),
+  );
+
+  await simAws.s3().putObject({
+    input: {
+      Bucket: "rainlytics-logs",
+      Key: `logs/${day}/part-0.json`,
+      Body: "x".repeat(1000),
+    },
+  });
+}
+
+const { QueryExecutionId } = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString:
+      "SELECT url FROM rainlytics.access_logs WHERE day = '2026-08-26'",
+    ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const execution = await simAws
+  .athena()
+  .getQueryExecution({ input: { QueryExecutionId } });
+
+// 1000
+console.log(execution.QueryExecution?.Statistics?.DataScannedInBytes);

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -419,9 +419,10 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
 - **`AWS::Glue::Crawler` is absent.** A crawler fills a catalog by reading objects, and every object
   stays unread here. A template declaring one deploys, with the crawler recorded on the stack's
   `skippedResources`.
-- **Athena ignores a registered partition.** A query expands the table's projection parameters and
-  reads nothing the partition commands wrote. Registering partitions changes what the catalog
-  reports and leaves query planning alone.
+- **A registered partition is read by Athena, and a projected one wins over it.** Simulated
+  [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") reads a table's
+  registered partitions when a query runs, unless `projection.enabled` is true. Real Athena stops
+  reading the catalog's partitions once projection is on.
 - **A `GetPartitions` `Expression` is the whole of the filtering.** `Segment` and parallel listing,
   `ExcludeColumnSchema` and `TransactionId` are absent, and so are partition indexes, which change
   which expressions real Glue will serve rather than what any of them mean.

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -106,6 +106,12 @@ entry per bracket level, and a subquery's own FROM then leaves the outer one sta
 `x AS (` is taken as a common table expression, since nothing else in a statement this scans puts a
 bracket straight after `AS`.
 
+`table/sim-athena-registered-partitions.ts` reads the partitions the Data Catalog holds against a
+table into those same prefixes, one per partition, each taken from the partition's own storage
+descriptor location. A partition with none falls back to the Hive layout under the table's location.
+`simAthenaTablePartitions` decides between the two. Projection wins where a table carries both, the
+way real Athena stops reading the catalog's partitions once `projection.enabled` is true.
+
 `projection/` expands a table's partition projection into the S3 prefixes its partitions sit under.
 `sim-athena-projection-parameters.ts` reads the `projection.*` keys off the Glue table, and every
 partition key needs a type once projection is on, since Athena has no other way to know what a

--- a/src/service/athena/execution/sim-athena-planned-partitions.ts
+++ b/src/service/athena/execution/sim-athena-planned-partitions.ts
@@ -1,0 +1,64 @@
+import { SimAthenaProjectionError } from "../projection/sim-athena-projection-error.js";
+import type { SimAthenaTablePartition } from "../projection/sim-athena-projection-location.js";
+import { simAthenaTablePartitions } from "../projection/sim-athena-table-partitions.js";
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
+import type { SimAthenaCatalog } from "../table/sim-athena-table-resolution.js";
+
+/** One table a query reads, with the partitions of it the query reaches. */
+export interface SimAthenaPlannedTable {
+  readonly table: SimAthenaCatalogTable;
+  readonly partitions: readonly SimAthenaTablePartition[];
+}
+
+interface SimAthenaPlannedPartitionsRequest {
+  readonly tables: readonly SimAthenaCatalogTable[];
+  readonly catalog: SimAthenaCatalog | undefined;
+  readonly queryString: string;
+  readonly now: Date;
+}
+
+/** What reading every table's partitions came to. */
+export interface SimAthenaPlannedPartitions {
+  readonly refusal: string | undefined;
+  readonly planned: readonly SimAthenaPlannedTable[];
+}
+
+/**
+ * The partitions every table a query names comes to.
+ *
+ * Glue accepts any projection parameters it is given, so a projection with a
+ * mistake in it is found here, when a query first asks what partitions the
+ * table has.
+ */
+export function simAthenaPlannedPartitions(
+  request: SimAthenaPlannedPartitionsRequest,
+): SimAthenaPlannedPartitions {
+  const planned: SimAthenaPlannedTable[] = [];
+
+  for (const table of request.tables) {
+    try {
+      planned.push({ table, partitions: partitionsOf(request, table) });
+    } catch (error) {
+      if (error instanceof SimAthenaProjectionError) {
+        return { refusal: error.message, planned: [] };
+      }
+
+      throw error;
+    }
+  }
+
+  return { refusal: undefined, planned };
+}
+
+function partitionsOf(
+  request: SimAthenaPlannedPartitionsRequest,
+  table: SimAthenaCatalogTable,
+): readonly SimAthenaTablePartition[] {
+  return simAthenaTablePartitions({
+    table,
+    registered:
+      request.catalog?.partitionsInTable(table.databaseName, table.name) ?? [],
+    queryString: request.queryString,
+    now: request.now,
+  });
+}

--- a/src/service/athena/execution/sim-athena-query-refusal.ts
+++ b/src/service/athena/execution/sim-athena-query-refusal.ts
@@ -1,20 +1,16 @@
 import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
-import { SimAthenaProjectionError } from "../projection/sim-athena-projection-error.js";
-import type { SimAthenaTablePartition } from "../projection/sim-athena-projection-location.js";
-import { simAthenaTablePartitions } from "../projection/sim-athena-table-partitions.js";
-import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
 import {
   simAthenaResolveTables,
   type SimAthenaCatalog,
 } from "../table/sim-athena-table-resolution.js";
 import type { SimAthenaWorkGroupStore } from "../workgroup/sim-athena-work-group-store.js";
+import {
+  simAthenaPlannedPartitions,
+  type SimAthenaPlannedTable,
+} from "./sim-athena-planned-partitions.js";
 import type { SimAthenaQueryExecution } from "./sim-athena-query-execution.js";
 
-/** One table a query reads, with the partitions of it the query reaches. */
-export interface SimAthenaPlannedTable {
-  readonly table: SimAthenaCatalogTable;
-  readonly partitions: readonly SimAthenaTablePartition[];
-}
+export type { SimAthenaPlannedTable } from "./sim-athena-planned-partitions.js";
 
 /** What planning one query came to. */
 export interface SimAthenaQueryPlan {
@@ -70,47 +66,23 @@ export function simAthenaPlanQuery(
     return { refusal: resolved.refusal, prefixes: [], tables: [] };
   }
 
-  return partitionsOf(properties, resolved.tables);
-}
+  const read = simAthenaPlannedPartitions({
+    tables: resolved.tables,
+    catalog: properties.catalog,
+    queryString: execution.queryString,
+    now: properties.now,
+  });
 
-/**
- * The prefixes every table a query names comes to.
- *
- * Glue accepts any projection parameters it is given, so a projection with a
- * mistake in it is found here, when a query first asks what partitions the
- * table has.
- */
-function partitionsOf(
-  properties: SimAthenaQueryRefusalProperties,
-  tables: readonly SimAthenaCatalogTable[],
-): SimAthenaQueryPlan {
-  const planned: SimAthenaPlannedTable[] = [];
-
-  for (const table of tables) {
-    try {
-      planned.push({
-        table,
-        partitions: simAthenaTablePartitions({
-          table,
-          queryString: properties.execution.queryString,
-          now: properties.now,
-        }),
-      });
-    } catch (error) {
-      if (error instanceof SimAthenaProjectionError) {
-        return { refusal: error.message, prefixes: [], tables: [] };
-      }
-
-      throw error;
-    }
+  if (read.refusal !== undefined) {
+    return { refusal: read.refusal, prefixes: [], tables: [] };
   }
 
   return {
     refusal: undefined,
-    prefixes: planned.flatMap((one) =>
+    prefixes: read.planned.flatMap((one) =>
       one.partitions.map((partition) => partition.prefix),
     ),
-    tables: planned,
+    tables: read.planned,
   };
 }
 

--- a/src/service/athena/projection/sim-athena-projection-location.ts
+++ b/src/service/athena/projection/sim-athena-projection-location.ts
@@ -50,7 +50,7 @@ export function simAthenaProjectedPartitions(
   }
 
   return combinations(projection, values).map((combination) => ({
-    prefix: withTrailingSlash(fill(template, combination)),
+    prefix: simAthenaLocationPrefix(fill(template, combination)),
     values: combination,
   }));
 }
@@ -67,15 +67,38 @@ function hivePartitions(
     );
   }
 
-  const base = withTrailingSlash(tableLocation);
+  return combinations(projection, values).map((combination) => ({
+    prefix: simAthenaHivePrefix(tableLocation, combination),
+    values: combination,
+  }));
+}
 
-  return combinations(projection, values).map((combination) => {
-    const segments = projection.columns.map(
-      (column) => `${column.name}=${combination.get(column.name) ?? ""}`,
-    );
+/**
+ * Where a partition of these values sits under a table's own location.
+ *
+ * This is the Hive layout, one `name=value` segment per partition column in
+ * the order the table declares them. Athena falls back to it for a partition
+ * that says nothing about where its own data is.
+ */
+export function simAthenaHivePrefix(
+  location: string,
+  values: ReadonlyMap<string, string>,
+): string {
+  const segments = values
+    .entries()
+    .map(([name, value]) => `${name}=${value}`)
+    .toArray();
 
-    return { prefix: `${base}${segments.join("/")}/`, values: combination };
-  });
+  return `${simAthenaLocationPrefix(location)}${segments.join("/")}/`;
+}
+
+/**
+ * A location as a prefix, which always ends in a slash.
+ *
+ * Without one, a prefix of `day=1` also reaches everything under `day=10`.
+ */
+export function simAthenaLocationPrefix(location: string): string {
+  return location.endsWith("/") ? location : `${location}/`;
 }
 
 function placeholder(name: string): string {
@@ -95,10 +118,6 @@ function fill(
   }
 
   return filled;
-}
-
-function withTrailingSlash(location: string): string {
-  return location.endsWith("/") ? location : `${location}/`;
 }
 
 /**

--- a/src/service/athena/projection/sim-athena-table-partitions.iso.test.ts
+++ b/src/service/athena/projection/sim-athena-table-partitions.iso.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import type { SimAthenaCatalogPartition } from "../table/sim-athena-registered-partitions.js";
 import {
   simAthenaTablePartitions,
   type SimAthenaPartitionedTable,
@@ -28,15 +29,28 @@ function aTable(
 function partitionsOf(
   table: SimAthenaPartitionedTable,
   queryString = "SELECT * FROM rainlytics.access_logs",
+  registered: readonly SimAthenaCatalogPartition[] = [],
 ): readonly string[] {
-  return simAthenaTablePartitions({ table, queryString, now: noon }).map(
-    (partition) => partition.prefix,
-  );
+  return simAthenaTablePartitions({
+    table,
+    registered,
+    queryString,
+    now: noon,
+  }).map((partition) => partition.prefix);
+}
+
+/** One partition the catalog holds, as a test writes it down. */
+function aPartition(
+  values: readonly string[],
+  Location: string,
+): SimAthenaCatalogPartition {
+  return { values, storageDescriptor: { Location } };
 }
 
 describe("the S3 prefixes a query reads for one table", () => {
-  it("reads the table's own location where projection is off", () => {
-    // Given a table with no projection configured.
+  it("reads the table's own location where it has neither", () => {
+    // Given a table with no projection configured and nothing registered
+    // against it.
     const table = aTable({}, ["day"]);
 
     // When its partitions are read.
@@ -44,6 +58,31 @@ describe("the S3 prefixes a query reads for one table", () => {
 
     // Then the table's location is the whole of it.
     assertArrayEquals(prefixes, ["s3://rainlytics-logs/cloudfront/"]);
+  });
+
+  it("reads the projected partitions where a table carries both", () => {
+    // Given a table projecting one day, with a different day registered
+    // against it.
+    const table = aTable(
+      {
+        "projection.enabled": "true",
+        "projection.day.type": "date",
+        "projection.day.format": "yyyy-MM-dd",
+        "projection.day.range": "2026-08-26,2026-08-26",
+      },
+      ["day"],
+    );
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table, undefined, [
+      aPartition(["2020-01-01"], "s3://rainlytics-logs/day=2020-01-01/"),
+    ]);
+
+    // Then the projection wins. Real Athena stops reading the catalog's
+    // partitions once projection is on, which is the point of turning it on.
+    assertArrayEquals(prefixes, [
+      "s3://rainlytics-logs/cloudfront/day=2026-08-26/",
+    ]);
   });
 
   it("fills the location template with each projected value", () => {

--- a/src/service/athena/projection/sim-athena-table-partitions.ts
+++ b/src/service/athena/projection/sim-athena-table-partitions.ts
@@ -1,5 +1,12 @@
 import { simAthenaPartitionFilters } from "../table/sim-athena-partition-filters.js";
-import type { SimAthenaProjectionColumn } from "./sim-athena-projection-column.js";
+import {
+  simAthenaRegisteredPartitions,
+  type SimAthenaCatalogPartition,
+} from "../table/sim-athena-registered-partitions.js";
+import type {
+  SimAthenaProjection,
+  SimAthenaProjectionColumn,
+} from "./sim-athena-projection-column.js";
 import { SimAthenaProjectionError } from "./sim-athena-projection-error.js";
 import {
   simAthenaProjectedPartitions,
@@ -20,6 +27,10 @@ export interface SimAthenaPartitionedTable extends SimAthenaProjectedTable {
 
 interface SimAthenaTablePartitionsRequest {
   readonly table: SimAthenaPartitionedTable;
+
+  /** What the catalog holds against this table, where anything does. */
+  readonly registered: readonly SimAthenaCatalogPartition[];
+
   readonly queryString: string;
   readonly now: Date;
 }
@@ -27,14 +38,16 @@ interface SimAthenaTablePartitionsRequest {
 /**
  * The partitions one query reads for one table.
  *
- * A table with projection off reads its own location and nothing else, since
- * the partitions it holds were registered rather than projected and simulated
- * Glue has no commands for registering one. Nothing then says what its
- * partition columns read, so that partition carries no values.
+ * Projection comes first. Real Athena stops reading the catalog's partitions
+ * once `projection.enabled` is true, which is the whole reason for turning it
+ * on. Every projected column is expanded and the query's own `WHERE` clause
+ * narrows what is left.
  *
- * With projection on, every column is expanded and the query's own `WHERE`
- * clause narrows what is left. A filter naming no projected column leaves
- * every partition in, which is what a query scanning the whole table does.
+ * A table with partitions registered against it reads those instead, one
+ * prefix per partition, narrowed by the same filters.
+ *
+ * A table with neither reads its own location and nothing else. Nothing then
+ * says what its partition columns read, so that partition carries no values.
  */
 export function simAthenaTablePartitions(
   request: SimAthenaTablePartitionsRequest,
@@ -42,12 +55,30 @@ export function simAthenaTablePartitions(
   const projection = simAthenaProjectionOf(request.table);
   const location = request.table.storageDescriptor?.Location;
 
-  if (!projection.enabled) {
-    return location === undefined
-      ? []
-      : [{ prefix: location, values: new Map() }];
+  if (projection.enabled) {
+    return projectedPartitions(request, projection, location);
   }
 
+  if (request.registered.length > 0) {
+    return simAthenaRegisteredPartitions({
+      partitionKeys: request.table.partitionKeys,
+      registered: request.registered,
+      tableLocation: location,
+      queryString: request.queryString,
+    });
+  }
+
+  return location === undefined
+    ? []
+    : [{ prefix: location, values: new Map() }];
+}
+
+/** The partitions a table's projection comes to for this query. */
+function projectedPartitions(
+  request: SimAthenaTablePartitionsRequest,
+  projection: SimAthenaProjection,
+  location: string | undefined,
+): readonly SimAthenaTablePartition[] {
   const filters = simAthenaPartitionFilters(request.queryString);
   const values = new Map<string, readonly string[]>();
 

--- a/src/service/athena/sim-athena-registered-partition.fixture.ts
+++ b/src/service/athena/sim-athena-registered-partition.fixture.ts
@@ -1,0 +1,58 @@
+import type { SimAws } from "../aws/sim-aws.js";
+import {
+  aCatalogTable,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+/**
+ * Register one partition against a table in the `rainlytics` database.
+ *
+ * A partition given no location of its own falls back to the Hive layout
+ * under its table's, the way Athena resolves one.
+ */
+export function aRegisteredPartition(
+  simAws: SimAws,
+  tableName: string,
+  values: readonly string[],
+  location?: string,
+): void {
+  simAws.glue().createPartition({
+    input: {
+      DatabaseName: "rainlytics",
+      TableName: tableName,
+      PartitionInput: {
+        Values: values,
+        ...(location !== undefined && {
+          StorageDescriptor: { Location: location },
+        }),
+      },
+    },
+  });
+}
+
+/**
+ * Declare a `stock` table partitioned by day, holding one column.
+ *
+ * Every registered partition test wants the same table, and what differs
+ * between them is what is registered against it.
+ */
+export function aStockTable(
+  simulation: SimAthenaEngineSimulation,
+  parameters: Record<string, string> = {},
+): void {
+  aCatalogTable(simulation.simAws, {
+    name: "stock",
+    columns: [{ Name: "sku", Type: "string" }],
+    partitionKeys: [{ Name: "day", Type: "string" }],
+    parameters,
+  });
+}
+
+/** Register one partition of that `stock` table. */
+export function aStockPartition(
+  simulation: SimAthenaEngineSimulation,
+  values: readonly string[],
+  location?: string,
+): void {
+  aRegisteredPartition(simulation.simAws, "stock", values, location);
+}

--- a/src/service/athena/sim-athena-registered-partitions.iso.test.ts
+++ b/src/service/athena/sim-athena-registered-partitions.iso.test.ts
@@ -1,0 +1,134 @@
+import { assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  anEngineSimulation,
+  aSeededJson,
+  logsBucket,
+} from "./sim-athena-engine.fixture.js";
+import {
+  aStockPartition,
+  aStockTable,
+} from "./sim-athena-registered-partition.fixture.js";
+
+describe("querying a table whose partitions are registered", () => {
+  it("reads a partition from the location it was registered with", async () => {
+    // Given a table partitioned by day, with one day registered under a
+    // prefix nothing about the table's own location would find.
+    const simulation = await anEngineSimulation();
+
+    aStockTable(simulation);
+    aStockPartition(
+      simulation,
+      ["2026-08-01"],
+      `s3://${logsBucket}/archived/august/`,
+    );
+
+    await aSeededJson(simulation.simAws, "archived/august/part-0.json", [
+      { sku: "bolt" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query reads the table.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, day FROM rainlytics.stock",
+    );
+
+    // Then the row comes back with the day it was registered under. Nothing
+    // in the object or its key says which partition it belongs to, so the
+    // registration is the only thing that knows.
+    assertObjectEquals(answered.rows, [["bolt", "2026-08-01"]]);
+  });
+
+  it("reads only the partitions the query's filter allows", async () => {
+    // Given two days registered, each holding one row.
+    const simulation = await anEngineSimulation();
+
+    aStockTable(simulation);
+
+    const days = ["2026-08-01", "2026-08-02"];
+
+    for (const day of days) {
+      aStockPartition(simulation, [day], `s3://${logsBucket}/${day}/`);
+    }
+
+    await Promise.all(
+      days.map(async (day) =>
+        aSeededJson(simulation.simAws, `${day}/part-0.json`, [
+          { sku: `sold-${day}` },
+        ]),
+      ),
+    );
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query pins one of them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku FROM rainlytics.stock WHERE day = '2026-08-02'",
+    );
+
+    // Then only that day's rows are read.
+    assertObjectEquals(answered.rows, [["sold-2026-08-02"]]);
+  });
+
+  it("reads a partition registered without a location of its own", async () => {
+    // Given a day registered with nothing said about where it sits.
+    const simulation = await anEngineSimulation();
+
+    aStockTable(simulation);
+    aStockPartition(simulation, ["2026-08-01"]);
+
+    await aSeededJson(simulation.simAws, "stock/day=2026-08-01/part-0.json", [
+      { sku: "bolt" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query reads the table.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, day FROM rainlytics.stock",
+    );
+
+    // Then it is found under the Hive layout beneath the table's location,
+    // which is where Athena looks for one.
+    assertObjectEquals(answered.rows, [["bolt", "2026-08-01"]]);
+  });
+
+  it("reads the projection where a table carries both", async () => {
+    // Given a table projecting one day, with another day registered against
+    // it holding rows of its own.
+    const simulation = await anEngineSimulation();
+
+    aStockTable(simulation, {
+      "projection.enabled": "true",
+      "projection.day.type": "date",
+      "projection.day.format": "yyyy-MM-dd",
+      "projection.day.range": "2026-08-01,2026-08-01",
+    });
+    aStockPartition(
+      simulation,
+      ["2026-08-02"],
+      `s3://${logsBucket}/registered/`,
+    );
+
+    await aSeededJson(simulation.simAws, "stock/day=2026-08-01/part-0.json", [
+      { sku: "projected" },
+    ]);
+    await aSeededJson(simulation.simAws, "registered/part-0.json", [
+      { sku: "registered" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query reads the table.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku FROM rainlytics.stock",
+    );
+
+    // Then the projected partition is the whole of it. Real Athena stops
+    // reading the catalog's partitions once projection is on.
+    assertObjectEquals(answered.rows, [["projected"]]);
+  });
+});

--- a/src/service/athena/sim-athena-scanned-bytes.fixture.ts
+++ b/src/service/athena/sim-athena-scanned-bytes.fixture.ts
@@ -3,6 +3,9 @@ import { faker } from "@faker-js/faker";
 import type { SimAws } from "../aws/sim-aws.js";
 import { SimAws as SimAwsClass } from "../aws/sim-aws.js";
 
+/** The one key every partitioned table in these fixtures declares. */
+export const dayKey = ["day"];
+
 /** A table projecting one prefix per day across three days. */
 export const projectedDays = {
   "projection.enabled": "true",
@@ -19,6 +22,7 @@ export const projectedDays = {
 export async function aScannedSimulation(
   parameters: Record<string, string> = {},
   cutoff?: number,
+  partitionKeyNames: readonly string[] = [],
 ): Promise<{ simAws: SimAws; workGroup: string }> {
   const simAws = new SimAwsClass();
   const workGroup = `analytics-${faker.string.uuid()}`;
@@ -43,10 +47,10 @@ export async function aScannedSimulation(
       DatabaseName: "rainlytics",
       TableInput: {
         Name: "access_logs",
-        PartitionKeys:
-          Object.keys(parameters).length === 0
-            ? []
-            : [{ Name: "day", Type: "string" }],
+        PartitionKeys: partitionKeyNames.map((Name) => ({
+          Name,
+          Type: "string",
+        })),
         StorageDescriptor: { Location: "s3://rainlytics-logs/logs/" },
         Parameters: parameters,
       },

--- a/src/service/athena/sim-athena-scanned-bytes.iso.test.ts
+++ b/src/service/athena/sim-athena-scanned-bytes.iso.test.ts
@@ -2,9 +2,11 @@ import { assertIdentical } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { aRanQuery } from "./sim-athena-ran-query.fixture.js";
+import { aRegisteredPartition } from "./sim-athena-registered-partition.fixture.js";
 import {
   aScannedSimulation,
   aSeededObject,
+  dayKey,
   projectedDays,
 } from "./sim-athena-scanned-bytes.fixture.js";
 
@@ -30,7 +32,11 @@ describe("measuring what an Athena query scans", () => {
 
   it("counts only the partitions a filter allows", async () => {
     // Given a table projecting three days, each holding an object.
-    const { simAws, workGroup } = await aScannedSimulation(projectedDays);
+    const { simAws, workGroup } = await aScannedSimulation(
+      projectedDays,
+      undefined,
+      dayKey,
+    );
 
     await aSeededObject(simAws, "logs/2026-08-24/part-0.json", 100);
     await aSeededObject(simAws, "logs/2026-08-25/part-0.json", 200);
@@ -54,6 +60,84 @@ describe("measuring what an Athena query scans", () => {
     // three. This is what partitioning a table is for.
     assertIdentical(oneDay.scanned, 200);
     assertIdentical(everyDay.scanned, 700);
+  });
+
+  it("counts only the registered partitions a filter allows", async () => {
+    // Given a table partitioned by day with nothing projected, holding three
+    // days registered against it and an object in each.
+    const { simAws, workGroup } = await aScannedSimulation(
+      {},
+      undefined,
+      dayKey,
+    );
+
+    for (const day of ["2026-08-24", "2026-08-25", "2026-08-26"]) {
+      aRegisteredPartition(
+        simAws,
+        "access_logs",
+        [day],
+        `s3://rainlytics-logs/logs/${day}/`,
+      );
+    }
+
+    await aSeededObject(simAws, "logs/2026-08-24/part-0.json", 100);
+    await aSeededObject(simAws, "logs/2026-08-25/part-0.json", 200);
+    await aSeededObject(simAws, "logs/2026-08-26/part-0.json", 400);
+
+    // When a query naming one day runs, and one naming none of them.
+    const oneDay = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs WHERE day = '2026-08-25'",
+    );
+    const everyDay = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs",
+    );
+
+    // Then the filtered query reads one partition. Before the catalog's
+    // partitions were read, both of these reported the whole table.
+    assertIdentical(oneDay.scanned, 200);
+    assertIdentical(everyDay.scanned, 700);
+  });
+
+  it("counts a registered partition sitting outside the table's location", async () => {
+    // Given a table with one day registered somewhere else entirely, which a
+    // catalog allows and a table location alone could never reach.
+    const { simAws, workGroup } = await aScannedSimulation(
+      {},
+      undefined,
+      dayKey,
+    );
+
+    await simAws.s3().createBucket({ input: { Bucket: "rainlytics-archive" } });
+    aRegisteredPartition(
+      simAws,
+      "access_logs",
+      ["2026-08-24"],
+      "s3://rainlytics-archive/old/2026-08-24/",
+    );
+
+    await simAws.s3().putObject({
+      input: {
+        Bucket: "rainlytics-archive",
+        Key: "old/2026-08-24/part-0.json",
+        Body: "x".repeat(500),
+      },
+    });
+    await aSeededObject(simAws, "logs/2026-08-25/part-0.json", 200);
+
+    // When a query runs against the table.
+    const ran = await aRanQuery(
+      simAws,
+      workGroup,
+      "SELECT url FROM rainlytics.access_logs",
+    );
+
+    // Then it reads the archived partition and nothing under the table's own
+    // location, since no partition registered points there.
+    assertIdentical(ran.scanned, 500);
   });
 
   it("scans nothing where the table points at a Bucket nobody made", async () => {

--- a/src/service/athena/table/sim-athena-registered-partitions.iso.test.ts
+++ b/src/service/athena/table/sim-athena-registered-partitions.iso.test.ts
@@ -1,0 +1,146 @@
+import { assertArrayEquals, assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simAthenaTablePartitions,
+  type SimAthenaPartitionedTable,
+} from "../projection/sim-athena-table-partitions.js";
+import type { SimAthenaCatalogPartition } from "./sim-athena-registered-partitions.js";
+
+const noon = new Date("2026-08-26T12:00:00.000Z");
+
+/** A table with no projection, laid out under its own location. */
+function aTable(
+  partitionKeys: readonly string[],
+  location = "s3://rainlytics-logs/cloudfront/",
+): SimAthenaPartitionedTable {
+  return {
+    parameters: {},
+    partitionKeys: partitionKeys.map((Name) => ({ Name })),
+    storageDescriptor: { Location: location },
+  };
+}
+
+/** A table that says nothing about where its data sits. */
+function aTableWithoutLocation(
+  partitionKeys: readonly string[],
+): SimAthenaPartitionedTable {
+  return {
+    parameters: {},
+    partitionKeys: partitionKeys.map((Name) => ({ Name })),
+    storageDescriptor: undefined,
+  };
+}
+
+/** One partition the catalog holds, as a test writes it down. */
+function aPartition(
+  values: readonly string[],
+  Location?: string,
+): SimAthenaCatalogPartition {
+  return {
+    values,
+    storageDescriptor: Location === undefined ? undefined : { Location },
+  };
+}
+
+function partitionsOf(
+  table: SimAthenaPartitionedTable,
+  queryString = "SELECT * FROM rainlytics.access_logs",
+  registered: readonly SimAthenaCatalogPartition[] = [],
+): readonly string[] {
+  return simAthenaTablePartitions({
+    table,
+    registered,
+    queryString,
+    now: noon,
+  }).map((partition) => partition.prefix);
+}
+
+describe("the S3 prefixes a query reads for registered partitions", () => {
+  it("reads one prefix per registered partition", () => {
+    // Given a table with two partitions registered against it, each saying
+    // where its own objects sit.
+    const table = aTable(["day"]);
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table, undefined, [
+      aPartition(["2026-08-25"], "s3://rainlytics-logs/day=2026-08-25/"),
+      aPartition(["2026-08-26"], "s3://elsewhere/2026-08-26"),
+    ]);
+
+    // Then each partition's own location is read, whether or not it sits
+    // under the table's, and each ends in a slash.
+    assertArrayEquals(prefixes, [
+      "s3://rainlytics-logs/day=2026-08-25/",
+      "s3://elsewhere/2026-08-26/",
+    ]);
+  });
+
+  it("falls back to the Hive layout for a partition with no location", () => {
+    // Given a table partitioned two ways, holding a partition registered
+    // without a location of its own.
+    const table = aTable(["day", "region"]);
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table, undefined, [
+      aPartition(["2026-08-26", "eu-west-2"]),
+    ]);
+
+    // Then it sits under the table's location, one segment per key in the
+    // order the table declares them.
+    assertArrayEquals(prefixes, [
+      "s3://rainlytics-logs/cloudfront/day=2026-08-26/region=eu-west-2/",
+    ]);
+  });
+
+  it("reads a registered partition short of a value as empty", () => {
+    // Given a table partitioned two ways, holding a partition registered with
+    // one value. The catalog writer takes the values it is given rather than
+    // holding them to the table, so this reaches here.
+    const table = aTable(["day", "region"]);
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table, undefined, [
+      aPartition(["2026-08-26"]),
+    ]);
+
+    // Then the key it has no value for reads as empty.
+    assertArrayEquals(prefixes, [
+      "s3://rainlytics-logs/cloudfront/day=2026-08-26/region=/",
+    ]);
+  });
+
+  it("narrows registered partitions by the query's filter", () => {
+    // Given a table with three days registered against it.
+    const table = aTable(["day"]);
+    const registered = [
+      aPartition(["2026-08-24"], "s3://rainlytics-logs/day=2026-08-24/"),
+      aPartition(["2026-08-25"], "s3://rainlytics-logs/day=2026-08-25/"),
+      aPartition(["2026-08-26"], "s3://rainlytics-logs/day=2026-08-26/"),
+    ];
+
+    // When a query pins the day.
+    const prefixes = partitionsOf(
+      table,
+      "SELECT * FROM rainlytics.access_logs WHERE day = '2026-08-25'",
+      registered,
+    );
+
+    // Then only that day's prefix is read.
+    assertArrayEquals(prefixes, ["s3://rainlytics-logs/day=2026-08-25/"]);
+  });
+
+  it("reads nothing for a partition with nowhere to look", () => {
+    // Given a table with no location, holding a partition with none either.
+    const table = aTableWithoutLocation(["day"]);
+
+    // When its partitions are read.
+    const prefixes = partitionsOf(table, undefined, [
+      aPartition(["2026-08-26"]),
+    ]);
+
+    // Then there is nowhere to read, and the query reads nothing rather than
+    // reading the wrong place.
+    assertArrayLength(prefixes, 0);
+  });
+});

--- a/src/service/athena/table/sim-athena-registered-partitions.ts
+++ b/src/service/athena/table/sim-athena-registered-partitions.ts
@@ -1,0 +1,108 @@
+import {
+  simAthenaHivePrefix,
+  simAthenaLocationPrefix,
+  type SimAthenaTablePartition,
+} from "../projection/sim-athena-projection-location.js";
+import {
+  simAthenaPartitionFilters,
+  type SimAthenaPartitionFilters,
+} from "./sim-athena-partition-filters.js";
+
+/** One partition the catalog holds, as reading it needs it. */
+export interface SimAthenaCatalogPartition {
+  readonly values: readonly string[];
+  readonly storageDescriptor:
+    | { readonly Location?: string | undefined }
+    | undefined;
+}
+
+interface SimAthenaRegisteredPartitionsRequest {
+  readonly partitionKeys: readonly { Name: string }[];
+  readonly registered: readonly SimAthenaCatalogPartition[];
+  readonly tableLocation: string | undefined;
+  readonly queryString: string;
+}
+
+/**
+ * The registered partitions one query reads for one table.
+ *
+ * A crawler, `MSCK REPAIR TABLE` or a Glue job puts these in the catalog, and
+ * each one says where its own objects sit. That location need not be under the
+ * table's, which is why a query reads one prefix per partition rather than the
+ * table's location alone.
+ *
+ * The query's `WHERE` clause narrows them through the same reader that narrows
+ * a projection, so a query pinning one day reads one day's objects.
+ */
+export function simAthenaRegisteredPartitions(
+  request: SimAthenaRegisteredPartitionsRequest,
+): readonly SimAthenaTablePartition[] {
+  const filters = simAthenaPartitionFilters(request.queryString);
+  const partitions: SimAthenaTablePartition[] = [];
+
+  for (const registered of request.registered) {
+    const values = valuesOf(request.partitionKeys, registered.values);
+
+    if (!allows(filters, values)) {
+      continue;
+    }
+
+    const prefix = prefixOf(registered, values, request.tableLocation);
+
+    if (prefix !== undefined) {
+      partitions.push({ prefix, values });
+    }
+  }
+
+  return partitions;
+}
+
+/**
+ * What each partition column reads for the rows under this partition.
+ *
+ * A partition's values are positional against the table's partition keys, the
+ * way the catalog stores them.
+ */
+function valuesOf(
+  partitionKeys: readonly { Name: string }[],
+  values: readonly string[],
+): ReadonlyMap<string, string> {
+  return new Map(
+    partitionKeys.map((key, index) => [key.Name, values.at(index) ?? ""]),
+  );
+}
+
+/** Whether the query's filters leave this partition in. */
+function allows(
+  filters: SimAthenaPartitionFilters,
+  values: ReadonlyMap<string, string>,
+): boolean {
+  return values
+    .entries()
+    .every(([name, value]) => filters.valuesFor(name)?.includes(value) ?? true);
+}
+
+/**
+ * Where one partition's objects sit, or nothing where there is nowhere to
+ * look.
+ *
+ * A partition registered with no location of its own falls back to the Hive
+ * layout under the table's location, as Athena resolves one. A partition with
+ * neither has no prefix, and a table with no location reads nothing either
+ * way.
+ */
+function prefixOf(
+  registered: SimAthenaCatalogPartition,
+  values: ReadonlyMap<string, string>,
+  tableLocation: string | undefined,
+): string | undefined {
+  const location = registered.storageDescriptor?.Location;
+
+  if (location !== undefined) {
+    return simAthenaLocationPrefix(location);
+  }
+
+  return tableLocation === undefined
+    ? undefined
+    : simAthenaHivePrefix(tableLocation, values);
+}

--- a/src/service/athena/table/sim-athena-table-resolution.ts
+++ b/src/service/athena/table/sim-athena-table-resolution.ts
@@ -6,6 +6,7 @@ import {
   type SimAthenaTableReference,
 } from "./sim-athena-table-reference.js";
 import type { SimAthenaCatalogTable } from "./sim-athena-catalog-table.js";
+import type { SimAthenaCatalogPartition } from "./sim-athena-registered-partitions.js";
 import { simAthenaTableReferences } from "./sim-athena-table-references.js";
 
 /**
@@ -21,6 +22,10 @@ export interface SimAthenaCatalog {
     databaseName: string,
     name: string,
   ): SimAthenaCatalogTable | undefined;
+  partitionsInTable(
+    databaseName: string,
+    name: string,
+  ): readonly SimAthenaCatalogPartition[];
 }
 
 /** What resolving a query's tables came to. */


### PR DESCRIPTION
A table whose partitions the Data Catalog holds read its whole storage descriptor location, so every query against one scanned every byte under it whatever the query filtered on. That is the common case on real AWS, where a crawler or a Glue job registers each partition and projection is the newer and less used of the two.

Such a table now reads one prefix per registered partition, taken from that partition's own storage descriptor location, and the query's `WHERE` clause narrows them through `simAthenaPartitionFilters`, the same reader that already narrows a projection. A partition registered without a location of its own falls back to the Hive layout under the table's, as Athena resolves one, and a partition registered somewhere else entirely is read there.

Projection still wins where a table carries both, since real Athena stops reading the catalog's partitions once `projection.enabled` is true. A table with neither reads its storage descriptor location, unchanged.

`SimAthenaCatalog` gained `partitionsInTable`, which `SimGlue` already answers structurally. The partition values travel with each prefix, so the engine writes the registered value into the partition column even where nothing in the object or its key says which partition it belongs to.

Resolves https://github.com/KensioSoftware/yulin/issues/1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Athena now reads registered Glue partitions, including custom storage locations and Hive-style fallback paths.
  * Query filters prune registered partitions, and scanned-byte reporting includes eligible registered data.
  * Partition projection takes precedence over registered partitions when enabled.
  * Added an executable example demonstrating registered-partition queries.

* **Documentation**
  * Updated Athena and Glue documentation with partition behavior, precedence rules, limitations, and usage details.

* **Tests**
  * Added coverage for partition filtering, locations, fallbacks, projection precedence, and scanned-byte calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->