### PR TITLE
fix: refuse a WAFv2 description AWS refuses

### DIFF
--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -1183,6 +1183,31 @@ take the token from the last read, and a write made against a stale one is refus
 `CreateWebACL` reports the first token in its summary, and `GetWebACL` reports the current one.
 `UpdateWebACL` answers with `NextLockToken` for the write after it.
 
+## Descriptions
+
+A web ACL, an IP set and a regex pattern set each take an optional `Description`. WAFv2 holds it to
+between 1 and 256 characters, and to a pattern of word characters, spaces and `+=:#@/-,.` with
+neither end a space. The shortest description it matches is three characters long.
+
+Both checks run on `CreateWebACL`, `UpdateWebACL`, `CreateIPSet`, `UpdateIPSet`,
+`CreateRegexPatternSet` and `UpdateRegexPatternSet`. A description outside either one is refused
+with `ValidationException`, naming every constraint it failed the way AWS names them. A write that
+leaves `Description` out is taken, and the resource keeps no description.
+
+The empty string is the case worth knowing about. Code that reads a web ACL, replaces the rules and
+writes every other field back hands the description straight through, because `UpdateWebACL` clears
+whatever a write leaves out. AWS answers `Description: ""` for some web ACLs nobody has described,
+and refuses the write that gives it back:
+
+```text
+ValidationException: 2 validation errors detected:
+Value '' at 'description' failed to satisfy constraint: Member must have length greater than or equal to 1;
+Value '' at 'description' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[\w+=:#@/\-,\.][\w+=:#@/\-,\.\s]+[\w+=:#@/\-,\.]$
+```
+
+Yulin leaves the field undefined for a web ACL nobody has described, and that difference stands. It
+is observed from one ACL and AWS documents nothing about it.
+
 ## Permissions
 
 Every command goes through simulated IAM. An operation on one resource authorizes against that

--- a/src/service/wafv2/README.md
+++ b/src/service/wafv2/README.md
@@ -34,6 +34,12 @@ token from an earlier read fails here the way it fails on AWS.
 scope, and a read takes the name and the id together, because a name can have belonged to more than
 one resource over time.
 
+`command/sim-wafv2-input.ts` holds the input checks the three types share. `Description` is the one
+with two constraints, a length and a pattern, and WAFv2 reports both failures of an empty string in
+one `ValidationException`. All six writes that take a description go through
+`checkedSimWafDescription`. An empty description reaches AWS from code that reads a resource and
+writes every field back, and taking it here would leave that failure for the account.
+
 `command/sim-wafv2-resource-lookup.ts` covers the reads, updates and deletes of all three types with
 one function. Authorizing happens before the lookup. That keeps a denial and a missing resource
 apart. A caller with no permission for a web ACL learns only about the permission.

--- a/src/service/wafv2/command/ip-set/sim-wafv2-ip-set-commands.ts
+++ b/src/service/wafv2/command/ip-set/sim-wafv2-ip-set-commands.ts
@@ -7,7 +7,11 @@ import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.
 import { requiredSimWafScope } from "../../scope/sim-waf-scope.js";
 import type { SimWafAuthorizer } from "../authorize/sim-wafv2-authorizer.js";
 import { SimWafPage } from "../sim-wafv2-page.js";
-import { refuseSimWafTags, requiredSimWafName } from "../sim-wafv2-input.js";
+import {
+  checkedSimWafDescription,
+  refuseSimWafTags,
+  requiredSimWafName,
+} from "../sim-wafv2-input.js";
 import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
 import { requireSimWafResource } from "../sim-wafv2-resource-lookup.js";
 import type {
@@ -65,7 +69,7 @@ export class SimWafIpSetCommands {
         this.#accountRegionScope.regionName,
       ),
       accountRegionScope: this.#accountRegionScope,
-      description: input.Description,
+      description: checkedSimWafDescription(input.Description),
       ipAddressVersion: requiredSimWafIpAddressVersion(input.IPAddressVersion),
       addresses: input.Addresses ?? [],
     });
@@ -110,11 +114,12 @@ export class SimWafIpSetCommands {
     options?: SimWafRequestOptions,
   ): SimUpdateIpSetCommandOutput {
     const { input } = command;
+    const description = checkedSimWafDescription(input.Description);
     const ipSet = this.require(input, "wafv2:UpdateIPSet", options);
 
     ipSet.replaceAddresses({
       addresses: input.Addresses ?? [],
-      description: input.Description,
+      description,
       lockToken: input.LockToken,
     });
 

--- a/src/service/wafv2/command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.ts
+++ b/src/service/wafv2/command/regex-pattern-set/sim-wafv2-regex-pattern-set-commands.ts
@@ -4,7 +4,11 @@ import type { SimWafResourceStore } from "../../resource/sim-waf-resource-store.
 import { requiredSimWafScope } from "../../scope/sim-waf-scope.js";
 import type { SimWafAuthorizer } from "../authorize/sim-wafv2-authorizer.js";
 import { SimWafPage } from "../sim-wafv2-page.js";
-import { refuseSimWafTags, requiredSimWafName } from "../sim-wafv2-input.js";
+import {
+  checkedSimWafDescription,
+  refuseSimWafTags,
+  requiredSimWafName,
+} from "../sim-wafv2-input.js";
 import type { SimWafRequestOptions } from "../sim-wafv2-request-options.js";
 import { requireSimWafResource } from "../sim-wafv2-resource-lookup.js";
 import type {
@@ -62,7 +66,7 @@ export class SimWafRegexPatternSetCommands {
         this.#accountRegionScope.regionName,
       ),
       accountRegionScope: this.#accountRegionScope,
-      description: input.Description,
+      description: checkedSimWafDescription(input.Description),
       regularExpressions: input.RegularExpressionList ?? [],
     });
 
@@ -118,6 +122,7 @@ export class SimWafRegexPatternSetCommands {
     options?: SimWafRequestOptions,
   ): SimUpdateRegexPatternSetCommandOutput {
     const { input } = command;
+    const description = checkedSimWafDescription(input.Description);
     const patternSet = this.require(
       input,
       "wafv2:UpdateRegexPatternSet",
@@ -126,7 +131,7 @@ export class SimWafRegexPatternSetCommands {
 
     patternSet.replaceExpressions({
       regularExpressions: input.RegularExpressionList ?? [],
-      description: input.Description,
+      description,
       lockToken: input.LockToken,
     });
 

--- a/src/service/wafv2/command/sim-wafv2-input.ts
+++ b/src/service/wafv2/command/sim-wafv2-input.ts
@@ -1,6 +1,7 @@
 import {
   SimWafInvalidParameterException,
   SimWafUnsimulatedInputException,
+  SimWafValidationException,
 } from "../error/sim-wafv2.error.js";
 
 /**
@@ -70,4 +71,91 @@ export function requiredSimWafArn(
   }
 
   return arn;
+}
+
+/**
+ * The shape WAFv2 documents for the description of a web ACL, an IP set and a
+ * regex pattern set.
+ *
+ * The refusal below quotes this expression back, the way WAFv2 quotes its own.
+ * WAFv2 writes the dots inside the character classes escaped and this does
+ * not, which is the same set of characters written two ways.
+ */
+const descriptionExpression = /^[\w+=:#@/\-,.][\w+=:#@/\-,.\s]+[\w+=:#@/\-,.]$/;
+
+const descriptionMaxLength = 256;
+
+/**
+ * Read the description a write gave, refusing one WAFv2 will not store.
+ *
+ * The empty string is the one worth catching. Code that reads a resource,
+ * changes part of it and writes the rest back hands the description straight
+ * through, and AWS answers `""` for some resources nobody has described. WAFv2
+ * refuses that write. A simulation that took it would leave the failure for
+ * the account to report.
+ *
+ * The two constraints are checked apart because AWS checks them apart. The
+ * pattern matches three characters at the shortest. `ab` is long enough for
+ * the length and still refused, and `""` fails both at once, which is how one
+ * message comes to report two errors.
+ */
+export function checkedSimWafDescription(
+  description: string | undefined,
+): string | undefined {
+  if (description === undefined) {
+    return undefined;
+  }
+
+  const failures = [
+    ...lengthFailures(description),
+    ...patternFailures(description),
+  ];
+
+  if (failures.length === 0) {
+    return description;
+  }
+
+  throw new SimWafValidationException(
+    `${failures.length} validation error${
+      failures.length === 1 ? "" : "s"
+    } detected: ${failures
+      .map(
+        (failure) =>
+          `Value '${description}' at 'description' failed to satisfy ` +
+          `constraint: ${failure}`,
+      )
+      .join("; ")}`,
+  );
+}
+
+/**
+ * What the length of a description falls foul of, if anything.
+ */
+function lengthFailures(description: string): readonly string[] {
+  if (description.length === 0) {
+    return ["Member must have length greater than or equal to 1"];
+  }
+
+  if (description.length > descriptionMaxLength) {
+    return [
+      `Member must have length less than or equal to ${descriptionMaxLength}`,
+    ];
+  }
+
+  return [];
+}
+
+/**
+ * What the shape of a description falls foul of, if anything.
+ */
+function patternFailures(description: string): readonly string[] {
+  if (descriptionExpression.test(description)) {
+    return [];
+  }
+
+  return [
+    `Member must satisfy regular expression pattern: ${
+      descriptionExpression.source
+    }`,
+  ];
 }

--- a/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
+++ b/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
@@ -10,7 +10,10 @@ import type { SimWafWebAclConfiguration } from "../../web-acl/sim-waf-web-acl-co
 import { SimWafWebAcl } from "../../web-acl/sim-waf-web-acl.js";
 import type { SimWafAuthorizer } from "../authorize/sim-wafv2-authorizer.js";
 import { SimWafPage } from "../sim-wafv2-page.js";
-import { requiredSimWafName } from "../sim-wafv2-input.js";
+import {
+  checkedSimWafDescription,
+  requiredSimWafName,
+} from "../sim-wafv2-input.js";
 import {
   requireSimWafResource,
   type SimWafResourceInput,
@@ -84,12 +87,13 @@ export class SimWafWebAclCommands {
 
     refuseUnsimulatedSimWafWebAclInput(input, "CreateWebACL");
 
+    const configuration = configurationOf(input);
     const webAcl = new SimWafWebAcl({
       name,
       scope,
       accountRegionScope: this.#accountRegionScope,
-      description: input.Description,
-      configuration: configurationOf(input),
+      description: configuration.description,
+      configuration,
       regexPatternSets: this.#regexPatternSets,
       managedRules: this.#managedRules,
       clock: this.#clock,
@@ -131,9 +135,10 @@ export class SimWafWebAclCommands {
 
     refuseUnsimulatedSimWafWebAclInput(input, "UpdateWebACL");
 
+    const configuration = configurationOf(input);
     const webAcl = this.require(input, "wafv2:UpdateWebACL", options);
 
-    webAcl.reconfigure(configurationOf(input), input.LockToken);
+    webAcl.reconfigure(configuration, input.LockToken);
 
     return { $metadata: {}, NextLockToken: webAcl.lockToken };
   }
@@ -226,6 +231,6 @@ function configurationOf(
     rules: input.Rules,
     customResponseBodies: input.CustomResponseBodies,
     visibilityConfig: input.VisibilityConfig,
-    description: input.Description,
+    description: checkedSimWafDescription(input.Description),
   };
 }

--- a/src/service/wafv2/error/sim-wafv2.error.ts
+++ b/src/service/wafv2/error/sim-wafv2.error.ts
@@ -124,6 +124,21 @@ export class SimWafAssociatedItemException extends SimWafError {
 }
 
 /**
+ * Simulated WAFv2 ValidationException error.
+ *
+ * WAFv2 checks the length and shape of a few members before the request
+ * reaches the rest of the API, and reports every failure in one message. A
+ * description of `""` fails two of those checks at once.
+ */
+export class SimWafValidationException extends SimWafError {
+  public override readonly name = "ValidationException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * A match declared against this simulation that it cannot answer with.
  *
  * The four `CrossSiteScripting_*` rules of the core rule set detect nothing

--- a/src/service/wafv2/sim-wafv2-description.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-description.iso.test.ts
@@ -1,0 +1,247 @@
+import {
+  CreateIPSetCommand,
+  CreateRegexPatternSetCommand,
+  GetWebACLCommand,
+  UpdateIPSetCommand,
+  UpdateRegexPatternSetCommand,
+} from "@aws-sdk/client-wafv2";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
+import { SimWafValidationException } from "./error/sim-wafv2.error.js";
+import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
+import type { SimWafV2 } from "./sim-wafv2.js";
+
+const lengthConstraint = "Member must have length greater than or equal to 1";
+const patternConstraint = "Member must satisfy regular expression pattern";
+
+describe("SimWafV2 descriptions", () => {
+  it("refuses a web ACL created with an empty description", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+
+    // When a web ACL is created with an empty description.
+    const error = await assertThrowsErrorAsync(async () => {
+      await createSimWafWebAcl(
+        waf,
+        simWafCreateWebAclFactory.make({ Description: "" }),
+      );
+    });
+
+    // Then it is refused for both of the constraints WAFv2 checks, in one
+    // message, as WAFv2 refuses it.
+    assertInstanceOf(error, SimWafValidationException);
+    assertStringIncludes(error.message, "2 validation errors detected");
+    assertStringIncludes(error.message, lengthConstraint);
+    assertStringIncludes(error.message, patternConstraint);
+  });
+
+  it("refuses an empty description written back over a web ACL", async () => {
+    // Given a web ACL that has been read back.
+    const waf = new SimAws().wafV2();
+    const input = simWafCreateWebAclFactory.make({ Description: "the API" });
+    const created = await createSimWafWebAcl(waf, input);
+
+    // When every field is written back with the description emptied, which is
+    // what a read of an undescribed ACL on real WAFv2 hands back.
+    const error = await assertThrowsErrorAsync(async () => {
+      await waf.updateWebAcl({
+        input: {
+          ...input,
+          Id: created.Id,
+          LockToken: created.LockToken,
+          Description: "",
+        },
+      });
+    });
+
+    // Then the write is refused, rather than landing here and failing in the
+    // account.
+    assertInstanceOf(error, SimWafValidationException);
+
+    // And the description it had is still there.
+    const read = await waf.getWebAcl(
+      new GetWebACLCommand({
+        Name: input.Name,
+        Scope: "REGIONAL",
+        Id: created.Id,
+      }),
+    );
+
+    assertIdentical(read.WebACL?.Description, "the API");
+  });
+
+  it("refuses a description the documented pattern cannot match", async () => {
+    // When a description is long enough and still outside the pattern: two
+    // characters, and one that ends in a space.
+    const tooShort = await webAclRefusal(new SimAws().wafV2(), "ab");
+    const trailingSpace = await webAclRefusal(new SimAws().wafV2(), "the API ");
+
+    // Then each is refused for the pattern alone, because the pattern matches
+    // three characters at the shortest and neither end may be whitespace.
+    assertStringIncludes(tooShort.message, "1 validation error detected");
+    assertStringIncludes(tooShort.message, patternConstraint);
+    assertStringIncludes(trailingSpace.message, patternConstraint);
+  });
+
+  it("refuses a description longer than WAFv2 stores", async () => {
+    // When a description runs to 257 characters.
+    const error = await webAclRefusal(new SimAws().wafV2(), "a".repeat(257));
+
+    // Then it is refused for the length WAFv2 documents.
+    assertStringIncludes(
+      error.message,
+      "Member must have length less than or equal to 256",
+    );
+  });
+
+  it("takes a description of the shape WAFv2 documents", async () => {
+    // Given a simulated WAFv2.
+    const waf = new SimAws().wafV2();
+    const description = "Edge protection for api.example.com - v2";
+    const input = simWafCreateWebAclFactory.make({ Description: description });
+
+    // When a web ACL is created with a description carrying spaces and
+    // punctuation.
+    const created = await createSimWafWebAcl(waf, input);
+    const read = await waf.getWebAcl(
+      new GetWebACLCommand({
+        Name: input.Name,
+        Scope: "REGIONAL",
+        Id: created.Id,
+      }),
+    );
+
+    // Then it is stored and read back.
+    assertIdentical(read.WebACL?.Description, description);
+  });
+
+  it("takes a write that names no description at all", async () => {
+    // Given a web ACL created without one.
+    const waf = new SimAws().wafV2();
+    const input = simWafCreateWebAclFactory.make();
+    const created = await createSimWafWebAcl(waf, input);
+
+    // When it is written back without one either.
+    await waf.updateWebAcl({
+      input: { ...input, Id: created.Id, LockToken: created.LockToken },
+    });
+
+    // Then both writes are taken, as AWS takes them.
+    const read = await waf.getWebAcl(
+      new GetWebACLCommand({
+        Name: input.Name,
+        Scope: "REGIONAL",
+        Id: created.Id,
+      }),
+    );
+
+    assertUndefined(read.WebACL?.Description);
+  });
+
+  it("refuses an empty description on an IP set write", async () => {
+    // Given a simulated WAFv2 holding an IP set.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createIpSet(
+      new CreateIPSetCommand({
+        Name: "office",
+        Scope: "REGIONAL",
+        IPAddressVersion: "IPV4",
+        Addresses: ["192.0.2.0/24"],
+      }),
+    );
+
+    // When an empty description is created with and then written over it.
+    const onCreate = await assertThrowsErrorAsync(async () => {
+      await waf.createIpSet(
+        new CreateIPSetCommand({
+          Name: "other-office",
+          Scope: "REGIONAL",
+          IPAddressVersion: "IPV4",
+          Addresses: ["192.0.2.0/24"],
+          Description: "",
+        }),
+      );
+    });
+    const onUpdate = await assertThrowsErrorAsync(async () => {
+      await waf.updateIpSet(
+        new UpdateIPSetCommand({
+          Name: "office",
+          Scope: "REGIONAL",
+          Id: created.Summary?.Id,
+          LockToken: created.Summary?.LockToken,
+          Addresses: ["192.0.2.0/24"],
+          Description: "",
+        }),
+      );
+    });
+
+    // Then both are refused: an IP set description carries the same
+    // constraints as a web ACL one.
+    assertInstanceOf(onCreate, SimWafValidationException);
+    assertInstanceOf(onUpdate, SimWafValidationException);
+  });
+
+  it("refuses an empty description on a regex pattern set write", async () => {
+    // Given a simulated WAFv2 holding a regex pattern set.
+    const waf = new SimAws().wafV2();
+    const created = await waf.createRegexPatternSet(
+      new CreateRegexPatternSetCommand({
+        Name: "bad-agents",
+        Scope: "REGIONAL",
+        RegularExpressionList: [{ RegexString: "sqlmap" }],
+      }),
+    );
+
+    // When an empty description is created with and then written over it.
+    const onCreate = await assertThrowsErrorAsync(async () => {
+      await waf.createRegexPatternSet(
+        new CreateRegexPatternSetCommand({
+          Name: "worse-agents",
+          Scope: "REGIONAL",
+          RegularExpressionList: [{ RegexString: "sqlmap" }],
+          Description: "",
+        }),
+      );
+    });
+    const onUpdate = await assertThrowsErrorAsync(async () => {
+      await waf.updateRegexPatternSet(
+        new UpdateRegexPatternSetCommand({
+          Name: "bad-agents",
+          Scope: "REGIONAL",
+          Id: created.Summary?.Id,
+          LockToken: created.Summary?.LockToken,
+          RegularExpressionList: [{ RegexString: "sqlmap" }],
+          Description: "",
+        }),
+      );
+    });
+
+    // Then both are refused, the same way.
+    assertInstanceOf(onCreate, SimWafValidationException);
+    assertInstanceOf(onUpdate, SimWafValidationException);
+  });
+});
+
+/**
+ * Try to create a web ACL with one description, and answer with the refusal.
+ */
+async function webAclRefusal(
+  waf: SimWafV2,
+  description: string,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await createSimWafWebAcl(
+      waf,
+      simWafCreateWebAclFactory.make({ Description: description }),
+    );
+  });
+}


### PR DESCRIPTION
WAFv2 holds the `Description` of a web ACL, an IP set and a regex pattern set to between 1 and 256 characters and to a documented pattern, and refuses anything else with a `ValidationException` naming every constraint that failed. The six writes that take a description now check it the same way through one helper in `command/sim-wafv2-input.ts`, so code that reads a resource, changes part of it and writes every field back finds an empty description refused here instead of at the last step of a release. A write that leaves `Description` out is unaffected.

The read half of the issue stands as recorded. `GetWebACL` here still leaves the field undefined for a web ACL nobody has described, and the docs say so.

Resolves #1058

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional descriptions for WAFv2 resources, including web ACLs, IP sets, and regex pattern sets.
  * Added validation for description length and allowed characters.
  * Invalid descriptions now return clear validation errors with HTTP 400 status.

* **Bug Fixes**
  * Ensured description validation is consistently applied during resource creation and updates.
  * Clarified behavior for omitted and empty descriptions.

* **Documentation**
  * Documented description support, validation rules, and update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->