### PR TITLE
fix: read a scheme-less URL in the url_extract functions

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -883,8 +883,9 @@ Current documented limitations:
   twenty-eighth of February is a whole month.
 - `at_timezone` answers with the wall clock of the zone and no zone on it, since a timestamp here
   carries none. Trino answers with a timestamp carrying the zone.
-- `json_parse`, `regexp_extract`, `regexp_replace` and the `url_extract` family answer null over
-  text they cannot read. Trino fails the query.
+- `json_parse`, `regexp_extract` and `regexp_replace` answer null over text they cannot read. Trino
+  fails the query. The `url_extract` family answers null too, and there Trino answers null as well,
+  since each of those functions is declared never to fail.
 - `json_extract` answers with JSON, so a string comes back quoted. SQLite's own unwraps it, and a
   statement comparing the answer against a bare string matches on one and not the other.
 - A timestamp carrying a numeric UTC offset falls outside the date functions, and so does one
@@ -893,9 +894,12 @@ Current documented limitations:
 - A JSON number beyond about fifteen significant digits loses the digits past that, wherever the
   engine reads JSON. An identifier of that size in a JSON lines object comes back rounded, and a
   filter on it can then match the wrong row.
-- The `url_extract` family reads a URL the way a browser does, so a percent escape in the path, the
-  query or the fragment comes back still escaped and a parameter name is matched decoded. Trino
-  reads a URL the way Java does and decodes each of those.
+- The `url_extract` family splits a URI reference the way RFC 3986 writes it, so a reference with no
+  scheme reads, as `/reports/august?tenant=acme`. That is the shape a CloudFront log holds, since it
+  carries the path and the query in columns of their own. Text carrying a character RFC 2396 leaves
+  out, or a percent naming no byte, answers null.
+- A percent escape in the path, the query or the fragment comes back still escaped, and a parameter
+  name is matched decoded. Trino reads a URL the way Java does and decodes each of those.
 - `url_decode` answers null over text it cannot read back. Trino raises over an escape that names
   no byte, such as `%zz`, and writes a replacement character where the escapes name bytes that are
   no UTF-8, such as `%C3%28`. `url_extract_parameter` decodes its own answer, the way Trino's does.

--- a/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-text-shims.iso.test.ts
@@ -210,7 +210,9 @@ describe("Trino's URL functions on SQLite", () => {
   it("answers null over text that is no URL", async () => {
     // Given text nobody could read as a URL.
     // When its host is read.
-    // Then the answer is null rather than a failed query. Trino fails.
+    // Then the answer is null, which is Trino's answer too. Each of the
+    // extract functions is declared never to fail and answers null off a URI
+    // that would not parse.
     assertIdentical(
       await anAnsweredExpression("url_extract_host('rain dot example')"),
       null,

--- a/src/service/athena/engine/sim-athena-url-parts.ts
+++ b/src/service/athena/engine/sim-athena-url-parts.ts
@@ -1,0 +1,105 @@
+/** One URI reference split the way Java's `URI` splits it. */
+export interface SimAthenaUrlParts {
+  readonly protocol: string;
+  readonly host: string;
+  readonly port: number | null;
+  readonly path: string;
+  readonly query: string;
+  readonly fragment: string;
+}
+
+/**
+ * A URI reference, split as RFC 3986 writes the expression for it.
+ *
+ * This is the expression the RFC prints in its own appendix, character for
+ * character. Its groups are optional and never nested, so what a reference
+ * that does not match costs in backtracking is bounded by the text's length.
+ */
+const reference =
+  // oxlint-disable-next-line security/detect-unsafe-regex
+  /^(?:([^:/?#]+):)?(?:\/\/([^/?#]*))?([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/u;
+
+/** The characters RFC 2396 allows, which is what Java's `URI` takes. */
+const disallowed = /[^A-Za-z0-9;/?:@&=+$,\-_.!~*'()%[\]#]/u;
+
+/** A percent naming no byte, which Java's `URI` reads as malformed. */
+const malformedEscape = /%(?![0-9A-Fa-f]{2})/u;
+
+/** A scheme starts with a letter and carries no other punctuation. */
+const schemeName = /^[A-Za-z][A-Za-z0-9+.-]*$/u;
+
+const digits = /^\d+$/u;
+
+/**
+ * One URI reference split into its parts, or nothing where it is no reference.
+ *
+ * Trino reads a URL with `new URI(text)`, which takes a reference with no
+ * scheme of its own. `/reports/august?tenant=acme` is one, and it is the shape
+ * a CloudFront access log holds, since the log carries the path and the query
+ * in columns of their own and no whole URL anywhere.
+ *
+ * The parts are read off the text rather than resolved against a base. That is
+ * what `URI` does, and it keeps a relative path as the text wrote it.
+ *
+ * A part the reference leaves out comes back as the empty string, which is
+ * what Trino answers for one. The port has no empty form and answers null.
+ */
+export function simAthenaUrlParts(text: string): SimAthenaUrlParts | undefined {
+  if (disallowed.test(text) || malformedEscape.test(text)) {
+    return undefined;
+  }
+
+  const found = reference.exec(text);
+
+  if (found === null) {
+    return undefined;
+  }
+
+  const scheme = found.at(1);
+
+  if (scheme !== undefined && !schemeName.test(scheme)) {
+    return undefined;
+  }
+
+  const authority = found.at(2);
+  const path = found.at(3) ?? "";
+  // A scheme followed by anything but a slash is an opaque URI, and Java reads
+  // neither a path nor a query out of one. `mailto:a@b` is the case.
+  const opaque =
+    scheme !== undefined && authority === undefined && !path.startsWith("/");
+
+  return {
+    protocol: scheme ?? "",
+    ...hostAndPort(authority),
+    path: opaque ? "" : path,
+    query: opaque ? "" : (found.at(4) ?? ""),
+    fragment: found.at(5) ?? "",
+  };
+}
+
+/**
+ * The host and the port one authority names.
+ *
+ * The user's own credentials sit before an `@` and are no part of the host, so
+ * the digits in `user:1234@rain.example` are no port. A colon with anything
+ * but digits after it belongs to the host, which is what keeps the one inside
+ * an IPv6 literal out of the port.
+ */
+function hostAndPort(authority: string | undefined): {
+  readonly host: string;
+  readonly port: number | null;
+} {
+  if (authority === undefined) {
+    return { host: "", port: null };
+  }
+
+  const written = authority.slice(authority.lastIndexOf("@") + 1);
+  const colon = written.lastIndexOf(":");
+  const port = written.slice(colon + 1);
+
+  if (colon === -1 || !digits.test(port)) {
+    return { host: written, port: null };
+  }
+
+  return { host: written.slice(0, colon), port: Number(port) };
+}

--- a/src/service/athena/engine/sim-athena-url-references.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-url-references.iso.test.ts
@@ -1,0 +1,136 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredExpression } from "./sim-athena-shim.fixture.js";
+
+const logFields = "'/reports/august?tenant=acme'";
+
+describe("a URI reference with no scheme of its own", () => {
+  it("reads the parts a CloudFront log column holds", async () => {
+    // Given the path and the query a log carries, with no whole URL anywhere.
+    // When each part is read.
+    // Then the reference answers, the way Trino's `new URI(text)` answers.
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_path(${logFields})`),
+      "/reports/august",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_query(${logFields})`),
+      "tenant=acme",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        `url_extract_parameter(${logFields}, 'tenant')`,
+      ),
+      "acme",
+    );
+  });
+
+  it("answers with the empty string for the parts it has not got", async () => {
+    // Given the same reference.
+    // When the parts only an absolute URL carries are read.
+    // Then each answers with the empty string, apart from the port. Trino
+    // answers the same, since a part a URI leaves out is null and it writes a
+    // null part out as empty.
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_protocol(${logFields})`),
+      "",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_host(${logFields})`),
+      "",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`url_extract_port(${logFields})`),
+      null,
+    );
+  });
+
+  it("reads a reference a statement built for itself", async () => {
+    // Given a query joining a log's stem and query columns, which is how a
+    // rollup reaches a parameter with no URL column to read.
+    // When the parameter is read off what that came to.
+    // Then it answers.
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_extract_parameter('/search' || '?' || 'q=1', 'q')",
+      ),
+      "1",
+    );
+  });
+
+  it("keeps a relative path as the text wrote it", async () => {
+    // Given a reference that is one path segment and nothing else.
+    // When its path is read.
+    // Then no leading slash is added. Trino reads the parts off the text
+    // rather than resolving them against a base, and asserts this one.
+    assertIdentical(
+      await anAnsweredExpression("url_extract_path('foo')"),
+      "foo",
+    );
+  });
+
+  it("reads no path or query out of an opaque URI", async () => {
+    // Given a scheme followed by something other than a slash.
+    // When its parts are read.
+    // Then the scheme answers and the rest are empty. Java calls this an
+    // opaque URI and keeps everything after the scheme out of the path.
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_extract_protocol('mailto:test@rain.example')",
+      ),
+      "mailto",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_extract_path('mailto:test@rain.example')",
+      ),
+      "",
+    );
+    assertIdentical(
+      await anAnsweredExpression(
+        "url_extract_host('mailto:test@rain.example')",
+      ),
+      "",
+    );
+  });
+
+  it("keeps the colons of an IPv6 literal out of the port", async () => {
+    // Given a host written as an IPv6 literal, with and without a port.
+    // When each is read.
+    // Then the brackets stay with the host and only the port after them is a
+    // port.
+    assertIdentical(
+      await anAnsweredExpression("url_extract_host('http://[::1]:8080/a')"),
+      "[::1]",
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_extract_port('http://[::1]:8080/a')"),
+      8080,
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_extract_port('http://[::1]/a')"),
+      null,
+    );
+  });
+
+  it("answers null over text no URI could carry", async () => {
+    // Given a character RFC 2396 leaves out, and a percent naming no byte.
+    // When each is read.
+    // Then the answer is null, which is Trino's answer too. Its own test
+    // asserts null for every part of the first of these.
+    assertIdentical(
+      await anAnsweredExpression("url_extract_host('http://rain.example/^')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_extract_path('/reports/%zz')"),
+      null,
+    );
+    assertIdentical(
+      await anAnsweredExpression("url_extract_protocol('1rain://example/a')"),
+      null,
+      "a scheme starts with a letter, so this is no reference at all",
+    );
+  });
+});

--- a/src/service/athena/engine/sim-athena-url-shims.ts
+++ b/src/service/athena/engine/sim-athena-url-shims.ts
@@ -1,21 +1,33 @@
 import type { DatabaseSync } from "node:sqlite";
 
 import { shimText, simAthenaScalarShim } from "./sim-athena-shim-registry.js";
+import {
+  simAthenaUrlParts,
+  type SimAthenaUrlParts,
+} from "./sim-athena-url-parts.js";
 
-/** What each `url_extract` function reads off a parsed URL. */
-const parts: ReadonlyMap<string, (url: URL) => string | null> = new Map([
-  ["url_extract_host", (url: URL) => url.hostname],
-  ["url_extract_path", (url: URL) => url.pathname],
-  ["url_extract_protocol", (url: URL) => url.protocol.replace(":", "")],
-  ["url_extract_fragment", (url: URL) => url.hash.replace("#", "")],
-  ["url_extract_query", (url: URL) => url.search.replace("?", "")],
+/** What one `url_extract` function reads off a split reference. */
+type SimAthenaUrlPart = (url: SimAthenaUrlParts) => string | number | null;
+
+/** What each `url_extract` function reads off a split reference. */
+const parts: ReadonlyMap<string, SimAthenaUrlPart> = new Map<
+  string,
+  SimAthenaUrlPart
+>([
+  ["url_extract_host", (url) => url.host],
+  ["url_extract_path", (url) => url.path],
+  ["url_extract_protocol", (url) => url.protocol],
+  ["url_extract_fragment", (url) => url.fragment],
+  ["url_extract_query", (url) => url.query],
+  ["url_extract_port", (url) => url.port],
 ]);
 
 /**
  * Trino's URL functions, which a query over access logs reaches for.
  *
- * Trino fails a query over text that is no URL and the extract functions
- * answer null, the same forgiving direction the rest of the engine takes.
+ * The extract functions answer null over text that is no URI reference, and so
+ * does Trino. Each one is `neverFails` there and answers null off a `URI` that
+ * would not parse.
  *
  * Trino answers with an empty string for a part the URL leaves out, apart from
  * the port, which has no empty form and answers null.
@@ -23,25 +35,21 @@ const parts: ReadonlyMap<string, (url: URL) => string | null> = new Map([
 export function simAthenaInstallUrlShims(database: DatabaseSync): void {
   for (const [name, read] of parts) {
     simAthenaScalarShim(database, name, (value) => {
-      const url = parsedUrl(shimText(value));
+      const url = readParts(shimText(value));
 
       return url === undefined ? null : read(url);
     });
   }
 
-  simAthenaScalarShim(database, "url_extract_port", (value) =>
-    writtenPort(shimText(value)),
-  );
-
   simAthenaScalarShim(database, "url_extract_parameter", (value, name) => {
     const wanted = shimText(name);
-    const url = parsedUrl(shimText(value));
+    const url = readParts(shimText(value));
 
     if (url === undefined || wanted === undefined) {
       return null;
     }
 
-    return url.searchParams.get(wanted);
+    return new URLSearchParams(url.query).get(wanted);
   });
 
   simAthenaScalarShim(database, "url_decode", (value) =>
@@ -102,30 +110,7 @@ function encoded(value: string | undefined): string | null {
     .replaceAll("%20", "+");
 }
 
-/** Everything between the scheme and the path, which is where a port is written. */
-const authority = /^[A-Za-z][\w+.-]*:\/\/[^/?#]*/u;
-
-/**
- * The port one URL names, or nothing where it names none.
- *
- * Read off the text rather than off the parsed URL, because the parser drops a
- * port that is the scheme's own default. Trino answers with the port a URL was
- * written with, so `http://rain.example:80/a` is eighty rather than nothing.
- */
-function writtenPort(value: string | undefined): number | null {
-  if (value === undefined || parsedUrl(value) === undefined) {
-    return null;
-  }
-
-  const written = /:(\d+)$/u.exec(authority.exec(value)?.[0] ?? "")?.[1];
-
-  return written === undefined ? null : Number(written);
-}
-
-function parsedUrl(value: string | undefined): URL | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  return URL.parse(value) ?? undefined;
+/** One value split into its URL parts, or nothing where it is null or no URL. */
+function readParts(value: string | undefined): SimAthenaUrlParts | undefined {
+  return value === undefined ? undefined : simAthenaUrlParts(value);
 }


### PR DESCRIPTION
`url_extract_parameter('/search?q=1', 'q')` answered null where Trino answers `1`. Every function in the family went through `URL.parse`, which wants an absolute URL, and Trino reads a URL with `new URI(text)`, which takes any reference. A CloudFront access log carries the path and the query in columns of their own and no whole URL anywhere, so a rollup joining the two had nothing the family would read.

The parts now come from the split RFC 3986 prints in its own appendix. Handing `URL.parse` a base was the fix the issue suggested, and it turned out to be the wrong one: a base makes text like `rain dot example` parse too, which would have taken the null that text answers today away from it. Splitting the reference instead keeps that null and matches `URI` in two more places, since the parts are read off the text rather than resolved against a base. `url_extract_path('foo')` is `foo` with no leading slash added, and text carrying a character RFC 2396 leaves out, or a percent naming no byte, answers null.

All nine of the extract vectors in Trino's own `TestUrlFunctions` now agree, where `mailto:test@example.com` and `http://example.com/^` did not before. So do all eight of its `url_extract_parameter` vectors, which went on running through `URLSearchParams` over the split query and are unchanged.

While the family was being rewritten to match `URI`, two comments claiming the opposite went with it. `url_extract` answers null over unreadable text and Trino does too, since each of those functions is declared `neverFails` and answers null off a `URI` that would not parse. The docs page and a test comment both said Trino fails the query there. `json_parse` and the `regexp` functions still do fail it, and that half of the sentence stays.

Resolves https://github.com/KensioSoftware/yulin/issues/1054

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/
