### PR TITLE
fix: serve .pdf files from a mounted Bucket

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -2701,8 +2701,8 @@ called `DeleteObject` would be a poor default. Leave a Bucket on the default in-
 when a test needs deletion to work.
 
 When reading files from filesystem-backed storage, Yulin infers common `content-type` metadata from
-file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.csv`, `.xml`, and
-common font and image formats. A served file whose extension falls outside that set gets
+file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.csv`, `.pdf`,
+`.xml`, and common font and image formats. A served file whose extension falls outside that set gets
 `binary/octet-stream`, as S3 reports for an Object whose type it was never told. That only comes up
 for an extension a mount named itself, below. No other file is served at all, with or without a
 type.

--- a/src/service/s3/mount/sim-s3-mount.type.ts
+++ b/src/service/s3/mount/sim-s3-mount.type.ts
@@ -39,7 +39,7 @@ export interface SimS3MountFilesystemOptions {
    * the web's own types, and nothing else — so that pointing a Bucket at a
    * directory cannot be talked into reading whatever else is in it. A site
    * serving a data file of its own needs its extension named here: a pinyin
-   * dictionary's `.freq`, a `.wasm` module, a `.pdf`.
+   * dictionary's `.freq`, a `.wasm` module, a `.parquet` table.
    *
    * Added to the list rather than replacing it, and a leading dot is optional.
    */

--- a/src/service/s3/storage/filesystem/s3-filesystem-allowed.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-allowed.ts
@@ -70,6 +70,7 @@ export const defaultAllowedObjectFileExtensions = new Set([
   ".map",
   ".mjs",
   ".otf",
+  ".pdf",
   ".png",
   ".svg",
   ".ttc",

--- a/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-object-metadata.ts
@@ -49,6 +49,7 @@ const contentTypesByExtension: ReadonlyMap<string, string> = new Map([
   [".mjs", "text/javascript"],
   [".json", "application/json"],
   [".map", "application/json"],
+  [".pdf", "application/pdf"],
   [".png", "image/png"],
   [".otf", "font/otf"],
   [".svg", "image/svg+xml"],

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
@@ -158,6 +158,7 @@ describe("Filesystem simulated S3 storage", () => {
     ["module.mjs", "text/javascript"],
     ["data.json", "application/json"],
     ["bundle.map", "application/json"],
+    ["guide.pdf", "application/pdf"],
     ["image.png", "image/png"],
     ["font.otf", "font/otf"],
     ["image.svg", "image/svg+xml"],
@@ -199,6 +200,29 @@ describe("Filesystem simulated S3 storage", () => {
     assertIdentical(object.metadata.values["content-type"], "text/csv");
     assertArrayLength(objects, 1);
     assertIdentical(objects[0].key, "data.csv");
+  });
+
+  // A PDF download is a web file in the same sense as a `.csv` or a `.txt`
+  // one, and a site publishing one had it 404 in simulation and serve in the
+  // deployment.
+  it("serves a PDF file without the mount naming the extension", async () => {
+    // Given a PDF file sitting in a mounted directory
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(["public", "guide.pdf"], "%PDF-1.7\n");
+
+    const storage = new FilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+    });
+
+    // When the Object is read and the Bucket listed
+    const object = await storage.getObject("guide.pdf");
+    const objects = await storage.listObjects();
+
+    // Then the file is served, typed as the PDF it is, and listed
+    assertNonNullable(object);
+    assertIdentical(object.metadata.values["content-type"], "application/pdf");
+    assertArrayLength(objects, 1);
+    assertIdentical(objects[0].key, "guide.pdf");
   });
 
   it("ignores unsupported file extensions when listing Objects", async () => {


### PR DESCRIPTION
Serves `.pdf` from a mounted Bucket, typed `application/pdf`. That is the type `aws s3 sync` sends and the type the S3 console assigns, so a static site publishing PDF downloads gets the same header from the simulator as from the deployment. The extension goes on `defaultAllowedObjectFileExtensions` and on `contentTypesByExtension`, the pair #1036 added `.csv` to.

The doc comment on `additionalFileExtensions` gave `.pdf` as an example of an extension a mount has to name for itself. It now gives `.parquet`.

Resolves https://github.com/KensioSoftware/yulin/issues/1040

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing and serving PDF files through filesystem-backed S3 storage.
  * PDF files now receive the `application/pdf` content type and appear in object listings.
* **Documentation**
  * Updated file-extension examples to reflect supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->