### PR TITLE
fix: read the inline regex flags a Trino pattern carries

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -902,6 +902,10 @@ Current documented limitations:
   A `url_decode` written after it reads the escapes a second time.
 - `regexp_replace` takes Trino's own spelling for a named group and an escaped dollar, `${name}`
   and `\$`. The rest of Java's replacement syntax is not translated.
+- A pattern runs under JavaScript's `RegExp` rather than under Joni. `(?i)`, `(?m)` and `(?s)` at
+  the head of a pattern are lifted onto the expression and apply to the whole of it, and the scoped
+  `(?i:...)` runs as written. `(?x)` and a flag group written anywhere but the head turn the pattern
+  down, since JavaScript can turn no flag on part way through one.
 - The date and time functions work on the ISO-8601 text a JSON or CSV object carries. A column
   written any other way gets whatever slicing that text comes to.
 - `approx_distinct` and `approx_percentile` are computed exactly. The simulation is more accurate

--- a/src/service/athena/engine/sim-athena-regexp-flags.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-regexp-flags.iso.test.ts
@@ -1,0 +1,84 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredExpression } from "./sim-athena-shim.fixture.js";
+
+describe("the inline flags a Trino pattern is written with", () => {
+  it("reads a flag group at the head of a pattern", async () => {
+    // Given patterns carrying the flags Java writes inside them.
+    // When each is matched.
+    // Then the flag applies to the whole pattern, the way Joni reads it.
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('BOT', '(?i)bot')"),
+      1,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('a CRAWLER', '(?i)bot|crawl')"),
+      1,
+      "the flag reaches past an alternation, since it is no group of its own",
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('a\nb', '(?s)a.b')"),
+      1,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('a\nBOT', '(?im)^bot')"),
+      1,
+      "two flags in one group",
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('a\nBOT', '(?i)(?m)^bot')"),
+      1,
+      "and two groups in a row",
+    );
+  });
+
+  it("leaves the capture groups numbered as they were written", async () => {
+    // Given a pattern whose flag group is followed by a capture group.
+    // When the first group is extracted.
+    // Then it is the pattern's own first group. A flag group captures nothing
+    // in Java, so taking one off the front moves no number.
+    assertIdentical(
+      await anAnsweredExpression(
+        String.raw`regexp_extract('Hello', '(?i)(h\w+)', 1)`,
+      ),
+      "Hello",
+    );
+  });
+
+  it("reads a flag group through a replacement", async () => {
+    // Given a pattern carrying a flag, used to replace rather than to match.
+    // When every match is replaced.
+    // Then the flag applied to all of them.
+    assertIdentical(
+      await anAnsweredExpression("regexp_replace('A1b2', '(?i)[ab]', 'x')"),
+      "x1x2",
+    );
+  });
+
+  it("runs the scoped form without touching it", async () => {
+    // Given the scoped spelling, which JavaScript reads for itself.
+    // When it is matched.
+    // Then it answers, and nothing had to be lifted out of it.
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('bot', '(?i:BOT)')"),
+      1,
+    );
+  });
+
+  it("turns down a flag it has no way to apply", async () => {
+    // Given a flag JavaScript has not got, and one written part way through a
+    // pattern rather than at its head.
+    // When each is matched.
+    // Then the answer is null, which leaves the declared result to answer.
+    // JavaScript can turn no flag on from the middle of a pattern.
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('ab', '(?x) a b')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("regexp_like('botX', 'bot(?i)x')"),
+      null,
+    );
+  });
+});

--- a/src/service/athena/engine/sim-athena-regexp-flags.ts
+++ b/src/service/athena/engine/sim-athena-regexp-flags.ts
@@ -1,0 +1,49 @@
+/** One of Java's inline flag groups at the head of a pattern, as `(?i)`. */
+const leadingFlag = /^\(\?[ims]+\)/u;
+
+/** One pattern and the flags to compile it with. */
+export interface SimAthenaLiftedPattern {
+  readonly pattern: string;
+  readonly flags: string;
+}
+
+/**
+ * One pattern with the flags Java writes inside it lifted out beside it.
+ *
+ * Athena's regular expressions are Joni, which reads `(?i)` at the head of a
+ * pattern as a flag over the whole of it. JavaScript reads the same text as a
+ * group and refuses it. `(?i)`, `(?m)` and `(?s)` map onto flags of the same
+ * letter, and lifting them is all it takes.
+ *
+ * A flag Joni has and JavaScript has not, `(?x)` among them, stays in the
+ * pattern for `RegExp` to turn down. So does a group written anywhere but the
+ * head, since JavaScript has no way to turn a flag on part way through. The
+ * scoped form `(?i:...)` needs nothing done to it and already runs.
+ *
+ * A flag group captures nothing in Java, so taking one off the front leaves
+ * the capture groups numbered as the statement wrote them.
+ */
+export function simAthenaLiftedPattern(
+  pattern: string,
+  flags: string,
+): SimAthenaLiftedPattern {
+  const letters = new Set<string>();
+  let rest = pattern;
+  let head = leadingFlag.exec(rest);
+
+  while (head !== null) {
+    // Everything the group holds between its `(?` and its `)`.
+    const written = head[0].slice(2, -1);
+
+    for (const letter of written) {
+      letters.add(letter);
+    }
+
+    rest = rest.slice(head[0].length);
+    head = leadingFlag.exec(rest);
+  }
+
+  const added = [...letters].filter((letter) => !flags.includes(letter));
+
+  return { pattern: rest, flags: flags + added.join("") };
+}

--- a/src/service/athena/engine/sim-athena-regexp-shims.ts
+++ b/src/service/athena/engine/sim-athena-regexp-shims.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 
 import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+import { simAthenaLiftedPattern } from "./sim-athena-regexp-flags.js";
 import {
   isExplicitNull,
   shimNumber,
@@ -133,10 +134,12 @@ function expressionFor(
     return undefined;
   }
 
+  const lifted = simAthenaLiftedPattern(pattern, flags);
+
   try {
     // The pattern is the query's own, which is the whole point of the function.
     // oxlint-disable-next-line security/detect-non-literal-regexp
-    return new RegExp(pattern, flags);
+    return new RegExp(lifted.pattern, lifted.flags);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
`regexp_like(x, '(?i)bot')` is a pattern Joni reads and JavaScript's `RegExp` refuses, and the shim answered null for every row. The condition was then null, `NOT` of it was null too, and a query filtering on it returned nothing while succeeding. A leading `(?i)`, `(?m)` or `(?s)` is now lifted onto the expression, where it applies to the whole pattern as Joni applies it. A run of them, as `(?i)(?m)`, is lifted the same way.

`(?x)` and a flag group written anywhere but the head still turn the pattern down, since JavaScript can turn no flag on part way through one. A flag group captures nothing in Java, so taking one off the front leaves the capture groups numbered as the statement wrote them.

The scoped form `(?i:...)` turned out to need nothing done to it. Node 24 reads the ES2025 regular expression modifiers, so `(?i:BOT)`, `(?s:a.b)` and `(?m:^b)` already ran and already matched correctly. The issue expected that one to be harder. There is a test pinning it so it stays working.

Resolves https://github.com/KensioSoftware/yulin/issues/1052

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Java-style inline regular-expression flags in Athena queries, including leading and scoped case-insensitive, multiline, and dot-all modes.
  * Improved handling of multiple inline flags while preserving existing replacement and capture behavior.
* **Bug Fixes**
  * Unsupported or misplaced inline flags now fail safely instead of producing incorrect results.
* **Documentation**
  * Documented supported Athena regular-expression syntax and fallback behavior.
* **Tests**
  * Added coverage for flags, alternation, captures, replacements, scoped modes, and invalid patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->