### PR TITLE
feat: serve an HTTP API on a custom domain

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1767,9 +1767,161 @@ these.
 ## Turning the generated endpoint off
 
 `DisableExecuteApiEndpoint: true` stops the generated endpoint serving. That is how an API reachable
-only through a custom domain is configured. A request to it is answered with a 403 and
-`{"message":"Forbidden"}`. AWS publishes neither the status nor the body for that case, so both are
-what a disabled endpoint was observed to answer.
+only through a custom domain is configured. It takes the generated hostname out of the set of
+hostnames the API answers on, and a request to it gets the same 403 any unserved `Host` gets (see
+[Which hostnames an API answers on](#which-hostnames-an-api-answers-on)). AWS publishes neither the
+status nor the body for that case, so both are what a disabled endpoint was observed to answer.
+
+## Serving an API on a custom domain name
+
+`CreateDomainNameCommand` creates a domain that answers on a hostname the project owns.
+`CreateApiMappingCommand` points a base path of that domain at one API and one of its stages. A
+domain with no mapping answers 404 to everything.
+
+An empty `ApiMappingKey` maps the root of the domain. Every request reaching the domain goes to that
+API, with the path as the client sent it. A non-empty key is one or more path segments (`orders`,
+`orders/v1`), and those segments come off the front of the path before route selection sees it. A
+request to `/orders/pets/6` under the key `orders` matches the route `GET /pets/{petId}`.
+
+The mapping names the stage. A request through a custom domain never goes through stage selection,
+so an API whose only stage is `dev` is served at the root of its domain with no `dev` segment in the
+path. The generated endpoint still wants that segment.
+
+Where two mappings both match, the longest base path wins. A domain mapping both its root and
+`orders` serves `/orders/6` from the `orders` mapping and everything else from the root one.
+
+The base path stays in `rawPath` and in `requestContext.http.path`, the way a named stage's segment
+does. `requestContext.domainName` is the custom domain and `domainPrefix` is its first label, so a
+handler behind `api.example.com` reads `api` where one behind the generated endpoint reads the API
+id.
+
+```typescript sim-apigatewayv2-custom-domain
+/**
+ * Serving a simulated HTTP API on a custom domain name and API mapping.
+ */
+
+import {
+  CreateApiCommand,
+  CreateApiMappingCommand,
+  CreateDomainNameCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pets",
+    Role: "arn:aws:iam::111111111111:role/PetsRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          rawPath: event.rawPath,
+          routeKey: event.routeKey,
+          stage: event.requestContext.stage,
+          domainName: event.requestContext.domainName,
+        }),
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "pets", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /pets/{petId}",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "dev", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "pets",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+await apiGateway.createDomainName(
+  new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+);
+
+await apiGateway.createApiMapping(
+  new CreateApiMappingCommand({
+    DomainName: "api.example.test",
+    ApiId,
+    Stage: "dev",
+    ApiMappingKey: "orders",
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(
+  srv.localUrl("https://api.example.test/orders/pets/6"),
+);
+
+console.log(await response.json());
+
+await srv.close();
+```
+
+### Which hostnames an API answers on
+
+An API answers on the endpoint API Gateway generated for it and on the domains mapped to it. A
+request carrying any other `Host` gets a 403 and `{"message":"Forbidden"}`, before the route's
+authorizer runs.
+
+That refusal is what a CloudFront behaviour whose cache key holds `host` produces on real AWS.
+Everything in a cache key is forwarded to the origin, and the API is then handed the viewer's
+hostname. The 403 carries `x-amzn-errortype: ForbiddenException` and `x-amzn-requestid`. CloudFront's
+own refusal to reach an origin carries `apigw-requestid` instead, and those two headers are how the
+pair were told apart against real AWS. Simulated CloudFront always sends the Origin's own domain
+(see the [CloudFront limitations](https://yulinsim.dev/services/cloudfront/#limitations)), so
+reaching this refusal here means calling the API on a hostname of your own. A Route53 CNAME pointing
+at the generated endpoint does it.
+
+### Deleting a domain name and its mappings
+
+`DeleteDomainNameCommand` takes the domain and its mappings away, and its hostname stops resolving.
+The APIs it mapped carry on serving their generated endpoints.
+
+`DeleteApiCommand` takes the mappings pointing at the deleted API with it. A base path that used to
+reach it answers 404, and the domain keeps whatever else it maps.
 
 ## Importing an OpenAPI definition
 
@@ -2268,6 +2420,14 @@ the simulation without being given one. See the
 - An integration URI or `AuthorizerUri` ending in a published version number or an alias name, read
   at each request so a route follows its alias, with the invoke permission decided against the
   qualified resource
+- `CreateDomainName`, `GetDomainName`, `GetDomainNames` and `DeleteDomainName`, with the domain
+  answering on its own hostname through `serveSimAws` and the name unique across every simulated
+  Account and Region
+- `CreateApiMapping`, `GetApiMapping`, `GetApiMappings` and `DeleteApiMapping`, serving an API at the
+  root of a domain or under a base path, with the longest matching base path winning and the
+  mappings of a deleted API going with it
+- A 403 with `x-amzn-errortype: ForbiddenException` for a request carrying a `Host` the API neither
+  generated nor has mapped
 - `DisableExecuteApiEndpoint`, refusing requests to the generated endpoint
 - `ImportApi` for an OpenAPI 3.0 document, creating one route and one integration per operation and
   one JWT or Lambda `REQUEST` authorizer per security scheme an operation names
@@ -2392,8 +2552,23 @@ Current documented limitations:
   by `CreateIntegration`. A permission on the function is the only way to admit the invocation.
 - No `Update*` commands. A route, integration or stage is changed by deleting it and creating it
   again. `DeleteApi` deletes everything under the API, as it does on AWS.
-- Custom domain names and API mappings are outside the simulation. They change what `rawPath` holds,
-  so an API reached through one behaves differently on AWS from what is served here.
+- A domain name's `DomainNameConfigurations` are recorded and never applied. A simulated request
+  arrives over plain HTTP on localhost, so a certificate and a TLS security policy have nothing to
+  decide, and the record is where a test checks the domain got the certificate its stack meant to
+  give it. `EndpointType: "EDGE"` is refused, since an edge-optimized custom domain is a REST API
+  feature. `MutualTlsAuthentication` and `Tags` are refused by name.
+- The regional domain name AWS issues a custom domain, which is what a Route53 alias record points
+  at, is outside the simulation. `DomainNameConfigurations` reports no `ApiGatewayDomainName` and no
+  `HostedZoneId`, and only the custom domain's own hostname resolves.
+- A mapped base path stays in `rawPath` and in `requestContext.http.path`. That follows the named
+  stage behaviour, which AWS publishes through the `$context.path` access log variable. AWS publishes
+  nothing equivalent for a base path.
+- `ApiMappingKey` is reported as an empty string for a mapping serving the root of its domain. What
+  real API Gateway reports for that field is unestablished.
+- An API mapping and the API it names are in one Account and Region, as they are on AWS. A domain
+  name is unique across every simulated Account and Region.
+- Deleting a domain name deletes its mappings without asking, as deleting an API does. Whether real
+  API Gateway refuses either is unestablished.
 - No paging. `MaxResults` and `NextToken` are refused, never ignored, and every list command answers
   in full.
 - `CorsConfiguration` and `Tags` are refused, as is the `RouteKey`/`Target` quick-create shorthand on

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1790,10 +1790,14 @@ path. The generated endpoint still wants that segment.
 Where two mappings both match, the longest base path wins. A domain mapping both its root and
 `orders` serves `/orders/6` from the `orders` mapping and everything else from the root one.
 
-The base path stays in `rawPath` and in `requestContext.http.path`, the way a named stage's segment
-does. `requestContext.domainName` is the custom domain and `domainPrefix` is its first label, so a
-handler behind `api.example.com` reads `api` where one behind the generated endpoint reads the API
-id.
+The base path does not reach the handler. AWS documents `rawPath` in a payload format 2.0 event as
+not carrying the API mapping value, and points a handler that needs the whole path at payload format
+1.0 and its `path` field. A request to `/orders/pets/6` under the key `orders` reports `/pets/6`, and
+a request to `/orders` itself reports `/`. A named stage's own segment behaves the other way and is
+reported, so the two are not the same rule.
+
+`requestContext.domainName` is the custom domain and `domainPrefix` is its first label, so a handler
+behind `api.example.com` reads `api` where one behind the generated endpoint reads the API id.
 
 ```typescript sim-apigatewayv2-custom-domain
 /**
@@ -2560,13 +2564,15 @@ Current documented limitations:
 - The regional domain name AWS issues a custom domain, which is what a Route53 alias record points
   at, is outside the simulation. `DomainNameConfigurations` reports no `ApiGatewayDomainName` and no
   `HostedZoneId`, and only the custom domain's own hostname resolves.
-- A mapped base path stays in `rawPath` and in `requestContext.http.path`. That follows the named
-  stage behaviour, which AWS publishes through the `$context.path` access log variable. AWS publishes
-  nothing equivalent for a base path.
+- `requestContext.http.path` drops a mapped base path alongside `rawPath`. AWS documents the
+  `rawPath` half and shows the two fields carrying the same value, and publishes nothing about
+  `http.path` under an API mapping on its own.
 - `ApiMappingKey` is reported as an empty string for a mapping serving the root of its domain. What
   real API Gateway reports for that field is unestablished.
 - An API mapping and the API it names are in one Account and Region, as they are on AWS. A domain
-  name is unique across every simulated Account and Region.
+  name is unique across every simulated Account and Region, and across simulated Cognito's hosted
+  domains too, since a public hostname is unique across the whole of AWS rather than within one
+  service.
 - Deleting a domain name deletes its mappings without asking, as deleting an API does. Whether real
   API Gateway refuses either is unestablished.
 - No paging. `MaxResults` and `NextToken` are refused, never ignored, and every list command answers

--- a/docs/services/apigatewayv2/sim-apigatewayv2-custom-domain.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-custom-domain.example.ts
@@ -1,0 +1,102 @@
+/**
+ * Serving a simulated HTTP API on a custom domain name and API mapping.
+ */
+
+import {
+  CreateApiCommand,
+  CreateApiMappingCommand,
+  CreateDomainNameCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import type { SimPayload2Event } from "@kensio/yulin/apigatewayv2";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "pets",
+    Role: "arn:aws:iam::111111111111:role/PetsRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimPayload2Event) => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          rawPath: event.rawPath,
+          routeKey: event.routeKey,
+          stage: event.requestContext.stage,
+          domainName: event.requestContext.domainName,
+        }),
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "pets", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /pets/{petId}",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "dev", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "pets",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+await apiGateway.createDomainName(
+  new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+);
+
+await apiGateway.createApiMapping(
+  new CreateApiMappingCommand({
+    DomainName: "api.example.test",
+    ApiId,
+    Stage: "dev",
+    ApiMappingKey: "orders",
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+
+const response = await fetch(
+  srv.localUrl("https://api.example.test/orders/pets/6"),
+);
+
+console.log(await response.json());
+
+await srv.close();

--- a/src/serve/controller/factory/sim-aws-service-controller-factory.ts
+++ b/src/serve/controller/factory/sim-aws-service-controller-factory.ts
@@ -1,6 +1,7 @@
 import type { SimAwsServiceController } from "../sim-service-controller.js";
 import type { SimAws } from "../../../service/aws/sim-aws.js";
 import { SimExecuteApiController } from "../../execute-api/sim-execute-api-controller.js";
+import { SimApiGatewayV2ServiceController } from "../../../service/apigatewayv2/serve/sim-api-gateway-v2-controller.js";
 import { SimCloudFrontServiceController } from "../../../service/cloudfront/controller/sim-cloudfront-controller.js";
 import { SimCognitoServiceController } from "../../../service/cognito/serve/sim-cognito-controller.js";
 import { SimElbV2ServiceController } from "../../../service/elbv2/serve/sim-elbv2-controller.js";
@@ -35,6 +36,9 @@ export class SimAwsServiceControllerFactory {
       }
       case "executeApi": {
         return new SimExecuteApiController({ simAws: this.simAws });
+      }
+      case "apiGatewayDomain": {
+        return new SimApiGatewayV2ServiceController({ simAws: this.simAws });
       }
       case "elbV2": {
         return new SimElbV2ServiceController({ simAws: this.simAws });

--- a/src/serve/controller/host/sim-aws-hostname-claims.ts
+++ b/src/serve/controller/host/sim-aws-hostname-claims.ts
@@ -1,0 +1,38 @@
+/**
+ * The hostnames simulated resources have claimed, across every service that
+ * hands one out.
+ *
+ * A public hostname is unique across the whole of AWS rather than within one
+ * service. A Cognito user pool custom domain and an API Gateway custom domain
+ * cannot both answer on `auth.example.com`, and real AWS refuses the second
+ * with a message about the CNAME already being associated with another
+ * resource. Each registry enforces uniqueness among its own domains, and this
+ * is what stops one service taking a hostname another already answers on.
+ *
+ * Resolution asks the claimants in a fixed order, so without this the second
+ * claim would be accepted and then never reached.
+ */
+export class SimAwsHostnameClaims {
+  private readonly claimed = new Set<string>();
+
+  /**
+   * Whether a hostname has already been claimed.
+   */
+  isClaimed(hostname: string): boolean {
+    return this.claimed.has(hostname.toLowerCase());
+  }
+
+  /**
+   * Record a hostname as claimed.
+   */
+  claim(hostname: string): void {
+    this.claimed.add(hostname.toLowerCase());
+  }
+
+  /**
+   * Give a hostname up, which is what deleting the resource holding it does.
+   */
+  release(hostname: string): void {
+    this.claimed.delete(hostname.toLowerCase());
+  }
+}

--- a/src/serve/controller/host/sim-aws-service-hosts.ts
+++ b/src/serve/controller/host/sim-aws-service-hosts.ts
@@ -28,3 +28,35 @@ export class SimAwsNoServiceHosts implements SimAwsServiceHosts {
     return;
   }
 }
+
+/**
+ * The hostnames claimed by any of several holders, asked in turn.
+ *
+ * More than one simulated service hands out hostnames of its own choosing: a
+ * Cognito user pool domain and an API Gateway custom domain are both names the
+ * project picked rather than names AWS generated. Resolution asks one thing
+ * about a hostname, so the holders are gathered here rather than each being
+ * threaded separately through it.
+ */
+export class SimAwsAnyServiceHosts implements SimAwsServiceHosts {
+  private readonly holders: readonly SimAwsServiceHosts[];
+
+  constructor(holders: readonly SimAwsServiceHosts[]) {
+    this.holders = holders;
+  }
+
+  /**
+   * The first target any holder claims for a hostname.
+   */
+  targetForHost(hostname: string): SimAwsServiceTarget | undefined {
+    for (const holder of this.holders) {
+      const target = holder.targetForHost(hostname);
+
+      if (target !== undefined) {
+        return target;
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/src/serve/controller/sim-aws-service-signing-name.ts
+++ b/src/serve/controller/sim-aws-service-signing-name.ts
@@ -33,6 +33,12 @@ export function simAwsServiceSigningName(
       // plane that created the API.
       return "execute-api";
     }
+    case "apiGatewayDomain": {
+      // A custom domain serves the same APIs the generated endpoint does, and
+      // an AWS_IAM route reached through one is signed for execute-api just
+      // the same. The hostname is the only thing that differs.
+      return "execute-api";
+    }
     case "elbV2": {
       // Nothing signs a request to a load balancer: what it serves is an
       // ordinary application rather than an AWS API. The name is here so the

--- a/src/serve/controller/sim-service-controller.ts
+++ b/src/serve/controller/sim-service-controller.ts
@@ -24,6 +24,7 @@ export interface SimAwsServiceTarget {
     | "route53"
     | "cognitoIdentityProvider"
     | "executeApi"
+    | "apiGatewayDomain"
     | "elbV2";
   readonly resourceName: string;
   // regionName is used for validation, not look-up

--- a/src/serve/payload-2/sim-payload-2-endpoint.ts
+++ b/src/serve/payload-2/sim-payload-2-endpoint.ts
@@ -14,6 +14,13 @@ export interface SimPayload2Endpoint {
   readonly domainName: string;
   /** The leading label of the endpoint hostname. */
   readonly domainPrefix: string;
+  /**
+   * The path the event reports, when the endpoint serves the request under
+   * something the event leaves out. An API mapping's base path comes off
+   * here. Absent for an endpoint serving the request path whole, which is
+   * every endpoint but a custom domain with a base path.
+   */
+  readonly requestPath?: string | undefined;
   /** The route this request matched, such as `$default` or `GET /orders`. */
   readonly routeKey: string;
   /** The stage that served the request. */
@@ -22,4 +29,18 @@ export interface SimPayload2Endpoint {
   readonly pathParameters?: Record<string, string> | undefined;
   /** The stage's variables, if it has any. */
   readonly stageVariables?: Record<string, string> | undefined;
+}
+
+/**
+ * The path an event reports for one request to an endpoint.
+ *
+ * It is the path the client asked for, unless the endpoint serves the request
+ * under something the event leaves out. A custom domain's API mapping base
+ * path is the one thing that does.
+ */
+export function simPayload2ReportedPath(
+  endpoint: SimPayload2Endpoint,
+  url: URL,
+): string {
+  return endpoint.requestPath ?? url.pathname;
 }

--- a/src/serve/payload-2/sim-payload-2-event-builder.ts
+++ b/src/serve/payload-2/sim-payload-2-event-builder.ts
@@ -4,16 +4,16 @@ import {
   simAwsProxiedTraceId,
 } from "../http/sim-aws-proxied-connection.js";
 import { SimProxyBodyEncoding } from "../proxy/sim-proxy-body-encoding.js";
-import type { SimPayload2Endpoint } from "./sim-payload-2-endpoint.js";
+import {
+  type SimPayload2Endpoint,
+  simPayload2ReportedPath,
+} from "./sim-payload-2-endpoint.js";
 import type { SimPayload2Event } from "./sim-payload-2-event.type.js";
 import {
   type SimPayload2Authorization,
   SimPayload2RequestContextBuilder,
 } from "./sim-payload-2-request-context.js";
-import {
-  simPayload2QueryStringParameters,
-  SimPayload2RequestParts,
-} from "./sim-payload-2-request-parts.js";
+import { SimPayload2RequestParts } from "./sim-payload-2-request-parts.js";
 
 interface SimPayload2EventBuilderProperties {
   /**
@@ -59,6 +59,7 @@ export class SimPayload2EventBuilder {
     authorization?: SimPayload2Authorization,
   ): Promise<SimPayload2Event> {
     const url = new URL(request.url);
+    const rawPath = simPayload2ReportedPath(endpoint, url);
     const bytes = new Uint8Array(await request.arrayBuffer());
     const contentType = request.headers.get("content-type");
     const at = this.clock.now();
@@ -66,7 +67,7 @@ export class SimPayload2EventBuilder {
     const event: SimPayload2Event = {
       version: "2.0",
       routeKey: endpoint.routeKey,
-      rawPath: url.pathname,
+      rawPath,
       rawQueryString: url.search.replace(/^\?/, ""),
       headers: this.requestParts.headers({
         request,
@@ -76,7 +77,7 @@ export class SimPayload2EventBuilder {
       }),
       requestContext: this.requestContext.build({
         request,
-        url,
+        rawPath,
         endpoint,
         at,
         ...(authorization !== undefined && { authorization }),
@@ -85,32 +86,11 @@ export class SimPayload2EventBuilder {
         bytes.length > 0 && !this.bodyEncoding.isText(contentType),
     };
 
-    this.addRequestFields(event, request, url);
+    this.requestParts.addTo(event, request, url);
     this.addRouteFields(event, endpoint);
     this.addBody(event, bytes, contentType);
 
     return event;
-  }
-
-  /**
-   * Add the fields read off the request itself, when the request has them.
-   */
-  private addRequestFields(
-    event: SimPayload2Event,
-    request: Request,
-    url: URL,
-  ): void {
-    const cookies = this.requestParts.cookies(request);
-    if (cookies.length > 0) {
-      event.cookies = cookies;
-    }
-
-    const queryStringParameters = simPayload2QueryStringParameters(
-      url.searchParams,
-    );
-    if (Object.keys(queryStringParameters).length > 0) {
-      event.queryStringParameters = queryStringParameters;
-    }
   }
 
   /**

--- a/src/serve/payload-2/sim-payload-2-request-context.ts
+++ b/src/serve/payload-2/sim-payload-2-request-context.ts
@@ -35,7 +35,8 @@ export interface SimPayload2Authorization {
 
 interface SimPayload2RequestContextInput {
   readonly request: Request;
-  readonly url: URL;
+  /** The path the event reports, which the builder has already settled. */
+  readonly rawPath: string;
   readonly endpoint: SimPayload2Endpoint;
   /** The simulated instant the request is stamped with. */
   readonly at: Date;
@@ -55,7 +56,7 @@ export class SimPayload2RequestContextBuilder {
    * Build the requestContext for one request.
    */
   build(input: SimPayload2RequestContextInput): SimPayload2RequestContext {
-    const { request, url, endpoint, at } = input;
+    const { request, rawPath, endpoint, at } = input;
     const iamCaller = this.iamCaller(input.authorization?.caller);
 
     const requestContext: SimPayload2RequestContext = {
@@ -67,7 +68,7 @@ export class SimPayload2RequestContextBuilder {
       domainPrefix: endpoint.domainPrefix,
       http: {
         method: request.method,
-        path: url.pathname,
+        path: rawPath,
         protocol: "HTTP/1.1",
         sourceIp: simAwsProxiedSourceIp,
         userAgent: request.headers.get("user-agent") ?? "",

--- a/src/serve/payload-2/sim-payload-2-request-parts.ts
+++ b/src/serve/payload-2/sim-payload-2-request-parts.ts
@@ -2,6 +2,7 @@ import {
   simProxyHeaders,
   type SimProxiedRequest,
 } from "../proxy/sim-proxy-headers.js";
+import type { SimPayload2Event } from "./sim-payload-2-event.type.js";
 
 /**
  * Collect query string parameters, joining repeated keys with commas as
@@ -28,6 +29,24 @@ export function simPayload2QueryStringParameters(
  * parts, without also owning the header and cookie conventions.
  */
 export class SimPayload2RequestParts {
+  /**
+   * Add the event fields read off the request itself, when the request has
+   * them. Each is left out rather than set empty, which is what real AWS does.
+   */
+  addTo(event: SimPayload2Event, request: Request, url: URL): void {
+    const cookies = this.cookies(request);
+    if (cookies.length > 0) {
+      event.cookies = cookies;
+    }
+
+    const queryStringParameters = simPayload2QueryStringParameters(
+      url.searchParams,
+    );
+    if (Object.keys(queryStringParameters).length > 0) {
+      event.queryStringParameters = queryStringParameters;
+    }
+  }
+
   /**
    * Collect request headers, which payload format 2.0 delivers as single
    * lowercased values.

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -37,6 +37,20 @@ construction.
 The API also carries the `SimHttpApiJwtIssuerKeys` port its authorizers verify against, for the same
 reason: a served request finds the API and nothing else.
 
+A custom domain name is the one thing under this service that the API does not own.
+`domain/sim-http-api-domain-name.ts` holds it, and owns its API mappings for the reason the API owns
+its routes. A mapping is addressed by domain on real AWS and none of them outlives the domain.
+
+```text
+SimHttpApiDomainName
+└── SimApiMappingStore        API mappings, keyed by allocated id
+    └── SimApiMapping         a base path, an API id and a stage
+        └── SimApiMappingKey  the base path, as segments
+```
+
+The domain and the APIs it maps live in one Account and Region, as they do on AWS, which is why a
+mapping names an API id and nothing more.
+
 Deleting one of them is `DeleteRoute`, `DeleteIntegration` or `DeleteStage`, each taking its own
 resource out of the store holding it. `SimHttpApi.assertIntegrationDeletable` is the one rule
 crossing two of those stores: an integration a route still targets is refused, as it is on real AWS,
@@ -46,6 +60,10 @@ so it lives on the API rather than in the command that asks.
 
 `api/sim-http-api-match.ts` is the entry point: the stage first, then the route, then the integration
 behind that route.
+
+`SimHttpApiMatcher.matchInStage` is the entry point for a request whose stage is already settled.
+That is how a request through a custom domain arrives. The API mapping names the stage, and its base
+path is what comes off the front of the path. Route selection is the same either way.
 
 The stage goes first because a named stage is a path segment the routes know nothing about, so
 `/dev/pets/6` served from stage `dev` reaches route selection as the path `/pets/6`.
@@ -154,6 +172,12 @@ API id and the region in its hostname, but not the Account, so the registry maps
 Account that owns it. Ids are allocated there, which is what makes them unique across every Account
 and Region of one simulated AWS.
 
+`registry/sim-http-api-domain-registry.ts` is the same hop for custom domains, and it does one more
+job. A request to a custom domain carries a hostname and nothing saying it is an API Gateway
+hostname at all, so the registry implements `SimAwsServiceHosts` and answers simulated DNS about the
+names it holds. `SimCognitoDomainRegistry` does the same for a user pool domain, and
+`SimAwsAnyServiceHosts` asks the two in turn.
+
 ## Command handling
 
 `command/` holds one directory per resource area, each with the structural command types
@@ -231,7 +255,13 @@ fails the stack rather than deploying a template written two ways at once.
 
 `serve/` turns a localhost HTTP request into a Lambda invocation:
 
-1. `sim-api-gateway-v2-router.ts` finds the API from the request hostname, through the registry, and
+1. `sim-http-api-serving.ts` settles what serves the request, and the service target says which of
+   the two ways in it came by. An `executeApi` target is the endpoint API Gateway generated. The
+   request hostname has to be that endpoint's own, and any other `Host` gets a 403 before a route is
+   looked at, which is also what `DisableExecuteApiEndpoint` produces. An `apiGatewayDomain` target
+   is a custom domain, where the request path picks the API mapping and the mapping names the API
+   and the stage. `sim-api-gateway-v2-router.ts` is the lookup under both: the API from the
+   registry, the domain from the domain registry, and
    the integrated function from the integration's ARN. The function is looked up in the Account and
    Region its own ARN names, which need not be the API's, and the router hands back that Account's
    IAM alongside the function. A version or alias qualifier on the ARN is resolved here, once per
@@ -370,6 +400,11 @@ simulation exists to avoid:
 - a stage name that is neither `$default` nor something a URL path segment could hold, and a stage
   without `AutoDeploy: true`, since Deployments are not simulated and such a stage serves nothing on
   real AWS
+- a `DomainNameConfigurations` entry with an `EndpointType` other than `REGIONAL`, and a
+  `MutualTlsAuthentication`, since an edge-optimized domain is a REST API feature and nothing here
+  speaks TLS
+- an `ApiMappingKey` with a leading or trailing slash, or an empty segment inside it, since trimming
+  one would serve a base path the command was never given
 - `MaxResults`/`NextToken`, since every list command answers in full
 - an OpenAPI document that is not 3.0.x, and every member of one this simulation cannot apply, each
   refused with the JSON pointer of the member rather than dropped

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -316,7 +316,10 @@ fails the stack rather than deploying a template written two ways at once.
    what the method and path segments of the ARN hold, since neither is documented by AWS.
 4. `sim-http-api-integration-invocation.ts` invokes the integrated function and turns its result into
    the response. `sim-http-api-endpoint.ts` describes the API, the matched route and the stage as a
-   `SimPayload2Endpoint`, including what the route captured from the path.
+   `SimPayload2Endpoint`, including what the route captured from the path. `requestPath` on that
+   endpoint is what the event reports as `rawPath`, and it is where an API mapping's base path has
+   already come off: AWS documents `rawPath` as not carrying the mapping value, unlike a named
+   stage's own segment.
 5. `src/serve/payload-2/` builds the payload format 2.0 event and turns the handler's result back
    into an HTTP response. That machinery is shared with Lambda Function URLs, which speak the same
    format.

--- a/src/service/apigatewayv2/api/sim-http-api-host.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-host.ts
@@ -14,7 +14,10 @@ export const executeApiHostLabel = "execute-api";
  */
 export const executeApiDomain = "amazonaws.com";
 
-interface SimHttpApiHostProperties {
+/**
+ * What an API's endpoint hostname is built from.
+ */
+export interface SimHttpApiHostParts {
   readonly apiId: string;
   readonly regionName: string;
 }
@@ -22,7 +25,7 @@ interface SimHttpApiHostProperties {
 /**
  * Build the real AWS endpoint hostname for an API.
  */
-export function simHttpApiHost(properties: SimHttpApiHostProperties): string {
+export function simHttpApiHost(properties: SimHttpApiHostParts): string {
   return `${simHttpApiLogicalHost(properties)}.${executeApiDomain}`;
 }
 
@@ -33,8 +36,6 @@ export function simHttpApiHost(properties: SimHttpApiHostProperties): string {
  * This is the form Yulin serves on localhost, where the `.amazonaws.com` tail
  * is replaced by the local suffix, in the same way S3 endpoint hostnames are.
  */
-export function simHttpApiLogicalHost(
-  properties: SimHttpApiHostProperties,
-): string {
+export function simHttpApiLogicalHost(properties: SimHttpApiHostParts): string {
   return `${properties.apiId}.${executeApiHostLabel}.${properties.regionName}`;
 }

--- a/src/service/apigatewayv2/api/sim-http-api-match.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-match.ts
@@ -21,14 +21,25 @@ export interface SimHttpApiMatch {
   readonly stage: SimHttpApiStage;
   readonly pathParameters: SimHttpApiPathParameters;
   /**
-   * The request path the stage left for the routes, with the stage segment and
-   * the leading slash taken off: `/dev/pets/6` served from stage `dev` is
-   * `pets/6`, and a request to the root is the empty string.
+   * The request path left for the routes, with the leading slash and whatever
+   * came before them taken off: `/dev/pets/6` served from stage `dev` is
+   * `pets/6`, and a request to the root is the empty string. On a custom
+   * domain it is the base path of the API mapping that comes off instead.
    *
    * This is the form an `execute-api` ARN names a request by, which is what
    * an `AWS_IAM` route is authorized against.
    */
   readonly pathAfterStage: string;
+}
+
+/**
+ * One request to a stage that has already been picked, and the path segments
+ * left for that stage's routes to compete for.
+ */
+export interface SimHttpApiStageRequest {
+  readonly stage: SimHttpApiStage;
+  readonly method: string;
+  readonly segments: readonly string[];
 }
 
 /**
@@ -67,11 +78,30 @@ export class SimHttpApiMatcher {
       return undefined;
     }
 
+    return this.matchInStage(stores, {
+      stage: stage.stage,
+      method: request.method,
+      segments: stage.segments,
+    });
+  }
+
+  /**
+   * Find what serves one request to a stage that has already been decided.
+   *
+   * A request reaching an API through a custom domain arrives this way: the
+   * API mapping names the stage, and the base path rather than a stage name is
+   * what has been taken off the front of the path. Route selection is the same
+   * either way, which is why it is here rather than repeated.
+   */
+  matchInStage(
+    stores: SimHttpApiStores,
+    request: SimHttpApiStageRequest,
+  ): SimHttpApiMatch | undefined {
     const selected = this.routeSelector.select(
       stores.routes.list(),
       new SimHttpApiRouteRequest({
         method: request.method,
-        segments: stage.segments,
+        segments: request.segments,
       }),
     );
 
@@ -89,9 +119,9 @@ export class SimHttpApiMatcher {
     return {
       route: selected.route,
       integration,
-      stage: stage.stage,
+      stage: request.stage,
       pathParameters: selected.pathParameters,
-      pathAfterStage: stage.segments.join("/"),
+      pathAfterStage: request.segments.join("/"),
     };
   }
 }

--- a/src/service/apigatewayv2/api/sim-http-api.ts
+++ b/src/service/apigatewayv2/api/sim-http-api.ts
@@ -5,10 +5,11 @@ import { SimHttpApiIntegrationStore } from "./integration/sim-http-api-integrati
 import { SimHttpApiRouteStore } from "./route/sim-http-api-route-store.js";
 import { SimHttpApiStageStore } from "./stage/sim-http-api-stage-store.js";
 import { SimApiGatewayV2BadRequest } from "../error/sim-api-gateway-v2.error.js";
-import { simHttpApiHost } from "./sim-http-api-host.js";
+import { simHttpApiHost, simHttpApiLogicalHost } from "./sim-http-api-host.js";
 import {
   type SimHttpApiMatch,
   SimHttpApiMatcher,
+  type SimHttpApiStageRequest,
 } from "./sim-http-api-match.js";
 import type { SimHttpApiId } from "./sim-http-api-id.js";
 import type { SimHttpApiRequest } from "./sim-http-api-request.js";
@@ -86,6 +87,17 @@ export class SimHttpApi {
   }
 
   /**
+   * The generated endpoint's hostname without the AWS domain, which is the
+   * form a request arriving at the simulator carries.
+   */
+  get logicalHostname(): string {
+    return simHttpApiLogicalHost({
+      apiId: this.apiId,
+      regionName: this.accountRegionScope.regionName,
+    });
+  }
+
+  /**
    * The generated endpoint for this API, which is what `ApiEndpoint` reports.
    *
    * It has no trailing slash, as real API Gateway returns it, so appending a
@@ -100,6 +112,14 @@ export class SimHttpApi {
    */
   match(request: SimHttpApiRequest): SimHttpApiMatch | undefined {
     return this.matcher.match(this, request);
+  }
+
+  /**
+   * Find what should handle one request whose stage an API mapping already
+   * named, which is how a request through a custom domain arrives.
+   */
+  matchInStage(request: SimHttpApiStageRequest): SimHttpApiMatch | undefined {
+    return this.matcher.matchInStage(this, request);
   }
 
   /**

--- a/src/service/apigatewayv2/command/api/sim-http-api-commands.ts
+++ b/src/service/apigatewayv2/command/api/sim-http-api-commands.ts
@@ -3,6 +3,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimHttpApiJwtIssuerKeys } from "../../api/authorizer/sim-http-api-jwt-issuer-keys.js";
 import { SimHttpApi } from "../../api/sim-http-api.js";
 import type { SimHttpApiStore } from "../../api/sim-http-api-store.js";
+import type { SimHttpApiDomainStore } from "../../domain/sim-http-api-domain-store.js";
 import type { SimHttpApiRegistry } from "../../registry/sim-http-api-registry.js";
 import type { SimApiGatewayV2RequestOptions } from "../sim-api-gateway-v2-request-options.js";
 import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
@@ -27,6 +28,7 @@ const acceptedCreateApiOptions = [
 
 interface SimHttpApiCommandsProperties {
   readonly apis: SimHttpApiStore;
+  readonly domains: SimHttpApiDomainStore;
   readonly registry: SimHttpApiRegistry;
   readonly access: SimHttpApiAccess;
   readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -39,6 +41,7 @@ interface SimHttpApiCommandsProperties {
  */
 export class SimHttpApiCommands {
   private readonly apis: SimHttpApiStore;
+  private readonly domains: SimHttpApiDomainStore;
   private readonly registry: SimHttpApiRegistry;
   private readonly access: SimHttpApiAccess;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
@@ -47,6 +50,7 @@ export class SimHttpApiCommands {
 
   constructor(properties: SimHttpApiCommandsProperties) {
     this.apis = properties.apis;
+    this.domains = properties.domains;
     this.registry = properties.registry;
     this.access = properties.access;
     this.accountRegionScope = properties.accountRegionScope;
@@ -134,6 +138,11 @@ export class SimHttpApiCommands {
    *
    * The API's routes, integrations and stages go with it, because they belong
    * to it, and its id stops resolving, because nothing serves it any more.
+   *
+   * Any API mapping pointing at it goes too. A mapping outliving its API would
+   * leave a custom domain serving a base path that answers nothing, and real
+   * API Gateway deletes the mappings with the API rather than refusing to
+   * delete an API that is mapped.
    */
   deleteApi(
     command: SimDeleteApiCommand,
@@ -151,6 +160,7 @@ export class SimHttpApiCommands {
 
     this.apis.remove(api.apiId);
     this.registry.deregisterApi(api.apiId);
+    this.domains.removeMappingsForApi(api.apiId);
 
     return { $metadata: {} };
   }

--- a/src/service/apigatewayv2/command/domain/api-mapping.command.ts
+++ b/src/service/apigatewayv2/command/domain/api-mapping.command.ts
@@ -1,0 +1,78 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimApiMappingView } from "../../domain/sim-api-mapping.js";
+
+/**
+ * Minimal structural sim API Gateway v2 CreateApiMapping command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/CreateApiMappingCommand/
+ */
+export interface SimCreateApiMappingCommand {
+  readonly input: SimCreateApiMappingCommandInput;
+}
+
+export interface SimCreateApiMappingCommandInput {
+  readonly DomainName?: string | undefined;
+  readonly ApiId?: string | undefined;
+  readonly Stage?: string | undefined;
+  readonly ApiMappingKey?: string | undefined;
+}
+
+export interface SimCreateApiMappingCommandOutput extends SimApiMappingView {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway v2 GetApiMapping command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/GetApiMappingCommand/
+ */
+export interface SimGetApiMappingCommand {
+  readonly input: SimGetApiMappingCommandInput;
+}
+
+export interface SimGetApiMappingCommandInput {
+  readonly DomainName?: string | undefined;
+  readonly ApiMappingId?: string | undefined;
+}
+
+export interface SimGetApiMappingCommandOutput extends SimApiMappingView {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway v2 GetApiMappings command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/GetApiMappingsCommand/
+ */
+export interface SimGetApiMappingsCommand {
+  readonly input: SimGetApiMappingsCommandInput;
+}
+
+export interface SimGetApiMappingsCommandInput {
+  readonly DomainName?: string | undefined;
+  readonly MaxResults?: string | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimGetApiMappingsCommandOutput {
+  readonly Items: readonly SimApiMappingView[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway v2 DeleteApiMapping command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/DeleteApiMappingCommand/
+ */
+export interface SimDeleteApiMappingCommand {
+  readonly input: SimDeleteApiMappingCommandInput;
+}
+
+export interface SimDeleteApiMappingCommandInput {
+  readonly DomainName?: string | undefined;
+  readonly ApiMappingId?: string | undefined;
+}
+
+export interface SimDeleteApiMappingCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/apigatewayv2/command/domain/domain.command.ts
+++ b/src/service/apigatewayv2/command/domain/domain.command.ts
@@ -1,0 +1,78 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimHttpApiDomainNameConfiguration,
+  SimHttpApiDomainNameView,
+} from "../../domain/sim-http-api-domain-name.js";
+
+/**
+ * Minimal structural sim API Gateway v2 CreateDomainName command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/CreateDomainNameCommand/
+ */
+export interface SimCreateDomainNameCommand {
+  readonly input: SimCreateDomainNameCommandInput;
+}
+
+export interface SimCreateDomainNameCommandInput {
+  readonly DomainName?: string | undefined;
+  readonly DomainNameConfigurations?:
+    | readonly SimHttpApiDomainNameConfiguration[]
+    | undefined;
+}
+
+export interface SimCreateDomainNameCommandOutput extends SimHttpApiDomainNameView {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway v2 GetDomainName command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/GetDomainNameCommand/
+ */
+export interface SimGetDomainNameCommand {
+  readonly input: SimGetDomainNameCommandInput;
+}
+
+export interface SimGetDomainNameCommandInput {
+  readonly DomainName?: string | undefined;
+}
+
+export interface SimGetDomainNameCommandOutput extends SimHttpApiDomainNameView {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway v2 GetDomainNames command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/GetDomainNamesCommand/
+ */
+export interface SimGetDomainNamesCommand {
+  readonly input: SimGetDomainNamesCommandInput;
+}
+
+export interface SimGetDomainNamesCommandInput {
+  readonly MaxResults?: string | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimGetDomainNamesCommandOutput {
+  readonly Items: readonly SimHttpApiDomainNameView[];
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim API Gateway v2 DeleteDomainName command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/apigatewayv2/command/DeleteDomainNameCommand/
+ */
+export interface SimDeleteDomainNameCommand {
+  readonly input: SimDeleteDomainNameCommandInput;
+}
+
+export interface SimDeleteDomainNameCommandInput {
+  readonly DomainName?: string | undefined;
+}
+
+export interface SimDeleteDomainNameCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/apigatewayv2/command/domain/sim-api-mapping-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/domain/sim-api-mapping-commands.iso.test.ts
@@ -1,0 +1,255 @@
+import {
+  CreateApiCommand,
+  CreateApiMappingCommand,
+  CreateDomainNameCommand,
+  CreateStageCommand,
+  DeleteApiMappingCommand,
+  GetApiMappingCommand,
+  GetApiMappingsCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimApiGatewayV2BadRequest,
+  SimApiGatewayV2Conflict,
+  SimApiGatewayV2NotFound,
+} from "../../error/sim-api-gateway-v2.error.js";
+
+/**
+ * An API with one stage, and a domain name with nothing mapped to it yet,
+ * which is what every mapping command here starts from.
+ */
+async function domainAndApi(
+  simAws: SimAws,
+  stageName = "$default",
+): Promise<string> {
+  const { ApiId: apiId } = await simAws
+    .apiGatewayV2()
+    .createApi(new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }));
+  await simAws.apiGatewayV2().createStage(
+    new CreateStageCommand({
+      ApiId: apiId,
+      StageName: stageName,
+      AutoDeploy: true,
+    }),
+  );
+  await simAws
+    .apiGatewayV2()
+    .createDomainName(
+      new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+    );
+
+  return apiId;
+}
+
+describe("Sim API Gateway v2 API mapping commands", () => {
+  it("maps the root of a domain to an API and a stage", async () => {
+    // Given a domain name and an API with a stage
+    const simAws = new SimAws();
+    const apiId = await domainAndApi(simAws);
+
+    // When the domain is mapped with no base path
+    const created = await simAws.apiGatewayV2().createApiMapping(
+      new CreateApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiId: apiId,
+        Stage: "$default",
+      }),
+    );
+
+    // Then the mapping serves the API at the root of the domain, which is
+    // what an empty ApiMappingKey reports
+    assertIdentical(created.ApiId, apiId);
+    assertIdentical(created.Stage, "$default");
+    assertIdentical(created.ApiMappingKey, "");
+    expect(created.ApiMappingId).toMatch(/^[a-z0-9]{6}$/u);
+  });
+
+  it("maps a base path of a domain", async () => {
+    // Given a domain name and an API with a named stage
+    const simAws = new SimAws();
+    const apiId = await domainAndApi(simAws, "dev");
+
+    // When a multi-segment base path is mapped
+    const created = await simAws.apiGatewayV2().createApiMapping(
+      new CreateApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiId: apiId,
+        Stage: "dev",
+        ApiMappingKey: "orders/v1",
+      }),
+    );
+
+    // Then the mapping reports the base path it serves
+    assertIdentical(created.ApiMappingKey, "orders/v1");
+    assertIdentical(created.Stage, "dev");
+  });
+
+  it("refuses a base path that could never match a request", async () => {
+    // Given a domain name and an API with a stage
+    const simAws = new SimAws();
+    const apiId = await domainAndApi(simAws);
+
+    // When a base path is written with a leading slash
+    // Then it is refused rather than trimmed, since trimming would serve the
+    // API under a base path the command was never given
+    await expect(
+      simAws.apiGatewayV2().createApiMapping(
+        new CreateApiMappingCommand({
+          DomainName: "api.example.test",
+          ApiId: apiId,
+          Stage: "$default",
+          ApiMappingKey: "/orders",
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2BadRequest);
+  });
+
+  it("refuses a second mapping of the same base path", async () => {
+    // Given a domain already mapping its root
+    const simAws = new SimAws();
+    const apiId = await domainAndApi(simAws);
+    await simAws.apiGatewayV2().createApiMapping(
+      new CreateApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiId: apiId,
+        Stage: "$default",
+      }),
+    );
+
+    // When the root is mapped again
+    // Then it is refused, since one base path serves one API
+    await expect(
+      simAws.apiGatewayV2().createApiMapping(
+        new CreateApiMappingCommand({
+          DomainName: "api.example.test",
+          ApiId: apiId,
+          Stage: "$default",
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2Conflict);
+  });
+
+  it("refuses a mapping naming a stage the API does not have", async () => {
+    // Given a domain name and an API with only its default stage
+    const simAws = new SimAws();
+    const apiId = await domainAndApi(simAws);
+
+    // When a mapping names another stage
+    // Then it is refused here rather than answering 404 on every request
+    await expect(
+      simAws.apiGatewayV2().createApiMapping(
+        new CreateApiMappingCommand({
+          DomainName: "api.example.test",
+          ApiId: apiId,
+          Stage: "dev",
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2BadRequest);
+  });
+
+  it("refuses a mapping naming an API that is not there", async () => {
+    // Given a domain name
+    const simAws = new SimAws();
+    await domainAndApi(simAws);
+
+    // When a mapping names an API id nothing allocated
+    // Then it is refused
+    await expect(
+      simAws.apiGatewayV2().createApiMapping(
+        new CreateApiMappingCommand({
+          DomainName: "api.example.test",
+          ApiId: "abcdefghij",
+          Stage: "$default",
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2NotFound);
+  });
+
+  it("reads its mappings back and forgets a deleted one", async () => {
+    // Given a domain mapping two base paths
+    const simAws = new SimAws();
+    const apiId = await domainAndApi(simAws);
+    const root = await simAws.apiGatewayV2().createApiMapping(
+      new CreateApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiId: apiId,
+        Stage: "$default",
+      }),
+    );
+    await simAws.apiGatewayV2().createApiMapping(
+      new CreateApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiId: apiId,
+        Stage: "$default",
+        ApiMappingKey: "orders",
+      }),
+    );
+
+    // When one is read back and then deleted
+    const fetched = await simAws.apiGatewayV2().getApiMapping(
+      new GetApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiMappingId: root.ApiMappingId,
+      }),
+    );
+    await simAws.apiGatewayV2().deleteApiMapping(
+      new DeleteApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiMappingId: root.ApiMappingId,
+      }),
+    );
+    const remaining = await simAws
+      .apiGatewayV2()
+      .getApiMappings(
+        new GetApiMappingsCommand({ DomainName: "api.example.test" }),
+      );
+
+    // Then the deleted one is gone and the other one stays
+    assertIdentical(fetched.ApiMappingId, root.ApiMappingId);
+    expect(
+      remaining.Items.map((mapping) => mapping.ApiMappingKey),
+    ).toStrictEqual(["orders"]);
+  });
+
+  it("refuses a mapping on a domain name nothing created", async () => {
+    // Given an API with a stage and no domain name for it
+    const simAws = new SimAws();
+    const { ApiId: apiId } = await simAws
+      .apiGatewayV2()
+      .createApi(
+        new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+      );
+
+    // When a mapping names a domain that is not there
+    // Then it is refused
+    await expect(
+      simAws.apiGatewayV2().createApiMapping(
+        new CreateApiMappingCommand({
+          DomainName: "api.example.test",
+          ApiId: apiId,
+          Stage: "$default",
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2NotFound);
+  });
+
+  it("refuses a command naming an API mapping the domain does not have", async () => {
+    // Given a domain with no mappings
+    const simAws = new SimAws();
+    await domainAndApi(simAws);
+
+    // When a mapping id nothing allocated is read back
+    // Then it is refused
+    await expect(
+      simAws.apiGatewayV2().getApiMapping(
+        new GetApiMappingCommand({
+          DomainName: "api.example.test",
+          ApiMappingId: "abc123",
+        }),
+      ),
+    ).rejects.toThrow(SimApiGatewayV2NotFound);
+  });
+});

--- a/src/service/apigatewayv2/command/domain/sim-api-mapping-commands.ts
+++ b/src/service/apigatewayv2/command/domain/sim-api-mapping-commands.ts
@@ -1,0 +1,180 @@
+import type { SimHttpApiStore } from "../../api/sim-http-api-store.js";
+import { makeSimApiMappingId } from "../../domain/sim-api-mapping-id.js";
+import { SimApiMappingKey } from "../../domain/sim-api-mapping-key.js";
+import { SimApiMapping } from "../../domain/sim-api-mapping.js";
+import { SimApiMappingRules } from "./sim-api-mapping-rules.js";
+import type { SimApiGatewayV2RequestOptions } from "../sim-api-gateway-v2-request-options.js";
+import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
+import type { SimHttpApiDomainAccess } from "../sim-http-api-domain-access.js";
+import type {
+  SimCreateApiMappingCommand,
+  SimCreateApiMappingCommandOutput,
+  SimDeleteApiMappingCommand,
+  SimDeleteApiMappingCommandOutput,
+  SimGetApiMappingCommand,
+  SimGetApiMappingCommandOutput,
+  SimGetApiMappingsCommand,
+  SimGetApiMappingsCommandOutput,
+} from "./api-mapping.command.js";
+
+const apiMappingsPath = "/apimappings";
+
+const acceptedCreateApiMappingOptions = [
+  "DomainName",
+  "ApiId",
+  "Stage",
+  "ApiMappingKey",
+];
+
+interface SimApiMappingCommandsProperties {
+  readonly apis: SimHttpApiStore;
+  readonly access: SimHttpApiDomainAccess;
+}
+
+/**
+ * The commands addressing the API mappings of a custom domain name.
+ *
+ * A mapping points a base path of the domain at one API and one of its stages.
+ * The domain and the API it maps are in the same Account and Region, as they
+ * are on real AWS, so a mapping names an API id and nothing more.
+ */
+export class SimApiMappingCommands {
+  private readonly access: SimHttpApiDomainAccess;
+  private readonly rules: SimApiMappingRules;
+
+  constructor(properties: SimApiMappingCommandsProperties) {
+    this.access = properties.access;
+    this.rules = new SimApiMappingRules(properties.apis);
+  }
+
+  /**
+   * Handle a CreateApiMapping command.
+   *
+   * An empty `ApiMappingKey` serves the API at the root of the domain. A
+   * non-empty one serves it under that base path, and the base path is taken
+   * off the request path before the API's routes see it.
+   */
+  createApiMapping(
+    command: SimCreateApiMappingCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): SimCreateApiMappingCommandOutput {
+    const { input } = command;
+    const unsimulated = new SimApiGatewayV2UnsimulatedInput("CreateApiMapping");
+    unsimulated.refuseUnaccepted(input, acceptedCreateApiMappingOptions);
+    const domainName = unsimulated.require("DomainName", input.DomainName);
+    const apiId = unsimulated.require("ApiId", input.ApiId);
+    const stage = unsimulated.require("Stage", input.Stage);
+    const apiMappingKey = SimApiMappingKey.parse(input.ApiMappingKey);
+
+    const domain = this.access.domain({
+      method: "POST",
+      domainName,
+      childPath: apiMappingsPath,
+      caller: options?.caller,
+    });
+    this.rules.requireStage(apiId, stage);
+    this.rules.requireUnusedKey(domain, apiMappingKey);
+
+    const mapping = new SimApiMapping({
+      apiMappingId: makeSimApiMappingId(),
+      apiMappingKey,
+      apiId,
+      stage,
+    });
+    domain.apiMappings.add(mapping);
+
+    return { ...mapping.view(), $metadata: {} };
+  }
+
+  /**
+   * Handle a GetApiMapping command.
+   */
+  getApiMapping(
+    command: SimGetApiMappingCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): SimGetApiMappingCommandOutput {
+    const unsimulated = new SimApiGatewayV2UnsimulatedInput("GetApiMapping");
+    unsimulated.refuseUnaccepted(command.input, ["DomainName", "ApiMappingId"]);
+    const domainName = unsimulated.require(
+      "DomainName",
+      command.input.DomainName,
+    );
+    const apiMappingId = unsimulated.require(
+      "ApiMappingId",
+      command.input.ApiMappingId,
+    );
+
+    const domain = this.access.domain({
+      method: "GET",
+      domainName,
+      childPath: `${apiMappingsPath}/${apiMappingId}`,
+      caller: options?.caller,
+    });
+
+    return {
+      ...this.rules.requireMapping(domain, apiMappingId).view(),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Handle a GetApiMappings command.
+   */
+  getApiMappings(
+    command: SimGetApiMappingsCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): SimGetApiMappingsCommandOutput {
+    const unsimulated = new SimApiGatewayV2UnsimulatedInput("GetApiMappings");
+    unsimulated.refusePaging(command.input);
+    unsimulated.refuseUnaccepted(command.input, ["DomainName"]);
+    const domainName = unsimulated.require(
+      "DomainName",
+      command.input.DomainName,
+    );
+
+    const domain = this.access.domain({
+      method: "GET",
+      domainName,
+      childPath: apiMappingsPath,
+      caller: options?.caller,
+    });
+
+    return {
+      Items: domain.apiMappings.list().map((mapping) => mapping.view()),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Handle a DeleteApiMapping command.
+   *
+   * The base path stops being served, and the domain and the API both stay.
+   */
+  deleteApiMapping(
+    command: SimDeleteApiMappingCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): SimDeleteApiMappingCommandOutput {
+    const unsimulated = new SimApiGatewayV2UnsimulatedInput("DeleteApiMapping");
+    unsimulated.refuseUnaccepted(command.input, ["DomainName", "ApiMappingId"]);
+    const domainName = unsimulated.require(
+      "DomainName",
+      command.input.DomainName,
+    );
+    const apiMappingId = unsimulated.require(
+      "ApiMappingId",
+      command.input.ApiMappingId,
+    );
+
+    const domain = this.access.domain({
+      method: "DELETE",
+      domainName,
+      childPath: `${apiMappingsPath}/${apiMappingId}`,
+      caller: options?.caller,
+    });
+    const mapping = this.rules.requireMapping(domain, apiMappingId);
+
+    domain.apiMappings.remove(mapping.apiMappingId);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/apigatewayv2/command/domain/sim-api-mapping-commands.ts
+++ b/src/service/apigatewayv2/command/domain/sim-api-mapping-commands.ts
@@ -1,5 +1,4 @@
 import type { SimHttpApiStore } from "../../api/sim-http-api-store.js";
-import { makeSimApiMappingId } from "../../domain/sim-api-mapping-id.js";
 import { SimApiMappingKey } from "../../domain/sim-api-mapping-key.js";
 import { SimApiMapping } from "../../domain/sim-api-mapping.js";
 import { SimApiMappingRules } from "./sim-api-mapping-rules.js";
@@ -76,7 +75,7 @@ export class SimApiMappingCommands {
     this.rules.requireUnusedKey(domain, apiMappingKey);
 
     const mapping = new SimApiMapping({
-      apiMappingId: makeSimApiMappingId(),
+      apiMappingId: domain.apiMappings.allocateId(),
       apiMappingKey,
       apiId,
       stage,

--- a/src/service/apigatewayv2/command/domain/sim-api-mapping-rules.ts
+++ b/src/service/apigatewayv2/command/domain/sim-api-mapping-rules.ts
@@ -1,0 +1,85 @@
+import type { SimHttpApiStore } from "../../api/sim-http-api-store.js";
+import type { SimApiMappingKey } from "../../domain/sim-api-mapping-key.js";
+import type { SimApiMapping } from "../../domain/sim-api-mapping.js";
+import type { SimHttpApiDomainName } from "../../domain/sim-http-api-domain-name.js";
+import {
+  SimApiGatewayV2BadRequest,
+  SimApiGatewayV2Conflict,
+  SimApiGatewayV2NotFound,
+} from "../../error/sim-api-gateway-v2.error.js";
+
+/**
+ * What an API mapping has to hold before a domain will serve anything through
+ * it.
+ *
+ * Each of these is checked when the mapping is made rather than when a request
+ * arrives, which is where real API Gateway checks them too. A mapping naming a
+ * stage that is not there would otherwise answer 404 on every request, far
+ * from the command that made it.
+ */
+export class SimApiMappingRules {
+  private readonly apis: SimHttpApiStore;
+
+  constructor(apis: SimHttpApiStore) {
+    this.apis = apis;
+  }
+
+  /**
+   * Require the API and the stage a mapping is about to point at.
+   */
+  requireStage(apiId: string, stage: string): void {
+    const httpApi = this.apis.find(apiId);
+
+    if (httpApi === undefined) {
+      throw new SimApiGatewayV2NotFound(
+        `No API with id ${apiId} in this Account and Region`,
+      );
+    }
+
+    if (httpApi.stages.find(stage) === undefined) {
+      throw new SimApiGatewayV2BadRequest(
+        `No stage named ${stage} on API ${apiId}`,
+      );
+    }
+  }
+
+  /**
+   * Require a base path this domain does not already serve, since one base
+   * path serves one API.
+   */
+  requireUnusedKey(
+    domain: SimHttpApiDomainName,
+    apiMappingKey: SimApiMappingKey,
+  ): void {
+    if (domain.apiMappings.findByKey(apiMappingKey.value) === undefined) {
+      return;
+    }
+
+    const base =
+      apiMappingKey.depth === 0
+        ? "the root of the domain"
+        : `the base path '${apiMappingKey.value}'`;
+
+    throw new SimApiGatewayV2Conflict(
+      `Domain name ${domain.domainName} already maps ${base}`,
+    );
+  }
+
+  /**
+   * Get the mapping a command names, or refuse.
+   */
+  requireMapping(
+    domain: SimHttpApiDomainName,
+    apiMappingId: string,
+  ): SimApiMapping {
+    const mapping = domain.apiMappings.find(apiMappingId);
+
+    if (mapping === undefined) {
+      throw new SimApiGatewayV2NotFound(
+        `No API mapping ${apiMappingId} on domain name ${domain.domainName}`,
+      );
+    }
+
+    return mapping;
+  }
+}

--- a/src/service/apigatewayv2/command/domain/sim-http-api-domain-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/domain/sim-http-api-domain-commands.iso.test.ts
@@ -1,0 +1,185 @@
+import {
+  CreateDomainNameCommand,
+  DeleteDomainNameCommand,
+  GetDomainNameCommand,
+  GetDomainNamesCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { simAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimApiGatewayV2BadRequest,
+  SimApiGatewayV2NotFound,
+} from "../../error/sim-api-gateway-v2.error.js";
+
+const certificateArn =
+  "arn:aws:acm:eu-west-2:111111111111:certificate/6d2c7a2e-0c7a-4d4e-9b6c-1f0a2b3c4d5e";
+
+describe("Sim API Gateway v2 custom domain name commands", () => {
+  it("creates a custom domain name", async () => {
+    // Given a simulated AWS with no domain names
+    const simAws = new SimAws();
+
+    // When a domain name is created
+    const created = await simAws.apiGatewayV2().createDomainName(
+      new CreateDomainNameCommand({
+        DomainName: "api.example.test",
+        DomainNameConfigurations: [
+          { CertificateArn: certificateArn, EndpointType: "REGIONAL" },
+        ],
+      }),
+    );
+
+    // Then it reports the domain API Gateway would have made, selecting its
+    // API mapping on the request base path
+    assertIdentical(created.DomainName, "api.example.test");
+    assertIdentical(created.ApiMappingSelectionExpression, "$request.basepath");
+    expect(created.DomainNameConfigurations).toStrictEqual([
+      { CertificateArn: certificateArn, EndpointType: "REGIONAL" },
+    ]);
+  });
+
+  it("reads a domain name back and lists the domains of the scope", async () => {
+    // Given two domain names
+    const simAws = new SimAws();
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "www.example.test" }),
+      );
+
+    // When they are read back
+    const fetched = await simAws
+      .apiGatewayV2()
+      .getDomainName(
+        new GetDomainNameCommand({ DomainName: "api.example.test" }),
+      );
+    const listed = await simAws
+      .apiGatewayV2()
+      .getDomainNames(new GetDomainNamesCommand({}));
+
+    // Then both are there, with no configuration for one created without any
+    assertIdentical(fetched.DomainName, "api.example.test");
+    expect(fetched.DomainNameConfigurations).toStrictEqual([]);
+    expect(listed.Items.map((domain) => domain.DomainName)).toStrictEqual([
+      "api.example.test",
+      "www.example.test",
+    ]);
+  });
+
+  it("refuses a domain name another simulated Account already holds", async () => {
+    // Given a domain name created in one Account
+    const simAws = new SimAws();
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+      );
+
+    // When another Account tries to create the same one
+    // Then it is refused, because a custom domain name is unique across the
+    // whole of AWS rather than within an Account
+    await expect(
+      simAws
+        .accountRegionScope(simAwsAccountId("222222222222"))
+        .apiGatewayV2()
+        .createDomainName(
+          new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+        ),
+    ).rejects.toThrow(SimApiGatewayV2BadRequest);
+  });
+
+  it("refuses an edge-optimized domain name configuration", async () => {
+    // Given a simulated AWS
+    const simAws = new SimAws();
+
+    // When a domain name asks for the edge-optimized endpoint type
+    // Then it is refused, since that is a REST API feature
+    await expect(
+      simAws.apiGatewayV2().createDomainName(
+        new CreateDomainNameCommand({
+          DomainName: "api.example.test",
+          DomainNameConfigurations: [{ EndpointType: "EDGE" }],
+        }),
+      ),
+    ).rejects.toThrow(/EndpointType 'EDGE' is not simulated/u);
+  });
+
+  it("refuses an option it does not simulate", async () => {
+    // Given a simulated AWS
+    const simAws = new SimAws();
+
+    // When a domain name is created with tags
+    // Then they are refused by name rather than dropped
+    await expect(
+      simAws.apiGatewayV2().createDomainName(
+        new CreateDomainNameCommand({
+          DomainName: "api.example.test",
+          Tags: { team: "orders" },
+        }),
+      ),
+    ).rejects.toThrow(/CreateDomainName Tags is not simulated/u);
+  });
+
+  it("stops answering for a deleted domain name", async () => {
+    // Given a domain name
+    const simAws = new SimAws();
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+      );
+
+    // When it is deleted
+    await simAws
+      .apiGatewayV2()
+      .deleteDomainName(
+        new DeleteDomainNameCommand({ DomainName: "api.example.test" }),
+      );
+
+    // Then nothing holds it any more, and its hostname resolves to nothing
+    await expect(
+      simAws
+        .apiGatewayV2()
+        .getDomainName(
+          new GetDomainNameCommand({ DomainName: "api.example.test" }),
+        ),
+    ).rejects.toThrow(SimApiGatewayV2NotFound);
+    expect(
+      simAws.route53().resolveHttpHost("api.example.test"),
+    ).toBeUndefined();
+  });
+
+  it("frees a deleted domain name for another Account to take", async () => {
+    // Given a domain name created and then deleted
+    const simAws = new SimAws();
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+      );
+    await simAws
+      .apiGatewayV2()
+      .deleteDomainName(
+        new DeleteDomainNameCommand({ DomainName: "api.example.test" }),
+      );
+
+    // When another Account creates it
+    const created = await simAws
+      .accountRegionScope(simAwsAccountId("222222222222"))
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+      );
+
+    // Then it is theirs, the way a released name is on real AWS
+    assertIdentical(created.DomainName, "api.example.test");
+  });
+});

--- a/src/service/apigatewayv2/command/domain/sim-http-api-domain-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/domain/sim-http-api-domain-commands.iso.test.ts
@@ -4,6 +4,10 @@ import {
   GetDomainNameCommand,
   GetDomainNamesCommand,
 } from "@aws-sdk/client-apigatewayv2";
+import {
+  CreateUserPoolCommand,
+  CreateUserPoolDomainCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
 import { assertIdentical } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
@@ -181,5 +185,56 @@ describe("Sim API Gateway v2 custom domain name commands", () => {
 
     // Then it is theirs, the way a released name is on real AWS
     assertIdentical(created.DomainName, "api.example.test");
+  });
+
+  it("refuses a hostname a Cognito hosted domain already answers on", async () => {
+    // Given a Cognito user pool with a custom domain
+    const simAws = new SimAws();
+    const { UserPool } = await simAws
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "customers" }));
+    await simAws.cognitoIdentityProvider().createUserPoolDomain(
+      new CreateUserPoolDomainCommand({
+        UserPoolId: UserPool?.Id,
+        Domain: "auth.example.test",
+        CustomDomainConfig: { CertificateArn: certificateArn },
+      }),
+    );
+
+    // When API Gateway is asked for the same hostname
+    // Then it is refused, because a public hostname is unique across services
+    // as well as across Accounts, as it is on real AWS
+    await expect(
+      simAws
+        .apiGatewayV2()
+        .createDomainName(
+          new CreateDomainNameCommand({ DomainName: "auth.example.test" }),
+        ),
+    ).rejects.toThrow(SimApiGatewayV2BadRequest);
+  });
+
+  it("refuses a Cognito hosted domain on a hostname it already answers on", async () => {
+    // Given an API Gateway custom domain
+    const simAws = new SimAws();
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "auth.example.test" }),
+      );
+    const { UserPool } = await simAws
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "customers" }));
+
+    // When Cognito is asked for the same hostname
+    // Then it is refused too, so neither service can take the other's name
+    await expect(
+      simAws.cognitoIdentityProvider().createUserPoolDomain(
+        new CreateUserPoolDomainCommand({
+          UserPoolId: UserPool?.Id,
+          Domain: "auth.example.test",
+          CustomDomainConfig: { CertificateArn: certificateArn },
+        }),
+      ),
+    ).rejects.toThrow(/already in use/u);
   });
 });

--- a/src/service/apigatewayv2/command/domain/sim-http-api-domain-commands.ts
+++ b/src/service/apigatewayv2/command/domain/sim-http-api-domain-commands.ts
@@ -1,0 +1,151 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimHttpApiDomainName } from "../../domain/sim-http-api-domain-name.js";
+import type { SimHttpApiDomainStore } from "../../domain/sim-http-api-domain-store.js";
+import type { SimHttpApiDomainRegistry } from "../../registry/sim-http-api-domain-registry.js";
+import type { SimApiGatewayV2RequestOptions } from "../sim-api-gateway-v2-request-options.js";
+import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
+import type { SimHttpApiDomainAccess } from "../sim-http-api-domain-access.js";
+import { simHttpApiDomainConfigurations } from "./sim-http-api-domain-configurations.js";
+import type {
+  SimCreateDomainNameCommand,
+  SimCreateDomainNameCommandOutput,
+  SimDeleteDomainNameCommand,
+  SimDeleteDomainNameCommandOutput,
+  SimGetDomainNameCommand,
+  SimGetDomainNameCommandOutput,
+  SimGetDomainNamesCommand,
+  SimGetDomainNamesCommandOutput,
+} from "./domain.command.js";
+
+const acceptedCreateDomainNameOptions = [
+  "DomainName",
+  "DomainNameConfigurations",
+];
+
+interface SimHttpApiDomainCommandsProperties {
+  readonly domains: SimHttpApiDomainStore;
+  readonly registry: SimHttpApiDomainRegistry;
+  readonly access: SimHttpApiDomainAccess;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The commands addressing custom domain names.
+ */
+export class SimHttpApiDomainCommands {
+  private readonly domains: SimHttpApiDomainStore;
+  private readonly registry: SimHttpApiDomainRegistry;
+  private readonly access: SimHttpApiDomainAccess;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimHttpApiDomainCommandsProperties) {
+    this.domains = properties.domains;
+    this.registry = properties.registry;
+    this.access = properties.access;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Handle a CreateDomainName command.
+   *
+   * The domain starts answering on its own hostname straight away, and serves
+   * nothing until an API mapping points it at an API and a stage.
+   */
+  createDomainName(
+    command: SimCreateDomainNameCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): SimCreateDomainNameCommandOutput {
+    const { input } = command;
+    const unsimulated = new SimApiGatewayV2UnsimulatedInput("CreateDomainName");
+    unsimulated.refuseUnaccepted(input, acceptedCreateDomainNameOptions);
+    const domainName = unsimulated.require("DomainName", input.DomainName);
+    const configurations = simHttpApiDomainConfigurations(
+      input.DomainNameConfigurations,
+      unsimulated,
+    );
+
+    this.access.authorizeCollection("POST", options?.caller);
+
+    const domain = new SimHttpApiDomainName({
+      domainName,
+      accountRegionScope: this.accountRegionScope,
+      configurations,
+    });
+    this.registry.register(domain);
+    this.domains.add(domain);
+
+    return { ...domain.view(), $metadata: {} };
+  }
+
+  /**
+   * Handle a GetDomainName command.
+   */
+  getDomainName(
+    command: SimGetDomainNameCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): SimGetDomainNameCommandOutput {
+    const unsimulated = new SimApiGatewayV2UnsimulatedInput("GetDomainName");
+    unsimulated.refuseUnaccepted(command.input, ["DomainName"]);
+    const domainName = unsimulated.require(
+      "DomainName",
+      command.input.DomainName,
+    );
+
+    const domain = this.access.domain({
+      method: "GET",
+      domainName,
+      caller: options?.caller,
+    });
+
+    return { ...domain.view(), $metadata: {} };
+  }
+
+  /**
+   * Handle a GetDomainNames command.
+   */
+  getDomainNames(
+    command: SimGetDomainNamesCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): SimGetDomainNamesCommandOutput {
+    const unsimulated = new SimApiGatewayV2UnsimulatedInput("GetDomainNames");
+    unsimulated.refusePaging(command.input);
+    unsimulated.refuseUnaccepted(command.input, []);
+
+    this.access.authorizeCollection("GET", options?.caller);
+
+    return {
+      Items: this.domains.list().map((domain) => domain.view()),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Handle a DeleteDomainName command.
+   *
+   * The domain's API mappings go with it, because they belong to it, and its
+   * hostname stops resolving, because nothing answers on it any more. The APIs
+   * it mapped are untouched and still serve their generated endpoints.
+   */
+  deleteDomainName(
+    command: SimDeleteDomainNameCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): SimDeleteDomainNameCommandOutput {
+    const unsimulated = new SimApiGatewayV2UnsimulatedInput("DeleteDomainName");
+    unsimulated.refuseUnaccepted(command.input, ["DomainName"]);
+    const domainName = unsimulated.require(
+      "DomainName",
+      command.input.DomainName,
+    );
+
+    const domain = this.access.domain({
+      method: "DELETE",
+      domainName,
+      caller: options?.caller,
+    });
+
+    this.domains.remove(domain.domainName);
+    this.registry.deregister(domain);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/apigatewayv2/command/domain/sim-http-api-domain-configurations.ts
+++ b/src/service/apigatewayv2/command/domain/sim-http-api-domain-configurations.ts
@@ -1,0 +1,47 @@
+import type { SimHttpApiDomainNameConfiguration } from "../../domain/sim-http-api-domain-name.js";
+import type { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
+
+const acceptedConfigurationOptions = [
+  "CertificateArn",
+  "CertificateName",
+  "EndpointType",
+  "SecurityPolicy",
+];
+
+/**
+ * Read the `DomainNameConfigurations` a domain was created with.
+ *
+ * Nothing in them is applied. A simulated request arrives over plain HTTP on
+ * localhost, so there is no TLS handshake for a certificate or a security
+ * policy to take part in, and the configuration is recorded and reported back
+ * the way `AWS::ApiGatewayV2::Api` records a `CorsConfiguration`. That is
+ * where a test asserts the domain was given the certificate its stack meant to
+ * give it.
+ *
+ * `EndpointType: "EDGE"` is refused. An edge-optimized custom domain is a
+ * REST API feature, and an HTTP API domain is regional.
+ */
+export function simHttpApiDomainConfigurations(
+  configurations: readonly SimHttpApiDomainNameConfiguration[] | undefined,
+  unsimulated: SimApiGatewayV2UnsimulatedInput,
+): readonly SimHttpApiDomainNameConfiguration[] {
+  if (configurations === undefined) {
+    return [];
+  }
+
+  return configurations.map((configuration, index) => {
+    unsimulated.refuseUnaccepted(
+      configuration,
+      acceptedConfigurationOptions,
+      `DomainNameConfigurations[${index}].`,
+    );
+    unsimulated.refuseUnless(
+      "DomainNameConfigurations.EndpointType",
+      configuration.EndpointType,
+      "REGIONAL",
+      "an edge-optimized custom domain name is a REST API feature",
+    );
+
+    return { ...configuration };
+  });
+}

--- a/src/service/apigatewayv2/command/sim-api-gateway-v2-command.types.ts
+++ b/src/service/apigatewayv2/command/sim-api-gateway-v2-command.types.ts
@@ -31,6 +31,34 @@ export type {
   SimHttpApiJwtConfigurationInput,
 } from "./authorizer/authorizer.command.js";
 export type {
+  SimCreateDomainNameCommand,
+  SimCreateDomainNameCommandInput,
+  SimCreateDomainNameCommandOutput,
+  SimDeleteDomainNameCommand,
+  SimDeleteDomainNameCommandInput,
+  SimDeleteDomainNameCommandOutput,
+  SimGetDomainNameCommand,
+  SimGetDomainNameCommandInput,
+  SimGetDomainNameCommandOutput,
+  SimGetDomainNamesCommand,
+  SimGetDomainNamesCommandInput,
+  SimGetDomainNamesCommandOutput,
+} from "./domain/domain.command.js";
+export type {
+  SimCreateApiMappingCommand,
+  SimCreateApiMappingCommandInput,
+  SimCreateApiMappingCommandOutput,
+  SimDeleteApiMappingCommand,
+  SimDeleteApiMappingCommandInput,
+  SimDeleteApiMappingCommandOutput,
+  SimGetApiMappingCommand,
+  SimGetApiMappingCommandInput,
+  SimGetApiMappingCommandOutput,
+  SimGetApiMappingsCommand,
+  SimGetApiMappingsCommandInput,
+  SimGetApiMappingsCommandOutput,
+} from "./domain/api-mapping.command.js";
+export type {
   SimCreateIntegrationCommand,
   SimCreateIntegrationCommandInput,
   SimCreateIntegrationCommandOutput,

--- a/src/service/apigatewayv2/command/sim-http-api-domain-access.ts
+++ b/src/service/apigatewayv2/command/sim-http-api-domain-access.ts
@@ -1,0 +1,74 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimHttpApiDomainName } from "../domain/sim-http-api-domain-name.js";
+import type { SimHttpApiDomainStore } from "../domain/sim-http-api-domain-store.js";
+import { SimApiGatewayV2NotFound } from "../error/sim-api-gateway-v2.error.js";
+import type {
+  SimApiGatewayV2Authorizer,
+  SimApiGatewayV2Method,
+} from "./authorize/sim-api-gateway-v2-authorizer.js";
+
+/**
+ * The collection path every custom domain name in one Account and Region is
+ * addressed under.
+ */
+export const simApiGatewayV2DomainNamesPath = "/domainnames";
+
+interface SimHttpApiDomainAccessProperties {
+  readonly domains: SimHttpApiDomainStore;
+  readonly authorizer: SimApiGatewayV2Authorizer;
+}
+
+interface SimHttpApiDomainRequest {
+  readonly method: SimApiGatewayV2Method;
+  readonly domainName: string;
+  /**
+   * The path of the child collection the command addresses, such as
+   * `/apimappings`. Absent for a command addressing the domain itself.
+   */
+  readonly childPath?: string;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * Reaching a custom domain name for a command, the way `SimHttpApiAccess`
+ * reaches an API: authorization first, then the lookup.
+ */
+export class SimHttpApiDomainAccess {
+  private readonly domains: SimHttpApiDomainStore;
+  private readonly authorizer: SimApiGatewayV2Authorizer;
+
+  constructor(properties: SimHttpApiDomainAccessProperties) {
+    this.domains = properties.domains;
+    this.authorizer = properties.authorizer;
+  }
+
+  /**
+   * Authorize a command against the domain name collection itself, which is
+   * what creating and listing domain names address.
+   */
+  authorizeCollection(
+    method: SimApiGatewayV2Method,
+    caller?: SimAwsCaller,
+  ): void {
+    this.authorizer.authorize(method, simApiGatewayV2DomainNamesPath, caller);
+  }
+
+  /**
+   * Get the domain name a command names, once the caller is allowed to address
+   * it.
+   */
+  domain(request: SimHttpApiDomainRequest): SimHttpApiDomainName {
+    const path = `${simApiGatewayV2DomainNamesPath}/${request.domainName}${request.childPath ?? ""}`;
+    this.authorizer.authorize(request.method, path, request.caller);
+
+    const found = this.domains.find(request.domainName);
+
+    if (found === undefined) {
+      throw new SimApiGatewayV2NotFound(
+        `No domain name ${request.domainName} in this Account and Region`,
+      );
+    }
+
+    return found;
+  }
+}

--- a/src/service/apigatewayv2/domain/sim-api-mapping-id.ts
+++ b/src/service/apigatewayv2/domain/sim-api-mapping-id.ts
@@ -1,0 +1,16 @@
+import { faker } from "@faker-js/faker";
+
+import type { Brand } from "../../../util/brand.type.js";
+
+/**
+ * The id API Gateway allocates for one API mapping.
+ */
+export type SimApiMappingId = Brand<string, "SimApiMappingId">;
+
+/**
+ * Allocate an API mapping id in the shape real API Gateway uses: six
+ * lowercase alphanumeric characters.
+ */
+export function makeSimApiMappingId(): SimApiMappingId {
+  return faker.helpers.fromRegExp(/[a-z0-9]{6}/) as SimApiMappingId;
+}

--- a/src/service/apigatewayv2/domain/sim-api-mapping-key.ts
+++ b/src/service/apigatewayv2/domain/sim-api-mapping-key.ts
@@ -1,0 +1,85 @@
+import { SimApiGatewayV2BadRequest } from "../error/sim-api-gateway-v2.error.js";
+
+/**
+ * The characters a base path segment may be written with, which is the set
+ * real API Gateway accepts for an `ApiMappingKey`.
+ */
+const mappingKeySegment = /^[\w$\-.+!*'()]+$/u;
+
+/**
+ * The base path a domain serves one API under.
+ *
+ * An empty key is the root of the domain, which is the mapping a request
+ * reaching a path no other mapping claims is served by. A non-empty key is one
+ * or more path segments, and the segments are kept rather than the string
+ * because that is what a request path is compared against.
+ */
+export class SimApiMappingKey {
+  public readonly segments: readonly string[];
+
+  private constructor(segments: readonly string[]) {
+    this.segments = segments;
+  }
+
+  /**
+   * Read an `ApiMappingKey` as it was written, refusing one that could never
+   * match a request path.
+   *
+   * An absent key and an empty one are the same thing, and both are the root
+   * of the domain. A leading or trailing slash, or an empty segment inside the
+   * key, is refused rather than trimmed: each is a path the writer did not
+   * mean, and trimming it here would serve requests under a base path the
+   * command was never given.
+   */
+  static parse(value: string | undefined): SimApiMappingKey {
+    if (value === undefined || value.length === 0) {
+      return new SimApiMappingKey([]);
+    }
+
+    const segments = value.split("/");
+
+    for (const segment of segments) {
+      if (!mappingKeySegment.test(segment)) {
+        throw new SimApiGatewayV2BadRequest(
+          `ApiMappingKey '${value}' is not a base path: a base path is one or ` +
+            `more path segments, with no leading or trailing slash`,
+        );
+      }
+    }
+
+    return new SimApiMappingKey(segments);
+  }
+
+  /**
+   * The key as `ApiMappingKey` reports it, which is the empty string for a
+   * mapping serving the root of its domain.
+   */
+  get value(): string {
+    return this.segments.join("/");
+  }
+
+  /**
+   * How many segments this key takes off a request path, which is what decides
+   * between two mappings that both match.
+   */
+  get depth(): number {
+    return this.segments.length;
+  }
+
+  /**
+   * Whether a request's path segments begin with this base path.
+   *
+   * The root mapping matches everything, since it takes no segments.
+   */
+  matches(pathSegments: readonly string[]): boolean {
+    return pathSegments.slice(0, this.depth).join("/") === this.value;
+  }
+
+  /**
+   * The request path segments left for the API's routes, once this base path
+   * has been taken off the front.
+   */
+  remainder(pathSegments: readonly string[]): readonly string[] {
+    return pathSegments.slice(this.depth);
+  }
+}

--- a/src/service/apigatewayv2/domain/sim-api-mapping-key.ts
+++ b/src/service/apigatewayv2/domain/sim-api-mapping-key.ts
@@ -82,4 +82,28 @@ export class SimApiMappingKey {
   remainder(pathSegments: readonly string[]): readonly string[] {
     return pathSegments.slice(this.depth);
   }
+
+  /**
+   * The request path as the invocation event reports it, with this base path
+   * taken off the front.
+   *
+   * AWS documents `rawPath` in a payload format 2.0 event as not carrying the
+   * API mapping value, and points a handler that needs the whole path at
+   * format 1.0 and its `path` field. A base path is therefore unlike a named
+   * stage's segment, which the event does report.
+   *
+   * The path is sliced rather than rebuilt from the segments, so a trailing
+   * slash the client sent survives.
+   */
+  remainingPath(path: string): string {
+    if (this.depth === 0) {
+      return path;
+    }
+
+    // The base path plus the slash in front of it. A request to the base path
+    // itself leaves nothing, which is the root of what the mapping serves.
+    const remaining = path.slice(this.value.length + 1);
+
+    return remaining.length === 0 ? "/" : remaining;
+  }
 }

--- a/src/service/apigatewayv2/domain/sim-api-mapping-store.ts
+++ b/src/service/apigatewayv2/domain/sim-api-mapping-store.ts
@@ -1,0 +1,77 @@
+import type { SimApiMappingId } from "./sim-api-mapping-id.js";
+import type { SimApiMapping } from "./sim-api-mapping.js";
+
+/**
+ * The API mappings of one custom domain, keyed by the id API Gateway
+ * allocated for each.
+ *
+ * A mapping is addressed by that id rather than by its base path, which is
+ * what `DeleteApiMapping` takes, so that is what they are stored by.
+ */
+export class SimApiMappingStore {
+  private readonly mappings = new Map<SimApiMappingId, SimApiMapping>();
+
+  /**
+   * Add a mapping to this domain.
+   */
+  add(mapping: SimApiMapping): void {
+    this.mappings.set(mapping.apiMappingId, mapping);
+  }
+
+  /**
+   * Find a mapping by id.
+   */
+  find(apiMappingId: string): SimApiMapping | undefined {
+    return this.mappings.get(apiMappingId as SimApiMappingId);
+  }
+
+  /**
+   * Find the mapping already serving a base path, if this domain has one.
+   */
+  findByKey(key: string): SimApiMapping | undefined {
+    return this.list().find((mapping) => mapping.apiMappingKey.value === key);
+  }
+
+  /**
+   * Forget a deleted mapping.
+   */
+  remove(apiMappingId: SimApiMappingId): void {
+    this.mappings.delete(apiMappingId);
+  }
+
+  /**
+   * Forget every mapping pointing at an API, which is what deleting that API
+   * leaves behind.
+   */
+  removeForApi(apiId: string): void {
+    for (const mapping of this.list()) {
+      if (mapping.apiId === apiId) {
+        this.mappings.delete(mapping.apiMappingId);
+      }
+    }
+  }
+
+  /**
+   * List every mapping of this domain, in the order they were created.
+   */
+  list(): SimApiMapping[] {
+    return this.mappings.values().toArray();
+  }
+
+  /**
+   * Pick the mapping serving a request path.
+   *
+   * The longest matching base path wins, so a domain mapping both the root and
+   * `orders` serves `/orders/6` from the `orders` mapping and `/pets/6` from
+   * the root one. A domain with no root mapping serves nothing under a path no
+   * base path claims.
+   */
+  select(pathSegments: readonly string[]): SimApiMapping | undefined {
+    return this.list()
+      .filter((mapping) => mapping.apiMappingKey.matches(pathSegments))
+      .toSorted(
+        (one, other) => other.apiMappingKey.depth - one.apiMappingKey.depth,
+      )
+      .at(0);
+  }
+}

--- a/src/service/apigatewayv2/domain/sim-api-mapping-store.ts
+++ b/src/service/apigatewayv2/domain/sim-api-mapping-store.ts
@@ -1,4 +1,7 @@
-import type { SimApiMappingId } from "./sim-api-mapping-id.js";
+import {
+  makeSimApiMappingId,
+  type SimApiMappingId,
+} from "./sim-api-mapping-id.js";
 import type { SimApiMapping } from "./sim-api-mapping.js";
 
 /**
@@ -10,6 +13,20 @@ import type { SimApiMapping } from "./sim-api-mapping.js";
  */
 export class SimApiMappingStore {
   private readonly mappings = new Map<SimApiMappingId, SimApiMapping>();
+
+  /**
+   * Allocate a mapping id this domain is not already using.
+   */
+  allocateId(): SimApiMappingId {
+    let apiMappingId = makeSimApiMappingId();
+
+    while (this.mappings.has(apiMappingId)) {
+      /* v8 ignore next -- does not happen in practice */
+      apiMappingId = makeSimApiMappingId();
+    }
+
+    return apiMappingId;
+  }
 
   /**
    * Add a mapping to this domain.

--- a/src/service/apigatewayv2/domain/sim-api-mapping.ts
+++ b/src/service/apigatewayv2/domain/sim-api-mapping.ts
@@ -1,0 +1,53 @@
+import type { SimApiMappingKey } from "./sim-api-mapping-key.js";
+import type { SimApiMappingId } from "./sim-api-mapping-id.js";
+
+interface SimApiMappingProperties {
+  readonly apiMappingId: SimApiMappingId;
+  readonly apiMappingKey: SimApiMappingKey;
+  readonly apiId: string;
+  readonly stage: string;
+}
+
+/**
+ * Minimal structural API mapping view, as the Create and Get commands return.
+ */
+export interface SimApiMappingView {
+  ApiMappingId: string;
+  ApiMappingKey: string;
+  ApiId: string;
+  Stage: string;
+}
+
+/**
+ * One API mapping: the base path of a custom domain, and the API and stage
+ * that serve requests arriving under it.
+ *
+ * The mapping names its stage, so a request reaching an API this way never
+ * goes through stage selection. That is the difference from the generated
+ * endpoint, where the first path segment is what picks the stage.
+ */
+export class SimApiMapping {
+  public readonly apiMappingId: SimApiMappingId;
+  public readonly apiMappingKey: SimApiMappingKey;
+  public readonly apiId: string;
+  public readonly stage: string;
+
+  constructor(properties: SimApiMappingProperties) {
+    this.apiMappingId = properties.apiMappingId;
+    this.apiMappingKey = properties.apiMappingKey;
+    this.apiId = properties.apiId;
+    this.stage = properties.stage;
+  }
+
+  /**
+   * Get the AWS-like view of this API mapping.
+   */
+  view(): SimApiMappingView {
+    return {
+      ApiMappingId: this.apiMappingId,
+      ApiMappingKey: this.apiMappingKey.value,
+      ApiId: this.apiId,
+      Stage: this.stage,
+    };
+  }
+}

--- a/src/service/apigatewayv2/domain/sim-http-api-domain-name.ts
+++ b/src/service/apigatewayv2/domain/sim-http-api-domain-name.ts
@@ -1,0 +1,82 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimApiMappingStore } from "./sim-api-mapping-store.js";
+
+/**
+ * The expression API Gateway selects an API mapping with, which is the request
+ * base path and is the only value the v2 API reports.
+ */
+export const simApiMappingSelectionExpression = "$request.basepath";
+
+/**
+ * One entry of a domain's `DomainNameConfigurations`, as it was written.
+ *
+ * Nothing here is applied. A simulated request arrives over plain HTTP on
+ * localhost, so a certificate and a TLS security policy have nothing to decide.
+ * They are kept so a test can assert the domain was configured with the
+ * certificate the stack meant to give it.
+ */
+export interface SimHttpApiDomainNameConfiguration {
+  CertificateArn?: string | undefined;
+  CertificateName?: string | undefined;
+  EndpointType?: string | undefined;
+  SecurityPolicy?: string | undefined;
+}
+
+/**
+ * Minimal structural domain name view, as the Create and Get commands return.
+ */
+export interface SimHttpApiDomainNameView {
+  DomainName: string;
+  ApiMappingSelectionExpression: string;
+  DomainNameConfigurations: readonly SimHttpApiDomainNameConfiguration[];
+}
+
+interface SimHttpApiDomainNameProperties {
+  readonly domainName: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly configurations: readonly SimHttpApiDomainNameConfiguration[];
+}
+
+/**
+ * A simulated API Gateway custom domain name.
+ *
+ * The domain answers on a hostname of its own rather than on one API Gateway
+ * generated, which is how an HTTP API is reached under a name the project
+ * owns. It owns its API mappings, because a mapping is addressed by domain on
+ * real AWS and none of them outlives the domain.
+ *
+ * A domain and the APIs it maps live in one Account and Region, as they do on
+ * real AWS, so a mapping names an API id and nothing more.
+ */
+export class SimHttpApiDomainName {
+  public readonly domainName: string;
+  public readonly accountRegionScope: SimAwsAccountRegionScope;
+  public readonly configurations: readonly SimHttpApiDomainNameConfiguration[];
+  public readonly apiMappings = new SimApiMappingStore();
+
+  constructor(properties: SimHttpApiDomainNameProperties) {
+    this.domainName = properties.domainName;
+    this.accountRegionScope = properties.accountRegionScope;
+    this.configurations = properties.configurations;
+  }
+
+  /**
+   * The hostname this domain answers requests on.
+   */
+  get hostname(): string {
+    return this.domainName;
+  }
+
+  /**
+   * Get the AWS-like view of this domain name.
+   */
+  view(): SimHttpApiDomainNameView {
+    return {
+      DomainName: this.domainName,
+      ApiMappingSelectionExpression: simApiMappingSelectionExpression,
+      DomainNameConfigurations: this.configurations.map((configuration) => ({
+        ...configuration,
+      })),
+    };
+  }
+}

--- a/src/service/apigatewayv2/domain/sim-http-api-domain-store.ts
+++ b/src/service/apigatewayv2/domain/sim-http-api-domain-store.ts
@@ -1,0 +1,47 @@
+import type { SimHttpApiDomainName } from "./sim-http-api-domain-name.js";
+
+/**
+ * The custom domain names of one Account and Region, keyed by domain name,
+ * which is what names a domain on real AWS.
+ */
+export class SimHttpApiDomainStore {
+  private readonly domains = new Map<string, SimHttpApiDomainName>();
+
+  /**
+   * Add a domain to this scope.
+   */
+  add(domain: SimHttpApiDomainName): void {
+    this.domains.set(domain.domainName.toLowerCase(), domain);
+  }
+
+  /**
+   * Find a domain by name.
+   */
+  find(domainName: string): SimHttpApiDomainName | undefined {
+    return this.domains.get(domainName.toLowerCase());
+  }
+
+  /**
+   * Forget a deleted domain.
+   */
+  remove(domainName: string): void {
+    this.domains.delete(domainName.toLowerCase());
+  }
+
+  /**
+   * List every domain in this scope, in the order they were created.
+   */
+  list(): SimHttpApiDomainName[] {
+    return this.domains.values().toArray();
+  }
+
+  /**
+   * Forget every API mapping pointing at an API, which is what deleting that
+   * API leaves behind on the domains mapping it.
+   */
+  removeMappingsForApi(apiId: string): void {
+    for (const domain of this.list()) {
+      domain.apiMappings.removeForApi(apiId);
+    }
+  }
+}

--- a/src/service/apigatewayv2/index.ts
+++ b/src/service/apigatewayv2/index.ts
@@ -76,6 +76,21 @@ export {
 export { SimHttpApiRoutePath } from "./api/route/path/sim-http-api-route-path.js";
 export { SimHttpApiRouteRank } from "./api/route/sim-http-api-route-rank.js";
 export {
+  simApiMappingSelectionExpression,
+  SimHttpApiDomainName,
+  type SimHttpApiDomainNameConfiguration,
+  type SimHttpApiDomainNameView,
+} from "./domain/sim-http-api-domain-name.js";
+export {
+  SimApiMapping,
+  type SimApiMappingView,
+} from "./domain/sim-api-mapping.js";
+export {
+  type SimApiMappingId,
+  makeSimApiMappingId,
+} from "./domain/sim-api-mapping-id.js";
+export { SimApiMappingKey } from "./domain/sim-api-mapping-key.js";
+export {
   simHttpApiDefaultStageName,
   SimHttpApiStage,
   type SimHttpApiStageView,

--- a/src/service/apigatewayv2/registry/sim-http-api-domain-registry.ts
+++ b/src/service/apigatewayv2/registry/sim-http-api-domain-registry.ts
@@ -1,0 +1,77 @@
+import type { SimAwsServiceHosts } from "../../../serve/controller/host/sim-aws-service-hosts.js";
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import type { SimHttpApiDomainName } from "../domain/sim-http-api-domain-name.js";
+import { SimApiGatewayV2BadRequest } from "../error/sim-api-gateway-v2.error.js";
+
+/**
+ * Simulated API Gateway cross-Account registry of custom domain names.
+ *
+ * A domain name is unique across the whole of real AWS rather than within one
+ * Account, so this is where that uniqueness is enforced, in the same way API
+ * ids are allocated against the API registry.
+ *
+ * It is also how a served request finds the domain it arrived at. A request to
+ * a custom domain carries a hostname and nothing else: no API id, no Account,
+ * and nothing saying it is an API Gateway hostname at all. That makes this the
+ * answer to which simulated service a hostname belongs to, which is what
+ * `SimAwsServiceHosts` asks.
+ */
+export class SimHttpApiDomainRegistry implements SimAwsServiceHosts {
+  private readonly domainsByHost = new Map<string, SimHttpApiDomainName>();
+
+  /**
+   * Register a newly created domain, so requests to it resolve.
+   */
+  register(domain: SimHttpApiDomainName): void {
+    this.requireUnused(domain);
+
+    this.domainsByHost.set(domain.hostname.toLowerCase(), domain);
+  }
+
+  /**
+   * Forget a deleted domain, so its hostname stops resolving.
+   */
+  deregister(domain: SimHttpApiDomainName): void {
+    this.domainsByHost.delete(domain.hostname.toLowerCase());
+  }
+
+  /**
+   * Find the domain a request's hostname reaches.
+   */
+  findByHost(hostname: string): SimHttpApiDomainName | undefined {
+    return this.domainsByHost.get(hostname.toLowerCase());
+  }
+
+  /**
+   * The simulated service target a hostname names, if a domain answers on it.
+   *
+   * The Region comes from the domain's own scope rather than from the
+   * hostname, because a custom domain's hostname says nothing about where it
+   * was created.
+   */
+  targetForHost(hostname: string): SimAwsServiceTarget | undefined {
+    const domain = this.findByHost(hostname);
+
+    if (domain === undefined) {
+      return undefined;
+    }
+
+    return {
+      service: "apiGatewayDomain",
+      resourceName: domain.domainName,
+      regionName: domain.accountRegionScope.regionName,
+    };
+  }
+
+  private requireUnused(domain: SimHttpApiDomainName): void {
+    if (!this.domainsByHost.has(domain.hostname.toLowerCase())) {
+      return;
+    }
+
+    throw new SimApiGatewayV2BadRequest(
+      `The domain name ${domain.domainName} already exists: a custom domain ` +
+        `name is unique across every simulated Account and Region, as it is ` +
+        `across the whole of real AWS`,
+    );
+  }
+}

--- a/src/service/apigatewayv2/registry/sim-http-api-domain-registry.ts
+++ b/src/service/apigatewayv2/registry/sim-http-api-domain-registry.ts
@@ -1,3 +1,4 @@
+import { SimAwsHostnameClaims } from "../../../serve/controller/host/sim-aws-hostname-claims.js";
 import type { SimAwsServiceHosts } from "../../../serve/controller/host/sim-aws-service-hosts.js";
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
 import type { SimHttpApiDomainName } from "../domain/sim-http-api-domain-name.js";
@@ -18,6 +19,11 @@ import { SimApiGatewayV2BadRequest } from "../error/sim-api-gateway-v2.error.js"
  */
 export class SimHttpApiDomainRegistry implements SimAwsServiceHosts {
   private readonly domainsByHost = new Map<string, SimHttpApiDomainName>();
+  private readonly claims: SimAwsHostnameClaims;
+
+  constructor(claims: SimAwsHostnameClaims = new SimAwsHostnameClaims()) {
+    this.claims = claims;
+  }
 
   /**
    * Register a newly created domain, so requests to it resolve.
@@ -26,6 +32,7 @@ export class SimHttpApiDomainRegistry implements SimAwsServiceHosts {
     this.requireUnused(domain);
 
     this.domainsByHost.set(domain.hostname.toLowerCase(), domain);
+    this.claims.claim(domain.hostname);
   }
 
   /**
@@ -33,6 +40,7 @@ export class SimHttpApiDomainRegistry implements SimAwsServiceHosts {
    */
   deregister(domain: SimHttpApiDomainName): void {
     this.domainsByHost.delete(domain.hostname.toLowerCase());
+    this.claims.release(domain.hostname);
   }
 
   /**
@@ -64,14 +72,14 @@ export class SimHttpApiDomainRegistry implements SimAwsServiceHosts {
   }
 
   private requireUnused(domain: SimHttpApiDomainName): void {
-    if (!this.domainsByHost.has(domain.hostname.toLowerCase())) {
+    if (!this.claims.isClaimed(domain.hostname)) {
       return;
     }
 
     throw new SimApiGatewayV2BadRequest(
       `The domain name ${domain.domainName} already exists: a custom domain ` +
-        `name is unique across every simulated Account and Region, as it is ` +
-        `across the whole of real AWS`,
+        `name is unique across every simulated Account and Region and across ` +
+        `every simulated service, as it is across the whole of real AWS`,
     );
   }
 }

--- a/src/service/apigatewayv2/sdk/sim-api-gateway-v2-sdk-command-router.ts
+++ b/src/service/apigatewayv2/sdk/sim-api-gateway-v2-sdk-command-router.ts
@@ -16,6 +16,18 @@ import type {
   SimGetAuthorizersCommand,
 } from "../command/authorizer/authorizer.command.js";
 import type {
+  SimCreateApiMappingCommand,
+  SimDeleteApiMappingCommand,
+  SimGetApiMappingCommand,
+  SimGetApiMappingsCommand,
+} from "../command/domain/api-mapping.command.js";
+import type {
+  SimCreateDomainNameCommand,
+  SimDeleteDomainNameCommand,
+  SimGetDomainNameCommand,
+  SimGetDomainNamesCommand,
+} from "../command/domain/domain.command.js";
+import type {
   SimCreateIntegrationCommand,
   SimDeleteIntegrationCommand,
   SimGetIntegrationsCommand,
@@ -77,6 +89,70 @@ export class SimApiGatewayV2SdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simApiGatewayV2.deleteApi(
             command as SimDeleteApiCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateDomainNameCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGatewayV2.createDomainName(
+            command as SimCreateDomainNameCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetDomainNameCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGatewayV2.getDomainName(
+            command as SimGetDomainNameCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetDomainNamesCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGatewayV2.getDomainNames(
+            command as SimGetDomainNamesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteDomainNameCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGatewayV2.deleteDomainName(
+            command as SimDeleteDomainNameCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateApiMappingCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGatewayV2.createApiMapping(
+            command as SimCreateApiMappingCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetApiMappingCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGatewayV2.getApiMapping(
+            command as SimGetApiMappingCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetApiMappingsCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGatewayV2.getApiMappings(
+            command as SimGetApiMappingsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteApiMappingCommand",
+        async (command, context): Promise<unknown> =>
+          await simApiGatewayV2.deleteApiMapping(
+            command as SimDeleteApiMappingCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/apigatewayv2/sdk/sim-api-gateway-v2-sdk-routing.iso.test.ts
+++ b/src/service/apigatewayv2/sdk/sim-api-gateway-v2-sdk-routing.iso.test.ts
@@ -1,18 +1,26 @@
 import {
   ApiGatewayV2Client,
   CreateApiCommand,
+  CreateApiMappingCommand,
   CreateAuthorizerCommand,
   CreateIntegrationCommand,
   CreateRouteCommand,
+  CreateDomainNameCommand,
   CreateStageCommand,
   DeleteApiCommand,
+  DeleteApiMappingCommand,
   DeleteAuthorizerCommand,
+  DeleteDomainNameCommand,
   DeleteIntegrationCommand,
   DeleteRouteCommand,
   DeleteStageCommand,
   GetApiCommand,
   GetApisCommand,
+  GetApiMappingCommand,
+  GetApiMappingsCommand,
   GetAuthorizersCommand,
+  GetDomainNameCommand,
+  GetDomainNamesCommand,
   GetIntegrationsCommand,
   GetRoutesCommand,
   GetStagesCommand,
@@ -132,6 +140,78 @@ describe("Intercepting an ApiGatewayV2 SDK client", () => {
 
     await client.send(new DeleteApiCommand({ ApiId: apiId }));
     const remaining = await client.send(new GetApisCommand({}));
+    expect(remaining.Items).toStrictEqual([]);
+  });
+
+  it("routes the custom domain name and API mapping Commands", async () => {
+    // Given a real SDK client intercepted into a simulated AWS, with an API
+    // to map
+    const simAws = new SimAws();
+    using simSdk = new SimSdk({ simAws });
+    const client = new ApiGatewayV2Client({ region: "eu-west-2" });
+    simSdk.intercept(client);
+    const created = await client.send(
+      new CreateApiCommand({ Name: "orders", ProtocolType: "HTTP" }),
+    );
+    await client.send(
+      new CreateStageCommand({
+        ApiId: created.ApiId,
+        StageName: "$default",
+        AutoDeploy: true,
+      }),
+    );
+
+    // When a domain name and a mapping are built through the client
+    const domain = await client.send(
+      new CreateDomainNameCommand({ DomainName: "api.example.test" }),
+    );
+    const mapping = await client.send(
+      new CreateApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiId: created.ApiId,
+        Stage: "$default",
+        ApiMappingKey: "orders",
+      }),
+    );
+
+    // Then the simulation answered, and reading them back finds what was
+    // built
+    assertIdentical(domain.DomainName, "api.example.test");
+    const domains = await client.send(new GetDomainNamesCommand({}));
+    expect(domains.Items?.map((one) => one.DomainName)).toStrictEqual([
+      "api.example.test",
+    ]);
+    const fetchedDomain = await client.send(
+      new GetDomainNameCommand({ DomainName: "api.example.test" }),
+    );
+    assertIdentical(
+      fetchedDomain.ApiMappingSelectionExpression,
+      "$request.basepath",
+    );
+    const fetchedMapping = await client.send(
+      new GetApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiMappingId: mapping.ApiMappingId,
+      }),
+    );
+    assertIdentical(fetchedMapping.ApiMappingKey, "orders");
+
+    // And deleting through the client takes them away again
+    await client.send(
+      new DeleteApiMappingCommand({
+        DomainName: "api.example.test",
+        ApiMappingId: mapping.ApiMappingId,
+      }),
+    );
+    const mappings = await client.send(
+      new GetApiMappingsCommand({ DomainName: "api.example.test" }),
+    );
+    expect(mappings.Items).toStrictEqual([]);
+
+    await client.send(
+      new DeleteDomainNameCommand({ DomainName: "api.example.test" }),
+    );
+    const remaining = await client.send(new GetDomainNamesCommand({}));
     expect(remaining.Items).toStrictEqual([]);
   });
 

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-invocation.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-invocation.ts
@@ -74,7 +74,7 @@ export class SimHttpApiAuthorizerInvocation {
     try {
       const event = await this.eventBuilder.build({
         request,
-        endpoint: simHttpApiEndpoint(api, match),
+        endpoint: simHttpApiEndpoint(api, match, input.domainName),
         routeArn,
         identitySource,
       });

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-invocation.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-invocation.ts
@@ -74,7 +74,7 @@ export class SimHttpApiAuthorizerInvocation {
     try {
       const event = await this.eventBuilder.build({
         request,
-        endpoint: simHttpApiEndpoint(api, match, input.domainName),
+        endpoint: simHttpApiEndpoint(input),
         routeArn,
         identitySource,
       });

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorize-input.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorize-input.ts
@@ -21,6 +21,11 @@ export interface SimHttpApiRouteAuthorizeInput {
    */
   readonly domainName: string;
   /**
+   * The path the authorizer's own event reports, settled the same way the
+   * integration event's is.
+   */
+  readonly rawPath: string;
+  /**
    * The principal the serving boundary attributed the request to, from a
    * signature or from a named caller, and anonymous when it carried neither.
    */

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorize-input.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorize-input.ts
@@ -15,6 +15,12 @@ export interface SimHttpApiRouteAuthorizeInput {
   readonly match: SimHttpApiMatch;
   readonly request: Request;
   /**
+   * The AWS-shaped hostname the request arrived on, which is the endpoint API
+   * Gateway generated or a custom domain mapped to the API. A `REQUEST`
+   * authorizer's event names it, the way an integration's event does.
+   */
+  readonly domainName: string;
+  /**
    * The principal the serving boundary attributed the request to, from a
    * signature or from a named caller, and anonymous when it carried neither.
    */

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
@@ -107,6 +107,7 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       caller: serviceRequest.caller,
       iam: this.router.iamFor(api),
       domainName: serving.domainName,
+      rawPath: serving.rawPath,
     });
 
     if (!authorization.admitted) {
@@ -119,6 +120,7 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       request,
       authorization,
       domainName: serving.domainName,
+      rawPath: serving.rawPath,
     });
   }
 }

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
@@ -3,13 +3,15 @@ import type {
   SimAwsServiceRequest,
 } from "../../../serve/controller/sim-service-controller.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import { SimHttpApiRequest } from "../api/sim-http-api-request.js";
-import type { SimHttpApi } from "../api/sim-http-api.js";
 import { SimHttpApiRouteAuthorizer } from "./auth/sim-http-api-route-authorizer.js";
 import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
 import { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
 import { SimHttpApiIntegrationInvocation } from "./sim-http-api-integration-invocation.js";
 import { SimHttpApiRefusalResponse } from "./sim-http-api-refusal-response.js";
+import {
+  type SimHttpApiServing,
+  SimHttpApiServingResolver,
+} from "./sim-http-api-serving.js";
 
 interface SimApiGatewayV2ServiceControllerProperties {
   readonly simAws?: SimAws;
@@ -19,9 +21,9 @@ interface SimApiGatewayV2ServiceControllerProperties {
 /**
  * Localhost HTTP controller for simulated API Gateway HTTP APIs.
  *
- * A request reaching the generated endpoint is matched to a route, and the
- * route's integration invokes a simulated Lambda function with a payload
- * format 2.0 event. The function runs as its execution Role, as it does for
+ * A request reaching the generated endpoint, or a custom domain mapped to the
+ * API, is matched to a route, and the route's integration invokes a simulated
+ * Lambda function with a payload format 2.0 event. The function runs as its execution Role, as it does for
  * any other invocation.
  *
  * The stage's throttle comes before any of that. A route whose bucket is empty
@@ -38,6 +40,7 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
   private readonly router: SimApiGatewayV2Router;
   private readonly routeAuthorizer: SimHttpApiRouteAuthorizer;
   private readonly integration: SimHttpApiIntegrationInvocation;
+  private readonly serving: SimHttpApiServingResolver;
   private readonly errorResponse = new SimApiGatewayV2ErrorResponse();
   private readonly refusalResponse = new SimHttpApiRefusalResponse();
 
@@ -55,44 +58,37 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       router: this.router,
       clock: this.router.simAws,
     });
+    this.serving = new SimHttpApiServingResolver({ router: this.router });
   }
 
   /**
    * Handle an HTTP request routed to a simulated HTTP API.
    */
   async handleRequest(serviceRequest: SimAwsServiceRequest): Promise<Response> {
-    const httpApi = this.router.route(serviceRequest.target);
+    const resolution = this.serving.resolve(
+      serviceRequest.target,
+      serviceRequest.request,
+    );
 
-    if (httpApi === undefined) {
-      return this.errorResponse.notFound();
+    switch (resolution.kind) {
+      case "notFound": {
+        return this.errorResponse.notFound();
+      }
+      case "refusedHost": {
+        return this.errorResponse.forbiddenHost();
+      }
+      case "served": {
+        return await this.invoke(resolution.serving, serviceRequest);
+      }
     }
-
-    if (httpApi.disableExecuteApiEndpoint) {
-      // The API exists but has switched its generated endpoint off, which is
-      // how an API reachable only through a custom domain is configured.
-      return this.errorResponse.forbidden();
-    }
-
-    return await this.invoke(httpApi, serviceRequest);
   }
 
   private async invoke(
-    api: SimHttpApi,
+    serving: SimHttpApiServing,
     serviceRequest: SimAwsServiceRequest,
   ): Promise<Response> {
     const { request } = serviceRequest;
-    // The whole request path, stage segment and all: the stage takes its own
-    // segment off, and `rawPath` reports the path as the client sent it.
-    const match = api.match(
-      new SimHttpApiRequest({
-        method: request.method,
-        path: new URL(request.url).pathname,
-      }),
-    );
-
-    if (match === undefined) {
-      return this.errorResponse.notFound();
-    }
+    const { api, match } = serving;
 
     // The stage's throttle is asked before the route's authorizer. A flood of
     // requests to a throttled route invokes neither. AWS publishes no order
@@ -110,6 +106,7 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       request,
       caller: serviceRequest.caller,
       iam: this.router.iamFor(api),
+      domainName: serving.domainName,
     });
 
     if (!authorization.admitted) {
@@ -121,6 +118,7 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
       match,
       request,
       authorization,
+      domainName: serving.domainName,
     });
   }
 }

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-error-response.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-error-response.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * The error responses an HTTP API endpoint returns itself, before or instead
  * of an integration producing one.
@@ -33,9 +35,9 @@ export class SimApiGatewayV2ErrorResponse {
   }
 
   /**
-   * The API's generated endpoint is switched off, the route asks for a scope
-   * the accepted token does not claim, or IAM denied the caller
-   * `execute-api:Invoke` on the `AWS_IAM` route being called.
+   * The route asks for a scope the accepted token does not claim, or IAM
+   * denied the caller `execute-api:Invoke` on the `AWS_IAM` route being
+   * called.
    *
    * AWS publishes neither the status nor the body for any of these, so both
    * are what the endpoint was observed to answer rather than something
@@ -43,6 +45,22 @@ export class SimApiGatewayV2ErrorResponse {
    */
   forbidden(): Response {
     return this.jsonResponse(403, "Forbidden");
+  }
+
+  /**
+   * The request carried a `Host` the API neither generated nor has mapped.
+   *
+   * This is the same status and body as any other 403, and it carries the two
+   * headers that tell it apart from CloudFront's own refusal to reach an
+   * origin: API Gateway answers with `x-amzn-errortype` and `x-amzn-requestid`,
+   * while CloudFront answers with `apigw-requestid`. Both were observed
+   * against real AWS rather than published.
+   */
+  forbiddenHost(): Response {
+    return this.jsonResponse(403, "Forbidden", {
+      "x-amzn-errortype": "ForbiddenException",
+      "x-amzn-requestid": randomUUID(),
+    });
   }
 
   /**

--- a/src/service/apigatewayv2/serve/sim-http-api-domain-router.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-domain-router.ts
@@ -1,0 +1,46 @@
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimHttpApiDomainName } from "../domain/sim-http-api-domain-name.js";
+import type { SimHttpApiDomainRegistry } from "../registry/sim-http-api-domain-registry.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+/**
+ * Routes a served request that reached a custom domain name.
+ *
+ * A custom domain hostname says nothing about the Account or the Region it was
+ * created in, so the registry holding every domain in the simulation is the
+ * only way from the hostname to the domain. An API mapping then names an API
+ * id, and the API is looked up in the domain's own scope, because a domain and
+ * the APIs it maps are in one Account and Region on real AWS.
+ */
+export class SimHttpApiDomainRouter {
+  private readonly simAws: SimAws;
+  private readonly domains: SimHttpApiDomainRegistry;
+
+  constructor(simAws: SimAws) {
+    this.simAws = simAws;
+    this.domains = simAws.serviceFactory.registries.httpApiDomains;
+  }
+
+  /**
+   * Find the custom domain name a request target addresses.
+   */
+  route(target: SimAwsServiceTarget): SimHttpApiDomainName | undefined {
+    return this.domains.findByHost(target.resourceName);
+  }
+
+  /**
+   * Find an API a mapping of this domain names.
+   */
+  mappedApi(
+    domain: SimHttpApiDomainName,
+    apiId: string,
+  ): SimHttpApi | undefined {
+    const { accountId, regionName } = domain.accountRegionScope;
+
+    return this.simAws
+      .accountRegionScope(accountId, regionName)
+      .apiGatewayV2()
+      .findApi(apiId);
+  }
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-endpoint.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-endpoint.ts
@@ -1,6 +1,5 @@
 import type { SimPayload2Endpoint } from "../../../serve/payload-2/sim-payload-2-endpoint.js";
-import type { SimHttpApiMatch } from "../api/sim-http-api-match.js";
-import type { SimHttpApi } from "../api/sim-http-api.js";
+import type { SimHttpApiServing } from "./sim-http-api-serving.js";
 
 /**
  * Describe an API and the route that matched as the endpoint a payload format
@@ -8,8 +7,11 @@ import type { SimHttpApi } from "../api/sim-http-api.js";
  *
  * The hostname is the one the request arrived on rather than the one API
  * Gateway generated, so a handler behind a custom domain reads the domain its
- * client asked for. The prefix is that hostname's first label, which is the
- * API id for a generated endpoint and the subdomain for a custom one.
+ * client asked for.
+ *
+ * The reported path is the one the resolver settled. An API mapping's base
+ * path has already come off it, which is what AWS documents `rawPath` as
+ * doing.
  *
  * The path parameters come from the matched route and the stage variables from
  * the stage that served the request. Either may be empty, and the event
@@ -17,14 +19,18 @@ import type { SimHttpApi } from "../api/sim-http-api.js";
  * does with them.
  */
 export function simHttpApiEndpoint(
-  api: SimHttpApi,
-  match: SimHttpApiMatch,
-  domainName: string,
+  serving: SimHttpApiServing,
 ): SimPayload2Endpoint {
+  const { api, match, domainName } = serving;
+
   return {
     apiId: api.apiId,
     domainName,
-    domainPrefix: domainName.split(".", 1)[0] ?? domainName,
+    // The first label, which is the API id for a generated endpoint and the
+    // subdomain for a custom one. `split` with a limit always yields it, so
+    // there is nothing to fall back to.
+    domainPrefix: domainName.split(".", 1).join(""),
+    requestPath: serving.rawPath,
     routeKey: match.route.routeKey,
     stage: match.stage.stageName,
     pathParameters: match.pathParameters.toRecord(),

--- a/src/service/apigatewayv2/serve/sim-http-api-endpoint.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-endpoint.ts
@@ -6,6 +6,11 @@ import type { SimHttpApi } from "../api/sim-http-api.js";
  * Describe an API and the route that matched as the endpoint a payload format
  * 2.0 event names.
  *
+ * The hostname is the one the request arrived on rather than the one API
+ * Gateway generated, so a handler behind a custom domain reads the domain its
+ * client asked for. The prefix is that hostname's first label, which is the
+ * API id for a generated endpoint and the subdomain for a custom one.
+ *
  * The path parameters come from the matched route and the stage variables from
  * the stage that served the request. Either may be empty, and the event
  * builder leaves an empty one out of the event, which is what real API Gateway
@@ -14,11 +19,12 @@ import type { SimHttpApi } from "../api/sim-http-api.js";
 export function simHttpApiEndpoint(
   api: SimHttpApi,
   match: SimHttpApiMatch,
+  domainName: string,
 ): SimPayload2Endpoint {
   return {
     apiId: api.apiId,
-    domainName: api.hostname,
-    domainPrefix: api.apiId,
+    domainName,
+    domainPrefix: domainName.split(".", 1)[0] ?? domainName,
     routeKey: match.route.routeKey,
     stage: match.stage.stageName,
     pathParameters: match.pathParameters.toRecord(),

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
@@ -25,6 +25,8 @@ interface SimHttpApiIntegrationInvocationInput {
   readonly authorization: SimHttpApiAdmitted;
   /** The AWS-shaped hostname the request arrived on. */
   readonly domainName: string;
+  /** The path the invocation event reports, which the resolver settled. */
+  readonly rawPath: string;
 }
 
 /**
@@ -53,7 +55,7 @@ export class SimHttpApiIntegrationInvocation {
    * Invoke the integration for one authorized request.
    */
   async invoke(input: SimHttpApiIntegrationInvocationInput): Promise<Response> {
-    const { api, match, request, authorization } = input;
+    const { match, request, authorization } = input;
     const target = this.router.targetFor(match.integration);
 
     if (target === undefined || this.mayNotInvoke(input, target)) {
@@ -66,7 +68,7 @@ export class SimHttpApiIntegrationInvocation {
     try {
       const event = await this.eventBuilder.build(
         request,
-        simHttpApiEndpoint(api, match, input.domainName),
+        simHttpApiEndpoint(input),
         {
           jwt: authorization.jwt,
           caller: authorization.caller,

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
@@ -23,6 +23,8 @@ interface SimHttpApiIntegrationInvocationInput {
   readonly request: Request;
   /** What the route's authorization knows about the caller. */
   readonly authorization: SimHttpApiAdmitted;
+  /** The AWS-shaped hostname the request arrived on. */
+  readonly domainName: string;
 }
 
 /**
@@ -64,7 +66,7 @@ export class SimHttpApiIntegrationInvocation {
     try {
       const event = await this.eventBuilder.build(
         request,
-        simHttpApiEndpoint(api, match),
+        simHttpApiEndpoint(api, match, input.domainName),
         {
           jwt: authorization.jwt,
           caller: authorization.caller,

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-custom-domain.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-custom-domain.iso.test.ts
@@ -1,0 +1,298 @@
+import {
+  CreateApiMappingCommand,
+  CreateDomainNameCommand,
+  DeleteApiCommand,
+  DeleteDomainNameCommand,
+  DeleteStageCommand,
+  GetApiMappingsCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+
+const domainName = "api.example.test";
+
+function localUrl(hostname: string, path: string): string {
+  return new SimAwsLocalUrl({ input: `https://${hostname}${path}` }).toString();
+}
+
+/** A handler echoing its invocation event back, so a test can assert on it. */
+const echoEvent = (event: SimPayload2Event): SimPayload2Event => event;
+
+/**
+ * Point a custom domain at an API, which is the domain and the mapping real
+ * API Gateway needs before it serves anything under a name of its own.
+ */
+async function mapDomainTo(
+  simAws: SimAws,
+  api: SimHttpApi,
+  apiMappingKey?: string,
+  stage = "$default",
+): Promise<void> {
+  await simAws
+    .apiGatewayV2()
+    .createDomainName(new CreateDomainNameCommand({ DomainName: domainName }));
+  await simAws.apiGatewayV2().createApiMapping(
+    new CreateApiMappingCommand({
+      DomainName: domainName,
+      ApiId: api.apiId,
+      Stage: stage,
+      ApiMappingKey: apiMappingKey,
+    }),
+  );
+}
+
+describe("Serving a sim HTTP API on a custom domain name", () => {
+  it("serves the API at the root of a domain mapped with an empty key", async () => {
+    // Given an API mapped to the root of a custom domain
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets/{petId}"] },
+      simAws,
+    );
+    await mapDomainTo(simAws, api);
+
+    // When a request arrives on the domain's own hostname
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/pets/6"),
+    );
+
+    // Then the API's routes serve it, and the event names the domain the
+    // client asked for rather than the endpoint API Gateway generated
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.routeKey, "GET /pets/{petId}");
+    assertIdentical(event.rawPath, "/pets/6");
+    assertIdentical(event.requestContext.domainName, domainName);
+    assertIdentical(event.requestContext.domainPrefix, "api");
+    assertIdentical(event.requestContext.apiId, api.apiId);
+    expect(event.pathParameters).toStrictEqual({ petId: "6" });
+  });
+
+  it("serves the API under a non-empty base path", async () => {
+    // Given an API mapped under a base path of a custom domain
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets/{petId}"] },
+      simAws,
+    );
+    await mapDomainTo(simAws, api, "orders");
+
+    // When a request arrives under that base path
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/orders/pets/6"),
+    );
+
+    // Then the base path is taken off before the routes see the path, and
+    // stays in rawPath, the way a named stage's segment does
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.routeKey, "GET /pets/{petId}");
+    assertIdentical(event.rawPath, "/orders/pets/6");
+    expect(event.pathParameters).toStrictEqual({ petId: "6" });
+  });
+
+  it("answers 404 under a base path the domain does not map", async () => {
+    // Given a domain mapping only one base path
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets"] },
+      simAws,
+    );
+    await mapDomainTo(simAws, api, "orders");
+
+    // When a request arrives under another one
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/pets"),
+    );
+
+    // Then nothing serves it, since the domain has no root mapping
+    assertIdentical(response.status, 404);
+    expect(await response.json()).toStrictEqual({ message: "Not Found" });
+  });
+
+  it("serves the longest matching base path", async () => {
+    // Given a domain mapping both its root and a base path, to two APIs
+    const simAws = new SimAws();
+    const root = await simHttpApiLambdaProxyFactory.make(
+      { apiName: "site", functionName: "site", handler: () => "root" },
+      simAws,
+    );
+    const orders = await simHttpApiLambdaProxyFactory.make(
+      { apiName: "orders", functionName: "orders", handler: () => "orders" },
+      simAws,
+    );
+    await mapDomainTo(simAws, root);
+    await simAws.apiGatewayV2().createApiMapping(
+      new CreateApiMappingCommand({
+        DomainName: domainName,
+        ApiId: orders.apiId,
+        Stage: "$default",
+        ApiMappingKey: "orders",
+      }),
+    );
+    const http = new SimAwsHttp({ simAws });
+
+    // When requests arrive under each of them
+    const underRoot = await http.fetch(localUrl(domainName, "/pets"));
+    const underOrders = await http.fetch(localUrl(domainName, "/orders/pets"));
+
+    // Then the most specific base path wins, and the root mapping takes the
+    // rest
+    assertIdentical(await underRoot.json(), "root");
+    assertIdentical(await underOrders.json(), "orders");
+  });
+
+  it("serves the stage the mapping names, without a stage segment", async () => {
+    // Given an API whose only stage is a named one, mapped to a domain
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets"], stageNames: ["dev"] },
+      simAws,
+    );
+    await mapDomainTo(simAws, api, undefined, "dev");
+
+    // When a request arrives with no stage in its path
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/pets"),
+    );
+
+    // Then the mapping's stage serves it, since a mapping names its stage
+    // rather than leaving it to the first path segment
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.requestContext.stage, "dev");
+    assertIdentical(event.routeKey, "GET /pets");
+  });
+
+  it("stops resolving a deleted domain name", async () => {
+    // Given an API served on a custom domain
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent },
+      simAws,
+    );
+    await mapDomainTo(simAws, api);
+
+    // When the domain is deleted
+    await simAws
+      .apiGatewayV2()
+      .deleteDomainName(
+        new DeleteDomainNameCommand({ DomainName: domainName }),
+      );
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/pets"),
+    );
+
+    // Then its hostname names no simulated service at all any more
+    assertIdentical(response.status, 501);
+  });
+
+  it("takes the mappings pointing at an API with the deleted API", async () => {
+    // Given an API served on a custom domain
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent },
+      simAws,
+    );
+    await mapDomainTo(simAws, api);
+
+    // When the API is deleted
+    await simAws
+      .apiGatewayV2()
+      .deleteApi(new DeleteApiCommand({ ApiId: api.apiId }));
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/pets"),
+    );
+
+    // Then the domain still answers and maps nothing, rather than holding a
+    // base path pointing at an API that is gone
+    const domain = simAws.apiGatewayV2().findDomainName(domainName);
+    expect(domain?.apiMappings.list()).toStrictEqual([]);
+    assertIdentical(response.status, 404);
+  });
+
+  it("answers 404 when no route of the mapped API matches", async () => {
+    // Given an API mapped to a domain, serving one route
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets"] },
+      simAws,
+    );
+    await mapDomainTo(simAws, api);
+
+    // When a request arrives for a path the API does not route
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/orders"),
+    );
+
+    // Then the domain answers the way the generated endpoint would
+    assertIdentical(response.status, 404);
+  });
+
+  it("answers 404 when the stage a mapping names has been deleted", async () => {
+    // Given an API mapped to a domain through its default stage
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets"] },
+      simAws,
+    );
+    await mapDomainTo(simAws, api);
+
+    // When that stage is deleted and the mapping is left pointing at it
+    await simAws
+      .apiGatewayV2()
+      .deleteStage(
+        new DeleteStageCommand({ ApiId: api.apiId, StageName: "$default" }),
+      );
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/pets"),
+    );
+
+    // Then the mapping serves nothing, and the mapping itself stays, since
+    // only DeleteApi takes mappings away
+    assertIdentical(response.status, 404);
+    const mappings = await simAws
+      .apiGatewayV2()
+      .getApiMappings(new GetApiMappingsCommand({ DomainName: domainName }));
+    assertArrayLength(mappings.Items, 1);
+  });
+
+  it("keeps the mappings of the APIs a deleted API does not name", async () => {
+    // Given a domain mapping two APIs under two base paths
+    const simAws = new SimAws();
+    const orders = await simHttpApiLambdaProxyFactory.make(
+      { apiName: "orders", functionName: "orders", handler: echoEvent },
+      simAws,
+    );
+    const pets = await simHttpApiLambdaProxyFactory.make(
+      { apiName: "pets", functionName: "pets", handler: echoEvent },
+      simAws,
+    );
+    await mapDomainTo(simAws, orders, "orders");
+    await simAws.apiGatewayV2().createApiMapping(
+      new CreateApiMappingCommand({
+        DomainName: domainName,
+        ApiId: pets.apiId,
+        Stage: "$default",
+        ApiMappingKey: "pets",
+      }),
+    );
+
+    // When one of the two APIs is deleted
+    await simAws
+      .apiGatewayV2()
+      .deleteApi(new DeleteApiCommand({ ApiId: orders.apiId }));
+
+    // Then only its own mapping went with it
+    const mappings = await simAws
+      .apiGatewayV2()
+      .getApiMappings(new GetApiMappingsCommand({ DomainName: domainName }));
+    expect(
+      mappings.Items.map((mapping) => mapping.ApiMappingKey),
+    ).toStrictEqual(["pets"]);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-custom-domain.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-custom-domain.iso.test.ts
@@ -88,11 +88,13 @@ describe("Serving a sim HTTP API on a custom domain name", () => {
       localUrl(domainName, "/orders/pets/6"),
     );
 
-    // Then the base path is taken off before the routes see the path, and
-    // stays in rawPath, the way a named stage's segment does
+    // Then the base path is taken off before the routes see the path, and is
+    // gone from the event too: AWS documents rawPath as not carrying the API
+    // mapping value, and points a handler that needs it at payload format 1.0
     const event = (await response.json()) as SimPayload2Event;
     assertIdentical(event.routeKey, "GET /pets/{petId}");
-    assertIdentical(event.rawPath, "/orders/pets/6");
+    assertIdentical(event.rawPath, "/pets/6");
+    assertIdentical(event.requestContext.http.path, "/pets/6");
     expect(event.pathParameters).toStrictEqual({ petId: "6" });
   });
 
@@ -294,5 +296,26 @@ describe("Serving a sim HTTP API on a custom domain name", () => {
     expect(
       mappings.Items.map((mapping) => mapping.ApiMappingKey),
     ).toStrictEqual(["pets"]);
+  });
+
+  it("reports the root path for a request to the base path itself", async () => {
+    // Given an API mapped under a base path, routing the root
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /"] },
+      simAws,
+    );
+    await mapDomainTo(simAws, api, "orders");
+
+    // When the base path itself is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/orders"),
+    );
+
+    // Then the event reports the root, since taking the base path off leaves
+    // no path at all
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.rawPath, "/");
+    assertIdentical(event.routeKey, "GET /");
   });
 });

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-host.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-host.iso.test.ts
@@ -1,0 +1,137 @@
+import {
+  CreateApiMappingCommand,
+  CreateDomainNameCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import { simHttpApiLogicalHost } from "../api/sim-http-api-host.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+
+function localUrl(hostname: string, path = "/"): string {
+  return new SimAwsLocalUrl({ input: `https://${hostname}${path}` }).toString();
+}
+
+/**
+ * Point a hostname at an API's generated endpoint with a Route53 CNAME, which
+ * is a name reaching the API that the API itself knows nothing about.
+ */
+async function cnameTo(
+  simAws: SimAws,
+  hostname: string,
+  api: SimHttpApi,
+): Promise<void> {
+  const simRoute53 = simAws.route53();
+  const zone = await simRoute53.createHostedZone({
+    input: { Name: "example.test", CallerReference: "host-refusal-test" },
+  });
+  await simRoute53.changeResourceRecordSets({
+    input: {
+      HostedZoneId: zone.HostedZone?.Id,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: hostname,
+              Type: "CNAME",
+              // The logical form of the generated endpoint, which is the
+              // name simulated DNS resolves.
+              ResourceRecords: [
+                {
+                  Value: simHttpApiLogicalHost({
+                    apiId: api.apiId,
+                    regionName: api.accountRegionScope.regionName,
+                  }),
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  });
+  await simAws.backgroundTasksComplete();
+}
+
+describe("Which hostnames a sim HTTP API answers on", () => {
+  it("refuses a request carrying a Host it neither generated nor has mapped", async () => {
+    // Given an API reachable under a name of the project's own, with no
+    // custom domain telling the API to serve that name
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make({}, simAws);
+    await cnameTo(simAws, "www.example.test", api);
+
+    // When a request arrives under that name
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl("www.example.test"),
+    );
+
+    // Then the API refuses it before any route or authorizer sees it, with
+    // the headers that tell this apart from CloudFront's own origin refusal
+    assertIdentical(response.status, 403);
+    expect(await response.json()).toStrictEqual({ message: "Forbidden" });
+    assertIdentical(
+      response.headers.get("x-amzn-errortype"),
+      "ForbiddenException",
+    );
+    expect(response.headers.get("x-amzn-requestid")).not.toBeNull();
+  });
+
+  it("serves the same name once a custom domain maps it", async () => {
+    // Given the same API, now with a custom domain for the name
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: () => "hello" },
+      simAws,
+    );
+    await cnameTo(simAws, "www.example.test", api);
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "www.example.test" }),
+      );
+    await simAws.apiGatewayV2().createApiMapping(
+      new CreateApiMappingCommand({
+        DomainName: "www.example.test",
+        ApiId: api.apiId,
+        Stage: "$default",
+      }),
+    );
+
+    // When the same request is sent again
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl("www.example.test"),
+    );
+
+    // Then the API serves it, because the domain is one it now answers on
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.json(), "hello");
+  });
+
+  it("refuses its own generated endpoint once that endpoint is disabled", async () => {
+    // Given an API reachable only through a custom domain
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { disableExecuteApiEndpoint: true },
+      simAws,
+    );
+
+    // When the generated endpoint is requested anyway
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(new URL(api.apiEndpoint).hostname),
+    );
+
+    // Then it is the same refusal a Host the API never served gets, because
+    // that is what the generated hostname has become
+    assertIdentical(response.status, 403);
+    assertIdentical(
+      response.headers.get("x-amzn-errortype"),
+      "ForbiddenException",
+    );
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-serving.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serving.ts
@@ -1,0 +1,169 @@
+import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import { simRoute53LogicalHostname } from "../../route53/local-name/sim-route53-local-name.js";
+import { simHttpApiPathSegments } from "../api/route/path/sim-http-api-path-segments.js";
+import type { SimHttpApiMatch } from "../api/sim-http-api-match.js";
+import { SimHttpApiRequest } from "../api/sim-http-api-request.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import type { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
+import { SimHttpApiDomainRouter } from "./sim-http-api-domain-router.js";
+
+/**
+ * What serves one request: the API, what it matched, and the hostname the
+ * request arrived on.
+ *
+ * The hostname is carried through because the event a handler receives names
+ * it, and a request through a custom domain names that domain rather than the
+ * endpoint API Gateway generated.
+ */
+export interface SimHttpApiServing {
+  readonly api: SimHttpApi;
+  readonly match: SimHttpApiMatch;
+  readonly domainName: string;
+}
+
+/**
+ * What an HTTP API endpoint decided about one request before any of it ran.
+ *
+ * `refusedHost` is a request carrying a `Host` the API neither generated nor
+ * has mapped, which real API Gateway answers 403 before the route's authorizer
+ * sees it. It is what a viewer reaches through a CloudFront behaviour whose
+ * cache key holds `host`, and what an API with `DisableExecuteApiEndpoint`
+ * answers on its generated endpoint.
+ */
+export type SimHttpApiResolution =
+  | { readonly kind: "served"; readonly serving: SimHttpApiServing }
+  | { readonly kind: "notFound" }
+  | { readonly kind: "refusedHost" };
+
+const notFound: SimHttpApiResolution = { kind: "notFound" };
+const refusedHost: SimHttpApiResolution = { kind: "refusedHost" };
+
+interface SimHttpApiServingResolverProperties {
+  readonly router: SimApiGatewayV2Router;
+}
+
+/**
+ * Decides what serves one request that reached an HTTP API endpoint.
+ *
+ * There are two ways in, and they differ in where the stage comes from. A
+ * request to the generated endpoint carries the stage as its first path
+ * segment, or is served by the `$default` stage. A request to a custom domain
+ * is matched to an API mapping, and the mapping names the stage outright, so
+ * what comes off the front of the path is the mapping's base path instead.
+ *
+ * Either way the hostname decides first. An API serves the endpoint API
+ * Gateway generated for it and the domains mapped to it, and refuses anything
+ * else with a 403 before a route or an authorizer is asked about the request.
+ */
+export class SimHttpApiServingResolver {
+  private readonly router: SimApiGatewayV2Router;
+  private readonly domains: SimHttpApiDomainRouter;
+
+  constructor(properties: SimHttpApiServingResolverProperties) {
+    this.router = properties.router;
+    this.domains = new SimHttpApiDomainRouter(properties.router.simAws);
+  }
+
+  /**
+   * Resolve one request routed to an HTTP API endpoint.
+   */
+  resolve(target: SimAwsServiceTarget, request: Request): SimHttpApiResolution {
+    const url = new URL(request.url);
+    const hostname = simRoute53LogicalHostname(url.hostname);
+
+    if (target.service === "apiGatewayDomain") {
+      return this.mapped(target, request.method, url.pathname);
+    }
+
+    return this.generated(target, request.method, url.pathname, hostname);
+  }
+
+  /**
+   * Resolve a request that reached the endpoint API Gateway generated.
+   */
+  private generated(
+    target: SimAwsServiceTarget,
+    method: string,
+    path: string,
+    hostname: string | undefined,
+  ): SimHttpApiResolution {
+    const httpApi = this.router.route(target);
+
+    if (httpApi === undefined) {
+      return notFound;
+    }
+
+    // An API answers on the endpoint API Gateway generated for it and on the
+    // domains mapped to it, and a mapped domain resolved to the other target.
+    // `DisableExecuteApiEndpoint` takes the generated hostname out of that
+    // set, which is why it produces the same refusal.
+    if (
+      httpApi.disableExecuteApiEndpoint ||
+      hostname !== httpApi.logicalHostname
+    ) {
+      return refusedHost;
+    }
+
+    // The whole request path, stage segment and all: the stage takes its own
+    // segment off, and `rawPath` reports the path as the client sent it.
+    const match = httpApi.match(new SimHttpApiRequest({ method, path }));
+
+    if (match === undefined) {
+      return notFound;
+    }
+
+    return {
+      kind: "served",
+      serving: { api: httpApi, match, domainName: httpApi.hostname },
+    };
+  }
+
+  /**
+   * Resolve a request that reached a custom domain name.
+   *
+   * Nothing here is a 403. The domain answers on its own hostname by
+   * definition, so a path no mapping claims, a mapping whose API or stage has
+   * since gone, and a path no route matches are all the one 404.
+   */
+  private mapped(
+    target: SimAwsServiceTarget,
+    method: string,
+    path: string,
+  ): SimHttpApiResolution {
+    const domain = this.domains.route(target);
+
+    /* v8 ignore if -- a domain target only resolves from a registered domain */
+    if (domain === undefined) {
+      return notFound;
+    }
+
+    const segments = simHttpApiPathSegments(path);
+    const mapping = domain.apiMappings.select(segments);
+
+    if (mapping === undefined) {
+      return notFound;
+    }
+
+    const httpApi = this.domains.mappedApi(domain, mapping.apiId);
+    const stage = httpApi?.stages.find(mapping.stage);
+
+    if (httpApi === undefined || stage === undefined) {
+      return notFound;
+    }
+
+    const match = httpApi.matchInStage({
+      stage,
+      method,
+      segments: mapping.apiMappingKey.remainder(segments),
+    });
+
+    if (match === undefined) {
+      return notFound;
+    }
+
+    return {
+      kind: "served",
+      serving: { api: httpApi, match, domainName: domain.domainName },
+    };
+  }
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-serving.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serving.ts
@@ -19,6 +19,13 @@ export interface SimHttpApiServing {
   readonly api: SimHttpApi;
   readonly match: SimHttpApiMatch;
   readonly domainName: string;
+  /**
+   * The path the invocation event reports. It is the request path for the
+   * generated endpoint, and the request path without the API mapping's base
+   * path for a custom domain, which is what AWS documents `rawPath` as
+   * carrying.
+   */
+  readonly rawPath: string;
 }
 
 /**
@@ -114,7 +121,12 @@ export class SimHttpApiServingResolver {
 
     return {
       kind: "served",
-      serving: { api: httpApi, match, domainName: httpApi.hostname },
+      serving: {
+        api: httpApi,
+        match,
+        domainName: httpApi.hostname,
+        rawPath: path,
+      },
     };
   }
 
@@ -163,7 +175,12 @@ export class SimHttpApiServingResolver {
 
     return {
       kind: "served",
-      serving: { api: httpApi, match, domainName: domain.domainName },
+      serving: {
+        api: httpApi,
+        match,
+        domainName: domain.domainName,
+        rawPath: mapping.apiMappingKey.remainingPath(path),
+      },
     };
   }
 }

--- a/src/service/apigatewayv2/sim-api-gateway-v2-commands.ts
+++ b/src/service/apigatewayv2/sim-api-gateway-v2-commands.ts
@@ -13,14 +13,19 @@ import {
   SimHttpApiNoJwtIssuerKeys,
 } from "./api/authorizer/sim-http-api-jwt-issuer-keys.js";
 import { SimHttpApiStore } from "./api/sim-http-api-store.js";
+import { SimHttpApiDomainStore } from "./domain/sim-http-api-domain-store.js";
 import { SimHttpApiCommands } from "./command/api/sim-http-api-commands.js";
 import { SimHttpApiImportCommands } from "./command/api/sim-http-api-import-commands.js";
 import { SimApiGatewayV2Authorizer } from "./command/authorize/sim-api-gateway-v2-authorizer.js";
 import { SimHttpApiAuthorizerCommands } from "./command/authorizer/sim-http-api-authorizer-commands.js";
+import { SimApiMappingCommands } from "./command/domain/sim-api-mapping-commands.js";
+import { SimHttpApiDomainCommands } from "./command/domain/sim-http-api-domain-commands.js";
 import { SimHttpApiIntegrationCommands } from "./command/integration/sim-http-api-integration-commands.js";
 import { SimHttpApiRouteCommands } from "./command/route/sim-http-api-route-commands.js";
 import { SimHttpApiAccess } from "./command/sim-http-api-access.js";
+import { SimHttpApiDomainAccess } from "./command/sim-http-api-domain-access.js";
 import { SimHttpApiStageCommands } from "./command/stage/sim-http-api-stage-commands.js";
+import { SimHttpApiDomainRegistry } from "./registry/sim-http-api-domain-registry.js";
 import { SimHttpApiRegistry } from "./registry/sim-http-api-registry.js";
 
 /**
@@ -31,6 +36,7 @@ export interface SimApiGatewayV2Properties {
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
   readonly registry?: SimHttpApiRegistry;
+  readonly domainRegistry?: SimHttpApiDomainRegistry;
   /**
    * The issuers this API Gateway's JWT authorizers can verify against. A
    * standalone simulated API Gateway has none, so a JWT route refuses every
@@ -49,12 +55,15 @@ export interface SimApiGatewayV2Properties {
  */
 export class SimApiGatewayV2Commands {
   public readonly apis = new SimHttpApiStore();
+  public readonly domains = new SimHttpApiDomainStore();
   public readonly api: SimHttpApiCommands;
   public readonly imports: SimHttpApiImportCommands;
   public readonly authorizers: SimHttpApiAuthorizerCommands;
   public readonly integrations: SimHttpApiIntegrationCommands;
   public readonly routes: SimHttpApiRouteCommands;
   public readonly stages: SimHttpApiStageCommands;
+  public readonly domainNames: SimHttpApiDomainCommands;
+  public readonly apiMappings: SimApiMappingCommands;
   public readonly background: BackgroundScheduler;
 
   constructor(properties: SimApiGatewayV2Properties = {}) {
@@ -63,17 +72,24 @@ export class SimApiGatewayV2Commands {
       iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       registry = new SimHttpApiRegistry(),
+      domainRegistry = new SimHttpApiDomainRegistry(),
       jwtIssuerKeys = new SimHttpApiNoJwtIssuerKeys(),
     } = properties;
 
-    const access = new SimHttpApiAccess({
-      apis: this.apis,
-      authorizer: new SimApiGatewayV2Authorizer({ iam, accountRegionScope }),
+    const authorizer = new SimApiGatewayV2Authorizer({
+      iam,
+      accountRegionScope,
+    });
+    const access = new SimHttpApiAccess({ apis: this.apis, authorizer });
+    const domainAccess = new SimHttpApiDomainAccess({
+      domains: this.domains,
+      authorizer,
     });
 
     this.background = background;
     this.api = new SimHttpApiCommands({
       apis: this.apis,
+      domains: this.domains,
       registry,
       access,
       accountRegionScope,
@@ -84,6 +100,16 @@ export class SimApiGatewayV2Commands {
     this.integrations = new SimHttpApiIntegrationCommands({ access });
     this.routes = new SimHttpApiRouteCommands({ access });
     this.stages = new SimHttpApiStageCommands({ access, clock: background });
+    this.domainNames = new SimHttpApiDomainCommands({
+      domains: this.domains,
+      registry: domainRegistry,
+      access: domainAccess,
+      accountRegionScope,
+    });
+    this.apiMappings = new SimApiMappingCommands({
+      apis: this.apis,
+      access: domainAccess,
+    });
     this.imports = new SimHttpApiImportCommands({
       apis: this.apis,
       registry,

--- a/src/service/apigatewayv2/sim-api-gateway-v2-custom-domains.ts
+++ b/src/service/apigatewayv2/sim-api-gateway-v2-custom-domains.ts
@@ -1,0 +1,127 @@
+import type * as simApiGatewayV2Commands from "./command/sim-api-gateway-v2-command.types.js";
+import type { SimApiGatewayV2RequestOptions } from "./command/sim-api-gateway-v2-request-options.js";
+import type { SimHttpApiDomainName } from "./domain/sim-http-api-domain-name.js";
+import type { SimApiGatewayV2Commands } from "./sim-api-gateway-v2-commands.js";
+
+interface SimApiGatewayV2CustomDomainsProperties {
+  readonly commands: SimApiGatewayV2Commands;
+}
+
+/**
+ * The custom domain name and API mapping operations of simulated API Gateway
+ * v2.
+ *
+ * A domain answers on a hostname the project owns, and an API mapping points a
+ * base path of that domain at one API and one of its stages. Neither is owned
+ * by an API, which is why they are here and not under one.
+ *
+ * They are a class of their own for the reason the Cognito chain is: one class
+ * holding every operation had outgrown the file-length limit, and
+ * `SimApiGatewayV2` above this holds the wiring the whole service is built
+ * from.
+ */
+export abstract class SimApiGatewayV2CustomDomains {
+  protected readonly commands: SimApiGatewayV2Commands;
+
+  protected constructor(properties: SimApiGatewayV2CustomDomainsProperties) {
+    this.commands = properties.commands;
+  }
+
+  /**
+   * Find a custom domain name by the name it was created with.
+   *
+   * This is the simulator's own accessor, for tests seeding or inspecting
+   * domain state without going through a Command and its authorization.
+   */
+  findDomainName(domainName: string): SimHttpApiDomainName | undefined {
+    return this.commands.domains.find(domainName);
+  }
+
+  /**
+   * Handle a CreateDomainName Command from the SDK.
+   */
+  async createDomainName(
+    command: simApiGatewayV2Commands.SimCreateDomainNameCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): Promise<simApiGatewayV2Commands.SimCreateDomainNameCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.domainNames.createDomainName(command, options);
+  }
+
+  /**
+   * Handle a GetDomainName Command from the SDK.
+   */
+  async getDomainName(
+    command: simApiGatewayV2Commands.SimGetDomainNameCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): Promise<simApiGatewayV2Commands.SimGetDomainNameCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.domainNames.getDomainName(command, options);
+  }
+
+  /**
+   * Handle a GetDomainNames Command from the SDK.
+   */
+  async getDomainNames(
+    command: simApiGatewayV2Commands.SimGetDomainNamesCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): Promise<simApiGatewayV2Commands.SimGetDomainNamesCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.domainNames.getDomainNames(command, options);
+  }
+
+  /**
+   * Handle a DeleteDomainName Command from the SDK.
+   */
+  async deleteDomainName(
+    command: simApiGatewayV2Commands.SimDeleteDomainNameCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): Promise<simApiGatewayV2Commands.SimDeleteDomainNameCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.domainNames.deleteDomainName(command, options);
+  }
+
+  /**
+   * Handle a CreateApiMapping Command from the SDK.
+   */
+  async createApiMapping(
+    command: simApiGatewayV2Commands.SimCreateApiMappingCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): Promise<simApiGatewayV2Commands.SimCreateApiMappingCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.apiMappings.createApiMapping(command, options);
+  }
+
+  /**
+   * Handle a GetApiMapping Command from the SDK.
+   */
+  async getApiMapping(
+    command: simApiGatewayV2Commands.SimGetApiMappingCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): Promise<simApiGatewayV2Commands.SimGetApiMappingCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.apiMappings.getApiMapping(command, options);
+  }
+
+  /**
+   * Handle a GetApiMappings Command from the SDK.
+   */
+  async getApiMappings(
+    command: simApiGatewayV2Commands.SimGetApiMappingsCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): Promise<simApiGatewayV2Commands.SimGetApiMappingsCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.apiMappings.getApiMappings(command, options);
+  }
+
+  /**
+   * Handle a DeleteApiMapping Command from the SDK.
+   */
+  async deleteApiMapping(
+    command: simApiGatewayV2Commands.SimDeleteApiMappingCommand,
+    options?: SimApiGatewayV2RequestOptions,
+  ): Promise<simApiGatewayV2Commands.SimDeleteApiMappingCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.apiMappings.deleteApiMapping(command, options);
+  }
+}

--- a/src/service/apigatewayv2/sim-api-gateway-v2.ts
+++ b/src/service/apigatewayv2/sim-api-gateway-v2.ts
@@ -8,6 +8,7 @@ import {
   SimApiGatewayV2Commands,
   type SimApiGatewayV2Properties,
 } from "./sim-api-gateway-v2-commands.js";
+import { SimApiGatewayV2CustomDomains } from "./sim-api-gateway-v2-custom-domains.js";
 
 /**
  * Simulated API Gateway v2. Handles SDK commands. Emulates AWS behaviour and
@@ -20,16 +21,19 @@ import {
  *
  * An API owns its own routes, integrations and stages, because every one of
  * them is addressed by ApiId on real AWS and none of them outlives the API.
+ *
+ * The custom domain name and API mapping operations are on
+ * `SimApiGatewayV2CustomDomains`, which this extends, so a caller reaches all
+ * of them on one service object.
  */
-export class SimApiGatewayV2 {
-  private readonly commands: SimApiGatewayV2Commands;
+export class SimApiGatewayV2 extends SimApiGatewayV2CustomDomains {
   private readonly sdkRouter = new SimApiGatewayV2SdkCommandRouter(this);
   private readonly cfnFactory = new SimApiGatewayV2CfnResourceFactory({
     apiGatewayV2: this,
   });
 
   constructor(properties: SimApiGatewayV2Properties = {}) {
-    this.commands = new SimApiGatewayV2Commands(properties);
+    super({ commands: new SimApiGatewayV2Commands(properties) });
   }
 
   /**

--- a/src/service/aws/factory/sim-aws-registered-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-registered-service-builder.ts
@@ -85,6 +85,10 @@ export class SimAwsRegisteredServiceBuilder {
       // API ids are unique across the simulation, and an API is reachable by
       // id alone from the serving layer, whichever scope created it.
       registry: this.registries.httpApi,
+      // A custom domain name is unique across the simulation, and a request to
+      // one carries only its hostname, so the domains are registered where
+      // resolution can find them.
+      domainRegistry: this.registries.httpApiDomains,
       jwtIssuerKeys: simAwsHttpApiJwtIssuerKeys(this.registries),
     });
   }

--- a/src/service/aws/factory/sim-aws-scoped-service-registries.ts
+++ b/src/service/aws/factory/sim-aws-scoped-service-registries.ts
@@ -1,5 +1,6 @@
 import { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
 import { SimRestApiRegistry } from "../../apigateway/registry/sim-rest-api-registry.js";
+import { SimHttpApiDomainRegistry } from "../../apigatewayv2/registry/sim-http-api-domain-registry.js";
 import { SimHttpApiRegistry } from "../../apigatewayv2/registry/sim-http-api-registry.js";
 import { SimCognitoDomainRegistry } from "../../cognito/registry/sim-cognito-domain-registry.js";
 import { SimCognitoUserPoolRegistry } from "../../cognito/registry/sim-cognito-user-pool-registry.js";
@@ -8,6 +9,10 @@ import { SimElbV2Registry } from "../../elbv2/registry/sim-elbv2-registry.js";
 import { SimKmsRegistry } from "../../kms/registry/sim-kms-registry.js";
 import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
+import {
+  SimAwsAnyServiceHosts,
+  type SimAwsServiceHosts,
+} from "../../../serve/controller/host/sim-aws-service-hosts.js";
 
 /**
  * The registries one simulation's scoped services share between them.
@@ -64,6 +69,14 @@ export class SimAwsScopedServiceRegistries {
   public readonly httpApi = new SimHttpApiRegistry();
 
   /**
+   * Indexes the custom domain names created in any Account and Region of one
+   * SimAws instance. A domain name is unique across the whole of AWS rather
+   * than within an Account, and a request to one carries only a hostname, so
+   * this is also where DNS resolution finds the domain a request arrived at.
+   */
+  public readonly httpApiDomains = new SimHttpApiDomainRegistry();
+
+  /**
    * Indexes the REST API ids allocated in any Account and Region of one SimAws
    * instance, the way `httpApi` does for HTTP APIs. The two services issue
    * endpoints under the same `execute-api` host, and a served request carries
@@ -90,4 +103,13 @@ export class SimAwsScopedServiceRegistries {
    * cross-region uniqueness and lookup behaviour of S3 Bucket names.
    */
   public readonly s3 = new SimS3GlobalRegistry();
+
+  /**
+   * Where a hostname a resource claimed for itself is looked up, which is what
+   * simulated DNS resolution asks after the built-in hostname shapes.
+   */
+  public readonly serviceHosts: SimAwsServiceHosts = new SimAwsAnyServiceHosts([
+    this.cognitoDomains,
+    this.httpApiDomains,
+  ]);
 }

--- a/src/service/aws/factory/sim-aws-scoped-service-registries.ts
+++ b/src/service/aws/factory/sim-aws-scoped-service-registries.ts
@@ -9,6 +9,7 @@ import { SimElbV2Registry } from "../../elbv2/registry/sim-elbv2-registry.js";
 import { SimKmsRegistry } from "../../kms/registry/sim-kms-registry.js";
 import { SimRoute53Registry } from "../../route53/registry/sim-route53-registry.js";
 import { SimS3GlobalRegistry } from "../../s3/sim-s3-global-registry.js";
+import { SimAwsHostnameClaims } from "../../../serve/controller/host/sim-aws-hostname-claims.js";
 import {
   SimAwsAnyServiceHosts,
   type SimAwsServiceHosts,
@@ -43,7 +44,7 @@ export class SimAwsScopedServiceRegistries {
    * Account, and a request to one carries only a hostname, so this is also
    * where DNS resolution finds the pool a hosted request is for.
    */
-  public readonly cognitoDomains = new SimCognitoDomainRegistry();
+  public readonly cognitoDomains: SimCognitoDomainRegistry;
 
   /**
    * Indexes the repositories created in any Account and Region of one SimAws
@@ -74,7 +75,7 @@ export class SimAwsScopedServiceRegistries {
    * than within an Account, and a request to one carries only a hostname, so
    * this is also where DNS resolution finds the domain a request arrived at.
    */
-  public readonly httpApiDomains = new SimHttpApiDomainRegistry();
+  public readonly httpApiDomains: SimHttpApiDomainRegistry;
 
   /**
    * Indexes the REST API ids allocated in any Account and Region of one SimAws
@@ -108,8 +109,21 @@ export class SimAwsScopedServiceRegistries {
    * Where a hostname a resource claimed for itself is looked up, which is what
    * simulated DNS resolution asks after the built-in hostname shapes.
    */
-  public readonly serviceHosts: SimAwsServiceHosts = new SimAwsAnyServiceHosts([
-    this.cognitoDomains,
-    this.httpApiDomains,
-  ]);
+  public readonly serviceHosts: SimAwsServiceHosts;
+
+  /**
+   * The hostnames the domain registries have handed out. A public hostname is
+   * unique across the whole of AWS rather than within one service, so the two
+   * services that hand them out share this rather than each keeping its own.
+   */
+  private readonly hostnameClaims = new SimAwsHostnameClaims();
+
+  constructor() {
+    this.cognitoDomains = new SimCognitoDomainRegistry(this.hostnameClaims);
+    this.httpApiDomains = new SimHttpApiDomainRegistry(this.hostnameClaims);
+    this.serviceHosts = new SimAwsAnyServiceHosts([
+      this.cognitoDomains,
+      this.httpApiDomains,
+    ]);
+  }
 }

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -139,9 +139,10 @@ export class SimAwsServiceFactory {
       cloudFrontRegistry: this.cloudFrontRegistry,
       route53Registry: this.registries.route53,
       kmsRegistry: this.registries.kms,
-      // A Cognito hosted domain answers on a hostname of its own, so DNS
-      // resolution asks the registry holding those domains about it.
-      serviceHosts: this.registries.cognitoDomains,
+      // A Cognito hosted domain and an API Gateway custom domain each answer
+      // on a hostname of their own, so DNS resolution asks the registries
+      // holding those domains about it.
+      serviceHosts: this.registries.serviceHosts,
       iamRegistry: this.iamRegistry,
       accessKeyRegistry: this.requestAuth.accessKeyRegistry,
     });

--- a/src/service/cognito/registry/sim-cognito-domain-registry.ts
+++ b/src/service/cognito/registry/sim-cognito-domain-registry.ts
@@ -1,3 +1,4 @@
+import { SimAwsHostnameClaims } from "../../../serve/controller/host/sim-aws-hostname-claims.js";
 import type { SimAwsServiceHosts } from "../../../serve/controller/host/sim-aws-service-hosts.js";
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
@@ -21,6 +22,11 @@ import { simCognitoUserPoolRegionName } from "../user-pool/sim-cognito-user-pool
 export class SimCognitoDomainRegistry implements SimAwsServiceHosts {
   private readonly domainsByName = new Map<string, SimCognitoUserPoolDomain>();
   private readonly domainsByHost = new Map<string, SimCognitoUserPoolDomain>();
+  private readonly claims: SimAwsHostnameClaims;
+
+  constructor(claims: SimAwsHostnameClaims = new SimAwsHostnameClaims()) {
+    this.claims = claims;
+  }
 
   /**
    * Register a newly created domain, so requests to it resolve.
@@ -36,6 +42,7 @@ export class SimCognitoDomainRegistry implements SimAwsServiceHosts {
 
     for (const hostname of domain.hostnames) {
       this.domainsByHost.set(hostname.toLowerCase(), domain);
+      this.claims.claim(hostname);
     }
   }
 
@@ -47,6 +54,7 @@ export class SimCognitoDomainRegistry implements SimAwsServiceHosts {
 
     for (const hostname of domain.hostnames) {
       this.domainsByHost.delete(hostname.toLowerCase());
+      this.claims.release(hostname);
     }
   }
 
@@ -92,14 +100,14 @@ export class SimCognitoDomainRegistry implements SimAwsServiceHosts {
 
   private requireUnused(domain: SimCognitoUserPoolDomain): void {
     const taken = domain.hostnames.some((hostname) =>
-      this.domainsByHost.has(hostname.toLowerCase()),
+      this.claims.isClaimed(hostname),
     );
 
     if (taken || this.domainsByName.has(domain.value)) {
       throw new SimCognitoInvalidParameterException(
-        `Domain '${domain.value}' is already in use: a user pool domain is ` +
-          `unique across every simulated Account and Region, as it is across ` +
-          `the whole of real AWS`,
+        `Domain '${domain.value}' is already in use: a hosted domain is ` +
+          `unique across every simulated Account, Region and service, as it ` +
+          `is across the whole of real AWS`,
       );
     }
   }


### PR DESCRIPTION
Serve a simulated HTTP API on a custom domain name and API mapping, and refuse a `Host` the API
neither generated nor has mapped.

Resolves https://github.com/KensioSoftware/yulin/issues/1033

`CreateDomainName` creates a domain answering on its own hostname, registered with
`SimAwsServiceHosts` where simulated DNS finds it, the way `SimCognitoDomainRegistry` registers a
user pool custom domain. `CreateApiMapping` points a base path of that domain at one API and one of
its stages, and an empty `ApiMappingKey` serves it at the root. The `Get` and `Delete` counterparts
of both follow the shape the existing commands take.

The mapping names the stage, so a request arriving through a domain skips stage selection and has
the base path taken off the front of the path instead. Where two mappings both match, the longest
base path wins. `requestContext.domainName` is the domain the client asked for and `domainPrefix` is
its first label.

A request carrying a `Host` the API neither generated nor has mapped is answered 403 with
`x-amzn-errortype: ForbiddenException` and `x-amzn-requestid`. `DisableExecuteApiEndpoint` now goes
through that same refusal, since it takes the generated hostname out of the set the API answers on.

## For a reviewer

Reaching the 403 means calling the API on a hostname of your own, because simulated CloudFront always
sends the Origin's own domain. The test uses a Route53 CNAME to the generated endpoint.

Four files crossed the FTA threshold on the way, all on cyclomatic complexity rather than length.
`SimApiMappingRules`, `SimHttpApiDomainAccess` and `SimHttpApiDomainRouter` were split out to bring
them back under, and `SimApiGatewayV2CustomDomains` also keeps the service facade under the 300-line
limit, in the shape the Cognito facade chain uses.

The CloudFormation Resource types are out of scope and are #1034. So is forwarding a viewer's `Host`
to a CloudFront Origin.

- [x] Conventional commit message, used as the title

- [ ] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for API Gateway HTTP API custom domains and API mappings.
  * Create, retrieve, list, and delete custom domains and mappings through the simulated API.
  * Route requests using root or multi-segment base paths, mapped stages, and longest-prefix matching.
  * Added hostname validation, DNS resolution, access controls, and realistic responses for unsupported or unmapped hosts.
  * Deleting APIs or domains now cleans up associated mappings.
* **Documentation**
  * Documented custom-domain capabilities, routing behavior, supported configurations, limitations, and an executable example.
* **Tests**
  * Added comprehensive coverage for domain and mapping lifecycle operations, routing, validation, authorization, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->