### PR TITLE
fix: apply OpenX JSON SerDe column mappings

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -318,6 +318,13 @@ text in one reads as null.
 A nested object or array is kept as its JSON text, and `json_extract_scalar`, `cardinality` and
 `element_at` reach into it.
 
+A `mapping.<column>` parameter on the OpenX JSON SerDe reads that column from the key it names. A
+CloudFront access log table needs it, since a record arrives keyed by `cs(Referer)` and no Athena
+column can be called that. The key matches a record's key of any case until the table sets
+`case.insensitive` to `FALSE`, and after that it matches as written. A mapped column reads null
+where the record holds no such key, including where the record holds a key of the column's own
+name. The Hive JSON SerDes have no `mapping` property, and their columns read by name.
+
 A partition column's value comes from the partition the object sits in. A table projecting its
 partitions takes it from the projection, and a table laid out Hive style under its own location
 takes it from the `key=value` segments of the object's key. Either way the column reads on every

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -190,6 +190,12 @@ field. It is a simulator accessor, read off `queryExecutions()`.
 descriptor. A table declaring Parquet lands in the same place as a table whose SerDe is absent.
 Guessing would answer a Parquet query with nonsense.
 
+`sim-athena-json-records.ts` lays the OpenX SerDe's `mapping.<column>` parameters over each record
+before a column is looked up. A CloudFront access log table is what needs them. Its records are
+keyed `cs(Referer)` and `timestamp(ms)`, and an Athena column name holds letters, digits and
+underscores. Only the OpenX class name takes the mappings. `case.insensitive` says whether a mapped
+key matches a record's key as written or with the case folded.
+
 `sim-athena-delimited-records.ts` reads a character at a time. A quoted CSV field carries both the
 delimiter and the line ending often enough to matter. An empty field reads as null, along with
 Hive's `\N`. Delimited text cannot tell an empty string from an absent value, and a numeric column

--- a/src/service/athena/engine/sim-athena-json-records.ts
+++ b/src/service/athena/engine/sim-athena-json-records.ts
@@ -1,0 +1,87 @@
+// A decoded record is keyed by whatever the object held, so every read of one
+// is by a name worked out at run time.
+// oxlint-disable security/detect-object-injection
+import type { SimAthenaEngineRow } from "./sim-athena-engine-row.js";
+
+/**
+ * How one table's JSON records reach its columns.
+ *
+ * `mappings` holds the column names the OpenX SerDe's `mapping.<column>`
+ * parameters declare, each against the record key it reads. A table declaring
+ * none leaves it empty, and every column is read by its own name.
+ *
+ * `caseInsensitive` is the SerDe's own `case.insensitive`, on unless a table
+ * turns it off. The SerDe folds a record's keys before looking one up. A
+ * mapping matches a key of any case until a table declares `FALSE`.
+ */
+export interface SimAthenaJsonFormat {
+  readonly mappings: ReadonlyMap<string, string>;
+  readonly caseInsensitive: boolean;
+}
+
+/**
+ * One object of JSON lines, read into rows.
+ *
+ * A nested object or array is kept as its JSON text, which is what makes
+ * `json_extract_scalar` and `cardinality` reach into it.
+ */
+export function simAthenaJsonRows(
+  text: string,
+  format: SimAthenaJsonFormat,
+): readonly SimAthenaEngineRow[] {
+  return text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as SimAthenaEngineRow)
+    .map((record) => mappedRow(record, format));
+}
+
+/**
+ * One record with its mapped columns laid over it.
+ *
+ * The record is kept whole underneath. A column no mapping names still reads
+ * by its own name. A mapped column is written whether or not the record
+ * carries the key, since the mapping is where that column reads from.
+ */
+function mappedRow(
+  record: SimAthenaEngineRow,
+  format: SimAthenaJsonFormat,
+): SimAthenaEngineRow {
+  if (format.mappings.size === 0) {
+    return record;
+  }
+
+  const row: Record<string, unknown> = { ...record };
+
+  for (const [column, key] of format.mappings) {
+    row[column] = mappedValue(record, key, format.caseInsensitive);
+  }
+
+  return row;
+}
+
+function mappedValue(
+  record: SimAthenaEngineRow,
+  key: string,
+  caseInsensitive: boolean,
+): unknown {
+  const exact = record[key];
+
+  if (exact !== undefined) {
+    return exact;
+  }
+
+  if (!caseInsensitive) {
+    return null;
+  }
+
+  const wanted = key.toLowerCase();
+
+  for (const [held, value] of Object.entries(record)) {
+    if (held.toLowerCase() === wanted) {
+      return value;
+    }
+  }
+
+  return null;
+}

--- a/src/service/athena/engine/sim-athena-record-reader.ts
+++ b/src/service/athena/engine/sim-athena-record-reader.ts
@@ -4,18 +4,28 @@ import {
   type SimAthenaDelimitedFormat,
 } from "./sim-athena-delimited-records.js";
 import type { SimAthenaEngineRow } from "./sim-athena-engine-row.js";
+import {
+  simAthenaJsonRows,
+  type SimAthenaJsonFormat,
+} from "./sim-athena-json-records.js";
 
 /** One object's bytes, read into the rows it holds. */
 export type SimAthenaRecordReader = (
   text: string,
 ) => readonly SimAthenaEngineRow[];
 
+/** The SerDe class name that takes `mapping.<column>` parameters. */
+const openXSerDe = "org.openx.data.jsonserde.jsonserde";
+
 /** The SerDe class names that mean JSON lines. */
 const jsonSerDes = new Set([
-  "org.openx.data.jsonserde.jsonserde",
+  openXSerDe,
   "org.apache.hive.hcatalog.data.jsonserde",
   "org.apache.hadoop.hive.serde2.jsonserde",
 ]);
+
+/** What a `mapping.<column>` parameter is named with. */
+const mappingPrefix = "mapping.";
 
 /** What one delimited SerDe reads before its parameters are applied. */
 interface SimAthenaSerDeDefaults {
@@ -63,7 +73,9 @@ export function simAthenaRecordReader(
   }
 
   if (jsonSerDes.has(library)) {
-    return jsonRows;
+    const format = jsonFormat(table, library);
+
+    return (text) => simAthenaJsonRows(text, format);
   }
 
   const defaults = delimitedSerDes.get(library);
@@ -79,16 +91,32 @@ export function simAthenaRecordReader(
 }
 
 /**
- * JSON lines, one record per line.
+ * How one table's JSON records reach its columns.
  *
- * A nested object or array is kept as its JSON text, which is what makes
- * `json_extract_scalar` and `cardinality` reach into it.
+ * Only the OpenX SerDe takes the mappings. The Hive JSON SerDes have no
+ * `mapping` property, and a table declaring one against them reads by its
+ * column names on real Athena the same as here.
  */
-function jsonRows(text: string): readonly SimAthenaEngineRow[] {
-  return text
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as SimAthenaEngineRow);
+function jsonFormat(
+  table: SimAthenaCatalogTable,
+  library: string,
+): SimAthenaJsonFormat {
+  const parameters =
+    library === openXSerDe
+      ? (table.storageDescriptor?.SerdeInfo?.Parameters ?? {})
+      : {};
+  const mappings = new Map<string, string>();
+
+  for (const [name, key] of Object.entries(parameters)) {
+    if (name.toLowerCase().startsWith(mappingPrefix)) {
+      mappings.set(name.slice(mappingPrefix.length), key);
+    }
+  }
+
+  return {
+    mappings,
+    caseInsensitive: parameters["case.insensitive"]?.toLowerCase() !== "false",
+  };
 }
 
 function delimitedFormat(

--- a/src/service/athena/sim-athena-json-mapping.iso.test.ts
+++ b/src/service/athena/sim-athena-json-mapping.iso.test.ts
@@ -1,0 +1,172 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+/** The SerDe class name a Hive JSON table declares. */
+const hiveJsonSerDe = "org.apache.hive.hcatalog.data.JsonSerDe";
+
+/** What a CloudFront access log table can name its columns. */
+const logColumns = [
+  { Name: "timestamp_ms", Type: "string" },
+  { Name: "cs_uri_stem", Type: "string" },
+  { Name: "cs_referer", Type: "string" },
+  { Name: "c_country", Type: "string" },
+];
+
+/** One access log record, keyed the way CloudFront delivers it. */
+const logRecord = {
+  "timestamp(ms)": "1787793822795",
+  "cs-uri-stem": "/",
+  "cs(Referer)": "https://rainlytics.example/",
+  c_country: "GB",
+};
+
+/** The mappings those columns are reached through. */
+const logMappings = {
+  "mapping.timestamp_ms": "timestamp(ms)",
+  "mapping.cs_uri_stem": "cs-uri-stem",
+  "mapping.cs_referer": "cs(Referer)",
+  "mapping.c_country": "c_country",
+};
+
+async function aLogsSimulation(
+  serDeParameters: Record<string, string>,
+  serDe?: string,
+): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "cloudfront_logs",
+    columns: logColumns,
+    serDe,
+    serDeParameters,
+  });
+
+  await simulation.simAws.athena().engine().enable();
+
+  return simulation;
+}
+
+describe("the JSON keys an Athena column is mapped to", () => {
+  it("reads a column through the key the SerDe maps it to", async () => {
+    // Given a table over CloudFront's own field names, which carry brackets
+    // and hyphens no Athena column name can.
+    const simulation = await aLogsSimulation({
+      "case.insensitive": "FALSE",
+      ...logMappings,
+    });
+
+    await aSeededJson(simulation.simAws, "cloudfront_logs/part-0.json", [
+      logRecord,
+    ]);
+
+    // When a query selects the mapped columns.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT timestamp_ms, cs_uri_stem, cs_referer, c_country " +
+        'FROM "rainlytics"."cloudfront_logs"',
+    );
+
+    // Then every one of them reads, the mapped ones along with the column
+    // whose mapping names the key it already had.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["1787793822795", "/", "https://rainlytics.example/", "GB"],
+    ]);
+  });
+
+  it("matches a mapped key of any case where the table stays case insensitive", async () => {
+    // Given a table declaring no `case.insensitive`, and a record whose key is
+    // written in another case than the mapping.
+    const simulation = await aLogsSimulation(logMappings);
+
+    await aSeededJson(simulation.simAws, "cloudfront_logs/part-0.json", [
+      { "CS(REFERER)": "https://rainlytics.example/pricing" },
+    ]);
+
+    // When a query selects the mapped column.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT cs_referer FROM rainlytics.cloudfront_logs " +
+        "WHERE cs_referer LIKE '%pricing'",
+    );
+
+    // Then the key matches, since the SerDe folds a record's keys before it
+    // looks one up unless a table turns that off.
+    assertObjectEquals(answered.rows, [["https://rainlytics.example/pricing"]]);
+  });
+
+  it("matches a mapped key as written where the table is case sensitive", async () => {
+    // Given a case sensitive table, and a record holding the mapped key in
+    // another case than the mapping names.
+    const simulation = await aLogsSimulation({
+      "case.insensitive": "FALSE",
+      ...logMappings,
+    });
+
+    await aSeededJson(simulation.simAws, "cloudfront_logs/part-0.json", [
+      { c_country: "GB", "cs(referer)": "https://rainlytics.example/" },
+    ]);
+
+    // When a query asks whether the column is null.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_country FROM rainlytics.cloudfront_logs " +
+        "WHERE cs_referer IS NULL",
+    );
+
+    // Then it is. `case.insensitive` off is what a table declares to keep the
+    // keys apart, and the mapping is matched as it was written.
+    assertObjectEquals(answered.rows, [["GB"]]);
+  });
+
+  it("reads a mapped column from its key rather than from its own name", async () => {
+    // Given a column mapped to a key the record does not carry, while the
+    // record does carry a key of the column's own name.
+    const simulation = await aLogsSimulation({
+      "mapping.cs_referer": "cs(Referer)",
+    });
+
+    await aSeededJson(simulation.simAws, "cloudfront_logs/part-0.json", [
+      { c_country: "GB", cs_referer: "https://rainlytics.example/" },
+    ]);
+
+    // When a query asks whether the mapped column is null.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_country FROM rainlytics.cloudfront_logs " +
+        "WHERE cs_referer IS NULL",
+    );
+
+    // Then it is. The mapping is where that column reads from, and a key of
+    // the column's own name is not it.
+    assertObjectEquals(answered.rows, [["GB"]]);
+  });
+
+  it("leaves a Hive JSON SerDe reading by column name", async () => {
+    // Given the same mappings against the Hive JSON SerDe, which has no
+    // `mapping` property of its own.
+    const simulation = await aLogsSimulation(logMappings, hiveJsonSerDe);
+
+    await aSeededJson(simulation.simAws, "cloudfront_logs/part-0.json", [
+      { ...logRecord, cs_referer: "https://rainlytics.example/pricing" },
+    ]);
+
+    // When a query selects the column both the mapping and the record name.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT cs_referer FROM rainlytics.cloudfront_logs",
+    );
+
+    // Then the record's own key is what it reads, the way real Athena reads
+    // that table.
+    assertObjectEquals(answered.rows, [["https://rainlytics.example/pricing"]]);
+  });
+});


### PR DESCRIPTION
The query engine read each JSON record by its own keys. A column reached through a
`mapping.<column>` SerDe parameter came back null on every row, and the query still succeeded. A
mapped column now reads from the key the mapping names, matched with the case folded unless the
table sets `case.insensitive` to `FALSE`. Only the OpenX class name takes the mappings, since the
Hive JSON SerDes have no `mapping` property.

Resolves https://github.com/KensioSoftware/yulin/issues/1045

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Athena OpenX JSON SerDe column mappings.
  * Added configurable case-sensitive and case-insensitive key matching.
  * Unmatched mapped columns now return `null`, while unmapped columns use their column names.
  * Preserved distinct behavior for Hive JSON SerDes, which ignore OpenX mappings.

* **Documentation**
  * Documented mapping behavior, key matching, and missing-key handling.

* **Tests**
  * Added coverage for mappings, matching modes, precedence, and Hive compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->