### PR TITLE
fix: decompress an object before reading it

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -318,6 +318,12 @@ text in one reads as null.
 A nested object or array is kept as its JSON text, and `json_extract_scalar`, `cardinality` and
 `element_at` reach into it.
 
+An object's key says how it is compressed. A key ending `.gz`, `.zst` or `.deflate` is decompressed
+before the SerDe reads it. A CloudFront standard logging table needs that, since every object
+delivered under one is gzipped. Node's own zlib covers those three codecs. A key ending `.bz2`,
+`.bzip2`, `.lz4`, `.lzo` or `.snappy` turns the query down, and the declaration a test wrote answers
+it. Any other key is read as text.
+
 A `mapping.<column>` parameter on the OpenX JSON SerDe reads that column from the key it names. A
 CloudFront access log table needs it, since a record arrives keyed by `cs(Referer)` and no Athena
 column can be called that. The key matches a record's key of any case until the table sets

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -190,6 +190,12 @@ field. It is a simulator accessor, read off `queryExecutions()`.
 descriptor. A table declaring Parquet lands in the same place as a table whose SerDe is absent.
 Guessing would answer a Parquet query with nonsense.
 
+`sim-athena-object-codec.ts` decompresses an object by the extension its key ends with, before a
+reader sees the bytes. Athena keys this on the extension too. Sniffing the magic number instead
+would read an object real Athena skips. `.gz`, `.zst` and `.deflate` are what Node's zlib covers,
+and an extension naming any other codec raises. The engine falls back to the declaration on that,
+because the alternative is a query succeeding with no rows.
+
 `sim-athena-json-records.ts` lays the OpenX SerDe's `mapping.<column>` parameters over each record
 before a column is looked up. A CloudFront access log table is what needs them. Its records are
 keyed `cs(Referer)` and `timestamp(ms)`, and an Athena column name holds letters, digits and

--- a/src/service/athena/engine/sim-athena-object-codec.ts
+++ b/src/service/athena/engine/sim-athena-object-codec.ts
@@ -1,0 +1,51 @@
+import { gunzipSync, inflateSync, zstdDecompressSync } from "node:zlib";
+
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+
+/** The file extensions naming a codec, against what decompresses each one. */
+const codecs = new Map<string, (bytes: Buffer) => Buffer>([
+  ["gz", gunzipSync],
+  ["zst", zstdDecompressSync],
+  ["deflate", inflateSync],
+]);
+
+/**
+ * The file extensions naming a codec nothing here decompresses.
+ *
+ * Node's standard library has gzip, zstd and deflate. The rest would need a
+ * dependency, and this package takes none for a test to install.
+ */
+const unreadableCodecs = new Set(["bz2", "bzip2", "lz4", "lzo", "snappy"]);
+
+/**
+ * One object's bytes, decompressed by the codec its key names.
+ *
+ * Athena reads the file extension, and so does this. A key ending `.gz` is
+ * gzip whatever its bytes hold, and a key ending anything else is text. The
+ * magic number would be the other way to tell, and it would read an object
+ * real Athena skips.
+ *
+ * A key naming a codec this simulation has no decompressor for raises, and the
+ * engine turns the query down. The declaration a test wrote answers it, which
+ * is what an object the engine cannot open already does.
+ */
+export function simAthenaDecompressedBytes(key: string, bytes: Buffer): Buffer {
+  const name = key.slice(key.lastIndexOf("/") + 1);
+  const dot = name.lastIndexOf(".");
+
+  if (dot === -1) {
+    return bytes;
+  }
+
+  const extension = name.slice(dot + 1).toLowerCase();
+
+  if (unreadableCodecs.has(extension)) {
+    throw new SimAthenaSetUpError(
+      `Unsupported sim Athena compression: ${extension}`,
+    );
+  }
+
+  const decompress = codecs.get(extension);
+
+  return decompress === undefined ? bytes : decompress(bytes);
+}

--- a/src/service/athena/engine/sim-athena-table-objects.ts
+++ b/src/service/athena/engine/sim-athena-table-objects.ts
@@ -1,5 +1,6 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAthenaScannedObjects } from "../execution/sim-athena-scanned-objects.js";
+import { simAthenaDecompressedBytes } from "./sim-athena-object-codec.js";
 
 /**
  * The narrow slice of simulated S3 the query engine reads a table through.
@@ -29,7 +30,7 @@ export function simAthenaTableObjects(
     : (s3 as SimAthenaTableObjects);
 }
 
-/** One object's bytes, read as UTF-8 text. */
+/** One object's bytes, decompressed by its key and read as UTF-8 text. */
 export async function simAthenaObjectText(
   objects: SimAthenaTableObjects,
   bucket: string,
@@ -42,6 +43,7 @@ export async function simAthenaObjectText(
   );
 
   const chunks = await Array.fromAsync(got.Body ?? []);
+  const bytes = simAthenaDecompressedBytes(key, Buffer.concat(chunks));
 
-  return new TextDecoder().decode(Buffer.concat(chunks));
+  return new TextDecoder().decode(bytes);
 }

--- a/src/service/athena/sim-athena-engine.fixture.ts
+++ b/src/service/athena/sim-athena-engine.fixture.ts
@@ -97,6 +97,17 @@ export async function aSeededObject(
     .putObject({ input: { Bucket: logsBucket, Key: key, Body: body } });
 }
 
+/** Put one object of raw bytes under the logs Bucket. */
+export async function aSeededBytes(
+  simAws: SimAws,
+  key: string,
+  body: Uint8Array,
+): Promise<void> {
+  await simAws
+    .s3()
+    .putObject({ input: { Bucket: logsBucket, Key: key, Body: body } });
+}
+
 /** Put one object of JSON lines under the logs Bucket. */
 export async function aSeededJson(
   simAws: SimAws,

--- a/src/service/athena/sim-athena-object-compression.iso.test.ts
+++ b/src/service/athena/sim-athena-object-compression.iso.test.ts
@@ -1,0 +1,171 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { deflateSync, gzipSync, zstdCompressSync } from "node:zlib";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededBytes,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+/** The prefix a delivered object sits under, partitioned by the hour. */
+const logsPrefix = "cloudfront_logs/year=2026/month=08/day=27/hour=01";
+
+/** One JSON record, as CloudFront standard logging writes it. */
+const logLines = '{"c_country":"GB","sc_status":200}\n';
+
+/** A simulation over a CloudFront log table, with the engine on. */
+async function aLogsSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "cloudfront_logs",
+    columns: [
+      { Name: "c_country", Type: "string" },
+      { Name: "sc_status", Type: "int" },
+    ],
+  });
+
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["c_country"], rows: [["declared"]] });
+
+  await simulation.simAws.athena().engine().enable();
+
+  return simulation;
+}
+
+describe("the compression an Athena query reads through", () => {
+  it("reads a gzipped object", async () => {
+    // Given a delivered object, gzipped under a key ending `.gz` the way
+    // CloudFront standard logging writes one.
+    const simulation = await aLogsSimulation();
+
+    await aSeededBytes(
+      simulation.simAws,
+      `${logsPrefix}/E1EXAMPLE1234.2026-08-27-01.f63cf97b.gz`,
+      gzipSync(logLines),
+    );
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_country FROM rainlytics.cloudfront_logs",
+    );
+
+    // Then the record behind the compression is what answers.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["GB"]]);
+  });
+
+  it("reads a zstd object", async () => {
+    // Given an object compressed with zstd.
+    const simulation = await aLogsSimulation();
+
+    await aSeededBytes(
+      simulation.simAws,
+      `${logsPrefix}/part-0.zst`,
+      zstdCompressSync(logLines),
+    );
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_country FROM rainlytics.cloudfront_logs",
+    );
+
+    // Then the extension is what says which codec opened it.
+    assertObjectEquals(answered.rows, [["GB"]]);
+  });
+
+  it("reads a deflated object", async () => {
+    // Given an object compressed with deflate.
+    const simulation = await aLogsSimulation();
+
+    await aSeededBytes(
+      simulation.simAws,
+      `${logsPrefix}/part-0.deflate`,
+      deflateSync(logLines),
+    );
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_country FROM rainlytics.cloudfront_logs",
+    );
+
+    // Then it reads, the same as the other two Node decompresses.
+    assertObjectEquals(answered.rows, [["GB"]]);
+  });
+
+  it("turns a query down where the key names a codec it cannot read", async () => {
+    // Given an object under a key ending `.bz2`, which nothing here opens.
+    const simulation = await aLogsSimulation();
+
+    await aSeededBytes(
+      simulation.simAws,
+      `${logsPrefix}/part-0.bz2`,
+      Buffer.from(logLines),
+    );
+
+    // When a query reads the table.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_country FROM rainlytics.cloudfront_logs",
+    );
+
+    // Then the declaration answers it. An unread codec would otherwise look
+    // like an object holding no rows, and the declaration would never get its
+    // turn.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("turns a query down where a compressed object does not decompress", async () => {
+    // Given an object whose key ends `.gz` and whose bytes are plain text.
+    const simulation = await aLogsSimulation();
+
+    await aSeededBytes(
+      simulation.simAws,
+      `${logsPrefix}/part-0.gz`,
+      Buffer.from(logLines),
+    );
+
+    // When a query reads the table.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_country FROM rainlytics.cloudfront_logs",
+    );
+
+    // Then the declaration answers it. Athena reads the extension rather than
+    // the bytes, and an object that fails to open is one the engine has no
+    // rows for.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("reads an uncompressed object under a key holding no extension", async () => {
+    // Given an object whose key ends in no extension at all.
+    const simulation = await aLogsSimulation();
+
+    await aSeededBytes(
+      simulation.simAws,
+      `${logsPrefix}/part-0`,
+      Buffer.from(logLines),
+    );
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_country FROM rainlytics.cloudfront_logs",
+    );
+
+    // Then it reads as text.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["GB"]]);
+  });
+});


### PR DESCRIPTION
The query engine read every object as UTF-8 text. A gzipped object decoded to mojibake, the JSON
reader found no parseable line, and the query succeeded with no rows. An object is now decompressed
by the extension its key ends with, the way Athena decides it. `.gz`, `.zst` and `.deflate` are
what Node's zlib covers. A key ending `.bz2`, `.bzip2`, `.lz4`, `.lzo` or `.snappy` turns the query
down instead of answering with no rows, and so does an object that fails to decompress.

Resolves https://github.com/KensioSoftware/yulin/issues/1046

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading gzip, zstd, and deflate-compressed Athena objects.
  * Objects without extensions or with unsupported-but-readable extensions are read unchanged.
  * Invalid or unsupported compression formats safely fall back to declared results.
* **Documentation**
  * Documented supported compression formats, fallback behavior, and handling of unsupported codecs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->