### PR TITLE
feat: deny an action with a service control policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [KMS](https://yulinsim.dev/services/kms/ "Simulated KMS usage docs")
 - [Lambda](https://yulinsim.dev/services/lambda/ "Simulated Lambda usage docs")
 - [CloudWatch Logs](https://yulinsim.dev/services/logs/ "Simulated CloudWatch Logs usage docs")
+- [Organizations](https://yulinsim.dev/services/organizations/ "Simulated Organizations service control policies usage docs")
 - [Personalize](https://yulinsim.dev/services/personalize/ "Simulated Amazon Personalize usage docs")
 - [Rekognition](https://yulinsim.dev/services/rekognition/ "Simulated Rekognition usage docs")
 - [Route53](https://yulinsim.dev/services/route53/ "Simulated Route53 usage docs")

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -1090,7 +1090,8 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
 
 - Groups are absent. An `AWS::IAM::User` naming one fails, and an `AWS::IAM::Policy` naming one
   fails too
-- Permissions boundaries, session policies, and service control policies are not evaluated
+- Permissions boundaries and session policies are not evaluated. Service control policies are, and
+  are attached through [simulated Organizations](https://yulinsim.dev/services/organizations/ "Simulated Organizations service control policies usage docs")
 - Managed Policies have a single version, and the policy version commands are absent
 - `DeleteUserPolicy` and `DetachUserPolicy` are absent, along with `DeleteAccessKey` and
   `DeleteLoginProfile`. `DeleteUserCommand` refuses a User that still holds a policy, and

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -1,0 +1,186 @@
+# Simulated Organizations
+
+Yulin simulates AWS Organizations service control policies. A test can find out that the
+organization around an account forbids something before a deployment does.
+
+A service control policy filters what an account's principals may do and grants nothing. Sim IAM
+evaluates the ones attached to an account ahead of that account's identity and resource policies,
+which means an SCP applies to a CloudFormation deployment, an intercepted SDK client, and a direct
+service call alike.
+
+## Attach a service control policy to an Account
+
+An organization spans accounts. It belongs to the whole simulated environment and is reached as
+`simAws.organizations()`, not from an account scope.
+
+```typescript sim-organizations-attach-scp
+/**
+ * Denying an action with a simulated service control policy.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+simAws.organizations().attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyBucketCreation",
+    Effect: "Deny",
+    Action: "s3:CreateBucket",
+    Resource: "*",
+  },
+});
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::reports-bucket",
+});
+
+console.log(decision.value); // "ExplicitDeny"
+console.log(decision.serviceControlPolicy.isDenied); // true
+console.log(decision.serviceControlPolicy.denyStatements[0]?.Sid); // "DenyBucketCreation"
+```
+
+The account also gets AWS's own `FullAWSAccess` policy, as it would in a real organization. One
+`Deny` statement therefore denies that one action and leaves the rest of the account working.
+
+An account nothing is attached to is outside the organization's reach, and its identity and
+resource policies decide its requests as they did before.
+
+## Catch a deployment the policy denies
+
+Sim CloudFormation creates each resource through the owning service's command handler, and that
+handler authorizes. A deployment carries no caller, so IAM decides it as the account root, and an
+SCP applies to a member account's root the same way AWS does.
+
+```typescript sim-organizations-scp-deployment
+/**
+ * A CloudFormation Resource a service control policy denies.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+simAws.organizations().attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+});
+
+try {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "reports-stack",
+    template: {
+      Resources: {
+        ReportsBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "reports-bucket" },
+        },
+      },
+    },
+  });
+
+  await stack.waitForDeployComplete();
+} catch (error) {
+  // "... is not authorized to perform: s3:CreateBucket on resource:
+  //  arn:aws:s3:::reports-bucket with an explicit deny in a service control policy"
+  console.log((error as Error).message);
+}
+
+const failed = simAws
+  .cloudFormation()
+  .getStackByName("reports-stack")
+  ?.getResource("ReportsBucket");
+
+console.log(failed?.status); // "CREATE_FAILED"
+```
+
+The resource is left `CREATE_FAILED` and the deployment rejects. A test asserting that a stack
+deploys then fails on the policy, with the policy named in the message.
+
+## Write an allow list instead of a deny list
+
+`detachFullAwsAccess` takes AWS's own policy off an account. What remains has to allow an action
+for the account to be allowed it, which is an organization run as an allow list.
+
+```typescript sim-organizations-scp-allow-list
+/**
+ * Allowing only what the attached policies name.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const organizations = simAws.organizations();
+
+organizations.detachFullAwsAccess("123456789012");
+organizations.attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "dynamodb:*", Resource: "*" },
+});
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:GetObject",
+  resource: "arn:aws:s3:::reports-bucket/summary.csv",
+});
+
+console.log(decision.value); // "ImplicitDeny"
+console.log(decision.denialReason);
+// "because no service control policy allows the s3:GetObject action"
+```
+
+An account root holds unrestricted access in sim IAM, and this denies it anyway. That is what an
+SCP does in AWS, and it is why an allow list is worth writing in a test at all.
+
+## Reading a denial
+
+An authorization decision reports the organization's verdict apart from the identity and resource
+sides, through `decision.serviceControlPolicy`:
+
+| Property          | Meaning                                                     |
+| ----------------- | ----------------------------------------------------------- |
+| `isApplied`       | Whether any service control policy applied to the request.  |
+| `isDenied`        | Whether the attached policies denied it, either way.        |
+| `isExplicitDeny`  | Whether a matching `Deny` statement denied it.              |
+| `isImplicitDeny`  | Whether the attached policies produced no matching `Allow`. |
+| `denyStatements`  | The matching `Deny` statements.                             |
+| `allowStatements` | The matching `Allow` statements.                            |
+
+`decision.denialReason` carries the wording AWS puts on the `AccessDenied` message, and every
+simulated service passes it through to the error it throws.
+
+`simAws.organizations().serviceControlPoliciesFor(accountId)` returns the policies in force for an
+account, in the order they were evaluated, including `FullAWSAccess` where it is still attached.
+
+## Available functionality
+
+Simulated Organizations supports:
+
+- `attachServiceControlPolicy`, attaching a policy document to a simulated Account
+- `detachFullAwsAccess`, turning an Account's policies into an allow list
+- `detachServiceControlPolicies`, putting an Account back outside the organization's reach
+- `serviceControlPoliciesFor`, reading the policies in force for an Account
+- The AWS-managed `FullAWSAccess` policy, attached by default as it is in AWS
+- Evaluation ahead of identity and resource policies, for every principal in the Account including
+  its root
+- `Action`, `NotAction`, `Resource`, `NotResource` and `Condition` in an SCP statement
+- The `ArnEquals`, `ArnLike`, `NumericLessThanEquals`, `StringEquals` and `StringLike` condition
+  operators, and their `ForAnyValue:` and `ForAllValues:` set forms
+- `AccessDenied` messages naming the service control policy, as AWS words them
+- Denial reporting through `decision.serviceControlPolicy`
+
+## Limitations
+
+| Limitation                  | Detail                                                                                                                                                         |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Organization structure      | Policies attach to an Account directly. Roots, organizational units and inheritance down a tree are not simulated.                                             |
+| Management account          | No Account is designated the management account, so no Account is exempt from evaluation. Attach nothing to an Account that stands for the management account. |
+| Service-linked roles        | Evaluated like any other principal. AWS exempts a service-linked role from SCPs.                                                                               |
+| Other policy types          | Resource control policies, declarative policies, tag policies, backup policies and AI services opt-out policies are not simulated.                             |
+| The Organizations SDK       | `CreatePolicy`, `AttachPolicy`, `ListAccounts` and the rest of the API are not handled. Policies are attached through the accessor.                            |
+| CloudFormation              | `AWS::Organizations::Organization`, `::OrganizationalUnit`, `::Account` and `::Policy` are not created from a template.                                        |
+| Organization condition keys | `aws:PrincipalOrgID` and `aws:PrincipalOrgPaths` are not populated. A condition naming either fails to match.                                                  |
+| Service principals          | A request whose caller is a service principal or anonymous belongs to no Account and is subject to no policy.                                                  |
+| Condition operator coverage | An operator sim IAM does not know fails closed, so the statement holding it never matches.                                                                     |
+| HTTP API                    | Organizations is not served as an HTTP API by `serveSimAws`.                                                                                                   |

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -45,8 +45,8 @@ console.log(decision.serviceControlPolicy.denyStatements[0]?.Sid); // "DenyBucke
 The account also gets AWS's own `FullAWSAccess` policy, as it would in a real organization. One
 `Deny` statement therefore denies that one action and leaves the rest of the account working.
 
-An account nothing is attached to is outside the organization's reach, and its identity and
-resource policies decide its requests as they did before.
+An account with no policy attached to it stays outside the organization's reach, and its identity
+and resource policies decide its requests as they did before.
 
 ## Catch a deployment the policy denies
 
@@ -133,6 +133,9 @@ console.log(decision.denialReason);
 An account root holds unrestricted access in sim IAM, and this denies it anyway. That is what an
 SCP does in AWS, and it is why an allow list is worth writing in a test at all.
 
+Detaching `FullAWSAccess` on its own leaves the account holding no policy, and every action is then
+denied. AWS behaves the same way, and warns about it.
+
 ## Reading a denial
 
 An authorization decision reports the organization's verdict apart from the identity and resource
@@ -153,6 +156,12 @@ simulated service passes it through to the error it throws.
 `simAws.organizations().serviceControlPoliciesFor(accountId)` returns the policies in force for an
 account, in the order they were evaluated, including `FullAWSAccess` where it is still attached.
 
+That list is empty in two cases that behave differently. An account that was never attached to sits
+outside the organization and stays unrestricted. An account left holding no policy is denied
+everything.
+`serviceControlPolicySetFor(accountId).applies` tells the two apart, and so does
+`decision.serviceControlPolicy.isApplied`.
+
 ## Available functionality
 
 Simulated Organizations supports:
@@ -161,6 +170,7 @@ Simulated Organizations supports:
 - `detachFullAwsAccess`, turning an Account's policies into an allow list
 - `detachServiceControlPolicies`, putting an Account back outside the organization's reach
 - `serviceControlPoliciesFor`, reading the policies in force for an Account
+- `serviceControlPolicySetFor`, reading those policies along with whether any apply
 - The AWS-managed `FullAWSAccess` policy, attached by default as it is in AWS
 - Evaluation ahead of identity and resource policies, for every principal in the Account including
   its root

--- a/docs/services/organizations/sim-organizations-attach-scp.example.ts
+++ b/docs/services/organizations/sim-organizations-attach-scp.example.ts
@@ -1,0 +1,26 @@
+/**
+ * Denying an action with a simulated service control policy.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+simAws.organizations().attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyBucketCreation",
+    Effect: "Deny",
+    Action: "s3:CreateBucket",
+    Resource: "*",
+  },
+});
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::reports-bucket",
+});
+
+console.log(decision.value); // "ExplicitDeny"
+console.log(decision.serviceControlPolicy.isDenied); // true
+console.log(decision.serviceControlPolicy.denyStatements[0]?.Sid); // "DenyBucketCreation"

--- a/docs/services/organizations/sim-organizations-scp-allow-list.example.ts
+++ b/docs/services/organizations/sim-organizations-scp-allow-list.example.ts
@@ -1,0 +1,23 @@
+/**
+ * Allowing only what the attached policies name.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const organizations = simAws.organizations();
+
+organizations.detachFullAwsAccess("123456789012");
+organizations.attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "dynamodb:*", Resource: "*" },
+});
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:GetObject",
+  resource: "arn:aws:s3:::reports-bucket/summary.csv",
+});
+
+console.log(decision.value); // "ImplicitDeny"
+console.log(decision.denialReason);
+// "because no service control policy allows the s3:GetObject action"

--- a/docs/services/organizations/sim-organizations-scp-deployment.example.ts
+++ b/docs/services/organizations/sim-organizations-scp-deployment.example.ts
@@ -1,0 +1,39 @@
+/**
+ * A CloudFormation Resource a service control policy denies.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+simAws.organizations().attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+});
+
+try {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "reports-stack",
+    template: {
+      Resources: {
+        ReportsBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "reports-bucket" },
+        },
+      },
+    },
+  });
+
+  await stack.waitForDeployComplete();
+} catch (error) {
+  // "... is not authorized to perform: s3:CreateBucket on resource:
+  //  arn:aws:s3:::reports-bucket with an explicit deny in a service control policy"
+  console.log((error as Error).message);
+}
+
+const failed = simAws
+  .cloudFormation()
+  .getStackByName("reports-stack")
+  ?.getResource("ReportsBucket");
+
+console.log(failed?.status); // "CREATE_FAILED"

--- a/package.json
+++ b/package.json
@@ -142,6 +142,10 @@
     },
     "./oxlint/cffjs2.oxlintrc.json": "./dist/config/oxlint/cffjs2.oxlintrc.json",
     "./package.json": "./package.json",
+    "./organizations": {
+      "import": "./dist/service/organizations/index.js",
+      "types": "./dist/service/organizations/index.d.ts"
+    },
     "./personalize": {
       "import": "./dist/service/personalize/index.js",
       "types": "./dist/service/personalize/index.d.ts"

--- a/src/service/acm/command/delete-certificate/delete-certificate-authorizer.ts
+++ b/src/service/acm/command/delete-certificate/delete-certificate-authorizer.ts
@@ -38,6 +38,7 @@ export class DeleteCertificateAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DeleteCertificateAuthorizer.action,
         resource: certificateArn,
       });

--- a/src/service/acm/command/describe-certificate/describe-certificate-authorizer.ts
+++ b/src/service/acm/command/describe-certificate/describe-certificate-authorizer.ts
@@ -43,6 +43,7 @@ export class DescribeCertificateAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DescribeCertificateAuthorizer.action,
         resource: certificateArn,
       });

--- a/src/service/acm/command/list-certificates/list-certificates-authorizer.ts
+++ b/src/service/acm/command/list-certificates/list-certificates-authorizer.ts
@@ -43,6 +43,7 @@ export class ListCertificatesAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: ListCertificatesAuthorizer.action,
         resource: ListCertificatesAuthorizer.resource,
       });

--- a/src/service/acm/command/request-certificate/request-certificate-authorizer.ts
+++ b/src/service/acm/command/request-certificate/request-certificate-authorizer.ts
@@ -41,6 +41,7 @@ export class RequestCertificateAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: RequestCertificateAuthorizer.action,
         resource: this.resource,
       });

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-policy.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-policy.ts
@@ -57,6 +57,9 @@ export class SimRestApiAuthorizerPolicy {
         },
       ],
       resourcePolicies: [],
+      // An authorizer's policy document is evaluated on its own. No Account
+      // boundary is being crossed here, so no service control policy applies.
+      serviceControlPolicies: [],
       allowRequirement: new SimIamEitherSideAllowRequirement(),
       action: simExecuteApiInvokeAction,
       resource: methodArn,

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-policy.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-policy.ts
@@ -59,7 +59,7 @@ export class SimRestApiAuthorizerPolicy {
       resourcePolicies: [],
       // An authorizer's policy document is evaluated on its own. No Account
       // boundary is being crossed here, so no service control policy applies.
-      serviceControlPolicies: [],
+      serviceControlPolicies: { applies: false, sources: [] },
       allowRequirement: new SimIamEitherSideAllowRequirement(),
       action: simExecuteApiInvokeAction,
       resource: methodArn,

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-policy.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-policy.ts
@@ -45,7 +45,7 @@ export class SimHttpApiAuthorizerPolicy {
       resourcePolicies: [],
       // An authorizer's policy document is evaluated on its own. No Account
       // boundary is being crossed here, so no service control policy applies.
-      serviceControlPolicies: [],
+      serviceControlPolicies: { applies: false, sources: [] },
       allowRequirement: new SimIamEitherSideAllowRequirement(),
       action: simExecuteApiInvokeAction,
       resource: routeArn,

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-policy.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-policy.ts
@@ -43,6 +43,9 @@ export class SimHttpApiAuthorizerPolicy {
         },
       ],
       resourcePolicies: [],
+      // An authorizer's policy document is evaluated on its own. No Account
+      // boundary is being crossed here, so no service control policy applies.
+      serviceControlPolicies: [],
       allowRequirement: new SimIamEitherSideAllowRequirement(),
       action: simExecuteApiInvokeAction,
       resource: routeArn,

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -16,6 +16,7 @@ import type { SimRoute53Registry } from "../../route53/registry/sim-route53-regi
 import type { SimKmsRegistry } from "../../kms/registry/sim-kms-registry.js";
 import { SimIam } from "../../iam/index.js";
 import type { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
+import type { SimIamServiceControlPolicyResolver } from "../../iam/authorize/scp/sim-iam-scp-resolver.js";
 import {
   SimIamAccountAccessKeyIndex,
   type SimIamAccessKeyRegistry,
@@ -37,6 +38,7 @@ interface SimAwsAccountServiceCacheProperties {
   readonly shadowableServiceHosts: SimAwsServiceHosts;
   readonly iamRegistry: SimIamRegistry;
   readonly accessKeyRegistry: SimIamAccessKeyRegistry;
+  readonly scpResolver: SimIamServiceControlPolicyResolver;
 }
 
 /**
@@ -67,6 +69,7 @@ export class SimAwsAccountServiceCache {
   private readonly cloudFrontRegistry: SimCloudFrontRegistry;
   private readonly iamRegistry: SimIamRegistry;
   private readonly accessKeyRegistry: SimIamAccessKeyRegistry;
+  private readonly scpResolver: SimIamServiceControlPolicyResolver;
   private readonly route53Registry: SimRoute53Registry;
   private readonly kmsRegistry: SimKmsRegistry;
   private readonly serviceHosts: SimAwsServiceHosts;
@@ -87,6 +90,7 @@ export class SimAwsAccountServiceCache {
     this.acmRegistry = properties.acmRegistry;
     this.cloudFrontRegistry = properties.cloudFrontRegistry;
     this.iamRegistry = properties.iamRegistry;
+    this.scpResolver = properties.scpResolver;
     this.accessKeyRegistry = properties.accessKeyRegistry;
     this.route53Registry = properties.route53Registry;
     this.kmsRegistry = properties.kmsRegistry;
@@ -153,6 +157,9 @@ export class SimAwsAccountServiceCache {
           // A cross-Account request is decided in both Accounts, so this IAM
           // needs to be able to reach the IAM of the caller's own Account.
           iamResolver: this.iamRegistry,
+          // What the Account's organization allows it to do is decided outside
+          // the Account, so IAM asks simulated Organizations about it.
+          scpResolver: this.scpResolver,
           // Access keys are indexed simulation-wide as they are issued, so a
           // signed request naming only a key id can be traced to this Account.
           credentialRegistry: new SimIamCredentialRegistry({

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -25,6 +25,7 @@ import type { SimScheduler } from "../../scheduler/index.js";
 import type { SimElbV2 } from "../../elbv2/index.js";
 import type { SimIam } from "../../iam/index.js";
 import { SimIamRegistry } from "../../iam/registry/sim-iam-registry.js";
+import { SimOrganizations } from "../../organizations/index.js";
 import type { SimFirehose } from "../../firehose/index.js";
 import type { SimGlue } from "../../glue/index.js";
 import type { SimKinesis } from "../../kinesis/index.js";
@@ -89,6 +90,15 @@ export class SimAwsServiceFactory {
   public readonly iamRegistry = new SimIamRegistry();
 
   /**
+   * Simulated AWS Organizations for this simulation.
+   *
+   * An organization spans Accounts, so one belongs to the simulation rather
+   * than to any scope in it. Sim IAM reads the service control policies it
+   * holds when it decides a request.
+   */
+  public readonly organizations = new SimOrganizations();
+
+  /**
    * Shared request authentication collaborators for this simulation.
    * @internal
    */
@@ -147,6 +157,7 @@ export class SimAwsServiceFactory {
       shadowableServiceHosts: this.registries.shadowableServiceHosts,
       iamRegistry: this.iamRegistry,
       accessKeyRegistry: this.requestAuth.accessKeyRegistry,
+      scpResolver: this.organizations,
     });
     this.accountRegionServices = new SimAwsAccountRegionServiceBuilder({
       simAws: properties.simAws,

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -17,6 +17,7 @@ import { SimAwsServiceFactory } from "./factory/sim-aws-service-factory.js";
 import { SimAwsScopeRegistry } from "./scope/sim-aws-scope-registry.js";
 import { SimAwsServiceAccessors } from "./sim-aws-service-accessors.js";
 import type { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
+import type { SimOrganizations } from "../organizations/index.js";
 import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
 import { simAwsRunAsContext } from "./caller/sim-aws-run-as-context.js";
 import type { SimClockControl } from "../../util/clock/sim-clock-control.js";
@@ -91,6 +92,26 @@ export class SimAws extends SimAwsServiceAccessors {
       requestAuth: this.serviceFactory.requestAuth,
       clock: background,
     });
+  }
+
+  /**
+   * Get simulated AWS Organizations for this simulated AWS environment.
+   *
+   * An organization spans Accounts, so this one belongs to the whole
+   * simulation and is reached here rather than from an Account scope. The
+   * service control policies attached through it filter what the Accounts in
+   * this simulation may do, whether a request arrives through a CloudFormation
+   * deployment, an intercepted SDK client, or a service call in a handler.
+   *
+   * ```typescript
+   * simAws.organizations().attachServiceControlPolicy("123456789012", {
+   *   Version: "2012-10-17",
+   *   Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+   * });
+   * ```
+   */
+  organizations(): SimOrganizations {
+    return this.serviceFactory.organizations;
   }
 
   /**

--- a/src/service/cloudfront/command/create-distribution/create-distribution-authorizer.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution-authorizer.ts
@@ -39,6 +39,7 @@ export class CreateDistributionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: CreateDistributionAuthorizer.action,
         resource: CreateDistributionAuthorizer.resource,
       });

--- a/src/service/cloudfront/command/create-function/create-function-authorizer.ts
+++ b/src/service/cloudfront/command/create-function/create-function-authorizer.ts
@@ -43,6 +43,7 @@ export class CreateFunctionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: CreateFunctionAuthorizer.action,
         resource,
       });

--- a/src/service/cloudfront/command/delete-distribution/delete-distribution-authorizer.ts
+++ b/src/service/cloudfront/command/delete-distribution/delete-distribution-authorizer.ts
@@ -48,6 +48,7 @@ export class DeleteDistributionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DeleteDistributionAuthorizer.action,
         resource,
       });

--- a/src/service/cloudfront/command/delete-function/delete-function-authorizer.ts
+++ b/src/service/cloudfront/command/delete-function/delete-function-authorizer.ts
@@ -44,6 +44,7 @@ export class DeleteFunctionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DeleteFunctionAuthorizer.action,
         resource,
       });

--- a/src/service/cloudfront/command/get-distribution/get-distribution-authorizer.ts
+++ b/src/service/cloudfront/command/get-distribution/get-distribution-authorizer.ts
@@ -44,6 +44,7 @@ export class GetDistributionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: GetDistributionAuthorizer.action,
         resource,
       });

--- a/src/service/cloudfront/command/update-distribution/update-distribution-authorizer.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution-authorizer.ts
@@ -44,6 +44,7 @@ export class UpdateDistributionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: UpdateDistributionAuthorizer.action,
         resource,
       });

--- a/src/service/cloudfront/edge/sim-cf-edge-association-auth-z.ts
+++ b/src/service/cloudfront/edge/sim-cf-edge-association-auth-z.ts
@@ -27,6 +27,7 @@ export function authorizeEdgeAssociation(
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource: functionArn,
       });

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-access.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-access.ts
@@ -43,6 +43,7 @@ export class SimCfKeyValueStoreAccess {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/cloudwatch/command/authorize/sim-cloudwatch-decide.ts
+++ b/src/service/cloudwatch/command/authorize/sim-cloudwatch-decide.ts
@@ -41,6 +41,7 @@ export function decideSimCloudWatchRequest(
   if (decision.isDenied) {
     throw new SimIamAccessDenied({
       principal: decision.caller.principal,
+      reason: decision.denialReason,
       action,
       resource,
     });

--- a/src/service/cognito/command/authorize/sim-cognito-authorizer.ts
+++ b/src/service/cognito/command/authorize/sim-cognito-authorizer.ts
@@ -73,6 +73,7 @@ export class SimCognitoAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-authorizer.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-authorizer.ts
@@ -91,6 +91,7 @@ export class SimDynamoDbAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/firehose/command/authorize/sim-firehose-authorizer.ts
+++ b/src/service/firehose/command/authorize/sim-firehose-authorizer.ts
@@ -63,6 +63,7 @@ export class SimFirehoseAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/glue/command/authorize/sim-glue-authorize-resources.ts
+++ b/src/service/glue/command/authorize/sim-glue-authorize-resources.ts
@@ -29,6 +29,7 @@ export function authorizeSimGlueResources(
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/iam/authorize/allow/sim-iam-policy-evaluation.ts
+++ b/src/service/iam/authorize/allow/sim-iam-policy-evaluation.ts
@@ -1,0 +1,85 @@
+import type { SimIamPolicyDocumentStatement } from "../../policy/sim-iam-policy.js";
+import type { SimIamPolicyDocumentParser } from "../../policy/parse/sim-iam-document-parser.js";
+import type { SimIamPolicyStatementMatcher } from "../match/sim-iam-policy-statement-matcher.js";
+import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
+import { SimIamAllowStatements } from "./sim-iam-allow-statements.js";
+import type { SimIamAllowSides } from "./sim-iam-allow-requirement.js";
+
+interface SimIamPolicyEvaluationProperties {
+  readonly policies: readonly SimIamAuthZPolicySource[];
+  readonly policyDocumentParser: SimIamPolicyDocumentParser;
+  readonly statementMatcher: SimIamPolicyStatementMatcher;
+}
+
+/**
+ * The statements of the identity and resource policies that matched one
+ * request.
+ *
+ * These are the two sides that can allow a request, so they are read together
+ * and kept apart by side afterwards. Which of them has to allow for the
+ * request to go ahead belongs to the allow requirement rather than here.
+ */
+export class SimIamPolicyEvaluation {
+  private readonly explicitDenyStatementRecords: SimIamPolicyDocumentStatement[] =
+    [];
+  private readonly allows = new SimIamAllowStatements();
+
+  constructor(properties: SimIamPolicyEvaluationProperties) {
+    for (const policy of properties.policies) {
+      this.evaluate(policy, properties);
+    }
+  }
+
+  /**
+   * Whether a matching Deny statement was found.
+   */
+  get isExplicitDeny(): boolean {
+    return this.explicitDenyStatementRecords.length > 0;
+  }
+
+  /**
+   * Matching explicit Deny statements.
+   */
+  get explicitDenyStatements(): readonly SimIamPolicyDocumentStatement[] {
+    return this.explicitDenyStatementRecords;
+  }
+
+  /**
+   * The matching Allow statements, kept per side.
+   */
+  get allowStatements(): SimIamAllowStatements {
+    return this.allows;
+  }
+
+  /**
+   * Which sides produced a matching Allow.
+   */
+  get sides(): SimIamAllowSides {
+    return this.allows.sides;
+  }
+
+  /**
+   * Record the matching statements of one policy.
+   */
+  private evaluate(
+    policy: SimIamAuthZPolicySource,
+    properties: SimIamPolicyEvaluationProperties,
+  ): void {
+    const parsedPolicy = properties.policyDocumentParser.parse(policy.document);
+
+    for (const statement of parsedPolicy.statements) {
+      const principal = properties.statementMatcher.matches(policy, statement);
+
+      if (!principal.matched) {
+        continue;
+      }
+
+      if (statement.effect === "Deny") {
+        this.explicitDenyStatementRecords.push(statement.source);
+        continue;
+      }
+
+      this.allows.record(policy, statement.source, principal);
+    }
+  }
+}

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -30,6 +30,8 @@ import type {
   SimAwsResolvedCaller,
 } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimIamUser, SimIamUsername } from "../../user/sim-iam-user.js";
+import { SimIamAuthZScpSourceBuilder } from "./sim-iam-auth-z-scp-source-builder.js";
+import type { SimIamServiceControlPolicyResolver } from "../scp/sim-iam-scp-resolver.js";
 
 export interface SimIamResourcePolicyInput {
   readonly document: SimIamPolicyDocument;
@@ -114,6 +116,12 @@ interface SimIamAuthZContextBuilderProperties {
    * of a cross-Account request.
    */
   readonly iamResolver?: SimIamAccountResolver | undefined;
+
+  /**
+   * Resolves the service control policies in force for an Account. A
+   * standalone SimIam has no organization around it and leaves this out.
+   */
+  readonly scpResolver?: SimIamServiceControlPolicyResolver | undefined;
 }
 
 /**
@@ -137,16 +145,21 @@ interface SimIamAuthZContextBuilderProperties {
  * They are passed through the authorization input rather than loaded from the
  * IAM role or managed-policy stores.
  *
- * Permissions boundaries, session policies, SCPs, and role trust-policy
- * assume-role semantics are not part of this context assembly path yet. Add
- * those concerns through separate policy-source builders so this class stays
- * focused on composing the authorization request.
+ * Service control policies come from the organization the caller's Account
+ * belongs to, read by SimIamAuthZScpSourceBuilder. They filter and grant
+ * nothing, so they travel apart from the sides that can allow a request.
+ *
+ * Permissions boundaries, session policies, and role trust-policy assume-role
+ * semantics are not part of this context assembly path yet. Add those concerns
+ * through separate policy-source builders so this class stays focused on
+ * composing the authorization request.
  */
 export class SimIamAuthZContextBuilder {
   private readonly callerContextBuilder: SimIamAuthZCallerContextBuilder;
   private readonly identityPolicyCoordinator: SimIamAuthZIdentityPolicyCoordinator;
   private readonly callerAccountResolver: SimIamCallerAccountResolver;
   private readonly allowRequirement = new SimIamAuthZAllowRequirement();
+  private readonly scpSourceBuilder: SimIamAuthZScpSourceBuilder;
 
   constructor(properties: SimIamAuthZContextBuilderProperties) {
     this.callerContextBuilder = new SimIamAuthZCallerContextBuilder(
@@ -161,6 +174,10 @@ export class SimIamAuthZContextBuilder {
     this.callerAccountResolver = new SimIamCallerAccountResolver({
       accountId: properties.accountId,
       iamResolver: properties.iamResolver,
+    });
+    this.scpSourceBuilder = new SimIamAuthZScpSourceBuilder({
+      accountId: properties.accountId,
+      scpResolver: properties.scpResolver,
     });
   }
 
@@ -179,6 +196,7 @@ export class SimIamAuthZContextBuilder {
         ...callerAccount.identityPolicies,
       ],
       resourcePolicies: this.resourcePolicySources(input),
+      serviceControlPolicies: this.scpSourceBuilder.build(callerContext.caller),
       allowRequirement: this.allowRequirement.resolve(
         callerAccount,
         input.requiresResourcePolicyAllow,

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
@@ -11,6 +11,7 @@ import type {
 export const simIamAuthZContextFactory = new StaticFactory<SimIamAuthZContext>({
   identityPolicies: [],
   resourcePolicies: [],
+  serviceControlPolicies: [],
   allowRequirement: new SimIamEitherSideAllowRequirement(),
   action: "s3:GetObject",
   resource: "arn:aws:s3:::test-bucket/test-key",

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
@@ -11,7 +11,7 @@ import type {
 export const simIamAuthZContextFactory = new StaticFactory<SimIamAuthZContext>({
   identityPolicies: [],
   resourcePolicies: [],
-  serviceControlPolicies: [],
+  serviceControlPolicies: { applies: false, sources: [] },
   allowRequirement: new SimIamEitherSideAllowRequirement(),
   action: "s3:GetObject",
   resource: "arn:aws:s3:::test-bucket/test-key",

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
@@ -12,7 +12,8 @@ export type SimIamAuthZPolicySourceType =
   | "resource"
   | "trust"
   | "permissions-boundary"
-  | "session";
+  | "session"
+  | "service-control";
 
 export interface SimIamAuthZPolicySource {
   readonly sourceType: SimIamAuthZPolicySourceType;
@@ -49,6 +50,15 @@ export interface SimIamAuthZContext {
    * Resource policies are not gathered from IAM's managed policy store.
    */
   readonly resourcePolicies: readonly SimIamAuthZPolicySource[];
+
+  /**
+   * Service control policies in force for the caller's Account.
+   *
+   * These filter what the Account's principals may do and grant nothing, so
+   * they are kept apart from the two sides that can allow a request. An empty
+   * list means the caller's Account is subject to none.
+   */
+  readonly serviceControlPolicies: readonly SimIamAuthZPolicySource[];
 
   /**
    * How an Allow from each policy side combines into the final decision.

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
@@ -36,6 +36,18 @@ export type SimIamAuthZResourcePolicySource = Omit<
   >;
 };
 
+/**
+ * The service control policies in force for an authorization request.
+ *
+ * `applies` is a separate fact from how many sources there are. An Account
+ * inside an organization that holds no policy allows nothing, while an Account
+ * outside every organization is unrestricted, and both carry no sources.
+ */
+export interface SimIamAuthZServiceControlPolicies {
+  readonly applies: boolean;
+  readonly sources: readonly SimIamAuthZPolicySource[];
+}
+
 export interface SimIamAuthZContext {
   /**
    * Identity-based policies that grant permissions to the principal.
@@ -55,10 +67,9 @@ export interface SimIamAuthZContext {
    * Service control policies in force for the caller's Account.
    *
    * These filter what the Account's principals may do and grant nothing, so
-   * they are kept apart from the two sides that can allow a request. An empty
-   * list means the caller's Account is subject to none.
+   * they are kept apart from the two sides that can allow a request.
    */
-  readonly serviceControlPolicies: readonly SimIamAuthZPolicySource[];
+  readonly serviceControlPolicies: SimIamAuthZServiceControlPolicies;
 
   /**
    * How an Allow from each policy side combines into the final decision.

--- a/src/service/iam/authorize/context/sim-iam-auth-z-scp-source-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-scp-source-builder.ts
@@ -1,0 +1,83 @@
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import { isSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamServiceControlPolicyResolver } from "../scp/sim-iam-scp-resolver.js";
+import type { SimIamAuthZPolicySource } from "./sim-iam-auth-z-context.js";
+
+interface SimIamAuthZScpSourceBuilderProperties {
+  /**
+   * The Account whose IAM is evaluating the request.
+   */
+  readonly accountId: SimAwsAccountId;
+
+  readonly scpResolver?: SimIamServiceControlPolicyResolver | undefined;
+}
+
+/**
+ * Finds the service control policies that apply to one request.
+ *
+ * An SCP belongs to the caller's own Account, which is the Account whose
+ * principal is asking. For a request within one Account that is the Account
+ * evaluating it. For a cross-Account request it is the other one, because AWS
+ * filters a principal by the organization its own account sits in and leaves
+ * the resource's organization to say nothing about it.
+ *
+ * A caller with no Account in its ARN, which means a service principal or an
+ * anonymous request, belongs to no Account and is subject to no SCP.
+ */
+export class SimIamAuthZScpSourceBuilder {
+  private readonly accountId: SimAwsAccountId;
+  private readonly scpResolver?: SimIamServiceControlPolicyResolver | undefined;
+
+  constructor(properties: SimIamAuthZScpSourceBuilderProperties) {
+    this.accountId = properties.accountId;
+    this.scpResolver = properties.scpResolver;
+  }
+
+  /**
+   * The service control policy sources in force for a resolved caller.
+   */
+  build(caller: SimAwsResolvedCaller): readonly SimIamAuthZPolicySource[] {
+    const scpResolver = this.scpResolver;
+
+    if (scpResolver === undefined) {
+      return [];
+    }
+
+    const accountId = this.callerAccountId(caller);
+
+    if (accountId === undefined) {
+      return [];
+    }
+
+    return scpResolver.serviceControlPoliciesFor(accountId).map((policy) => ({
+      sourceType: "service-control" as const,
+      document: policy.document,
+      policyName: policy.policyName,
+    }));
+  }
+
+  /**
+   * The Account whose organization decides this request.
+   *
+   * A caller identified only by a service name or by nothing at all has no
+   * Account of its own. The Account root fallback IAM applies to a request
+   * with no caller carries this Account's id, so a CloudFormation deployment
+   * is filtered like any other principal in it.
+   */
+  private callerAccountId(
+    caller: SimAwsResolvedCaller,
+  ): SimAwsAccountId | undefined {
+    if (caller.principal.kind === "anonymous" || caller.service !== undefined) {
+      return undefined;
+    }
+
+    const callerAccountId = caller.accountId;
+
+    if (callerAccountId === undefined) {
+      return this.accountId;
+    }
+
+    return isSimAwsAccountId(callerAccountId) ? callerAccountId : undefined;
+  }
+}

--- a/src/service/iam/authorize/context/sim-iam-auth-z-scp-source-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-scp-source-builder.ts
@@ -2,7 +2,7 @@ import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import { isSimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import type { SimIamServiceControlPolicyResolver } from "../scp/sim-iam-scp-resolver.js";
-import type { SimIamAuthZPolicySource } from "./sim-iam-auth-z-context.js";
+import type { SimIamAuthZServiceControlPolicies } from "./sim-iam-auth-z-context.js";
 
 interface SimIamAuthZScpSourceBuilderProperties {
   /**
@@ -26,6 +26,14 @@ interface SimIamAuthZScpSourceBuilderProperties {
  * anonymous request, belongs to no Account and is subject to no SCP.
  */
 export class SimIamAuthZScpSourceBuilder {
+  /**
+   * What a caller no organization reaches is subject to.
+   */
+  private static readonly unrestricted: SimIamAuthZServiceControlPolicies = {
+    applies: false,
+    sources: [],
+  };
+
   private readonly accountId: SimAwsAccountId;
   private readonly scpResolver?: SimIamServiceControlPolicyResolver | undefined;
 
@@ -35,26 +43,31 @@ export class SimIamAuthZScpSourceBuilder {
   }
 
   /**
-   * The service control policy sources in force for a resolved caller.
+   * The service control policies in force for a resolved caller.
    */
-  build(caller: SimAwsResolvedCaller): readonly SimIamAuthZPolicySource[] {
+  build(caller: SimAwsResolvedCaller): SimIamAuthZServiceControlPolicies {
     const scpResolver = this.scpResolver;
 
     if (scpResolver === undefined) {
-      return [];
+      return SimIamAuthZScpSourceBuilder.unrestricted;
     }
 
     const accountId = this.callerAccountId(caller);
 
     if (accountId === undefined) {
-      return [];
+      return SimIamAuthZScpSourceBuilder.unrestricted;
     }
 
-    return scpResolver.serviceControlPoliciesFor(accountId).map((policy) => ({
-      sourceType: "service-control" as const,
-      document: policy.document,
-      policyName: policy.policyName,
-    }));
+    const set = scpResolver.serviceControlPolicySetFor(accountId);
+
+    return {
+      applies: set.applies,
+      sources: set.policies.map((policy) => ({
+        sourceType: "service-control" as const,
+        document: policy.document,
+        policyName: policy.policyName,
+      })),
+    };
   }
 
   /**

--- a/src/service/iam/authorize/scp/sim-iam-scp-gate.ts
+++ b/src/service/iam/authorize/scp/sim-iam-scp-gate.ts
@@ -1,11 +1,14 @@
 import type { SimIamPolicyDocumentStatement } from "../../policy/sim-iam-policy.js";
 import type { SimIamPolicyDocumentParser } from "../../policy/parse/sim-iam-document-parser.js";
 import type { SimIamPolicyStatementMatcher } from "../match/sim-iam-policy-statement-matcher.js";
-import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
-import { SimIamPolicyDecisionValue } from "../sim-iam-decision.js";
+import type {
+  SimIamAuthZPolicySource,
+  SimIamAuthZServiceControlPolicies,
+} from "../context/sim-iam-auth-z-context.js";
+import { SimIamPolicyDecisionValue } from "../sim-iam-decision-value.js";
 
 interface SimIamScpGateProperties {
-  readonly policies: readonly SimIamAuthZPolicySource[];
+  readonly serviceControlPolicies: SimIamAuthZServiceControlPolicies;
   readonly policyDocumentParser: SimIamPolicyDocumentParser;
   readonly statementMatcher: SimIamPolicyStatementMatcher;
 }
@@ -21,8 +24,9 @@ interface SimIamScpGateProperties {
  * - a matching Deny in any attached policy ends the request;
  * - the attached policies have to produce a matching Allow between them.
  *
- * An Account with nothing attached is outside any organization's reach, and
- * this gate stands open for it.
+ * An Account outside any organization's reach is unrestricted, and this gate
+ * stands open for it. An Account inside one that holds no policy is a
+ * different case: nothing allows it anything, so the gate is shut.
  */
 export class SimIamScpGate {
   private readonly applies: boolean;
@@ -30,9 +34,9 @@ export class SimIamScpGate {
   private readonly allowStatementRecords: SimIamPolicyDocumentStatement[] = [];
 
   constructor(properties: SimIamScpGateProperties) {
-    this.applies = properties.policies.length > 0;
+    this.applies = properties.serviceControlPolicies.applies;
 
-    for (const policy of properties.policies) {
+    for (const policy of properties.serviceControlPolicies.sources) {
       this.evaluate(policy, properties);
     }
   }

--- a/src/service/iam/authorize/scp/sim-iam-scp-gate.ts
+++ b/src/service/iam/authorize/scp/sim-iam-scp-gate.ts
@@ -1,0 +1,146 @@
+import type { SimIamPolicyDocumentStatement } from "../../policy/sim-iam-policy.js";
+import type { SimIamPolicyDocumentParser } from "../../policy/parse/sim-iam-document-parser.js";
+import type { SimIamPolicyStatementMatcher } from "../match/sim-iam-policy-statement-matcher.js";
+import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
+import { SimIamPolicyDecisionValue } from "../sim-iam-decision.js";
+
+interface SimIamScpGateProperties {
+  readonly policies: readonly SimIamAuthZPolicySource[];
+  readonly policyDocumentParser: SimIamPolicyDocumentParser;
+  readonly statementMatcher: SimIamPolicyStatementMatcher;
+}
+
+/**
+ * What an Account's service control policies say about one request.
+ *
+ * An SCP is a filter on the permissions an Account's principals can be given.
+ * It grants nothing, so this runs as a gate in front of the identity and
+ * resource policy evaluation instead of contributing Allows to it. The rules
+ * are the two AWS applies at the Account boundary:
+ *
+ * - a matching Deny in any attached policy ends the request;
+ * - the attached policies have to produce a matching Allow between them.
+ *
+ * An Account with nothing attached is outside any organization's reach, and
+ * this gate stands open for it.
+ */
+export class SimIamScpGate {
+  private readonly applies: boolean;
+  private readonly denyStatementRecords: SimIamPolicyDocumentStatement[] = [];
+  private readonly allowStatementRecords: SimIamPolicyDocumentStatement[] = [];
+
+  constructor(properties: SimIamScpGateProperties) {
+    this.applies = properties.policies.length > 0;
+
+    for (const policy of properties.policies) {
+      this.evaluate(policy, properties);
+    }
+  }
+
+  /**
+   * Whether any service control policy applied to this request at all.
+   */
+  get isApplied(): boolean {
+    return this.applies;
+  }
+
+  /**
+   * Whether an attached policy explicitly denied the request.
+   */
+  get isExplicitDeny(): boolean {
+    return this.denyStatementRecords.length > 0;
+  }
+
+  /**
+   * Whether the attached policies left the request unallowed.
+   *
+   * A Deny is reported by `isExplicitDeny` and leaves this false, so the two
+   * name different denials and a reader can tell them apart.
+   */
+  get isImplicitDeny(): boolean {
+    return (
+      this.applies &&
+      !this.isExplicitDeny &&
+      this.allowStatementRecords.length === 0
+    );
+  }
+
+  /**
+   * Whether the service control policies denied the request either way.
+   */
+  get isDenied(): boolean {
+    return this.isExplicitDeny || this.isImplicitDeny;
+  }
+
+  /**
+   * The decision this gate forces, where it forces one.
+   *
+   * Undefined leaves the request to the identity and resource policies, which
+   * is what an open gate means.
+   */
+  get value(): SimIamPolicyDecisionValue | undefined {
+    if (this.isExplicitDeny) {
+      return SimIamPolicyDecisionValue.ExplicitDeny;
+    }
+
+    return this.isImplicitDeny
+      ? SimIamPolicyDecisionValue.ImplicitDeny
+      : undefined;
+  }
+
+  /**
+   * Matching Deny statements from the attached policies.
+   */
+  get denyStatements(): readonly SimIamPolicyDocumentStatement[] {
+    return this.denyStatementRecords;
+  }
+
+  /**
+   * Matching Allow statements from the attached policies.
+   */
+  get allowStatements(): readonly SimIamPolicyDocumentStatement[] {
+    return this.allowStatementRecords;
+  }
+
+  /**
+   * How an AWS error explains this denial, if this gate is what denied it.
+   *
+   * The wording follows the AccessDenied messages AWS returns for the two
+   * cases, so a test asserting on the message reads what it would in a real
+   * account.
+   */
+  denialReason(action: string): string | undefined {
+    if (this.isExplicitDeny) {
+      return "with an explicit deny in a service control policy";
+    }
+
+    if (this.isImplicitDeny) {
+      return `because no service control policy allows the ${action} action`;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Record the matching statements of one attached policy.
+   */
+  private evaluate(
+    policy: SimIamAuthZPolicySource,
+    properties: SimIamScpGateProperties,
+  ): void {
+    const parsedPolicy = properties.policyDocumentParser.parse(policy.document);
+
+    for (const statement of parsedPolicy.statements) {
+      if (!properties.statementMatcher.matches(policy, statement).matched) {
+        continue;
+      }
+
+      if (statement.effect === "Deny") {
+        this.denyStatementRecords.push(statement.source);
+        continue;
+      }
+
+      this.allowStatementRecords.push(statement.source);
+    }
+  }
+}

--- a/src/service/iam/authorize/scp/sim-iam-scp-resolver.ts
+++ b/src/service/iam/authorize/scp/sim-iam-scp-resolver.ts
@@ -13,6 +13,20 @@ export interface SimIamServiceControlPolicy {
 }
 
 /**
+ * The service control policies in force for one Account.
+ *
+ * Whether any apply is a separate fact from how many there are. An Account
+ * whose only attached policy has been detached is still inside the
+ * organization, and nothing allowing an action there denies it. An Account
+ * outside every organization is unrestricted. Both hold no policies, so the
+ * list alone cannot tell them apart.
+ */
+export interface SimIamServiceControlPolicySet {
+  readonly applies: boolean;
+  readonly policies: readonly SimIamServiceControlPolicy[];
+}
+
+/**
  * Where sim IAM asks what an Account's organization allows it to do.
  *
  * IAM belongs to one Account and an organization spans several, so the
@@ -24,10 +38,10 @@ export interface SimIamServiceControlPolicyResolver {
   /**
    * The service control policies in force for an Account.
    *
-   * An empty result means the Account is subject to none, and its identity and
-   * resource policies decide the request on their own.
+   * A set that does not apply leaves the Account's identity and resource
+   * policies to decide the request on their own.
    */
-  serviceControlPoliciesFor(
+  serviceControlPolicySetFor(
     accountId: SimAwsAccountId,
-  ): readonly SimIamServiceControlPolicy[];
+  ): SimIamServiceControlPolicySet;
 }

--- a/src/service/iam/authorize/scp/sim-iam-scp-resolver.ts
+++ b/src/service/iam/authorize/scp/sim-iam-scp-resolver.ts
@@ -1,0 +1,33 @@
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamPolicyDocument } from "../../policy/sim-iam-policy.js";
+
+/**
+ * One service control policy applying to a simulated Account.
+ *
+ * The name travels with the document so a denial can say which policy produced
+ * it, the way an AWS denial names the policy in the console.
+ */
+export interface SimIamServiceControlPolicy {
+  readonly document: SimIamPolicyDocument;
+  readonly policyName?: string | undefined;
+}
+
+/**
+ * Where sim IAM asks what an Account's organization allows it to do.
+ *
+ * IAM belongs to one Account and an organization spans several, so the
+ * organization is reached through this interface instead of being held by IAM
+ * itself. A standalone SimIam has no organization around it and leaves the
+ * resolver out, which is the same as an Account outside any organization.
+ */
+export interface SimIamServiceControlPolicyResolver {
+  /**
+   * The service control policies in force for an Account.
+   *
+   * An empty result means the Account is subject to none, and its identity and
+   * resource policies decide the request on their own.
+   */
+  serviceControlPoliciesFor(
+    accountId: SimAwsAccountId,
+  ): readonly SimIamServiceControlPolicy[];
+}

--- a/src/service/iam/authorize/sim-iam-account-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-account-auth-z.ts
@@ -11,6 +11,7 @@ import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-context-
 import type { SimIamAuthZPolicySource } from "./context/sim-iam-auth-z-context.js";
 import type { SimIamAccountIdentityPolicies } from "./identity/sim-iam-account-identity-policies.js";
 import type { SimIamPolicyDecision } from "./sim-iam-decision.js";
+import type { SimIamServiceControlPolicyResolver } from "./scp/sim-iam-scp-resolver.js";
 
 interface SimIamAccountAuthZProperties {
   readonly accountId: SimAwsAccountId;
@@ -27,6 +28,14 @@ interface SimIamAccountAuthZProperties {
    * standalone SimIam has no simulation around it and so no resolver.
    */
   readonly iamResolver?: SimIamAccountResolver | undefined;
+
+  /**
+   * Resolves the service control policies in force for an Account.
+   *
+   * A simulation with an organization in it supplies this. A standalone SimIam
+   * has none, and its Accounts sit outside any organization.
+   */
+  readonly scpResolver?: SimIamServiceControlPolicyResolver | undefined;
 }
 
 /**
@@ -75,6 +84,7 @@ export class SimIamAccountAuthZ implements SimIamAccountIdentityPolicies {
       users: this.properties.users,
       credentialIdentityResolver: this.properties.credentialIdentityResolver,
       iamResolver: this.properties.iamResolver,
+      scpResolver: this.properties.scpResolver,
     });
   }
 }

--- a/src/service/iam/authorize/sim-iam-action-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-action-authorizer.ts
@@ -35,6 +35,7 @@ export class SimIamActionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/iam/authorize/sim-iam-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-authorizer.ts
@@ -13,6 +13,7 @@ import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimIamAccountResolver } from "../registry/sim-iam-account-resolver.js";
 import type { SimIamAuthZPolicySource } from "./context/sim-iam-auth-z-context.js";
 import type { SimIamAccountIdentityPolicies } from "./identity/sim-iam-account-identity-policies.js";
+import type { SimIamServiceControlPolicyResolver } from "./scp/sim-iam-scp-resolver.js";
 
 interface SimIamAuthorizerProperties {
   readonly accountId: SimAwsAccountId;
@@ -21,6 +22,7 @@ interface SimIamAuthorizerProperties {
   readonly users: ReadonlyMap<SimIamUsername, SimIamUser>;
   readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
   readonly iamResolver?: SimIamAccountResolver | undefined;
+  readonly scpResolver?: SimIamServiceControlPolicyResolver | undefined;
 }
 
 /**
@@ -42,6 +44,7 @@ export class SimIamAuthorizer implements SimIamAccountIdentityPolicies {
       users: properties.users,
       credentialIdentityResolver: properties.credentialIdentityResolver,
       iamResolver: properties.iamResolver,
+      scpResolver: properties.scpResolver,
     });
   }
 

--- a/src/service/iam/authorize/sim-iam-decision-value.ts
+++ b/src/service/iam/authorize/sim-iam-decision-value.ts
@@ -1,0 +1,15 @@
+/**
+ * What one simulated IAM authorization attempt came to.
+ *
+ * A denial is one of two things, and which one it is says what to change. An
+ * explicit deny means a statement matched and refused. An implicit deny means
+ * nothing allowed the request in the first place.
+ */
+export const SimIamPolicyDecisionValue = {
+  ExplicitDeny: "ExplicitDeny",
+  Allow: "Allow",
+  ImplicitDeny: "ImplicitDeny",
+} as const;
+
+export type SimIamPolicyDecisionValue =
+  (typeof SimIamPolicyDecisionValue)[keyof typeof SimIamPolicyDecisionValue];

--- a/src/service/iam/authorize/sim-iam-decision.ts
+++ b/src/service/iam/authorize/sim-iam-decision.ts
@@ -51,7 +51,7 @@ export class SimIamPolicyDecision {
       statementMatcher,
     });
     this.scpGate = new SimIamScpGate({
-      policies: request.serviceControlPolicies,
+      serviceControlPolicies: request.serviceControlPolicies,
       policyDocumentParser,
       statementMatcher,
     });
@@ -144,9 +144,15 @@ export class SimIamPolicyDecision {
    * to say than the action and the resource.
    *
    * A service turns a denied decision into an error and passes this through,
-   * so an SCP denial reads the way it does in a real account.
+   * so an SCP denial reads the way it does in a real account. A matching Deny
+   * in an identity or resource policy is what `value` reports first, and it
+   * needs nothing added to the message, so it leaves this absent.
    */
   get denialReason(): string | undefined {
+    if (this.policies.isExplicitDeny) {
+      return undefined;
+    }
+
     return this.scpGate.denialReason(this.request.action);
   }
 

--- a/src/service/iam/authorize/sim-iam-decision.ts
+++ b/src/service/iam/authorize/sim-iam-decision.ts
@@ -1,57 +1,60 @@
 import type { SimIamPolicyDocumentStatement } from "../policy/sim-iam-policy.js";
-import type {
-  SimIamAuthZContext,
-  SimIamAuthZPolicySource,
-} from "./context/sim-iam-auth-z-context.js";
+import type { SimIamAuthZContext } from "./context/sim-iam-auth-z-context.js";
 import { SimIamPolicyDocumentParser } from "../policy/parse/sim-iam-document-parser.js";
 import { SimIamPolicyStatementMatcher } from "./match/sim-iam-policy-statement-matcher.js";
 import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
-import { SimIamAllowStatements } from "./allow/sim-iam-allow-statements.js";
+import { SimIamPolicyEvaluation } from "./allow/sim-iam-policy-evaluation.js";
+import { SimIamScpGate } from "./scp/sim-iam-scp-gate.js";
+import { SimIamPolicyDecisionValue } from "./sim-iam-decision-value.js";
 
-export const SimIamPolicyDecisionValue = {
-  ExplicitDeny: "ExplicitDeny",
-  Allow: "Allow",
-  ImplicitDeny: "ImplicitDeny",
-} as const;
-
-export type SimIamPolicyDecisionValue =
-  (typeof SimIamPolicyDecisionValue)[keyof typeof SimIamPolicyDecisionValue];
+export { SimIamPolicyDecisionValue } from "./sim-iam-decision-value.js";
 
 /**
  * Decision for one simulated IAM policy authorization attempt.
  *
- * This evaluates already-discovered identity and resource policy documents. It
- * does not fetch attached policies itself, apply trust policy semantics,
- * evaluate permissions boundaries, evaluate SCPs, or enforce service command
- * access.
+ * This evaluates already-discovered identity, resource, and service control
+ * policy documents. It does not fetch attached policies itself, apply trust
+ * policy semantics, evaluate permissions boundaries, or enforce service
+ * command access.
  *
  * The simulator currently models the common IAM authorization rules:
  *
  * - an explicit Deny in any evaluated policy wins;
+ * - the caller's Account has to get past its service control policies, which
+ *   filter permissions and grant none;
  * - the Allows found must satisfy the request's allow requirement, which is
  *   either side within one Account and both sides across Accounts;
  * - otherwise the request is implicitly denied.
+ *
+ * Reading the policies belongs to SimIamPolicyEvaluation for the two sides
+ * that can allow, and to SimIamScpGate for the Account boundary. This class
+ * combines what they found.
  *
  * Resource policies are expected to be supplied by the service that owns the
  * target resource.
  */
 export class SimIamPolicyDecision {
   private readonly request: SimIamAuthZContext;
-  private readonly policyDocumentParser: SimIamPolicyDocumentParser;
-  private readonly statementMatcher: SimIamPolicyStatementMatcher;
-  private readonly explicitDenyStatementRecords: SimIamPolicyDocumentStatement[] =
-    [];
-  private readonly allows = new SimIamAllowStatements();
+  private readonly policies: SimIamPolicyEvaluation;
+  private readonly scpGate: SimIamScpGate;
 
   constructor(
     request: SimIamAuthZContext,
     policyDocumentParser: SimIamPolicyDocumentParser = new SimIamPolicyDocumentParser(),
   ) {
-    this.request = request;
-    this.policyDocumentParser = policyDocumentParser;
-    this.statementMatcher = new SimIamPolicyStatementMatcher(request);
+    const statementMatcher = new SimIamPolicyStatementMatcher(request);
 
-    this.evaluate();
+    this.request = request;
+    this.policies = new SimIamPolicyEvaluation({
+      policies: [...request.identityPolicies, ...request.resourcePolicies],
+      policyDocumentParser,
+      statementMatcher,
+    });
+    this.scpGate = new SimIamScpGate({
+      policies: request.serviceControlPolicies,
+      policyDocumentParser,
+      statementMatcher,
+    });
   }
 
   /**
@@ -68,15 +71,17 @@ export class SimIamPolicyDecision {
    * Final IAM decision value.
    */
   get value(): SimIamPolicyDecisionValue {
-    if (this.explicitDenyStatementRecords.length > 0) {
+    if (this.policies.isExplicitDeny) {
       return SimIamPolicyDecisionValue.ExplicitDeny;
     }
 
-    if (this.request.allowRequirement.isSatisfiedBy(this.allows.sides)) {
-      return SimIamPolicyDecisionValue.Allow;
+    if (this.scpGate.value !== undefined) {
+      return this.scpGate.value;
     }
 
-    return SimIamPolicyDecisionValue.ImplicitDeny;
+    return this.request.allowRequirement.isSatisfiedBy(this.policies.sides)
+      ? SimIamPolicyDecisionValue.Allow
+      : SimIamPolicyDecisionValue.ImplicitDeny;
   }
 
   /**
@@ -113,14 +118,36 @@ export class SimIamPolicyDecision {
    * An identity-policy Allow cannot substitute for the target role's trust.
    */
   get isAllowedByTrustPolicy(): boolean {
-    return this.allows.trust.length > 0;
+    return this.policies.allowStatements.trust.length > 0;
   }
 
   /**
    * Matching explicit Deny statements.
    */
   get explicitDenyStatements(): readonly SimIamPolicyDocumentStatement[] {
-    return this.explicitDenyStatementRecords;
+    return this.policies.explicitDenyStatements;
+  }
+
+  /**
+   * What the caller Account's service control policies said about the request.
+   *
+   * This is the organization's verdict on its own, apart from the identity and
+   * resource sides. It reports whether the Account boundary denied the request
+   * and which of its statements matched.
+   */
+  get serviceControlPolicy(): SimIamScpGate {
+    return this.scpGate;
+  }
+
+  /**
+   * How an AccessDenied error should explain this denial, where there is more
+   * to say than the action and the resource.
+   *
+   * A service turns a denied decision into an error and passes this through,
+   * so an SCP denial reads the way it does in a real account.
+   */
+  get denialReason(): string | undefined {
+    return this.scpGate.denialReason(this.request.action);
   }
 
   /**
@@ -131,55 +158,27 @@ export class SimIamPolicyDecision {
    * from each side.
    */
   get allowStatements(): readonly SimIamPolicyDocumentStatement[] {
-    return this.allows.all;
+    return this.policies.allowStatements.all;
   }
 
   /**
    * Matching Allow statements from identity-based policies.
    */
   get identityAllowStatements(): readonly SimIamPolicyDocumentStatement[] {
-    return this.allows.identity;
+    return this.policies.allowStatements.identity;
   }
 
   /**
    * Matching Allow statements from resource-based policies.
    */
   get resourceAllowStatements(): readonly SimIamPolicyDocumentStatement[] {
-    return this.allows.resource;
+    return this.policies.allowStatements.resource;
   }
 
   /**
    * Matching Allow statements originating from trust policies.
    */
   get trustAllowStatements(): readonly SimIamPolicyDocumentStatement[] {
-    return this.allows.trust;
-  }
-
-  private evaluate(): void {
-    for (const policy of [
-      ...this.request.identityPolicies,
-      ...this.request.resourcePolicies,
-    ]) {
-      this.evaluatePolicy(policy);
-    }
-  }
-
-  private evaluatePolicy(policy: SimIamAuthZPolicySource): void {
-    const parsedPolicy = this.policyDocumentParser.parse(policy.document);
-
-    for (const statement of parsedPolicy.statements) {
-      const principal = this.statementMatcher.matches(policy, statement);
-
-      if (!principal.matched) {
-        continue;
-      }
-
-      if (statement.effect === "Deny") {
-        this.explicitDenyStatementRecords.push(statement.source);
-        continue;
-      }
-
-      this.allows.record(policy, statement.source, principal);
-    }
+    return this.policies.allowStatements.trust;
   }
 }

--- a/src/service/iam/authorize/sim-iam-inter-service-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-inter-service-auth-z.ts
@@ -17,6 +17,15 @@ export interface SimIamAuthorizationDecision {
   readonly caller: SimAwsResolvedCaller;
   readonly isAllowed: boolean;
   readonly isDenied: boolean;
+
+  /**
+   * How an AccessDenied error should explain this denial, where the action and
+   * the resource leave something out.
+   *
+   * A service control policy denial is the case this exists for. Absent for a
+   * denial an identity or resource policy accounts for on its own.
+   */
+  readonly denialReason?: string | undefined;
 }
 
 /**
@@ -68,6 +77,7 @@ export class SimIamAllowAllAuth implements SimIamInterServiceAuthZ {
       caller,
       isAllowed: true,
       isDenied: false,
+      denialReason: undefined,
     };
   }
 }

--- a/src/service/iam/error/sim-iam.error.ts
+++ b/src/service/iam/error/sim-iam.error.ts
@@ -27,6 +27,15 @@ export interface SimIamAccessDeniedInput {
   readonly principal: SimAwsPrincipal;
   readonly action: string;
   readonly resource: string;
+
+  /**
+   * What else the message should say about why the request was denied.
+   *
+   * AWS names the source of a denial when it is something beyond the caller's
+   * own permissions, such as a service control policy. A denial the caller's
+   * identity and resource policies account for adds nothing here.
+   */
+  readonly reason?: string | undefined;
 }
 
 /**
@@ -50,8 +59,10 @@ export class SimIamAccessDenied extends SimIamError {
     const iamCallerIdentifier = new SimIamCallerIdentifier();
     const callerIdentifier = iamCallerIdentifier.format(input.principal);
 
+    const reason = input.reason === undefined ? "" : ` ${input.reason}`;
+
     super(
-      `User: ${callerIdentifier} is not authorized to perform: ${input.action} on resource: ${input.resource}`,
+      `User: ${callerIdentifier} is not authorized to perform: ${input.action} on resource: ${input.resource}${reason}`,
       { httpStatusCode: 403 },
     );
 

--- a/src/service/iam/sim-iam-account-parts.ts
+++ b/src/service/iam/sim-iam-account-parts.ts
@@ -21,6 +21,7 @@ import {
 } from "./credential/user/sim-iam-user-credential-generator.js";
 import type { SimIamManagedPolicy } from "./policy/sim-iam-policy.js";
 import type { SimIamAccountResolver } from "./registry/sim-iam-account-resolver.js";
+import type { SimIamServiceControlPolicyResolver } from "./authorize/scp/sim-iam-scp-resolver.js";
 import type { SimIamRole, SimIamRoleName } from "./role/sim-iam-role.js";
 import type { SimIamUser, SimIamUsername } from "./user/sim-iam-user.js";
 
@@ -39,6 +40,15 @@ export interface SimIamProperties {
    * simulation around it and so leaves this out.
    */
   readonly iamResolver?: SimIamAccountResolver;
+
+  /**
+   * Resolves the service control policies in force for this Account.
+   *
+   * Simulated Organizations supplies this when a SimAws builds IAM. A
+   * standalone SimIam has no organization around it, which is the same as an
+   * Account belonging to none.
+   */
+  readonly scpResolver?: SimIamServiceControlPolicyResolver;
 }
 
 /**
@@ -94,6 +104,7 @@ export class SimIamAccountParts {
       users: this.users,
       credentialIdentityResolver: credentialRegistry,
       iamResolver: properties.iamResolver,
+      scpResolver: properties.scpResolver,
     });
   }
 

--- a/src/service/kinesis/command/authorize/sim-kinesis-authorizer.ts
+++ b/src/service/kinesis/command/authorize/sim-kinesis-authorizer.ts
@@ -61,6 +61,7 @@ export class SimKinesisAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/kms/command/authorize/sim-kms-authorizer.ts
+++ b/src/service/kms/command/authorize/sim-kms-authorizer.ts
@@ -62,6 +62,7 @@ export class SimKmsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource: key.arn,
       });
@@ -85,6 +86,7 @@ export class SimKmsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/lambda/command/create-function/create-function-authorizer.ts
+++ b/src/service/lambda/command/create-function/create-function-authorizer.ts
@@ -38,6 +38,7 @@ export class CreateFunctionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: CreateFunctionAuthorizer.action,
         resource: functionArn,
       });

--- a/src/service/lambda/command/delete-function/delete-function-authorizer.ts
+++ b/src/service/lambda/command/delete-function/delete-function-authorizer.ts
@@ -34,6 +34,7 @@ export class DeleteFunctionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DeleteFunctionAuthorizer.action,
         resource: functionArn,
       });

--- a/src/service/lambda/command/event-invoke-config/event-invoke-config-authorizer.ts
+++ b/src/service/lambda/command/event-invoke-config/event-invoke-config-authorizer.ts
@@ -41,6 +41,7 @@ export class EventInvokeConfigAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: this.action,
         resource: functionArn,
       });

--- a/src/service/lambda/command/function-url/function-url-authorizer.ts
+++ b/src/service/lambda/command/function-url/function-url-authorizer.ts
@@ -41,6 +41,7 @@ export class FunctionUrlAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: this.action,
         resource: functionArn,
       });

--- a/src/service/lambda/command/get-function/get-function-authorizer.ts
+++ b/src/service/lambda/command/get-function/get-function-authorizer.ts
@@ -38,6 +38,7 @@ export class GetFunctionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: GetFunctionAuthorizer.action,
         resource: functionArn,
       });

--- a/src/service/lambda/command/invoke/invoke-authorizer.ts
+++ b/src/service/lambda/command/invoke/invoke-authorizer.ts
@@ -53,6 +53,7 @@ export class InvokeAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: InvokeAuthorizer.action,
         resource: functionArn,
       });

--- a/src/service/lambda/command/list-functions/list-functions-authorizer.ts
+++ b/src/service/lambda/command/list-functions/list-functions-authorizer.ts
@@ -43,6 +43,7 @@ export class ListFunctionsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: ListFunctionsAuthorizer.action,
         resource: ListFunctionsAuthorizer.resource,
       });

--- a/src/service/lambda/command/update-function-code/update-function-code-authorizer.ts
+++ b/src/service/lambda/command/update-function-code/update-function-code-authorizer.ts
@@ -39,6 +39,7 @@ export class UpdateFunctionCodeAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: UpdateFunctionCodeAuthorizer.action,
         resource: functionArn,
       });

--- a/src/service/lambda/command/update-function-configuration/update-function-configuration-authorizer.ts
+++ b/src/service/lambda/command/update-function-configuration/update-function-configuration-authorizer.ts
@@ -40,6 +40,7 @@ export class UpdateFunctionConfigurationAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: UpdateFunctionConfigurationAuthorizer.action,
         resource: functionArn,
       });

--- a/src/service/lambda/command/version/version-authorizer.ts
+++ b/src/service/lambda/command/version/version-authorizer.ts
@@ -41,6 +41,7 @@ export class VersionAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: this.action,
         resource: functionArn,
       });

--- a/src/service/logs/command/authorize/sim-logs-authorizer.ts
+++ b/src/service/logs/command/authorize/sim-logs-authorizer.ts
@@ -89,6 +89,7 @@ export class SimLogsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/organizations/index.ts
+++ b/src/service/organizations/index.ts
@@ -1,0 +1,8 @@
+export {
+  SimOrganizations,
+  type SimOrganizationsAttachOptions,
+} from "./sim-organizations.js";
+export {
+  SIM_ORGANIZATIONS_FULL_AWS_ACCESS,
+  SimOrganizationsScpStore,
+} from "./policy/sim-organizations-scp-store.js";

--- a/src/service/organizations/policy/sim-organizations-scp-store.ts
+++ b/src/service/organizations/policy/sim-organizations-scp-store.ts
@@ -1,0 +1,107 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+import type { SimIamServiceControlPolicy } from "../../iam/authorize/scp/sim-iam-scp-resolver.js";
+
+/**
+ * The AWS-managed policy attached to every organization node by default.
+ *
+ * Turning service control policies on in an organization leaves every
+ * account's permissions as they were, because this policy comes with them. A
+ * simulated Account gets the same treatment, so attaching one Deny statement
+ * denies that one action and leaves the rest of the Account working.
+ */
+export const SIM_ORGANIZATIONS_FULL_AWS_ACCESS: SimIamServiceControlPolicy = {
+  policyName: "FullAWSAccess",
+  document: {
+    Version: "2012-10-17",
+    Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+  },
+};
+
+interface SimOrganizationsAccountPolicies {
+  readonly attached: SimIamServiceControlPolicy[];
+  fullAwsAccess: boolean;
+}
+
+/**
+ * The service control policies attached to each simulated Account.
+ *
+ * An Account absent from the store is outside the organization's reach and is
+ * decided by IAM alone. An Account present in it carries FullAWSAccess along
+ * with whatever was attached, until a test detaches FullAWSAccess to write an
+ * allow list instead of a deny list.
+ */
+export class SimOrganizationsScpStore {
+  private readonly byAccountId = new Map<
+    SimAwsAccountId,
+    SimOrganizationsAccountPolicies
+  >();
+
+  /**
+   * Attach a service control policy to an Account.
+   */
+  attach(
+    accountId: SimAwsAccountId,
+    document: SimIamPolicyDocument,
+    policyName?: string,
+  ): void {
+    this.accountPolicies(accountId).attached.push({ document, policyName });
+  }
+
+  /**
+   * Take the AWS-managed FullAWSAccess policy off an Account.
+   *
+   * What remains has to allow an action for the Account to be allowed it,
+   * which is how an organization is turned into an allow list.
+   */
+  detachFullAwsAccess(accountId: SimAwsAccountId): void {
+    this.accountPolicies(accountId).fullAwsAccess = false;
+  }
+
+  /**
+   * Remove every service control policy from an Account, FullAWSAccess
+   * included, putting it back outside the organization's reach.
+   */
+  detachAll(accountId: SimAwsAccountId): void {
+    this.byAccountId.delete(accountId);
+  }
+
+  /**
+   * The policies in force for an Account, FullAWSAccess first.
+   */
+  policiesFor(
+    accountId: SimAwsAccountId,
+  ): readonly SimIamServiceControlPolicy[] {
+    const account = this.byAccountId.get(accountId);
+
+    if (account === undefined) {
+      return [];
+    }
+
+    return account.fullAwsAccess
+      ? [SIM_ORGANIZATIONS_FULL_AWS_ACCESS, ...account.attached]
+      : [...account.attached];
+  }
+
+  /**
+   * The record for an Account, created on first use.
+   */
+  private accountPolicies(
+    accountId: SimAwsAccountId,
+  ): SimOrganizationsAccountPolicies {
+    const existing = this.byAccountId.get(accountId);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const created: SimOrganizationsAccountPolicies = {
+      attached: [],
+      fullAwsAccess: true,
+    };
+
+    this.byAccountId.set(accountId, created);
+
+    return created;
+  }
+}

--- a/src/service/organizations/policy/sim-organizations-scp-store.ts
+++ b/src/service/organizations/policy/sim-organizations-scp-store.ts
@@ -1,6 +1,9 @@
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
-import type { SimIamServiceControlPolicy } from "../../iam/authorize/scp/sim-iam-scp-resolver.js";
+import type {
+  SimIamServiceControlPolicy,
+  SimIamServiceControlPolicySet,
+} from "../../iam/authorize/scp/sim-iam-scp-resolver.js";
 
 /**
  * The AWS-managed policy attached to every organization node by default.
@@ -68,19 +71,26 @@ export class SimOrganizationsScpStore {
 
   /**
    * The policies in force for an Account, FullAWSAccess first.
+   *
+   * An Account nothing was ever attached to is outside the organization and
+   * gets a set that does not apply. An Account left holding no policies, which
+   * detaching FullAWSAccess on its own produces, gets one that applies and is
+   * empty. Nothing then allows it anything, which is what AWS does to an
+   * account whose every policy has been taken off it.
    */
-  policiesFor(
-    accountId: SimAwsAccountId,
-  ): readonly SimIamServiceControlPolicy[] {
+  policySetFor(accountId: SimAwsAccountId): SimIamServiceControlPolicySet {
     const account = this.byAccountId.get(accountId);
 
     if (account === undefined) {
-      return [];
+      return { applies: false, policies: [] };
     }
 
-    return account.fullAwsAccess
-      ? [SIM_ORGANIZATIONS_FULL_AWS_ACCESS, ...account.attached]
-      : [...account.attached];
+    return {
+      applies: true,
+      policies: account.fullAwsAccess
+        ? [SIM_ORGANIZATIONS_FULL_AWS_ACCESS, ...account.attached]
+        : [...account.attached],
+    };
   }
 
   /**

--- a/src/service/organizations/sim-organizations-scp-deploy.iso.test.ts
+++ b/src/service/organizations/sim-organizations-scp-deploy.iso.test.ts
@@ -1,0 +1,97 @@
+import { CreateBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../iam/error/sim-iam.error.js";
+import { SimSdk } from "../../sdk/index.js";
+
+const denyBucketCreation = {
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Deny",
+    Action: "s3:CreateBucket",
+    Resource: "*",
+  },
+} as const;
+
+describe("Simulated Organizations service control policies at deployment", () => {
+  it("fails a CloudFormation Resource its service control policy denies", async () => {
+    // Given an Account whose organization denies creating Buckets.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyBucketCreation);
+
+    // When a Stack declaring a Bucket is deployed into it.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "reports-stack",
+        template: {
+          Resources: {
+            ReportsBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "reports-bucket" },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the Resource failed, the Bucket was never created, and the error
+    // says which kind of policy stopped it.
+    assertStringIncludes(
+      error.message,
+      "with an explicit deny in a service control policy",
+    );
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName("reports-stack")
+        ?.getResource("ReportsBucket")?.status,
+      "CREATE_FAILED",
+    );
+    assertUndefined(simAws.s3().getSimBucketByName("reports-bucket"));
+  });
+
+  it("denies an intercepted SDK call made under a run-as caller", async () => {
+    // Given an Account whose organization denies creating Buckets.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyBucketCreation);
+
+    const s3 = new S3Client({ region: "eu-west-1" });
+    new SimSdk({ simAws }).intercept(s3);
+
+    // When an intercepted client asks for a Bucket as the Account root.
+    const error = await simAws.runAs(
+      { kind: "arn", arn: `arn:aws:iam::${accountId}:root` },
+      async () =>
+        await assertThrowsErrorAsync(async () => {
+          await s3.send(new CreateBucketCommand({ Bucket: "reports-bucket" }));
+        }),
+    );
+
+    // Then the organization denied it before S3 held anything.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "s3:CreateBucket");
+    assertStringIncludes(
+      error.message,
+      "with an explicit deny in a service control policy",
+    );
+    assertUndefined(simAws.s3().getSimBucketByName("reports-bucket"));
+  });
+});

--- a/src/service/organizations/sim-organizations-scp.iso.test.ts
+++ b/src/service/organizations/sim-organizations-scp.iso.test.ts
@@ -1,0 +1,198 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimIamPolicyDecisionValue } from "../iam/authorize/sim-iam-decision.js";
+
+const denyBucketCreation = {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyBucketCreation",
+    Effect: "Deny",
+    Action: "s3:CreateBucket",
+    Resource: "*",
+  },
+} as const;
+
+describe("Simulated Organizations service control policies", () => {
+  it("explicitly denies an action a service control policy denies", () => {
+    // Given an Account whose organization denies creating Buckets.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyBucketCreation);
+
+    // When the Account root, which every permission is otherwise open to,
+    // asks to create one.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    // Then the organization is what stopped it.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertTrue(decision.serviceControlPolicy.isDenied);
+    assertArrayLength(decision.serviceControlPolicy.denyStatements, 1);
+    assertIdentical(
+      decision.serviceControlPolicy.denyStatements[0].Sid,
+      "DenyBucketCreation",
+    );
+    assertStringIncludes(
+      decision.denialReason ?? "",
+      "with an explicit deny in a service control policy",
+    );
+  });
+
+  it("leaves an action the service control policy says nothing about alone", () => {
+    // Given the same organization, denying only Bucket creation.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyBucketCreation);
+
+    // When the Account root reads an Object instead.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+      });
+
+    // Then FullAWSAccess carries it through, as it does in a real
+    // organization.
+    assertTrue(decision.isAllowed);
+    assertTrue(decision.serviceControlPolicy.isApplied);
+    assertFalse(decision.serviceControlPolicy.isDenied);
+    assertArrayLength(decision.serviceControlPolicy.allowStatements, 1);
+  });
+
+  it("denies an action an identity policy allows and no service control policy does", async () => {
+    // Given a Role allowed to read Objects.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.account(accountId).iam();
+
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "ReportReaderRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ReportReaderRole",
+        PolicyName: "ReadReports",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "s3:GetObject",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    // Given an organization whose policies allow DynamoDB and nothing else.
+    simAws.organizations().detachFullAwsAccess(accountId);
+    simAws.organizations().attachServiceControlPolicy(accountId, {
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "dynamodb:*", Resource: "*" },
+    });
+
+    // When the Role uses the permission its identity policy grants.
+    const decision = simIam.authorize({
+      action: "s3:GetObject",
+      resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+      caller: { kind: "arn", arn: roleCreation.Role.Arn },
+    });
+
+    // Then the Account boundary denies it without any statement matching.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertTrue(decision.serviceControlPolicy.isDenied);
+    assertArrayLength(decision.serviceControlPolicy.denyStatements, 0);
+    assertArrayLength(decision.identityAllowStatements, 1);
+    assertStringIncludes(
+      decision.denialReason ?? "",
+      "because no service control policy allows the s3:GetObject action",
+    );
+  });
+
+  it("decides an Account with nothing attached as it did before", () => {
+    // Given a simulation with an organization holding no policy for this
+    // Account.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(makeSimAwsAccountId(), denyBucketCreation);
+
+    // When the Account root asks to create a Bucket.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    // Then another Account's organization policy says nothing about it.
+    assertTrue(decision.isAllowed);
+    assertFalse(decision.serviceControlPolicy.isApplied);
+    assertFalse(decision.serviceControlPolicy.isDenied);
+    assertUndefined(decision.denialReason);
+  });
+
+  it("puts an Account back outside the organization when its policies are detached", () => {
+    // Given an Account denied Bucket creation.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyBucketCreation);
+
+    // When every policy is taken off it.
+    simAws.organizations().detachServiceControlPolicies(accountId);
+
+    // Then nothing filters its requests.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    assertTrue(decision.isAllowed);
+    assertArrayLength(
+      simAws.organizations().serviceControlPoliciesFor(accountId),
+      0,
+    );
+  });
+});

--- a/src/service/organizations/sim-organizations-scp.iso.test.ts
+++ b/src/service/organizations/sim-organizations-scp.iso.test.ts
@@ -142,6 +142,72 @@ describe("Simulated Organizations service control policies", () => {
     );
   });
 
+  it("denies everything for an Account left holding no policy", () => {
+    // Given an Account inside the organization whose every policy has been
+    // taken off it.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws.organizations().detachFullAwsAccess(accountId);
+
+    // When the Account root, which holds unrestricted access, asks for
+    // anything at all.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+      });
+
+    // Then nothing allows it, which is what AWS does to an account whose
+    // policies have all been detached.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertTrue(decision.serviceControlPolicy.isApplied);
+    assertTrue(decision.serviceControlPolicy.isDenied);
+    assertArrayLength(
+      simAws.organizations().serviceControlPoliciesFor(accountId),
+      0,
+    );
+  });
+
+  it("blames the identity policy, not the organization, for an explicit Deny", () => {
+    // Given an Account whose organization allows nothing, and a resource
+    // policy that explicitly denies the same action.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws.organizations().detachFullAwsAccess(accountId);
+
+    // When a request matches both.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+        resourcePolicies: [
+          {
+            document: {
+              Version: "2012-10-17",
+              Statement: {
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: "*",
+              },
+            },
+          },
+        ],
+      });
+
+    // Then the explicit Deny is what decided it, and the message says nothing
+    // about a service control policy.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertArrayLength(decision.explicitDenyStatements, 1);
+    assertUndefined(decision.denialReason);
+  });
+
   it("decides an Account with nothing attached as it did before", () => {
     // Given a simulation with an organization holding no policy for this
     // Account.

--- a/src/service/organizations/sim-organizations.ts
+++ b/src/service/organizations/sim-organizations.ts
@@ -6,6 +6,7 @@ import type { SimIamPolicyDocument } from "../iam/policy/sim-iam-policy.js";
 import type {
   SimIamServiceControlPolicy,
   SimIamServiceControlPolicyResolver,
+  SimIamServiceControlPolicySet,
 } from "../iam/authorize/scp/sim-iam-scp-resolver.js";
 import { SimOrganizationsScpStore } from "./policy/sim-organizations-scp-store.js";
 
@@ -80,11 +81,28 @@ export class SimOrganizations implements SimIamServiceControlPolicyResolver {
    * The service control policies in force for an Account.
    *
    * This is what sim IAM evaluates, in the order it evaluates them, so a test
-   * tracking down a denial can read the same list the decision did.
+   * tracking down a denial can read the same list the decision did. An empty
+   * list means either that the Account is outside the organization or that
+   * every policy has been taken off it, which
+   * `serviceControlPolicySetFor(...).applies` tells apart.
    */
   serviceControlPoliciesFor(
     accountId: SimAwsAccountId | string,
   ): readonly SimIamServiceControlPolicy[] {
-    return this.scpStore.policiesFor(simAwsAccountId(accountId));
+    return this.serviceControlPolicySetFor(simAwsAccountId(accountId)).policies;
+  }
+
+  /**
+   * The policies in force for an Account, along with whether the Account is
+   * inside this organization at all.
+   *
+   * Sim IAM reads this rather than the list, because an Account left holding
+   * no policies is denied everything while an Account outside the organization
+   * is unrestricted.
+   */
+  serviceControlPolicySetFor(
+    accountId: SimAwsAccountId | string,
+  ): SimIamServiceControlPolicySet {
+    return this.scpStore.policySetFor(simAwsAccountId(accountId));
   }
 }

--- a/src/service/organizations/sim-organizations.ts
+++ b/src/service/organizations/sim-organizations.ts
@@ -1,0 +1,90 @@
+import {
+  simAwsAccountId,
+  type SimAwsAccountId,
+} from "../aws/sim-aws-account.js";
+import type { SimIamPolicyDocument } from "../iam/policy/sim-iam-policy.js";
+import type {
+  SimIamServiceControlPolicy,
+  SimIamServiceControlPolicyResolver,
+} from "../iam/authorize/scp/sim-iam-scp-resolver.js";
+import { SimOrganizationsScpStore } from "./policy/sim-organizations-scp-store.js";
+
+/**
+ * Options for one attached service control policy.
+ */
+export interface SimOrganizationsAttachOptions {
+  /**
+   * What to call the policy in a denial. Defaults to `ServiceControlPolicy`.
+   */
+  readonly policyName?: string | undefined;
+}
+
+/**
+ * Simulated AWS Organizations, holding the service control policies that
+ * decide what the Accounts in this simulation may do.
+ *
+ * An organization spans Accounts, so one of these belongs to a SimAws rather
+ * than to an Account scope, and it is reached as `simAws.organizations()`.
+ *
+ * A service control policy filters permissions and grants none. An Account
+ * with policies attached needs an Allow among them for an action, on top of
+ * whatever its identity and resource policies say, and a Deny among them ends
+ * the request whatever else allows it. That applies to the Account root as
+ * well as to its Roles and Users, so it catches a CloudFormation deployment
+ * and an intercepted SDK call alike.
+ */
+export class SimOrganizations implements SimIamServiceControlPolicyResolver {
+  private readonly scpStore = new SimOrganizationsScpStore();
+
+  /**
+   * Attach a service control policy to a simulated Account.
+   *
+   * The Account also gets AWS's own FullAWSAccess policy, as it would in a
+   * real organization, so one Deny statement denies that action and leaves the
+   * rest of the Account working.
+   */
+  attachServiceControlPolicy(
+    accountId: string,
+    document: SimIamPolicyDocument,
+    options: SimOrganizationsAttachOptions = {},
+  ): void {
+    this.scpStore.attach(
+      simAwsAccountId(accountId),
+      document,
+      options.policyName ?? "ServiceControlPolicy",
+    );
+  }
+
+  /**
+   * Take AWS's FullAWSAccess policy off an Account, leaving only the policies
+   * attached to it to allow anything.
+   *
+   * This turns the Account's service control policies into an allow list. An
+   * action no attached policy allows is denied.
+   */
+  detachFullAwsAccess(accountId: string): void {
+    this.scpStore.detachFullAwsAccess(simAwsAccountId(accountId));
+  }
+
+  /**
+   * Remove every service control policy from an Account.
+   *
+   * The Account is then decided by its identity and resource policies alone,
+   * as it was before anything was attached.
+   */
+  detachServiceControlPolicies(accountId: string): void {
+    this.scpStore.detachAll(simAwsAccountId(accountId));
+  }
+
+  /**
+   * The service control policies in force for an Account.
+   *
+   * This is what sim IAM evaluates, in the order it evaluates them, so a test
+   * tracking down a denial can read the same list the decision did.
+   */
+  serviceControlPoliciesFor(
+    accountId: SimAwsAccountId | string,
+  ): readonly SimIamServiceControlPolicy[] {
+    return this.scpStore.policiesFor(simAwsAccountId(accountId));
+  }
+}

--- a/src/service/route53/command/change-resource-record-sets/change-resource-record-sets-authorizer.ts
+++ b/src/service/route53/command/change-resource-record-sets/change-resource-record-sets-authorizer.ts
@@ -44,6 +44,7 @@ export class ChangeResourceRecordSetsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: ChangeResourceRecordSetsAuthorizer.action,
         resource: hostedZoneArn,
       });

--- a/src/service/route53/command/create-hosted-zone/create-hosted-zone-authorizer.ts
+++ b/src/service/route53/command/create-hosted-zone/create-hosted-zone-authorizer.ts
@@ -40,6 +40,7 @@ export class CreateHostedZoneAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: CreateHostedZoneAuthorizer.action,
         resource: CreateHostedZoneAuthorizer.resource,
       });

--- a/src/service/route53/command/delete-hosted-zone/delete-hosted-zone-authorizer.ts
+++ b/src/service/route53/command/delete-hosted-zone/delete-hosted-zone-authorizer.ts
@@ -38,6 +38,7 @@ export class DeleteHostedZoneAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DeleteHostedZoneAuthorizer.action,
         resource: hostedZoneArn,
       });

--- a/src/service/route53/command/dnssec/sim-route53-dnssec-authorizer.ts
+++ b/src/service/route53/command/dnssec/sim-route53-dnssec-authorizer.ts
@@ -37,6 +37,7 @@ export class SimRoute53DnssecAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/route53/command/get-hosted-zone/get-hosted-zone-authorizer.ts
+++ b/src/service/route53/command/get-hosted-zone/get-hosted-zone-authorizer.ts
@@ -42,6 +42,7 @@ export class GetHostedZoneAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: GetHostedZoneAuthorizer.action,
         resource: hostedZoneArn,
       });

--- a/src/service/route53/command/list-hosted-zones-by-name/list-hosted-zones-by-name-authorizer.ts
+++ b/src/service/route53/command/list-hosted-zones-by-name/list-hosted-zones-by-name-authorizer.ts
@@ -41,6 +41,7 @@ export class ListHostedZonesByNameAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: ListHostedZonesByNameAuthorizer.action,
         resource: ListHostedZonesByNameAuthorizer.resource,
       });

--- a/src/service/route53/command/list-resource-record-sets/list-resource-record-sets-authorizer.ts
+++ b/src/service/route53/command/list-resource-record-sets/list-resource-record-sets-authorizer.ts
@@ -44,6 +44,7 @@ export class ListResourceRecordSetsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: ListResourceRecordSetsAuthorizer.action,
         resource: hostedZoneArn,
       });

--- a/src/service/s3/command/create-bucket/create-bucket.handler.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.handler.ts
@@ -88,6 +88,7 @@ export class CreateBucketCommandHandler implements CommandHandler<
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: "s3:CreateBucket",
         resource,
       });

--- a/src/service/s3/command/delete-bucket-policy/delete-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/delete-bucket-policy/delete-bucket-policy-authorizer.ts
@@ -41,6 +41,7 @@ export class DeleteBucketPolicyAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DeleteBucketPolicyAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/delete-bucket/delete-bucket-authorizer.ts
+++ b/src/service/s3/command/delete-bucket/delete-bucket-authorizer.ts
@@ -42,6 +42,7 @@ export class DeleteBucketAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DeleteBucketAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/delete-object/delete-object-authorizer.ts
+++ b/src/service/s3/command/delete-object/delete-object-authorizer.ts
@@ -55,6 +55,7 @@ export class DeleteObjectAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: DeleteObjectAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/get-bucket-policy/get-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/get-bucket-policy/get-bucket-policy-authorizer.ts
@@ -38,6 +38,7 @@ export class GetBucketPolicyAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: GetBucketPolicyAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/get-object/get-object-authorizer.ts
+++ b/src/service/s3/command/get-object/get-object-authorizer.ts
@@ -58,6 +58,7 @@ export class GetObjectAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: GetObjectAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/head-bucket/head-bucket-authorizer.ts
+++ b/src/service/s3/command/head-bucket/head-bucket-authorizer.ts
@@ -52,6 +52,7 @@ export class HeadBucketAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: HeadBucketAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/lifecycle/sim-s3-lifecycle-authorizer.ts
+++ b/src/service/s3/command/lifecycle/sim-s3-lifecycle-authorizer.ts
@@ -60,6 +60,7 @@ export class SimS3LifecycleAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/s3/command/list-buckets/list-buckets-authorizer.ts
+++ b/src/service/s3/command/list-buckets/list-buckets-authorizer.ts
@@ -48,6 +48,7 @@ export class ListBucketsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: ListBucketsAuthorizer.action,
         resource: ListBucketsAuthorizer.resource,
       });

--- a/src/service/s3/command/list-objects/list-objects-authorizer.ts
+++ b/src/service/s3/command/list-objects/list-objects-authorizer.ts
@@ -69,6 +69,7 @@ export class ListObjectsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: ListObjectsAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/multipart/sim-s3-multipart-authorizer.ts
+++ b/src/service/s3/command/multipart/sim-s3-multipart-authorizer.ts
@@ -59,6 +59,7 @@ export class SimS3MultipartAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: SimS3MultipartAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/notification/sim-s3-notification-authorizer.ts
+++ b/src/service/s3/command/notification/sim-s3-notification-authorizer.ts
@@ -61,6 +61,7 @@ export class SimS3NotificationAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/s3/command/public-access-block/sim-s3-public-access-block-authorizer.ts
+++ b/src/service/s3/command/public-access-block/sim-s3-public-access-block-authorizer.ts
@@ -67,6 +67,7 @@ export class SimS3PublicAccessBlockAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy-authorizer.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy-authorizer.ts
@@ -35,6 +35,7 @@ export class PutBucketPolicyAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: PutBucketPolicyAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/put-bucket-website/put-bucket-website-authorizer.ts
+++ b/src/service/s3/command/put-bucket-website/put-bucket-website-authorizer.ts
@@ -52,6 +52,7 @@ export class PutBucketWebsiteAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: PutBucketWebsiteAuthorizer.action,
         resource,
       });

--- a/src/service/s3/command/put-object/put-object-authorizer.ts
+++ b/src/service/s3/command/put-object/put-object-authorizer.ts
@@ -59,6 +59,7 @@ export class PutObjectAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: PutObjectAuthorizer.action,
         resource,
       });

--- a/src/service/secretsmanager/command/authorize/sim-secrets-manager-authorizer.ts
+++ b/src/service/secretsmanager/command/authorize/sim-secrets-manager-authorizer.ts
@@ -60,6 +60,7 @@ export class SimSecretsManagerAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/ses/command/authorize/sim-ses-authorizer.ts
+++ b/src/service/ses/command/authorize/sim-ses-authorizer.ts
@@ -131,6 +131,7 @@ export class SimSesAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
@@ -110,6 +110,7 @@ export class SimSqsAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action: input.action,
         resource: input.resource,
       });

--- a/src/service/ssm/command/authorize/sim-ssm-authorizer.ts
+++ b/src/service/ssm/command/authorize/sim-ssm-authorizer.ts
@@ -88,6 +88,7 @@ export class SimSsmAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });

--- a/src/service/wafv2/command/authorize/sim-wafv2-authorizer.ts
+++ b/src/service/wafv2/command/authorize/sim-wafv2-authorizer.ts
@@ -50,6 +50,7 @@ export class SimWafAuthorizer {
     if (decision.isDenied) {
       throw new SimIamAccessDenied({
         principal: decision.caller.principal,
+        reason: decision.denialReason,
         action,
         resource,
       });


### PR DESCRIPTION
Simulated Organizations holds the service control policies attached to each simulated Account, reached as `simAws.organizations()`. Sim IAM evaluates them as a gate in front of the identity and resource sides, so an SCP filters what an Account may do and grants nothing.

Resolves https://github.com/KensioSoftware/yulin/issues/1059

The gate covers the Account root along with the Account's Roles and Users, which is what makes it catch a deployment. Sim CloudFormation creates each resource through the owning service's command handler, and that handler already authorizes, so no new CloudFormation hook was needed. A denial leaves the resource `CREATE_FAILED` and rejects the deployment, and the `AccessDenied` message names the service control policy the way AWS words it. An intercepted SDK client is filtered the same way. `FullAWSAccess` is attached by default as it is in AWS, and `detachFullAwsAccess` turns an Account's policies into an allow list.

Two refactors ride along, both needed to get `sim-iam-decision.ts` back under the FTA threshold once the gate was added. The identity and resource evaluation moved to `SimIamPolicyEvaluation`, mirroring `SimIamScpGate`, and `SimIamPolicyDecisionValue` moved to its own module and is re-exported.

The wide part of the diff is one line at each of the 60 `new SimIamAccessDenied` sites, passing `decision.denialReason` through so the SCP wording reaches the error wherever a service throws one.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS Organizations service control policies (SCPs), including policy attachment, removal, default full access, allow-list behavior, and account-level evaluation.
  * SCP decisions now support explicit and implicit denials, policy details, and CloudFormation enforcement.
* **Bug Fixes**
  * Access-denied errors across supported services now include clearer IAM denial reasons.
* **Documentation**
  * Added Organizations service documentation, IAM limitations, usage guidance, and practical SCP examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->