### PR TITLE
feat: fold Glue and Athena catalog names to lower case

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -531,6 +531,14 @@ The `WHERE` clause narrows what is projected. `day = '2026-08-25'` and `day IN (
 
 A table with projection on and no `storage.location.template` gets the Hive layout under its own location, as `<location>/day=2026-08-25/`.
 
+## Names are folded to lower case
+
+Athena accepts mixed case in a query and lower cases the names when it executes it. A query naming `Rainlytics.Access_Logs` resolves against the table the catalog holds as `rainlytics.access_logs`, and so does one naming `"Rainlytics"."Access_Logs"`. Quoting an identifier says what characters it may hold rather than what case it keeps.
+
+The database in a query's execution context folds the same way, and a refusal names the table the way Athena went looking for it. Simulated [Glue](https://yulinsim.dev/services/glue/ "Simulated Glue usage docs") folds a database and a table name when it stores one, so both ends of the lookup agree.
+
+Column names are left alone here. Real Athena folds those too, and nothing in this simulation resolves a column by name.
+
 ## Registered partitions
 
 A table that registers its partitions rather than projecting them is read from the catalog. A query against one reads a prefix per registered partition, taken from that partition's own storage descriptor location, and the `WHERE` clause narrows them the way it narrows projected ones.

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -91,6 +91,46 @@ A broken projection fails that query.
 
 `Ref` answers with the database name and with the table name.
 
+## Names are folded to lower case
+
+A database name and a table name are both folded to lower case when they are stored. Real Glue folds
+them the same way, for compatibility with Apache Hive. A database created as `Rainlytics` is stored,
+reported and queried as `rainlytics`.
+
+```typescript sim-glue-name-folding
+/**
+ * A catalog name folded on its way in.
+ */
+
+import {
+  CreateDatabaseCommand,
+  GetDatabaseCommand,
+} from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const glue = new SimAws().glue();
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "Rainlytics" } }),
+);
+
+const { Database } = glue.getDatabase(
+  new GetDatabaseCommand({ Name: "Rainlytics" }),
+);
+
+// rainlytics
+console.log(Database.Name);
+```
+
+Two names differing only by case are one name. A second `CreateDatabase` for `Rainlytics` after one
+for `rainlytics` is an `AlreadyExistsException`, and a `GetTable` finds the table under whichever
+spelling it is asked for.
+
+Column names keep the case they were given, including partition keys. Real Glue leaves those alone,
+and simulated [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") folds a
+column name only when it runs a query.
+
 ## Reading the catalog back
 
 `GetDatabase`, `GetDatabases`, `GetTable` and `GetTables` answer through the SDK. A `SimGlue` also
@@ -407,6 +447,7 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
 - `AWS::Glue::Database` and `AWS::Glue::Table`, deployed and deleted with the stack.
 - `TableInput.Parameters`, `PartitionKeys` and `StorageDescriptor`, held and read back as declared.
 - IAM authorization on every Command, over the resource and its ancestors.
+- Database and table names folded to lower case, as the Data Catalog folds them.
 
 ## Limitations
 
@@ -442,8 +483,12 @@ A policy listing only the table ARN is refused here, and refused by real Glue fo
   the attribute exists and documents nothing about its value, so a template asserting on it agrees
   with this simulation and may disagree with a real deploy. Confirming it takes one stack deployed
   to an account with `!GetAtt Table.Id` as an output.
-- **Names keep the case they were given.** Real Glue lowercases a database or table name for Hive
-  compatibility. A name that differs only by case is a different name here.
+- **A lookup finds a name under any spelling.** Real Glue documents the fold on the way in and asks
+  the caller to pass lower case on the way back out. `GetDatabase` and `GetTable` fold the name they
+  are given here, so a request naming `Rainlytics` reaches the database stored as `rainlytics`. This
+  is the one piece of the fold nothing has checked against AWS. A test relying on it agrees with
+  this simulation and may disagree with a real call, and passing the name in lower case avoids the
+  question.
 - **Cross-account catalogs are refused.** A `CatalogId` naming another account is refused, in a
   Command and in a template.
 - **Versions, statistics and Lake Formation are absent.** A table has no version history and no

--- a/docs/services/glue/sim-glue-name-folding.example.ts
+++ b/docs/services/glue/sim-glue-name-folding.example.ts
@@ -1,0 +1,23 @@
+/**
+ * A catalog name folded on its way in.
+ */
+
+import {
+  CreateDatabaseCommand,
+  GetDatabaseCommand,
+} from "@aws-sdk/client-glue";
+
+import { SimAws } from "@kensio/yulin";
+
+const glue = new SimAws().glue();
+
+glue.createDatabase(
+  new CreateDatabaseCommand({ DatabaseInput: { Name: "Rainlytics" } }),
+);
+
+const { Database } = glue.getDatabase(
+  new GetDatabaseCommand({ Name: "Rainlytics" }),
+);
+
+// rainlytics
+console.log(Database.Name);

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -106,6 +106,11 @@ entry per bracket level, and a subquery's own FROM then leaves the outer one sta
 `x AS (` is taken as a common table expression, since nothing else in a statement this scans puts a
 bracket straight after `AS`.
 
+`simAthenaFoldedName` folds the database and table names a query holds before the catalog is asked
+for them. Athena lower cases the names when it executes a query, and it does that to a quoted
+identifier as well. The tokeniser keeps a quoted identifier's case because quoting says what
+characters a name may hold, and resolution is where that case stops counting.
+
 `table/sim-athena-registered-partitions.ts` reads the partitions the Data Catalog holds against a
 table into those same prefixes, one per partition, each taken from the partition's own storage
 descriptor location. A partition with none falls back to the Hive layout under the table's location.

--- a/src/service/athena/sim-athena-name-folding.iso.test.ts
+++ b/src/service/athena/sim-athena-name-folding.iso.test.ts
@@ -1,0 +1,115 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+} from "./sim-athena-engine.fixture.js";
+import { aRanQuery } from "./sim-athena-ran-query.fixture.js";
+
+describe("folding the names an Athena query holds", () => {
+  it("resolves a table named in mixed case", async () => {
+    // Given a table in the catalog, holding one row.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "stock",
+      columns: [{ Name: "sku", Type: "string" }],
+    });
+
+    await aSeededJson(simulation.simAws, "stock/part-0.json", [
+      { sku: "bolt" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When a query names it with capitals in both parts.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku FROM Rainlytics.Stock",
+    );
+
+    // Then it resolves. Athena accepts mixed case in a query and lower cases
+    // the names when it executes it.
+    assertObjectEquals(answered.rows, [["bolt"]]);
+  });
+
+  it("folds a quoted identifier too", async () => {
+    // Given the same table.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "stock",
+      columns: [{ Name: "sku", Type: "string" }],
+    });
+
+    await aSeededJson(simulation.simAws, "stock/part-0.json", [
+      { sku: "bolt" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When the query quotes the names and writes them in mixed case.
+    const answered = await anAnsweredQuery(
+      simulation,
+      'SELECT sku FROM "rainlytics"."Stock"',
+    );
+
+    // Then quoting does not hold the case. Real Athena folds a quoted
+    // identifier when it executes the query as well.
+    assertObjectEquals(answered.rows, [["bolt"]]);
+  });
+
+  it("resolves against a mixed case database in the query context", async () => {
+    // Given the same table, queried without qualifying it.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "stock",
+      columns: [{ Name: "sku", Type: "string" }],
+    });
+
+    await aSeededJson(simulation.simAws, "stock/part-0.json", [
+      { sku: "bolt" },
+    ]);
+    await simulation.simAws.athena().engine().enable();
+
+    // When the execution's own database carries capitals.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku FROM Stock",
+      "Rainlytics",
+    );
+
+    // Then it resolves the same way.
+    assertObjectEquals(answered.rows, [["bolt"]]);
+  });
+
+  it("names the folded table where one is absent", async () => {
+    // Given a catalog holding a database and no such table.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "stock",
+      columns: [{ Name: "sku", Type: "string" }],
+    });
+
+    // When a query names a table nobody made, in mixed case.
+    const ran = await aRanQuery(
+      simulation.simAws,
+      simulation.workGroup,
+      "SELECT * FROM Rainlytics.Missing_Table",
+    );
+
+    // Then it fails, naming the table the way Athena went looking for it.
+    assertIdentical(ran.state, "FAILED");
+    assertStringIncludes(
+      ran.reason ?? "",
+      "awsdatacatalog.rainlytics.missing_table",
+    );
+  });
+});

--- a/src/service/athena/table/sim-athena-table-reference.ts
+++ b/src/service/athena/table/sim-athena-table-reference.ts
@@ -26,8 +26,24 @@ export const defaultAthenaCatalog = "awsdatacatalog";
 export const informationSchemaName = "information_schema";
 
 /**
+ * A catalog name as Athena reads one.
+ *
+ * Athena accepts mixed case in a query and lower cases the names when it
+ * executes it. A quoted identifier keeps its case through the tokeniser, since
+ * quoting matters for what a name may contain, and this is where that case
+ * stops counting.
+ *
+ * https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html
+ */
+export function simAthenaFoldedName(name: string): string {
+  return name.toLowerCase();
+}
+
+/**
  * How a reference reads back in an error, qualified the way Athena qualifies
  * one.
+ *
+ * Folded, because the name Athena went looking for is the folded one.
  */
 export function simAthenaTableReferenceText(
   reference: SimAthenaTableReference,
@@ -39,5 +55,5 @@ export function simAthenaTableReferenceText(
     reference.name,
   ];
 
-  return parts.join(".");
+  return simAthenaFoldedName(parts.join("."));
 }

--- a/src/service/athena/table/sim-athena-table-resolution.ts
+++ b/src/service/athena/table/sim-athena-table-resolution.ts
@@ -2,6 +2,7 @@ import { simAthenaSqlPosition } from "./sim-athena-sql-tokens.js";
 import {
   defaultAthenaCatalog,
   informationSchemaName,
+  simAthenaFoldedName,
   simAthenaTableReferenceText,
   type SimAthenaTableReference,
 } from "./sim-athena-table-reference.js";
@@ -82,11 +83,13 @@ export function simAthenaResolveTables(
       continue;
     }
 
-    const database = reference.database ?? request.database;
+    const declared = reference.database ?? request.database;
+    const database =
+      declared === undefined ? undefined : simAthenaFoldedName(declared);
     const found =
       database === undefined
         ? undefined
-        : catalog.findTable(database, reference.name);
+        : catalog.findTable(database, simAthenaFoldedName(reference.name));
 
     if (found === undefined) {
       return { refusal: refusalFor(reference, request, database), tables: [] };

--- a/src/service/glue/README.md
+++ b/src/service/glue/README.md
@@ -92,6 +92,18 @@ one bad registration hide every good one.
 Glue, and a real policy grants `glue:CreatePartition` on the table. `SimGluePartitionRegistry`
 resolves the table first and every partition command goes through it.
 
+**A database and a table name are folded to lower case.** Real Glue documents the same thing for
+both. `DatabaseInput.Name` and `TableInput.Name` each say the name is folded to lowercase when it is
+stored, for compatibility with Apache Hive. `foldedSimGlueName` is what every command reads a
+catalog name through, and the stores fold again on the way to a key so the CloudFormation writer and
+the simulator's own accessors agree with it. Column names go through `requiredSimGlueName` instead
+and keep their case, since real Glue leaves those alone.
+
+**A lookup folds the name it is given, which AWS does not document.** Real Glue states the fold for
+storing and says only that a `GetDatabase` name should be lower case. Folding the lookup is the
+forgiving reading, and it is the second guess in this service after `Fn::GetAtt Id`. The usage docs
+say so. Storing a name that is already lower case makes the question go away.
+
 **A `CatalogId` naming another account is refused.** Creating the resource in this account's catalog
 would give a template that deploys and a catalog holding something the template never asked for.
 

--- a/src/service/glue/command/database/sim-glue-database-commands.ts
+++ b/src/service/glue/command/database/sim-glue-database-commands.ts
@@ -1,6 +1,6 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
-import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
+import { foldedSimGlueName } from "../../database/sim-glue-catalog-name.js";
 import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
 import type { SimGluePartitionStore } from "../../partition/sim-glue-partition-store.js";
 import type { SimGlueTableStore } from "../../table/sim-glue-table-store.js";
@@ -61,7 +61,7 @@ export class SimGlueDatabaseCommands {
     requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
 
     const input = command.input.DatabaseInput ?? {};
-    const name = requiredSimGlueName("DatabaseInput.Name", input.Name);
+    const name = foldedSimGlueName("DatabaseInput.Name", input.Name);
 
     this.#authorizer.authorizeDatabase(
       "glue:CreateDatabase",
@@ -87,7 +87,7 @@ export class SimGlueDatabaseCommands {
   ): SimGetDatabaseCommandOutput {
     requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
 
-    const name = requiredSimGlueName("Name", command.input.Name);
+    const name = foldedSimGlueName("Name", command.input.Name);
 
     this.#authorizer.authorizeDatabase(
       "glue:GetDatabase",
@@ -127,7 +127,7 @@ export class SimGlueDatabaseCommands {
   ): SimDeleteDatabaseCommandOutput {
     requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
 
-    const name = requiredSimGlueName("Name", command.input.Name);
+    const name = foldedSimGlueName("Name", command.input.Name);
 
     this.#authorizer.authorizeDatabaseDeletion(
       name,

--- a/src/service/glue/command/partition/sim-glue-partition-registry.ts
+++ b/src/service/glue/command/partition/sim-glue-partition-registry.ts
@@ -1,6 +1,6 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
-import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
+import { foldedSimGlueName } from "../../database/sim-glue-catalog-name.js";
 import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
 import { simGluePartitionExpressionFilter } from "../../expression/sim-glue-partition-expression.js";
 import type { SimGluePartition } from "../../partition/sim-glue-partition.js";
@@ -72,11 +72,8 @@ export class SimGluePartitionRegistry {
   ): SimGlueTable {
     requireSimGlueCatalogId(this.#accountRegionScope, input.CatalogId);
 
-    const databaseName = requiredSimGlueName(
-      "DatabaseName",
-      input.DatabaseName,
-    );
-    const tableName = requiredSimGlueName("TableName", input.TableName);
+    const databaseName = foldedSimGlueName("DatabaseName", input.DatabaseName);
+    const tableName = foldedSimGlueName("TableName", input.TableName);
 
     this.#authorizer.authorizeTable(
       action,

--- a/src/service/glue/command/table/sim-glue-table-commands.ts
+++ b/src/service/glue/command/table/sim-glue-table-commands.ts
@@ -1,6 +1,6 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
-import { requiredSimGlueName } from "../../database/sim-glue-catalog-name.js";
+import { foldedSimGlueName } from "../../database/sim-glue-catalog-name.js";
 import type { SimGlueDatabaseStore } from "../../database/sim-glue-database-store.js";
 import type { SimGluePartitionStore } from "../../partition/sim-glue-partition-store.js";
 import type { SimGlueTableStore } from "../../table/sim-glue-table-store.js";
@@ -64,12 +64,12 @@ export class SimGlueTableCommands {
   ): SimCreateTableCommandOutput {
     requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
 
-    const databaseName = requiredSimGlueName(
+    const databaseName = foldedSimGlueName(
       "DatabaseName",
       command.input.DatabaseName,
     );
     const input = command.input.TableInput ?? {};
-    const name = requiredSimGlueName(
+    const name = foldedSimGlueName(
       "TableInput.Name",
       input.Name ?? command.input.Name,
     );
@@ -111,11 +111,11 @@ export class SimGlueTableCommands {
   ): SimGetTableCommandOutput {
     requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
 
-    const databaseName = requiredSimGlueName(
+    const databaseName = foldedSimGlueName(
       "DatabaseName",
       command.input.DatabaseName,
     );
-    const name = requiredSimGlueName("Name", command.input.Name);
+    const name = foldedSimGlueName("Name", command.input.Name);
 
     this.#authorizer.authorizeTable(
       "glue:GetTable",
@@ -141,7 +141,7 @@ export class SimGlueTableCommands {
   ): SimGetTablesCommandOutput {
     requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
 
-    const databaseName = requiredSimGlueName(
+    const databaseName = foldedSimGlueName(
       "DatabaseName",
       command.input.DatabaseName,
     );
@@ -169,11 +169,11 @@ export class SimGlueTableCommands {
   ): SimDeleteTableCommandOutput {
     requireSimGlueCatalogId(this.#accountRegionScope, command.input.CatalogId);
 
-    const databaseName = requiredSimGlueName(
+    const databaseName = foldedSimGlueName(
       "DatabaseName",
       command.input.DatabaseName,
     );
-    const name = requiredSimGlueName("Name", command.input.Name);
+    const name = foldedSimGlueName("Name", command.input.Name);
 
     this.#authorizer.authorizeTable(
       "glue:DeleteTable",

--- a/src/service/glue/database/sim-glue-catalog-name.ts
+++ b/src/service/glue/database/sim-glue-catalog-name.ts
@@ -14,8 +14,8 @@ const nameEncoder = new TextEncoder();
 /**
  * Read a Data Catalog name, refusing one real Glue would refuse.
  *
- * Real Glue lowercases these names for Hive compatibility. This keeps the
- * name as it was given, which is recorded in the docs page's Limitations list.
+ * The case is kept as it was given. Column names are read through this, and
+ * they are the names real Glue leaves alone.
  */
 export function requiredSimGlueName(
   label: string,
@@ -32,4 +32,28 @@ export function requiredSimGlueName(
   }
 
   return value;
+}
+
+/**
+ * Read a database or table name, folded the way the Data Catalog folds one.
+ *
+ * Real Glue states the same thing for both. `DatabaseInput.Name` and
+ * `TableInput.Name` are each documented as folded to lowercase when they are
+ * stored, for compatibility with Apache Hive.
+ *
+ * The fold is locale independent, since a Data Catalog name means the same
+ * thing wherever it is read.
+ *
+ * https://docs.aws.amazon.com/glue/latest/webapi/API_TableInput.html
+ */
+export function foldedSimGlueName(
+  label: string,
+  value: string | undefined,
+): string {
+  return simGlueFolded(requiredSimGlueName(label, value));
+}
+
+/** Fold a name that has already been read. */
+export function simGlueFolded(name: string): string {
+  return name.toLowerCase();
 }

--- a/src/service/glue/database/sim-glue-database-store.ts
+++ b/src/service/glue/database/sim-glue-database-store.ts
@@ -1,8 +1,9 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import {
-  SimGlueAlreadyExistsException,
-  SimGlueEntityNotFoundException,
-} from "../error/sim-glue.error.js";
+  refuseSimGlueNameInPlace,
+  requireSimGlueFound,
+} from "../error/sim-glue-catalog-refusal.js";
+import { simGlueFolded } from "./sim-glue-catalog-name.js";
 import { SimGlueDatabase } from "./sim-glue-database.js";
 
 interface SimGlueDatabaseStoreProperties {
@@ -20,7 +21,8 @@ export interface SimGlueDatabaseInput {
  * The databases of one simulated Glue catalog.
  *
  * Keyed by name, which is the whole of a database's identity within one
- * account and region.
+ * account and region. Every name is folded to lower case on the way in and on
+ * the way to a lookup, the way the Data Catalog folds one when it stores it.
  */
 export class SimGlueDatabaseStore {
   readonly #accountRegionScope: SimAwsAccountRegionScope;
@@ -39,15 +41,13 @@ export class SimGlueDatabaseStore {
    * Make a database, refusing a name that is taken.
    */
   create(
-    name: string,
+    declared: string,
     createTime: Date,
     input: SimGlueDatabaseInput = {},
   ): SimGlueDatabase {
-    if (this.#databases.has(name)) {
-      throw new SimGlueAlreadyExistsException(
-        `Database already exists: ${name}`,
-      );
-    }
+    const name = simGlueFolded(declared);
+
+    refuseSimGlueNameInPlace(this.#databases.has(name), "Database", name);
 
     const database = new SimGlueDatabase({
       name,
@@ -61,26 +61,24 @@ export class SimGlueDatabaseStore {
     return database;
   }
 
-  /** Find a database by name. */
+  /** Find a database by name, however it was spelled. */
   find(name: string): SimGlueDatabase | undefined {
-    return this.#databases.get(name);
+    return this.#databases.get(simGlueFolded(name));
   }
 
   /**
    * Get a database by name, refusing one that is absent.
    */
   require(name: string): SimGlueDatabase {
-    const database = this.find(name);
-
-    if (database === undefined) {
-      throw new SimGlueEntityNotFoundException(`Database not found: ${name}`);
-    }
-
-    return database;
+    return requireSimGlueFound(
+      this.find(name),
+      "Database",
+      simGlueFolded(name),
+    );
   }
 
   /** Remove a database. */
   delete(name: string): void {
-    this.#databases.delete(name);
+    this.#databases.delete(simGlueFolded(name));
   }
 }

--- a/src/service/glue/error/sim-glue-catalog-refusal.ts
+++ b/src/service/glue/error/sim-glue-catalog-refusal.ts
@@ -1,0 +1,33 @@
+import {
+  SimGlueAlreadyExistsException,
+  SimGlueEntityNotFoundException,
+} from "./sim-glue.error.js";
+
+/**
+ * Refuse a name an entity of this kind already has.
+ *
+ * Creating is not idempotent on real Glue. A second `CreateDatabase` for one
+ * name is an `AlreadyExistsException` rather than an update.
+ */
+export function refuseSimGlueNameInPlace(
+  taken: boolean,
+  kind: string,
+  name: string,
+): void {
+  if (taken) {
+    throw new SimGlueAlreadyExistsException(`${kind} already exists: ${name}`);
+  }
+}
+
+/** Refuse a name nothing of this kind is stored under. */
+export function requireSimGlueFound<T>(
+  found: T | undefined,
+  kind: string,
+  name: string,
+): T {
+  if (found === undefined) {
+    throw new SimGlueEntityNotFoundException(`${kind} not found: ${name}`);
+  }
+
+  return found;
+}

--- a/src/service/glue/partition/sim-glue-partition-store.ts
+++ b/src/service/glue/partition/sim-glue-partition-store.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simGlueFolded } from "../database/sim-glue-catalog-name.js";
 import { SimGlueTablePartitions } from "./sim-glue-table-partitions.js";
 
 interface SimGluePartitionStoreProperties {
@@ -14,6 +15,9 @@ interface SimGluePartitionStoreProperties {
  *
  * Each table's partitions are one object, which is what a partition command
  * works through once it has resolved the table it was given.
+ *
+ * Both names are folded to lower case, as they are in the table store, so a
+ * partition is reached under whatever spelling the table is asked for.
  */
 export class SimGluePartitionStore {
   readonly #accountRegionScope: SimAwsAccountRegionScope;
@@ -26,7 +30,13 @@ export class SimGluePartitionStore {
   /**
    * The partitions of one table, empty until something registers one.
    */
-  inTable(databaseName: string, tableName: string): SimGlueTablePartitions {
+  inTable(
+    declaredDatabase: string,
+    declaredTable: string,
+  ): SimGlueTablePartitions {
+    const databaseName = simGlueFolded(declaredDatabase);
+    const tableName = simGlueFolded(declaredTable);
+
     return mapEntry(
       this.#inDatabase(databaseName),
       tableName,
@@ -41,12 +51,14 @@ export class SimGluePartitionStore {
 
   /** Remove every partition of a table, as deleting the table does. */
   deleteTable(databaseName: string, tableName: string): void {
-    this.#tables.get(databaseName)?.delete(tableName);
+    this.#tables
+      .get(simGlueFolded(databaseName))
+      ?.delete(simGlueFolded(tableName));
   }
 
   /** Remove every partition in a database, as deleting the database does. */
   deleteDatabase(databaseName: string): void {
-    this.#tables.delete(databaseName);
+    this.#tables.delete(simGlueFolded(databaseName));
   }
 
   #inDatabase(databaseName: string): Map<string, SimGlueTablePartitions> {

--- a/src/service/glue/sim-glue-name-folding.iso.test.ts
+++ b/src/service/glue/sim-glue-name-folding.iso.test.ts
@@ -1,0 +1,218 @@
+import {
+  CreateDatabaseCommand,
+  CreatePartitionCommand,
+  CreateTableCommand,
+  DeleteTableCommand,
+  GetDatabaseCommand,
+  GetPartitionsCommand,
+  GetTableCommand,
+  GetTablesCommand,
+} from "@aws-sdk/client-glue";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { SimGlueAlreadyExistsException } from "./error/sim-glue.error.js";
+import type { SimGlue } from "./sim-glue.js";
+
+/** A catalog holding one mixed case database and one mixed case table. */
+function aMixedCaseCatalog(glue: SimGlue): void {
+  glue.createDatabase(
+    new CreateDatabaseCommand({ DatabaseInput: { Name: "Rainlytics" } }),
+  );
+  glue.createTable(
+    new CreateTableCommand({
+      DatabaseName: "Rainlytics",
+      TableInput: {
+        Name: "Access_Logs",
+        PartitionKeys: [{ Name: "day", Type: "string" }],
+        StorageDescriptor: { Location: "s3://rainlytics-logs/" },
+      },
+    }),
+  );
+}
+
+describe("folding Glue catalog names", () => {
+  it("reads a database back under the name it was folded to", () => {
+    // Given a database created with a capital letter in its name.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "Rainlytics" } }),
+    );
+
+    // When it is read back by the name it was given.
+    const { Database } = glue.getDatabase(
+      new GetDatabaseCommand({ Name: "Rainlytics" }),
+    );
+
+    // Then it reports the folded name. Real Glue folds a database name to
+    // lower case when it stores it, for compatibility with Apache Hive.
+    assertIdentical(Database.Name, "rainlytics");
+  });
+
+  it("finds a database under either spelling", () => {
+    // Given a database created in lower case.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "rainlytics" } }),
+    );
+
+    // When it is read back with a capital letter.
+    const { Database } = glue.getDatabase(
+      new GetDatabaseCommand({ Name: "RAINLYTICS" }),
+    );
+
+    // Then it is found, since there is only one spelling it could be stored
+    // under.
+    assertIdentical(Database.Name, "rainlytics");
+  });
+
+  it("refuses a second database differing only by case", () => {
+    // Given a database already created.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "rainlytics" } }),
+    );
+
+    // When one is created whose name differs only by case.
+    const error = assertThrowsError(() => {
+      glue.createDatabase(
+        new CreateDatabaseCommand({ DatabaseInput: { Name: "Rainlytics" } }),
+      );
+    });
+
+    // Then it is the same database, and creating it again fails.
+    assertInstanceOf(error, SimGlueAlreadyExistsException);
+  });
+
+  it("folds a table name and the database it names", () => {
+    // Given a table created with capitals in both names.
+    const glue = new SimAws().glue();
+
+    aMixedCaseCatalog(glue);
+
+    // When it is read back.
+    const { Table } = glue.getTable(
+      new GetTableCommand({
+        DatabaseName: "rainlytics",
+        Name: "access_logs",
+      }),
+    );
+
+    // Then both come back folded. Real Glue says the same thing of
+    // TableInput.Name as it does of DatabaseInput.Name.
+    assertIdentical(Table.Name, "access_logs");
+    assertIdentical(Table.DatabaseName, "rainlytics");
+  });
+
+  it("lists and deletes a table under either spelling", () => {
+    // Given a mixed case table in a mixed case database.
+    const glue = new SimAws().glue();
+
+    aMixedCaseCatalog(glue);
+
+    // When it is listed and then deleted under different spellings.
+    const { TableList } = glue.getTables(
+      new GetTablesCommand({ DatabaseName: "RAINLYTICS" }),
+    );
+
+    glue.deleteTable(
+      new DeleteTableCommand({
+        DatabaseName: "Rainlytics",
+        Name: "ACCESS_LOGS",
+      }),
+    );
+
+    // Then every command reaches the one table there is.
+    assertArrayEquals(
+      TableList.map((table) => table.Name),
+      ["access_logs"],
+    );
+    assertArrayLength(glue.tablesInDatabase("rainlytics"), 0);
+  });
+
+  it("reaches a partition under either spelling of its table", () => {
+    // Given a partition registered against a mixed case table.
+    const glue = new SimAws().glue();
+
+    aMixedCaseCatalog(glue);
+    glue.createPartition(
+      new CreatePartitionCommand({
+        DatabaseName: "RAINLYTICS",
+        TableName: "Access_Logs",
+        PartitionInput: { Values: ["2026-08-26"] },
+      }),
+    );
+
+    // When the table's partitions are listed under a third spelling.
+    const { Partitions } = glue.getPartitions(
+      new GetPartitionsCommand({
+        DatabaseName: "rainlytics",
+        TableName: "ACCESS_LOGS",
+      }),
+    );
+
+    // Then the partition is there, reported against the folded names.
+    assertArrayLength(Partitions, 1);
+    assertIdentical(Partitions[0].TableName, "access_logs");
+    assertIdentical(Partitions[0].DatabaseName, "rainlytics");
+  });
+
+  it("finds a table through the simulator's own accessors", () => {
+    // Given a mixed case table.
+    const glue = new SimAws().glue();
+
+    aMixedCaseCatalog(glue);
+
+    // When it is looked for without going through a Command.
+    const found = glue.findTable("Rainlytics", "Access_Logs");
+
+    // Then the accessors fold too, so a test reading state back is not
+    // holding a spelling the catalog never stored.
+    assertNonNullable(found);
+    assertIdentical(found.name, "access_logs");
+    assertNonNullable(glue.findDatabase("RAINLYTICS"));
+  });
+
+  it("leaves a column name the case it was given", () => {
+    // Given a table whose columns carry capitals.
+    const glue = new SimAws().glue();
+
+    glue.createDatabase(
+      new CreateDatabaseCommand({ DatabaseInput: { Name: "rainlytics" } }),
+    );
+    glue.createTable(
+      new CreateTableCommand({
+        DatabaseName: "rainlytics",
+        TableInput: {
+          Name: "access_logs",
+          PartitionKeys: [{ Name: "Day", Type: "string" }],
+          StorageDescriptor: { Columns: [{ Name: "Url", Type: "string" }] },
+        },
+      }),
+    );
+
+    // When the table is read back.
+    const { Table } = glue.getTable(
+      new GetTableCommand({
+        DatabaseName: "rainlytics",
+        Name: "access_logs",
+      }),
+    );
+
+    // Then the column names keep their case. Athena folds a column name when
+    // it runs a query, and nothing here resolves one by name.
+    assertIdentical(Table.PartitionKeys[0]?.Name, "Day");
+    assertIdentical(Table.StorageDescriptor?.Columns?.[0]?.Name, "Url");
+  });
+});

--- a/src/service/glue/sim-glue-partitions.fixture.ts
+++ b/src/service/glue/sim-glue-partitions.fixture.ts
@@ -15,14 +15,23 @@ import type { SimGlue } from "./sim-glue.js";
  * file. The colocated tests cover SDK-shaped input.
  */
 
-/** A table name nothing else in the run will use. */
+/**
+ * A table name nothing else in the run will use.
+ *
+ * Lower case, because that is the only spelling the Data Catalog stores. A
+ * mixed case name is folded on the way in and would not read back as written.
+ */
 export function fixtureTableName(): string {
-  return `access_logs_${faker.string.alphanumeric(8)}`;
+  return `access_logs_${fixtureSuffix()}`;
 }
 
 /** A database name nothing else in the run will use. */
 export function fixtureDatabaseName(): string {
-  return `site_logs_${faker.string.alphanumeric(8)}`;
+  return `site_logs_${fixtureSuffix()}`;
+}
+
+function fixtureSuffix(): string {
+  return faker.string.alphanumeric({ length: 8, casing: "lower" });
 }
 
 /**

--- a/src/service/glue/table/sim-glue-table-store.ts
+++ b/src/service/glue/table/sim-glue-table-store.ts
@@ -1,8 +1,9 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { simGlueFolded } from "../database/sim-glue-catalog-name.js";
 import {
-  SimGlueAlreadyExistsException,
-  SimGlueEntityNotFoundException,
-} from "../error/sim-glue.error.js";
+  refuseSimGlueNameInPlace,
+  requireSimGlueFound,
+} from "../error/sim-glue-catalog-refusal.js";
 import { SimGlueTable } from "./sim-glue-table.js";
 import type { SimGlueTableInput } from "./sim-glue-table-schema.js";
 
@@ -16,6 +17,10 @@ interface SimGlueTableStoreProperties {
  * Keyed by database name and then by table name, so a database's tables go
  * with it when it is deleted, and so two databases may hold a table of the
  * same name.
+ *
+ * Both names are folded to lower case, the way the Data Catalog folds one when
+ * it stores it. Two tables differing only by case are one table here, as they
+ * are on real Glue.
  */
 export class SimGlueTableStore {
   readonly #accountRegionScope: SimAwsAccountRegionScope;
@@ -29,16 +34,16 @@ export class SimGlueTableStore {
    * Make a table, refusing a name already taken in the same database.
    */
   create(
-    databaseName: string,
-    name: string,
+    declaredDatabase: string,
+    declaredName: string,
     createTime: Date,
     input: SimGlueTableInput = {},
   ): SimGlueTable {
+    const databaseName = simGlueFolded(declaredDatabase);
+    const name = simGlueFolded(declaredName);
     const inDatabase = this.#inDatabase(databaseName);
 
-    if (inDatabase.has(name)) {
-      throw new SimGlueAlreadyExistsException(`Table already exists: ${name}`);
-    }
+    refuseSimGlueNameInPlace(inDatabase.has(name), "Table", name);
 
     const table = new SimGlueTable({
       name,
@@ -53,39 +58,40 @@ export class SimGlueTableStore {
     return table;
   }
 
-  /** Find a table by database and name. */
+  /** Find a table by database and name, however either was spelled. */
   find(databaseName: string, name: string): SimGlueTable | undefined {
-    return this.#tables.get(databaseName)?.get(name);
+    return this.#found(databaseName)?.get(simGlueFolded(name));
   }
 
   /**
    * Get a table by database and name, refusing one that is absent.
    */
   require(databaseName: string, name: string): SimGlueTable {
-    const table = this.find(databaseName, name);
-
-    if (table === undefined) {
-      throw new SimGlueEntityNotFoundException(
-        `Table not found: ${databaseName}.${name}`,
-      );
-    }
-
-    return table;
+    return requireSimGlueFound(
+      this.find(databaseName, name),
+      "Table",
+      `${simGlueFolded(databaseName)}.${simGlueFolded(name)}`,
+    );
   }
 
   /** Every table in one database, in creation order. */
   inDatabase(databaseName: string): readonly SimGlueTable[] {
-    return this.#tables.get(databaseName)?.values().toArray() ?? [];
+    return this.#found(databaseName)?.values().toArray() ?? [];
   }
 
   /** Remove a table. */
   delete(databaseName: string, name: string): void {
-    this.#tables.get(databaseName)?.delete(name);
+    this.#found(databaseName)?.delete(simGlueFolded(name));
   }
 
   /** Remove every table in a database, as deleting the database does. */
   deleteDatabase(databaseName: string): void {
-    this.#tables.delete(databaseName);
+    this.#tables.delete(simGlueFolded(databaseName));
+  }
+
+  /** The tables of one database, however its name was spelled. */
+  #found(databaseName: string): Map<string, SimGlueTable> | undefined {
+    return this.#tables.get(simGlueFolded(databaseName));
   }
 
   #inDatabase(databaseName: string): Map<string, SimGlueTable> {


### PR DESCRIPTION
A database name and a table name are folded to lower case when they are stored, and a lookup folds the name it is given. Two names differing only by case are one name, a `GetTable` finds its table under whichever spelling it is asked for, and Athena folds the database and table names it reads out of a query before resolving them, quoted or not.

## The open question is settled

The issue asked whether real Glue folds a **table** name or only wants one lower case for Hive's sake. Both shapes say the same thing in the same words:

- [`DatabaseInput.Name`](https://docs.aws.amazon.com/glue/latest/webapi/API_DatabaseInput.html) — "The name of the database. For Hive compatibility, this is folded to lowercase when it is stored."
- [`TableInput.Name`](https://docs.aws.amazon.com/glue/latest/webapi/API_TableInput.html) — "The table name. For Hive compatibility, this is folded to lowercase when it is stored."

The doubt came from the [`CreateTable`](https://docs.aws.amazon.com/glue/latest/webapi/API_CreateTable.html) request page, which states the fact for `DatabaseName` and says nothing about `Name`. The input shape is where AWS documents it for both.

## One thing AWS does not document

The lookup side reads as a requirement rather than a fold. `GetDatabase.Name` says the name "should be all lowercase", and `GetTable` says it "is entirely lowercase". Neither promises that AWS folds a mixed-case lookup for you.

Folding it here is the acceptance criteria's choice and the forgiving one, so it is recorded in the Glue Limitations list as the second unverified guess in that service, alongside `Fn::GetAtt Id`. Passing a lower case name makes the question moot.

Column names keep their case throughout, which is what real Glue does with them and what the issue put out of scope.

Resolves https://github.com/KensioSoftware/yulin/issues/1023