### PR TITLE
feat: derive aws:RequestedRegion in sim IAM

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -227,9 +227,19 @@ them. A wildcard stays inside the component it is written in. `arn:aws:s3:*` mat
 because a pattern needs as many components as the ARN it is matched against.
 
 Condition context values are supplied by the service handling the simulated request, such as S3
-object tags. Sim IAM automatically derives global values it can work out itself, such as
-`aws:PrincipalArn` from the resolved caller. Context-key names are matched case-insensitively,
-while string values remain case-sensitive.
+object tags. Sim IAM automatically derives the global values it can work out itself, `aws:PrincipalArn`
+from the resolved caller and `aws:RequestedRegion` from the Region the request was made in. A value a
+service supplies under either name is overwritten by the derived one. Context-key names are matched
+case-insensitively, while string values remain case-sensitive.
+
+Every simulated service supplies its own Region. A policy conditioned on `aws:RequestedRegion`
+therefore sees the Region of the service that handled the request, whichever Region the caller was
+in, and a CloudFormation deployment carries the Region of the Stack it is deploying. IAM, CloudFront
+and Route53 are global, with one endpoint between all Regions. Their requests carry `us-east-1`, as
+they do on AWS (which is why a service control policy confining an Account to a list of Regions has
+to leave the global services' actions out of the condition). A request made straight to
+`simIam.authorize(...)` carries no Region unless it is given one, and a statement conditioned on the
+key then matches nothing.
 
 ```typescript sim-iam-policy-conditions
 /**

--- a/src/service/acm/sim-acm.ts
+++ b/src/service/acm/sim-acm.ts
@@ -32,10 +32,8 @@ import { ListCertificatesCommandHandler } from "./command/list-certificates/list
 import { SimAcmCfnResourceFactory } from "./cfn/sim-cfn-acm-resource-factory.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimAcmSdkCommandRouter } from "./sdk/sim-acm-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import { SimAcmCertificateValidation } from "./validation/sim-acm-certificate-validation.js";
@@ -72,10 +70,11 @@ export class SimAcm {
   constructor(properties: SimAcmProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       dnsRecords,
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.accountRegionScope = accountRegionScope;
     this.iam = iam;

--- a/src/service/apigateway/serve/sim-api-gateway-router.ts
+++ b/src/service/apigateway/serve/sim-api-gateway-router.ts
@@ -7,6 +7,7 @@ import type { SimRestApiLambdaUri } from "../api/method/sim-rest-api-lambda-uri.
 import type { SimRestApi } from "../api/sim-rest-api.js";
 import type { SimRestApiRegistry } from "../registry/sim-rest-api-registry.js";
 import type { SimRestApiFunctionTarget } from "./sim-rest-api-function-target.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimApiGatewayRouterProperties {
   readonly simAws?: SimAws;
@@ -63,7 +64,9 @@ export class SimApiGatewayRouter {
   iamFor(restApi: SimRestApi): SimIamInterServiceAuthZ {
     const { accountId, regionName } = restApi.accountRegionScope;
 
-    return this.simAws.accountRegionScope(accountId, regionName).iam();
+    return simScopeIamAuthZ(
+      this.simAws.accountRegionScope(accountId, regionName),
+    );
   }
 
   /**
@@ -89,6 +92,8 @@ export class SimApiGatewayRouter {
       .lambda()
       .getSimFunctionTarget(lambdaUri.functionName, lambdaUri.qualifier);
 
-    return target === undefined ? undefined : { ...target, iam: scope.iam() };
+    return target === undefined
+      ? undefined
+      : { ...target, iam: simScopeIamAuthZ(scope) };
   }
 }

--- a/src/service/apigateway/sim-api-gateway-commands.ts
+++ b/src/service/apigateway/sim-api-gateway-commands.ts
@@ -4,10 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import {
   SimRestApiNoUserPools,
   type SimRestApiUserPools,
@@ -75,12 +73,13 @@ export class SimApiGatewayCommands {
   constructor(properties: SimApiGatewayProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       registry = new SimRestApiRegistry(),
       userPools = new SimRestApiNoUserPools(),
       webAcls = new SimWafNoProtection(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const access = new SimRestApiAccess({
       apis: this.apis,

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-router.ts
@@ -8,6 +8,7 @@ import type { SimHttpApi } from "../api/sim-http-api.js";
 import type { SimHttpApiRegistry } from "../registry/sim-http-api-registry.js";
 import type { SimHttpApiFunctionTarget } from "./sim-http-api-function-target.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimApiGatewayV2RouterProperties {
   readonly simAws?: SimAws;
@@ -66,7 +67,9 @@ export class SimApiGatewayV2Router {
   iamFor(api: SimHttpApi): SimIamInterServiceAuthZ {
     const { accountId, regionName } = api.accountRegionScope;
 
-    return this.simAws.accountRegionScope(accountId, regionName).iam();
+    return simScopeIamAuthZ(
+      this.simAws.accountRegionScope(accountId, regionName),
+    );
   }
 
   /**
@@ -108,6 +111,8 @@ export class SimApiGatewayV2Router {
       .lambda()
       .getSimFunctionTarget(lambdaUri.functionName, lambdaUri.qualifier);
 
-    return target === undefined ? undefined : { ...target, iam: scope.iam() };
+    return target === undefined
+      ? undefined
+      : { ...target, iam: simScopeIamAuthZ(scope) };
   }
 }

--- a/src/service/apigatewayv2/sim-api-gateway-v2-commands.ts
+++ b/src/service/apigatewayv2/sim-api-gateway-v2-commands.ts
@@ -4,10 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import {
   type SimHttpApiJwtIssuerKeys,
   SimHttpApiNoJwtIssuerKeys,
@@ -69,12 +67,13 @@ export class SimApiGatewayV2Commands {
   constructor(properties: SimApiGatewayV2Properties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       registry = new SimHttpApiRegistry(),
       domainRegistry = new SimHttpApiDomainRegistry(),
       jwtIssuerKeys = new SimHttpApiNoJwtIssuerKeys(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const authorizer = new SimApiGatewayV2Authorizer({
       iam,

--- a/src/service/athena/sim-athena-executions.ts
+++ b/src/service/athena/sim-athena-executions.ts
@@ -4,10 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type * as simAthenaCommands from "./command/sim-athena-command.types.js";
 import { SimAthenaCommands } from "./command/sim-athena-commands.js";
 import type { SimAthenaRequestOptions } from "./command/sim-athena-request-options.js";
@@ -96,9 +94,10 @@ export class SimAthenaExecutions {
   constructor(properties: SimAthenaProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const writer = new SimAthenaResultWriter({
       s3: properties.s3 ?? new SimAthenaNoResultDestination(),

--- a/src/service/bedrock/sim-bedrock.ts
+++ b/src/service/bedrock/sim-bedrock.ts
@@ -3,10 +3,8 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../util/background/background.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimBedrockAuthorizer } from "./command/authorize/sim-bedrock-authorizer.js";
@@ -64,9 +62,10 @@ export class SimBedrock {
   constructor(properties: SimBedrockProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
     const commandProperties = {
       responses: this.responseRules,
       authorizer: new SimBedrockAuthorizer({ iam }),

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -42,10 +42,8 @@ import { SimCloudFormationSdkCommandRouter } from "./sdk/sim-cloudformation-sdk-
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import { SimCloudFormationAuthorization } from "./authorize/sim-cloudformation-authorization.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 
 /**
  * Options accepted by simulated CloudFormation command operations.
@@ -79,9 +77,10 @@ export class SimCloudFormation {
     const {
       simAws,
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background,
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.simAws = simAws;
     this.background = background;

--- a/src/service/cloudfront/edge/sim-aws-cf-edge-functions.ts
+++ b/src/service/cloudfront/edge/sim-aws-cf-edge-functions.ts
@@ -84,7 +84,7 @@ export class SimAwsCfEdgeFunctions implements SimCfEdgeFunctions {
       target: simServiceRoleTarget(target.simFunction.roleArn),
       servicePrincipal: simLambdaEdgeServicePrincipal,
       sessionName,
-      iam: this.simAws.accountRegionScope(accountId, regionName).iam(),
+      scope: this.simAws.accountRegionScope(accountId, regionName),
       refusals: executionRoleRefusals(functionArn),
     });
   }

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -6,10 +6,11 @@ import type { SimAcmRegistry } from "../acm/registry/sim-acm-registry.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+  simIamGlobalServiceRegion,
+  simIamInRegion,
+} from "../iam/authorize/sim-iam-region-auth-z.js";
 import type {
   SimCreateDistributionCommand,
   SimCreateDistributionCommandOutput,
@@ -162,13 +163,15 @@ export class SimCloudFrontCommands {
       cloudFrontRegistry = new SimCloudFrontRegistry(),
       s3OriginResolver = emptyCloudFrontS3OriginResolver,
       customOriginDispatcher,
-      iam = new SimIamAllowAllAuth(),
       acmRegistry,
       webAclResolver,
       edgeFunctions,
       background = new BackgroundTasks(),
     } = properties;
 
+    // CloudFront is global rather than Region-scoped, so its requests are made
+    // in the Region its one endpoint is in.
+    const iam = simIamInRegion(properties.iam, simIamGlobalServiceRegion);
     const keyValueStores = new SimCloudFrontKeyValueStoreRegistry();
 
     this.edgeFunctions = edgeFunctions;

--- a/src/service/cloudwatch/sim-cloudwatch-commands.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-commands.ts
@@ -4,10 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimCloudWatchAlarmActions } from "./alarm/action/sim-cloudwatch-alarm-actions.js";
 import {
   SimCloudWatchNoAlarmTargets,
@@ -61,10 +59,11 @@ export class SimCloudWatchCommands {
   constructor(properties: SimCloudWatchProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       alarmTargets = new SimCloudWatchNoAlarmTargets(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const authorizer = new SimCloudWatchAuthorizer({ iam, accountRegionScope });
     const metrics = new SimCloudWatchMetricStore();

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -6,10 +6,8 @@ import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-route
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimAwsMessageLog } from "../aws/message/sim-aws-message-log.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import {
   SimWafNoProtection,
   type SimWafProtection,
@@ -121,7 +119,6 @@ export class SimCognitoIdentityProvider extends SimCognitoUserPools {
   constructor(properties: SimCognitoIdentityProviderProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       userPoolRegistry = new SimCognitoUserPoolRegistry(),
       domainRegistry = new SimCognitoDomainRegistry(),
@@ -130,6 +127,8 @@ export class SimCognitoIdentityProvider extends SimCognitoUserPools {
       webAcls = new SimWafNoProtection(),
       messageLog = new SimAwsMessageLog(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
     const pools = new SimCognitoUserPoolStore({
       registry: userPoolRegistry,
       domains: domainRegistry,

--- a/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.ts
+++ b/src/service/cognito/user-pool/trigger/sim-aws-cognito-trigger-functions.ts
@@ -10,6 +10,7 @@ import type {
   SimCognitoTriggerFunctionRequest,
   SimCognitoTriggerFunctions,
 } from "./sim-cognito-trigger-functions.js";
+import { simScopeIamAuthZ } from "../../../iam/authorize/sim-iam-region-auth-z.js";
 
 /**
  * The service principal real Cognito invokes a user pool trigger as.
@@ -137,7 +138,9 @@ export class SimAwsCognitoTriggerFunctions implements SimCognitoTriggerFunctions
   private iam(target: SimLambdaFunctionTarget): SimIamInterServiceAuthZ {
     const { accountId, regionName } = target.simFunction.accountRegionScope;
 
-    return this.simAws.accountRegionScope(accountId, regionName).iam();
+    return simScopeIamAuthZ(
+      this.simAws.accountRegionScope(accountId, regionName),
+    );
   }
 }
 

--- a/src/service/dynamodb/sim-dynamodb.ts
+++ b/src/service/dynamodb/sim-dynamodb.ts
@@ -10,7 +10,7 @@ import type { SimDynamoDbStream } from "./stream/sim-dynamodb-stream.js";
 import { SimDynamoDbStreams } from "./sim-dynamodb-streams.js";
 import { SimDynamoDbTableStore } from "./table/sim-dynamodb-table-store.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimDynamoDatabaseSdkCommandRouter } from "./sdk/sim-dynamodb-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
 import { SimDynamoDbCfnResourceFactory } from "./cfn/sim-cfn-dynamodb-resource-factory.js";
@@ -43,9 +43,10 @@ export class SimDynamoDb {
   constructor(properties: SimDynamoDbProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.background = background;
     this.commands = new SimDynamoDbCommandHandlers({

--- a/src/service/ecs/sim-ecs-commands.ts
+++ b/src/service/ecs/sim-ecs-commands.ts
@@ -1,7 +1,7 @@
 import { BackgroundTasks } from "../../util/background/background.js";
 import type { SimAwsRunAsOwner } from "../aws/caller/sim-aws-run-as-context.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimEcsContainerBindings } from "./bind/sim-ecs-container-bindings.js";
 import { SimEcsUnreachableConsumerQueues } from "./service/consume/sim-ecs-consumer-queues.js";
 import { SimEcsUnreachableTargetGroups } from "./service/load-balancer/sim-ecs-target-groups.js";
@@ -90,13 +90,14 @@ export class SimEcsCommands {
   constructor(properties: SimEcsCommandsProperties) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       runAsOwner,
       secretStores = new SimEcsUnreachableSecretStores(),
       consumerQueues = new SimEcsUnreachableConsumerQueues(),
       targetGroups = new SimEcsUnreachableTargetGroups(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const contexts = new SimEcsCommandContexts({
       accountRegionScope,

--- a/src/service/elbv2/serve/sim-elbv2-router.ts
+++ b/src/service/elbv2/serve/sim-elbv2-router.ts
@@ -9,6 +9,7 @@ import type { SimElbV2LoadBalancer } from "../load-balancer/sim-elbv2-load-balan
 import type { SimElbV2Registry } from "../registry/sim-elbv2-registry.js";
 import type { SimElbV2 } from "../sim-elbv2.js";
 import type { SimElbV2TargetGroup } from "../target-group/sim-elbv2-target-group.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimElbV2RouterProperties {
   /**
@@ -134,7 +135,7 @@ export class SimElbV2Router {
       return undefined;
     }
 
-    return { simFunction, iam: scope.iam() };
+    return { simFunction, iam: simScopeIamAuthZ(scope) };
   }
 
   /**

--- a/src/service/elbv2/sim-elbv2.ts
+++ b/src/service/elbv2/sim-elbv2.ts
@@ -2,7 +2,7 @@ import { BackgroundTasks } from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
-import { SimIamAllowAllAuth } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimElbV2CfnResourceFactory } from "./cfn/sim-elbv2-cfn-resource-factory.js";
 import type * as elbV2 from "./command/sim-elbv2-command.types.js";
 import { SimElbV2Commands } from "./command/sim-elbv2-commands.js";
@@ -40,7 +40,6 @@ export class SimElbV2 {
   constructor(properties: SimElbV2Properties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       registry = new SimElbV2Registry(),
     } = properties;
@@ -48,7 +47,7 @@ export class SimElbV2 {
     this.stores = new SimElbV2Stores({ registry });
     this.commands = new SimElbV2Commands({
       stores: this.stores,
-      iam,
+      iam: simIamInRegion(properties.iam, accountRegionScope.regionName),
       background,
       accountRegionScope,
       acmRegistry: properties.acmRegistry,

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-function.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-function.ts
@@ -10,6 +10,7 @@ import {
   simEventBridgeDeliverySource,
   simEventBridgeServicePrincipal,
 } from "./sim-event-bridge-delivery.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimEventBridgeDeliveryFunctionProperties {
   readonly scope: SimAwsAccountRegionContainer;
@@ -61,7 +62,7 @@ export class SimEventBridgeDeliveryFunction {
     }
 
     const decision = new SimLambdaServiceInvokeAuthorizer({
-      iam: this.scope.iam(),
+      iam: simScopeIamAuthZ(this.scope),
     }).authorize({
       resource: target.resource,
       servicePrincipal: simEventBridgeServicePrincipal,

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-queue.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-queue.ts
@@ -10,6 +10,7 @@ import {
   simEventBridgeDeliverySource,
   simEventBridgeServicePrincipal,
 } from "./sim-event-bridge-delivery.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimEventBridgeDeliveryQueueProperties {
   readonly scope: SimAwsAccountRegionContainer;
@@ -45,7 +46,7 @@ export class SimEventBridgeDeliveryQueue {
     }
 
     const decision = new SimSqsServiceSendAuthorizer({
-      iam: this.scope.iam(),
+      iam: simScopeIamAuthZ(this.scope),
     }).authorize({
       queue,
       servicePrincipal: simEventBridgeServicePrincipal,

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-task.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-task.ts
@@ -40,7 +40,7 @@ export class SimEventBridgeDeliveryTask {
       role.accountId,
       arn.regionName,
     );
-    const caller = await assumeEventBridgeTargetRole(role, roleScope.iam());
+    const caller = await assumeEventBridgeTargetRole(role, roleScope);
 
     await new SimEcsTargetRun({
       scope: this.simAws.accountRegionScope(arn.accountId, arn.regionName),

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-topic.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-topic.ts
@@ -10,6 +10,7 @@ import {
   simEventBridgeDeliverySource,
   simEventBridgeServicePrincipal,
 } from "./sim-event-bridge-delivery.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimEventBridgeDeliveryTopicProperties {
   readonly scope: SimAwsAccountRegionContainer;
@@ -46,7 +47,7 @@ export class SimEventBridgeDeliveryTopic {
     }
 
     const decision = new SimSnsServicePublishAuthorizer({
-      iam: this.scope.iam(),
+      iam: simScopeIamAuthZ(this.scope),
     }).authorize({
       topic,
       servicePrincipal: simEventBridgeServicePrincipal,

--- a/src/service/eventbridge/delivery/sim-event-bridge-target-role.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-target-role.ts
@@ -1,5 +1,5 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
-import type { SimIam } from "../../iam/sim-iam.js";
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
 import {
   assumeSimServiceRole,
   type SimServiceRoleRefusals,
@@ -51,13 +51,13 @@ const refusals: SimServiceRoleRefusals = {
  */
 export async function assumeEventBridgeTargetRole(
   target: SimEventBridgeTargetRole,
-  iam: SimIam,
+  scope: SimAwsAccountRegionContainer,
 ): Promise<SimAwsCaller> {
   return await assumeSimServiceRole({
     target,
     servicePrincipal: simEventBridgeServicePrincipal,
     sessionName,
-    iam,
+    scope,
     refusals,
   });
 }

--- a/src/service/eventbridge/sim-event-bridge.ts
+++ b/src/service/eventbridge/sim-event-bridge.ts
@@ -5,10 +5,8 @@ import {
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimEventBus } from "./bus/sim-event-bus.js";
 import { SimEventBusStore } from "./bus/sim-event-bus-store.js";
 import type * as simEventBridgeCommands from "./command/sim-event-bridge-command.types.js";
@@ -65,9 +63,10 @@ export class SimEventBridge extends SimEventBridgeInspection {
 
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.background = background;
     this.buses = new SimEventBusStore(

--- a/src/service/firehose/sim-firehose.ts
+++ b/src/service/firehose/sim-firehose.ts
@@ -5,10 +5,8 @@ import {
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type * as simFirehoseCommands from "./command/sim-firehose-command.types.js";
 import { SimFirehoseCommands } from "./command/sim-firehose-commands.js";
 import type { SimFirehoseRequestOptions } from "./command/sim-firehose-request-options.js";
@@ -78,10 +76,11 @@ export class SimFirehose {
   constructor(properties: SimFirehoseProperties) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       kinesis = new SimFirehoseNoRecordSource(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.background = background;
     this.commands = new SimFirehoseCommands({

--- a/src/service/glue/sim-glue.ts
+++ b/src/service/glue/sim-glue.ts
@@ -6,10 +6,8 @@ import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/fa
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimGlueAuthorizer } from "./command/authorize/sim-glue-authorizer.js";
 import { SimGlueDatabaseCommands } from "./command/database/sim-glue-database-commands.js";
 import type * as simGlueCommands from "./command/database/database.command.js";
@@ -63,9 +61,10 @@ export class SimGlue {
   constructor(properties: SimGlueProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const authorizer = new SimGlueAuthorizer({ iam, accountRegionScope });
 

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -1,4 +1,5 @@
 import type { SimArn } from "../../../aws/arn.js";
+import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import { makeSimAwsAccountRootPrincipal } from "../../../aws/caller/sim-aws-account-root-principal.js";
 import type {
   SimAwsCaller,
@@ -31,6 +32,7 @@ import type {
 } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimIamUser, SimIamUsername } from "../../user/sim-iam-user.js";
 import { SimIamAuthZScpSourceBuilder } from "./sim-iam-auth-z-scp-source-builder.js";
+import { SimIamDerivedConditions } from "./sim-iam-derived-conditions.js";
 import type { SimIamServiceControlPolicyResolver } from "../scp/sim-iam-scp-resolver.js";
 
 export interface SimIamResourcePolicyInput {
@@ -49,6 +51,18 @@ export interface SimIamResourcePolicyInput {
 export interface SimIamAuthorizationInput {
   readonly action: string;
   readonly resource: string;
+
+  /**
+   * The Region the request was made in, which sim IAM derives
+   * `aws:RequestedRegion` from.
+   *
+   * A simulated service supplies its own Region. A request reaching one
+   * through its command handlers therefore carries it, with the caller saying
+   * nothing. IAM itself belongs to an Account and has no Region to fall back
+   * on. A request arriving without one leaves the key out of the condition
+   * context, and a statement conditioned on it matches nothing.
+   */
+  readonly region?: AwsRegionName | undefined;
 
   /**
    * Condition values known by the service handling the simulated request, such
@@ -159,6 +173,7 @@ export class SimIamAuthZContextBuilder {
   private readonly identityPolicyCoordinator: SimIamAuthZIdentityPolicyCoordinator;
   private readonly callerAccountResolver: SimIamCallerAccountResolver;
   private readonly allowRequirement = new SimIamAuthZAllowRequirement();
+  private readonly derivedConditions = new SimIamDerivedConditions();
   private readonly scpSourceBuilder: SimIamAuthZScpSourceBuilder;
 
   constructor(properties: SimIamAuthZContextBuilderProperties) {
@@ -239,8 +254,8 @@ export class SimIamAuthZContextBuilder {
   }
 
   /**
-   * Combine service-provided condition values with global values that IAM can
-   * derive from the resolved caller.
+   * Combine service-provided condition values with the global values IAM
+   * derives itself.
    *
    * A service supplies values it knows from the request, and values it can
    * only work out once the caller is resolved. IAM's own values are applied
@@ -253,28 +268,8 @@ export class SimIamAuthZContextBuilder {
     return {
       ...input.conditionContext,
       ...input.callerConditions?.conditionValuesFor(caller),
-      ...this.callerDerivedConditions(caller),
+      ...this.derivedConditions.of({ caller, region: input.region }),
     };
-  }
-
-  /**
-   * The condition values IAM derives from the caller itself.
-   *
-   * AWS:PrincipalArn identifies the IAM identity whose policies apply; for
-   * temporary Role credentials this is the underlying Role ARN, rather than
-   * the STS assumed-role session ARN retained as the effective caller for
-   * diagnostics.
-   */
-  private callerDerivedConditions(
-    caller: SimAwsResolvedCaller,
-  ): Readonly<Record<string, SimIamConditionValue>> {
-    const principalArn = caller.identityPolicyArn ?? caller.arn;
-
-    if (principalArn === undefined) {
-      return {};
-    }
-
-    return { "aws:PrincipalArn": principalArn };
   }
 
   /**

--- a/src/service/iam/authorize/context/sim-iam-derived-conditions.ts
+++ b/src/service/iam/authorize/context/sim-iam-derived-conditions.ts
@@ -1,0 +1,68 @@
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
+import type { SimIamConditionValue } from "../../policy/sim-iam-policy.js";
+
+/**
+ * What a request has to say about itself for IAM to derive its global
+ * condition values.
+ */
+export interface SimIamDerivedConditionRequest {
+  readonly caller: SimAwsResolvedCaller;
+  readonly region?: AwsRegionName | undefined;
+}
+
+/**
+ * The global condition values IAM works out for itself.
+ *
+ * These are the keys a policy can be written against without the service
+ * handling the request supplying anything. They are applied over the values a
+ * service does supply. A service cannot overwrite one of them.
+ *
+ * A key the request leaves unsaid is left out. The condition matcher counts a
+ * missing key as no match, and a statement conditioned on one then matches
+ * nothing.
+ */
+export class SimIamDerivedConditions {
+  /**
+   * Derive what IAM knows about this request.
+   */
+  of(
+    request: SimIamDerivedConditionRequest,
+  ): Readonly<Record<string, SimIamConditionValue>> {
+    return { ...this.principalArn(request.caller), ...this.region(request) };
+  }
+
+  /**
+   * AWS:PrincipalArn identifies the IAM identity whose policies apply. For
+   * temporary Role credentials this is the underlying Role ARN, rather than
+   * the STS assumed-role session ARN retained as the effective caller for
+   * diagnostics.
+   */
+  private principalArn(
+    caller: SimAwsResolvedCaller,
+  ): Readonly<Record<string, SimIamConditionValue>> {
+    const principalArn = caller.identityPolicyArn ?? caller.arn;
+
+    if (principalArn === undefined) {
+      return {};
+    }
+
+    return { "aws:PrincipalArn": principalArn };
+  }
+
+  /**
+   * AWS:RequestedRegion is the Region the request was made in, which on real
+   * AWS is the Region of the endpoint it was sent to. Here it is the Region of
+   * the simulated service handling the request. A service in one Region's
+   * scope answers only requests made to that Region.
+   */
+  private region(
+    request: SimIamDerivedConditionRequest,
+  ): Readonly<Record<string, SimIamConditionValue>> {
+    if (request.region === undefined) {
+      return {};
+    }
+
+    return { "aws:RequestedRegion": request.region };
+  }
+}

--- a/src/service/iam/authorize/sim-iam-region-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-region-auth-z.ts
@@ -1,0 +1,83 @@
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-context-builder.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamAuthorizationDecision,
+  type SimIamInterServiceAuthZ,
+} from "./sim-iam-inter-service-auth-z.js";
+
+/**
+ * The Region a global service's requests are made in.
+ *
+ * IAM, CloudFront and Route53 each have one endpoint between all Regions, and
+ * that endpoint is in us-east-1. A request to one is made in us-east-1
+ * wherever the caller is. A service control policy confining an Account to a
+ * list of Regions therefore has to leave the global services' actions out of
+ * the condition, or it loses access to all of them.
+ */
+export const simIamGlobalServiceRegion: AwsRegionName = "us-east-1";
+
+/**
+ * IAM authorization for the requests one Region's services make.
+ *
+ * IAM belongs to an Account and is shared by every Region in it. It has no
+ * Region of its own to derive `aws:RequestedRegion` from. A simulated service
+ * has one. It is built for a single Account and Region, and answers only the
+ * requests made to that Region. Carrying that Region into each authorization
+ * request is what lets a service control policy confine an Account to a list
+ * of Regions.
+ *
+ * A service wraps its IAM in this once, where it is wired up, and its
+ * authorization call sites go on saying nothing about the Region. A request
+ * that already names one keeps it, and that is how a service authorizes on
+ * behalf of another Region.
+ */
+class SimIamRegionAuthZ implements SimIamInterServiceAuthZ {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly regionName: AwsRegionName;
+
+  constructor(iam: SimIamInterServiceAuthZ, regionName: AwsRegionName) {
+    this.iam = iam;
+    this.regionName = regionName;
+  }
+
+  /**
+   * Evaluate an authorization request made in this Region.
+   */
+  authorize(input: SimIamAuthorizationInput): SimIamAuthorizationDecision {
+    return this.iam.authorize({
+      ...input,
+      region: input.region ?? this.regionName,
+    });
+  }
+}
+
+/**
+ * The IAM one simulated service authorizes against, bound to its Region.
+ *
+ * A service is built for one Account and Region, and this is where it tells
+ * IAM which. A service built without IAM (a service constructed on its own,
+ * outside a simulation) gets the permissive fallback it has always had, bound
+ * to the same Region.
+ */
+export function simIamInRegion(
+  iam: SimIamInterServiceAuthZ | undefined,
+  regionName: AwsRegionName,
+): SimIamInterServiceAuthZ {
+  return new SimIamRegionAuthZ(iam ?? new SimIamAllowAllAuth(), regionName);
+}
+
+/**
+ * The IAM deciding the requests made to one Account and Region scope.
+ *
+ * A service reaching into another scope authorizes there. Both the IAM and
+ * the Region come from the scope being reached into, wherever the request
+ * came from. This is what a scheduled invocation, an event delivery and an
+ * HTTP request served on a function's behalf all decide against.
+ */
+export function simScopeIamAuthZ(
+  scope: SimAwsAccountRegionContainer,
+): SimIamInterServiceAuthZ {
+  return simIamInRegion(scope.iam(), scope.accountRegionScope.regionName);
+}

--- a/src/service/iam/authorize/sim-iam-requested-region.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-requested-region.iso.test.ts
@@ -1,0 +1,112 @@
+import { assertFalse, assertIdentical, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamPolicyDocument } from "../policy/sim-iam-policy.js";
+import { SimIamPolicyDecisionValue } from "./sim-iam-decision.js";
+
+/**
+ * A resource policy denying the caller anything asked for in one Region.
+ */
+function denyInRegion(
+  accountId: string,
+  regionName: string,
+): SimIamPolicyDocument {
+  return {
+    Version: "2012-10-17",
+    Statement: {
+      Sid: "DenyOutsideLondon",
+      Effect: "Deny",
+      Principal: `arn:aws:iam::${accountId}:root`,
+      Action: "s3:GetObject",
+      Resource: "*",
+      Condition: { StringEquals: { "aws:RequestedRegion": regionName } },
+    },
+  };
+}
+
+describe("Sim IAM requested Region condition key", () => {
+  it("derives the key from the Region the request was made in", () => {
+    // Given an Account whose Bucket policy denies reads made in us-east-1.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    // When a read is made there.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+        region: "us-east-1",
+        resourcePolicies: [{ document: denyInRegion(accountId, "us-east-1") }],
+      });
+
+    // Then the condition matched the Region the request carried.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+  });
+
+  it("leaves a request made in another Region alone", () => {
+    // Given the same policy, denying reads made in us-east-1.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    // When the read is made in eu-west-2 instead.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+        region: "eu-west-2",
+        resourcePolicies: [{ document: denyInRegion(accountId, "us-east-1") }],
+      });
+
+    // Then the condition matched nothing and the root principal is allowed.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("keeps the derived value when the service supplies its own", () => {
+    // Given a request made in us-east-1 that says it was made somewhere else.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    // When it is authorized.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+        region: "us-east-1",
+        conditionContext: { "aws:RequestedRegion": "eu-west-2" },
+        resourcePolicies: [{ document: denyInRegion(accountId, "us-east-1") }],
+      });
+
+    // Then IAM's own value is the one the condition is matched against, as it
+    // is for every other key IAM derives.
+    assertIdentical(decision.value, SimIamPolicyDecisionValue.ExplicitDeny);
+  });
+
+  it("supplies no value for a request naming no Region", () => {
+    // Given a request made straight to IAM, which is Account-scoped and has no
+    // Region of its own to name.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    // When it is authorized.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: `arn:aws:s3:::${accountId}-reports/summary.csv`,
+        resourcePolicies: [{ document: denyInRegion(accountId, "us-east-1") }],
+      });
+
+    // Then the key is missing rather than guessed at, and the statement
+    // conditioned on it matches nothing.
+    assertTrue(decision.isAllowed);
+    assertFalse(decision.isDenied);
+  });
+});

--- a/src/service/iam/command/sim-iam-command-handlers.ts
+++ b/src/service/iam/command/sim-iam-command-handlers.ts
@@ -3,6 +3,10 @@ import type { SimArn } from "../../aws/arn.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { SimIamActionAuthorizer } from "../authorize/sim-iam-action-authorizer.js";
 import type { SimIamInterServiceAuthZ } from "../authorize/sim-iam-inter-service-auth-z.js";
+import {
+  simIamGlobalServiceRegion,
+  simIamInRegion,
+} from "../authorize/sim-iam-region-auth-z.js";
 import type { SimIamCredentialRegistry } from "../credential/sim-iam-credential-registry.js";
 import type { SimIamUserCredentialGenerator } from "../credential/user/sim-iam-user-credential-generator.js";
 import type { SimIamManagedPolicy } from "../policy/sim-iam-policy.js";
@@ -41,7 +45,11 @@ export class SimIamCommandHandlers {
   readonly policies: SimIamPolicyCommandHandlers;
 
   constructor(properties: SimIamCommandHandlersProperties) {
-    const authorizer = new SimIamActionAuthorizer({ iam: properties.iam });
+    // IAM is global rather than Region-scoped, so its own control-plane
+    // requests are made in the Region its one endpoint is in.
+    const authorizer = new SimIamActionAuthorizer({
+      iam: simIamInRegion(properties.iam, simIamGlobalServiceRegion),
+    });
 
     this.roles = new SimIamRoleCommandHandlers({
       accountId: properties.accountId,

--- a/src/service/kinesis/sim-kinesis.ts
+++ b/src/service/kinesis/sim-kinesis.ts
@@ -5,10 +5,8 @@ import {
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type * as simKinesisCommands from "./command/sim-kinesis-command.types.js";
 import { SimKinesisCommands } from "./command/sim-kinesis-commands.js";
 import type { SimKinesisRequestOptions } from "./command/sim-kinesis-request-options.js";
@@ -53,9 +51,10 @@ export class SimKinesis {
   constructor(properties: SimKinesisProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.background = background;
     this.commands = new SimKinesisCommands({

--- a/src/service/kms/sim-kms-commands.ts
+++ b/src/service/kms/sim-kms-commands.ts
@@ -4,10 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimKmsAliasCommands } from "./command/alias/sim-kms-alias-commands.js";
 import { SimKmsAuthorizer } from "./command/authorize/sim-kms-authorizer.js";
 import { SimKmsCryptoCommands } from "./command/crypto/sim-kms-crypto-commands.js";
@@ -53,9 +51,10 @@ export class SimKmsCommands {
   constructor(properties: SimKmsProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const keyFactory = new SimKmsKeyFactory({
       accountRegionScope,

--- a/src/service/lambda/serve/sim-lambda-url-router.ts
+++ b/src/service/lambda/serve/sim-lambda-url-router.ts
@@ -7,6 +7,7 @@ import type {
 } from "../function/url/sim-lambda-function-url.js";
 import type { SimLambdaUrlRegistry } from "../registry/sim-lambda-url-registry.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 export interface SimLambdaFunctionUrlRoute {
   readonly functionUrl: SimLambdaFunctionUrl;
@@ -74,6 +75,6 @@ export class SimLambdaUrlRouter {
       return undefined;
     }
 
-    return { functionUrl, simFunction, iam: scope.iam() };
+    return { functionUrl, simFunction, iam: simScopeIamAuthZ(scope) };
   }
 }

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -6,10 +6,8 @@ import type { SimAwsRunAsOwner } from "../aws/caller/sim-aws-run-as-context.js";
 import type { SimSqsPollQueues } from "../sqs/poll/sim-sqs-poll-queues.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimLambdaAliasCommands } from "./command/alias/sim-lambda-alias-commands.js";
 import { SimLambdaEventInvokeConfigCommands } from "./command/event-invoke-config/sim-lambda-event-invoke-config-commands.js";
 import { SimLambdaEventSourceMappingCommands } from "./command/event-source-mapping/sim-lambda-event-source-mapping-commands.js";
@@ -116,7 +114,6 @@ export class SimLambdaCommands {
   constructor(properties: SimLambdaCommandsProperties) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       codeStore,
       vmSdkModuleProvider,
@@ -137,6 +134,8 @@ export class SimLambdaCommands {
       containerImages = new SimLambdaNoContainerImages(),
       destinations = new SimLambdaNoDestinationTargets(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.containerImages = containerImages;
     this.eventInvokeConfigStore = new SimLambdaEventInvokeConfigStore({

--- a/src/service/logs/sim-logs-commands.ts
+++ b/src/service/logs/sim-logs-commands.ts
@@ -4,10 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimLogsAuthorizer } from "./command/authorize/sim-logs-authorizer.js";
 import { SimLogsDeliveryCommands } from "./command/delivery/sim-logs-delivery-commands.js";
 import { SimLogsDeliveryDestinationCommands } from "./command/delivery/sim-logs-delivery-destination-commands.js";
@@ -85,11 +83,12 @@ export class SimLogsCommands {
   constructor(properties: SimLogsProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       subscriptionDestinations = new SimLogsNoSubscriptionDestinations(),
       deliverySourceResources = new SimLogsUncheckedDeliverySourceResources(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const authorizer = new SimLogsAuthorizer({ iam, accountRegionScope });
     const groups = new SimLogsLogGroupStore({ accountRegionScope });

--- a/src/service/logs/subscription/lambda/sim-logs-destination-permission.ts
+++ b/src/service/logs/subscription/lambda/sim-logs-destination-permission.ts
@@ -4,6 +4,7 @@ import type { SimLambdaFunctionTarget } from "../../../lambda/function/version/s
 import { SimLogsDeliveryNotPermitted } from "../../error/sim-logs-delivery.error.js";
 import { SimLogsResourceNotFoundException } from "../../error/sim-logs.error.js";
 import type { SimLogsSubscriptionFunctionArn } from "./sim-logs-subscription-function-arn.js";
+import { simScopeIamAuthZ } from "../../../iam/authorize/sim-iam-region-auth-z.js";
 
 /**
  * The service principal CloudWatch Logs invokes a destination function as.
@@ -44,7 +45,7 @@ export function permittedSimLogsDestinationFunction(
 
   const servicePrincipal = simLogsServicePrincipal(scope.region.regionName);
   const decision = new SimLambdaServiceInvokeAuthorizer({
-    iam: scope.iam(),
+    iam: simScopeIamAuthZ(scope),
   }).authorize({ resource: target.resource, servicePrincipal });
 
   if (decision.isDenied) {

--- a/src/service/organizations/sim-organizations-scp-region.iso.test.ts
+++ b/src/service/organizations/sim-organizations-scp-region.iso.test.ts
@@ -1,0 +1,121 @@
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../aws/sim-aws-account.js";
+import type { CfnTemplateBodyRecord } from "../cloudformation/template/sim-cfn-template.js";
+
+/**
+ * The commonest shape of Region-confining service control policy: everything
+ * asked for in a Region the Account has no business in is denied.
+ */
+const denyNorthVirginia = {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyNorthVirginia",
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { StringEquals: { "aws:RequestedRegion": "us-east-1" } },
+  },
+} as const;
+
+/**
+ * The template CDK synthesizes for a Stack holding one Bucket.
+ */
+function bucketTemplate(bucketName: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: bucketName },
+      },
+    },
+  };
+}
+
+describe("Simulated Organizations Region-confining service control policy", () => {
+  it("denies a Bucket created in the Region the organization denies", async () => {
+    // Given an Account whose organization denies everything in us-east-1.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyNorthVirginia);
+
+    // When a Bucket is created there.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .accountRegionScope(accountId, "us-east-1")
+        .s3()
+        .createBucket(
+          new CreateBucketCommand({ Bucket: `${accountId}-reports` }),
+        );
+    });
+
+    // Then S3 supplied its own Region and the organization denied the request.
+    assertStringIncludes(error.message, "s3:CreateBucket");
+    assertStringIncludes(error.message, "service control policy");
+  });
+
+  it("allows the same Bucket in a Region the organization leaves alone", async () => {
+    // Given the same organization, denying only us-east-1.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyNorthVirginia);
+
+    // When the Bucket is created in eu-west-2 instead.
+    const output = await simAws
+      .accountRegionScope(accountId, "eu-west-2")
+      .s3()
+      .createBucket(
+        new CreateBucketCommand({ Bucket: `${accountId}-reports` }),
+      );
+
+    // Then it was created, because the Region S3 supplied is not the denied
+    // one.
+    assertIdentical(output.Location, `/${accountId}-reports`);
+  });
+
+  it("deploys a Stack in the Region the Stack is deployed into", async () => {
+    // Given the same organization, and a Stack holding one Bucket.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyNorthVirginia);
+
+    // When the Stack is deployed into eu-west-2 and then into us-east-1.
+    await simAws
+      .accountRegionScope(accountId, "eu-west-2")
+      .cloudFormation()
+      .deployTemplate({
+        stackName: "reports-stack",
+        template: bucketTemplate(`${accountId}-london-reports`),
+      });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .accountRegionScope(accountId, "us-east-1")
+        .cloudFormation()
+        .deployTemplate({
+          stackName: "reports-stack",
+          template: bucketTemplate(`${accountId}-virginia-reports`),
+        });
+    });
+
+    // Then the deployment carried the Region of the Stack it was deploying,
+    // rather than the Region of whoever asked for the deployment.
+    assertStringIncludes(error.message, "s3:CreateBucket");
+    assertStringIncludes(error.message, "service control policy");
+  });
+});

--- a/src/service/personalize/sim-personalize-data-operations.ts
+++ b/src/service/personalize/sim-personalize-data-operations.ts
@@ -4,10 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type * as simPersonalizeCommands from "./command/sim-personalize-command.types.js";
 import { SimPersonalizeCommands } from "./command/sim-personalize-commands.js";
 import type { SimPersonalizeRequestOptions } from "./command/sim-personalize-request-options.js";
@@ -39,9 +37,10 @@ export abstract class SimPersonalizeDataOperations {
   constructor(properties: SimPersonalizeProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.background = background;
     this.commands = new SimPersonalizeCommands({

--- a/src/service/rekognition/sim-rekognition.ts
+++ b/src/service/rekognition/sim-rekognition.ts
@@ -26,10 +26,8 @@ import type {
   SimListCollectionsCommand,
   SimListCollectionsCommandOutput,
 } from "./command/collection/collection.command.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimRekognitionAuthorizer } from "./command/authorize/sim-rekognition-authorizer.js";
 import type {
   SimDetectFacesCommand,
@@ -89,10 +87,11 @@ export class SimRekognition {
   constructor(properties: SimRekognitionProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       images = new SimRekognitionUnreachableImageObjects(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
     const authorizer = new SimRekognitionAuthorizer({ iam });
 
     this.collectionStore = new SimRekognitionCollections({

--- a/src/service/route53/sim-route53.ts
+++ b/src/service/route53/sim-route53.ts
@@ -15,10 +15,11 @@ import {
 import { SimRoute53CloudFormationResourceFactory } from "./cfn/sim-cfn-route53-resource-factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimRoute53Registry } from "./registry/sim-route53-registry.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
 import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+  simIamGlobalServiceRegion,
+  simIamInRegion,
+} from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimRoute53SdkCommandRouter } from "./sdk/sim-route53-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
 import type { SimKmsKeyResolver } from "../kms/registry/sim-kms-registry.js";
@@ -73,10 +74,13 @@ export class SimRoute53 {
 
   constructor(properties: SimRoute53Properties = {}) {
     const {
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       route53Registry = new SimRoute53Registry(),
     } = properties;
+
+    // Route53 is global rather than Region-scoped, so its requests are made in
+    // the Region its one endpoint is in.
+    const iam = simIamInRegion(properties.iam, simIamGlobalServiceRegion);
 
     this.route53Registry = route53Registry;
     this.resolver = new SimRoute53Resolver({

--- a/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
+++ b/src/service/s3/notification/destination/lambda/sim-aws-s3-notification-functions.ts
@@ -6,6 +6,7 @@ import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification
 import { simS3ServicePrincipal } from "../sim-s3-service-principal.js";
 import { SimS3NotificationFunctionArn } from "./sim-s3-notification-function-arn.js";
 import type { SimS3NotificationFunctions } from "./sim-s3-notification-functions.js";
+import { simScopeIamAuthZ } from "../../../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimAwsS3NotificationFunctionsProperties {
   readonly simAws: SimAws;
@@ -99,7 +100,7 @@ export class SimAwsS3NotificationFunctions implements SimS3NotificationFunctions
   }
 
   private iam(arn: SimS3NotificationFunctionArn): SimIamInterServiceAuthZ {
-    return this.scope(arn).iam();
+    return simScopeIamAuthZ(this.scope(arn));
   }
 
   private scope(

--- a/src/service/s3/notification/destination/sns/sim-s3-notification-topic.ts
+++ b/src/service/s3/notification/destination/sns/sim-s3-notification-topic.ts
@@ -3,6 +3,7 @@ import { SimSnsServicePublishAuthorizer } from "../../../../sns/command/authoriz
 import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
 import { simS3ServicePrincipal } from "../sim-s3-service-principal.js";
 import type { SimS3NotificationTopicArn } from "./sim-s3-notification-topic-arn.js";
+import { simScopeIamAuthZ } from "../../../../iam/authorize/sim-iam-region-auth-z.js";
 
 /**
  * The subject real S3 publishes every event notification with.
@@ -48,7 +49,7 @@ export class SimS3NotificationTopic {
     }
 
     const decision = new SimSnsServicePublishAuthorizer({
-      iam: this.scope.iam(),
+      iam: simScopeIamAuthZ(this.scope),
     }).authorize({
       topic,
       servicePrincipal: simS3ServicePrincipal,

--- a/src/service/s3/notification/destination/sqs/sim-s3-notification-queue.ts
+++ b/src/service/s3/notification/destination/sqs/sim-s3-notification-queue.ts
@@ -3,6 +3,7 @@ import { SimSqsServiceSendAuthorizer } from "../../../../sqs/command/authorize/s
 import type { SimS3NotificationDestinationRequest } from "../sim-s3-notification-destination.js";
 import { simS3ServicePrincipal } from "../sim-s3-service-principal.js";
 import type { SimS3NotificationQueueArn } from "./sim-s3-notification-queue-arn.js";
+import { simScopeIamAuthZ } from "../../../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimS3NotificationQueueProperties {
   readonly arn: SimS3NotificationQueueArn;
@@ -38,7 +39,7 @@ export class SimS3NotificationQueue {
     }
 
     const decision = new SimSqsServiceSendAuthorizer({
-      iam: this.scope.iam(),
+      iam: simScopeIamAuthZ(this.scope),
     }).authorize({
       queue,
       servicePrincipal: simS3ServicePrincipal,

--- a/src/service/s3/sim-s3-commands.ts
+++ b/src/service/s3/sim-s3-commands.ts
@@ -3,10 +3,8 @@ import {
   BackgroundTasks,
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
 import { SimS3BucketCommands } from "./command/bucket/sim-s3-bucket-commands.js";
 import { SimS3BucketPolicyCommands } from "./command/bucket-policy/sim-s3-bucket-policy-commands.js";
@@ -70,10 +68,14 @@ export class SimS3Commands {
 
   constructor(properties: SimS3CommandsProperties) {
     const {
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       notificationDestinations = new SimS3NoNotificationDestinations(),
     } = properties;
+
+    const iam = simIamInRegion(
+      properties.iam,
+      properties.accountRegionScope.regionName,
+    );
 
     this.objectNotifier = new SimS3ObjectNotifier({
       destinations: notificationDestinations,

--- a/src/service/scheduler/delivery/sim-aws-scheduler-delivery-targets.ts
+++ b/src/service/scheduler/delivery/sim-aws-scheduler-delivery-targets.ts
@@ -50,7 +50,7 @@ export class SimAwsSchedulerDeliveryTargets implements SimSchedulerDeliveryTarge
       arn.regionName,
     );
 
-    const caller = await assumeSchedulerExecutionRole(role, roleScope.iam());
+    const caller = await assumeSchedulerExecutionRole(role, roleScope);
 
     await this.invoke(arn.service, { request, caller });
   }

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-function.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-function.ts
@@ -7,6 +7,7 @@ import {
   type SimSchedulerAssumedDelivery,
   simSchedulerDeliveryDocument,
 } from "./sim-scheduler-delivery.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 const invokeAction = "lambda:InvokeFunction";
 
@@ -44,7 +45,7 @@ export class SimSchedulerDeliveryFunction {
       );
     }
 
-    const decision = this.scope.iam().authorize({
+    const decision = simScopeIamAuthZ(this.scope).authorize({
       action: invokeAction,
       resource: targetArn.value,
       caller: delivery.caller,

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-queue.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-queue.ts
@@ -7,6 +7,7 @@ import {
   type SimSchedulerAssumedDelivery,
   simSchedulerDeliveryJson,
 } from "./sim-scheduler-delivery.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 const sendAction = "sqs:SendMessage";
 
@@ -37,7 +38,7 @@ export class SimSchedulerDeliveryQueue {
       );
     }
 
-    const decision = this.scope.iam().authorize({
+    const decision = simScopeIamAuthZ(this.scope).authorize({
       action: sendAction,
       resource: targetArn.value,
       caller: delivery.caller,

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-topic.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-topic.ts
@@ -7,6 +7,7 @@ import {
   type SimSchedulerAssumedDelivery,
   simSchedulerDeliveryJson,
 } from "./sim-scheduler-delivery.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 const publishAction = "sns:Publish";
 
@@ -37,7 +38,7 @@ export class SimSchedulerDeliveryTopic {
       );
     }
 
-    const decision = this.scope.iam().authorize({
+    const decision = simScopeIamAuthZ(this.scope).authorize({
       action: publishAction,
       resource: targetArn.value,
       caller: delivery.caller,

--- a/src/service/scheduler/delivery/sim-scheduler-execution-role.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-execution-role.ts
@@ -1,5 +1,5 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
-import type { SimIam } from "../../iam/sim-iam.js";
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
 import {
   assumeSimServiceRole,
   type SimServiceRoleRefusals,
@@ -56,13 +56,13 @@ const refusals: SimServiceRoleRefusals = {
  */
 export async function assumeSchedulerExecutionRole(
   target: SimSchedulerExecutionRoleTarget,
-  iam: SimIam,
+  scope: SimAwsAccountRegionContainer,
 ): Promise<SimAwsCaller> {
   return await assumeSimServiceRole({
     target,
     servicePrincipal: simSchedulerServicePrincipal,
     sessionName,
-    iam,
+    scope,
     refusals,
   });
 }

--- a/src/service/scheduler/sim-scheduler.ts
+++ b/src/service/scheduler/sim-scheduler.ts
@@ -5,10 +5,8 @@ import {
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type * as simSchedulerCommands from "./command/sim-scheduler-command.types.js";
 import type { SimSchedulerDeliveryTargets } from "./delivery/sim-scheduler-delivery.js";
 import type { SimSchedulerDeliveryFailure } from "./delivery/sim-scheduler-delivery-failures.js";
@@ -59,9 +57,10 @@ export class SimScheduler extends SimSchedulerInspection {
 
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.background = background;
     this.commands = new SimSchedulerCommands({

--- a/src/service/secretsmanager/sim-secrets-manager.ts
+++ b/src/service/secretsmanager/sim-secrets-manager.ts
@@ -6,10 +6,8 @@ import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-route
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimKms } from "../kms/index.js";
 import { SimSecretsManagerCfnResourceFactory } from "./cfn/sim-cfn-secrets-manager-resource-factory.js";
 import { SimSecretsManagerAuthorizer } from "./command/authorize/sim-secrets-manager-authorizer.js";
@@ -68,9 +66,10 @@ export class SimSecretsManager {
   constructor(properties: SimSecretsManagerProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const { kms = new SimKms({ accountRegionScope, iam, background }) } =
       properties;

--- a/src/service/ses/sim-ses-commands.ts
+++ b/src/service/ses/sim-ses-commands.ts
@@ -5,10 +5,8 @@ import {
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { SimAwsMessageLog } from "../aws/message/sim-aws-message-log.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimSesAccount } from "./account/sim-ses-account.js";
 import { SimSesAccountCommands } from "./command/account/sim-ses-account-commands.js";
 import { SimSesAuthorizer } from "./command/authorize/sim-ses-authorizer.js";
@@ -71,10 +69,11 @@ export class SimSesCommands {
   constructor(properties: SimSesV2Properties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       messageLog = new SimAwsMessageLog(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const authorizer = new SimSesAuthorizer({ iam, accountRegionScope });
     const identities = new SimSesIdentityStore({ accountRegionScope });

--- a/src/service/sns/delivery/lambda/sim-sns-delivery-function.ts
+++ b/src/service/sns/delivery/lambda/sim-sns-delivery-function.ts
@@ -9,6 +9,7 @@ import {
   simSnsServicePrincipal,
 } from "../sim-sns-delivery.js";
 import { simSnsLambdaEventDocument } from "./sim-sns-lambda-event.js";
+import { simScopeIamAuthZ } from "../../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimSnsDeliveryFunctionProperties {
   readonly arn: SimSnsFunctionEndpointArn;
@@ -63,7 +64,7 @@ export class SimSnsDeliveryFunction {
     }
 
     const decision = new SimLambdaServiceInvokeAuthorizer({
-      iam: this.scope.iam(),
+      iam: simScopeIamAuthZ(this.scope),
     }).authorize({
       resource: target.resource,
       servicePrincipal: simSnsServicePrincipal,

--- a/src/service/sns/delivery/sqs/sim-sns-delivery-queue.ts
+++ b/src/service/sns/delivery/sqs/sim-sns-delivery-queue.ts
@@ -9,6 +9,7 @@ import {
   simSnsServicePrincipal,
 } from "../sim-sns-delivery.js";
 import { SimSnsQueueMessage } from "./sim-sns-queue-message.js";
+import { simScopeIamAuthZ } from "../../../iam/authorize/sim-iam-region-auth-z.js";
 
 interface SimSnsDeliveryQueueProperties {
   readonly arn: SimSnsQueueEndpointArn;
@@ -56,7 +57,7 @@ export class SimSnsDeliveryQueue {
     }
 
     const decision = new SimSqsServiceSendAuthorizer({
-      iam: this.scope.iam(),
+      iam: simScopeIamAuthZ(this.scope),
     }).authorize({
       queue,
       servicePrincipal: simSnsServicePrincipal,

--- a/src/service/sns/sim-sns.ts
+++ b/src/service/sns/sim-sns.ts
@@ -6,10 +6,8 @@ import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-route
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimAwsMessageLog } from "../aws/message/sim-aws-message-log.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type { SimSnsDeliveryFailure } from "./delivery/sim-sns-delivery-failures.js";
 import { simSnsNoDeliveryEndpoints } from "./delivery/sim-sns-no-delivery-endpoints.js";
 import type { SimSnsOutwardDeliveryEndpoints } from "./delivery/sim-sns-protocol-delivery-endpoints.js";
@@ -64,11 +62,12 @@ export class SimSns extends SimSnsSms {
   constructor(properties: SimSnsProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       deliveryEndpoints = simSnsNoDeliveryEndpoints(),
       messageLog = new SimAwsMessageLog(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
     const topics = new SimSnsTopicStore();
     const subscriptions = new SimSnsSubscriptionStore();
 

--- a/src/service/sqs/sim-sqs.ts
+++ b/src/service/sqs/sim-sqs.ts
@@ -5,10 +5,8 @@ import {
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimSqsAuthorizer } from "./command/authorize/sim-sqs-authorizer.js";
 import { SimSqsChangeMessageVisibility } from "./command/message/sim-sqs-change-message-visibility.js";
 import { SimSqsDeleteMessageCommands } from "./command/message/sim-sqs-delete-message-commands.js";
@@ -60,9 +58,10 @@ export class SimSqs {
   constructor(properties: SimSqsProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const access = new SimSqsQueueAccess({
       queues: this.queues,

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -6,10 +6,8 @@ import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-route
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimKms } from "../kms/index.js";
 import { SimSsmAuthorizer } from "./command/authorize/sim-ssm-authorizer.js";
 import { SimSsmDeleteParameterCommands } from "./command/parameter/sim-ssm-delete-parameter-commands.js";
@@ -70,9 +68,10 @@ export class SimSsm {
   constructor(properties: SimSsmProperties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const { kms = new SimKms({ accountRegionScope, iam, background }) } =
       properties;

--- a/src/service/stepfunctions/task/sim-aws-states-task-targets.ts
+++ b/src/service/stepfunctions/task/sim-aws-states-task-targets.ts
@@ -47,11 +47,11 @@ export class SimAwsStatesTaskTargets implements SimStatesTaskTargets {
   async invoke(invocation: SimStatesTaskInvocation): Promise<JSONValue> {
     const { stateName, target } = invocation;
     const role = simStatesExecutionRoleTarget(invocation.roleArn, stateName);
-    const iam = this.#simAws
-      .accountRegionScope(role.accountId, this.#accountRegionScope.regionName)
-      .iam();
-
-    const caller = await assumeSimStatesExecutionRole(role, iam);
+    const roleScope = this.#simAws.accountRegionScope(
+      role.accountId,
+      this.#accountRegionScope.regionName,
+    );
+    const caller = await assumeSimStatesExecutionRole(role, roleScope);
 
     return await target.run({
       stateName,

--- a/src/service/stepfunctions/task/sim-states-execution-role.ts
+++ b/src/service/stepfunctions/task/sim-states-execution-role.ts
@@ -1,5 +1,5 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
-import type { SimIam } from "../../iam/sim-iam.js";
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
 import {
   assumeSimServiceRole,
   type SimServiceRoleRefusals,
@@ -69,13 +69,13 @@ const refusals: SimServiceRoleRefusals = {
  */
 export async function assumeSimStatesExecutionRole(
   target: SimServiceRoleTarget,
-  iam: SimIam,
+  scope: SimAwsAccountRegionContainer,
 ): Promise<SimAwsCaller> {
   return await assumeSimServiceRole({
     target,
     servicePrincipal: simStatesServicePrincipal,
     sessionName,
-    iam,
+    scope,
     refusals,
   });
 }

--- a/src/service/stepfunctions/task/sim-states-task-function.ts
+++ b/src/service/stepfunctions/task/sim-states-task-function.ts
@@ -5,6 +5,7 @@ import type { SimLambdaFunctionReference } from "../../lambda/function/sim-lambd
 import type { JSONValue } from "../../../util/type-guard/json.js";
 import { SimStatesTaskFailure } from "../error/sim-step-functions.error.js";
 import type { SimStatesLambdaTarget } from "./sim-states-lambda-target.js";
+import { simScopeIamAuthZ } from "../../iam/authorize/sim-iam-region-auth-z.js";
 
 /**
  * The action an execution needs to invoke a function.
@@ -84,7 +85,7 @@ export class SimStatesTaskFunction {
     request: SimStatesTaskFunctionRequest,
     functionArn: string,
   ): void {
-    const decision = this.#scope.iam().authorize({
+    const decision = simScopeIamAuthZ(this.#scope).authorize({
       action: invokeAction,
       resource: functionArn,
       caller: request.caller,

--- a/src/service/sts/auth-z/assume-role-auth-z-coordinator.ts
+++ b/src/service/sts/auth-z/assume-role-auth-z-coordinator.ts
@@ -3,6 +3,7 @@ import type {
   SimAwsPrincipal,
 } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimGetRoleCommandOutput } from "../../iam/command/role/get-role/get-role.command.js";
 import type { SimIamConditionValue } from "../../iam/policy/sim-iam-policy.js";
 import type { SimIamAccountResolver } from "../../iam/registry/sim-iam-account-resolver.js";
@@ -13,6 +14,9 @@ import { AssumeRoleTargetRoleAuthorizer } from "./assume-role-target-auth-z.js";
 interface AssumeRoleAuthorizationCoordinatorProperties {
   readonly sourceAccountId: SimAwsAccountId;
   readonly iamResolver: SimIamAccountResolver;
+
+  /** The Region the STS request was made in. */
+  readonly regionName: AwsRegionName;
 }
 
 interface AssumeRoleAuthorizationInput {
@@ -47,13 +51,10 @@ export class AssumeRoleAuthorizationCoordinator {
 
   constructor(properties: AssumeRoleAuthorizationCoordinatorProperties) {
     this.sourceAccountId = properties.sourceAccountId;
-    this.sourcePrincipalAuthorizer = new AssumeRoleSourcePrincipalAuthorizer({
-      sourceAccountId: properties.sourceAccountId,
-      iamResolver: properties.iamResolver,
-    });
-    this.targetRoleAuthorizer = new AssumeRoleTargetRoleAuthorizer({
-      iamResolver: properties.iamResolver,
-    });
+    this.sourcePrincipalAuthorizer = new AssumeRoleSourcePrincipalAuthorizer(
+      properties,
+    );
+    this.targetRoleAuthorizer = new AssumeRoleTargetRoleAuthorizer(properties);
   }
 
   /**

--- a/src/service/sts/auth-z/assume-role-source-account-auth-z.ts
+++ b/src/service/sts/auth-z/assume-role-source-account-auth-z.ts
@@ -1,5 +1,6 @@
 import type { SimIamAccountResolver } from "../../iam/registry/sim-iam-account-resolver.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
 import { makeSimAwsAccountRootPrincipal } from "../../aws/caller/sim-aws-account-root-principal.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
@@ -7,6 +8,11 @@ import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 interface AssumeRoleSourceAccountAuthorizerProperties {
   readonly sourceAccountId: SimAwsAccountId;
   readonly iamResolver: SimIamAccountResolver;
+
+  /**
+   * The Region the STS request was made in.
+   */
+  readonly regionName: AwsRegionName;
 }
 
 export interface AssumeRoleSourceAuthorizationInput {
@@ -38,10 +44,12 @@ export interface AssumeRoleSourceAuthorizationInput {
 export class AssumeRoleSourcePrincipalAuthorizer {
   private readonly sourceAccountId: SimAwsAccountId;
   private readonly iamResolver: SimIamAccountResolver;
+  private readonly regionName: AwsRegionName;
 
   constructor(properties: AssumeRoleSourceAccountAuthorizerProperties) {
     this.sourceAccountId = properties.sourceAccountId;
     this.iamResolver = properties.iamResolver;
+    this.regionName = properties.regionName;
   }
 
   /**
@@ -59,6 +67,7 @@ export class AssumeRoleSourcePrincipalAuthorizer {
     const decision = sourceIam.authorize({
       action: "sts:AssumeRole",
       resource: input.roleArn,
+      region: this.regionName,
       caller: callerPrincipal,
     });
 

--- a/src/service/sts/auth-z/assume-role-target-auth-z.ts
+++ b/src/service/sts/auth-z/assume-role-target-auth-z.ts
@@ -1,5 +1,6 @@
 import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimIamAccountResolver } from "../../iam/registry/sim-iam-account-resolver.js";
 import type { IamRoleArnParts } from "../../iam/role/arn/sim-iam-role-arn-parser.js";
 import type { SimGetRoleCommandOutput } from "../../iam/command/role/get-role/get-role.command.js";
@@ -12,6 +13,11 @@ import {
 
 interface AssumeRoleTargetRoleAuthorizerProperties {
   readonly iamResolver: SimIamAccountResolver;
+
+  /**
+   * The Region the STS request was made in.
+   */
+  readonly regionName: AwsRegionName;
 }
 
 type AssumeRoleTargetRole = SimGetRoleCommandOutput["Role"];
@@ -42,12 +48,14 @@ interface AssumeRoleTargetAuthorization {
  */
 export class AssumeRoleTargetRoleAuthorizer {
   private readonly iamResolver: SimIamAccountResolver;
+  private readonly regionName: AwsRegionName;
   private readonly targetResolver = new AssumeRoleTargetResolver();
   private readonly trustPolicyAuthorizer =
     new AssumeRoleTrustPolicyAuthorizer();
 
   constructor(properties: AssumeRoleTargetRoleAuthorizerProperties) {
     this.iamResolver = properties.iamResolver;
+    this.regionName = properties.regionName;
   }
 
   /**
@@ -77,6 +85,7 @@ export class AssumeRoleTargetRoleAuthorizer {
       roleArn: input.roleArn,
       role,
       targetIam,
+      region: this.regionName,
       caller: input.caller,
       conditionContext: input.conditionContext,
     });

--- a/src/service/sts/auth-z/assume-role-trust-policy-authorizer.ts
+++ b/src/service/sts/auth-z/assume-role-trust-policy-authorizer.ts
@@ -1,6 +1,7 @@
 import type { JSONString } from "../../../util/type-guard/json.js";
 import { jsonParse } from "../../../util/type-guard/json.js";
 import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimGetRoleCommandOutput } from "../../iam/command/role/get-role/get-role.command.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import type {
@@ -17,6 +18,13 @@ interface AssumeRoleTrustPolicyAuthorizationInput {
   readonly roleArn: string;
   readonly role: AssumeRoleTargetRole;
   readonly targetIam: SimIam;
+
+  /**
+   * The Region the assume request was made in, which the trust policy and the
+   * target Account's service control policies can be conditioned on.
+   */
+  readonly region?: AwsRegionName | undefined;
+
   readonly caller: SimAwsPrincipal;
   readonly conditionContext?:
     | Readonly<Record<string, SimIamConditionValue>>
@@ -71,6 +79,7 @@ export class AssumeRoleTrustPolicyAuthorizer {
     const decision = input.targetIam.authorize({
       action: "sts:AssumeRole",
       resource: input.roleArn,
+      region: input.region,
       caller: input.caller,
       conditionContext: input.conditionContext,
       resourcePolicies: [

--- a/src/service/sts/command/assume-role/assume-role.handler.ts
+++ b/src/service/sts/command/assume-role/assume-role.handler.ts
@@ -9,6 +9,7 @@ import {
   BackgroundTasks,
 } from "../../../../util/background/background.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import { makeSimAwsAccountRootPrincipal } from "../../../aws/caller/sim-aws-account-root-principal.js";
 import { SimStsAssumeRoleSessionCreator } from "../../assume/sim-sts-assume-role-session-creator.js";
 import { SimStsAssumeRoleRequestParser } from "../../assume/sim-sts-assume-role-request-parser.js";
@@ -19,6 +20,12 @@ import { AssumeRoleAuthorizationCoordinator } from "../../auth-z/assume-role-aut
 
 interface AssumeRoleCommandHandlerProperties {
   readonly sourceAccountId: SimAwsAccountId;
+
+  /**
+   * The Region this STS is in, which is the Region its requests are made in.
+   */
+  readonly regionName: AwsRegionName;
+
   readonly iamResolver: SimIamAccountResolver;
   readonly background?: BackgroundScheduler;
 }
@@ -46,6 +53,7 @@ export class AssumeRoleCommandHandler implements CommandHandler<
   constructor(properties: AssumeRoleCommandHandlerProperties) {
     const {
       sourceAccountId,
+      regionName,
       iamResolver,
       background = new BackgroundTasks(),
     } = properties;
@@ -55,6 +63,7 @@ export class AssumeRoleCommandHandler implements CommandHandler<
     this.authorizationCoordinator = new AssumeRoleAuthorizationCoordinator({
       sourceAccountId,
       iamResolver,
+      regionName,
     });
     this.sessionCreator = new SimStsAssumeRoleSessionCreator({
       iamResolver,

--- a/src/service/sts/service-role/sim-service-role.ts
+++ b/src/service/sts/service-role/sim-service-role.ts
@@ -1,5 +1,6 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import { IamRoleArnParser } from "../../iam/role/arn/sim-iam-role-arn-parser.js";
 import type { SimIam } from "../../iam/sim-iam.js";
@@ -47,9 +48,12 @@ export interface SimServiceRoleAssumption {
   readonly sessionName: string;
 
   /**
-   * The IAM of the role's own Account, which is not always the target's.
+   * The Account and Region scope the role is assumed in.
+   *
+   * Its IAM is the role's own Account's, which is not always the target's, and
+   * its Region is the one the assume request is made in.
    */
-  readonly iam: SimIam;
+  readonly scope: SimAwsAccountRegionContainer;
 
   readonly refusals: SimServiceRoleRefusals;
 }
@@ -83,7 +87,8 @@ export function simServiceRoleTarget(roleArn: string): SimServiceRoleTarget {
 export async function assumeSimServiceRole(
   assumption: SimServiceRoleAssumption,
 ): Promise<SimAwsCaller> {
-  const { target, servicePrincipal, sessionName, iam, refusals } = assumption;
+  const { target, servicePrincipal, sessionName, scope, refusals } = assumption;
+  const iam = scope.iam();
   const role = await roleOrRefuse(target, iam, refusals);
 
   try {
@@ -91,6 +96,7 @@ export async function assumeSimServiceRole(
       roleArn: target.roleArn,
       role,
       targetIam: iam,
+      region: scope.accountRegionScope.regionName,
       caller: { kind: "service", service: servicePrincipal },
     });
   } catch (error) {

--- a/src/service/sts/sim-sts.ts
+++ b/src/service/sts/sim-sts.ts
@@ -57,6 +57,7 @@ export class SimSts {
   ): Promise<SimAssumeRoleCommandOutput> {
     const handler = new AssumeRoleCommandHandler({
       sourceAccountId: this.accountRegionScope.accountId,
+      regionName: this.accountRegionScope.regionName,
       iamResolver: this.iamResolver,
       background: this.background,
     });

--- a/src/service/wafv2/sim-wafv2-commands.ts
+++ b/src/service/wafv2/sim-wafv2-commands.ts
@@ -4,10 +4,8 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import {
-  SimIamAllowAllAuth,
-  type SimIamInterServiceAuthZ,
-} from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import { SimWafAssociations } from "./association/sim-waf-associations.js";
 import {
   SimWafNoProtectedResources,
@@ -73,10 +71,11 @@ export class SimWafCommands {
   constructor(properties: SimWafV2Properties = {}) {
     const {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
-      iam = new SimIamAllowAllAuth(),
       background = new BackgroundTasks(),
       protectedResources = new SimWafNoProtectedResources(),
     } = properties;
+
+    const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     const authorizer = new SimWafAuthorizer({ iam });
 


### PR DESCRIPTION
An authorization request now carries the Region it was made in, and sim IAM derives `aws:RequestedRegion` from it the way it derives `aws:PrincipalArn`, ahead of any value the service supplied. Every simulated service binds its IAM to its own Region where it is wired up. A request reaching one through its command handlers therefore carries that Region with the caller saying nothing, and a CloudFormation deployment carries the Region of the Stack it deploys, which the tests check against a Stack deployed into each of two Regions. IAM, CloudFront and Route53 are global and carry us-east-1, as they do on AWS. A service control policy denying everything in one Region now denies a Bucket created there and allows the same Bucket elsewhere.

Resolves #1070