### PR TITLE
fix: let a record win over an API custom domain

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1904,6 +1904,20 @@ console.log(await response.json());
 await srv.close();
 ```
 
+### The two names a domain has
+
+API Gateway gives the domain a regional endpoint of its own alongside the name it was created with.
+`DomainNameConfigurations[0].ApiGatewayDomainName` reports it, in the shape
+`d-<id>.execute-api.<region>.amazonaws.com`, and the domain answers there too. That is the published
+address. A CloudFront Origin points at it directly, and a Route53 record points the custom domain
+name at it.
+
+A record for the custom domain name decides where that name goes, as it does on AWS. A distribution
+serving `www.example.com` through an alias record keeps it after an API is given `www.example.com` as
+a custom domain, and requests to the domain's regional endpoint carry on reaching the API. Where a
+simulated hosted zone holds no record for the custom domain name, the name reaches the domain. That
+is how a test that creates only a domain reaches it.
+
 ### Which hostnames an API answers on
 
 An API answers on the endpoint API Gateway generated for it and on the domains mapped to it. A
@@ -1918,6 +1932,10 @@ pair were told apart against real AWS. Simulated CloudFront always sends the Ori
 (see the [CloudFront limitations](https://yulinsim.dev/services/cloudfront/#limitations)), so
 reaching this refusal here means calling the API on a hostname of your own. A Route53 CNAME pointing
 at the generated endpoint does it.
+
+A custom domain of that hostname makes no difference to it. The record still decides where the name
+goes, and a record pointing at the generated endpoint sends the request to an API answering on its
+own hostname. Point the record at the domain's regional endpoint to reach the mappings behind it.
 
 ### Deleting a domain name and its mappings
 
@@ -2380,16 +2398,15 @@ needs its stage to exist, and CDK gives it an explicit `DependsOn` for that, bec
 property carries the stage's name rather than a `Ref` CloudFormation could take an order from. A
 hand-written template wanting the same order writes that `DependsOn` itself.
 
-`Fn::GetAtt: ["Domain", "RegionalDomainName"]` answers with the hostname the domain serves, so a
-CloudFront Origin or a Route53 alias record built on it reaches the API behind the domain. That is
+`Fn::GetAtt: ["Domain", "RegionalDomainName"]` answers with the `d-<id>.execute-api.<region>.amazonaws.com`
+endpoint API Gateway issued the domain (see [The two names a domain has](#the-two-names-a-domain-has)).
+A CloudFront Origin or a Route53 alias record built on it reaches the API behind the domain. That is
 the stack shape a cache policy keying on `host` needs, since the generated endpoint refuses a
 forwarded viewer hostname (see [Which hostnames an API answers on](#which-hostnames-an-api-answers-on)).
 
-Real API Gateway issues a separate `d-<id>.execute-api.<region>.amazonaws.com` name here and expects
-DNS to point the custom domain at it. Answering with that name would leave the Origin pointing at a
-hostname simulated DNS reads as a generated API endpoint, resolving to no API at all.
 `RegionalHostedZoneId` answers with one fixed value for every Region, the way a load balancer's
-`CanonicalHostedZoneID` does.
+`CanonicalHostedZoneID` does. Nothing resolves through it, and an alias record reaches the domain by
+the endpoint name it points at.
 
 ## Authorization
 
@@ -2582,10 +2599,11 @@ Current documented limitations:
   decide, and the record is where a test checks the domain got the certificate its stack meant to
   give it. `EndpointType: "EDGE"` is refused, since an edge-optimized custom domain is a REST API
   feature. `MutualTlsAuthentication` and `Tags` are refused by name.
-- The regional domain name AWS issues a custom domain is the domain's own hostname here.
-  `Fn::GetAtt RegionalDomainName` answers with it, and `RegionalHostedZoneId` answers with one fixed
-  value for every Region. `DomainNameConfigurations` reports no `ApiGatewayDomainName` and no
-  `HostedZoneId`, and only the custom domain's own hostname resolves.
+- A domain's `RegionalHostedZoneId` is one fixed value for every Region, where AWS publishes a
+  different id per Region. Resolution ignores it.
+- A domain created without a `DomainNameConfigurations` entry is reported with one holding only the
+  endpoint it was issued. Real API Gateway needs a certificate for a regional domain, so it always
+  has an entry to report that in.
 - `AWS::ApiGatewayV2::DomainName` records `RoutingMode`, `MutualTlsAuthentication` and `Tags` rather
   than applying them, and records the `DomainNameConfigurations` members it does not read. Routing
   rules are a second way to reach an API that nothing here models, and a simulated request carries no

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -957,11 +957,14 @@ their shape, and the value to point a record at is whatever the service reported
 | `<bucket>.s3.<region>`                   | the S3 REST endpoint                                                     |
 | `<url-id>.lambda-url.<region>`           | a [Lambda](https://yulinsim.dev/services/lambda/) Function URL           |
 | `<api-id>.execute-api.<region>`          | an [API Gateway](https://yulinsim.dev/services/apigatewayv2/) HTTP API   |
+| `d-<id>.execute-api.<region>`            | an API Gateway custom domain                                             |
 | `cognito-idp.<region>`                   | the [Cognito](https://yulinsim.dev/services/cognito/) user pool endpoint |
 
 The hostnames the AWS SDK talks to are written without their `.amazonaws.com` or `.on.aws` tail,
 the same rewriting Yulin applies to an SDK endpoint. A load balancer's name keeps its whole domain,
-since it goes unrewritten. `DNSName` is what a record points at and what a client asks for.
+since it goes unrewritten. `DNSName` is what a record points at and what a client asks for. A custom
+domain's regional endpoint is read either way, so a record can point at `RegionalDomainName` as API
+Gateway answered it.
 
 A name pointing at a load balancer resolves to it. A request to that name reaches the load balancer's
 listeners and rules, and a `host-header` condition on a rule sees the name the request was made to,
@@ -1059,6 +1062,16 @@ try {
 A request served under the suffix reaches the listener on port 80, since the port such a request
 carries is the local server's and never one a client chose. See
 [Simulated Elastic Load Balancing](https://yulinsim.dev/services/elbv2/) for what happens once the request is there.
+
+### A hostname a resource claimed for itself
+
+An API Gateway custom domain answers on the hostname it was created with, and a record for that
+hostname takes it back. The record decides where the name goes, as it does on AWS, where the custom
+domain name is reached only through one. A custom domain no record names resolves to the domain.
+
+A Cognito hosted domain answers on its hostname whatever records exist. Real Cognito puts a
+CloudFront distribution in front of a custom domain and expects a record pointing at that
+distribution, and the distribution name it reports resolves to no simulated service here.
 
 ## DNSSEC
 

--- a/src/serve/controller/host/sim-aws-service-hosts.ts
+++ b/src/serve/controller/host/sim-aws-service-hosts.ts
@@ -37,6 +37,10 @@ export class SimAwsNoServiceHosts implements SimAwsServiceHosts {
  * project picked rather than names AWS generated. Resolution asks one thing
  * about a hostname, so the holders are gathered here rather than each being
  * threaded separately through it.
+ *
+ * Resolution asks twice. A hosted-zone record outranks some claims and leaves
+ * others alone, and which of these a holder is gathered into is what says when
+ * the hostnames it holds are answered for.
  */
 export class SimAwsAnyServiceHosts implements SimAwsServiceHosts {
   private readonly holders: readonly SimAwsServiceHosts[];

--- a/src/service/apigatewayv2/README.md
+++ b/src/service/apigatewayv2/README.md
@@ -175,8 +175,17 @@ and Region of one simulated AWS.
 `registry/sim-http-api-domain-registry.ts` is the same hop for custom domains, and it does one more
 job. A request to a custom domain carries a hostname and nothing saying it is an API Gateway
 hostname at all, so the registry implements `SimAwsServiceHosts` and answers simulated DNS about the
-names it holds. `SimCognitoDomainRegistry` does the same for a user pool domain, and
-`SimAwsAnyServiceHosts` asks the two in turn.
+names it holds. `SimCognitoDomainRegistry` does the same for a user pool domain, and the two are
+asked at different points of resolution. A hosted-zone record for a custom domain name outranks the
+API Gateway claim, the way the custom domain name is reached through a record on AWS, and
+`SimAwsScopedServiceRegistries` says which claims a record outranks by which of the two
+`SimAwsAnyServiceHosts` it gathers them into.
+
+A domain holds two hostnames, and the registry indexes both. One is the name the domain was created
+with. The other is the `d-<id>.execute-api.<region>` endpoint API Gateway issued it, built by
+`domain/sim-http-api-domain-endpoint.ts` and read back there by `SimRoute53ServiceTargetResolver`.
+That endpoint has the shape of an API's own endpoint (the `d-` prefix is what separates them), and
+the resolver reads it ahead of that one.
 
 ## Command handling
 

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-domain.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-domain.iso.test.ts
@@ -143,10 +143,14 @@ describe("HTTP API custom domain CloudFormation Resources", () => {
     const hostedZoneId = stack.outputs.get("RegionalHostedZoneId")?.value;
     const mappingRef = stack.outputs.get("MappingRef")?.value;
 
-    // Then Ref is the domain name, the regional name is the hostname the
-    // domain answers on, and the mapping's Ref is the id it was allocated
+    // Then Ref is the domain name, the regional name is the endpoint API
+    // Gateway issued the domain, and the mapping's Ref is the id it was
+    // allocated
     assertIdentical(domainRef, domainName);
-    assertIdentical(regionalDomainName, domainName);
+    assertTypeString(regionalDomainName);
+    expect(regionalDomainName).toMatch(
+      /^d-[a-z0-9]{10}\.execute-api\.eu-west-2\.amazonaws\.com$/u,
+    );
     assertIdentical(hostedZoneId, simHttpApiRegionalHostedZoneId);
     assertTypeString(mappingRef);
     expect(mappingRef).toMatch(/^[a-z0-9]{6}$/u);

--- a/src/service/apigatewayv2/command/domain/sim-http-api-domain-commands.iso.test.ts
+++ b/src/service/apigatewayv2/command/domain/sim-http-api-domain-commands.iso.test.ts
@@ -8,11 +8,12 @@ import {
   CreateUserPoolCommand,
   CreateUserPoolDomainCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
-import { assertIdentical } from "@kensio/smartass";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import { simAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimAws } from "../../../aws/sim-aws.js";
+import { simHttpApiRegionalHostedZoneId } from "../../domain/sim-http-api-domain-name.js";
 import {
   SimApiGatewayV2BadRequest,
   SimApiGatewayV2NotFound,
@@ -37,12 +38,18 @@ describe("Sim API Gateway v2 custom domain name commands", () => {
     );
 
     // Then it reports the domain API Gateway would have made, selecting its
-    // API mapping on the request base path
+    // API mapping on the request base path, and the regional endpoint it was
+    // issued alongside the name the project owns
     assertIdentical(created.DomainName, "api.example.test");
     assertIdentical(created.ApiMappingSelectionExpression, "$request.basepath");
-    expect(created.DomainNameConfigurations).toStrictEqual([
-      { CertificateArn: certificateArn, EndpointType: "REGIONAL" },
-    ]);
+    const [configuration] = created.DomainNameConfigurations;
+    assertNonNullable(configuration);
+    assertIdentical(configuration.CertificateArn, certificateArn);
+    assertIdentical(configuration.EndpointType, "REGIONAL");
+    assertIdentical(configuration.HostedZoneId, simHttpApiRegionalHostedZoneId);
+    expect(configuration.ApiGatewayDomainName).toMatch(
+      /^d-[a-z0-9]{10}\.execute-api\.us-east-1\.amazonaws\.com$/u,
+    );
   });
 
   it("reads a domain name back and lists the domains of the scope", async () => {
@@ -69,9 +76,17 @@ describe("Sim API Gateway v2 custom domain name commands", () => {
       .apiGatewayV2()
       .getDomainNames(new GetDomainNamesCommand({}));
 
-    // Then both are there, with no configuration for one created without any
+    // Then both are there, and one created without a configuration still
+    // reports the endpoint API Gateway issued it
     assertIdentical(fetched.DomainName, "api.example.test");
-    expect(fetched.DomainNameConfigurations).toStrictEqual([]);
+    expect(fetched.DomainNameConfigurations).toStrictEqual([
+      {
+        ApiGatewayDomainName: simAws
+          .apiGatewayV2()
+          .findDomainName("api.example.test")?.regionalDomainName,
+        HostedZoneId: simHttpApiRegionalHostedZoneId,
+      },
+    ]);
     expect(listed.Items.map((domain) => domain.DomainName)).toStrictEqual([
       "api.example.test",
       "www.example.test",

--- a/src/service/apigatewayv2/domain/sim-http-api-domain-endpoint.ts
+++ b/src/service/apigatewayv2/domain/sim-http-api-domain-endpoint.ts
@@ -1,0 +1,116 @@
+import { faker } from "@faker-js/faker";
+
+import type { Brand } from "../../../util/brand.type.js";
+import {
+  executeApiDomain,
+  executeApiHostLabel,
+} from "../api/sim-http-api-host.js";
+
+/**
+ * The first character of the id API Gateway allocates a custom domain, which
+ * is what tells its endpoint hostname apart from the one an API gets.
+ */
+const domainIdPrefix = "d-";
+
+/**
+ * The id API Gateway allocates for the regional endpoint of one custom domain,
+ * which is the leading DNS label of that endpoint's hostname.
+ */
+export type SimHttpApiDomainId = Brand<string, "SimHttpApiDomainId">;
+
+/**
+ * What a custom domain's regional endpoint hostname is built from.
+ */
+export interface SimHttpApiDomainEndpointParts {
+  readonly domainId: SimHttpApiDomainId;
+  readonly regionName: string;
+}
+
+/**
+ * Allocate a domain endpoint id in the shape real API Gateway uses: `d-`
+ * followed by 10 lowercase alphanumeric characters, forming one DNS label.
+ */
+export function makeSimHttpApiDomainId(): SimHttpApiDomainId {
+  return `${domainIdPrefix}${faker.helpers.fromRegExp(/[a-z0-9]{10}/)}` as SimHttpApiDomainId;
+}
+
+/**
+ * Whether a DNS label is a custom domain endpoint id rather than an API id.
+ *
+ * A custom domain and an API are issued endpoints of the same shape, so this
+ * is what decides which of the two a hostname names. API ids carry no hyphen,
+ * which is what leaves the prefix free to say it.
+ */
+export function isSimHttpApiDomainId(label: string): boolean {
+  return label.startsWith(domainIdPrefix);
+}
+
+/**
+ * Build the real AWS endpoint hostname for a custom domain, which is what
+ * `RegionalDomainName` answers with and what a record for the custom domain
+ * name points at.
+ */
+export function simHttpApiDomainEndpointHost(
+  parts: SimHttpApiDomainEndpointParts,
+): string {
+  return `${simHttpApiDomainEndpointLogicalHost(parts)}.${executeApiDomain}`;
+}
+
+/**
+ * Build the logical hostname for a custom domain endpoint: the AWS endpoint
+ * hostname without the real AWS domain, which is the form Yulin serves on
+ * localhost.
+ */
+export function simHttpApiDomainEndpointLogicalHost(
+  parts: SimHttpApiDomainEndpointParts,
+): string {
+  return `${parts.domainId}.${executeApiHostLabel}.${parts.regionName}`;
+}
+
+/**
+ * A custom domain's regional endpoint hostname, as it was read.
+ */
+export interface SimHttpApiDomainEndpointHost {
+  /**
+   * The hostname without the AWS domain, which is the name simulated DNS
+   * resolves and the domain registry holds.
+   */
+  readonly logicalHost: string;
+  readonly regionName: string;
+}
+
+/**
+ * Read a custom domain's regional endpoint hostname, in either the form real
+ * API Gateway reports it or the local form the AWS domain is dropped from.
+ *
+ * Both forms are read here because a request arriving over HTTP has had the
+ * AWS domain rewritten away and a record value written as `RegionalDomainName`
+ * answered has not, and a record pointing the custom domain name at the
+ * endpoint is how the domain is reached on AWS.
+ */
+export function readSimHttpApiDomainEndpointHost(
+  hostname: string,
+): SimHttpApiDomainEndpointHost | undefined {
+  const awsDomainSuffix = `.${executeApiDomain}`;
+  const logicalHost = hostname.endsWith(awsDomainSuffix)
+    ? hostname.slice(0, -awsDomainSuffix.length)
+    : hostname;
+  const labels = logicalHost.split(".");
+
+  if (labels.length !== 3) {
+    return undefined;
+  }
+
+  const [domainId, service, regionName] = labels;
+
+  if (
+    domainId === undefined ||
+    regionName === undefined ||
+    service !== executeApiHostLabel ||
+    !isSimHttpApiDomainId(domainId)
+  ) {
+    return undefined;
+  }
+
+  return { logicalHost, regionName };
+}

--- a/src/service/apigatewayv2/domain/sim-http-api-domain-name.ts
+++ b/src/service/apigatewayv2/domain/sim-http-api-domain-name.ts
@@ -1,4 +1,11 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import {
+  makeSimHttpApiDomainId,
+  type SimHttpApiDomainEndpointParts,
+  simHttpApiDomainEndpointHost,
+  simHttpApiDomainEndpointLogicalHost,
+  type SimHttpApiDomainId,
+} from "./sim-http-api-domain-endpoint.js";
 import { SimApiMappingStore } from "./sim-api-mapping-store.js";
 
 /**
@@ -14,7 +21,7 @@ export const simApiMappingSelectionExpression = "$request.basepath";
  * Real API Gateway publishes a different id per Region. One fixed value stands
  * for all of them here, the way `simElbV2CanonicalHostedZoneId` does for a
  * load balancer: nothing resolves through it, and an alias record reaches the
- * domain by the name it points at.
+ * domain by the regional endpoint name it points at.
  */
 export const simHttpApiRegionalHostedZoneId = "Z0000000000001";
 
@@ -34,12 +41,21 @@ export interface SimHttpApiDomainNameConfiguration {
 }
 
 /**
+ * One entry of a domain's `DomainNameConfigurations` as a command reports it,
+ * which is what was written plus the endpoint API Gateway made for it.
+ */
+export interface SimHttpApiDomainNameConfigurationView extends SimHttpApiDomainNameConfiguration {
+  ApiGatewayDomainName: string;
+  HostedZoneId: string;
+}
+
+/**
  * Minimal structural domain name view, as the Create and Get commands return.
  */
 export interface SimHttpApiDomainNameView {
   DomainName: string;
   ApiMappingSelectionExpression: string;
-  DomainNameConfigurations: readonly SimHttpApiDomainNameConfiguration[];
+  DomainNameConfigurations: readonly SimHttpApiDomainNameConfigurationView[];
 }
 
 interface SimHttpApiDomainNameProperties {
@@ -51,9 +67,11 @@ interface SimHttpApiDomainNameProperties {
 /**
  * A simulated API Gateway custom domain name.
  *
- * The domain answers on a hostname of its own rather than on one API Gateway
- * generated, which is how an HTTP API is reached under a name the project
- * owns. It owns its API mappings, because a mapping is addressed by domain on
+ * The domain has the two names real API Gateway gives it. One is the hostname
+ * the project owns, which is how an HTTP API is reached under a name of its
+ * own. The other is the regional endpoint API Gateway issues alongside it,
+ * which a record for the custom domain name points at. The domain answers on
+ * both. It owns its API mappings, because a mapping is addressed by domain on
  * real AWS and none of them outlives the domain.
  *
  * A domain and the APIs it maps live in one Account and Region, as they do on
@@ -64,6 +82,11 @@ export class SimHttpApiDomainName {
   public readonly accountRegionScope: SimAwsAccountRegionScope;
   public readonly configurations: readonly SimHttpApiDomainNameConfiguration[];
   public readonly apiMappings = new SimApiMappingStore();
+
+  /**
+   * The id API Gateway allocated this domain's regional endpoint.
+   */
+  public readonly domainId: SimHttpApiDomainId = makeSimHttpApiDomainId();
 
   constructor(properties: SimHttpApiDomainNameProperties) {
     this.domainName = properties.domainName;
@@ -82,14 +105,24 @@ export class SimHttpApiDomainName {
    * The hostname a DNS record pointing at this domain names, which is what
    * `Fn::GetAtt RegionalDomainName` answers with.
    *
-   * Real API Gateway issues a separate `d-<id>.execute-api.<region>` name here
-   * and expects the custom domain to be pointed at it. This answers with the
-   * custom domain's own hostname instead, so a CloudFront Origin or a Route53
-   * alias built on it reaches the domain. An `execute-api` name would be read
-   * as a generated API endpoint by simulated DNS and route to no API at all.
+   * This is the domain's published address. A CloudFront Origin points at it
+   * directly, and a record for the custom domain name points at it. The custom
+   * domain name is reached through that record.
    */
   get regionalDomainName(): string {
-    return this.hostname;
+    return simHttpApiDomainEndpointHost(this.endpointParts);
+  }
+
+  /**
+   * The hostnames a request can reach this domain by. They are the custom
+   * domain name and the regional endpoint, the second without the AWS domain
+   * the local URL rewriting drops.
+   */
+  get hostnames(): readonly string[] {
+    return [
+      this.hostname,
+      simHttpApiDomainEndpointLogicalHost(this.endpointParts),
+    ];
   }
 
   /**
@@ -110,9 +143,41 @@ export class SimHttpApiDomainName {
     return {
       DomainName: this.domainName,
       ApiMappingSelectionExpression: simApiMappingSelectionExpression,
-      DomainNameConfigurations: this.configurations.map((configuration) => ({
-        ...configuration,
-      })),
+      DomainNameConfigurations: this.configurationViews(),
     };
+  }
+
+  /**
+   * What this domain's regional endpoint hostname is built from.
+   */
+  private get endpointParts(): SimHttpApiDomainEndpointParts {
+    return {
+      domainId: this.domainId,
+      regionName: this.accountRegionScope.regionName,
+    };
+  }
+
+  /**
+   * The domain's configurations as a command reports them.
+   *
+   * Each one is what was written plus the endpoint API Gateway made for it. A
+   * domain created without a configuration still reports one, because the
+   * endpoint exists whether or not anything was written about the certificate
+   * in front of it, and real API Gateway reports it there.
+   */
+  private configurationViews(): readonly SimHttpApiDomainNameConfigurationView[] {
+    const endpoint = {
+      ApiGatewayDomainName: this.regionalDomainName,
+      HostedZoneId: simHttpApiRegionalHostedZoneId,
+    };
+
+    if (this.configurations.length === 0) {
+      return [endpoint];
+    }
+
+    return this.configurations.map((configuration) => ({
+      ...configuration,
+      ...endpoint,
+    }));
   }
 }

--- a/src/service/apigatewayv2/registry/sim-http-api-domain-registry.ts
+++ b/src/service/apigatewayv2/registry/sim-http-api-domain-registry.ts
@@ -16,6 +16,11 @@ import { SimApiGatewayV2BadRequest } from "../error/sim-api-gateway-v2.error.js"
  * and nothing saying it is an API Gateway hostname at all. That makes this the
  * answer to which simulated service a hostname belongs to, which is what
  * `SimAwsServiceHosts` asks.
+ *
+ * Simulated DNS asks a hosted-zone record about a custom domain name first,
+ * the way the custom domain name reaches the domain through a record on AWS.
+ * This answers where no record names the hostname. That is how a test that
+ * creates only a domain reaches it.
  */
 export class SimHttpApiDomainRegistry implements SimAwsServiceHosts {
   private readonly domainsByHost = new Map<string, SimHttpApiDomainName>();
@@ -31,7 +36,12 @@ export class SimHttpApiDomainRegistry implements SimAwsServiceHosts {
   register(domain: SimHttpApiDomainName): void {
     this.requireUnused(domain);
 
-    this.domainsByHost.set(domain.hostname.toLowerCase(), domain);
+    for (const hostname of domain.hostnames) {
+      this.domainsByHost.set(hostname.toLowerCase(), domain);
+    }
+
+    // Only the custom domain name is claimed. The regional endpoint is a name
+    // API Gateway made up, and takes no hostname away from another service.
     this.claims.claim(domain.hostname);
   }
 
@@ -39,12 +49,16 @@ export class SimHttpApiDomainRegistry implements SimAwsServiceHosts {
    * Forget a deleted domain, so its hostname stops resolving.
    */
   deregister(domain: SimHttpApiDomainName): void {
-    this.domainsByHost.delete(domain.hostname.toLowerCase());
+    for (const hostname of domain.hostnames) {
+      this.domainsByHost.delete(hostname.toLowerCase());
+    }
+
     this.claims.release(domain.hostname);
   }
 
   /**
-   * Find the domain a request's hostname reaches.
+   * Find the domain a request's hostname reaches, by either of the two names
+   * the domain answers on.
    */
   findByHost(hostname: string): SimHttpApiDomainName | undefined {
     return this.domainsByHost.get(hostname.toLowerCase());

--- a/src/service/apigatewayv2/serve/sim-http-api-domain-distribution.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-domain-distribution.iso.test.ts
@@ -1,0 +1,202 @@
+import {
+  CreateApiMappingCommand,
+  CreateDomainNameCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertIsSimRoute53HostedZoneId } from "../../route53/command/create-hosted-zone/sim-route53-zone-id.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import type { SimHttpApiDomainName } from "../domain/sim-http-api-domain-name.js";
+
+const viewerHostname = "www.example.test";
+
+/**
+ * The header the Distribution adds to every Origin request, which is how the
+ * API behind it tells a request that came through the Distribution from one
+ * that reached it directly.
+ */
+const originSecretHeader = "x-origin-secret";
+const originSecret = "3f9c1d";
+
+/**
+ * An API answering only a request carrying the Origin's own header, which is
+ * the shape a Distribution in front of an API is given so nothing reaches the
+ * API around it.
+ */
+async function apiBehindOriginSecret(simAws: SimAws): Promise<SimHttpApi> {
+  return await simHttpApiLambdaProxyFactory.make(
+    {
+      routeKeys: ["GET /{proxy+}"],
+      handler: () => "served",
+      requestAuthorizer: {
+        functionName: "origin-secret-authorizer",
+        handler: (event: { identitySource: string[] }) => ({
+          isAuthorized: event.identitySource[0] === originSecret,
+        }),
+        identitySource: [`$request.header.${originSecretHeader}`],
+        enableSimpleResponses: true,
+        invokePermission: true,
+      },
+    },
+    simAws,
+  );
+}
+
+/**
+ * Put a Distribution in front of a hostname, with the API's Origin adding the
+ * header the API requires, and a record sending the viewer's name to it.
+ */
+async function distributionInFrontOf(
+  simAws: SimAws,
+  originDomainName: string,
+): Promise<void> {
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "api-distribution",
+        Comment: "API CDN",
+        Enabled: true,
+        Aliases: { Quantity: 1, Items: [viewerHostname] },
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "ApiOrigin",
+              DomainName: originDomainName,
+              CustomOriginConfig: {
+                HTTPPort: 80,
+                HTTPSPort: 443,
+                OriginProtocolPolicy: "https-only",
+              },
+              CustomHeaders: {
+                Quantity: 1,
+                Items: [
+                  {
+                    HeaderName: originSecretHeader,
+                    HeaderValue: originSecret,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "ApiOrigin",
+          ViewerProtocolPolicy: "allow-all",
+        },
+      },
+    }),
+  );
+
+  const distributionHostname = creation.Distribution?.DomainName;
+  assertNonNullable(distributionHostname);
+
+  const simRoute53 = simAws.route53();
+  const zone = await simRoute53.createHostedZone({
+    input: { Name: "example.test", CallerReference: "api-distribution" },
+  });
+  const hostedZoneId = zone.HostedZone?.Id;
+  assertIsSimRoute53HostedZoneId(hostedZoneId);
+
+  await simRoute53.changeResourceRecordSets({
+    input: {
+      HostedZoneId: hostedZoneId,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: viewerHostname,
+              Type: "A",
+              AliasTarget: {
+                DNSName: distributionHostname,
+                HostedZoneId: "Z2FDTNDATAQYW2",
+                EvaluateTargetHealth: false,
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * The stack in the report this covers: an API behind an Origin header, a
+ * custom domain carrying the viewer's own hostname, and a Distribution
+ * serving that hostname with the domain's regional endpoint as its Origin.
+ */
+async function apiBehindDistribution(
+  simAws: SimAws,
+): Promise<SimHttpApiDomainName> {
+  const api = await apiBehindOriginSecret(simAws);
+  await simAws
+    .apiGatewayV2()
+    .createDomainName(
+      new CreateDomainNameCommand({ DomainName: viewerHostname }),
+    );
+  const domain = simAws.apiGatewayV2().findDomainName(viewerHostname);
+  assertNonNullable(domain);
+
+  await simAws.apiGatewayV2().createApiMapping(
+    new CreateApiMappingCommand({
+      DomainName: viewerHostname,
+      ApiId: api.apiId,
+      Stage: "$default",
+    }),
+  );
+  await distributionInFrontOf(simAws, domain.regionalDomainName);
+
+  return domain;
+}
+
+function viewerRequest(simAws: SimAws): Promise<Response> {
+  return new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `https://${viewerHostname}/anything`,
+    }).toString(),
+  );
+}
+
+describe("A Distribution serving the hostname an HTTP API also has as a custom domain", () => {
+  it("reaches the API through the Distribution once the domain is created", async () => {
+    // Given a Distribution serving a hostname in front of an API that answers
+    // only requests carrying the Origin's own header
+    const simAws = new SimAws();
+    await apiBehindDistribution(simAws);
+
+    // When a viewer asks for the hostname
+    const response = await viewerRequest(simAws);
+
+    // Then the request went through the Distribution, so it carried the
+    // header the API requires. Giving the API the viewer's hostname as a
+    // custom domain leaves the record deciding where that hostname goes
+    assertIdentical(response.status, 200);
+    assertIdentical(await response.json(), "served");
+  });
+
+  it("refuses a viewer reaching the API around the Distribution", async () => {
+    // Given the same stack
+    const simAws = new SimAws();
+    const domain = await apiBehindDistribution(simAws);
+
+    // When the domain's regional endpoint is asked for directly
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({
+        input: `https://${domain.regionalDomainName}/anything`,
+      }).toString(),
+    );
+
+    // Then the authorizer refuses it, since nothing added the Origin header
+    assertIdentical(response.status, 401);
+    expect(await response.json()).toStrictEqual({ message: "Unauthorized" });
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-custom-domain.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-custom-domain.iso.test.ts
@@ -6,7 +6,11 @@ import {
   DeleteStageCommand,
   GetApiMappingsCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
@@ -317,5 +321,42 @@ describe("Serving a sim HTTP API on a custom domain name", () => {
     const event = (await response.json()) as SimPayload2Event;
     assertIdentical(event.rawPath, "/");
     assertIdentical(event.routeKey, "GET /");
+  });
+  it("serves the mappings at the endpoint API Gateway issued the domain", async () => {
+    // Given an API mapped to the root of a custom domain
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: echoEvent, routeKeys: ["GET /pets/{petId}"] },
+      simAws,
+    );
+    await mapDomainTo(simAws, api);
+    const domain = simAws.apiGatewayV2().findDomainName(domainName);
+    assertNonNullable(domain);
+
+    // When a request arrives at the domain's regional endpoint instead, which
+    // is what a CloudFront Origin built on `RegionalDomainName` reaches
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(domain.regionalDomainName, "/pets/6"),
+    );
+
+    // Then the same mappings serve it, and the event names the custom domain
+    const event = (await response.json()) as SimPayload2Event;
+    assertIdentical(event.routeKey, "GET /pets/{petId}");
+    assertIdentical(event.rawPath, "/pets/6");
+    assertIdentical(event.requestContext.domainName, domainName);
+  });
+
+  it("answers 404 at a domain endpoint no domain was issued", async () => {
+    // Given a simulation holding no custom domain
+    const simAws = new SimAws();
+
+    // When a request arrives at a domain endpoint hostname anyway
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl("d-abcdefghij.execute-api.us-east-1.amazonaws.com", "/pets"),
+    );
+
+    // Then nothing serves it, the way a path no mapping claims is answered
+    assertIdentical(response.status, 404);
+    expect(await response.json()).toStrictEqual({ message: "Not Found" });
   });
 });

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-host.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-host.iso.test.ts
@@ -2,13 +2,14 @@ import {
   CreateApiMappingCommand,
   CreateDomainNameCommand,
 } from "@aws-sdk/client-apigatewayv2";
-import { assertIdentical } from "@kensio/smartass";
+import { assertIdentical, assertNonNullable } from "@kensio/smartass";
 import { describe, expect, it } from "vitest";
 
 import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
 import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimHttpApi } from "../api/sim-http-api.js";
+import type { SimHttpApiDomainName } from "../domain/sim-http-api-domain-name.js";
 import { simHttpApiLogicalHost } from "../api/sim-http-api-host.js";
 import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
 
@@ -17,13 +18,49 @@ function localUrl(hostname: string, path = "/"): string {
 }
 
 /**
- * Point a hostname at an API's generated endpoint with a Route53 CNAME, which
- * is a name reaching the API that the API itself knows nothing about.
+ * The logical form of an API's generated endpoint, which is the name
+ * simulated DNS resolves.
+ */
+function generatedEndpointOf(api: SimHttpApi): string {
+  return simHttpApiLogicalHost({
+    apiId: api.apiId,
+    regionName: api.accountRegionScope.regionName,
+  });
+}
+
+/**
+ * Give an API a custom domain of its own, mapped at the root.
+ */
+async function mapDomainTo(
+  simAws: SimAws,
+  domainName: string,
+  api: SimHttpApi,
+): Promise<SimHttpApiDomainName> {
+  await simAws
+    .apiGatewayV2()
+    .createDomainName(new CreateDomainNameCommand({ DomainName: domainName }));
+  await simAws.apiGatewayV2().createApiMapping(
+    new CreateApiMappingCommand({
+      DomainName: domainName,
+      ApiId: api.apiId,
+      Stage: "$default",
+    }),
+  );
+
+  const domain = simAws.apiGatewayV2().findDomainName(domainName);
+  assertNonNullable(domain);
+
+  return domain;
+}
+
+/**
+ * Point a hostname at another with a Route53 CNAME, which is how a name the
+ * project owns reaches a hostname AWS issued.
  */
 async function cnameTo(
   simAws: SimAws,
   hostname: string,
-  api: SimHttpApi,
+  target: string,
 ): Promise<void> {
   const simRoute53 = simAws.route53();
   const zone = await simRoute53.createHostedZone({
@@ -39,16 +76,7 @@ async function cnameTo(
             ResourceRecordSet: {
               Name: hostname,
               Type: "CNAME",
-              // The logical form of the generated endpoint, which is the
-              // name simulated DNS resolves.
-              ResourceRecords: [
-                {
-                  Value: simHttpApiLogicalHost({
-                    apiId: api.apiId,
-                    regionName: api.accountRegionScope.regionName,
-                  }),
-                },
-              ],
+              ResourceRecords: [{ Value: target }],
             },
           },
         ],
@@ -64,7 +92,7 @@ describe("Which hostnames a sim HTTP API answers on", () => {
     // custom domain telling the API to serve that name
     const simAws = new SimAws();
     const api = await simHttpApiLambdaProxyFactory.make({}, simAws);
-    await cnameTo(simAws, "www.example.test", api);
+    await cnameTo(simAws, "www.example.test", generatedEndpointOf(api));
 
     // When a request arrives under that name
     const response = await new SimAwsHttp({ simAws }).fetch(
@@ -82,33 +110,47 @@ describe("Which hostnames a sim HTTP API answers on", () => {
     expect(response.headers.get("x-amzn-requestid")).not.toBeNull();
   });
 
-  it("serves the same name once a custom domain maps it", async () => {
-    // Given the same API, now with a custom domain for the name
+  it("refuses it still when a custom domain of that name points elsewhere", async () => {
+    // Given the same API and CNAME, and a custom domain of that name mapped
+    // to the API
     const simAws = new SimAws();
     const api = await simHttpApiLambdaProxyFactory.make(
       { handler: () => "hello" },
       simAws,
     );
-    await cnameTo(simAws, "www.example.test", api);
-    await simAws
-      .apiGatewayV2()
-      .createDomainName(
-        new CreateDomainNameCommand({ DomainName: "www.example.test" }),
-      );
-    await simAws.apiGatewayV2().createApiMapping(
-      new CreateApiMappingCommand({
-        DomainName: "www.example.test",
-        ApiId: api.apiId,
-        Stage: "$default",
-      }),
-    );
+    await cnameTo(simAws, "www.example.test", generatedEndpointOf(api));
+    await mapDomainTo(simAws, "www.example.test", api);
 
     // When the same request is sent again
     const response = await new SimAwsHttp({ simAws }).fetch(
       localUrl("www.example.test"),
     );
 
-    // Then the API serves it, because the domain is one it now answers on
+    // Then the record still decides where the name goes, so the request
+    // reaches the generated endpoint under a Host it does not answer on. The
+    // custom domain has a published address of its own, and this record does
+    // not point at it
+    assertIdentical(response.status, 403);
+  });
+
+  it("serves the name through a record pointing at the domain's own endpoint", async () => {
+    // Given the same API, with a custom domain for the name and a record
+    // pointing that name at the endpoint API Gateway issued the domain
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: () => "hello" },
+      simAws,
+    );
+    const domain = await mapDomainTo(simAws, "www.example.test", api);
+    await cnameTo(simAws, "www.example.test", domain.regionalDomainName);
+
+    // When the request is sent
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl("www.example.test"),
+    );
+
+    // Then the domain's mappings serve it, which is the pair of record and
+    // domain a stack fronting an API with a name of its own deploys
     assertIdentical(response.status, 200);
     assertIdentical(await response.json(), "hello");
   });

--- a/src/service/apigatewayv2/serve/sim-http-api-serving.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serving.ts
@@ -144,7 +144,9 @@ export class SimHttpApiServingResolver {
   ): SimHttpApiResolution {
     const domain = this.domains.route(target);
 
-    /* v8 ignore if -- a domain target only resolves from a registered domain */
+    // A regional endpoint hostname is recognised by its shape, as a generated
+    // API endpoint is, so one naming no domain arrives here and is answered
+    // the way a path no mapping claims is.
     if (domain === undefined) {
       return notFound;
     }

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -34,6 +34,7 @@ interface SimAwsAccountServiceCacheProperties {
   readonly route53Registry: SimRoute53Registry;
   readonly kmsRegistry: SimKmsRegistry;
   readonly serviceHosts: SimAwsServiceHosts;
+  readonly shadowableServiceHosts: SimAwsServiceHosts;
   readonly iamRegistry: SimIamRegistry;
   readonly accessKeyRegistry: SimIamAccessKeyRegistry;
 }
@@ -69,6 +70,7 @@ export class SimAwsAccountServiceCache {
   private readonly route53Registry: SimRoute53Registry;
   private readonly kmsRegistry: SimKmsRegistry;
   private readonly serviceHosts: SimAwsServiceHosts;
+  private readonly shadowableServiceHosts: SimAwsServiceHosts;
 
   /**
    * Shared memo for account-scoped service instances.
@@ -89,6 +91,7 @@ export class SimAwsAccountServiceCache {
     this.route53Registry = properties.route53Registry;
     this.kmsRegistry = properties.kmsRegistry;
     this.serviceHosts = properties.serviceHosts;
+    this.shadowableServiceHosts = properties.shadowableServiceHosts;
   }
 
   /**
@@ -182,6 +185,7 @@ export class SimAwsAccountServiceCache {
           background: this.background,
           route53Registry: this.route53Registry,
           serviceHosts: this.serviceHosts,
+          shadowableServiceHosts: this.shadowableServiceHosts,
           // A DNSSEC key-signing key names a KMS key by ARN, in whichever
           // Region holds it, so Route53 resolves it through the registry.
           kmsKeys: this.kmsRegistry,

--- a/src/service/aws/factory/sim-aws-scoped-service-registries.ts
+++ b/src/service/aws/factory/sim-aws-scoped-service-registries.ts
@@ -112,6 +112,14 @@ export class SimAwsScopedServiceRegistries {
   public readonly serviceHosts: SimAwsServiceHosts;
 
   /**
+   * Where a hostname a hosted-zone record outranks is looked up. An API
+   * Gateway custom domain name is reached through a record on AWS, so a record
+   * for one decides where the name goes and the domain answers where no record
+   * names it.
+   */
+  public readonly shadowableServiceHosts: SimAwsServiceHosts;
+
+  /**
    * The hostnames the domain registries have handed out. A public hostname is
    * unique across the whole of AWS rather than within one service, so the two
    * services that hand them out share this rather than each keeping its own.
@@ -121,8 +129,8 @@ export class SimAwsScopedServiceRegistries {
   constructor() {
     this.cognitoDomains = new SimCognitoDomainRegistry(this.hostnameClaims);
     this.httpApiDomains = new SimHttpApiDomainRegistry(this.hostnameClaims);
-    this.serviceHosts = new SimAwsAnyServiceHosts([
-      this.cognitoDomains,
+    this.serviceHosts = new SimAwsAnyServiceHosts([this.cognitoDomains]);
+    this.shadowableServiceHosts = new SimAwsAnyServiceHosts([
       this.httpApiDomains,
     ]);
   }

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -141,8 +141,10 @@ export class SimAwsServiceFactory {
       kmsRegistry: this.registries.kms,
       // A Cognito hosted domain and an API Gateway custom domain each answer
       // on a hostname of their own, so DNS resolution asks the registries
-      // holding those domains about it.
+      // holding those domains about it. A record outranks the API Gateway one,
+      // as it does on AWS, which is what keeps the two apart here.
       serviceHosts: this.registries.serviceHosts,
+      shadowableServiceHosts: this.registries.shadowableServiceHosts,
       iamRegistry: this.iamRegistry,
       accessKeyRegistry: this.requestAuth.accessKeyRegistry,
     });

--- a/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-domain-name-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/apigatewayv2/sim-http-api-domain-name-cfn.ts
@@ -31,10 +31,10 @@ export class SimHttpApiDomainNameCfn implements SimCfnResourceValueAdapter {
    * AWS::ApiGatewayV2::DomainName publishes RegionalDomainName,
    * RegionalHostedZoneId and DomainNameArn.
    *
-   * `RegionalDomainName` is the hostname the domain answers on, so a
-   * CloudFront Origin or a Route53 alias built on it reaches the domain. Real
-   * API Gateway answers with a separate `d-<id>.execute-api.<region>` name and
-   * expects DNS to point the custom domain at it.
+   * `RegionalDomainName` is the `d-<id>.execute-api.<region>` endpoint API
+   * Gateway issued the domain, which is the published address a CloudFront
+   * Origin reaches directly and a Route53 alias points the custom domain name
+   * at.
    */
   attributeValue(attributeName: string): SimCfnTemplateValue {
     if (attributeName === "RegionalDomainName") {

--- a/src/service/route53/README.md
+++ b/src/service/route53/README.md
@@ -341,6 +341,13 @@ If the incoming hostname is already a built-in simulated service hostname, the r
 target directly. Otherwise, it looks for a `CNAME` record matching the logical name and follows the
 target.
 
+A hostname a resource claimed for itself is asked about in one of two places, and `SimRoute53Resolver`
+takes one `SimAwsServiceHosts` for each. `serviceHosts` is asked after the built-in shapes and
+before any record. A Cognito hosted domain answers there. `shadowableServiceHosts` is asked where no
+record names the hostname, and an API Gateway custom domain answers there. An alias record for a
+hostname therefore still decides where the name goes after an HTTP API is given that hostname as a
+custom domain.
+
 CNAME resolution is bounded:
 
 - the resolver tracks visited names to stop cycles immediately

--- a/src/service/route53/resolve/sim-r53-service-target-resolver.ts
+++ b/src/service/route53/resolve/sim-r53-service-target-resolver.ts
@@ -1,4 +1,5 @@
 import type { SimAwsServiceTarget } from "../../../serve/controller/sim-service-controller.js";
+import { readSimHttpApiDomainEndpointHost } from "../../apigatewayv2/domain/sim-http-api-domain-endpoint.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import { readSimElbV2LoadBalancerHost } from "../../elbv2/load-balancer/sim-elbv2-load-balancer-host.js";
 import { simRoute53LogicalName } from "../local-name/sim-route53-local-name.js";
@@ -45,8 +46,36 @@ export class SimRoute53ServiceTargetResolver {
       this.s3Targets.resolve(logicalName) ??
       this.cloudFrontServiceTarget(logicalName) ??
       this.loadBalancerServiceTarget(logicalName) ??
+      this.apiGatewayDomainServiceTarget(logicalName) ??
       this.regionalTargets.resolve(logicalName)
     );
+  }
+
+  /**
+   * Resolve the regional endpoint hostname of an API Gateway custom domain:
+   *
+   *   d-<id>.execute-api.<region>.amazonaws.com
+   *
+   * This is read ahead of the endpoints below, because a domain endpoint and
+   * the endpoint of an API have the same shape and only the `d-` prefix tells
+   * them apart. The whole hostname is the resource name, since the domain
+   * registry answers about both of the names a domain has and the custom
+   * domain name is a hostname too.
+   */
+  private apiGatewayDomainServiceTarget(
+    logicalName: string,
+  ): SimAwsServiceTarget | undefined {
+    const endpoint = readSimHttpApiDomainEndpointHost(logicalName);
+
+    if (endpoint === undefined) {
+      return undefined;
+    }
+
+    return {
+      service: "apiGatewayDomain",
+      resourceName: endpoint.logicalHost,
+      regionName: endpoint.regionName as AwsRegionName,
+    };
   }
 
   /**

--- a/src/service/route53/resolve/sim-route53-resolve-claimed-host.iso.test.ts
+++ b/src/service/route53/resolve/sim-route53-resolve-claimed-host.iso.test.ts
@@ -1,0 +1,173 @@
+import { CreateDomainNameCommand } from "@aws-sdk/client-apigatewayv2";
+import {
+  CreateUserPoolCommand,
+  CreateUserPoolDomainCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertNonNullable,
+  assertObjectMatches,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { assertIsSimRoute53HostedZoneId } from "../command/create-hosted-zone/sim-route53-zone-id.js";
+import { simRoute53LocalName } from "../local-name/sim-route53-local-name.js";
+
+const certificateArn =
+  "arn:aws:acm:us-east-1:111111111111:certificate/6d2c7a2e-0c7a-4d4e-9b6c-1f0a2b3c4d5e";
+
+const distributionHostname = "EDFDVBD6EXAMPLE.cloudfront.net";
+
+/**
+ * Point a hostname at a CloudFront distribution with an A alias, which is the
+ * record a distribution serving a name of the project's own is reached by.
+ */
+async function aliasToDistribution(
+  simAws: SimAws,
+  hostname: string,
+): Promise<void> {
+  const simRoute53 = simAws.route53();
+  const zone = await simRoute53.createHostedZone({
+    input: { Name: "example.test", CallerReference: `${hostname}-test` },
+  });
+  const hostedZoneId = zone.HostedZone?.Id;
+  assertIsSimRoute53HostedZoneId(hostedZoneId);
+
+  await simRoute53.changeResourceRecordSets({
+    input: {
+      HostedZoneId: hostedZoneId,
+      ChangeBatch: {
+        Changes: [
+          {
+            Action: "CREATE",
+            ResourceRecordSet: {
+              Name: hostname,
+              Type: "A",
+              AliasTarget: {
+                DNSName: distributionHostname,
+                HostedZoneId: "Z2FDTNDATAQYW2",
+                EvaluateTargetHealth: false,
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("Resolving a hostname a simulated resource claimed", () => {
+  it("resolves an API Gateway custom domain no record names", async () => {
+    // Given a custom domain and no hosted zone at all
+    const simAws = new SimAws();
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "www.example.test" }),
+      );
+
+    // When the domain's own hostname is resolved
+    const target = simAws
+      .route53()
+      .resolveHttpHost(simRoute53LocalName("www.example.test"));
+
+    // Then it reaches the domain, since nothing else says where the name goes
+    assertObjectMatches(target, {
+      service: "apiGatewayDomain",
+      resourceName: "www.example.test",
+    });
+  });
+
+  it("resolves the endpoint API Gateway issued the domain", async () => {
+    // Given a custom domain
+    const simAws = new SimAws();
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "www.example.test" }),
+      );
+    const domain = simAws.apiGatewayV2().findDomainName("www.example.test");
+    assertNonNullable(domain);
+
+    // When its regional domain name is resolved, as it was answered and with
+    // the AWS domain a record value keeps
+    const target = simAws.route53().resolveHttpHost(domain.regionalDomainName);
+
+    // Then that reaches the domain too, which is the published address a
+    // CloudFront Origin reaches it by
+    assertObjectMatches(target, {
+      service: "apiGatewayDomain",
+      resourceName: domain.hostnames[1],
+    });
+  });
+
+  it("gives a record the hostname an API Gateway custom domain also holds", async () => {
+    // Given a distribution serving a hostname through an alias record
+    const simAws = new SimAws();
+    await aliasToDistribution(simAws, "www.example.test");
+
+    // When an HTTP API is given that hostname as a custom domain
+    await simAws
+      .apiGatewayV2()
+      .createDomainName(
+        new CreateDomainNameCommand({ DomainName: "www.example.test" }),
+      );
+
+    // Then the record still decides where the name goes, as it does on AWS,
+    // where a custom domain name is reached only through a record
+    assertObjectMatches(
+      simAws.route53().resolveHttpHost(simRoute53LocalName("www.example.test")),
+      { service: "cloudFront", resourceName: "edfdvbd6example" },
+    );
+  });
+
+  it("keeps a Cognito hosted domain whatever a record says", async () => {
+    // Given a user pool custom domain and a record for the same hostname
+    const simAws = new SimAws();
+    const { UserPool } = await simAws
+      .cognitoIdentityProvider()
+      .createUserPool(new CreateUserPoolCommand({ PoolName: "people" }));
+    await simAws.cognitoIdentityProvider().createUserPoolDomain(
+      new CreateUserPoolDomainCommand({
+        UserPoolId: UserPool?.Id,
+        Domain: "auth.example.test",
+        CustomDomainConfig: { CertificateArn: certificateArn },
+      }),
+    );
+    await aliasToDistribution(simAws, "auth.example.test");
+
+    // When the hostname is resolved
+    const target = simAws
+      .route53()
+      .resolveHttpHost(simRoute53LocalName("auth.example.test"));
+
+    // Then the pool still answers on it. Real Cognito puts a distribution in
+    // front of a custom domain and expects a record pointing at that one,
+    // which is a name nothing here serves, so the record a stack writes would
+    // otherwise take the domain away from the pool it belongs to
+    assertObjectMatches(target, { service: "cognitoIdentityProvider" });
+  });
+
+  it("names API Gateway for a domain endpoint no domain holds", () => {
+    // Given a simulation with no custom domain at all
+    const simAws = new SimAws();
+
+    // When a domain endpoint hostname is resolved anyway
+    const target = simAws
+      .route53()
+      .resolveHttpHost(
+        simRoute53LocalName("d-abcdefghij.execute-api.us-east-1"),
+      );
+
+    // Then it names API Gateway, which is what the hostname says, and the
+    // request is answered when nothing is found behind it
+    assertObjectMatches(target, {
+      service: "apiGatewayDomain",
+      resourceName: "d-abcdefghij.execute-api.us-east-1",
+    });
+    assertUndefined(simAws.apiGatewayV2().findDomainName("d-abcdefghij"));
+  });
+});

--- a/src/service/route53/resolve/sim-route53-resolver.ts
+++ b/src/service/route53/resolve/sim-route53-resolver.ts
@@ -23,6 +23,12 @@ interface SimRoute53ResolverProperties {
    * such as a Cognito user pool custom domain.
    */
   readonly serviceHosts?: SimAwsServiceHosts | undefined;
+
+  /**
+   * Where a hostname a hosted-zone record outranks is looked up, which is a
+   * claim answering only where no record names the hostname.
+   */
+  readonly shadowableServiceHosts?: SimAwsServiceHosts | undefined;
 }
 
 /**
@@ -33,12 +39,15 @@ export class SimRoute53Resolver {
   private readonly serviceTargetResolver =
     new SimRoute53ServiceTargetResolver();
   private readonly serviceHosts: SimAwsServiceHosts;
+  private readonly shadowableServiceHosts: SimAwsServiceHosts;
 
   constructor(properties: SimRoute53ResolverProperties) {
     this.recordFinder = new SimRoute53HostedZoneRecordFinder(
       properties.hostedZones,
     );
     this.serviceHosts = properties.serviceHosts ?? new SimAwsNoServiceHosts();
+    this.shadowableServiceHosts =
+      properties.shadowableServiceHosts ?? new SimAwsNoServiceHosts();
   }
 
   /**
@@ -50,7 +59,9 @@ export class SimRoute53Resolver {
    *    logical Route53 name.
    * 2. Check whether that name already points at a built-in simulated service.
    * 3. If not, follow CNAME or alias records to the next hostname.
-   * 4. Stop when a service target is found, a chain breaks, a cycle appears, or
+   * 4. Where no record names it, answer with a hostname a resource claimed for
+   *    itself, such as an API Gateway custom domain.
+   * 5. Stop when a service target is found, a chain breaks, a cycle appears, or
    *    the maximum CNAME depth is reached.
    *
    * The suffix is optional because the simulated DNS server answers for logical
@@ -97,7 +108,10 @@ export class SimRoute53Resolver {
       const nextRecord = this.findNextResolutionRecord(logicalName);
       const nextTarget = nextRecord?.values[0];
       if (nextTarget === undefined || nextTarget.length === 0) {
-        return undefined;
+        // An API Gateway custom domain is reached through a record on AWS, so
+        // the record decides where the name goes and the claim answers only
+        // where no record names it.
+        return this.shadowableServiceHosts.targetForHost(logicalName);
       }
 
       localName = simRoute53LocalName(nextTarget);

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -41,6 +41,13 @@ interface SimRoute53Properties {
   readonly serviceHosts?: SimAwsServiceHosts | undefined;
 
   /**
+   * Where a hostname a hosted-zone record outranks is looked up, such as an
+   * API Gateway custom domain, which is reached through a record on AWS. A
+   * claim there answers only where no record names the hostname.
+   */
+  readonly shadowableServiceHosts?: SimAwsServiceHosts | undefined;
+
+  /**
    * Where a KMS key ARN is looked up. A DNSSEC key-signing key is built on a
    * customer managed key, and Route53 checks that key before it takes one.
    */
@@ -75,6 +82,7 @@ export class SimRoute53 {
     this.resolver = new SimRoute53Resolver({
       hostedZones: route53Registry.hostedZones,
       serviceHosts: properties.serviceHosts,
+      shadowableServiceHosts: properties.shadowableServiceHosts,
     });
     this.commands = new SimRoute53Commands({
       hostedZones: this.hostedZones,


### PR DESCRIPTION
A custom domain now has the two names API Gateway gives it. `RegionalDomainName` answers with a `d-<id>.execute-api.<region>.amazonaws.com` endpoint of its own, a request to that name is served by the domain's API mappings, and a hosted-zone record for the custom domain name decides where that name goes. Creating a custom domain no longer takes a hostname away from the distribution an alias record already pointed it at, so an API behind an Origin header carries on answering the viewer through its distribution. A custom domain no record names still resolves to the domain.

Resolves #1041
