### PR TITLE
feat: shim url_decode and url_encode for Athena

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -896,9 +896,10 @@ Current documented limitations:
 - The `url_extract` family reads a URL the way a browser does, so a percent escape in the path, the
   query or the fragment comes back still escaped and a parameter name is matched decoded. Trino
   reads a URL the way Java does and decodes each of those.
-- `url_decode` answers null over an escape that names no byte, such as `%zz`. Trino raises and the
-  query fails. `url_extract_parameter` decodes its own answer, the way Trino's does, so a
-  `url_decode` written after it would read the escapes a second time.
+- `url_decode` answers null over text it cannot read back. Trino raises over an escape that names
+  no byte, such as `%zz`, and writes a replacement character where the escapes name bytes that are
+  no UTF-8, such as `%C3%28`. `url_extract_parameter` decodes its own answer, the way Trino's does.
+  A `url_decode` written after it reads the escapes a second time.
 - `regexp_replace` takes Trino's own spelling for a named group and an escaped dollar, `${name}`
   and `\$`. The rest of Java's replacement syntax is not translated.
 - The date and time functions work on the ISO-8601 text a JSON or CSV object carries. A column

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -380,7 +380,7 @@ its declared result.
 | JSON          | `json_extract`, `json_extract_scalar`, `json_parse`, `json_size`                                                                                                                                      |
 | Array and map | `array_agg`, `cardinality`, `contains`, `element_at`, `array_join`, `slice`                                                                                                                           |
 | String        | `regexp_like`, `regexp_extract`, `regexp_replace`, `split_part`, `strpos`                                                                                                                             |
-| URL           | `url_extract_host`, `url_extract_path`, `url_extract_protocol`, `url_extract_port`, `url_extract_query`, `url_extract_fragment`, `url_extract_parameter`                                              |
+| URL           | `url_extract_host`, `url_extract_path`, `url_extract_protocol`, `url_extract_port`, `url_extract_query`, `url_extract_fragment`, `url_extract_parameter`, `url_decode`, `url_encode`                  |
 | Approximate   | `approx_distinct`, `approx_percentile`                                                                                                                                                                |
 
 `substr` and `format` are SQLite's own. Both count from one and take the same `%s` and `%d` a
@@ -896,6 +896,9 @@ Current documented limitations:
 - The `url_extract` family reads a URL the way a browser does, so a percent escape in the path, the
   query or the fragment comes back still escaped and a parameter name is matched decoded. Trino
   reads a URL the way Java does and decodes each of those.
+- `url_decode` answers null over an escape that names no byte, such as `%zz`. Trino raises and the
+  query fails. `url_extract_parameter` decodes its own answer, the way Trino's does, so a
+  `url_decode` written after it would read the escapes a second time.
 - `regexp_replace` takes Trino's own spelling for a named group and an escaped dollar, `${name}`
   and `\$`. The rest of Java's replacement syntax is not translated.
 - The date and time functions work on the ISO-8601 text a JSON or CSV object carries. A column

--- a/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
@@ -297,11 +297,14 @@ describe("Trino's URL escaping functions on SQLite", () => {
     );
   });
 
-  it("answers null over an escape that names no byte", async () => {
-    // Given text carrying an escape nobody could read.
-    // When it is read back.
-    // Then the answer is null rather than a failed query. Trino raises.
+  it("answers null over text it cannot read back", async () => {
+    // Given an escape naming no byte, and escapes naming bytes that are no
+    // UTF-8.
+    // When each is read back.
+    // Then the answer is null rather than a failed query. Trino raises over
+    // the first and writes a replacement character for the second.
     assertIdentical(await anAnsweredExpression("url_decode('%zz')"), null);
+    assertIdentical(await anAnsweredExpression("url_decode('%C3%28')"), null);
     assertIdentical(await anAnsweredExpression("url_decode(NULL)"), null);
     assertIdentical(await anAnsweredExpression("url_encode(NULL)"), null);
   });

--- a/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
@@ -230,6 +230,83 @@ describe("Trino's URL functions on SQLite", () => {
   });
 });
 
+describe("Trino's URL escaping functions on SQLite", () => {
+  it("escapes a value the way a form parameter is escaped", async () => {
+    // Given values carrying reserved characters, a space and a plus.
+    // When each is escaped.
+    // Then a space is written as `+` and a plus as `%2B`, and only `-`, `_`,
+    // `.` and `*` come through unescaped. These are Trino's own vectors.
+    assertIdentical(
+      await anAnsweredExpression("url_encode('http://test?a=b&c=d')"),
+      "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_encode('~@:.-*_+ \u{2603}')"),
+      "%7E%40%3A.-*_%2B+%E2%98%83",
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_encode('!''()~')"),
+      "%21%27%28%29%7E",
+      "the five characters encodeURIComponent keeps and Guava's escaper escapes",
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_encode('\u{29E3D}')"),
+      "%F0%A9%B8%BD",
+      "a character outside the basic plane is written as its UTF-8 bytes",
+    );
+    assertIdentical(await anAnsweredExpression("url_encode('test')"), "test");
+  });
+
+  it("reads a value back out of its escapes", async () => {
+    // Given the escaped forms above.
+    // When each is read back.
+    // Then `+` comes back as a space and `%2B` as a plus, which is what
+    // `URLDecoder.decode` does over UTF-8.
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_decode('http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd')",
+      ),
+      "http://test?a=b&c=d",
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_decode('%7E%40%3A.-*_%2B+%E2%98%83')"),
+      "~@:.-*_+ \u{2603}",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_decode('http%3A%2F%2F%E3%83%86%E3%82%B9%E3%83%88')",
+      ),
+      "http://\u{30C6}\u{30B9}\u{30C8}",
+    );
+    assertIdentical(await anAnsweredExpression("url_decode('test')"), "test");
+  });
+
+  it("reads a doubly escaped access log field in two passes", async () => {
+    // Given a search a reader typed as `caf\u00E9`, which the browser sends as
+    // `caf%C3%A9` and a CloudFront access log then escapes a second time.
+    // When the field is read back once and then twice.
+    // Then one pass leaves the browser's own escapes standing, and the second
+    // reaches the text the reader typed.
+    assertIdentical(
+      await anAnsweredExpression("url_decode('q=caf%25C3%25A9')"),
+      "q=caf%C3%A9",
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_decode(url_decode('q=caf%25C3%25A9'))"),
+      "q=caf\u{E9}",
+    );
+  });
+
+  it("answers null over an escape that names no byte", async () => {
+    // Given text carrying an escape nobody could read.
+    // When it is read back.
+    // Then the answer is null rather than a failed query. Trino raises.
+    assertIdentical(await anAnsweredExpression("url_decode('%zz')"), null);
+    assertIdentical(await anAnsweredExpression("url_decode(NULL)"), null);
+    assertIdentical(await anAnsweredExpression("url_encode(NULL)"), null);
+  });
+});
+
 describe("the string functions SQLite already carries", () => {
   it("counts from one, as Trino does", async () => {
     // Given a value and a format string.

--- a/src/service/athena/engine/sim-athena-url-shims.ts
+++ b/src/service/athena/engine/sim-athena-url-shims.ts
@@ -60,8 +60,10 @@ export function simAthenaInstallUrlShims(database: DatabaseSync): void {
  * `%2B` as a plus. Replacing the plus before decoding is what keeps the two
  * apart.
  *
- * Trino raises over an escape it cannot read, such as `%zz`, and this answers
- * null, the same forgiving direction the rest of the file takes.
+ * Trino raises over an escape that names no byte, and writes a replacement
+ * character where the bytes it names are no UTF-8. `decodeURIComponent` throws
+ * over both, and this answers null for both, the same forgiving direction the
+ * rest of the file takes.
  */
 function decoded(value: string | undefined): string | null {
   if (value === undefined) {

--- a/src/service/athena/engine/sim-athena-url-shims.ts
+++ b/src/service/athena/engine/sim-athena-url-shims.ts
@@ -14,8 +14,8 @@ const parts: ReadonlyMap<string, (url: URL) => string | null> = new Map([
 /**
  * Trino's URL functions, which a query over access logs reaches for.
  *
- * Trino fails a query over text that is no URL and these answer null, the same
- * forgiving direction the rest of the engine takes.
+ * Trino fails a query over text that is no URL and the extract functions
+ * answer null, the same forgiving direction the rest of the engine takes.
  *
  * Trino answers with an empty string for a part the URL leaves out, apart from
  * the port, which has no empty form and answers null.
@@ -43,6 +43,61 @@ export function simAthenaInstallUrlShims(database: DatabaseSync): void {
 
     return url.searchParams.get(wanted);
   });
+
+  simAthenaScalarShim(database, "url_decode", (value) =>
+    decoded(shimText(value)),
+  );
+
+  simAthenaScalarShim(database, "url_encode", (value) =>
+    encoded(shimText(value)),
+  );
+}
+
+/**
+ * One value with its escapes read back, the way `url_decode` reads them.
+ *
+ * Trino runs `URLDecoder.decode` over UTF-8, which reads `+` as a space and
+ * `%2B` as a plus. Replacing the plus before decoding is what keeps the two
+ * apart.
+ *
+ * Trino raises over an escape it cannot read, such as `%zz`, and this answers
+ * null, the same forgiving direction the rest of the file takes.
+ */
+function decoded(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(value.replaceAll("+", " "));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One value escaped for a query string, the way `url_encode` escapes it.
+ *
+ * Trino runs Guava's form-parameter escaper, which keeps `-`, `_`, `.` and `*`
+ * alone and writes a space as `+`. `encodeURIComponent` keeps five characters
+ * beyond those four, and each of those is escaped here.
+ *
+ * No escape written here carries a character a later pass looks for, and a
+ * space is the only character `encodeURIComponent` writes as `%20`, since a
+ * percent in the value has already become `%25` by then.
+ */
+function encoded(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  return encodeURIComponent(value)
+    .replaceAll("!", "%21")
+    .replaceAll("'", "%27")
+    .replaceAll("(", "%28")
+    .replaceAll(")", "%29")
+    .replaceAll("~", "%7E")
+    .replaceAll("%20", "+");
 }
 
 /** Everything between the scheme and the path, which is where a port is written. */


### PR DESCRIPTION
Athena engine v3 is Trino, and a query over CloudFront access logs reaches for `url_decode` to read a field the log escaped twice. Neither function was shimmed, and a query calling either fell back to its declared result. Both now run under the engine and agree with Trino's own test vectors, the plus that stands for a space included.

Resolves https://github.com/KensioSoftware/yulin/issues/1053

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `url_encode` and `url_decode` functions for query-string URL handling.
  * Supports UTF-8 characters, reserved characters, form-style spaces, and double-decoding scenarios.
  * Invalid URL input now returns a null result.

* **Documentation**
  * Updated Athena documentation with the new URL functions and decoding behavior.

* **Tests**
  * Added coverage for encoding, decoding, invalid input, null values, and access-log URL values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->