### PR TITLE
feat: inherit a service control policy from an OU

### DIFF
--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -276,9 +276,10 @@ account, in the order they were evaluated, including `FullAWSAccess` where it is
 `serviceControlPolicySetFor(accountId).levels` keeps the policies grouped by the node they hang on,
 root first. That grouping is what sim IAM evaluates.
 
-The flattened list is empty in two cases that behave differently. An account that was never named
-sits outside the organization and stays unrestricted. An account left holding no policy is denied
-everything.
+The flattened list is empty in three cases that behave differently. An account that was never named
+sits outside the organization and stays unrestricted. The management account is exempt and equally
+unrestricted. An account left holding no policy is denied everything. `applies` separates the last
+of those from the other two.
 `serviceControlPolicySetFor(accountId).applies` tells the two apart, and so does
 `decision.serviceControlPolicy.isApplied`.
 
@@ -292,7 +293,8 @@ Simulated Organizations supports:
 - `setManagementAccount`, exempting the Account AWS exempts
 - `attachServiceControlPolicy`, attaching a policy document to the root, a unit, or an Account
 - `detachFullAwsAccess`, turning a node's policies into an allow list
-- `detachServiceControlPolicies`, taking every policy back off a node
+- `detachServiceControlPolicies`, taking every policy back off one node and leaving the rest alone
+- `removeAccount`, taking an Account out of the organization
 - `serviceControlPoliciesFor`, reading the policies in force for an Account
 - `serviceControlPolicySetFor`, reading those policies along with whether any apply
 - The AWS-managed `FullAWSAccess` policy, attached by default as it is in AWS

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -3,14 +3,131 @@
 Yulin simulates AWS Organizations service control policies. A test can find out that the
 organization around an account forbids something before a deployment does.
 
-A service control policy filters what an account's principals may do and grants nothing. Sim IAM
-evaluates the ones attached to an account ahead of that account's identity and resource policies,
-which means an SCP applies to a CloudFormation deployment, an intercepted SDK client, and a direct
-service call alike.
+A service control policy filters what an account's principals may do and grants nothing. Policies
+attach to the organization root, to an organizational unit, or to one account, and an account
+inherits every policy on the path down to it. Sim IAM evaluates them ahead of that account's
+identity and resource policies. An SCP therefore applies to a CloudFormation deployment, an
+intercepted SDK client, and a direct service call alike.
+
+## Attach a policy to an organizational unit
+
+A policy is usually attached to an organizational unit rather than to one account, and every account
+under that unit inherits it. Units nest, and the root sits above all of them.
+
+```typescript sim-organizations-organizational-unit
+/**
+ * Inheriting a service control policy from an organizational unit.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const organizations = simAws.organizations();
+
+const workloads = organizations.createOrganizationalUnit("Workloads");
+const production = organizations.createOrganizationalUnit(
+  "Production",
+  workloads,
+);
+
+organizations.moveAccount("123456789012", production);
+organizations.attachServiceControlPolicy(workloads, {
+  Version: "2012-10-17",
+  Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+});
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::reports-bucket",
+});
+
+console.log(decision.value); // "ExplicitDeny"
+```
+
+The policy hangs two levels above the account and still reaches it. `createOrganizationalUnit` takes
+a parent unit as its second argument, and leaves the unit under the root without one.
+`organizations.root()` is the node above everything, and a policy attached there covers every
+account in the organization.
+
+## Every level has to allow the action
+
+An account is filtered by each node on the path from the root down to it, and each one has to allow
+an action on its own. A root allowing S3 and a unit allowing DynamoDB leave an account beneath them
+able to do neither.
+
+```typescript sim-organizations-every-level-allows
+/**
+ * Each level of the organization allowing the action separately.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const organizations = simAws.organizations();
+const workloads = organizations.createOrganizationalUnit("Workloads");
+
+organizations.moveAccount("123456789012", workloads);
+
+organizations.detachFullAwsAccess(organizations.root());
+organizations.attachServiceControlPolicy(organizations.root(), {
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+});
+
+organizations.detachFullAwsAccess(workloads);
+organizations.attachServiceControlPolicy(workloads, {
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "dynamodb:*", Resource: "*" },
+});
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:GetObject",
+  resource: "arn:aws:s3:::reports-bucket/summary.csv",
+});
+
+console.log(decision.value); // "ImplicitDeny"
+console.log(decision.serviceControlPolicy.unallowedLevels); // [ "Workloads" ]
+```
+
+`unallowedLevels` names the nodes that allowed nothing matching. That is the part of a real SCP
+denial that takes longest to track down.
+
+A `Deny` at any level ends the request whatever another level allows.
+
+## The management account
+
+`setManagementAccount` names the account AWS exempts from every service control policy. That account
+is decided by its identity and resource policies alone, whatever is attached above it.
+
+```typescript sim-organizations-management-account
+/**
+ * Exempting the management account.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const organizations = simAws.organizations();
+
+organizations.attachServiceControlPolicy(organizations.root(), {
+  Version: "2012-10-17",
+  Statement: { Effect: "Deny", Action: "*", Resource: "*" },
+});
+organizations.setManagementAccount("111111111111");
+
+const decision = simAws.account("111111111111").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::reports-bucket",
+});
+
+console.log(decision.isAllowed); // true
+console.log(decision.serviceControlPolicy.isApplied); // false
+```
 
 ## Attach a service control policy to an Account
 
-An organization spans accounts. It belongs to the whole simulated environment and is reached as
+A policy attached straight to an account applies to that account alone. An organization spans
+accounts, so it belongs to the whole simulated environment and is reached as
 `simAws.organizations()`, not from an account scope.
 
 ```typescript sim-organizations-attach-scp
@@ -102,7 +219,7 @@ deploys then fails on the policy, with the policy named in the message.
 ## Write an allow list instead of a deny list
 
 `detachFullAwsAccess` takes AWS's own policy off an account. What remains has to allow an action
-for the account to be allowed it, which is an organization run as an allow list.
+for the account to be allowed it. That is an organization run as an allow list.
 
 ```typescript sim-organizations-scp-allow-list
 /**
@@ -156,8 +273,11 @@ simulated service passes it through to the error it throws.
 `simAws.organizations().serviceControlPoliciesFor(accountId)` returns the policies in force for an
 account, in the order they were evaluated, including `FullAWSAccess` where it is still attached.
 
-That list is empty in two cases that behave differently. An account that was never attached to sits
-outside the organization and stays unrestricted. An account left holding no policy is denied
+`serviceControlPolicySetFor(accountId).levels` keeps the policies grouped by the node they hang on,
+root first. That grouping is what sim IAM evaluates.
+
+The flattened list is empty in two cases that behave differently. An account that was never named
+sits outside the organization and stays unrestricted. An account left holding no policy is denied
 everything.
 `serviceControlPolicySetFor(accountId).applies` tells the two apart, and so does
 `decision.serviceControlPolicy.isApplied`.
@@ -166,31 +286,37 @@ everything.
 
 Simulated Organizations supports:
 
-- `attachServiceControlPolicy`, attaching a policy document to a simulated Account
-- `detachFullAwsAccess`, turning an Account's policies into an allow list
-- `detachServiceControlPolicies`, putting an Account back outside the organization's reach
+- `createOrganizationalUnit`, creating a unit under the root or under another unit
+- `moveAccount`, putting an Account under a unit or under the root
+- `root`, the node above every Account in the organization
+- `setManagementAccount`, exempting the Account AWS exempts
+- `attachServiceControlPolicy`, attaching a policy document to the root, a unit, or an Account
+- `detachFullAwsAccess`, turning a node's policies into an allow list
+- `detachServiceControlPolicies`, taking every policy back off a node
 - `serviceControlPoliciesFor`, reading the policies in force for an Account
 - `serviceControlPolicySetFor`, reading those policies along with whether any apply
 - The AWS-managed `FullAWSAccess` policy, attached by default as it is in AWS
 - Evaluation ahead of identity and resource policies, for every principal in the Account including
   its root
+- Inheritance down the root-to-Account path, with every level having to allow the action
+- AWS-shaped `r-` and `ou-` node ids
 - `Action`, `NotAction`, `Resource`, `NotResource` and `Condition` in an SCP statement
 - The `ArnEquals`, `ArnLike`, `NumericLessThanEquals`, `StringEquals` and `StringLike` condition
   operators, and their `ForAnyValue:` and `ForAllValues:` set forms
 - `AccessDenied` messages naming the service control policy, as AWS words them
-- Denial reporting through `decision.serviceControlPolicy`
+- Denial reporting through `decision.serviceControlPolicy`, naming the levels that allowed nothing
 
 ## Limitations
 
-| Limitation                  | Detail                                                                                                                                                         |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Organization structure      | Policies attach to an Account directly. Roots, organizational units and inheritance down a tree are not simulated.                                             |
-| Management account          | No Account is designated the management account, so no Account is exempt from evaluation. Attach nothing to an Account that stands for the management account. |
-| Service-linked roles        | Evaluated like any other principal. AWS exempts a service-linked role from SCPs.                                                                               |
-| Other policy types          | Resource control policies, declarative policies, tag policies, backup policies and AI services opt-out policies are not simulated.                             |
-| The Organizations SDK       | `CreatePolicy`, `AttachPolicy`, `ListAccounts` and the rest of the API are not handled. Policies are attached through the accessor.                            |
-| CloudFormation              | `AWS::Organizations::Organization`, `::OrganizationalUnit`, `::Account` and `::Policy` are not created from a template.                                        |
-| Organization condition keys | `aws:PrincipalOrgID` and `aws:PrincipalOrgPaths` are not populated. A condition naming either fails to match.                                                  |
-| Service principals          | A request whose caller is a service principal or anonymous belongs to no Account and is subject to no policy.                                                  |
-| Condition operator coverage | An operator sim IAM does not know fails closed, so the statement holding it never matches.                                                                     |
-| HTTP API                    | Organizations is not served as an HTTP API by `serveSimAws`.                                                                                                   |
+| Limitation                  | Detail                                                                                                                              |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Management account          | Named with `setManagementAccount`. An organization with none named exempts no Account.                                              |
+| Moving an Account           | `moveAccount` places an Account and can move it again. Nothing records where it was before.                                         |
+| Service-linked roles        | Evaluated like any other principal. AWS exempts a service-linked role from SCPs.                                                    |
+| Other policy types          | Resource control policies, declarative policies, tag policies, backup policies and AI services opt-out policies are not simulated.  |
+| The Organizations SDK       | `CreatePolicy`, `AttachPolicy`, `ListAccounts` and the rest of the API are not handled. Policies are attached through the accessor. |
+| CloudFormation              | `AWS::Organizations::Organization`, `::OrganizationalUnit`, `::Account` and `::Policy` are not created from a template.             |
+| Organization condition keys | `aws:PrincipalOrgID` and `aws:PrincipalOrgPaths` are not populated. A condition naming either fails to match.                       |
+| Service principals          | A request whose caller is a service principal or anonymous belongs to no Account and is subject to no policy.                       |
+| Condition operator coverage | An operator sim IAM does not know fails closed, so the statement holding it never matches.                                          |
+| HTTP API                    | Organizations is not served as an HTTP API by `serveSimAws`.                                                                        |

--- a/docs/services/organizations/sim-organizations-every-level-allows.example.ts
+++ b/docs/services/organizations/sim-organizations-every-level-allows.example.ts
@@ -1,0 +1,31 @@
+/**
+ * Each level of the organization allowing the action separately.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const organizations = simAws.organizations();
+const workloads = organizations.createOrganizationalUnit("Workloads");
+
+organizations.moveAccount("123456789012", workloads);
+
+organizations.detachFullAwsAccess(organizations.root());
+organizations.attachServiceControlPolicy(organizations.root(), {
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+});
+
+organizations.detachFullAwsAccess(workloads);
+organizations.attachServiceControlPolicy(workloads, {
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow", Action: "dynamodb:*", Resource: "*" },
+});
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:GetObject",
+  resource: "arn:aws:s3:::reports-bucket/summary.csv",
+});
+
+console.log(decision.value); // "ImplicitDeny"
+console.log(decision.serviceControlPolicy.unallowedLevels); // [ "Workloads" ]

--- a/docs/services/organizations/sim-organizations-management-account.example.ts
+++ b/docs/services/organizations/sim-organizations-management-account.example.ts
@@ -1,0 +1,22 @@
+/**
+ * Exempting the management account.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const organizations = simAws.organizations();
+
+organizations.attachServiceControlPolicy(organizations.root(), {
+  Version: "2012-10-17",
+  Statement: { Effect: "Deny", Action: "*", Resource: "*" },
+});
+organizations.setManagementAccount("111111111111");
+
+const decision = simAws.account("111111111111").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::reports-bucket",
+});
+
+console.log(decision.isAllowed); // true
+console.log(decision.serviceControlPolicy.isApplied); // false

--- a/docs/services/organizations/sim-organizations-organizational-unit.example.ts
+++ b/docs/services/organizations/sim-organizations-organizational-unit.example.ts
@@ -1,0 +1,27 @@
+/**
+ * Inheriting a service control policy from an organizational unit.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const organizations = simAws.organizations();
+
+const workloads = organizations.createOrganizationalUnit("Workloads");
+const production = organizations.createOrganizationalUnit(
+  "Production",
+  workloads,
+);
+
+organizations.moveAccount("123456789012", production);
+organizations.attachServiceControlPolicy(workloads, {
+  Version: "2012-10-17",
+  Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+});
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::reports-bucket",
+});
+
+console.log(decision.value); // "ExplicitDeny"

--- a/src/service/apigateway/serve/auth/sim-rest-api-authorizer-policy.ts
+++ b/src/service/apigateway/serve/auth/sim-rest-api-authorizer-policy.ts
@@ -59,7 +59,7 @@ export class SimRestApiAuthorizerPolicy {
       resourcePolicies: [],
       // An authorizer's policy document is evaluated on its own. No Account
       // boundary is being crossed here, so no service control policy applies.
-      serviceControlPolicies: { applies: false, sources: [] },
+      serviceControlPolicies: { applies: false, levels: [] },
       allowRequirement: new SimIamEitherSideAllowRequirement(),
       action: simExecuteApiInvokeAction,
       resource: methodArn,

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-policy.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-authorizer-policy.ts
@@ -45,7 +45,7 @@ export class SimHttpApiAuthorizerPolicy {
       resourcePolicies: [],
       // An authorizer's policy document is evaluated on its own. No Account
       // boundary is being crossed here, so no service control policy applies.
-      serviceControlPolicies: { applies: false, sources: [] },
+      serviceControlPolicies: { applies: false, levels: [] },
       allowRequirement: new SimIamEitherSideAllowRequirement(),
       action: simExecuteApiInvokeAction,
       resource: routeArn,

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.factory.ts
@@ -11,7 +11,7 @@ import type {
 export const simIamAuthZContextFactory = new StaticFactory<SimIamAuthZContext>({
   identityPolicies: [],
   resourcePolicies: [],
-  serviceControlPolicies: { applies: false, sources: [] },
+  serviceControlPolicies: { applies: false, levels: [] },
   allowRequirement: new SimIamEitherSideAllowRequirement(),
   action: "s3:GetObject",
   resource: "arn:aws:s3:::test-bucket/test-key",

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context.ts
@@ -37,15 +37,28 @@ export type SimIamAuthZResourcePolicySource = Omit<
 };
 
 /**
+ * The service control policies attached at one level above the caller's
+ * Account, which is the root, an organizational unit, or the Account itself.
+ *
+ * Each level has to allow the action on its own. A level allowing nothing
+ * denies the request whatever another level allows, which is why the sources
+ * stay grouped rather than being read as one list.
+ */
+export interface SimIamAuthZServiceControlPolicyLevel {
+  readonly nodeName: string;
+  readonly sources: readonly SimIamAuthZPolicySource[];
+}
+
+/**
  * The service control policies in force for an authorization request.
  *
- * `applies` is a separate fact from how many sources there are. An Account
- * inside an organization that holds no policy allows nothing, while an Account
- * outside every organization is unrestricted, and both carry no sources.
+ * `applies` is a separate fact from how many levels there are. An Account
+ * inside an organization holding no policy allows nothing, while an Account
+ * outside every organization is unrestricted, and both can carry no levels.
  */
 export interface SimIamAuthZServiceControlPolicies {
   readonly applies: boolean;
-  readonly sources: readonly SimIamAuthZPolicySource[];
+  readonly levels: readonly SimIamAuthZServiceControlPolicyLevel[];
 }
 
 export interface SimIamAuthZContext {

--- a/src/service/iam/authorize/context/sim-iam-auth-z-scp-source-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-scp-source-builder.ts
@@ -31,7 +31,7 @@ export class SimIamAuthZScpSourceBuilder {
    */
   private static readonly unrestricted: SimIamAuthZServiceControlPolicies = {
     applies: false,
-    sources: [],
+    levels: [],
   };
 
   private readonly accountId: SimAwsAccountId;
@@ -62,10 +62,13 @@ export class SimIamAuthZScpSourceBuilder {
 
     return {
       applies: set.applies,
-      sources: set.policies.map((policy) => ({
-        sourceType: "service-control" as const,
-        document: policy.document,
-        policyName: policy.policyName,
+      levels: set.levels.map((level) => ({
+        nodeName: level.nodeName,
+        sources: level.policies.map((policy) => ({
+          sourceType: "service-control" as const,
+          document: policy.document,
+          policyName: policy.policyName,
+        })),
       })),
     };
   }

--- a/src/service/iam/authorize/scp/sim-iam-scp-gate.iso.test.ts
+++ b/src/service/iam/authorize/scp/sim-iam-scp-gate.iso.test.ts
@@ -1,0 +1,34 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimIamPolicyDocumentParser } from "../../policy/parse/sim-iam-document-parser.js";
+import { SimIamPolicyStatementMatcher } from "../match/sim-iam-policy-statement-matcher.js";
+import { simIamAuthZContextFactory } from "../context/sim-iam-auth-z-context.factory.js";
+import { SimIamPolicyDecisionValue } from "../sim-iam-decision-value.js";
+import { SimIamScpGate } from "./sim-iam-scp-gate.js";
+
+describe("Sim IAM service control policy gate", () => {
+  it("denies everything for an organization holding no level", () => {
+    // Given an organization that applies to the caller's Account and holds
+    // nothing to allow anything with.
+    const context = simIamAuthZContextFactory.make({
+      serviceControlPolicies: { applies: true, levels: [] },
+    });
+
+    // When the gate is asked about a request.
+    const gate = new SimIamScpGate({
+      serviceControlPolicies: context.serviceControlPolicies,
+      policyDocumentParser: new SimIamPolicyDocumentParser(),
+      statementMatcher: new SimIamPolicyStatementMatcher(context),
+    });
+
+    // Then it is shut, because nothing allowed the action.
+    assertTrue(gate.isApplied);
+    assertTrue(gate.isImplicitDeny);
+    assertIdentical(gate.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertArrayEquals(gate.unallowedLevels, ["the organization"]);
+  });
+});

--- a/src/service/iam/authorize/scp/sim-iam-scp-gate.ts
+++ b/src/service/iam/authorize/scp/sim-iam-scp-gate.ts
@@ -4,6 +4,7 @@ import type { SimIamPolicyStatementMatcher } from "../match/sim-iam-policy-state
 import type {
   SimIamAuthZPolicySource,
   SimIamAuthZServiceControlPolicies,
+  SimIamAuthZServiceControlPolicyLevel,
 } from "../context/sim-iam-auth-z-context.js";
 import { SimIamPolicyDecisionValue } from "../sim-iam-decision-value.js";
 
@@ -19,10 +20,15 @@ interface SimIamScpGateProperties {
  * An SCP is a filter on the permissions an Account's principals can be given.
  * It grants nothing, so this runs as a gate in front of the identity and
  * resource policy evaluation instead of contributing Allows to it. The rules
- * are the two AWS applies at the Account boundary:
+ * are the ones AWS applies at the Account boundary:
  *
- * - a matching Deny in any attached policy ends the request;
- * - the attached policies have to produce a matching Allow between them.
+ * - a matching Deny at any level ends the request;
+ * - every level between the root and the Account has to produce a matching
+ *   Allow of its own.
+ *
+ * The second rule is what makes the levels worth keeping apart. A root
+ * allowing S3 and an organizational unit allowing DynamoDB leave an Account
+ * beneath them able to do neither, because each level is asked separately.
  *
  * An Account outside any organization's reach is unrestricted, and this gate
  * stands open for it. An Account inside one that holds no policy is a
@@ -32,12 +38,17 @@ export class SimIamScpGate {
   private readonly applies: boolean;
   private readonly denyStatementRecords: SimIamPolicyDocumentStatement[] = [];
   private readonly allowStatementRecords: SimIamPolicyDocumentStatement[] = [];
+  private readonly unallowedLevelNames: string[] = [];
 
   constructor(properties: SimIamScpGateProperties) {
     this.applies = properties.serviceControlPolicies.applies;
 
-    for (const policy of properties.serviceControlPolicies.sources) {
-      this.evaluate(policy, properties);
+    for (const level of properties.serviceControlPolicies.levels) {
+      this.evaluateLevel(level, properties);
+    }
+
+    if (this.applies && properties.serviceControlPolicies.levels.length === 0) {
+      this.unallowedLevelNames.push("the organization");
     }
   }
 
@@ -56,7 +67,7 @@ export class SimIamScpGate {
   }
 
   /**
-   * Whether the attached policies left the request unallowed.
+   * Whether a level left the request unallowed.
    *
    * A Deny is reported by `isExplicitDeny` and leaves this false, so the two
    * name different denials and a reader can tell them apart.
@@ -65,7 +76,7 @@ export class SimIamScpGate {
     return (
       this.applies &&
       !this.isExplicitDeny &&
-      this.allowStatementRecords.length === 0
+      this.unallowedLevelNames.length > 0
     );
   }
 
@@ -100,10 +111,20 @@ export class SimIamScpGate {
   }
 
   /**
-   * Matching Allow statements from the attached policies.
+   * Matching Allow statements from the attached policies, across every level.
    */
   get allowStatements(): readonly SimIamPolicyDocumentStatement[] {
     return this.allowStatementRecords;
+  }
+
+  /**
+   * The levels that allowed nothing matching the request, root first.
+   *
+   * This is what a test reads to find which node in the organization is in the
+   * way, which is the part of an SCP denial AWS makes hardest to work out.
+   */
+  get unallowedLevels(): readonly string[] {
+    return this.unallowedLevelNames;
   }
 
   /**
@@ -126,13 +147,33 @@ export class SimIamScpGate {
   }
 
   /**
-   * Record the matching statements of one attached policy.
+   * Record what one level of the organization said.
    */
-  private evaluate(
-    policy: SimIamAuthZPolicySource,
+  private evaluateLevel(
+    level: SimIamAuthZServiceControlPolicyLevel,
     properties: SimIamScpGateProperties,
   ): void {
+    let allowed = false;
+
+    for (const policy of level.sources) {
+      allowed = this.evaluatePolicy(policy, properties) || allowed;
+    }
+
+    if (!allowed) {
+      this.unallowedLevelNames.push(level.nodeName);
+    }
+  }
+
+  /**
+   * Record the matching statements of one attached policy, and say whether it
+   * allowed the request.
+   */
+  private evaluatePolicy(
+    policy: SimIamAuthZPolicySource,
+    properties: SimIamScpGateProperties,
+  ): boolean {
     const parsedPolicy = properties.policyDocumentParser.parse(policy.document);
+    let allowed = false;
 
     for (const statement of parsedPolicy.statements) {
       if (!properties.statementMatcher.matches(policy, statement).matched) {
@@ -145,6 +186,9 @@ export class SimIamScpGate {
       }
 
       this.allowStatementRecords.push(statement.source);
+      allowed = true;
     }
+
+    return allowed;
   }
 }

--- a/src/service/iam/authorize/scp/sim-iam-scp-resolver.ts
+++ b/src/service/iam/authorize/scp/sim-iam-scp-resolver.ts
@@ -13,17 +13,29 @@ export interface SimIamServiceControlPolicy {
 }
 
 /**
+ * The policies attached at one level of the organization above an Account.
+ *
+ * AWS requires an Allow at every level between the root and the Account, so
+ * which level a policy came from decides the request rather than decorating
+ * it. The name is what a denial calls the level.
+ */
+export interface SimIamServiceControlPolicyLevel {
+  readonly nodeName: string;
+  readonly policies: readonly SimIamServiceControlPolicy[];
+}
+
+/**
  * The service control policies in force for one Account.
  *
- * Whether any apply is a separate fact from how many there are. An Account
- * whose only attached policy has been detached is still inside the
+ * Whether any apply is a separate fact from how many levels there are. An
+ * Account whose every policy has been detached is still inside the
  * organization, and nothing allowing an action there denies it. An Account
- * outside every organization is unrestricted. Both hold no policies, so the
- * list alone cannot tell them apart.
+ * outside every organization is unrestricted. Both can hold no policy, so the
+ * levels alone cannot tell them apart.
  */
 export interface SimIamServiceControlPolicySet {
   readonly applies: boolean;
-  readonly policies: readonly SimIamServiceControlPolicy[];
+  readonly levels: readonly SimIamServiceControlPolicyLevel[];
 }
 
 /**

--- a/src/service/organizations/index.ts
+++ b/src/service/organizations/index.ts
@@ -2,7 +2,23 @@ export {
   SimOrganizations,
   type SimOrganizationsAttachOptions,
 } from "./sim-organizations.js";
+export { SimOrganizationsStructure } from "./sim-organizations-structure.js";
 export {
   SIM_ORGANIZATIONS_FULL_AWS_ACCESS,
   SimOrganizationsScpStore,
 } from "./policy/sim-organizations-scp-store.js";
+export { SimOrganizationsEffectivePolicies } from "./policy/sim-organizations-effective-policies.js";
+export {
+  makeSimOrganizationsOrganizationalUnitId,
+  makeSimOrganizationsRootId,
+  SimOrganizationsOrganizationalUnit,
+  type SimOrganizationsNodeId,
+  type SimOrganizationsOrganizationalUnitId,
+  SimOrganizationsRoot,
+  type SimOrganizationsRootId,
+  type SimOrganizationsTarget,
+} from "./tree/sim-organizations-node.js";
+export {
+  SimOrganizationsTree,
+  SimOrganizationsUnknownNode,
+} from "./tree/sim-organizations-tree.js";

--- a/src/service/organizations/policy/sim-organizations-effective-policies.ts
+++ b/src/service/organizations/policy/sim-organizations-effective-policies.ts
@@ -1,0 +1,86 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type {
+  SimIamServiceControlPolicyLevel,
+  SimIamServiceControlPolicySet,
+} from "../../iam/authorize/scp/sim-iam-scp-resolver.js";
+import type { SimOrganizationsNodeId } from "../tree/sim-organizations-node.js";
+import type { SimOrganizationsTree } from "../tree/sim-organizations-tree.js";
+import type { SimOrganizationsScpStore } from "./sim-organizations-scp-store.js";
+
+interface SimOrganizationsEffectivePoliciesProperties {
+  readonly tree: SimOrganizationsTree;
+  readonly scpStore: SimOrganizationsScpStore;
+}
+
+/**
+ * Works out which service control policies an Account is actually subject to.
+ *
+ * The tree says which nodes lie above an Account and the store says what hangs
+ * on each of them. Putting the two together is the whole of what sim IAM asks
+ * an organization, so it lives here rather than in the facade.
+ */
+export class SimOrganizationsEffectivePolicies {
+  private readonly tree: SimOrganizationsTree;
+  private readonly scpStore: SimOrganizationsScpStore;
+
+  private managementAccountId?: SimAwsAccountId | undefined;
+
+  constructor(properties: SimOrganizationsEffectivePoliciesProperties) {
+    this.tree = properties.tree;
+    this.scpStore = properties.scpStore;
+  }
+
+  /**
+   * Name the Account AWS exempts from every service control policy.
+   */
+  setManagementAccount(accountId: SimAwsAccountId): void {
+    this.managementAccountId = accountId;
+  }
+
+  /**
+   * The policies in force for an Account, level by level, root first.
+   */
+  setFor(accountId: SimAwsAccountId): SimIamServiceControlPolicySet {
+    if (accountId === this.managementAccountId) {
+      return { applies: false, levels: [] };
+    }
+
+    const path = this.pathFor(accountId);
+
+    if (path.length === 0) {
+      return { applies: false, levels: [] };
+    }
+
+    return { applies: true, levels: path.map((node) => this.levelAt(node)) };
+  }
+
+  /**
+   * The nodes filtering an Account's requests.
+   *
+   * An Account placed in the organization is filtered by the path down to it.
+   * An Account only ever named by having a policy attached to it is filtered
+   * by that policy alone, which is what attaching to an Account meant before
+   * the organization had a shape.
+   */
+  private pathFor(
+    accountId: SimAwsAccountId,
+  ): readonly SimOrganizationsNodeId[] {
+    if (this.tree.holds(accountId)) {
+      return this.tree.pathTo(accountId);
+    }
+
+    return this.scpStore.holds(accountId) ? [accountId] : [];
+  }
+
+  /**
+   * What one node contributes to an Account's decision.
+   */
+  private levelAt(
+    nodeId: SimOrganizationsNodeId,
+  ): SimIamServiceControlPolicyLevel {
+    return {
+      nodeName: this.tree.nameOf(nodeId),
+      policies: this.scpStore.policiesAt(nodeId),
+    };
+  }
+}

--- a/src/service/organizations/policy/sim-organizations-scp-store.ts
+++ b/src/service/organizations/policy/sim-organizations-scp-store.ts
@@ -1,17 +1,14 @@
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamServiceControlPolicy } from "../../iam/authorize/scp/sim-iam-scp-resolver.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
-import type {
-  SimIamServiceControlPolicy,
-  SimIamServiceControlPolicySet,
-} from "../../iam/authorize/scp/sim-iam-scp-resolver.js";
+import type { SimOrganizationsNodeId } from "../tree/sim-organizations-node.js";
 
 /**
  * The AWS-managed policy attached to every organization node by default.
  *
  * Turning service control policies on in an organization leaves every
  * account's permissions as they were, because this policy comes with them. A
- * simulated Account gets the same treatment, so attaching one Deny statement
- * denies that one action and leaves the rest of the Account working.
+ * simulated node gets the same treatment, so attaching one Deny statement
+ * denies that one action and leaves the rest working.
  */
 export const SIM_ORGANIZATIONS_FULL_AWS_ACCESS: SimIamServiceControlPolicy = {
   policyName: "FullAWSAccess",
@@ -21,96 +18,95 @@ export const SIM_ORGANIZATIONS_FULL_AWS_ACCESS: SimIamServiceControlPolicy = {
   },
 };
 
-interface SimOrganizationsAccountPolicies {
+interface SimOrganizationsNodePolicies {
   readonly attached: SimIamServiceControlPolicy[];
   fullAwsAccess: boolean;
 }
 
 /**
- * The service control policies attached to each simulated Account.
+ * The service control policies attached to each node of an organization.
  *
- * An Account absent from the store is outside the organization's reach and is
- * decided by IAM alone. An Account present in it carries FullAWSAccess along
- * with whatever was attached, until a test detaches FullAWSAccess to write an
- * allow list instead of a deny list.
+ * A node holds FullAWSAccess along with whatever was attached to it, until a
+ * test detaches FullAWSAccess to write an allow list at that node. A node
+ * nothing was attached to still holds FullAWSAccess, so an organizational unit
+ * a test never mentions allows everything through it.
  */
 export class SimOrganizationsScpStore {
-  private readonly byAccountId = new Map<
-    SimAwsAccountId,
-    SimOrganizationsAccountPolicies
+  private readonly byNodeId = new Map<
+    SimOrganizationsNodeId,
+    SimOrganizationsNodePolicies
   >();
 
   /**
-   * Attach a service control policy to an Account.
+   * Attach a service control policy to a node.
    */
   attach(
-    accountId: SimAwsAccountId,
+    nodeId: SimOrganizationsNodeId,
     document: SimIamPolicyDocument,
     policyName?: string,
   ): void {
-    this.accountPolicies(accountId).attached.push({ document, policyName });
+    this.nodePolicies(nodeId).attached.push({ document, policyName });
   }
 
   /**
-   * Take the AWS-managed FullAWSAccess policy off an Account.
+   * Take the AWS-managed FullAWSAccess policy off a node.
    *
-   * What remains has to allow an action for the Account to be allowed it,
-   * which is how an organization is turned into an allow list.
+   * What remains at that node has to allow an action for a request through it
+   * to go ahead, which is how a level is turned into an allow list.
    */
-  detachFullAwsAccess(accountId: SimAwsAccountId): void {
-    this.accountPolicies(accountId).fullAwsAccess = false;
+  detachFullAwsAccess(nodeId: SimOrganizationsNodeId): void {
+    this.nodePolicies(nodeId).fullAwsAccess = false;
   }
 
   /**
-   * Remove every service control policy from an Account, FullAWSAccess
-   * included, putting it back outside the organization's reach.
+   * Put a node back to holding FullAWSAccess and nothing else.
    */
-  detachAll(accountId: SimAwsAccountId): void {
-    this.byAccountId.delete(accountId);
+  detachAll(nodeId: SimOrganizationsNodeId): void {
+    this.byNodeId.delete(nodeId);
   }
 
   /**
-   * The policies in force for an Account, FullAWSAccess first.
-   *
-   * An Account nothing was ever attached to is outside the organization and
-   * gets a set that does not apply. An Account left holding no policies, which
-   * detaching FullAWSAccess on its own produces, gets one that applies and is
-   * empty. Nothing then allows it anything, which is what AWS does to an
-   * account whose every policy has been taken off it.
+   * The policies in force at one node, FullAWSAccess first.
    */
-  policySetFor(accountId: SimAwsAccountId): SimIamServiceControlPolicySet {
-    const account = this.byAccountId.get(accountId);
+  policiesAt(
+    nodeId: SimOrganizationsNodeId,
+  ): readonly SimIamServiceControlPolicy[] {
+    const node = this.byNodeId.get(nodeId);
 
-    if (account === undefined) {
-      return { applies: false, policies: [] };
+    if (node === undefined) {
+      return [SIM_ORGANIZATIONS_FULL_AWS_ACCESS];
     }
 
-    return {
-      applies: true,
-      policies: account.fullAwsAccess
-        ? [SIM_ORGANIZATIONS_FULL_AWS_ACCESS, ...account.attached]
-        : [...account.attached],
-    };
+    return node.fullAwsAccess
+      ? [SIM_ORGANIZATIONS_FULL_AWS_ACCESS, ...node.attached]
+      : [...node.attached];
   }
 
   /**
-   * The record for an Account, created on first use.
+   * Whether anything has been attached to or detached from a node.
    */
-  private accountPolicies(
-    accountId: SimAwsAccountId,
-  ): SimOrganizationsAccountPolicies {
-    const existing = this.byAccountId.get(accountId);
+  holds(nodeId: SimOrganizationsNodeId): boolean {
+    return this.byNodeId.has(nodeId);
+  }
+
+  /**
+   * The record for a node, created on first use.
+   */
+  private nodePolicies(
+    nodeId: SimOrganizationsNodeId,
+  ): SimOrganizationsNodePolicies {
+    const existing = this.byNodeId.get(nodeId);
 
     if (existing !== undefined) {
       return existing;
     }
 
-    const created: SimOrganizationsAccountPolicies = {
+    const created: SimOrganizationsNodePolicies = {
       attached: [],
       fullAwsAccess: true,
     };
 
-    this.byAccountId.set(accountId, created);
+    this.byNodeId.set(nodeId, created);
 
     return created;
   }

--- a/src/service/organizations/sim-organizations-inheritance.iso.test.ts
+++ b/src/service/organizations/sim-organizations-inheritance.iso.test.ts
@@ -225,6 +225,66 @@ describe("Simulated Organizations policy inheritance", () => {
     assertTrue(decision.serviceControlPolicy.isApplied);
   });
 
+  it("keeps inheriting after the Account's own policies are detached", () => {
+    // Given an Account in a unit that denies Bucket creation, with a policy of
+    // its own as well.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    organizations.moveAccount(accountId, workloads);
+    organizations.attachServiceControlPolicy(workloads, {
+      Version: "2012-10-17",
+      Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+    });
+    organizations.attachServiceControlPolicy(accountId, allowOnly("s3:*"));
+
+    // When the Account's own policies are taken off it.
+    organizations.detachServiceControlPolicies(accountId);
+
+    // Then it stays where it sits and the unit above it still denies, the way
+    // detaching a policy in AWS leaves an account in its unit.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+  });
+
+  it("stops filtering an Account taken out of the organization", () => {
+    // Given an Account in a unit that denies Bucket creation.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    organizations.moveAccount(accountId, workloads);
+    organizations.attachServiceControlPolicy(workloads, {
+      Version: "2012-10-17",
+      Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+    });
+
+    // When the Account leaves the organization.
+    organizations.removeAccount(accountId);
+
+    // Then nothing above it reaches it any more.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    assertTrue(decision.isAllowed);
+    assertFalse(decision.serviceControlPolicy.isApplied);
+  });
+
   it("gives no path for an Account outside the tree", () => {
     // Given an organization holding no Accounts.
     const tree = new SimOrganizationsTree();
@@ -242,6 +302,24 @@ describe("Simulated Organizations policy inheritance", () => {
     assertStringStartsWith(organizations.root().id, "r-");
     assertStringStartsWith(workloads.id, "ou-");
     assertIdentical(workloads.parentId, organizations.root().id);
+  });
+
+  it("refuses a policy attached to another organization's unit", () => {
+    // Given a unit belonging to a different simulated organization.
+    const other = new SimAws()
+      .organizations()
+      .createOrganizationalUnit("Other");
+    const simAws = new SimAws();
+
+    // When a policy is attached to it here.
+    const error = assertThrowsError(() => {
+      simAws
+        .organizations()
+        .attachServiceControlPolicy(other, allowOnly("s3:*"));
+    });
+
+    // Then it is refused, rather than attached where no Account would read it.
+    assertInstanceOf(error, SimOrganizationsUnknownNode);
   });
 
   it("refuses an organizational unit from another organization", () => {

--- a/src/service/organizations/sim-organizations-inheritance.iso.test.ts
+++ b/src/service/organizations/sim-organizations-inheritance.iso.test.ts
@@ -1,0 +1,262 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringStartsWith,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimIamPolicyDecisionValue } from "../iam/authorize/sim-iam-decision-value.js";
+import {
+  SimOrganizationsTree,
+  SimOrganizationsUnknownNode,
+} from "./tree/sim-organizations-tree.js";
+
+const allowOnly = (action: string) => ({
+  Version: "2012-10-17",
+  Statement: { Effect: "Allow" as const, Action: action, Resource: "*" },
+});
+
+describe("Simulated Organizations policy inheritance", () => {
+  it("denies an Account beneath the organizational unit the policy hangs on", () => {
+    // Given an Account in a unit whose policy denies creating Buckets.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    organizations.moveAccount(accountId, workloads);
+    organizations.attachServiceControlPolicy(workloads, {
+      Version: "2012-10-17",
+      Statement: {
+        Sid: "DenyBucketCreation",
+        Effect: "Deny",
+        Action: "s3:CreateBucket",
+        Resource: "*",
+      },
+    });
+
+    // When the Account asks to create one.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    // Then the unit above it denied the request, with nothing attached to the
+    // Account itself.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertIdentical(
+      decision.serviceControlPolicy.denyStatements[0]?.Sid,
+      "DenyBucketCreation",
+    );
+  });
+
+  it("inherits a policy through nested organizational units", () => {
+    // Given an Account two units deep, denied at the outer one.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+    const production = organizations.createOrganizationalUnit(
+      "Production",
+      workloads,
+    );
+
+    organizations.moveAccount(accountId, production);
+    organizations.attachServiceControlPolicy(workloads, {
+      Version: "2012-10-17",
+      Statement: { Effect: "Deny", Action: "s3:*", Resource: "*" },
+    });
+
+    // When the Account reads an Object.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+      });
+
+    // Then the policy reached it through the unit in between.
+    assertTrue(decision.serviceControlPolicy.isExplicitDeny);
+    assertArrayEquals(
+      simAws
+        .organizations()
+        .serviceControlPolicySetFor(accountId)
+        .levels.map((level) => level.nodeName),
+      ["Root", "Workloads", "Production", accountId],
+    );
+  });
+
+  it("requires every level to allow the action, not just one of them", () => {
+    // Given a root allowing only S3 and a unit allowing only DynamoDB.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    organizations.moveAccount(accountId, workloads);
+
+    organizations.detachFullAwsAccess(organizations.root());
+    organizations.attachServiceControlPolicy(
+      organizations.root(),
+      allowOnly("s3:*"),
+    );
+
+    organizations.detachFullAwsAccess(workloads);
+    organizations.attachServiceControlPolicy(
+      workloads,
+      allowOnly("dynamodb:*"),
+    );
+
+    // When the Account asks for the action only the root allows.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+      });
+
+    // Then the unit that allowed nothing matching is what denied it.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ImplicitDeny);
+    assertArrayEquals(decision.serviceControlPolicy.unallowedLevels, [
+      "Workloads",
+    ]);
+  });
+
+  it("leaves a Deny at one level standing against an Allow at another", () => {
+    // Given a unit denying Bucket creation and the Account allowing it.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    organizations.moveAccount(accountId, workloads);
+    organizations.attachServiceControlPolicy(workloads, {
+      Version: "2012-10-17",
+      Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+    });
+    organizations.attachServiceControlPolicy(
+      accountId,
+      allowOnly("s3:CreateBucket"),
+    );
+
+    // When the Account asks to create a Bucket.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    // Then the Deny above it wins, as it does in AWS.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+  });
+
+  it("exempts the management account from every policy above it", () => {
+    // Given a management account in a unit that denies everything.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    organizations.moveAccount(accountId, workloads);
+    organizations.attachServiceControlPolicy(workloads, {
+      Version: "2012-10-17",
+      Statement: { Effect: "Deny", Action: "*", Resource: "*" },
+    });
+    organizations.setManagementAccount(accountId);
+
+    // When it asks for something that policy denies.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    // Then no service control policy was applied to it at all.
+    assertTrue(decision.isAllowed);
+    assertFalse(decision.serviceControlPolicy.isApplied);
+    assertArrayLength(
+      organizations.serviceControlPolicySetFor(accountId).levels,
+      0,
+    );
+  });
+
+  it("takes a policy back off an organizational unit", () => {
+    // Given an Account under a unit that denies Bucket creation.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    organizations.moveAccount(accountId, workloads);
+    organizations.attachServiceControlPolicy(workloads, {
+      Version: "2012-10-17",
+      Statement: { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+    });
+
+    // When the unit's policies are taken off it.
+    organizations.detachServiceControlPolicies(workloads);
+
+    // Then the Account is left in the organization, and the unit allows
+    // everything through it again.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    assertTrue(decision.isAllowed);
+    assertTrue(decision.serviceControlPolicy.isApplied);
+  });
+
+  it("gives no path for an Account outside the tree", () => {
+    // Given an organization holding no Accounts.
+    const tree = new SimOrganizationsTree();
+
+    // When the path to an Account it never placed is asked for.
+    // Then there is none, and no level filters that Account.
+    assertArrayLength(tree.pathTo(makeSimAwsAccountId()), 0);
+  });
+
+  it("gives the root and its units AWS-shaped ids", () => {
+    const simAws = new SimAws();
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    assertStringStartsWith(organizations.root().id, "r-");
+    assertStringStartsWith(workloads.id, "ou-");
+    assertIdentical(workloads.parentId, organizations.root().id);
+  });
+
+  it("refuses an organizational unit from another organization", () => {
+    // Given a unit belonging to a different simulated organization.
+    const other = new SimAws()
+      .organizations()
+      .createOrganizationalUnit("Other");
+    const simAws = new SimAws();
+
+    // When it is used as a parent here.
+    // Then the organization refuses it rather than inventing a branch.
+    const error = assertThrowsError(() =>
+      simAws.organizations().createOrganizationalUnit("Child", other),
+    );
+
+    assertInstanceOf(error, SimOrganizationsUnknownNode);
+  });
+});

--- a/src/service/organizations/sim-organizations-structure.ts
+++ b/src/service/organizations/sim-organizations-structure.ts
@@ -1,7 +1,4 @@
-import {
-  simAwsAccountId,
-  type SimAwsAccountId,
-} from "../aws/sim-aws-account.js";
+import { simAwsAccountId } from "../aws/sim-aws-account.js";
 import { SimOrganizationsEffectivePolicies } from "./policy/sim-organizations-effective-policies.js";
 import { SimOrganizationsScpStore } from "./policy/sim-organizations-scp-store.js";
 import type {
@@ -73,18 +70,29 @@ export abstract class SimOrganizationsStructure {
 
   /**
    * Take an Account out of the organization.
+   *
+   * Nothing then filters its requests, whatever is attached above where it
+   * sat. This is how an Account leaves an organization, and it is a different
+   * thing from taking the policies off it.
    */
-  protected removeAccount(accountId: SimAwsAccountId): void {
-    this.tree.removeAccount(accountId);
+  removeAccount(accountId: string): void {
+    this.tree.removeAccount(simAwsAccountId(accountId));
   }
 
   /**
    * The node a target names.
+   *
+   * An Account is named by its id and needs no place in the organization yet,
+   * because attaching a policy to one is what puts it there. A root or
+   * organizational unit has to be this organization's own, so a handle from
+   * another one is refused rather than attached to and never read.
    */
   protected nodeIdOf(target: SimOrganizationsTarget): SimOrganizationsNodeId {
     if (typeof target === "string") {
       return simAwsAccountId(target);
     }
+
+    this.tree.requireNode(target.id);
 
     return target.id;
   }

--- a/src/service/organizations/sim-organizations-structure.ts
+++ b/src/service/organizations/sim-organizations-structure.ts
@@ -1,0 +1,91 @@
+import {
+  simAwsAccountId,
+  type SimAwsAccountId,
+} from "../aws/sim-aws-account.js";
+import { SimOrganizationsEffectivePolicies } from "./policy/sim-organizations-effective-policies.js";
+import { SimOrganizationsScpStore } from "./policy/sim-organizations-scp-store.js";
+import type {
+  SimOrganizationsNodeId,
+  SimOrganizationsOrganizationalUnit,
+  SimOrganizationsRoot,
+  SimOrganizationsTarget,
+} from "./tree/sim-organizations-node.js";
+import { SimOrganizationsTree } from "./tree/sim-organizations-tree.js";
+
+/**
+ * The shape of one simulated organization: its root, the organizational units
+ * under it, and where its Accounts sit.
+ *
+ * SimOrganizations is the facade a test reaches through, and this is the half
+ * of it concerned with structure. The policies that hang on that structure are
+ * the other half.
+ */
+export abstract class SimOrganizationsStructure {
+  protected readonly scpStore = new SimOrganizationsScpStore();
+  protected readonly tree = new SimOrganizationsTree();
+  protected readonly effectivePolicies = new SimOrganizationsEffectivePolicies({
+    tree: this.tree,
+    scpStore: this.scpStore,
+  });
+
+  /**
+   * The root of this organization, which every Account sits under.
+   */
+  root(): SimOrganizationsRoot {
+    return this.tree.root;
+  }
+
+  /**
+   * Create an organizational unit, under the root unless a parent unit is
+   * given.
+   */
+  createOrganizationalUnit(
+    name: string,
+    parent?: SimOrganizationsOrganizationalUnit,
+  ): SimOrganizationsOrganizationalUnit {
+    return this.tree.createOrganizationalUnit(name, parent);
+  }
+
+  /**
+   * Put an Account in the organization, under an organizational unit or under
+   * the root.
+   */
+  moveAccount(
+    accountId: string,
+    parent?: SimOrganizationsOrganizationalUnit,
+  ): void {
+    this.tree.placeAccount(simAwsAccountId(accountId), parent);
+  }
+
+  /**
+   * Name the Account that pays the organization's bills.
+   *
+   * AWS exempts the management account from every service control policy, and
+   * so does this. An Account named here is decided by its identity and
+   * resource policies alone, whatever is attached above it.
+   */
+  setManagementAccount(accountId: string): void {
+    const account = simAwsAccountId(accountId);
+
+    this.effectivePolicies.setManagementAccount(account);
+    this.tree.placeAccount(account);
+  }
+
+  /**
+   * Take an Account out of the organization.
+   */
+  protected removeAccount(accountId: SimAwsAccountId): void {
+    this.tree.removeAccount(accountId);
+  }
+
+  /**
+   * The node a target names.
+   */
+  protected nodeIdOf(target: SimOrganizationsTarget): SimOrganizationsNodeId {
+    if (typeof target === "string") {
+      return simAwsAccountId(target);
+    }
+
+    return target.id;
+  }
+}

--- a/src/service/organizations/sim-organizations.ts
+++ b/src/service/organizations/sim-organizations.ts
@@ -8,7 +8,8 @@ import type {
   SimIamServiceControlPolicyResolver,
   SimIamServiceControlPolicySet,
 } from "../iam/authorize/scp/sim-iam-scp-resolver.js";
-import { SimOrganizationsScpStore } from "./policy/sim-organizations-scp-store.js";
+import { SimOrganizationsStructure } from "./sim-organizations-structure.js";
+import type { SimOrganizationsTarget } from "./tree/sim-organizations-node.js";
 
 /**
  * Options for one attached service control policy.
@@ -21,88 +22,94 @@ export interface SimOrganizationsAttachOptions {
 }
 
 /**
- * Simulated AWS Organizations, holding the service control policies that
- * decide what the Accounts in this simulation may do.
+ * Simulated AWS Organizations, holding the organization structure and the
+ * service control policies that decide what its Accounts may do.
  *
  * An organization spans Accounts, so one of these belongs to a SimAws rather
  * than to an Account scope, and it is reached as `simAws.organizations()`.
  *
- * A service control policy filters permissions and grants none. An Account
- * with policies attached needs an Allow among them for an action, on top of
- * whatever its identity and resource policies say, and a Deny among them ends
- * the request whatever else allows it. That applies to the Account root as
- * well as to its Roles and Users, so it catches a CloudFormation deployment
- * and an intercepted SDK call alike.
+ * A service control policy filters permissions and grants none. Every level
+ * between the root and an Account has to allow an action for the Account to be
+ * allowed it, and a Deny at any level ends the request whatever else allows
+ * it. That applies to the Account root as well as to its Roles and Users, so
+ * it catches a CloudFormation deployment and an intercepted SDK call alike.
+ *
+ * The root, the organizational units and where the Accounts sit come from
+ * SimOrganizationsStructure, which this extends.
  */
-export class SimOrganizations implements SimIamServiceControlPolicyResolver {
-  private readonly scpStore = new SimOrganizationsScpStore();
-
+export class SimOrganizations
+  extends SimOrganizationsStructure
+  implements SimIamServiceControlPolicyResolver
+{
   /**
-   * Attach a service control policy to a simulated Account.
+   * Attach a service control policy to the root, an organizational unit, or an
+   * Account.
    *
-   * The Account also gets AWS's own FullAWSAccess policy, as it would in a
-   * real organization, so one Deny statement denies that action and leaves the
-   * rest of the Account working.
+   * The node also holds AWS's own FullAWSAccess policy, as it would in a real
+   * organization, so one Deny statement denies that action and leaves the rest
+   * of the node's Accounts working.
    */
   attachServiceControlPolicy(
-    accountId: string,
+    target: SimOrganizationsTarget,
     document: SimIamPolicyDocument,
     options: SimOrganizationsAttachOptions = {},
   ): void {
-    this.scpStore.attach(
-      simAwsAccountId(accountId),
-      document,
-      options.policyName ?? "ServiceControlPolicy",
-    );
+    const policyName = options.policyName ?? "ServiceControlPolicy";
+
+    this.scpStore.attach(this.nodeIdOf(target), document, policyName);
   }
 
   /**
-   * Take AWS's FullAWSAccess policy off an Account, leaving only the policies
-   * attached to it to allow anything.
+   * Take AWS's FullAWSAccess policy off a node, leaving only the policies
+   * attached to it to allow anything through that level.
    *
-   * This turns the Account's service control policies into an allow list. An
-   * action no attached policy allows is denied.
+   * This turns the node into an allow list. An action no policy attached there
+   * allows is denied for every Account beneath it.
    */
-  detachFullAwsAccess(accountId: string): void {
-    this.scpStore.detachFullAwsAccess(simAwsAccountId(accountId));
+  detachFullAwsAccess(target: SimOrganizationsTarget): void {
+    this.scpStore.detachFullAwsAccess(this.nodeIdOf(target));
   }
 
   /**
-   * Remove every service control policy from an Account.
+   * Remove every service control policy attached to a node.
    *
-   * The Account is then decided by its identity and resource policies alone,
-   * as it was before anything was attached.
+   * An Account is then decided by its identity and resource policies alone,
+   * along with whatever the levels above it still say.
    */
-  detachServiceControlPolicies(accountId: string): void {
-    this.scpStore.detachAll(simAwsAccountId(accountId));
+  detachServiceControlPolicies(target: SimOrganizationsTarget): void {
+    this.scpStore.detachAll(this.nodeIdOf(target));
+
+    if (typeof target === "string") {
+      this.removeAccount(simAwsAccountId(target));
+    }
   }
 
   /**
-   * The service control policies in force for an Account.
+   * The service control policies in force for an Account, root level first.
    *
-   * This is what sim IAM evaluates, in the order it evaluates them, so a test
-   * tracking down a denial can read the same list the decision did. An empty
-   * list means either that the Account is outside the organization or that
-   * every policy has been taken off it, which
-   * `serviceControlPolicySetFor(...).applies` tells apart.
+   * This flattens the levels, so it says what was evaluated without saying
+   * which level each policy came from. `serviceControlPolicySetFor` keeps that
+   * apart, and a denial needs it, because a level allowing nothing denies the
+   * Account whatever another level allows.
    */
   serviceControlPoliciesFor(
     accountId: SimAwsAccountId | string,
   ): readonly SimIamServiceControlPolicy[] {
-    return this.serviceControlPolicySetFor(simAwsAccountId(accountId)).policies;
+    const set = this.serviceControlPolicySetFor(accountId);
+
+    return set.levels.flatMap((level) => level.policies);
   }
 
   /**
-   * The policies in force for an Account, along with whether the Account is
-   * inside this organization at all.
+   * The policies in force for an Account, level by level, along with whether
+   * the Account is inside this organization at all.
    *
-   * Sim IAM reads this rather than the list, because an Account left holding
-   * no policies is denied everything while an Account outside the organization
-   * is unrestricted.
+   * Sim IAM reads this rather than the flattened list, because each level has
+   * to allow an action on its own.
    */
   serviceControlPolicySetFor(
     accountId: SimAwsAccountId | string,
   ): SimIamServiceControlPolicySet {
-    return this.scpStore.policySetFor(simAwsAccountId(accountId));
+    return this.effectivePolicies.setFor(simAwsAccountId(accountId));
   }
 }

--- a/src/service/organizations/sim-organizations.ts
+++ b/src/service/organizations/sim-organizations.ts
@@ -73,15 +73,13 @@ export class SimOrganizations
   /**
    * Remove every service control policy attached to a node.
    *
-   * An Account is then decided by its identity and resource policies alone,
-   * along with whatever the levels above it still say.
+   * Only that node is cleared. An Account sitting in an organizational unit
+   * goes on inheriting what the levels above it say, as it does in AWS, where
+   * detaching a policy from an account leaves the account where it is. Take an
+   * Account out of the organization with `removeAccount`.
    */
   detachServiceControlPolicies(target: SimOrganizationsTarget): void {
     this.scpStore.detachAll(this.nodeIdOf(target));
-
-    if (typeof target === "string") {
-      this.removeAccount(simAwsAccountId(target));
-    }
   }
 
   /**

--- a/src/service/organizations/tree/sim-organizations-node.ts
+++ b/src/service/organizations/tree/sim-organizations-node.ts
@@ -1,0 +1,73 @@
+import { faker } from "@faker-js/faker";
+import type { Brand } from "../../../util/brand.type.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+
+export type SimOrganizationsRootId = Brand<string, "SimOrganizationsRootId">;
+export type SimOrganizationsOrganizationalUnitId = Brand<
+  string,
+  "SimOrganizationsOrganizationalUnitId"
+>;
+
+/**
+ * Anything a service control policy can hang on.
+ *
+ * AWS attaches a policy to the root, to an organizational unit, or to one
+ * account, and an account inherits every policy on the path down to it.
+ */
+export type SimOrganizationsNodeId =
+  | SimOrganizationsRootId
+  | SimOrganizationsOrganizationalUnitId
+  | SimAwsAccountId;
+
+/**
+ * Generate an AWS-shaped organization root id.
+ */
+export function makeSimOrganizationsRootId(): SimOrganizationsRootId {
+  return `r-${faker.string.alphanumeric({
+    length: 4,
+    casing: "lower",
+  })}` as SimOrganizationsRootId;
+}
+
+/**
+ * Generate an AWS-shaped organizational unit id.
+ */
+export function makeSimOrganizationsOrganizationalUnitId(
+  rootId: SimOrganizationsRootId,
+): SimOrganizationsOrganizationalUnitId {
+  const suffix = faker.string.alphanumeric({ length: 8, casing: "lower" });
+
+  return `ou-${rootId.slice(2)}-${suffix}` as SimOrganizationsOrganizationalUnitId;
+}
+
+/**
+ * An organizational unit in a simulated organization.
+ *
+ * This is the handle a test holds on to. Pass it where a policy is attached or
+ * an Account is moved, so neither reads back as a bare string.
+ */
+export class SimOrganizationsOrganizationalUnit {
+  constructor(
+    public readonly id: SimOrganizationsOrganizationalUnitId,
+    public readonly name: string,
+    public readonly parentId: SimOrganizationsNodeId,
+  ) {}
+}
+
+/**
+ * The root of a simulated organization.
+ */
+export class SimOrganizationsRoot {
+  public readonly name = "Root";
+
+  constructor(public readonly id: SimOrganizationsRootId) {}
+}
+
+/**
+ * Somewhere a policy can be attached, given either as a handle or as the
+ * Account id of an Account.
+ */
+export type SimOrganizationsTarget =
+  | SimOrganizationsRoot
+  | SimOrganizationsOrganizationalUnit
+  | string;

--- a/src/service/organizations/tree/sim-organizations-tree.ts
+++ b/src/service/organizations/tree/sim-organizations-tree.ts
@@ -1,0 +1,150 @@
+import {
+  makeSimOrganizationsOrganizationalUnitId,
+  makeSimOrganizationsRootId,
+  SimOrganizationsOrganizationalUnit,
+  type SimOrganizationsNodeId,
+  SimOrganizationsRoot,
+} from "./sim-organizations-node.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+
+/**
+ * Thrown for an organizational unit this organization has never seen.
+ */
+export class SimOrganizationsUnknownNode extends Error {
+  constructor(nodeId: string) {
+    super(`Unknown simulated Organizations node "${nodeId}"`);
+    this.name = "SimOrganizationsUnknownNode";
+  }
+}
+
+/**
+ * Where the Accounts and organizational units of one simulated organization
+ * sit relative to each other.
+ *
+ * The tree answers one question for authorization: which nodes lie on the path
+ * from the root down to an Account. Every policy on that path applies to the
+ * Account, which is what makes an organizational unit worth modelling at all.
+ *
+ * An Account joins the organization the moment it is named, whether by being
+ * moved into a unit or by having a policy attached to it. An Account never
+ * named sits outside the organization and is unrestricted.
+ */
+export class SimOrganizationsTree {
+  public readonly root = new SimOrganizationsRoot(makeSimOrganizationsRootId());
+
+  private readonly organizationalUnits = new Map<
+    SimOrganizationsNodeId,
+    SimOrganizationsOrganizationalUnit
+  >();
+
+  private readonly accountParents = new Map<
+    SimAwsAccountId,
+    SimOrganizationsNodeId
+  >();
+
+  /**
+   * Create an organizational unit, under the root unless another unit is
+   * named as its parent.
+   */
+  createOrganizationalUnit(
+    name: string,
+    parent?: SimOrganizationsOrganizationalUnit,
+  ): SimOrganizationsOrganizationalUnit {
+    const parentId = parent === undefined ? this.root.id : parent.id;
+
+    this.requireKnown(parentId);
+
+    const unit = new SimOrganizationsOrganizationalUnit(
+      makeSimOrganizationsOrganizationalUnitId(this.root.id),
+      name,
+      parentId,
+    );
+
+    this.organizationalUnits.set(unit.id, unit);
+
+    return unit;
+  }
+
+  /**
+   * Place an Account under a node, joining the organization if it was outside
+   * it.
+   */
+  placeAccount(
+    accountId: SimAwsAccountId,
+    parent?: SimOrganizationsOrganizationalUnit,
+  ): void {
+    const parentId = parent === undefined ? this.root.id : parent.id;
+
+    this.requireKnown(parentId);
+
+    this.accountParents.set(accountId, parentId);
+  }
+
+  /**
+   * Take an Account out of the organization.
+   */
+  removeAccount(accountId: SimAwsAccountId): void {
+    this.accountParents.delete(accountId);
+  }
+
+  /**
+   * Whether this Account is in the organization.
+   */
+  holds(accountId: SimAwsAccountId): boolean {
+    return this.accountParents.has(accountId);
+  }
+
+  /**
+   * The nodes a request against an Account is filtered by, root first.
+   *
+   * The Account itself is the last of them, because a policy attached to an
+   * Account applies alongside the ones it inherits.
+   */
+  pathTo(accountId: SimAwsAccountId): readonly SimOrganizationsNodeId[] {
+    const parentId = this.accountParents.get(accountId);
+
+    if (parentId === undefined) {
+      return [];
+    }
+
+    return [...this.ancestors(parentId), accountId];
+  }
+
+  /**
+   * What to call a node in a denial.
+   */
+  nameOf(nodeId: SimOrganizationsNodeId): string {
+    if (nodeId === this.root.id) {
+      return this.root.name;
+    }
+
+    return this.organizationalUnits.get(nodeId)?.name ?? String(nodeId);
+  }
+
+  /**
+   * The nodes from the root down to one node, root first.
+   */
+  private ancestors(
+    nodeId: SimOrganizationsNodeId,
+  ): readonly SimOrganizationsNodeId[] {
+    const path: SimOrganizationsNodeId[] = [];
+
+    let currentId: SimOrganizationsNodeId | undefined = nodeId;
+
+    while (currentId !== undefined && currentId !== this.root.id) {
+      path.unshift(currentId);
+      currentId = this.organizationalUnits.get(currentId)?.parentId;
+    }
+
+    return [this.root.id, ...path];
+  }
+
+  /**
+   * Refuse a node this organization never created.
+   */
+  private requireKnown(nodeId: SimOrganizationsNodeId): void {
+    if (nodeId !== this.root.id && !this.organizationalUnits.has(nodeId)) {
+      throw new SimOrganizationsUnknownNode(nodeId);
+    }
+  }
+}

--- a/src/service/organizations/tree/sim-organizations-tree.ts
+++ b/src/service/organizations/tree/sim-organizations-tree.ts
@@ -95,6 +95,17 @@ export class SimOrganizationsTree {
   }
 
   /**
+   * Refuse a root or organizational unit this organization never created.
+   *
+   * A handle from another simulated organization would otherwise be attached
+   * to and then never read, because no Account here has it on its path. A
+   * policy that silently applies to nothing is worse than a refusal.
+   */
+  requireNode(nodeId: SimOrganizationsNodeId): void {
+    this.requireKnown(nodeId);
+  }
+
+  /**
    * The nodes a request against an Account is filtered by, root first.
    *
    * The Account itself is the last of them, because a policy attached to an


### PR DESCRIPTION
A simulated organization now has a root and organizational units under it, and an Account inherits every service control policy on the path down to it.

Resolves https://github.com/KensioSoftware/yulin/issues/1060

The behaviour change worth reviewing is that each level is asked separately. #1059 read an Account's policies as one flat list, so a single matching `Allow` anywhere opened the gate. AWS requires an `Allow` at every level between the root and the Account, so a root allowing `s3:*` and a unit allowing `dynamodb:*` leave an Account under both able to do neither. `SimIamScpGate` now evaluates level by level, and a denial reports `unallowedLevels`, naming the nodes that allowed nothing matching.

`setManagementAccount` names the Account AWS exempts from every SCP. An Account that only ever had a policy attached to it directly is still filtered by that policy alone, so everything #1059 shipped keeps working unchanged.

`SimOrganizations` is split across `SimOrganizationsStructure` (root, units, Account placement) and the policy half, following the `SimS3 extends SimS3Operations` pattern. That split was forced by the FTA threshold, and extracting to a collaborator made the score worse rather than better, which is the usual density trap.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hierarchical Organizations support with roots, organizational units, account placement, and policy inheritance.
  - Service control policies can now be attached and evaluated at each organizational level.
  - Added management-account exemptions and support for accounts outside an organization.
  - Exposed organization structure, node identifiers, effective policies, and policy evaluation results.
  - Added examples demonstrating inheritance, multi-level authorization, and management-account behavior.

- **Documentation**
  - Expanded Organizations guidance with evaluation rules, examples, terminology, and updated limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->