### PR TITLE
feat: evaluate negated IAM condition operators

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -296,10 +296,11 @@ const decision = simIam.authorize({
 console.log(decision.isAllowed);
 ```
 
-A positive operator naming a context key the request supplies no value for fails to match, leaving
-the request implicitly denied unless another statement allows it. A negated operator matches an
-absent key, as AWS documents. With no value in the request there is none for the policy value to
-equal.
+An unqualified positive operator naming a context key the request supplies no value for fails to
+match, leaving the request implicitly denied unless another statement allows it. Its negated form
+matches instead, as AWS documents. With no value in the request there is none for the policy value
+to equal. A `ForAnyValue:` operator answers false for an absent key whatever it wraps, because no
+request value is there to satisfy it.
 
 ## Users and access keys
 
@@ -1108,6 +1109,8 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
   CloudFormation teardown clears a User's policies before deleting it
 - Only the condition operators listed above are supported. A statement using any other operator
   fails closed, matching no request
+- A positive `ForAllValues:` condition fails to match a request carrying no value for the key, and
+  fails to match an empty value set. AWS matches both, and the negated form here matches both
 - Signature age is deliberately not enforced. `X-Amz-Date` must be present, well formed, and agree
   with the credential scope date, but is never compared to a clock. A client stamping real time can
   therefore reach a simulation keeping a different one. Session expiry _is_ enforced, against

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -221,10 +221,18 @@ Policy statements can carry `Condition` blocks. Sim IAM currently supports the `
 `StringLike`, `ArnLike`, `ArnEquals` and `NumericLessThanEquals` operators, along with the
 `ForAllValues:` and `ForAnyValue:` set variants of `StringEquals` and `StringLike`.
 
+The negated operators `StringNotEquals`, `StringNotLike`, `ArnNotEquals` and `ArnNotLike` are
+supported too, each unqualified and in both set forms. A list of policy values under a negated
+operator is an AND (the request value has to differ from every one of them), where the same list
+under a positive operator is an OR. A service control policy writes its carve-outs this way, hanging
+`ArnNotLike` on `aws:PrincipalArn` to deny an action to every principal outside a named set of
+roles.
+
 `ArnLike` and `ArnEquals` behave identically, as AWS documents them doing. Both compare the six
 colon-delimited components of an ARN separately, and both accept `*` and `?` wildcards in any of
 them. A wildcard stays inside the component it is written in. `arn:aws:s3:*` matches nothing,
-because a pattern needs as many components as the ARN it is matched against.
+because a pattern needs as many components as the ARN it is matched against. `ArnNotEquals` and
+`ArnNotLike` compare an ARN the same way and answer the opposite.
 
 Condition context values are supplied by the service handling the simulated request, such as S3
 object tags. Sim IAM automatically derives global values it can work out itself, such as
@@ -288,8 +296,10 @@ const decision = simIam.authorize({
 console.log(decision.isAllowed);
 ```
 
-A condition that references a context key with no supplied value fails to match, leaving the
-request implicitly denied unless another statement allows it.
+A positive operator naming a context key the request supplies no value for fails to match, leaving
+the request implicitly denied unless another statement allows it. A negated operator matches an
+absent key, as AWS documents. With no value in the request there is none for the policy value to
+equal.
 
 ## Users and access keys
 

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -391,6 +391,8 @@ Simulated Organizations supports:
 - `Action`, `NotAction`, `Resource`, `NotResource` and `Condition` in an SCP statement
 - The `ArnEquals`, `ArnLike`, `NumericLessThanEquals`, `StringEquals` and `StringLike` condition
   operators, and their `ForAnyValue:` and `ForAllValues:` set forms
+- The negated `ArnNotEquals`, `ArnNotLike`, `StringNotEquals` and `StringNotLike` operators and
+  their set forms, which a `Deny` statement exempting named roles hangs on `aws:PrincipalArn`
 - `AccessDenied` messages naming the service control policy, as AWS words them
 - Denial reporting through `decision.serviceControlPolicy`, naming the levels that allowed nothing
 - The `AWS::Organizations::Organization`, `::OrganizationalUnit`, `::Account` and `::Policy`
@@ -408,5 +410,5 @@ Simulated Organizations supports:
 | CloudFormation              | `AWS::Organizations::Organization`, `::OrganizationalUnit`, `::Account` and `::Policy` are not created from a template.             |
 | Organization condition keys | `aws:PrincipalOrgID` and `aws:PrincipalOrgPaths` are not populated. A condition naming either fails to match.                       |
 | Service principals          | A request whose caller is a service principal or anonymous belongs to no Account and is subject to no policy.                       |
-| Condition operator coverage | An operator sim IAM does not know fails closed, so the statement holding it never matches.                                          |
+| Condition operator coverage | The operators above are evaluated. Anything else fails closed and the statement holding it matches nothing.                         |
 | HTTP API                    | Organizations is not served as an HTTP API by `serveSimAws`.                                                                        |

--- a/src/service/iam/authorize/match/condition/arn/equals/sim-iam-arn-equals.ts
+++ b/src/service/iam/authorize/match/condition/arn/equals/sim-iam-arn-equals.ts
@@ -1,4 +1,4 @@
-import { simIamArnMatch } from "../../../../sim-iam-arn-match.js";
+import { simIamArnComparison } from "../../sim-iam-string-comparison.js";
 import { SimIamScalarStringConditionOperator } from "../../string/sim-iam-scalar-string-condition-operator.js";
 
 /**
@@ -12,6 +12,6 @@ import { SimIamScalarStringConditionOperator } from "../../string/sim-iam-scalar
  */
 export class SimIamArnEquals extends SimIamScalarStringConditionOperator {
   protected override valueMatches(actual: string, expected: string): boolean {
-    return simIamArnMatch(expected, actual);
+    return simIamArnComparison(actual, expected);
   }
 }

--- a/src/service/iam/authorize/match/condition/arn/like/sim-iam-arn-like.ts
+++ b/src/service/iam/authorize/match/condition/arn/like/sim-iam-arn-like.ts
@@ -1,4 +1,4 @@
-import { simIamArnMatch } from "../../../../sim-iam-arn-match.js";
+import { simIamArnComparison } from "../../sim-iam-string-comparison.js";
 import { SimIamScalarStringConditionOperator } from "../../string/sim-iam-scalar-string-condition-operator.js";
 
 /**
@@ -11,6 +11,6 @@ import { SimIamScalarStringConditionOperator } from "../../string/sim-iam-scalar
  */
 export class SimIamArnLike extends SimIamScalarStringConditionOperator {
   protected override valueMatches(actual: string, expected: string): boolean {
-    return simIamArnMatch(expected, actual);
+    return simIamArnComparison(actual, expected);
   }
 }

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-all-values-string-operator.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-all-values-string-operator.iso.test.ts
@@ -1,0 +1,130 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimIam } from "../../../../sim-iam.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../context/sim-iam-auth-z-context.factory.js";
+import type {
+  SimIamConditionValue,
+  SimIamPolicyDocumentCondition,
+} from "../../../../policy/sim-iam-policy.js";
+import type { SimIamPolicyDecision } from "../../../sim-iam-decision.js";
+
+const reportObject = "arn:aws:s3:::reports-bucket/summary.csv";
+
+/**
+ * Authorize a tagging request against a resource policy allowing it on one
+ * condition, with the request context supplied alongside.
+ */
+function decide(
+  condition: SimIamPolicyDocumentCondition,
+  conditionContext: Readonly<Record<string, SimIamConditionValue>> = {},
+): SimIamPolicyDecision {
+  const simIam = new SimIam();
+
+  return simIam.authorize({
+    action: "s3:PutObjectTagging",
+    resource: reportObject,
+    caller: { kind: "anonymous" },
+    conditionContext,
+    resourcePolicies: [
+      simIamAuthZResourcePolicySourceFactory.make({
+        document: {
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:PutObjectTagging",
+            Resource: reportObject,
+            Condition: condition,
+          },
+        },
+      }),
+    ],
+  });
+}
+
+describe("sim IAM ForAllValues negated condition operators", () => {
+  it("matches when every request value differs from every policy value", () => {
+    // Given a grant withheld from two tag keys
+    // When the request supplies neither of them
+    const decision = decide(
+      {
+        "ForAllValues:StringNotEquals": {
+          "aws:TagKeys": ["classification", "owner"],
+        },
+      },
+      { "aws:TagKeys": ["environment", "cost-centre"] },
+    );
+
+    // Then the condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match when one request value equals a policy value", () => {
+    // Given the same grant
+    // When one of the tag keys the request supplies is one the policy names
+    const decision = decide(
+      {
+        "ForAllValues:StringNotEquals": {
+          "aws:TagKeys": ["classification", "owner"],
+        },
+      },
+      { "aws:TagKeys": ["environment", "owner"] },
+    );
+
+    // Then the single match is enough to fail the condition
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches a request supplying the key with no values", () => {
+    // Given the same grant
+    // When the request supplies the tag-key context with nothing in it
+    const decision = decide(
+      {
+        "ForAllValues:StringNotEquals": {
+          "aws:TagKeys": ["classification", "owner"],
+        },
+      },
+      { "aws:TagKeys": [] },
+    );
+
+    // Then there is no value to contradict the condition
+    assertTrue(decision.isAllowed);
+  });
+
+  it("matches a request carrying no value for the key", () => {
+    // Given the same grant
+    // When the request supplies no tag-key context at all
+    const decision = decide({
+      "ForAllValues:StringNotEquals": {
+        "aws:TagKeys": ["classification", "owner"],
+      },
+    });
+
+    // Then the negated operator matches an absent key, as AWS documents
+    assertTrue(decision.isAllowed);
+  });
+
+  it("matches when every request value falls outside the policy pattern", () => {
+    // Given a grant withheld from the application namespace
+    // When every tag key the request supplies is outside it
+    const decision = decide(
+      { "ForAllValues:StringNotLike": { "aws:TagKeys": "application:*" } },
+      { "aws:TagKeys": ["owner", "environment"] },
+    );
+
+    // Then the condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match when one request value falls inside the policy pattern", () => {
+    // Given the same grant
+    // When one tag key the request supplies is in the namespace
+    const decision = decide(
+      { "ForAllValues:StringNotLike": { "aws:TagKeys": "application:*" } },
+      { "aws:TagKeys": ["owner", "application:name"] },
+    );
+
+    // Then the wildcard covers it, so the condition does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-all-values-string-operator.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-all-values-string-operator.ts
@@ -1,0 +1,39 @@
+import type { SimIamConditionValue } from "../../../../policy/sim-iam-policy.js";
+import type { SimIamConditionOperator } from "../sim-iam-condition-operator.js";
+import type { SimIamStringComparison } from "../sim-iam-string-comparison.js";
+import { simIamStringValues } from "../string/sim-iam-string-values.js";
+
+/**
+ * A `ForAllValues` negated IAM string operator, such as
+ * `ForAllValues:StringNotEquals`.
+ *
+ * Every request value has to differ from every policy value. A request
+ * supplying no values leaves nothing to contradict that, so an empty set
+ * matches, as an absent key does.
+ */
+export class SimIamNegatedForAllValuesStringOperator implements SimIamConditionOperator {
+  readonly matchesAbsentKey = true;
+
+  constructor(private readonly comparison: SimIamStringComparison) {}
+
+  /**
+   * Check whether every request value differs from every policy value.
+   */
+  matches(
+    actual: SimIamConditionValue,
+    expected: SimIamConditionValue,
+  ): boolean {
+    const actualValues = simIamStringValues(actual);
+    const expectedValues = simIamStringValues(expected);
+
+    if (actualValues === undefined || expectedValues === undefined) {
+      return false;
+    }
+
+    return actualValues.every((actualValue) =>
+      expectedValues.every(
+        (expectedValue) => !this.comparison(actualValue, expectedValue),
+      ),
+    );
+  }
+}

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.iso.test.ts
@@ -91,7 +91,7 @@ describe("sim IAM ForAnyValue negated condition operators", () => {
     assertTrue(decision.isImplicitDeny);
   });
 
-  it("matches a request carrying no value for the key", () => {
+  it("does not match a request carrying no value for the key", () => {
     // Given the same grant
     // When the request supplies no tag-key context at all
     const decision = decide({
@@ -100,8 +100,9 @@ describe("sim IAM ForAnyValue negated condition operators", () => {
       },
     });
 
-    // Then the negated operator matches an absent key, as AWS documents
-    assertTrue(decision.isAllowed);
+    // Then `ForAnyValue` answers false for an absent key whatever it wraps,
+    // as AWS documents, leaving the negation nothing to apply to
+    assertTrue(decision.isImplicitDeny);
   });
 
   it("matches when one request value falls outside every policy pattern", () => {

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.iso.test.ts
@@ -1,0 +1,130 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimIam } from "../../../../sim-iam.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../context/sim-iam-auth-z-context.factory.js";
+import type {
+  SimIamConditionValue,
+  SimIamPolicyDocumentCondition,
+} from "../../../../policy/sim-iam-policy.js";
+import type { SimIamPolicyDecision } from "../../../sim-iam-decision.js";
+
+const reportObject = "arn:aws:s3:::reports-bucket/summary.csv";
+
+/**
+ * Authorize a tagging request against a resource policy allowing it on one
+ * condition, with the request context supplied alongside.
+ */
+function decide(
+  condition: SimIamPolicyDocumentCondition,
+  conditionContext: Readonly<Record<string, SimIamConditionValue>> = {},
+): SimIamPolicyDecision {
+  const simIam = new SimIam();
+
+  return simIam.authorize({
+    action: "s3:PutObjectTagging",
+    resource: reportObject,
+    caller: { kind: "anonymous" },
+    conditionContext,
+    resourcePolicies: [
+      simIamAuthZResourcePolicySourceFactory.make({
+        document: {
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:PutObjectTagging",
+            Resource: reportObject,
+            Condition: condition,
+          },
+        },
+      }),
+    ],
+  });
+}
+
+describe("sim IAM ForAnyValue negated condition operators", () => {
+  it("matches when one request value differs from every policy value", () => {
+    // Given a grant asking for a tag key outside the two it names
+    // When the request supplies one of those two and one other
+    const decision = decide(
+      {
+        "ForAnyValue:StringNotEquals": {
+          "aws:TagKeys": ["classification", "owner"],
+        },
+      },
+      { "aws:TagKeys": ["owner", "environment"] },
+    );
+
+    // Then the one value differing from both policy values is enough
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match when every request value equals a policy value", () => {
+    // Given the same grant
+    // When every tag key the request supplies is one the policy names
+    const decision = decide(
+      {
+        "ForAnyValue:StringNotEquals": {
+          "aws:TagKeys": ["classification", "owner"],
+        },
+      },
+      { "aws:TagKeys": ["owner", "classification"] },
+    );
+
+    // Then no value is left to differ from them
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("does not match a request supplying the key with no values", () => {
+    // Given the same grant
+    // When the request supplies the tag-key context with nothing in it
+    const decision = decide(
+      {
+        "ForAnyValue:StringNotEquals": {
+          "aws:TagKeys": ["classification", "owner"],
+        },
+      },
+      { "aws:TagKeys": [] },
+    );
+
+    // Then there is no value that could satisfy the condition
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches a request carrying no value for the key", () => {
+    // Given the same grant
+    // When the request supplies no tag-key context at all
+    const decision = decide({
+      "ForAnyValue:StringNotEquals": {
+        "aws:TagKeys": ["classification", "owner"],
+      },
+    });
+
+    // Then the negated operator matches an absent key, as AWS documents
+    assertTrue(decision.isAllowed);
+  });
+
+  it("matches when one request value falls outside every policy pattern", () => {
+    // Given a grant asking for a tag key outside the application namespace
+    // When the request supplies one inside it and one outside
+    const decision = decide(
+      { "ForAnyValue:StringNotLike": { "aws:TagKeys": "application:*" } },
+      { "aws:TagKeys": ["application:name", "owner"] },
+    );
+
+    // Then the value the pattern does not cover is enough
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match when every request value falls inside a policy pattern", () => {
+    // Given the same grant
+    // When every tag key the request supplies is in the namespace
+    const decision = decide(
+      { "ForAnyValue:StringNotLike": { "aws:TagKeys": "application:*" } },
+      { "aws:TagKeys": ["application:name", "application:owner"] },
+    );
+
+    // Then the wildcard covers them all, so the condition does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.ts
@@ -8,11 +8,12 @@ import { simIamStringValues } from "../string/sim-iam-string-values.js";
  * `ForAnyValue:StringNotEquals`.
  *
  * One request value differing from every policy value is enough. A request
- * supplying no values at all satisfies nothing, so an empty set does not
- * match, while an absent key does.
+ * supplying no such value satisfies nothing, which covers both an empty value
+ * set and a key the request omits. The `ForAnyValue` qualifier settles the
+ * absent key here, ahead of the rule that a negated operator matches one.
  */
 export class SimIamNegatedForAnyValueStringOperator implements SimIamConditionOperator {
-  readonly matchesAbsentKey = true;
+  readonly matchesAbsentKey = false;
 
   constructor(private readonly comparison: SimIamStringComparison) {}
 

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.ts
@@ -1,0 +1,39 @@
+import type { SimIamConditionValue } from "../../../../policy/sim-iam-policy.js";
+import type { SimIamConditionOperator } from "../sim-iam-condition-operator.js";
+import type { SimIamStringComparison } from "../sim-iam-string-comparison.js";
+import { simIamStringValues } from "../string/sim-iam-string-values.js";
+
+/**
+ * A `ForAnyValue` negated IAM string operator, such as
+ * `ForAnyValue:StringNotEquals`.
+ *
+ * One request value differing from every policy value is enough. A request
+ * supplying no values at all satisfies nothing, so an empty set does not
+ * match, while an absent key does.
+ */
+export class SimIamNegatedForAnyValueStringOperator implements SimIamConditionOperator {
+  readonly matchesAbsentKey = true;
+
+  constructor(private readonly comparison: SimIamStringComparison) {}
+
+  /**
+   * Check whether any request value differs from every policy value.
+   */
+  matches(
+    actual: SimIamConditionValue,
+    expected: SimIamConditionValue,
+  ): boolean {
+    const actualValues = simIamStringValues(actual);
+    const expectedValues = simIamStringValues(expected);
+
+    if (actualValues === undefined || expectedValues === undefined) {
+      return false;
+    }
+
+    return actualValues.some((actualValue) =>
+      expectedValues.every(
+        (expectedValue) => !this.comparison(actualValue, expectedValue),
+      ),
+    );
+  }
+}

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-operator-factories.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-operator-factories.ts
@@ -1,0 +1,60 @@
+import type { SimIamConditionOperatorFactory } from "../sim-iam-condition-operator.js";
+import type { SimIamStringComparison } from "../sim-iam-string-comparison.js";
+import {
+  simIamArnComparison,
+  simIamStringEqualsComparison,
+  simIamStringLikeComparison,
+} from "../sim-iam-string-comparison.js";
+import { SimIamNegatedForAllValuesStringOperator } from "./sim-iam-negated-for-all-values-string-operator.js";
+import { SimIamNegatedForAnyValueStringOperator } from "./sim-iam-negated-for-any-value-string-operator.js";
+import { SimIamNegatedScalarStringOperator } from "./sim-iam-negated-scalar-string-operator.js";
+
+/**
+ * The comparison behind each negated operator keyword.
+ */
+const negatedComparisons: ReadonlyMap<string, SimIamStringComparison> = new Map(
+  [
+    ["ArnNotEquals", simIamArnComparison],
+    ["ArnNotLike", simIamArnComparison],
+    ["StringNotEquals", simIamStringEqualsComparison],
+    ["StringNotLike", simIamStringLikeComparison],
+  ],
+);
+
+/**
+ * Build the unqualified and set forms of one negated keyword.
+ */
+function keywordForms(
+  keyword: string,
+  comparison: SimIamStringComparison,
+): readonly [string, SimIamConditionOperatorFactory][] {
+  return [
+    [
+      keyword,
+      (): SimIamNegatedScalarStringOperator =>
+        new SimIamNegatedScalarStringOperator(comparison),
+    ],
+    [
+      `ForAnyValue:${keyword}`,
+      (): SimIamNegatedForAnyValueStringOperator =>
+        new SimIamNegatedForAnyValueStringOperator(comparison),
+    ],
+    [
+      `ForAllValues:${keyword}`,
+      (): SimIamNegatedForAllValuesStringOperator =>
+        new SimIamNegatedForAllValuesStringOperator(comparison),
+    ],
+  ];
+}
+
+/**
+ * Every negated condition operator sim IAM evaluates, keyed by its keyword.
+ */
+export const simIamNegatedOperatorFactories: ReadonlyMap<
+  string,
+  SimIamConditionOperatorFactory
+> = new Map(
+  [...negatedComparisons].flatMap(([keyword, comparison]) =>
+    keywordForms(keyword, comparison),
+  ),
+);

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-scalar-string-operator.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-scalar-string-operator.iso.test.ts
@@ -1,0 +1,238 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimIam } from "../../../../sim-iam.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../context/sim-iam-auth-z-context.factory.js";
+import type {
+  SimIamConditionValue,
+  SimIamPolicyDocumentCondition,
+} from "../../../../policy/sim-iam-policy.js";
+import type { SimIamPolicyDecision } from "../../../sim-iam-decision.js";
+
+const reportObject = "arn:aws:s3:::reports-bucket/summary.csv";
+
+/**
+ * Authorize a read against a resource policy allowing it on one condition,
+ * with the request context supplied alongside.
+ */
+function decide(
+  condition: SimIamPolicyDocumentCondition,
+  conditionContext: Readonly<Record<string, SimIamConditionValue>> = {},
+): SimIamPolicyDecision {
+  const simIam = new SimIam();
+
+  return simIam.authorize({
+    action: "s3:GetObject",
+    resource: reportObject,
+    caller: { kind: "anonymous" },
+    conditionContext,
+    resourcePolicies: [
+      simIamAuthZResourcePolicySourceFactory.make({
+        document: {
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:GetObject",
+            Resource: reportObject,
+            Condition: condition,
+          },
+        },
+      }),
+    ],
+  });
+}
+
+describe("sim IAM negated scalar condition operators", () => {
+  it("matches a StringNotEquals value differing from the policy value", () => {
+    // Given a grant withheld from one classification
+    // When the request carries another one
+    const decision = decide(
+      { StringNotEquals: { "s3:ExistingObjectTag/classification": "secret" } },
+      { "s3:ExistingObjectTag/classification": "public" },
+    );
+
+    // Then the condition matches and the grant stands
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match a StringNotEquals value equal to the policy value", () => {
+    // Given the same grant
+    // When the request carries the classification it is withheld from
+    const decision = decide(
+      { StringNotEquals: { "s3:ExistingObjectTag/classification": "secret" } },
+      { "s3:ExistingObjectTag/classification": "secret" },
+    );
+
+    // Then the statement does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("requires a StringNotEquals value to differ from every policy value", () => {
+    // Given a grant withheld from two classifications, which AWS reads as an
+    // AND rather than the OR a positive operator makes of a list
+    // When the request carries the second of them
+    const decision = decide(
+      {
+        StringNotEquals: {
+          "s3:ExistingObjectTag/classification": ["secret", "internal"],
+        },
+      },
+      { "s3:ExistingObjectTag/classification": "internal" },
+    );
+
+    // Then one match is enough to fail the condition
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches a StringNotEquals value differing from all of several policy values", () => {
+    // Given the same two-value grant
+    // When the request carries neither of them
+    const decision = decide(
+      {
+        StringNotEquals: {
+          "s3:ExistingObjectTag/classification": ["secret", "internal"],
+        },
+      },
+      { "s3:ExistingObjectTag/classification": "public" },
+    );
+
+    // Then the condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("matches a negated operator when the request carries no value for the key", () => {
+    // Given a grant withheld from one classification
+    // When the request supplies no classification at all
+    const decision = decide({
+      StringNotEquals: { "s3:ExistingObjectTag/classification": "secret" },
+    });
+
+    // Then the condition matches, as AWS documents: with no value in the
+    // request there is none that could equal the policy value
+    assertTrue(decision.isAllowed);
+  });
+
+  it("compares StringNotEquals values case-sensitively", () => {
+    // Given a grant withheld from a lower-case classification
+    // When the request carries the same word in a different case
+    const decision = decide(
+      { StringNotEquals: { "s3:ExistingObjectTag/classification": "secret" } },
+      { "s3:ExistingObjectTag/classification": "Secret" },
+    );
+
+    // Then the two values differ, so the condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match a StringNotEquals request value that is not scalar", () => {
+    // Given a grant using an unqualified operator, which needs a scalar
+    // When the request supplies a multi-valued key instead
+    const decision = decide(
+      { StringNotEquals: { "aws:TagKeys": "classification" } },
+      { "aws:TagKeys": ["owner", "environment"] },
+    );
+
+    // Then the operand is rejected rather than compared
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("does not match a StringNotEquals policy value that is not a string", () => {
+    // Given a grant whose policy value is a number
+    // When the request carries a string
+    const decision = decide(
+      { StringNotEquals: { "s3:ExistingObjectTag/version": 2 } },
+      { "s3:ExistingObjectTag/version": "3" },
+    );
+
+    // Then the operand is rejected rather than coerced
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches a StringNotLike value no policy pattern covers", () => {
+    // Given a grant withheld from the internal key prefix
+    // When the request carries a key outside it
+    const decision = decide(
+      { StringNotLike: { "s3:prefix": "internal/*" } },
+      { "s3:prefix": "public/summary.csv" },
+    );
+
+    // Then the condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match a StringNotLike value a policy pattern covers", () => {
+    // Given the same grant
+    // When the request carries a key inside the withheld prefix
+    const decision = decide(
+      { StringNotLike: { "s3:prefix": "internal/*" } },
+      { "s3:prefix": "internal/payroll.csv" },
+    );
+
+    // Then the wildcard matches, so the condition does not
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches an ArnNotLike principal outside the policy pattern", () => {
+    // Given a grant withheld from the landing zone roles
+    // When an application role asks
+    const decision = decide(
+      {
+        ArnNotLike: {
+          "aws:PrincipalArn": "arn:aws:iam::*:role/LandingZone/*",
+        },
+      },
+      { "aws:PrincipalArn": "arn:aws:iam::123456789012:role/OrdersService" },
+    );
+
+    // Then the condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match an ArnNotLike principal inside the policy pattern", () => {
+    // Given the same grant
+    // When a landing zone role asks
+    const decision = decide(
+      {
+        ArnNotLike: {
+          "aws:PrincipalArn": "arn:aws:iam::*:role/LandingZone/*",
+        },
+      },
+      {
+        "aws:PrincipalArn":
+          "arn:aws:iam::123456789012:role/LandingZone/Deployment",
+      },
+    );
+
+    // Then the pattern matches, so the condition does not
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("keeps an ArnNotEquals wildcard inside the component it is written in", () => {
+    // Given a grant withheld from a pattern with fewer components than an ARN
+    // has, which therefore matches no ARN at all
+    // When any principal asks
+    const decision = decide(
+      { ArnNotEquals: { "aws:PrincipalArn": "arn:aws:iam:*" } },
+      { "aws:PrincipalArn": "arn:aws:iam::123456789012:role/OrdersService" },
+    );
+
+    // Then nothing matched the pattern, so the negated condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("does not match an ArnNotEquals principal the policy names", () => {
+    // Given a grant withheld from one role
+    // When that role asks
+    const decision = decide(
+      {
+        ArnNotEquals: {
+          "aws:PrincipalArn": "arn:aws:iam::123456789012:role/OrdersService",
+        },
+      },
+      { "aws:PrincipalArn": "arn:aws:iam::123456789012:role/OrdersService" },
+    );
+
+    // Then the statement does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-scalar-string-operator.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-scalar-string-operator.ts
@@ -1,0 +1,40 @@
+import type { SimIamConditionValue } from "../../../../policy/sim-iam-policy.js";
+import type { SimIamConditionOperator } from "../sim-iam-condition-operator.js";
+import type { SimIamStringComparison } from "../sim-iam-string-comparison.js";
+import { simIamStringValues } from "../string/sim-iam-string-values.js";
+
+/**
+ * An unqualified negated IAM string operator, such as `StringNotEquals`.
+ *
+ * The request value must be scalar, as it must for the positive operators.
+ * Several policy values are an AND rather than an OR: the request value has to
+ * differ from every one of them, so a carve-out naming three roles exempts all
+ * three.
+ */
+export class SimIamNegatedScalarStringOperator implements SimIamConditionOperator {
+  readonly matchesAbsentKey = true;
+
+  constructor(private readonly comparison: SimIamStringComparison) {}
+
+  /**
+   * Check whether a request value differs from every policy value.
+   */
+  matches(
+    actual: SimIamConditionValue,
+    expected: SimIamConditionValue,
+  ): boolean {
+    if (typeof actual !== "string") {
+      return false;
+    }
+
+    const expectedValues = simIamStringValues(expected);
+
+    if (expectedValues === undefined) {
+      return false;
+    }
+
+    return expectedValues.every(
+      (expectedValue) => !this.comparison(actual, expectedValue),
+    );
+  }
+}

--- a/src/service/iam/authorize/match/condition/numeric/less-than-equals/sim-iam-number-lte.ts
+++ b/src/service/iam/authorize/match/condition/numeric/less-than-equals/sim-iam-number-lte.ts
@@ -16,6 +16,8 @@ import type { SimIamConditionOperator } from "../../sim-iam-condition-operator.j
  * are rejected rather than being converted through JavaScript coercion rules.
  */
 export class SimIamNumericLessThanEquals implements SimIamConditionOperator {
+  readonly matchesAbsentKey = false;
+
   /**
    * Compare one request value with one or more policy limits.
    */

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.iso.test.ts
@@ -1,0 +1,50 @@
+import {
+  assertArrayLength,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimIamConditionOperatorParser } from "./sim-iam-condition-operator-parser.js";
+
+const negatedKeywords = [
+  "ArnNotEquals",
+  "ArnNotLike",
+  "StringNotEquals",
+  "StringNotLike",
+];
+
+const setQualifiers = ["ForAnyValue", "ForAllValues"];
+
+describe("sim IAM condition operator parsing", () => {
+  it("has an operator for every form of every negated keyword", () => {
+    // Given the keywords a service control policy writes a carve-out with
+    const parser = new SimIamConditionOperatorParser();
+
+    // When each is parsed unqualified and in both of its set forms
+    const operators = negatedKeywords
+      .flatMap((keyword) => [
+        keyword,
+        ...setQualifiers.map((qualifier) => `${qualifier}:${keyword}`),
+      ])
+      .map((keyword) => parser.parse(keyword));
+
+    // Then each yields an operator, and each of those matches a request
+    // carrying no value for the key
+    assertArrayLength(operators, negatedKeywords.length * 3);
+    assertTrue(
+      operators.every((operator) => operator?.matchesAbsentKey === true),
+    );
+  });
+
+  it("has no operator for a keyword it cannot evaluate", () => {
+    // Given the parser
+    const parser = new SimIamConditionOperatorParser();
+
+    // When a keyword sim IAM does not implement is parsed
+    const operator = parser.parse("StringEqualsIgnoreCase");
+
+    // Then nothing comes back, leaving the statement holding it to fail closed
+    assertUndefined(operator);
+  });
+});

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  assertArrayEquals,
   assertArrayLength,
   assertTrue,
   assertUndefined,
@@ -29,11 +30,27 @@ describe("sim IAM condition operator parsing", () => {
       ])
       .map((keyword) => parser.parse(keyword));
 
-    // Then each yields an operator, and each of those matches a request
-    // carrying no value for the key
+    // Then each yields an operator
     assertArrayLength(operators, negatedKeywords.length * 3);
-    assertTrue(
-      operators.every((operator) => operator?.matchesAbsentKey === true),
+    assertTrue(operators.every((operator) => operator !== undefined));
+  });
+
+  it("matches an absent context key everywhere but the ForAnyValue forms", () => {
+    // Given the same keywords
+    const parser = new SimIamConditionOperatorParser();
+
+    // When each form is asked whether an absent context key matches it
+    const matchesAbsentKey = negatedKeywords.flatMap((keyword) => [
+      parser.parse(keyword)?.matchesAbsentKey,
+      parser.parse(`ForAllValues:${keyword}`)?.matchesAbsentKey,
+      parser.parse(`ForAnyValue:${keyword}`)?.matchesAbsentKey,
+    ]);
+
+    // Then only the `ForAnyValue` forms answer false, because no request value
+    // is there to satisfy them
+    assertArrayEquals(
+      matchesAbsentKey,
+      negatedKeywords.flatMap(() => [true, true, false]),
     );
   });
 

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
@@ -1,4 +1,8 @@
-import type { SimIamConditionOperator } from "./sim-iam-condition-operator.js";
+import type {
+  SimIamConditionOperator,
+  SimIamConditionOperatorFactory,
+} from "./sim-iam-condition-operator.js";
+import { simIamNegatedOperatorFactories } from "./negated/sim-iam-negated-operator-factories.js";
 import { SimIamForAllValuesStringEquals } from "./string/all-values/sim-iam-for-all-values-string-equals.js";
 import { SimIamForAllValuesStringLike } from "./string/all-values/sim-iam-for-all-values-string-like.js";
 import { SimIamForAnyValueStringEquals } from "./string/any-value/sim-iam-for-any-value-string-equals.js";
@@ -8,8 +12,6 @@ import { SimIamStringLike } from "./string/like/sim-iam-string-like.js";
 import { SimIamNumericLessThanEquals } from "./numeric/less-than-equals/sim-iam-number-lte.js";
 import { SimIamArnEquals } from "./arn/equals/sim-iam-arn-equals.js";
 import { SimIamArnLike } from "./arn/like/sim-iam-arn-like.js";
-
-type SimIamConditionOperatorFactory = () => SimIamConditionOperator;
 
 const operatorFactories = new Map<string, SimIamConditionOperatorFactory>([
   ["ArnEquals", (): SimIamConditionOperator => new SimIamArnEquals()],
@@ -36,6 +38,7 @@ const operatorFactories = new Map<string, SimIamConditionOperatorFactory>([
     "ForAllValues:StringLike",
     (): SimIamConditionOperator => new SimIamForAllValuesStringLike(),
   ],
+  ...simIamNegatedOperatorFactories,
 ]);
 
 /**

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
@@ -11,9 +11,12 @@ export interface SimIamConditionOperator {
   /**
    * Whether the operator matches a request carrying no value for the key.
    *
-   * A positive operator has nothing to compare and so matches nothing. A
-   * negated one matches, as AWS documents: with no value in the request there
-   * is none that could equal the policy value.
+   * An unqualified positive operator has nothing to compare and matches
+   * nothing, while its negated form matches. With no value in the request
+   * there is none for the policy value to equal.
+   *
+   * A `ForAnyValue` operator answers false whatever it wraps, because no
+   * request value is there to satisfy it. AWS documents both rules.
    */
   readonly matchesAbsentKey: boolean;
 

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
@@ -9,6 +9,15 @@ import type { SimIamConditionValue } from "../../../policy/sim-iam-policy.js";
  */
 export interface SimIamConditionOperator {
   /**
+   * Whether the operator matches a request carrying no value for the key.
+   *
+   * A positive operator has nothing to compare and so matches nothing. A
+   * negated one matches, as AWS documents: with no value in the request there
+   * is none that could equal the policy value.
+   */
+  readonly matchesAbsentKey: boolean;
+
+  /**
    * Determine whether an actual request value satisfies the expected policy value.
    */
   matches(
@@ -16,3 +25,8 @@ export interface SimIamConditionOperator {
     expected: SimIamConditionValue,
   ): boolean;
 }
+
+/**
+ * Builds a fresh condition operator for one keyword.
+ */
+export type SimIamConditionOperatorFactory = () => SimIamConditionOperator;

--- a/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
@@ -13,9 +13,8 @@ import { SimIamConditionOperatorParser } from "./sim-iam-condition-operator-pars
  * comparison, and set semantics.
  *
  * An unsupported operator fails closed by making the condition non-matching. A
- * context key the request carries no value for is left to the operator: a
- * positive one has nothing to compare and matches nothing, while a negated one
- * matches, as AWS documents.
+ * context key the request carries no value for is left to the operator, which
+ * answers for itself whether an absent key matches it.
  */
 export class SimIamPolicyConditionMatcher {
   private readonly conditionContext: ReadonlyMap<string, SimIamConditionValue>;

--- a/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
@@ -12,8 +12,10 @@ import { SimIamConditionOperatorParser } from "./sim-iam-condition-operator-pars
  * key lookup. Individual condition operators encapsulate value validation,
  * comparison, and set semantics.
  *
- * Unsupported operators and missing context keys fail closed by making the
- * condition non-matching.
+ * An unsupported operator fails closed by making the condition non-matching. A
+ * context key the request carries no value for is left to the operator: a
+ * positive one has nothing to compare and matches nothing, while a negated one
+ * matches, as AWS documents.
  */
 export class SimIamPolicyConditionMatcher {
   private readonly conditionContext: ReadonlyMap<string, SimIamConditionValue>;
@@ -69,7 +71,7 @@ export class SimIamPolicyConditionMatcher {
     const actual = this.conditionContext.get(this.normalizeContextKey(key));
 
     if (actual === undefined) {
-      return false;
+      return operator.matchesAbsentKey;
     }
 
     return operator.matches(actual, expected);

--- a/src/service/iam/authorize/match/condition/sim-iam-string-comparison.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-string-comparison.ts
@@ -1,0 +1,40 @@
+import { simIamArnMatch } from "../../sim-iam-arn-match.js";
+import { simIamWildcardMatch } from "../../sim-iam-wildcard.js";
+
+/**
+ * Compares one request value with one policy value.
+ *
+ * Condition operators differ in how they quantify over the values on each
+ * side, and in whether they negate the result. The comparison of a single
+ * pair is the part they share, so `StringNotLike` is the same comparison as
+ * `StringLike` with the answer turned around.
+ */
+export type SimIamStringComparison = (
+  actual: string,
+  expected: string,
+) => boolean;
+
+/**
+ * The comparison `StringEquals` and `StringNotEquals` are built from.
+ */
+export const simIamStringEqualsComparison: SimIamStringComparison = (
+  actual,
+  expected,
+) => actual === expected;
+
+/**
+ * The comparison `StringLike` and `StringNotLike` are built from.
+ */
+export const simIamStringLikeComparison: SimIamStringComparison = (
+  actual,
+  expected,
+) => simIamWildcardMatch(expected, actual, { caseSensitive: true });
+
+/**
+ * The comparison the four ARN operators are built from.
+ *
+ * AWS documents `ArnEquals` and `ArnLike` as behaving identically, so one
+ * comparison serves both of them and both of their negated forms.
+ */
+export const simIamArnComparison: SimIamStringComparison = (actual, expected) =>
+  simIamArnMatch(expected, actual);

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-condition-operator.ts
@@ -6,6 +6,8 @@ import { simIamStringValues } from "../sim-iam-string-values.js";
  * Base for `ForAllValues` IAM string operators.
  */
 export abstract class SimIamForAllValuesStringConditionOperator implements SimIamConditionOperator {
+  readonly matchesAbsentKey = false;
+
   /**
    * Check whether a given value matches the expected value.
    */

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.ts
@@ -1,3 +1,4 @@
+import { simIamStringEqualsComparison } from "../../sim-iam-string-comparison.js";
 import { SimIamForAllValuesStringConditionOperator } from "./sim-iam-for-all-values-string-condition-operator.js";
 
 /**
@@ -5,6 +6,6 @@ import { SimIamForAllValuesStringConditionOperator } from "./sim-iam-for-all-val
  */
 export class SimIamForAllValuesStringEquals extends SimIamForAllValuesStringConditionOperator {
   protected override valueMatches(actual: string, expected: string): boolean {
-    return actual === expected;
+    return simIamStringEqualsComparison(actual, expected);
   }
 }

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.ts
@@ -1,4 +1,4 @@
-import { simIamWildcardMatch } from "../../../../sim-iam-wildcard.js";
+import { simIamStringLikeComparison } from "../../sim-iam-string-comparison.js";
 import { SimIamForAllValuesStringConditionOperator } from "./sim-iam-for-all-values-string-condition-operator.js";
 
 /**
@@ -6,8 +6,6 @@ import { SimIamForAllValuesStringConditionOperator } from "./sim-iam-for-all-val
  */
 export class SimIamForAllValuesStringLike extends SimIamForAllValuesStringConditionOperator {
   protected override valueMatches(actual: string, expected: string): boolean {
-    return simIamWildcardMatch(expected, actual, {
-      caseSensitive: true,
-    });
+    return simIamStringLikeComparison(actual, expected);
   }
 }

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-condition-operator.ts
@@ -6,6 +6,8 @@ import { simIamStringValues } from "../sim-iam-string-values.js";
  * Base for `ForAnyValue` IAM string operators.
  */
 export abstract class SimIamForAnyValueStringConditionOperator implements SimIamConditionOperator {
+  readonly matchesAbsentKey = false;
+
   /**
    * Check whether a given value matches the expected value.
    */

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-equals.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-equals.ts
@@ -1,3 +1,4 @@
+import { simIamStringEqualsComparison } from "../../sim-iam-string-comparison.js";
 import { SimIamForAnyValueStringConditionOperator } from "./sim-iam-for-any-value-string-condition-operator.js";
 
 /**
@@ -5,6 +6,6 @@ import { SimIamForAnyValueStringConditionOperator } from "./sim-iam-for-any-valu
  */
 export class SimIamForAnyValueStringEquals extends SimIamForAnyValueStringConditionOperator {
   protected override valueMatches(actual: string, expected: string): boolean {
-    return actual === expected;
+    return simIamStringEqualsComparison(actual, expected);
   }
 }

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-like.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-like.ts
@@ -1,4 +1,4 @@
-import { simIamWildcardMatch } from "../../../../sim-iam-wildcard.js";
+import { simIamStringLikeComparison } from "../../sim-iam-string-comparison.js";
 import { SimIamForAnyValueStringConditionOperator } from "./sim-iam-for-any-value-string-condition-operator.js";
 
 /**
@@ -6,8 +6,6 @@ import { SimIamForAnyValueStringConditionOperator } from "./sim-iam-for-any-valu
  */
 export class SimIamForAnyValueStringLike extends SimIamForAnyValueStringConditionOperator {
   protected override valueMatches(actual: string, expected: string): boolean {
-    return simIamWildcardMatch(expected, actual, {
-      caseSensitive: true,
-    });
+    return simIamStringLikeComparison(actual, expected);
   }
 }

--- a/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals.ts
+++ b/src/service/iam/authorize/match/condition/string/equals/sim-iam-string-equals.ts
@@ -1,3 +1,4 @@
+import { simIamStringEqualsComparison } from "../../sim-iam-string-comparison.js";
 import { SimIamScalarStringConditionOperator } from "../sim-iam-scalar-string-condition-operator.js";
 
 /**
@@ -5,6 +6,6 @@ import { SimIamScalarStringConditionOperator } from "../sim-iam-scalar-string-co
  */
 export class SimIamStringEquals extends SimIamScalarStringConditionOperator {
   protected override valueMatches(actual: string, expected: string): boolean {
-    return actual === expected;
+    return simIamStringEqualsComparison(actual, expected);
   }
 }

--- a/src/service/iam/authorize/match/condition/string/like/sim-iam-string-like.ts
+++ b/src/service/iam/authorize/match/condition/string/like/sim-iam-string-like.ts
@@ -1,4 +1,4 @@
-import { simIamWildcardMatch } from "../../../../sim-iam-wildcard.js";
+import { simIamStringLikeComparison } from "../../sim-iam-string-comparison.js";
 import { SimIamScalarStringConditionOperator } from "../sim-iam-scalar-string-condition-operator.js";
 
 /**
@@ -6,8 +6,6 @@ import { SimIamScalarStringConditionOperator } from "../sim-iam-scalar-string-co
  */
 export class SimIamStringLike extends SimIamScalarStringConditionOperator {
   protected override valueMatches(actual: string, expected: string): boolean {
-    return simIamWildcardMatch(expected, actual, {
-      caseSensitive: true,
-    });
+    return simIamStringLikeComparison(actual, expected);
   }
 }

--- a/src/service/iam/authorize/match/condition/string/sim-iam-scalar-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/sim-iam-scalar-string-condition-operator.ts
@@ -9,6 +9,8 @@ import { simIamStringValues } from "./sim-iam-string-values.js";
  * scalar or an array, with multiple policy values using OR semantics.
  */
 export abstract class SimIamScalarStringConditionOperator implements SimIamConditionOperator {
+  readonly matchesAbsentKey = false;
+
   /**
    * Check whether a given value matches the expected value.
    */

--- a/src/service/organizations/sim-organizations-scp-exemption.iso.test.ts
+++ b/src/service/organizations/sim-organizations-scp-exemption.iso.test.ts
@@ -1,0 +1,139 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { assertIdentical, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimIamPolicyDecisionValue } from "../iam/authorize/sim-iam-decision.js";
+import type { SimIam } from "../iam/sim-iam.js";
+import type { SimIamPolicyDocument } from "../iam/policy/sim-iam-policy.js";
+
+/**
+ * A service control policy denying instance launches to everything but the
+ * landing zone roles, in the shape a real organization writes the carve-out.
+ */
+const denyInstancesOutsideLandingZone: SimIamPolicyDocument = {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyInstancesOutsideLandingZone",
+    Effect: "Deny",
+    Action: "ec2:RunInstances",
+    Resource: "*",
+    Condition: {
+      ArnNotLike: {
+        "aws:PrincipalArn": [
+          "arn:aws:iam::*:role/LandingZone/*",
+          "arn:aws:iam::*:role/AWSControlTowerExecution",
+        ],
+      },
+    },
+  },
+};
+
+/**
+ * Create a Role able to launch instances, at the given path.
+ */
+async function makeLaunchingRole(
+  simIam: SimIam,
+  accountId: string,
+  path: string,
+): Promise<string> {
+  const roleCreation = await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: "InstanceLauncher",
+      Path: path,
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "InstanceLauncher",
+      PolicyName: "LaunchInstances",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "ec2:RunInstances",
+          Resource: "*",
+        },
+      }),
+    }),
+  );
+
+  return roleCreation.Role.Arn;
+}
+
+describe("Simulated Organizations service control policy carve-outs", () => {
+  it("denies a principal the carve-out leaves out", async () => {
+    // Given an organization denying instance launches to every principal but
+    // the landing zone roles, and an application Role allowed to launch them.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.account(accountId).iam();
+    const roleArn = await makeLaunchingRole(simIam, accountId, "/application/");
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyInstancesOutsideLandingZone);
+
+    // When the application Role asks to launch one.
+    const decision = simIam.authorize({
+      action: "ec2:RunInstances",
+      resource: "*",
+      caller: { kind: "arn", arn: roleArn },
+    });
+
+    // Then its ARN is outside the exempted patterns, so the deny applies.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+    assertTrue(decision.serviceControlPolicy.isDenied);
+  });
+
+  it("leaves a principal the carve-out names alone", async () => {
+    // Given the same organization, and a Role on the landing zone path.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.account(accountId).iam();
+    const roleArn = await makeLaunchingRole(simIam, accountId, "/LandingZone/");
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyInstancesOutsideLandingZone);
+
+    // When it asks to launch an instance.
+    const decision = simIam.authorize({
+      action: "ec2:RunInstances",
+      resource: "*",
+      caller: { kind: "arn", arn: roleArn },
+    });
+
+    // Then the exemption holds and its identity policy carries it through.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("denies the Account root, which the carve-out does not name", () => {
+    // Given the same organization.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyInstancesOutsideLandingZone);
+
+    // When the Account root, which every permission is otherwise open to,
+    // asks to launch an instance.
+    const decision = simAws.account(accountId).iam().authorize({
+      action: "ec2:RunInstances",
+      resource: "*",
+    });
+
+    // Then the root ARN is outside the exempted patterns too.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+  });
+});


### PR DESCRIPTION
Sim IAM registered no negated condition operator. A service control policy writing its carve-out as `ArnNotLike` on `aws:PrincipalArn` matched nothing, and the `Deny` statement carrying it let the action through. `StringNotEquals`, `StringNotLike`, `ArnNotEquals` and `ArnNotLike` now parse, along with their `ForAnyValue:` and `ForAllValues:` set forms. A list of policy values under one of them is an AND, and a negated operator matches a request carrying no value for the key (as AWS documents).

Resolves #1069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for negated IAM condition operators, including string and ARN comparisons and `ForAnyValue`/`ForAllValues` variants.
  * Missing context keys now follow operator-specific behavior: positive operators fail, while negated operators match.
  * Added support for negated condition operators in Organizations SCP statements, including ARN-based role exemptions.
  * Unsupported condition operators now fail closed.

* **Bug Fixes**
  * Improved ARN equality, wildcard, and inverse matching behavior.

* **Tests**
  * Expanded coverage for negated operators, missing keys, wildcard matching, and SCP exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->