### PR TITLE
feat: deploy an organization from CloudFormation

### DIFF
--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -311,7 +311,9 @@ console.log(decision.value); // "ExplicitDeny"
 ```
 
 `Content` takes the policy document inline or as JSON text. `TargetIds` takes a list or a single
-value, and each entry names the root, a unit, or an Account.
+value, and each entry names the root, a unit, or an Account. A policy reaches every target it names
+or none of them. A target this organization has never heard of fails the resource before anything is
+attached.
 
 A simulated environment has one organization from the start, so
 `AWS::Organizations::Organization` records the one already there rather than making another. It is
@@ -329,9 +331,10 @@ These are the properties read from each resource:
 | `AWS::Organizations::Account`            | `AccountName`, `Email`, `ParentIds`    | `Tags`, `RoleName`    |
 | `AWS::Organizations::Policy`             | `Name`, `Type`, `Content`, `TargetIds` | `Tags`, `Description` |
 
-Tearing the stack down takes the policies off the nodes they were attached to, removes the units,
-and takes any Account the stack created back out of the organization. A unit that still holds
-something when it goes hands what it holds to its parent, so every Account keeps a path to the root.
+Tearing the stack down takes its own policies off the nodes they were attached to, removes the
+units, and takes any Account the stack created back out of the organization. A node holding
+policies from more than one stack keeps the others. A unit that still holds something when it goes
+hands what it holds to its parent, so every Account keeps a path to the root.
 
 ## Reading a denial
 
@@ -371,7 +374,10 @@ Simulated Organizations supports:
 - `moveAccount`, putting an Account under a unit or under the root
 - `root`, the node above every Account in the organization
 - `setManagementAccount`, exempting the Account AWS exempts
-- `attachServiceControlPolicy`, attaching a policy document to the root, a unit, or an Account
+- `attachServiceControlPolicy`, attaching a policy document to the root, a unit, or an Account, and
+  answering with the id that takes it off again
+- `detachServiceControlPolicy`, taking one policy off a node and leaving the rest
+- `accountIds`, reading which Accounts the organization holds
 - `detachFullAwsAccess`, turning a node's policies into an allow list
 - `detachServiceControlPolicies`, taking every policy back off one node and leaving the rest alone
 - `removeAccount`, taking an Account out of the organization

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -253,6 +253,86 @@ SCP does in AWS, and it is why an allow list is worth writing in a test at all.
 Detaching `FullAWSAccess` on its own leaves the account holding no policy, and every action is then
 denied. AWS behaves the same way, and warns about it.
 
+## Deploy an organization from CloudFormation
+
+A template's `AWS::Organizations::*` resources build the organization they describe, so a stack
+already managing the org chart is the same one a test deploys.
+
+```typescript sim-organizations-cloudformation
+/**
+ * Building an organization from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "org-stack",
+  template: {
+    Resources: {
+      Organization: { Type: "AWS::Organizations::Organization" },
+      Workloads: {
+        Type: "AWS::Organizations::OrganizationalUnit",
+        Properties: {
+          Name: "Workloads",
+          ParentId: { "Fn::GetAtt": ["Organization", "RootId"] },
+        },
+      },
+      DenyBucketCreation: {
+        Type: "AWS::Organizations::Policy",
+        Properties: {
+          Name: "DenyBucketCreation",
+          Type: "SERVICE_CONTROL_POLICY",
+          TargetIds: [{ Ref: "Workloads" }],
+          Content: {
+            Version: "2012-10-17",
+            Statement: [
+              { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+            ],
+          },
+        },
+      },
+    },
+    Outputs: { WorkloadsId: { Value: { Ref: "Workloads" } } },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+simAws.organizations().moveAccount("123456789012", stack.output("WorkloadsId"));
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::reports-bucket",
+});
+
+console.log(decision.value); // "ExplicitDeny"
+```
+
+`Content` takes the policy document inline or as JSON text. `TargetIds` takes a list or a single
+value, and each entry names the root, a unit, or an Account.
+
+A simulated environment has one organization from the start, so
+`AWS::Organizations::Organization` records the one already there rather than making another. It is
+worth declaring for `RootId`, which is what a unit hangs off.
+
+`AWS::Organizations::Account` creates an Account with an id nobody chose, as AWS does. Read that id
+back with `Ref` or `Fn::GetAtt AccountId`.
+
+These are the properties read from each resource:
+
+| Resource                                 | Read                                   | Recorded and skipped  |
+| ---------------------------------------- | -------------------------------------- | --------------------- |
+| `AWS::Organizations::Organization`       | `FeatureSet`                           | `FeatureSet`          |
+| `AWS::Organizations::OrganizationalUnit` | `Name`, `ParentId`                     | `Tags`                |
+| `AWS::Organizations::Account`            | `AccountName`, `Email`, `ParentIds`    | `Tags`, `RoleName`    |
+| `AWS::Organizations::Policy`             | `Name`, `Type`, `Content`, `TargetIds` | `Tags`, `Description` |
+
+Tearing the stack down takes the policies off the nodes they were attached to, removes the units,
+and takes any Account the stack created back out of the organization. A unit that still holds
+something when it goes hands what it holds to its parent, so every Account keeps a path to the root.
+
 ## Reading a denial
 
 An authorization decision reports the organization's verdict apart from the identity and resource
@@ -307,6 +387,8 @@ Simulated Organizations supports:
   operators, and their `ForAnyValue:` and `ForAllValues:` set forms
 - `AccessDenied` messages naming the service control policy, as AWS words them
 - Denial reporting through `decision.serviceControlPolicy`, naming the levels that allowed nothing
+- The `AWS::Organizations::Organization`, `::OrganizationalUnit`, `::Account` and `::Policy`
+  CloudFormation resources, with `Ref` and `Fn::GetAtt`, and teardown
 
 ## Limitations
 

--- a/docs/services/organizations/sim-organizations-cloudformation.example.ts
+++ b/docs/services/organizations/sim-organizations-cloudformation.example.ts
@@ -1,0 +1,49 @@
+/**
+ * Building an organization from a CloudFormation template.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "org-stack",
+  template: {
+    Resources: {
+      Organization: { Type: "AWS::Organizations::Organization" },
+      Workloads: {
+        Type: "AWS::Organizations::OrganizationalUnit",
+        Properties: {
+          Name: "Workloads",
+          ParentId: { "Fn::GetAtt": ["Organization", "RootId"] },
+        },
+      },
+      DenyBucketCreation: {
+        Type: "AWS::Organizations::Policy",
+        Properties: {
+          Name: "DenyBucketCreation",
+          Type: "SERVICE_CONTROL_POLICY",
+          TargetIds: [{ Ref: "Workloads" }],
+          Content: {
+            Version: "2012-10-17",
+            Statement: [
+              { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+            ],
+          },
+        },
+      },
+    },
+    Outputs: { WorkloadsId: { Value: { Ref: "Workloads" } } },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+simAws.organizations().moveAccount("123456789012", stack.output("WorkloadsId"));
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::reports-bucket",
+});
+
+console.log(decision.value); // "ExplicitDeny"

--- a/src/service/cloudformation/resource/cfn/organizations/sim-organizations-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/organizations/sim-organizations-cfn-value-adapter.ts
@@ -1,0 +1,44 @@
+import {
+  SimCfnOrganization,
+  SimCfnOrganizationsAccount,
+  SimCfnOrganizationsPolicy,
+} from "../../../../organizations/cfn/sim-cfn-organizations-record.js";
+import { SimOrganizationsOrganizationalUnit } from "../../../../organizations/tree/sim-organizations-node.js";
+import type {
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+import {
+  SimOrganizationalUnitCfn,
+  SimOrganizationCfn,
+  SimOrganizationsAccountCfn,
+  SimOrganizationsPolicyCfn,
+} from "./sim-organizations-cfn.js";
+
+/**
+ * The CloudFormation-facing value adapter for a simulated Organizations
+ * Resource.
+ */
+export function organizationsValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  const { simResource } = properties;
+
+  if (simResource instanceof SimCfnOrganization) {
+    return new SimOrganizationCfn(simResource);
+  }
+
+  if (simResource instanceof SimOrganizationsOrganizationalUnit) {
+    return new SimOrganizationalUnitCfn(simResource);
+  }
+
+  if (simResource instanceof SimCfnOrganizationsAccount) {
+    return new SimOrganizationsAccountCfn(simResource);
+  }
+
+  if (simResource instanceof SimCfnOrganizationsPolicy) {
+    return new SimOrganizationsPolicyCfn(simResource);
+  }
+
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/organizations/sim-organizations-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/organizations/sim-organizations-cfn.ts
@@ -1,0 +1,159 @@
+import type {
+  SimCfnOrganization,
+  SimCfnOrganizationsAccount,
+  SimCfnOrganizationsPolicy,
+} from "../../../../organizations/cfn/sim-cfn-organizations-record.js";
+import type { SimOrganizationsOrganizationalUnit } from "../../../../organizations/tree/sim-organizations-node.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+/**
+ * Refuse an attribute the AWS Resource reference does not list.
+ */
+function unknownAttribute(resourceType: string, attributeName: string): never {
+  throw new Error(
+    `AWS::Organizations::${resourceType} has no attribute ${attributeName}`,
+  );
+}
+
+/**
+ * CloudFormation-facing values for a simulated organization.
+ */
+export class SimOrganizationCfn implements SimCfnResourceValueAdapter {
+  constructor(private readonly organization: SimCfnOrganization) {}
+
+  /**
+   * AWS::Organizations::Organization Ref returns the organization id.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.organization.id;
+  }
+
+  /**
+   * The attributes the AWS Resource reference lists, less the management
+   * account email, which a simulation has no address for.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const { organization } = this;
+    const values = new Map<string, SimCfnTemplateValue>([
+      ["Id", organization.id],
+      [
+        "Arn",
+        `arn:aws:organizations::${organization.managementAccountId}:organization/${organization.id}`,
+      ],
+      ["RootId", organization.rootId],
+      ["ManagementAccountId", organization.managementAccountId],
+      [
+        "ManagementAccountArn",
+        `arn:aws:organizations::${organization.managementAccountId}:account/${organization.id}/${organization.managementAccountId}`,
+      ],
+    ]);
+
+    return (
+      values.get(attributeName) ??
+      unknownAttribute("Organization", attributeName)
+    );
+  }
+}
+
+/**
+ * CloudFormation-facing values for a simulated organizational unit.
+ */
+export class SimOrganizationalUnitCfn implements SimCfnResourceValueAdapter {
+  constructor(private readonly unit: SimOrganizationsOrganizationalUnit) {}
+
+  /**
+   * AWS::Organizations::OrganizationalUnit Ref returns the unit id.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.unit.id;
+  }
+
+  /**
+   * Id, Arn and Name, as the AWS Resource reference lists.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const { unit } = this;
+    const values = new Map<string, SimCfnTemplateValue>([
+      ["Id", unit.id],
+      ["Arn", `arn:aws:organizations::organizational-unit/${unit.id}`],
+      ["Name", unit.name],
+    ]);
+
+    return (
+      values.get(attributeName) ??
+      unknownAttribute("OrganizationalUnit", attributeName)
+    );
+  }
+}
+
+/**
+ * CloudFormation-facing values for an Account a template put in the
+ * organization.
+ */
+export class SimOrganizationsAccountCfn implements SimCfnResourceValueAdapter {
+  constructor(private readonly account: SimCfnOrganizationsAccount) {}
+
+  /**
+   * AWS::Organizations::Account Ref returns the Account id.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.account.accountId;
+  }
+
+  /**
+   * The attributes the AWS Resource reference lists.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const { account } = this;
+    const values = new Map<string, SimCfnTemplateValue>([
+      ["AccountId", account.accountId],
+      [
+        "Arn",
+        `arn:aws:organizations::${account.accountId}:account/${account.accountId}`,
+      ],
+      ["Email", account.email],
+      ["AccountName", account.accountName],
+      ["JoinedMethod", "CREATED"],
+      ["JoinedTimestamp", account.joinedTimestamp.toISOString()],
+      ["Status", "ACTIVE"],
+    ]);
+
+    return (
+      values.get(attributeName) ?? unknownAttribute("Account", attributeName)
+    );
+  }
+}
+
+/**
+ * CloudFormation-facing values for a simulated service control policy.
+ */
+export class SimOrganizationsPolicyCfn implements SimCfnResourceValueAdapter {
+  constructor(private readonly policy: SimCfnOrganizationsPolicy) {}
+
+  /**
+   * AWS::Organizations::Policy Ref returns the policy id.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.policy.id;
+  }
+
+  /**
+   * Id, Arn and AwsManaged, as the AWS Resource reference lists.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    const { policy } = this;
+    const values = new Map<string, SimCfnTemplateValue>([
+      ["Id", policy.id],
+      [
+        "Arn",
+        `arn:aws:organizations::policy/service_control_policy/${policy.id}`,
+      ],
+      ["AwsManaged", false],
+    ]);
+
+    return (
+      values.get(attributeName) ?? unknownAttribute("Policy", attributeName)
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -18,6 +18,7 @@ import { iamValueAdapter } from "./iam/sim-iam-cfn-value-adapter.js";
 import { kinesisValueAdapter } from "./kinesis/sim-kinesis-cfn-value-adapter.js";
 import { kmsValueAdapter } from "./kms/sim-kms-cfn-value-adapter.js";
 import { lambdaValueAdapter } from "./lambda/sim-lambda-cfn-value-adapter.js";
+import { organizationsValueAdapter } from "./organizations/sim-organizations-cfn-value-adapter.js";
 import { personalizeValueAdapter } from "./personalize/sim-personalize-cfn-value-adapter.js";
 import { route53ValueAdapter } from "./route53/sim-route53-cfn-value-adapter.js";
 import { s3ValueAdapter } from "./s3/sim-s3-cfn-value-adapter.js";
@@ -67,6 +68,7 @@ export const simCfnServiceValueAdapters: readonly ((
   kinesisValueAdapter,
   kmsValueAdapter,
   lambdaValueAdapter,
+  organizationsValueAdapter,
   personalizeValueAdapter,
   route53ValueAdapter,
   s3ValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionContainer } from "../../../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnServiceResourceFactory } from "../../factory/sim-cfn-resource-factory.type.js";
 import { SimCfnCfnResourceFactory } from "../../factory/sim-cfn-cfn-resource-factory.js";
+import { SimOrganizationsCfnResourceFactory } from "../../../../organizations/cfn/sim-organizations-cfn-resource-factory.js";
 
 /**
  * How one simulated service hands over its CloudFormation Resource factory,
@@ -53,6 +54,13 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
   [
     "CloudFormation",
     (): SimCfnServiceResourceFactory => new SimCfnCfnResourceFactory(),
+  ],
+  // An organization spans Accounts, so this factory reads the one on the
+  // creation context rather than the Account and Region scope it deploys into.
+  [
+    "Organizations",
+    (): SimCfnServiceResourceFactory =>
+      new SimOrganizationsCfnResourceFactory(),
   ],
   [
     "CloudFront",

--- a/src/service/organizations/cfn/sim-cfn-organization-creator.ts
+++ b/src/service/organizations/cfn/sim-cfn-organization-creator.ts
@@ -1,0 +1,47 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnOrganization } from "./sim-cfn-organizations-record.js";
+import { SimCfnOrganizationsProperties } from "./sim-cfn-organizations-properties.js";
+
+/**
+ * Records the organization an `AWS::Organizations::Organization` declares.
+ *
+ * A SimAws already has one organization, so this brings nothing into being.
+ * The Resource earns its place by answering `RootId`, which is what the rest
+ * of a template hangs off.
+ */
+export class SimCfnOrganizationCreator {
+  readonly #simAws: SimAws;
+
+  constructor(simAws: SimAws) {
+    this.#simAws = simAws;
+  }
+
+  /**
+   * Record the organization a template declares.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnOrganization {
+    const values = new SimCfnOrganizationsProperties(
+      resource,
+      "AWS::Organizations::Organization",
+    );
+    const featureSet = properties["FeatureSet"];
+
+    values.ignore(
+      featureSet,
+      "FeatureSet",
+      "Simulated Organizations evaluates service control policies whatever " +
+        "the feature set says",
+    );
+
+    return new SimCfnOrganization(
+      this.#simAws.organizations().root().id,
+      values.optionalString(featureSet) ?? "ALL",
+      this.#simAws.defaultAccountId,
+    );
+  }
+}

--- a/src/service/organizations/cfn/sim-cfn-organizational-unit-creator.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizational-unit-creator.ts
@@ -1,0 +1,43 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimOrganizationsOrganizationalUnit } from "../tree/sim-organizations-node.js";
+import { SimCfnOrganizationsProperties } from "./sim-cfn-organizations-properties.js";
+
+/**
+ * Creates organizational units from
+ * `AWS::Organizations::OrganizationalUnit` Resources.
+ */
+export class SimCfnOrganizationalUnitCreator {
+  readonly #simAws: SimAws;
+
+  constructor(simAws: SimAws) {
+    this.#simAws = simAws;
+  }
+
+  /**
+   * Create a unit under the node its `ParentId` names.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimOrganizationsOrganizationalUnit {
+    const values = new SimCfnOrganizationsProperties(
+      resource,
+      "AWS::Organizations::OrganizationalUnit",
+    );
+
+    values.ignore(
+      properties["Tags"],
+      "Tags",
+      "Simulated Organizations reads no unit tags",
+    );
+
+    return this.#simAws
+      .organizations()
+      .createOrganizationalUnit(
+        values.requiredString(properties["Name"], "Name"),
+        values.requiredString(properties["ParentId"], "ParentId"),
+      );
+  }
+}

--- a/src/service/organizations/cfn/sim-cfn-organizations-account-creator.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-account-creator.ts
@@ -1,0 +1,59 @@
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnOrganizationsAccount } from "./sim-cfn-organizations-record.js";
+import { SimCfnOrganizationsProperties } from "./sim-cfn-organizations-properties.js";
+
+/**
+ * Puts Accounts in the organization from `AWS::Organizations::Account`
+ * Resources.
+ *
+ * AWS creates a new account here and gives it an id nobody chose, so this does
+ * the same. A template reads that id back with `Ref` or with
+ * `Fn::GetAtt AccountId`.
+ */
+export class SimCfnOrganizationsAccountCreator {
+  readonly #simAws: SimAws;
+
+  constructor(simAws: SimAws) {
+    this.#simAws = simAws;
+  }
+
+  /**
+   * Create an Account under the first node its `ParentIds` names.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnOrganizationsAccount {
+    const values = new SimCfnOrganizationsProperties(
+      resource,
+      "AWS::Organizations::Account",
+    );
+
+    values.ignore(
+      properties["Tags"],
+      "Tags",
+      "Simulated Organizations reads no Account tags",
+    );
+    values.ignore(
+      properties["RoleName"],
+      "RoleName",
+      "Simulated Organizations creates no cross-account access Role",
+    );
+
+    const accountId = makeSimAwsAccountId();
+
+    this.#simAws
+      .organizations()
+      .moveAccount(accountId, values.stringList(properties["ParentIds"])[0]);
+
+    return new SimCfnOrganizationsAccount(
+      accountId,
+      values.requiredString(properties["AccountName"], "AccountName"),
+      values.requiredString(properties["Email"], "Email"),
+      this.#simAws.now(),
+    );
+  }
+}

--- a/src/service/organizations/cfn/sim-cfn-organizations-account-creator.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-account-creator.ts
@@ -43,16 +43,23 @@ export class SimCfnOrganizationsAccountCreator {
       "Simulated Organizations creates no cross-account access Role",
     );
 
+    // Everything the Resource needs is read before the organization changes.
+    // A property that fails after the Account was placed would leave it in the
+    // organization with no record for a teardown to take it out again.
+    const accountName = values.requiredString(
+      properties["AccountName"],
+      "AccountName",
+    );
+    const email = values.requiredString(properties["Email"], "Email");
+    const parentId = values.stringList(properties["ParentIds"])[0];
     const accountId = makeSimAwsAccountId();
 
-    this.#simAws
-      .organizations()
-      .moveAccount(accountId, values.stringList(properties["ParentIds"])[0]);
+    this.#simAws.organizations().moveAccount(accountId, parentId);
 
     return new SimCfnOrganizationsAccount(
       accountId,
-      values.requiredString(properties["AccountName"], "AccountName"),
-      values.requiredString(properties["Email"], "Email"),
+      accountName,
+      email,
       this.#simAws.now(),
     );
   }

--- a/src/service/organizations/cfn/sim-cfn-organizations-policy-creator.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-policy-creator.ts
@@ -1,0 +1,78 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+import type { SimOrganizationsNodeId } from "../tree/sim-organizations-node.js";
+import { SimCfnOrganizationsPolicy } from "./sim-cfn-organizations-record.js";
+import { SimCfnOrganizationsProperties } from "./sim-cfn-organizations-properties.js";
+
+const SERVICE_CONTROL_POLICY = "SERVICE_CONTROL_POLICY";
+
+/**
+ * Attaches service control policies from `AWS::Organizations::Policy`
+ * Resources to the nodes they target.
+ *
+ * A policy of any other type is refused as an unsupported Resource, so the
+ * Stack records it and deploys on. Simulated Organizations evaluates service
+ * control policies and nothing else, and a tag policy stored here would look
+ * like one that does something.
+ */
+export class SimCfnOrganizationsPolicyCreator {
+  readonly #simAws: SimAws;
+
+  constructor(simAws: SimAws) {
+    this.#simAws = simAws;
+  }
+
+  /**
+   * Attach a policy to every node its `TargetIds` names.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnOrganizationsPolicy {
+    const values = new SimCfnOrganizationsProperties(
+      resource,
+      "AWS::Organizations::Policy",
+    );
+    const policyType = values.requiredString(properties["Type"], "Type");
+
+    if (policyType !== SERVICE_CONTROL_POLICY) {
+      throw new Error(
+        `Unsupported sim Organizations CloudFormation Resource Policy of ` +
+          `type ${policyType}`,
+      );
+    }
+
+    values.ignore(
+      properties["Tags"],
+      "Tags",
+      "Simulated Organizations reads no policy tags",
+    );
+    values.ignore(
+      properties["Description"],
+      "Description",
+      "A policy description decides nothing",
+    );
+
+    const name = values.requiredString(properties["Name"], "Name");
+    const document = values.documentValue(
+      properties["Content"],
+      "Content",
+    ) as SimIamPolicyDocument;
+    const targetIds = values.stringList(properties["TargetIds"]);
+
+    for (const targetId of targetIds) {
+      this.#simAws
+        .organizations()
+        .attachServiceControlPolicy(targetId, document, { policyName: name });
+    }
+
+    return new SimCfnOrganizationsPolicy(
+      `p-${resource.logicalId.toLowerCase()}`,
+      name,
+      policyType,
+      targetIds as readonly SimOrganizationsNodeId[],
+    );
+  }
+}

--- a/src/service/organizations/cfn/sim-cfn-organizations-policy-creator.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-policy-creator.ts
@@ -1,12 +1,12 @@
 import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
-import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
-import type { SimOrganizationsNodeId } from "../tree/sim-organizations-node.js";
+import {
+  makeSimOrganizationsPolicyId,
+  type SimOrganizationsNodeId,
+} from "../tree/sim-organizations-node.js";
 import { SimCfnOrganizationsPolicy } from "./sim-cfn-organizations-record.js";
-import { SimCfnOrganizationsProperties } from "./sim-cfn-organizations-properties.js";
-
-const SERVICE_CONTROL_POLICY = "SERVICE_CONTROL_POLICY";
+import { SimCfnOrganizationsPolicyInput } from "./sim-cfn-organizations-policy-input.js";
 
 /**
  * Attaches service control policies from `AWS::Organizations::Policy`
@@ -31,48 +31,31 @@ export class SimCfnOrganizationsPolicyCreator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
   ): SimCfnOrganizationsPolicy {
-    const values = new SimCfnOrganizationsProperties(
-      resource,
-      "AWS::Organizations::Policy",
-    );
-    const policyType = values.requiredString(properties["Type"], "Type");
+    const input = new SimCfnOrganizationsPolicyInput(resource, properties);
+    const organizations = this.#simAws.organizations();
 
-    if (policyType !== SERVICE_CONTROL_POLICY) {
-      throw new Error(
-        `Unsupported sim Organizations CloudFormation Resource Policy of ` +
-          `type ${policyType}`,
-      );
-    }
+    // Every target is resolved before any of them is attached to. Refusing one
+    // partway through would leave the earlier targets holding a policy no
+    // teardown knows about.
+    organizations.requireTargets(input.targetIds);
 
-    values.ignore(
-      properties["Tags"],
-      "Tags",
-      "Simulated Organizations reads no policy tags",
-    );
-    values.ignore(
-      properties["Description"],
-      "Description",
-      "A policy description decides nothing",
-    );
+    // An id of its own, rather than one derived from the logical id. Two
+    // Stacks can each declare a Policy called the same thing, and a shared id
+    // would let one Stack's teardown take the other's policy off.
+    const policyId = makeSimOrganizationsPolicyId();
 
-    const name = values.requiredString(properties["Name"], "Name");
-    const document = values.documentValue(
-      properties["Content"],
-      "Content",
-    ) as SimIamPolicyDocument;
-    const targetIds = values.stringList(properties["TargetIds"]);
-
-    for (const targetId of targetIds) {
-      this.#simAws
-        .organizations()
-        .attachServiceControlPolicy(targetId, document, { policyName: name });
+    for (const targetId of input.targetIds) {
+      organizations.attachServiceControlPolicy(targetId, input.document, {
+        policyName: input.name,
+        policyId,
+      });
     }
 
     return new SimCfnOrganizationsPolicy(
-      `p-${resource.logicalId.toLowerCase()}`,
-      name,
-      policyType,
-      targetIds as readonly SimOrganizationsNodeId[],
+      policyId,
+      input.name,
+      input.policyType,
+      input.targetIds as readonly SimOrganizationsNodeId[],
     );
   }
 }

--- a/src/service/organizations/cfn/sim-cfn-organizations-policy-input.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-policy-input.ts
@@ -1,0 +1,56 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+import { SimCfnOrganizationsProperties } from "./sim-cfn-organizations-properties.js";
+
+const SERVICE_CONTROL_POLICY = "SERVICE_CONTROL_POLICY";
+
+/**
+ * What an `AWS::Organizations::Policy` Resource asks for.
+ *
+ * Every property is read here before the creator changes anything, so a
+ * Resource that cannot be satisfied fails with the organization untouched.
+ */
+export class SimCfnOrganizationsPolicyInput {
+  public readonly name: string;
+  public readonly document: SimIamPolicyDocument;
+  public readonly targetIds: readonly string[];
+
+  constructor(resource: SimCfnResource, properties: SimCfnTemplateValueRecord) {
+    const values = new SimCfnOrganizationsProperties(
+      resource,
+      "AWS::Organizations::Policy",
+    );
+    const policyType = values.requiredString(properties["Type"], "Type");
+
+    if (policyType !== SERVICE_CONTROL_POLICY) {
+      throw new Error(
+        `Unsupported sim Organizations CloudFormation Resource Policy of ` +
+          `type ${policyType}`,
+      );
+    }
+
+    values.ignore(
+      properties["Tags"],
+      "Tags",
+      "Simulated Organizations reads no policy tags",
+    );
+    values.ignore(
+      properties["Description"],
+      "Description",
+      "A policy description decides nothing",
+    );
+
+    this.name = values.requiredString(properties["Name"], "Name");
+    this.document = values.documentValue(properties["Content"], "Content");
+    this.targetIds = values.stringList(properties["TargetIds"]);
+  }
+
+  /**
+   * The policy type this Resource carries, which is the only one simulated
+   * Organizations evaluates.
+   */
+  get policyType(): string {
+    return SERVICE_CONTROL_POLICY;
+  }
+}

--- a/src/service/organizations/cfn/sim-cfn-organizations-properties.iso.test.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-properties.iso.test.ts
@@ -1,9 +1,9 @@
 import {
   assertArrayEquals,
+  assertArrayLength,
   assertIdentical,
   assertStringIncludes,
   assertThrowsErrorAsync,
-  assertTrue,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
@@ -14,6 +14,12 @@ const denyBucketCreation = {
   Version: "2012-10-17",
   Statement: [{ Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" }],
 };
+
+/**
+ * The Accounts a simulated organization has been told about.
+ */
+const organizationAccountIds = (simAws: SimAws): readonly string[] =>
+  simAws.organizations().accountIds();
 
 describe("Simulated Organizations CloudFormation properties", () => {
   it("reads a policy document given as JSON text", async () => {
@@ -137,49 +143,57 @@ describe("Simulated Organizations CloudFormation properties", () => {
     );
   });
 
-  it("moves a nested unit up when the unit above it goes", async () => {
-    // Given a Stack with a unit inside a unit, and an Account under the inner
-    // one.
-    const accountId = makeSimAwsAccountId();
-    const simAws = new SimAws({ defaultAccountId: accountId });
-    const organizations = simAws.organizations();
+  it("fails a policy whose Content is not a document", async () => {
+    // Given a template whose Content is a number.
+    const simAws = new SimAws();
 
-    const stack = await simAws.cloudFormation().deployTemplate({
-      stackName: "nested-unit-stack",
-      template: {
-        Resources: {
-          Workloads: {
-            Type: "AWS::Organizations::OrganizationalUnit",
-            Properties: {
-              Name: "Workloads",
-              ParentId: organizations.root().id,
+    // Then the Resource says what it needed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "scalar-content-stack",
+        template: {
+          Resources: {
+            Deny: {
+              Type: "AWS::Organizations::Policy",
+              Properties: {
+                Name: "Broken",
+                Type: "SERVICE_CONTROL_POLICY",
+                Content: 5,
+              },
             },
           },
-          Production: {
-            Type: "AWS::Organizations::OrganizationalUnit",
-            Properties: { Name: "Production", ParentId: { Ref: "Workloads" } },
-          },
         },
-        Outputs: {
-          WorkloadsId: { Value: { Ref: "Workloads" } },
-          ProductionId: { Value: { Ref: "Production" } },
-        },
-      },
+      });
+
+      await stack.waitForDeployComplete();
     });
 
-    await stack.waitForDeployComplete();
-    organizations.moveAccount(accountId, stack.output("ProductionId"));
+    assertStringIncludes(error.message, "requires Content to be a policy");
+  });
 
-    // When only the outer unit is taken away.
-    organizations.removeOrganizationalUnit(stack.output("WorkloadsId"));
+  it("leaves an Account out of the organization when its Email is missing", async () => {
+    // Given an Account Resource with no Email.
+    const simAws = new SimAws();
 
-    // Then the Account still has a path back to the root.
-    assertArrayEquals(
-      organizations
-        .serviceControlPolicySetFor(accountId)
-        .levels.map((level) => level.nodeName),
-      ["Root", "Production", accountId],
-    );
+    // When the Stack is deployed.
+    await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "no-email-stack",
+        template: {
+          Resources: {
+            Payments: {
+              Type: "AWS::Organizations::Account",
+              Properties: { AccountName: "Payments" },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then nothing was placed in the organization on the way to failing.
+    assertArrayLength(organizationAccountIds(simAws), 0);
   });
 
   it("reads an Organization that names no feature set", async () => {
@@ -201,59 +215,5 @@ describe("Simulated Organizations CloudFormation properties", () => {
 
     // Then it still answers the value the rest of a template hangs off.
     assertStringIncludes(stack.output("RootId"), "r-");
-  });
-
-  it("takes a deployed Account back out of the organization", async () => {
-    // Given a Stack that created an Account under a denying unit.
-    const simAws = new SimAws();
-    const stack = await simAws.cloudFormation().deployTemplate({
-      stackName: "account-teardown-stack",
-      template: {
-        Resources: {
-          Workloads: {
-            Type: "AWS::Organizations::OrganizationalUnit",
-            Properties: {
-              Name: "Workloads",
-              ParentId: simAws.organizations().root().id,
-            },
-          },
-          Payments: {
-            Type: "AWS::Organizations::Account",
-            Properties: {
-              AccountName: "Payments",
-              Email: "payments@example.com",
-              ParentIds: [{ Ref: "Workloads" }],
-              RoleName: "OrganizationAccountAccessRole",
-            },
-          },
-          Deny: {
-            Type: "AWS::Organizations::Policy",
-            Properties: {
-              Name: "DenyBucketCreation",
-              Type: "SERVICE_CONTROL_POLICY",
-              TargetIds: [{ Ref: "Workloads" }],
-              Content: denyBucketCreation,
-            },
-          },
-        },
-        Outputs: { AccountId: { Value: { Ref: "Payments" } } },
-      },
-    });
-
-    await stack.waitForDeployComplete();
-
-    const accountId = stack.output("AccountId");
-
-    assertTrue(
-      simAws.organizations().serviceControlPolicySetFor(accountId).applies,
-    );
-
-    // When the Stack comes down.
-    await stack.teardown();
-
-    // Then the Account is no longer in the organization.
-    assertTrue(
-      !simAws.organizations().serviceControlPolicySetFor(accountId).applies,
-    );
   });
 });

--- a/src/service/organizations/cfn/sim-cfn-organizations-properties.iso.test.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-properties.iso.test.ts
@@ -1,0 +1,259 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimIamPolicyDecisionValue } from "../../iam/authorize/sim-iam-decision-value.js";
+
+const denyBucketCreation = {
+  Version: "2012-10-17",
+  Statement: [{ Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" }],
+};
+
+describe("Simulated Organizations CloudFormation properties", () => {
+  it("reads a policy document given as JSON text", async () => {
+    // Given a template carrying Content as a JSON string, which is how a
+    // template that built the document elsewhere passes it.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "json-content-stack",
+      template: {
+        Resources: {
+          Deny: {
+            Type: "AWS::Organizations::Policy",
+            Properties: {
+              Name: "DenyBucketCreation",
+              Type: "SERVICE_CONTROL_POLICY",
+              TargetIds: accountId,
+              Content: JSON.stringify(denyBucketCreation),
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then it was parsed and attached, and a bare TargetIds read as one
+    // target.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+  });
+
+  it("fails a policy whose Content is not valid JSON", async () => {
+    // Given a template whose Content string cannot be parsed.
+    const simAws = new SimAws();
+
+    // Then the Resource says so rather than attaching nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "bad-content-stack",
+        template: {
+          Resources: {
+            Deny: {
+              Type: "AWS::Organizations::Policy",
+              Properties: {
+                Name: "Broken",
+                Type: "SERVICE_CONTROL_POLICY",
+                Content: "{not json",
+              },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(error.message, "Content is not valid JSON");
+  });
+
+  it("fails a unit that names no parent", async () => {
+    // Given a unit Resource missing its required ParentId.
+    const simAws = new SimAws();
+
+    // Then the Resource names the property it needs.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "no-parent-stack",
+        template: {
+          Resources: {
+            Workloads: {
+              Type: "AWS::Organizations::OrganizationalUnit",
+              Properties: { Name: "Workloads" },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(error.message, "requires ParentId");
+  });
+
+  it("skips an Organizations Resource type it does not model", async () => {
+    // Given a template declaring a resource policy alongside a unit.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "resource-policy-stack",
+      template: {
+        Resources: {
+          Workloads: {
+            Type: "AWS::Organizations::OrganizationalUnit",
+            Properties: {
+              Name: "Workloads",
+              ParentId: simAws.organizations().root().id,
+            },
+          },
+          Shared: {
+            Type: "AWS::Organizations::ResourcePolicy",
+            Properties: { Content: {} },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then it was recorded as skipped and the Stack carried on.
+    assertArrayEquals(
+      stack.skippedResources.map((skipped) => skipped.logicalId),
+      ["Shared"],
+    );
+  });
+
+  it("moves a nested unit up when the unit above it goes", async () => {
+    // Given a Stack with a unit inside a unit, and an Account under the inner
+    // one.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "nested-unit-stack",
+      template: {
+        Resources: {
+          Workloads: {
+            Type: "AWS::Organizations::OrganizationalUnit",
+            Properties: {
+              Name: "Workloads",
+              ParentId: organizations.root().id,
+            },
+          },
+          Production: {
+            Type: "AWS::Organizations::OrganizationalUnit",
+            Properties: { Name: "Production", ParentId: { Ref: "Workloads" } },
+          },
+        },
+        Outputs: {
+          WorkloadsId: { Value: { Ref: "Workloads" } },
+          ProductionId: { Value: { Ref: "Production" } },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+    organizations.moveAccount(accountId, stack.output("ProductionId"));
+
+    // When only the outer unit is taken away.
+    organizations.removeOrganizationalUnit(stack.output("WorkloadsId"));
+
+    // Then the Account still has a path back to the root.
+    assertArrayEquals(
+      organizations
+        .serviceControlPolicySetFor(accountId)
+        .levels.map((level) => level.nodeName),
+      ["Root", "Production", accountId],
+    );
+  });
+
+  it("reads an Organization that names no feature set", async () => {
+    // Given an Organization Resource with no properties at all.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "bare-organization-stack",
+      template: {
+        Resources: {
+          Organization: { Type: "AWS::Organizations::Organization" },
+        },
+        Outputs: {
+          RootId: { Value: { "Fn::GetAtt": ["Organization", "RootId"] } },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then it still answers the value the rest of a template hangs off.
+    assertStringIncludes(stack.output("RootId"), "r-");
+  });
+
+  it("takes a deployed Account back out of the organization", async () => {
+    // Given a Stack that created an Account under a denying unit.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "account-teardown-stack",
+      template: {
+        Resources: {
+          Workloads: {
+            Type: "AWS::Organizations::OrganizationalUnit",
+            Properties: {
+              Name: "Workloads",
+              ParentId: simAws.organizations().root().id,
+            },
+          },
+          Payments: {
+            Type: "AWS::Organizations::Account",
+            Properties: {
+              AccountName: "Payments",
+              Email: "payments@example.com",
+              ParentIds: [{ Ref: "Workloads" }],
+              RoleName: "OrganizationAccountAccessRole",
+            },
+          },
+          Deny: {
+            Type: "AWS::Organizations::Policy",
+            Properties: {
+              Name: "DenyBucketCreation",
+              Type: "SERVICE_CONTROL_POLICY",
+              TargetIds: [{ Ref: "Workloads" }],
+              Content: denyBucketCreation,
+            },
+          },
+        },
+        Outputs: { AccountId: { Value: { Ref: "Payments" } } },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    const accountId = stack.output("AccountId");
+
+    assertTrue(
+      simAws.organizations().serviceControlPolicySetFor(accountId).applies,
+    );
+
+    // When the Stack comes down.
+    await stack.teardown();
+
+    // Then the Account is no longer in the organization.
+    assertTrue(
+      !simAws.organizations().serviceControlPolicySetFor(accountId).applies,
+    );
+  });
+});

--- a/src/service/organizations/cfn/sim-cfn-organizations-properties.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-properties.ts
@@ -58,19 +58,25 @@ export class SimCfnOrganizationsProperties {
   /**
    * A property holding an IAM policy document, given inline or as JSON text.
    */
-  documentValue(value: SimCfnTemplateValue | undefined, name: string): unknown {
-    if (typeof value !== "string") {
-      return value;
-    }
+  documentValue(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): Readonly<Record<string, unknown>> {
+    const document =
+      typeof value === "string" ? this.#parse(value, name) : value;
 
-    try {
-      return JSON.parse(value) as unknown;
-    } catch {
+    if (
+      typeof document !== "object" ||
+      document === null ||
+      Array.isArray(document)
+    ) {
       throw new Error(
-        `${this.#resourceType} ${this.#resource.logicalId} ${name} is not ` +
-          `valid JSON`,
+        `${this.#resourceType} ${this.#resource.logicalId} requires ${name} ` +
+          `to be a policy document`,
       );
     }
+
+    return document as Readonly<Record<string, unknown>>;
   }
 
   /**
@@ -83,6 +89,20 @@ export class SimCfnOrganizationsProperties {
   ): void {
     if (value !== undefined) {
       this.#resource.ignoreProperty(name, reason);
+    }
+  }
+
+  /**
+   * Read a document a template gave as JSON text.
+   */
+  #parse(value: string, name: string): unknown {
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      throw new Error(
+        `${this.#resourceType} ${this.#resource.logicalId} ${name} is not ` +
+          `valid JSON`,
+      );
     }
   }
 }

--- a/src/service/organizations/cfn/sim-cfn-organizations-properties.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-properties.ts
@@ -1,0 +1,88 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * Reading the properties of an `AWS::Organizations::*` Resource.
+ *
+ * Each property is passed in by the caller under its own literal name, the way
+ * the other services read a template. A required one that is absent or of the
+ * wrong shape fails the Resource rather than quietly creating something else.
+ */
+export class SimCfnOrganizationsProperties {
+  readonly #resource: SimCfnResource;
+  readonly #resourceType: string;
+
+  constructor(resource: SimCfnResource, resourceType: string) {
+    this.#resource = resource;
+    this.#resourceType = resourceType;
+  }
+
+  /**
+   * A property that has to be a string for the Resource to mean anything.
+   */
+  requiredString(value: SimCfnTemplateValue | undefined, name: string): string {
+    if (typeof value !== "string" || value.length === 0) {
+      throw new Error(
+        `${this.#resourceType} ${this.#resource.logicalId} requires ${name}`,
+      );
+    }
+
+    return value;
+  }
+
+  /**
+   * A property that is a string where a template gives one.
+   */
+  optionalString(value: SimCfnTemplateValue | undefined): string | undefined {
+    return typeof value === "string" ? value : undefined;
+  }
+
+  /**
+   * A list-valued property, read as the strings in it.
+   *
+   * A template may give one value where a list is allowed, which
+   * CloudFormation accepts, so a bare string reads as a list of one.
+   */
+  stringList(value: SimCfnTemplateValue | undefined): readonly string[] {
+    if (typeof value === "string") {
+      return [value];
+    }
+
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value.filter((item): item is string => typeof item === "string");
+  }
+
+  /**
+   * A property holding an IAM policy document, given inline or as JSON text.
+   */
+  documentValue(value: SimCfnTemplateValue | undefined, name: string): unknown {
+    if (typeof value !== "string") {
+      return value;
+    }
+
+    try {
+      return JSON.parse(value) as unknown;
+    } catch {
+      throw new Error(
+        `${this.#resourceType} ${this.#resource.logicalId} ${name} is not ` +
+          `valid JSON`,
+      );
+    }
+  }
+
+  /**
+   * Record a property the simulation creates the Resource without acting on.
+   */
+  ignore(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+    reason: string,
+  ): void {
+    if (value !== undefined) {
+      this.#resource.ignoreProperty(name, reason);
+    }
+  }
+}

--- a/src/service/organizations/cfn/sim-cfn-organizations-record.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-record.ts
@@ -1,0 +1,52 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type {
+  SimOrganizationsNodeId,
+  SimOrganizationsRootId,
+} from "../tree/sim-organizations-node.js";
+
+/**
+ * What a template's `AWS::Organizations::Organization` produced.
+ *
+ * A simulated organization exists as soon as a SimAws does, so this records
+ * the one already there rather than making another. What the Resource is for
+ * is the values a template reads back off it, `RootId` above all, since that
+ * is how an organizational unit says where it hangs.
+ */
+export class SimCfnOrganization {
+  constructor(
+    public readonly rootId: SimOrganizationsRootId,
+    public readonly featureSet: string,
+    public readonly managementAccountId: SimAwsAccountId,
+  ) {}
+
+  /**
+   * AWS gives an organization an `o-` id of its own, apart from its root's.
+   */
+  get id(): string {
+    return `o-${this.rootId.slice(2)}`;
+  }
+}
+
+/**
+ * What a template's `AWS::Organizations::Account` produced.
+ */
+export class SimCfnOrganizationsAccount {
+  constructor(
+    public readonly accountId: SimAwsAccountId,
+    public readonly accountName: string,
+    public readonly email: string,
+    public readonly joinedTimestamp: Date,
+  ) {}
+}
+
+/**
+ * What a template's `AWS::Organizations::Policy` produced.
+ */
+export class SimCfnOrganizationsPolicy {
+  constructor(
+    public readonly id: string,
+    public readonly name: string,
+    public readonly policyType: string,
+    public readonly targetIds: readonly SimOrganizationsNodeId[],
+  ) {}
+}

--- a/src/service/organizations/cfn/sim-cfn-organizations-remover.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-remover.ts
@@ -29,7 +29,7 @@ export class SimCfnOrganizationsRemover {
 
     if (simResource instanceof SimCfnOrganizationsPolicy) {
       for (const targetId of simResource.targetIds) {
-        organizations.detachServiceControlPolicies(targetId);
+        organizations.detachServiceControlPolicy(targetId, simResource.id);
       }
 
       return;

--- a/src/service/organizations/cfn/sim-cfn-organizations-remover.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-remover.ts
@@ -1,0 +1,57 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import {
+  SimCfnOrganizationsAccount,
+  SimCfnOrganizationsPolicy,
+} from "./sim-cfn-organizations-record.js";
+import { SimOrganizationsOrganizationalUnit } from "../tree/sim-organizations-node.js";
+
+/**
+ * Takes back what an `AWS::Organizations::*` Resource did.
+ *
+ * A Stack tears down in reverse dependency order, so a policy comes off before
+ * the unit it was attached to goes, and a unit goes before the root it hung
+ * on. Each Resource here undoes its own step and nothing else.
+ */
+export class SimCfnOrganizationsRemover {
+  readonly #simAws: SimAws;
+
+  constructor(simAws: SimAws) {
+    this.#simAws = simAws;
+  }
+
+  /**
+   * Undo one Resource.
+   */
+  remove(resourceTypeName: string, resource: SimCfnResource): void {
+    const simResource = resource.simResource;
+    const organizations = this.#simAws.organizations();
+
+    if (simResource instanceof SimCfnOrganizationsPolicy) {
+      for (const targetId of simResource.targetIds) {
+        organizations.detachServiceControlPolicies(targetId);
+      }
+
+      return;
+    }
+
+    if (simResource instanceof SimCfnOrganizationsAccount) {
+      organizations.removeAccount(simResource.accountId);
+
+      return;
+    }
+
+    if (simResource instanceof SimOrganizationsOrganizationalUnit) {
+      organizations.removeOrganizationalUnit(simResource);
+
+      return;
+    }
+
+    if (resourceTypeName !== "Organization") {
+      throw new Error(
+        `Unsupported sim Organizations CloudFormation Resource ` +
+          `${resourceTypeName} deletion`,
+      );
+    }
+  }
+}

--- a/src/service/organizations/cfn/sim-cfn-organizations-teardown.iso.test.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations-teardown.iso.test.ts
@@ -1,0 +1,244 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimIamPolicyDecisionValue } from "../../iam/authorize/sim-iam-decision-value.js";
+
+const denyBucketCreation = {
+  Version: "2012-10-17",
+  Statement: [{ Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" }],
+};
+
+describe("Simulated Organizations CloudFormation teardown", () => {
+  it("moves a nested unit up when the unit above it goes", async () => {
+    // Given a Stack with a unit inside a unit, and an Account under the inner
+    // one.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "nested-unit-stack",
+      template: {
+        Resources: {
+          Workloads: {
+            Type: "AWS::Organizations::OrganizationalUnit",
+            Properties: {
+              Name: "Workloads",
+              ParentId: organizations.root().id,
+            },
+          },
+          Production: {
+            Type: "AWS::Organizations::OrganizationalUnit",
+            Properties: { Name: "Production", ParentId: { Ref: "Workloads" } },
+          },
+        },
+        Outputs: {
+          WorkloadsId: { Value: { Ref: "Workloads" } },
+          ProductionId: { Value: { Ref: "Production" } },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+    organizations.moveAccount(accountId, stack.output("ProductionId"));
+
+    // When only the outer unit is taken away.
+    organizations.removeOrganizationalUnit(stack.output("WorkloadsId"));
+
+    // Then the Account still has a path back to the root.
+    assertArrayEquals(
+      organizations
+        .serviceControlPolicySetFor(accountId)
+        .levels.map((level) => level.nodeName),
+      ["Root", "Production", accountId],
+    );
+  });
+
+  it("tears down when a policy's target unit has already gone", async () => {
+    // Given a Stack whose policy targets an Account and a unit created
+    // outside it.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const outside = organizations.createOrganizationalUnit("Outside");
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "detach-order-stack",
+      template: {
+        Resources: {
+          Deny: {
+            Type: "AWS::Organizations::Policy",
+            Properties: {
+              Name: "DenyBucketCreation",
+              Type: "SERVICE_CONTROL_POLICY",
+              TargetIds: [outside.id, accountId],
+              Content: denyBucketCreation,
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When that unit goes before the Stack comes down.
+    organizations.removeOrganizationalUnit(outside);
+
+    // Then the teardown gets past the unit that has gone and still takes the
+    // policy off the Account.
+    await stack.teardown();
+
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    assertTrue(decision.isAllowed);
+  });
+
+  it("leaves another Stack's policy on a node it shares", async () => {
+    // Given two Stacks whose policies both target the same Account.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const policyStack = (stackName: string) =>
+      simAws.cloudFormation().deployTemplate({
+        stackName,
+        template: {
+          Resources: {
+            Deny: {
+              Type: "AWS::Organizations::Policy",
+              Properties: {
+                Name: stackName,
+                Type: "SERVICE_CONTROL_POLICY",
+                TargetIds: [accountId],
+                Content: denyBucketCreation,
+              },
+            },
+          },
+        },
+      });
+
+    const first = await policyStack("guardrails");
+    const second = await policyStack("extra-guardrails");
+
+    await first.waitForDeployComplete();
+    await second.waitForDeployComplete();
+
+    // When one of them comes down.
+    await second.teardown();
+
+    // Then the other Stack's policy is still denying.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertArrayLength(decision.serviceControlPolicy.denyStatements, 1);
+  });
+
+  it("attaches a policy to no target when one of them is unknown", async () => {
+    // Given a policy naming a good target and a unit from elsewhere.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const foreign = new SimAws()
+      .organizations()
+      .createOrganizationalUnit("Other");
+
+    // When the Stack is deployed.
+    await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "partial-attach-stack",
+        template: {
+          Resources: {
+            Deny: {
+              Type: "AWS::Organizations::Policy",
+              Properties: {
+                Name: "DenyBucketCreation",
+                Type: "SERVICE_CONTROL_POLICY",
+                TargetIds: [accountId, foreign.id],
+                Content: denyBucketCreation,
+              },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the good target was left alone, rather than holding a policy no
+    // teardown knows about.
+    assertTrue(
+      !simAws.organizations().serviceControlPolicySetFor(accountId).applies,
+    );
+  });
+
+  it("takes a deployed Account back out of the organization", async () => {
+    // Given a Stack that created an Account under a denying unit.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "account-teardown-stack",
+      template: {
+        Resources: {
+          Workloads: {
+            Type: "AWS::Organizations::OrganizationalUnit",
+            Properties: {
+              Name: "Workloads",
+              ParentId: simAws.organizations().root().id,
+            },
+          },
+          Payments: {
+            Type: "AWS::Organizations::Account",
+            Properties: {
+              AccountName: "Payments",
+              Email: "payments@example.com",
+              ParentIds: [{ Ref: "Workloads" }],
+              RoleName: "OrganizationAccountAccessRole",
+            },
+          },
+          Deny: {
+            Type: "AWS::Organizations::Policy",
+            Properties: {
+              Name: "DenyBucketCreation",
+              Type: "SERVICE_CONTROL_POLICY",
+              TargetIds: [{ Ref: "Workloads" }],
+              Content: denyBucketCreation,
+            },
+          },
+        },
+        Outputs: { AccountId: { Value: { Ref: "Payments" } } },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    const accountId = stack.output("AccountId");
+
+    assertTrue(
+      simAws.organizations().serviceControlPolicySetFor(accountId).applies,
+    );
+
+    // When the Stack comes down.
+    await stack.teardown();
+
+    // Then the Account is no longer in the organization.
+    assertTrue(
+      !simAws.organizations().serviceControlPolicySetFor(accountId).applies,
+    );
+  });
+});

--- a/src/service/organizations/cfn/sim-cfn-organizations.iso.test.ts
+++ b/src/service/organizations/cfn/sim-cfn-organizations.iso.test.ts
@@ -1,0 +1,245 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertStringIncludes,
+  assertStringLength,
+  assertStringStartsWith,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimIamPolicyDecisionValue } from "../../iam/authorize/sim-iam-decision-value.js";
+
+const organizationTemplate = {
+  Resources: {
+    Organization: {
+      Type: "AWS::Organizations::Organization",
+      Properties: { FeatureSet: "ALL" },
+    },
+    Workloads: {
+      Type: "AWS::Organizations::OrganizationalUnit",
+      Properties: {
+        Name: "Workloads",
+        ParentId: { "Fn::GetAtt": ["Organization", "RootId"] },
+      },
+    },
+    DenyBucketCreation: {
+      Type: "AWS::Organizations::Policy",
+      Properties: {
+        Name: "DenyBucketCreation",
+        Type: "SERVICE_CONTROL_POLICY",
+        TargetIds: [{ Ref: "Workloads" }],
+        Content: {
+          Version: "2012-10-17",
+          Statement: [
+            { Effect: "Deny", Action: "s3:CreateBucket", Resource: "*" },
+          ],
+        },
+      },
+    },
+  },
+  Outputs: {
+    WorkloadsId: { Value: { Ref: "Workloads" } },
+  },
+};
+
+describe("Simulated Organizations from CloudFormation", () => {
+  it("denies an Account under the unit the deployed policy targets", async () => {
+    // Given a Stack declaring a unit and a policy that targets it.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "org-stack",
+      template: organizationTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When an Account is put under that unit and asks to create a Bucket.
+    simAws.organizations().moveAccount(accountId, stack.output("WorkloadsId"));
+
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    // Then the deployed policy denied it.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertArrayLength(decision.serviceControlPolicy.denyStatements, 1);
+  });
+
+  it("resolves Ref and GetAtt for each Resource type", async () => {
+    // Given a deployed organization Stack that also creates an Account.
+    const simAws = new SimAws();
+    const template = {
+      Resources: {
+        ...organizationTemplate.Resources,
+        Payments: {
+          Type: "AWS::Organizations::Account",
+          Properties: {
+            AccountName: "Payments",
+            Email: "payments@example.com",
+            ParentIds: [{ Ref: "Workloads" }],
+          },
+        },
+      },
+      Outputs: {
+        ...organizationTemplate.Outputs,
+        RootId: { Value: { "Fn::GetAtt": ["Organization", "RootId"] } },
+        UnitRef: { Value: { Ref: "Workloads" } },
+        UnitName: { Value: { "Fn::GetAtt": ["Workloads", "Name"] } },
+        OrgRef: { Value: { Ref: "Organization" } },
+        OrgArn: { Value: { "Fn::GetAtt": ["Organization", "Arn"] } },
+        OrgManagementId: {
+          Value: { "Fn::GetAtt": ["Organization", "ManagementAccountId"] },
+        },
+        OrgManagementArn: {
+          Value: { "Fn::GetAtt": ["Organization", "ManagementAccountArn"] },
+        },
+        UnitArn: { Value: { "Fn::GetAtt": ["Workloads", "Arn"] } },
+        AccountId: { Value: { "Fn::GetAtt": ["Payments", "AccountId"] } },
+        AccountArn: { Value: { "Fn::GetAtt": ["Payments", "Arn"] } },
+        AccountEmail: { Value: { "Fn::GetAtt": ["Payments", "Email"] } },
+        AccountJoined: {
+          Value: { "Fn::GetAtt": ["Payments", "JoinedMethod"] },
+        },
+        AccountStatus: { Value: { "Fn::GetAtt": ["Payments", "Status"] } },
+        PolicyRef: { Value: { Ref: "DenyBucketCreation" } },
+        PolicyId: { Value: { "Fn::GetAtt": ["DenyBucketCreation", "Id"] } },
+        PolicyArn: { Value: { "Fn::GetAtt": ["DenyBucketCreation", "Arn"] } },
+      },
+    };
+
+    const stack = await simAws
+      .cloudFormation()
+      .deployTemplate({ stackName: "org-values-stack", template });
+
+    await stack.waitForDeployComplete();
+
+    // When the outputs are read.
+    // Then each carries the value the AWS Resource reference gives.
+    assertStringStartsWith(stack.output("RootId"), "r-");
+    assertStringStartsWith(stack.output("OrgRef"), "o-");
+    assertStringStartsWith(stack.output("OrgArn"), "arn:aws:organizations::");
+    assertStringLength(stack.output("OrgManagementId"), 12);
+    assertStringIncludes(stack.output("OrgManagementArn"), ":account/");
+    assertStringStartsWith(stack.output("UnitRef"), "ou-");
+    assertIdentical(stack.output("UnitName"), "Workloads");
+    assertStringIncludes(stack.output("UnitArn"), "organizational-unit/ou-");
+    assertStringLength(stack.output("AccountId"), 12);
+    assertStringIncludes(stack.output("AccountArn"), ":account/");
+    assertIdentical(stack.output("AccountEmail"), "payments@example.com");
+    assertIdentical(stack.output("AccountJoined"), "CREATED");
+    assertIdentical(stack.output("AccountStatus"), "ACTIVE");
+    assertStringStartsWith(stack.output("PolicyRef"), "p-");
+    assertIdentical(stack.output("PolicyId"), stack.output("PolicyRef"));
+    assertStringIncludes(
+      stack.output("PolicyArn"),
+      "policy/service_control_policy/p-",
+    );
+  });
+
+  it("refuses an attribute the AWS Resource reference does not list", async () => {
+    // Given a Stack reading an attribute no Organizations Resource has.
+    const simAws = new SimAws();
+
+    // Then the deployment says which attribute it has no answer for.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "bad-attribute-stack",
+        template: {
+          Resources: {
+            Workloads: {
+              Type: "AWS::Organizations::OrganizationalUnit",
+              Properties: {
+                Name: "Workloads",
+                ParentId: simAws.organizations().root().id,
+              },
+            },
+          },
+          Outputs: {
+            Nonsense: { Value: { "Fn::GetAtt": ["Workloads", "Nonsense"] } },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    assertStringIncludes(error.message, "Nonsense");
+  });
+
+  it("skips a policy type it evaluates nothing for and deploys on", async () => {
+    // Given a Stack carrying a tag policy alongside a unit.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "tag-policy-stack",
+      template: {
+        Resources: {
+          Workloads: {
+            Type: "AWS::Organizations::OrganizationalUnit",
+            Properties: {
+              Name: "Workloads",
+              ParentId: simAws.organizations().root().id,
+            },
+          },
+          CostCentre: {
+            Type: "AWS::Organizations::Policy",
+            Properties: {
+              Name: "CostCentre",
+              Type: "TAG_POLICY",
+              Content: { tags: {} },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the tag policy was recorded as skipped and the unit still exists.
+    assertArrayEquals(
+      stack.skippedResources.map((skipped) => skipped.logicalId),
+      ["CostCentre"],
+    );
+    assertNonNullable(stack.getResource("Workloads")?.simResource);
+  });
+
+  it("takes the organization back down with the Stack", async () => {
+    // Given a deployed organization Stack.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "org-teardown",
+      template: organizationTemplate,
+    });
+
+    await stack.waitForDeployComplete();
+
+    simAws.organizations().moveAccount(accountId, stack.output("WorkloadsId"));
+
+    // When the Stack is deleted.
+    await stack.teardown();
+
+    // Then the policy is off the unit, so nothing denies the Account.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    assertTrue(decision.isAllowed);
+    assertArrayLength(decision.serviceControlPolicy.denyStatements, 0);
+  });
+});

--- a/src/service/organizations/cfn/sim-organizations-cfn-resource-factory.ts
+++ b/src/service/organizations/cfn/sim-organizations-cfn-resource-factory.ts
@@ -1,0 +1,92 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import { SimCfnOrganizationCreator } from "./sim-cfn-organization-creator.js";
+import { SimCfnOrganizationalUnitCreator } from "./sim-cfn-organizational-unit-creator.js";
+import { SimCfnOrganizationsAccountCreator } from "./sim-cfn-organizations-account-creator.js";
+import { SimCfnOrganizationsPolicyCreator } from "./sim-cfn-organizations-policy-creator.js";
+import { SimCfnOrganizationsRemover } from "./sim-cfn-organizations-remover.js";
+
+/**
+ * CloudFormation Resource factory for simulated Organizations resources.
+ *
+ * An organization belongs to a whole SimAws rather than to the Account and
+ * Region scope a Stack deploys into, so this reads the organization off the
+ * creation context instead of being handed one. That leaves the factory with
+ * no state and lets one serve every scope.
+ *
+ * `AWS::Organizations::ResourcePolicy` is left out, along with every policy
+ * type but `SERVICE_CONTROL_POLICY`, and a template declaring either is
+ * recorded as a skipped Resource.
+ */
+export class SimOrganizationsCfnResourceFactory implements SimCfnServiceResourceFactory {
+  /**
+   * Create a simulated Organizations resource from a CloudFormation Resource.
+   */
+  create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+    const { simAws } = context;
+
+    switch (resourceTypeName) {
+      case "Organization": {
+        return Promise.resolve(
+          new SimCfnOrganizationCreator(simAws).create(resource, properties),
+        );
+      }
+      case "OrganizationalUnit": {
+        return Promise.resolve(
+          new SimCfnOrganizationalUnitCreator(simAws).create(
+            resource,
+            properties,
+          ),
+        );
+      }
+      case "Account": {
+        return Promise.resolve(
+          new SimCfnOrganizationsAccountCreator(simAws).create(
+            resource,
+            properties,
+          ),
+        );
+      }
+      case "Policy": {
+        return Promise.resolve(
+          new SimCfnOrganizationsPolicyCreator(simAws).create(
+            resource,
+            properties,
+          ),
+        );
+      }
+      default: {
+        throw new Error(
+          `Unsupported sim Organizations CloudFormation Resource ${
+            resourceTypeName
+          }`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Remove a simulated Organizations resource a Stack created.
+   */
+  delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    new SimCfnOrganizationsRemover(context.simAws).remove(
+      resourceTypeName,
+      resource,
+    );
+
+    return Promise.resolve();
+  }
+}

--- a/src/service/organizations/policy/sim-organizations-scp-store.ts
+++ b/src/service/organizations/policy/sim-organizations-scp-store.ts
@@ -18,8 +18,13 @@ export const SIM_ORGANIZATIONS_FULL_AWS_ACCESS: SimIamServiceControlPolicy = {
   },
 };
 
+interface SimOrganizationsAttachedPolicy {
+  readonly policyId: string;
+  readonly policy: SimIamServiceControlPolicy;
+}
+
 interface SimOrganizationsNodePolicies {
-  readonly attached: SimIamServiceControlPolicy[];
+  readonly attached: SimOrganizationsAttachedPolicy[];
   fullAwsAccess: boolean;
 }
 
@@ -38,14 +43,43 @@ export class SimOrganizationsScpStore {
   >();
 
   /**
-   * Attach a service control policy to a node.
+   * Attach a service control policy to a node under an id of its own.
+   *
+   * The id is what takes the policy off again. One policy attached to several
+   * nodes carries the same id at each of them, the way an AWS policy attached
+   * to several targets is one policy.
    */
   attach(
     nodeId: SimOrganizationsNodeId,
+    policyId: string,
     document: SimIamPolicyDocument,
     policyName?: string,
   ): void {
-    this.nodePolicies(nodeId).attached.push({ document, policyName });
+    this.nodePolicies(nodeId).attached.push({
+      policyId,
+      policy: { document, policyName },
+    });
+  }
+
+  /**
+   * Take one service control policy off a node, leaving the rest.
+   *
+   * A node can hold policies from more than one source, so taking the wrong
+   * ones off would change what an Account may do behind the caller's back.
+   */
+  detach(nodeId: SimOrganizationsNodeId, policyId: string): void {
+    const node = this.byNodeId.get(nodeId);
+
+    if (node === undefined) {
+      return;
+    }
+
+    const remaining = node.attached.filter(
+      (attached) => attached.policyId !== policyId,
+    );
+
+    node.attached.length = 0;
+    node.attached.push(...remaining);
   }
 
   /**
@@ -77,9 +111,11 @@ export class SimOrganizationsScpStore {
       return [SIM_ORGANIZATIONS_FULL_AWS_ACCESS];
     }
 
+    const attached = node.attached.map((entry) => entry.policy);
+
     return node.fullAwsAccess
-      ? [SIM_ORGANIZATIONS_FULL_AWS_ACCESS, ...node.attached]
-      : [...node.attached];
+      ? [SIM_ORGANIZATIONS_FULL_AWS_ACCESS, ...attached]
+      : attached;
   }
 
   /**

--- a/src/service/organizations/sim-organizations-structure.ts
+++ b/src/service/organizations/sim-organizations-structure.ts
@@ -1,11 +1,12 @@
 import { simAwsAccountId } from "../aws/sim-aws-account.js";
 import { SimOrganizationsEffectivePolicies } from "./policy/sim-organizations-effective-policies.js";
 import { SimOrganizationsScpStore } from "./policy/sim-organizations-scp-store.js";
-import type {
-  SimOrganizationsNodeId,
-  SimOrganizationsOrganizationalUnit,
-  SimOrganizationsRoot,
-  SimOrganizationsTarget,
+import {
+  isSimOrganizationsUnitId,
+  type SimOrganizationsNodeId,
+  type SimOrganizationsOrganizationalUnit,
+  type SimOrganizationsRoot,
+  type SimOrganizationsTarget,
 } from "./tree/sim-organizations-node.js";
 import { SimOrganizationsTree } from "./tree/sim-organizations-tree.js";
 
@@ -38,20 +39,17 @@ export abstract class SimOrganizationsStructure {
    */
   createOrganizationalUnit(
     name: string,
-    parent?: SimOrganizationsOrganizationalUnit,
+    parent?: SimOrganizationsTarget,
   ): SimOrganizationsOrganizationalUnit {
-    return this.tree.createOrganizationalUnit(name, parent);
+    return this.tree.createOrganizationalUnit(name, this.parentIdOf(parent));
   }
 
   /**
    * Put an Account in the organization, under an organizational unit or under
    * the root.
    */
-  moveAccount(
-    accountId: string,
-    parent?: SimOrganizationsOrganizationalUnit,
-  ): void {
-    this.tree.placeAccount(simAwsAccountId(accountId), parent);
+  moveAccount(accountId: string, parent?: SimOrganizationsTarget): void {
+    this.tree.placeAccount(simAwsAccountId(accountId), this.parentIdOf(parent));
   }
 
   /**
@@ -80,20 +78,48 @@ export abstract class SimOrganizationsStructure {
   }
 
   /**
+   * Take an organizational unit out of the organization.
+   *
+   * Anything still under it moves up to its parent, so every Account keeps a
+   * path back to the root.
+   */
+  removeOrganizationalUnit(target: SimOrganizationsTarget): void {
+    this.tree.removeOrganizationalUnit(this.nodeIdOf(target));
+  }
+
+  /**
    * The node a target names.
    *
-   * An Account is named by its id and needs no place in the organization yet,
-   * because attaching a policy to one is what puts it there. A root or
-   * organizational unit has to be this organization's own, so a handle from
-   * another one is refused rather than attached to and never read.
+   * An Account is named by its twelve-digit id and needs no place in the
+   * organization yet, because attaching a policy to one is what puts it there.
+   * A root or organizational unit, whether given as a handle or as the `r-` or
+   * `ou-` id a template carries, has to be this organization's own. One from
+   * another organization is refused rather than attached to and never read.
    */
   protected nodeIdOf(target: SimOrganizationsTarget): SimOrganizationsNodeId {
-    if (typeof target === "string") {
+    if (typeof target !== "string") {
+      this.tree.requireNode(target.id);
+
+      return target.id;
+    }
+
+    if (!isSimOrganizationsUnitId(target)) {
       return simAwsAccountId(target);
     }
 
-    this.tree.requireNode(target.id);
+    const nodeId = target as SimOrganizationsNodeId;
 
-    return target.id;
+    this.tree.requireNode(nodeId);
+
+    return nodeId;
+  }
+
+  /**
+   * The node something sits under, defaulting to the root.
+   */
+  private parentIdOf(
+    parent: SimOrganizationsTarget | undefined,
+  ): SimOrganizationsNodeId | undefined {
+    return parent === undefined ? undefined : this.nodeIdOf(parent);
   }
 }

--- a/src/service/organizations/sim-organizations-structure.ts
+++ b/src/service/organizations/sim-organizations-structure.ts
@@ -67,6 +67,16 @@ export abstract class SimOrganizationsStructure {
   }
 
   /**
+   * Every Account this organization holds.
+   *
+   * A test tracking down where a denial came from reads this to see which
+   * Accounts the organization is filtering at all.
+   */
+  accountIds(): readonly string[] {
+    return this.tree.accountIds();
+  }
+
+  /**
    * Take an Account out of the organization.
    *
    * Nothing then filters its requests, whatever is attached above where it
@@ -84,7 +94,11 @@ export abstract class SimOrganizationsStructure {
    * path back to the root.
    */
   removeOrganizationalUnit(target: SimOrganizationsTarget): void {
-    this.tree.removeOrganizationalUnit(this.nodeIdOf(target));
+    const nodeId = this.knownNodeIdOf(target);
+
+    if (nodeId !== undefined) {
+      this.tree.removeOrganizationalUnit(nodeId);
+    }
   }
 
   /**
@@ -112,6 +126,43 @@ export abstract class SimOrganizationsStructure {
     this.tree.requireNode(nodeId);
 
     return nodeId;
+  }
+
+  /**
+   * Refuse the whole set unless every target names a node this organization
+   * has.
+   *
+   * Attaching one policy to several nodes is one act, so it either reaches all
+   * of them or none. Failing partway would leave a policy attached where
+   * nothing knows to take it off.
+   */
+  requireTargets(targets: readonly SimOrganizationsTarget[]): void {
+    for (const target of targets) {
+      this.nodeIdOf(target);
+    }
+  }
+
+  /**
+   * The node a target names, or nothing where this organization has no such
+   * node.
+   *
+   * Taking something off a node that has already gone is what a Stack teardown
+   * asks for when a unit came down before the policy pointing at it. There is
+   * nothing to take off, and refusing would fail a teardown over work already
+   * done.
+   */
+  protected knownNodeIdOf(
+    target: SimOrganizationsTarget,
+  ): SimOrganizationsNodeId | undefined {
+    if (typeof target === "string" && !isSimOrganizationsUnitId(target)) {
+      return simAwsAccountId(target);
+    }
+
+    const nodeId = (
+      typeof target === "string" ? target : target.id
+    ) as SimOrganizationsNodeId;
+
+    return this.tree.hasNode(nodeId) ? nodeId : undefined;
   }
 
   /**

--- a/src/service/organizations/sim-organizations.ts
+++ b/src/service/organizations/sim-organizations.ts
@@ -9,7 +9,10 @@ import type {
   SimIamServiceControlPolicySet,
 } from "../iam/authorize/scp/sim-iam-scp-resolver.js";
 import { SimOrganizationsStructure } from "./sim-organizations-structure.js";
-import type { SimOrganizationsTarget } from "./tree/sim-organizations-node.js";
+import {
+  makeSimOrganizationsPolicyId,
+  type SimOrganizationsTarget,
+} from "./tree/sim-organizations-node.js";
 
 /**
  * Options for one attached service control policy.
@@ -19,6 +22,14 @@ export interface SimOrganizationsAttachOptions {
    * What to call the policy in a denial. Defaults to `ServiceControlPolicy`.
    */
   readonly policyName?: string | undefined;
+
+  /**
+   * The id to attach the policy under, for taking it off again later.
+   *
+   * One policy attached to several nodes takes the same id at each of them.
+   * Defaults to an id of this attachment's own.
+   */
+  readonly policyId?: string | undefined;
 }
 
 /**
@@ -53,10 +64,32 @@ export class SimOrganizations
     target: SimOrganizationsTarget,
     document: SimIamPolicyDocument,
     options: SimOrganizationsAttachOptions = {},
-  ): void {
+  ): string {
     const policyName = options.policyName ?? "ServiceControlPolicy";
+    const policyId = options.policyId ?? makeSimOrganizationsPolicyId();
 
-    this.scpStore.attach(this.nodeIdOf(target), document, policyName);
+    this.scpStore.attach(this.nodeIdOf(target), policyId, document, policyName);
+
+    return policyId;
+  }
+
+  /**
+   * Take one service control policy off a node, leaving whatever else is
+   * attached there.
+   *
+   * This is what a CloudFormation teardown uses, because a node can hold
+   * policies from more than one Stack and clearing it would take another
+   * Stack's guardrail away.
+   */
+  detachServiceControlPolicy(
+    target: SimOrganizationsTarget,
+    policyId: string,
+  ): void {
+    const nodeId = this.knownNodeIdOf(target);
+
+    if (nodeId !== undefined) {
+      this.scpStore.detach(nodeId, policyId);
+    }
   }
 
   /**
@@ -77,9 +110,17 @@ export class SimOrganizations
    * goes on inheriting what the levels above it say, as it does in AWS, where
    * detaching a policy from an account leaves the account where it is. Take an
    * Account out of the organization with `removeAccount`.
+   *
+   * A node that has already gone leaves nothing to take off, so this does
+   * nothing rather than refusing. A Stack teardown reaches that case whenever
+   * a unit came down before the policy pointing at it.
    */
   detachServiceControlPolicies(target: SimOrganizationsTarget): void {
-    this.scpStore.detachAll(this.nodeIdOf(target));
+    const nodeId = this.knownNodeIdOf(target);
+
+    if (nodeId !== undefined) {
+      this.scpStore.detachAll(nodeId);
+    }
   }
 
   /**

--- a/src/service/organizations/tree/sim-organizations-node.ts
+++ b/src/service/organizations/tree/sim-organizations-node.ts
@@ -41,6 +41,13 @@ export function makeSimOrganizationsOrganizationalUnitId(
 }
 
 /**
+ * Generate an AWS-shaped service control policy id.
+ */
+export function makeSimOrganizationsPolicyId(): string {
+  return `p-${faker.string.alphanumeric({ length: 8, casing: "lower" })}`;
+}
+
+/**
  * An organizational unit in a simulated organization.
  *
  * This is the handle a test holds on to. Pass it where a policy is attached or

--- a/src/service/organizations/tree/sim-organizations-node.ts
+++ b/src/service/organizations/tree/sim-organizations-node.ts
@@ -64,10 +64,22 @@ export class SimOrganizationsRoot {
 }
 
 /**
- * Somewhere a policy can be attached, given either as a handle or as the
- * Account id of an Account.
+ * Somewhere a policy can be attached, given as a handle or as an id.
+ *
+ * An id is what a CloudFormation template carries, since a `Ref` to a unit
+ * resolves to the id AWS gave it rather than to anything holding a reference.
  */
 export type SimOrganizationsTarget =
   | SimOrganizationsRoot
   | SimOrganizationsOrganizationalUnit
   | string;
+
+/**
+ * Whether an id names the root or an organizational unit.
+ *
+ * AWS ids carry their own kind in a prefix, and an Account id is twelve
+ * digits, so nothing here has to guess which of the two a string is.
+ */
+export function isSimOrganizationsUnitId(value: string): boolean {
+  return value.startsWith("r-") || value.startsWith("ou-");
+}

--- a/src/service/organizations/tree/sim-organizations-tree.ts
+++ b/src/service/organizations/tree/sim-organizations-tree.ts
@@ -103,6 +103,13 @@ export class SimOrganizationsTree {
   }
 
   /**
+   * Every Account in the organization.
+   */
+  accountIds(): readonly SimAwsAccountId[] {
+    return this.accountParents.keys().toArray();
+  }
+
+  /**
    * Whether this Account is in the organization.
    */
   holds(accountId: SimAwsAccountId): boolean {
@@ -118,6 +125,13 @@ export class SimOrganizationsTree {
    */
   requireNode(nodeId: SimOrganizationsNodeId): void {
     this.requireKnown(nodeId);
+  }
+
+  /**
+   * Whether this organization has a root or unit under an id.
+   */
+  hasNode(nodeId: SimOrganizationsNodeId): boolean {
+    return nodeId === this.root.id || this.organizationalUnits.has(nodeId);
   }
 
   /**

--- a/src/service/organizations/tree/sim-organizations-tree.ts
+++ b/src/service/organizations/tree/sim-organizations-tree.ts
@@ -48,10 +48,8 @@ export class SimOrganizationsTree {
    */
   createOrganizationalUnit(
     name: string,
-    parent?: SimOrganizationsOrganizationalUnit,
+    parentId: SimOrganizationsNodeId = this.root.id,
   ): SimOrganizationsOrganizationalUnit {
-    const parentId = parent === undefined ? this.root.id : parent.id;
-
     this.requireKnown(parentId);
 
     const unit = new SimOrganizationsOrganizationalUnit(
@@ -71,10 +69,8 @@ export class SimOrganizationsTree {
    */
   placeAccount(
     accountId: SimAwsAccountId,
-    parent?: SimOrganizationsOrganizationalUnit,
+    parentId: SimOrganizationsNodeId = this.root.id,
   ): void {
-    const parentId = parent === undefined ? this.root.id : parent.id;
-
     this.requireKnown(parentId);
 
     this.accountParents.set(accountId, parentId);
@@ -85,6 +81,25 @@ export class SimOrganizationsTree {
    */
   removeAccount(accountId: SimAwsAccountId): void {
     this.accountParents.delete(accountId);
+  }
+
+  /**
+   * Take an organizational unit out of the organization.
+   *
+   * Whatever still sits under it moves up to its parent, which is the only
+   * answer that leaves every Account on a path back to the root. AWS refuses
+   * to delete a unit that still holds anything, and a Stack tears down in
+   * reverse dependency order, so nothing should still be there.
+   */
+  removeOrganizationalUnit(unitId: SimOrganizationsNodeId): void {
+    const unit = this.organizationalUnits.get(unitId);
+
+    if (unit === undefined) {
+      return;
+    }
+
+    this.organizationalUnits.delete(unitId);
+    this.reparent(unitId, unit.parentId);
   }
 
   /**
@@ -130,6 +145,32 @@ export class SimOrganizationsTree {
     }
 
     return this.organizationalUnits.get(nodeId)?.name ?? String(nodeId);
+  }
+
+  /**
+   * Move everything under one node up to another.
+   */
+  private reparent(
+    fromId: SimOrganizationsNodeId,
+    toId: SimOrganizationsNodeId,
+  ): void {
+    for (const [accountId, parentId] of this.accountParents) {
+      if (parentId === fromId) {
+        this.accountParents.set(accountId, toId);
+      }
+    }
+
+    const orphaned = this.organizationalUnits
+      .values()
+      .filter((unit) => unit.parentId === fromId)
+      .toArray();
+
+    for (const unit of orphaned) {
+      this.organizationalUnits.set(
+        unit.id,
+        new SimOrganizationsOrganizationalUnit(unit.id, unit.name, toId),
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
`AWS::Organizations::Organization`, `::OrganizationalUnit`, `::Account` and `::Policy` now build the simulated organization a template describes, so a stack already managing the org chart is the one a test deploys.

Resolves https://github.com/KensioSoftware/yulin/issues/1061

The issue's implementation note assumed the factory would need a route from the Account and Region scope up to `SimAws`. It does not: `SimCloudFormationResourceCreateContext` already carries `simAws`, so the factory is stateless and registers like the CloudFormation one does, with no scope accessor added.

`Content` is read inline or as JSON text, and `TargetIds` takes a list or a single value, since real templates use both. `Ref` and `Fn::GetAtt` answer what the AWS resource reference gives for each type, and an attribute it does not list is refused by name rather than resolving to nothing. A `Policy` of any type but `SERVICE_CONTROL_POLICY` is recorded as a skipped Resource and the stack deploys on, because nothing here evaluates a tag or backup policy and storing one would look like it did something.

Teardown takes the policies back off their nodes, removes the units, and takes any Account the stack created back out of the organization. A unit removed while it still holds something hands what it holds to its parent, so every Account keeps a path to the root.

Two supporting changes reach earlier work. A root or unit id is now a valid policy target alongside a handle, which is what a template carries after a `Ref` resolves, and `removeOrganizationalUnit` is new. Both are additive.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CloudFormation support for simulated Organizations resources, including organizations, organizational units, accounts, and service control policies.
  * Added support for policy attachment, enforcement, `Ref`, and `Fn::GetAtt` outputs.
  * Added organizational unit removal with account and child-unit reparenting.
  * Added end-to-end deployment documentation and examples.

* **Bug Fixes**
  * CloudFormation teardown now removes accounts, organizational units, and policy enforcement cleanly.

* **Tests**
  * Added comprehensive coverage for validation, deployment, policy enforcement, outputs, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->