### PR TITLE
fix: serve .csv files from a mounted Bucket

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -2701,8 +2701,8 @@ called `DeleteObject` would be a poor default. Leave a Bucket on the default in-
 when a test needs deletion to work.
 
 When reading files from filesystem-backed storage, Yulin infers common `content-type` metadata from
-file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.xml`, and common
-font and image formats. A served file whose extension falls outside that set gets
+file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.csv`, `.xml`, and
+common font and image formats. A served file whose extension falls outside that set gets
 `binary/octet-stream`, as S3 reports for an Object whose type it was never told. That only comes up
 for an extension a mount named itself, below. No other file is served at all, with or without a
 type.

--- a/src/service/s3/storage/filesystem/s3-filesystem-allowed.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-allowed.ts
@@ -57,6 +57,7 @@ export function normaliseExtension(extension: string): string {
  */
 export const defaultAllowedObjectFileExtensions = new Set([
   ".css",
+  ".csv",
   ".eot",
   ".gif",
   ".htm",

--- a/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
@@ -37,6 +37,7 @@ function contentTypeForFilesystemS3ObjectKey(key: string): string | undefined {
 
 const contentTypesByExtension: ReadonlyMap<string, string> = new Map([
   [".css", "text/css"],
+  [".csv", "text/csv"],
   [".eot", "application/vnd.ms-fontobject"],
   [".gif", "image/gif"],
   [".html", "text/html"],

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
@@ -147,6 +147,7 @@ describe("Filesystem simulated S3 storage", () => {
 
   it.each([
     ["style.css", "text/css"],
+    ["data.csv", "text/csv"],
     ["font.eot", "application/vnd.ms-fontobject"],
     ["image.gif", "image/gif"],
     ["page.htm", "text/html"],
@@ -176,6 +177,28 @@ describe("Filesystem simulated S3 storage", () => {
 
     assertNonNullable(object);
     assertIdentical(object.metadata.values["content-type"], contentType);
+  });
+
+  // A CSV download is as much a web file as a `.txt` or an `.xml` one, and a
+  // site publishing one had it 404 in simulation and serve in the deployment.
+  it("serves a CSV file without the mount naming the extension", async () => {
+    // Given a CSV file sitting in a mounted directory
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(["public", "data.csv"], "a,b\n1,2\n");
+
+    const storage = new FilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+    });
+
+    // When the Object is read and the Bucket listed
+    const object = await storage.getObject("data.csv");
+    const objects = await storage.listObjects();
+
+    // Then the file is served, typed as the CSV it is, and listed
+    assertNonNullable(object);
+    assertIdentical(object.metadata.values["content-type"], "text/csv");
+    assertArrayLength(objects, 1);
+    assertIdentical(objects[0].key, "data.csv");
   });
 
   it("ignores unsupported file extensions when listing Objects", async () => {


### PR DESCRIPTION
A mounted Bucket refused any key ending `.csv`, and a mount that named the extension for itself got
the file typed `binary/octet-stream`. CSV is a web file type in the same sense as `.txt`, `.json` and
`.xml`, and both tables now carry it. The content type is `text/csv`, what `aws s3 sync` sends and
what the S3 console assigns.

Resolves https://github.com/KensioSoftware/yulin/issues/1035

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`