### PR TITLE
feat: deploy an HTTP API domain from a template

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -2127,18 +2127,21 @@ and a value carrying more is refused, as more than one `IdentitySource` is on `C
 
 [Simulated CloudFormation](https://yulinsim.dev/services/cloudformation/ "Simulated CloudFormation docs") deploys
 `AWS::ApiGatewayV2::Api`, `AWS::ApiGatewayV2::Authorizer`, `AWS::ApiGatewayV2::Integration`,
-`AWS::ApiGatewayV2::Route` and `AWS::ApiGatewayV2::Stage`. A synthesized or hand-written template
-produces an API that serves requests.
+`AWS::ApiGatewayV2::Route`, `AWS::ApiGatewayV2::Stage`, `AWS::ApiGatewayV2::DomainName` and
+`AWS::ApiGatewayV2::ApiMapping`. A synthesized or hand-written template produces an API that serves
+requests.
 
 `Ref` and `Fn::GetAtt` return what real CloudFormation returns for each type:
 
-| Resource type | `Ref`              | `Fn::GetAtt`                |
-| ------------- | ------------------ | --------------------------- |
-| `Api`         | the API id         | `ApiId`, `ApiEndpoint`      |
-| `Authorizer`  | the authorizer id  | `AuthorizerId`              |
-| `Integration` | the integration id | `IntegrationId`             |
-| `Route`       | the route id       | `RouteId`                   |
-| `Stage`       | the stage name     | none, as AWS documents none |
+| Resource type | `Ref`              | `Fn::GetAtt`                                                  |
+| ------------- | ------------------ | ------------------------------------------------------------- |
+| `Api`         | the API id         | `ApiId`, `ApiEndpoint`                                        |
+| `Authorizer`  | the authorizer id  | `AuthorizerId`                                                |
+| `Integration` | the integration id | `IntegrationId`                                               |
+| `Route`       | the route id       | `RouteId`                                                     |
+| `Stage`       | the stage name     | none, as AWS documents none                                   |
+| `DomainName`  | the domain name    | `RegionalDomainName`, `RegionalHostedZoneId`, `DomainNameArn` |
+| `ApiMapping`  | the mapping id     | `ApiMappingId`                                                |
 
 `Fn::GetAtt: ["Api", "ApiEndpoint"]` is the generated endpoint with no trailing slash and no stage
 segment, on the real `amazonaws.com` hostname. CDK's `httpApi.url` is built from `AWS::URLSuffix`
@@ -2366,9 +2369,27 @@ An `Api` carrying a `Policy` property is refused with its own message, in place 
 AWS has no such property on this Resource type, because an HTTP API has no resource policy. A template
 carrying one was written for a REST API.
 
-`AWS::ApiGatewayV2::Deployment`, `DomainName`, `ApiMapping`, `VpcLink` and the WebSocket-only
-`Model`, `RouteResponse` and `IntegrationResponse` create no resource. A template carrying one has
-that resource skipped.
+`AWS::ApiGatewayV2::Deployment`, `VpcLink` and the WebSocket-only `Model`, `RouteResponse` and
+`IntegrationResponse` create no resource. A template carrying one has that resource skipped.
+
+### A custom domain from a template
+
+`AWS::ApiGatewayV2::DomainName` creates the domain and `AWS::ApiGatewayV2::ApiMapping` points a base
+path of it at an API and a stage, the pair CDK's `apigatewayv2.DomainName` synthesizes. The mapping
+needs its stage to exist, and CDK gives it an explicit `DependsOn` for that, because the `Stage`
+property carries the stage's name rather than a `Ref` CloudFormation could take an order from. A
+hand-written template wanting the same order writes that `DependsOn` itself.
+
+`Fn::GetAtt: ["Domain", "RegionalDomainName"]` answers with the hostname the domain serves, so a
+CloudFront Origin or a Route53 alias record built on it reaches the API behind the domain. That is
+the stack shape a cache policy keying on `host` needs, since the generated endpoint refuses a
+forwarded viewer hostname (see [Which hostnames an API answers on](#which-hostnames-an-api-answers-on)).
+
+Real API Gateway issues a separate `d-<id>.execute-api.<region>.amazonaws.com` name here and expects
+DNS to point the custom domain at it. Answering with that name would leave the Origin pointing at a
+hostname simulated DNS reads as a generated API endpoint, resolving to no API at all.
+`RegionalHostedZoneId` answers with one fixed value for every Region, the way a load balancer's
+`CanonicalHostedZoneID` does.
 
 ## Authorization
 
@@ -2435,9 +2456,9 @@ the simulation without being given one. See the
 - `DisableExecuteApiEndpoint`, refusing requests to the generated endpoint
 - `ImportApi` for an OpenAPI 3.0 document, creating one route and one integration per operation and
   one JWT or Lambda `REQUEST` authorizer per security scheme an operation names
-- Deployment of `AWS::ApiGatewayV2::Api`, `Authorizer`, `Integration`, `Route` and `Stage` from a
-  CloudFormation template, including one synthesized by CDK from an `HttpApi`, and an `Api` declared
-  as an OpenAPI document through `Body`
+- Deployment of `AWS::ApiGatewayV2::Api`, `Authorizer`, `Integration`, `Route`, `Stage`, `DomainName`
+  and `ApiMapping` from a CloudFormation template, including one synthesized by CDK from an `HttpApi`,
+  and an `Api` declared as an OpenAPI document through `Body`
 - Authorization of every command by simulated IAM, against the HTTP method and resource path real
   API Gateway uses
 - SDK interception of an `ApiGatewayV2Client`
@@ -2561,9 +2582,14 @@ Current documented limitations:
   decide, and the record is where a test checks the domain got the certificate its stack meant to
   give it. `EndpointType: "EDGE"` is refused, since an edge-optimized custom domain is a REST API
   feature. `MutualTlsAuthentication` and `Tags` are refused by name.
-- The regional domain name AWS issues a custom domain, which is what a Route53 alias record points
-  at, is outside the simulation. `DomainNameConfigurations` reports no `ApiGatewayDomainName` and no
+- The regional domain name AWS issues a custom domain is the domain's own hostname here.
+  `Fn::GetAtt RegionalDomainName` answers with it, and `RegionalHostedZoneId` answers with one fixed
+  value for every Region. `DomainNameConfigurations` reports no `ApiGatewayDomainName` and no
   `HostedZoneId`, and only the custom domain's own hostname resolves.
+- `AWS::ApiGatewayV2::DomainName` records `RoutingMode`, `MutualTlsAuthentication` and `Tags` rather
+  than applying them, and records the `DomainNameConfigurations` members it does not read. Routing
+  rules are a second way to reach an API that nothing here models, and a simulated request carries no
+  client certificate to check.
 - `requestContext.http.path` drops a mapped base path alongside `rawPath`. AWS documents the
   `rawPath` half and shows the two fields carrying the same value, and publishes nothing about
   `http.path` under an API mapping on its own.

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -342,8 +342,8 @@ settles the request, except where its path is a template, which captures nothing
 
 ## CloudFormation
 
-`cfn/` creates the five `AWS::ApiGatewayV2::*` Resource types this simulation deploys, one directory
-per type, each with a creator and a properties reader:
+`cfn/` creates the seven `AWS::ApiGatewayV2::*` Resource types this simulation deploys, one directory
+per area, each with a creator and a properties reader:
 
 ```text
 cfn/
@@ -354,10 +354,15 @@ cfn/
 ├── sim-cfn-http-api-imports.ts                 which APIs a Body declared
 ├── api/         Api, and the Body an imported one carries
 ├── authorizer/  Authorizer
+├── domain/      DomainName and ApiMapping
 ├── integration/ Integration, and the two IntegrationUri forms
 ├── route/       Route
 └── stage/       Stage
 ```
+
+`domain/` holds two types rather than one, because a mapping is addressed by the domain holding it
+and neither is a part of an API. That is also why the resource deleter reaches both directly instead
+of through `SimCfnHttpApiPartDeleter`, which finds an API from a Resource's `ApiId` first.
 
 Every creator goes through the ordinary command, so a template is held to the same rules an SDK
 caller is, and the refusals above apply to a deployed Resource as well. Each properties reader states

--- a/src/service/apigatewayv2/cfn/domain/sim-cfn-api-mapping-creator.ts
+++ b/src/service/apigatewayv2/cfn/domain/sim-cfn-api-mapping-creator.ts
@@ -1,0 +1,49 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimApiMapping } from "../../domain/sim-api-mapping.js";
+import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
+import { SimCfnApiMappingProperties } from "./sim-cfn-api-mapping-properties.js";
+
+interface SimCfnApiMappingCreatorProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * Creates simulated API mappings from AWS::ApiGatewayV2::ApiMapping Resources.
+ */
+export class SimCfnApiMappingCreator {
+  private readonly apiGatewayV2: SimApiGatewayV2;
+
+  constructor(properties: SimCfnApiMappingCreatorProperties) {
+    this.apiGatewayV2 = properties.apiGatewayV2;
+  }
+
+  /**
+   * Create an API mapping from an AWS::ApiGatewayV2::ApiMapping Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimApiMapping> {
+    const mappingProperties = new SimCfnApiMappingProperties({
+      resource,
+      properties,
+    });
+    const domainName = mappingProperties.domainName();
+
+    const created = await this.apiGatewayV2.createApiMapping({
+      input: mappingProperties.createApiMappingInput(),
+    });
+
+    const mapping = this.apiGatewayV2
+      .findDomainName(domainName)
+      ?.apiMappings.find(created.ApiMappingId);
+    assertDefined(
+      mapping,
+      `sim API mapping ${created.ApiMappingId} after CloudFormation creation`,
+    );
+
+    return mapping;
+  }
+}

--- a/src/service/apigatewayv2/cfn/domain/sim-cfn-api-mapping-properties.ts
+++ b/src/service/apigatewayv2/cfn/domain/sim-cfn-api-mapping-properties.ts
@@ -1,0 +1,75 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateApiMappingCommandInput } from "../../command/domain/api-mapping.command.js";
+import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+/**
+ * The AWS::ApiGatewayV2::ApiMapping properties this simulation deploys, which
+ * is every property the Resource type has.
+ */
+const simulatedProperties = ["ApiId", "DomainName", "Stage", "ApiMappingKey"];
+
+interface SimCfnApiMappingPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGatewayV2::ApiMapping CloudFormation properties into the
+ * CreateApiMapping input the mapping creator needs.
+ */
+export class SimCfnApiMappingProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayV2PropertyParser({
+    resourceType: "AWS::ApiGatewayV2::ApiMapping",
+    simulated: simulatedProperties,
+  });
+
+  constructor(properties: SimCfnApiMappingPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The domain name this mapping belongs to, which a template reaches with a
+   * `Ref` on its AWS::ApiGatewayV2::DomainName.
+   */
+  domainName(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["DomainName"],
+      "DomainName",
+    );
+  }
+
+  /**
+   * The CreateApiMapping input this Resource asks for.
+   *
+   * The stage has to exist already. CDK gives the mapping an explicit
+   * dependency on its stage, because the `Stage` property is the stage's name
+   * rather than a `Ref` that CloudFormation could take an order from.
+   */
+  createApiMappingInput(): SimCreateApiMappingCommandInput {
+    return {
+      DomainName: this.domainName(),
+      ApiId: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["ApiId"],
+        "ApiId",
+      ),
+      Stage: this.propertyParser.requiredString(
+        this.resource,
+        this.properties["Stage"],
+        "Stage",
+      ),
+      ApiMappingKey: this.propertyParser.optionalString(
+        this.resource,
+        this.properties["ApiMappingKey"],
+        "ApiMappingKey",
+      ),
+    };
+  }
+}

--- a/src/service/apigatewayv2/cfn/domain/sim-cfn-domain-configurations.ts
+++ b/src/service/apigatewayv2/cfn/domain/sim-cfn-domain-configurations.ts
@@ -1,0 +1,69 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimHttpApiDomainNameConfiguration } from "../../domain/sim-http-api-domain-name.js";
+import type { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+/**
+ * The members of a `DomainNameConfigurations` entry that reach the command.
+ * The rest are recorded against the Resource the way a whole property is.
+ */
+const simulatedMembers = new Set([
+  "CertificateArn",
+  "CertificateName",
+  "EndpointType",
+  "SecurityPolicy",
+]);
+
+interface SimCfnDomainConfigurationsProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnApiGatewayV2PropertyParser;
+}
+
+/**
+ * Reads the `DomainNameConfigurations` of an AWS::ApiGatewayV2::DomainName.
+ *
+ * A member this simulation does not read is recorded and left out rather than
+ * refusing the Resource, which is what the property allow-list does one level
+ * up. A member `CreateDomainName` refuses, such as an `EndpointType` of
+ * `EDGE`, is kept and refused there, which is where the reason lives.
+ */
+export class SimCfnDomainConfigurations {
+  private readonly resource: SimCfnResource;
+  private readonly propertyParser: SimCfnApiGatewayV2PropertyParser;
+
+  constructor(properties: SimCfnDomainConfigurationsProperties) {
+    this.resource = properties.resource;
+    this.propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * Read one `DomainNameConfigurations` entry.
+   */
+  configuration(
+    configuration: SimCfnTemplateValueRecord,
+    index: number,
+  ): SimHttpApiDomainNameConfiguration {
+    const label = `DomainNameConfigurations[${String(index)}]`;
+    const read: SimHttpApiDomainNameConfiguration = {};
+
+    for (const [member, value] of Object.entries(configuration)) {
+      if (simulatedMembers.has(member)) {
+        read[member as keyof SimHttpApiDomainNameConfiguration] =
+          this.propertyParser.requiredString(
+            this.resource,
+            value,
+            `${label}.${member}`,
+          );
+        continue;
+      }
+
+      this.resource.ignoreProperty(
+        `${label}.${member}`,
+        `AWS::ApiGatewayV2::DomainName ${label}.${member} is not simulated, ` +
+          `so the domain is created without it.`,
+      );
+    }
+
+    return read;
+  }
+}

--- a/src/service/apigatewayv2/cfn/domain/sim-cfn-http-api-domain-creator.ts
+++ b/src/service/apigatewayv2/cfn/domain/sim-cfn-http-api-domain-creator.ts
@@ -1,0 +1,52 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimHttpApiDomainName } from "../../domain/sim-http-api-domain-name.js";
+import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
+import { SimCfnHttpApiDomainProperties } from "./sim-cfn-http-api-domain-properties.js";
+
+interface SimCfnHttpApiDomainCreatorProperties {
+  readonly apiGatewayV2: SimApiGatewayV2;
+}
+
+/**
+ * Creates simulated custom domain names from AWS::ApiGatewayV2::DomainName
+ * Resources.
+ *
+ * A domain depends on nothing, and serves nothing until an
+ * AWS::ApiGatewayV2::ApiMapping points it at an API and a stage. That is the
+ * order real CloudFormation uses, since a mapping names its domain and takes
+ * its dependency from doing so.
+ */
+export class SimCfnHttpApiDomainCreator {
+  private readonly apiGatewayV2: SimApiGatewayV2;
+
+  constructor(properties: SimCfnHttpApiDomainCreatorProperties) {
+    this.apiGatewayV2 = properties.apiGatewayV2;
+  }
+
+  /**
+   * Create a domain name from an AWS::ApiGatewayV2::DomainName Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<SimHttpApiDomainName> {
+    const domainProperties = new SimCfnHttpApiDomainProperties({
+      resource,
+      properties,
+    });
+
+    const created = await this.apiGatewayV2.createDomainName({
+      input: domainProperties.createDomainNameInput(),
+    });
+
+    const domain = this.apiGatewayV2.findDomainName(created.DomainName);
+    assertDefined(
+      domain,
+      `sim HTTP API domain name ${created.DomainName} after CloudFormation creation`,
+    );
+
+    return domain;
+  }
+}

--- a/src/service/apigatewayv2/cfn/domain/sim-cfn-http-api-domain-properties.ts
+++ b/src/service/apigatewayv2/cfn/domain/sim-cfn-http-api-domain-properties.ts
@@ -1,0 +1,86 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCreateDomainNameCommandInput } from "../../command/domain/domain.command.js";
+import type { SimHttpApiDomainNameConfiguration } from "../../domain/sim-http-api-domain-name.js";
+import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+import { SimCfnDomainConfigurations } from "./sim-cfn-domain-configurations.js";
+
+/**
+ * The AWS::ApiGatewayV2::DomainName properties this simulation deploys.
+ *
+ * `MutualTlsAuthentication`, `RoutingMode` and `Tags` are left out, so a
+ * template carrying one is recorded and the domain is created without it. A
+ * simulated request arrives over plain HTTP, so there is no client
+ * certificate to check, and routing rules are a second way to reach an API
+ * that nothing here models.
+ */
+const simulatedProperties = ["DomainName", "DomainNameConfigurations"];
+
+interface SimCfnHttpApiDomainPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::ApiGatewayV2::DomainName CloudFormation properties into the
+ * CreateDomainName input the domain creator needs.
+ */
+export class SimCfnHttpApiDomainProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly propertyParser = new SimCfnApiGatewayV2PropertyParser({
+    resourceType: "AWS::ApiGatewayV2::DomainName",
+    simulated: simulatedProperties,
+  });
+
+  private readonly configurationReader: SimCfnDomainConfigurations;
+
+  constructor(properties: SimCfnHttpApiDomainPropertiesProperties) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+    this.configurationReader = new SimCfnDomainConfigurations({
+      resource: this.resource,
+      propertyParser: this.propertyParser,
+    });
+
+    this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
+  }
+
+  /**
+   * The domain name, which is also what a `Ref` on this Resource returns.
+   */
+  domainName(): string {
+    return this.propertyParser.requiredString(
+      this.resource,
+      this.properties["DomainName"],
+      "DomainName",
+    );
+  }
+
+  /**
+   * The CreateDomainName input this Resource asks for.
+   */
+  createDomainNameInput(): SimCreateDomainNameCommandInput {
+    return {
+      DomainName: this.domainName(),
+      DomainNameConfigurations: this.configurations(),
+    };
+  }
+
+  /**
+   * The domain name configurations, read into the shape the command takes.
+   */
+  private configurations():
+    | readonly SimHttpApiDomainNameConfiguration[]
+    | undefined {
+    const configurations = this.propertyParser.optionalRecordList(
+      this.resource,
+      this.properties["DomainNameConfigurations"],
+      "DomainNameConfigurations",
+    );
+
+    return configurations?.map((configuration, index) =>
+      this.configurationReader.configuration(configuration, index),
+    );
+  }
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-property-values.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-property-values.ts
@@ -42,6 +42,46 @@ export class SimCfnApiGatewayV2PropertyValues extends SimCfnApiGatewayV2ScalarVa
   }
 
   /**
+   * Parse a property value that must be a list of objects when present, which
+   * is the shape a domain name's `DomainNameConfigurations` takes.
+   */
+  optionalRecordList(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): SimCfnTemplateValueRecord[] | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (!Array.isArray(value)) {
+      throw this.invalidPropertyError(resource, label, "a list of objects");
+    }
+
+    return value.map((entry, index) =>
+      this.requiredRecord(resource, entry, `${label}[${String(index)}]`),
+    );
+  }
+
+  /**
+   * Parse a property value that must be an object, which is what one entry of
+   * a list of objects has to be.
+   */
+  requiredRecord(
+    resource: SimCfnResource,
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): SimCfnTemplateValueRecord {
+    const record = this.optionalRecord(resource, value, label);
+
+    if (record === undefined) {
+      throw this.invalidPropertyError(resource, label, "an object");
+    }
+
+    return record;
+  }
+
+  /**
    * Parse a property value that must be a record of further properties when
    * present, which is the shape an authorizer's `JwtConfiguration` takes.
    */

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-deleter.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-deleter.ts
@@ -2,6 +2,8 @@ import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resou
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimApiGatewayV2 } from "../sim-api-gateway-v2.js";
 import type { SimHttpApi } from "../api/sim-http-api.js";
+import type { SimApiMapping } from "../domain/sim-api-mapping.js";
+import type { SimHttpApiDomainName } from "../domain/sim-http-api-domain-name.js";
 import { SimCfnHttpApiPartDeleter } from "./sim-cfn-http-api-part-deleter.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 
@@ -13,8 +15,9 @@ interface SimCfnApiGatewayV2ResourceDeleterProperties {
  * Deletes the simulated API Gateway v2 resources a CloudFormation Stack
  * created.
  *
- * The API itself is the only Resource type addressed by nothing but its own
- * object. Everything else is a part of an API, and is deleted by
+ * The API and the custom domain name are the Resource types addressed by
+ * nothing but their own object. An API mapping is addressed by the domain
+ * holding it, and everything else is a part of an API, deleted by
  * SimCfnHttpApiPartDeleter, which knows to find the API first.
  */
 export class SimCfnApiGatewayV2ResourceDeleter {
@@ -35,18 +38,72 @@ export class SimCfnApiGatewayV2ResourceDeleter {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): Promise<void> {
-    if (resourceTypeName !== "Api") {
-      await this.partDeleter.delete(resourceTypeName, resource, properties);
+    if (resourceTypeName === "Api") {
+      const api = this.deleted<SimHttpApi>(resource, "HTTP API");
+
+      await this.apiGatewayV2.deleteApi({ input: { ApiId: api.apiId } });
 
       return;
     }
 
-    const api = resource.simResource as SimHttpApi | undefined;
+    if (resourceTypeName === "DomainName") {
+      const domain = this.deleted<SimHttpApiDomainName>(
+        resource,
+        "HTTP API domain name",
+      );
+
+      await this.apiGatewayV2.deleteDomainName({
+        input: { DomainName: domain.domainName },
+      });
+
+      return;
+    }
+
+    if (resourceTypeName === "ApiMapping") {
+      await this.deleteApiMapping(resource, properties);
+
+      return;
+    }
+
+    await this.partDeleter.delete(resourceTypeName, resource, properties);
+  }
+
+  /**
+   * Delete an API mapping, which is addressed by its domain and its own id.
+   *
+   * The domain name comes from the Resource's own property, where creation
+   * read it from, and still resolves because a mapping never outlives the
+   * domain holding it.
+   */
+  private async deleteApiMapping(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): Promise<void> {
+    const mapping = this.deleted<SimApiMapping>(resource, "API mapping");
+    const domainName = properties["DomainName"];
+
+    /* v8 ignore if -- creation refused the Resource without a DomainName */
+    if (typeof domainName !== "string") {
+      throw new TypeError(
+        `AWS::ApiGatewayV2::ApiMapping ${resource.logicalId} requires a DomainName string to delete`,
+      );
+    }
+
+    await this.apiGatewayV2.deleteApiMapping({
+      input: { DomainName: domainName, ApiMappingId: mapping.apiMappingId },
+    });
+  }
+
+  private deleted<T extends object>(
+    resource: SimCfnResource,
+    described: string,
+  ): T {
+    const simResource = resource.simResource as T | undefined;
     assertDefined(
-      api,
-      `sim HTTP API for CloudFormation Resource ${resource.logicalId}`,
+      simResource,
+      `sim ${described} for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.apiGatewayV2.deleteApi({ input: { ApiId: api.apiId } });
+    return simResource;
   }
 }

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-factory.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-factory.ts
@@ -6,6 +6,8 @@ import type {
 import type { SimApiGatewayV2 } from "../sim-api-gateway-v2.js";
 import { SimCfnHttpApiCreator } from "./api/sim-cfn-http-api-creator.js";
 import { SimCfnHttpApiAuthorizerCreator } from "./authorizer/sim-cfn-http-api-authorizer-creator.js";
+import { SimCfnApiMappingCreator } from "./domain/sim-cfn-api-mapping-creator.js";
+import { SimCfnHttpApiDomainCreator } from "./domain/sim-cfn-http-api-domain-creator.js";
 import { SimCfnHttpApiIntegrationCreator } from "./integration/sim-cfn-http-api-integration-creator.js";
 import { SimCfnHttpApiRouteCreator } from "./route/sim-cfn-http-api-route-creator.js";
 import { SimCfnHttpApiImports } from "./sim-cfn-http-api-imports.js";
@@ -36,6 +38,8 @@ export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceF
   private readonly integrationCreator: SimCfnHttpApiIntegrationCreator;
   private readonly routeCreator: SimCfnHttpApiRouteCreator;
   private readonly stageCreator: SimCfnHttpApiStageCreator;
+  private readonly domainCreator: SimCfnHttpApiDomainCreator;
+  private readonly mappingCreator: SimCfnApiMappingCreator;
   private readonly deleter: SimCfnApiGatewayV2ResourceDeleter;
 
   constructor(properties: SimApiGatewayV2CfnResourceFactoryProperties) {
@@ -56,15 +60,17 @@ export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceF
       imports,
     });
     this.stageCreator = new SimCfnHttpApiStageCreator({ apiGatewayV2 });
+    this.domainCreator = new SimCfnHttpApiDomainCreator({ apiGatewayV2 });
+    this.mappingCreator = new SimCfnApiMappingCreator({ apiGatewayV2 });
     this.deleter = new SimCfnApiGatewayV2ResourceDeleter({ apiGatewayV2 });
   }
 
   /**
    * Create a simulated API Gateway v2 resource from a CloudFormation Resource.
    *
-   * Deployments, custom domain names and the WebSocket-only Resource types are
-   * not simulated, so their Resource types are reported as unsupported rather
-   * than quietly treated as deployed.
+   * Deployments, VPC links and the WebSocket-only Resource types are not
+   * simulated, so their Resource types are reported as unsupported rather than
+   * quietly treated as deployed.
    */
   async create(
     resourceTypeName: string,
@@ -88,6 +94,12 @@ export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceF
       }
       case "Stage": {
         return await this.stageCreator.create(resource, properties);
+      }
+      case "DomainName": {
+        return await this.domainCreator.create(resource, properties);
+      }
+      case "ApiMapping": {
+        return await this.mappingCreator.create(resource, properties);
       }
       default: {
         throw new Error(

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-domain.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-domain.iso.test.ts
@@ -1,0 +1,292 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTypeString,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import {
+  deployHttpApi,
+  ignoredReasons,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { simHttpApiRegionalHostedZoneId } from "../domain/sim-http-api-domain-name.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+const domainName = "api.example.test";
+
+const certificateArn =
+  "arn:aws:acm:eu-west-2:111111111111:certificate/6d2c7a2e-0c7a-4d4e-9b6c-1f0a2b3c4d5e";
+
+/** A handler reporting the path the event carried, so a base path shows up. */
+const pathReportingHandler = `
+exports.handler = async (event) => ({
+  statusCode: 200,
+  headers: { "content-type": "text/plain" },
+  body: event.rawPath,
+});
+`;
+
+/**
+ * The two Resources CDK's `apigatewayv2.DomainName` synthesises, with the
+ * mapping depending on the stage the way CDK makes it.
+ */
+function domainResources(
+  apiMappingKey?: string,
+  domainProperties: SimCfnTemplateValueRecord = {},
+): SimCfnTemplateValueRecord {
+  return {
+    Domain: {
+      Type: "AWS::ApiGatewayV2::DomainName",
+      Properties: {
+        DomainName: domainName,
+        DomainNameConfigurations: [
+          { CertificateArn: certificateArn, EndpointType: "REGIONAL" },
+        ],
+        ...domainProperties,
+      },
+    },
+    Mapping: {
+      Type: "AWS::ApiGatewayV2::ApiMapping",
+      DependsOn: ["Stage"],
+      Properties: {
+        ApiId: { Ref: "Api" },
+        DomainName: { Ref: "Domain" },
+        Stage: "$default",
+        ...(apiMappingKey !== undefined && { ApiMappingKey: apiMappingKey }),
+      },
+    },
+  };
+}
+
+const domainOutputs = {
+  DomainRef: { Value: { Ref: "Domain" } },
+  RegionalDomainName: {
+    Value: { "Fn::GetAtt": ["Domain", "RegionalDomainName"] },
+  },
+  RegionalHostedZoneId: {
+    Value: { "Fn::GetAtt": ["Domain", "RegionalHostedZoneId"] },
+  },
+  MappingRef: { Value: { Ref: "Mapping" } },
+};
+
+function localUrl(hostname: string, path = "/"): string {
+  return new SimAwsLocalUrl({ input: `https://${hostname}${path}` }).toString();
+}
+
+describe("HTTP API custom domain CloudFormation Resources", () => {
+  it("serves the API on the domain the template declared", async () => {
+    // Given a template carrying an API, a stage, a domain name and a mapping
+    const simAws = simAwsInEuWest2();
+    await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        handlerSource: pathReportingHandler,
+        routeKeys: ["GET /orders"],
+        resources: domainResources(),
+      }),
+    );
+
+    // When the domain's own hostname is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/orders"),
+    );
+
+    // Then the deployed API served it
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "/orders");
+  });
+
+  it("serves the API under the base path the mapping declared", async () => {
+    // Given the same template with a non-empty ApiMappingKey
+    const simAws = simAwsInEuWest2();
+    await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        handlerSource: pathReportingHandler,
+        routeKeys: ["GET /orders"],
+        resources: domainResources("shop"),
+      }),
+    );
+
+    // When the base path is requested
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domainName, "/shop/orders"),
+    );
+
+    // Then the route matched what was left, and the base path is gone from
+    // the event, as AWS documents rawPath
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "/orders");
+  });
+
+  it("resolves Ref and the Fn::GetAtt attributes of both Resources", async () => {
+    // Given the same deployed template, with the values a stack reads out
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        resources: domainResources(),
+        outputs: domainOutputs,
+      }),
+    );
+
+    // When the outputs are read
+    const domainRef = stack.outputs.get("DomainRef")?.value;
+    const regionalDomainName = stack.outputs.get("RegionalDomainName")?.value;
+    const hostedZoneId = stack.outputs.get("RegionalHostedZoneId")?.value;
+    const mappingRef = stack.outputs.get("MappingRef")?.value;
+
+    // Then Ref is the domain name, the regional name is the hostname the
+    // domain answers on, and the mapping's Ref is the id it was allocated
+    assertIdentical(domainRef, domainName);
+    assertIdentical(regionalDomainName, domainName);
+    assertIdentical(hostedZoneId, simHttpApiRegionalHostedZoneId);
+    assertTypeString(mappingRef);
+    expect(mappingRef).toMatch(/^[a-z0-9]{6}$/u);
+  });
+
+  it("stops the domain resolving when the stack is torn down", async () => {
+    // Given a deployed stack serving an API on a custom domain
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        resources: domainResources(),
+      }),
+    );
+
+    // When the stack is torn down
+    await stack.teardown();
+
+    // Then nothing holds the domain and its hostname names no service
+    assertUndefined(simAws.apiGatewayV2().findDomainName(domainName));
+    assertUndefined(simAws.route53().resolveHttpHost(domainName));
+    assertIdentical(stack.getResource("Domain")?.status, "DELETE_COMPLETE");
+    assertIdentical(stack.getResource("Mapping")?.status, "DELETE_COMPLETE");
+  });
+
+  it("records the domain name properties it does not simulate", async () => {
+    // Given a domain declaring properties this simulation does not model
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        resources: domainResources(undefined, {
+          RoutingMode: "API_MAPPING_ONLY",
+          Tags: { team: "orders" },
+          DomainNameConfigurations: [
+            {
+              CertificateArn: certificateArn,
+              EndpointType: "REGIONAL",
+              OwnershipVerificationCertificateArn: certificateArn,
+            },
+          ],
+        }),
+      }),
+    );
+
+    // Then the domain is created without them rather than failing the stack,
+    // and the record says which properties were left out
+    const reasons = ignoredReasons(stack).filter((reason) =>
+      reason.startsWith("Domain "),
+    );
+    expect(reasons.join("\n")).toMatch(/RoutingMode is not simulated/u);
+    expect(reasons.join("\n")).toMatch(/Tags is not simulated/u);
+    expect(reasons.join("\n")).toMatch(
+      /DomainNameConfigurations\[0\]\.OwnershipVerificationCertificateArn is not simulated/u,
+    );
+    assertIdentical(
+      simAws.apiGatewayV2().findDomainName(domainName)?.domainName,
+      domainName,
+    );
+  });
+
+  it("serves through a Distribution whose Origin is the regional domain name", async () => {
+    // Given a template whose CloudFront Origin takes its domain from the
+    // custom domain, which is the shape a stack fronting an HTTP API uses
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        handlerSource: pathReportingHandler,
+        routeKeys: ["GET /orders"],
+        resources: {
+          ...domainResources(),
+          Distribution: {
+            Type: "AWS::CloudFront::Distribution",
+            DependsOn: ["Mapping"],
+            Properties: {
+              DistributionConfig: {
+                Enabled: true,
+                Origins: [
+                  {
+                    Id: "ApiOrigin",
+                    DomainName: {
+                      "Fn::GetAtt": ["Domain", "RegionalDomainName"],
+                    },
+                    CustomOriginConfig: {
+                      OriginProtocolPolicy: "https-only",
+                    },
+                  },
+                ],
+                DefaultCacheBehavior: {
+                  TargetOriginId: "ApiOrigin",
+                  ViewerProtocolPolicy: "redirect-to-https",
+                },
+              },
+            },
+          },
+        },
+        outputs: {
+          DistributionDomainName: {
+            Value: { "Fn::GetAtt": ["Distribution", "DomainName"] },
+          },
+        },
+      }),
+    );
+
+    // When the Distribution is requested
+    const distributionDomainName = stack.outputs.get(
+      "DistributionDomainName",
+    )?.value;
+    assertTypeString(distributionDomainName);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(distributionDomainName.toLowerCase(), "/orders"),
+    );
+
+    // Then the Origin resolved to the domain and the API behind it answered
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.text(), "/orders");
+  });
+
+  it("says so when asked for an attribute neither Resource type publishes", async () => {
+    // Given a deployed domain and mapping
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({ resources: domainResources() }),
+    );
+    const domain = stack.getResource("Domain");
+    const mapping = stack.getResource("Mapping");
+    assertNonNullable(domain);
+    assertNonNullable(mapping);
+
+    // When an attribute neither publishes is asked for
+    // Then each says so rather than answering with nothing
+    assertStringIncludes(
+      assertThrowsError(() => domain.attributeValue("DomainName")).message,
+      "Unsupported AWS::ApiGatewayV2::DomainName attribute DomainName",
+    );
+    assertStringIncludes(
+      assertThrowsError(() => mapping.attributeValue("Stage")).message,
+      "Unsupported AWS::ApiGatewayV2::ApiMapping attribute Stage",
+    );
+  });
+});

--- a/src/service/apigatewayv2/domain/sim-http-api-domain-name.ts
+++ b/src/service/apigatewayv2/domain/sim-http-api-domain-name.ts
@@ -8,6 +8,17 @@ import { SimApiMappingStore } from "./sim-api-mapping-store.js";
 export const simApiMappingSelectionExpression = "$request.basepath";
 
 /**
+ * The Route53 Hosted Zone the regional endpoint of every custom domain sits
+ * in, which is what an alias record pointing at one names.
+ *
+ * Real API Gateway publishes a different id per Region. One fixed value stands
+ * for all of them here, the way `simElbV2CanonicalHostedZoneId` does for a
+ * load balancer: nothing resolves through it, and an alias record reaches the
+ * domain by the name it points at.
+ */
+export const simHttpApiRegionalHostedZoneId = "Z0000000000001";
+
+/**
  * One entry of a domain's `DomainNameConfigurations`, as it was written.
  *
  * Nothing here is applied. A simulated request arrives over plain HTTP on
@@ -65,6 +76,31 @@ export class SimHttpApiDomainName {
    */
   get hostname(): string {
     return this.domainName;
+  }
+
+  /**
+   * The hostname a DNS record pointing at this domain names, which is what
+   * `Fn::GetAtt RegionalDomainName` answers with.
+   *
+   * Real API Gateway issues a separate `d-<id>.execute-api.<region>` name here
+   * and expects the custom domain to be pointed at it. This answers with the
+   * custom domain's own hostname instead, so a CloudFront Origin or a Route53
+   * alias built on it reaches the domain. An `execute-api` name would be read
+   * as a generated API endpoint by simulated DNS and route to no API at all.
+   */
+  get regionalDomainName(): string {
+    return this.hostname;
+  }
+
+  /**
+   * The ARN of this domain, which `Fn::GetAtt DomainNameArn` answers with.
+   *
+   * API Gateway control-plane ARNs leave the Account segment empty and name
+   * the resource by its request path, as the ARNs commands are authorized
+   * against do.
+   */
+  get arn(): string {
+    return `arn:aws:apigateway:${this.accountRegionScope.regionName}::/domainnames/${this.domainName}`;
   }
 
   /**

--- a/src/service/apigatewayv2/index.ts
+++ b/src/service/apigatewayv2/index.ts
@@ -78,6 +78,7 @@ export { SimHttpApiRouteRank } from "./api/route/sim-http-api-route-rank.js";
 export {
   simApiMappingSelectionExpression,
   SimHttpApiDomainName,
+  simHttpApiRegionalHostedZoneId,
   type SimHttpApiDomainNameConfiguration,
   type SimHttpApiDomainNameView,
 } from "./domain/sim-http-api-domain-name.js";

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.ts
@@ -2,6 +2,8 @@ import { SimHttpApiAuthorizer } from "../../../../apigatewayv2/api/authorizer/si
 import { SimHttpApiIntegration } from "../../../../apigatewayv2/api/integration/sim-http-api-integration.js";
 import { SimHttpApiRoute } from "../../../../apigatewayv2/api/route/sim-http-api-route.js";
 import { SimHttpApi } from "../../../../apigatewayv2/api/sim-http-api.js";
+import { SimApiMapping } from "../../../../apigatewayv2/domain/sim-api-mapping.js";
+import { SimHttpApiDomainName } from "../../../../apigatewayv2/domain/sim-http-api-domain-name.js";
 import { SimHttpApiStage } from "../../../../apigatewayv2/api/stage/sim-http-api-stage.js";
 import type {
   SimCfnResourceValueAdapterProperties,
@@ -11,6 +13,8 @@ import { SimHttpApiAuthorizerCfn } from "./sim-http-api-authorizer-cfn.js";
 import { SimHttpApiCfn } from "./sim-http-api-cfn.js";
 import { SimHttpApiIntegrationCfn } from "./sim-http-api-integration-cfn.js";
 import { SimHttpApiRouteCfn } from "./sim-http-api-route-cfn.js";
+import { SimApiMappingCfn } from "./sim-api-mapping-cfn.js";
+import { SimHttpApiDomainNameCfn } from "./sim-http-api-domain-name-cfn.js";
 import { SimHttpApiStageCfn } from "./sim-http-api-stage-cfn.js";
 
 /**
@@ -55,6 +59,20 @@ export function apiGatewayV2ValueAdapter(
     properties.simResource instanceof SimHttpApiStage
   ) {
     return new SimHttpApiStageCfn({ stage: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ApiGatewayV2::DomainName" &&
+    properties.simResource instanceof SimHttpApiDomainName
+  ) {
+    return new SimHttpApiDomainNameCfn({ domain: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::ApiGatewayV2::ApiMapping" &&
+    properties.simResource instanceof SimApiMapping
+  ) {
+    return new SimApiMappingCfn({ mapping: properties.simResource });
   }
 
   return undefined;

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-api-mapping-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-api-mapping-cfn.ts
@@ -1,0 +1,40 @@
+import type { SimApiMapping } from "../../../../apigatewayv2/domain/sim-api-mapping.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimApiMappingCfnProperties {
+  readonly mapping: SimApiMapping;
+}
+
+/**
+ * CloudFormation-facing values for a simulated API mapping.
+ */
+export class SimApiMappingCfn implements SimCfnResourceValueAdapter {
+  private readonly mapping: SimApiMapping;
+
+  constructor(properties: SimApiMappingCfnProperties) {
+    this.mapping = properties.mapping;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::ApiMapping Ref returns the API mapping id, which is
+   * what every mapping operation names it by.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.mapping.apiMappingId;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::ApiMapping publishes ApiMappingId, which is the same
+   * value Ref returns.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "ApiMappingId") {
+      return this.mapping.apiMappingId;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGatewayV2::ApiMapping attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-domain-name-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-domain-name-cfn.ts
@@ -1,0 +1,56 @@
+import {
+  type SimHttpApiDomainName,
+  simHttpApiRegionalHostedZoneId,
+} from "../../../../apigatewayv2/domain/sim-http-api-domain-name.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimHttpApiDomainNameCfnProperties {
+  readonly domain: SimHttpApiDomainName;
+}
+
+/**
+ * CloudFormation-facing values for a simulated HTTP API custom domain name.
+ */
+export class SimHttpApiDomainNameCfn implements SimCfnResourceValueAdapter {
+  private readonly domain: SimHttpApiDomainName;
+
+  constructor(properties: SimHttpApiDomainNameCfnProperties) {
+    this.domain = properties.domain;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::DomainName Ref returns the domain name, which is what
+   * an API mapping names its domain by.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.domain.domainName;
+  }
+
+  /**
+   * AWS::ApiGatewayV2::DomainName publishes RegionalDomainName,
+   * RegionalHostedZoneId and DomainNameArn.
+   *
+   * `RegionalDomainName` is the hostname the domain answers on, so a
+   * CloudFront Origin or a Route53 alias built on it reaches the domain. Real
+   * API Gateway answers with a separate `d-<id>.execute-api.<region>` name and
+   * expects DNS to point the custom domain at it.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    if (attributeName === "RegionalDomainName") {
+      return this.domain.regionalDomainName;
+    }
+
+    if (attributeName === "RegionalHostedZoneId") {
+      return simHttpApiRegionalHostedZoneId;
+    }
+
+    if (attributeName === "DomainNameArn") {
+      return this.domain.arn;
+    }
+
+    throw new Error(
+      `Unsupported AWS::ApiGatewayV2::DomainName attribute ${attributeName}`,
+    );
+  }
+}


### PR DESCRIPTION
Deploy `AWS::ApiGatewayV2::DomainName` and `AWS::ApiGatewayV2::ApiMapping`, the pair CDK's
`apigatewayv2.DomainName` synthesizes.

Resolves https://github.com/KensioSoftware/yulin/issues/1034

Both Resource types go through the SDK commands added in #1033, with creators alongside
`SimCfnHttpApiStageCreator`. `Fn::GetAtt RegionalDomainName` answers with the hostname the domain
serves, so a CloudFront Origin or a Route53 alias built on it reaches the API behind the domain.
That was the failing case in the issue. `RegionalHostedZoneId` answers with one fixed value for
every Region, and `Ref` gives the domain name. Deleting the stack takes the domain and its mappings
with it.

## For a reviewer

Real API Gateway issues a separate `d-<id>.execute-api.<region>.amazonaws.com` name for
`RegionalDomainName`. This answers with the custom domain's own hostname, which the issue asks for.
An `execute-api` name would leave the Origin pointing at a hostname simulated DNS reads as a
generated API endpoint, resolving to no API at all. That divergence is in the limitations.

An `ApiMapping` needs its stage to exist. The `Stage` property carries the stage's name, so
CloudFormation has no `Ref` to take an order from, and CDK adds an explicit `DependsOn` for it. A
hand-written template needs that `DependsOn` too, which the docs say.

`RoutingMode`, `MutualTlsAuthentication` and `Tags` on a domain are recorded and never applied, as
is any `DomainNameConfigurations` member this simulation does not read. A template carrying one
deploys with the property left out, and the stack records what it dropped.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CloudFormation support for API Gateway HTTP API custom domains and API mappings.
  - Added support for domain routing, base-path mappings, regional hostnames, hosted-zone IDs, and resource references.
  - Added CloudFormation outputs for domain ARNs, regional domain names, mapping IDs, and related attributes.

- **Bug Fixes**
  - Improved cleanup when deleting APIs, custom domains, and mappings.
  - Added validation and clearer errors for invalid property structures and unsupported attributes.

- **Documentation**
  - Updated supported-resource lists and documented regional hostname behavior and current feature limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->