### PR TITLE
feat: choose the principal a deployment runs as

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1385,6 +1385,87 @@ handed an empty one. Naming the Stacks in the order they have to go in is what p
 there in time, since two Stacks passing a plain string between them declare no dependency for the
 manifest to carry.
 
+## The principal a deployment runs as
+
+Each resource is created through the command an SDK caller would reach, and that command
+authorizes. A deployment that names no principal is decided as the account root, which is what IAM
+falls back to everywhere else in the simulation. `caller` says otherwise.
+
+```typescript sim-cloudformation-deployment-caller
+/**
+ * Deploying a template as the principal a real deployment would run as.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reports-stack",
+  template: {
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "reports-bucket" },
+      },
+    },
+  },
+  caller: {
+    kind: "arn",
+    arn: "arn:aws:iam::123456789012:role/cdk-deploy-role",
+  },
+});
+
+console.log(stack.getResource("ReportsBucket")?.status); // "CREATE_COMPLETE"
+```
+
+`deployTemplateFile(...)` takes the same option. Every resource the stack creates is authorized as
+that principal, and so is every resource its teardown deletes. An update applied through
+`updateTemplateFile(...)` runs as it too, unless the update names a principal of its own.
+
+The named principal has to be allowed what the template asks for. IAM allows the account root by
+default and allows a role only what its policies say, so a role with no S3 permission leaves the
+bucket above `CREATE_FAILED` with the role's ARN in the message.
+
+### One caller for an assembly, and one per Stack
+
+`deployCdkOut(...)` takes a caller for every Stack in the assembly. A Stack deployed by a different
+role names its own in `stackOptions`, beside its parameters and its bindings.
+
+```typescript sim-cloudformation-cdk-out-caller
+/**
+ * A caller for the whole cloud assembly, and one for a single Stack.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  defaultAccountId: "123456789012",
+  defaultRegionName: "eu-west-2",
+});
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  caller: {
+    kind: "arn",
+    arn: "arn:aws:iam::123456789012:role/cdk-deploy-role",
+  },
+  stackOptions: {
+    PipelineStack: {
+      caller: {
+        kind: "arn",
+        arn: "arn:aws:iam::123456789012:role/pipeline-deploy-role",
+      },
+    },
+  },
+});
+
+console.log(stacks.get("PipelineStack")?.stackName);
+```
+
+A staged CDK asset is published under the same principal, before CloudFormation reads the template
+that points at it.
+
 ## Editing a synthesized template before deploying it
 
 Sometimes a synthesized template needs a change before Yulin will deploy it, such as dropping a

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1424,8 +1424,8 @@ that principal, and so is every resource its teardown deletes. An update applied
 `updateTemplateFile(...)` runs as it too, unless the update names a principal of its own.
 
 The named principal has to be allowed what the template asks for. IAM allows the account root by
-default and allows a role only what its policies say, so a role with no S3 permission leaves the
-bucket above `CREATE_FAILED` with the role's ARN in the message.
+default and allows a role only what its policies say. A role with no S3 permission leaves the bucket
+above `CREATE_FAILED`, with the role's ARN in the message.
 
 ### One caller for an assembly, and one per Stack
 

--- a/docs/services/cloudformation/sim-cloudformation-cdk-out-caller.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-cdk-out-caller.example.ts
@@ -1,0 +1,28 @@
+/**
+ * A caller for the whole cloud assembly, and one for a single Stack.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  defaultAccountId: "123456789012",
+  defaultRegionName: "eu-west-2",
+});
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  caller: {
+    kind: "arn",
+    arn: "arn:aws:iam::123456789012:role/cdk-deploy-role",
+  },
+  stackOptions: {
+    PipelineStack: {
+      caller: {
+        kind: "arn",
+        arn: "arn:aws:iam::123456789012:role/pipeline-deploy-role",
+      },
+    },
+  },
+});
+
+console.log(stacks.get("PipelineStack")?.stackName);

--- a/docs/services/cloudformation/sim-cloudformation-deployment-caller.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-deployment-caller.example.ts
@@ -1,0 +1,25 @@
+/**
+ * Deploying a template as the principal a real deployment would run as.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reports-stack",
+  template: {
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "reports-bucket" },
+      },
+    },
+  },
+  caller: {
+    kind: "arn",
+    arn: "arn:aws:iam::123456789012:role/cdk-deploy-role",
+  },
+});
+
+console.log(stack.getResource("ReportsBucket")?.status); // "CREATE_COMPLETE"

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -168,8 +168,8 @@ and resource policies decide its requests as they did before.
 ## Catch a deployment the policy denies
 
 Sim CloudFormation creates each resource through the owning service's command handler, and that
-handler authorizes. A deployment carries no caller, so IAM decides it as the account root, and an
-SCP applies to a member account's root the same way AWS does.
+handler authorizes. A deployment that names no principal is decided as the account root. An SCP
+applies to a member account's root the same way AWS does.
 
 ```typescript sim-organizations-scp-deployment
 /**
@@ -215,6 +215,78 @@ console.log(failed?.status); // "CREATE_FAILED"
 
 The resource is left `CREATE_FAILED` and the deployment rejects. A test asserting that a stack
 deploys then fails on the policy, with the policy named in the message.
+
+## Name the principal a deployment runs as
+
+An organization that denies its accounts' root principals is ordinary, and a deployment decided as
+the root fails under one. `caller` says which principal the resources are created as, and a
+statement conditioned on `aws:PrincipalArn` then has a deploy role to match against.
+
+```typescript sim-organizations-scp-deploy-role
+/**
+ * A policy denying the account root, and a deployment that names a Role.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const simIam = simAws.iam();
+
+const roleCreation = await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "cdk-deploy-role",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "cloudformation.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "cdk-deploy-role",
+    PolicyName: "Deploy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+    }),
+  }),
+);
+
+simAws.organizations().attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyRootPrincipal",
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { ArnLike: { "aws:PrincipalArn": "arn:aws:iam::*:root" } },
+  },
+});
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reports-stack",
+  template: {
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "reports-bucket" },
+      },
+    },
+  },
+  caller: { kind: "arn", arn: roleCreation.Role.Arn },
+});
+
+console.log(stack.getResource("ReportsBucket")?.status); // "CREATE_COMPLETE"
+```
+
+The Role is created before the policy is attached. Creating it afterwards is a call the policy
+denies the root, and the account root is who a bare `createRole` runs as.
 
 ## Write an allow list instead of a deny list
 

--- a/docs/services/organizations/sim-organizations-scp-deploy-role.example.ts
+++ b/docs/services/organizations/sim-organizations-scp-deploy-role.example.ts
@@ -1,0 +1,60 @@
+/**
+ * A policy denying the account root, and a deployment that names a Role.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const simIam = simAws.iam();
+
+const roleCreation = await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "cdk-deploy-role",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "cloudformation.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "cdk-deploy-role",
+    PolicyName: "Deploy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+    }),
+  }),
+);
+
+simAws.organizations().attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyRootPrincipal",
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { ArnLike: { "aws:PrincipalArn": "arn:aws:iam::*:root" } },
+  },
+});
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reports-stack",
+  template: {
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "reports-bucket" },
+      },
+    },
+  },
+  caller: { kind: "arn", arn: roleCreation.Role.Arn },
+});
+
+console.log(stack.getResource("ReportsBucket")?.status); // "CREATE_COMPLETE"

--- a/src/service/acm/cfn/certificate/sim-cfn-acm-cert-creator.ts
+++ b/src/service/acm/cfn/certificate/sim-cfn-acm-cert-creator.ts
@@ -7,6 +7,10 @@ import type { SimAcmCertificate } from "../../certificate/sim-acm-certificate.js
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimCfnAcmCertificatePropertyReader } from "../property/sim-cfn-acm-cert-properties.js";
 import { SimCfnAcmCertificateValidation } from "../validation/sim-cfn-acm-cert-validation.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnAcmCertificateCreatorProperties {
   readonly acm: SimAcm;
@@ -38,7 +42,12 @@ export class SimCfnAcmCertificateCreator {
       properties: context.resolvedProperties ?? resource.properties,
     });
 
-    const certificate = await this.requestCertificate(resource, properties);
+    const options = simCfnResourceCallerOptions(context.caller);
+    const certificate = await this.requestCertificate(
+      resource,
+      properties,
+      options,
+    );
 
     // Creating the Resource is not complete until the certificate is issued,
     // so anything depending on it is created afterwards, as in real
@@ -52,6 +61,7 @@ export class SimCfnAcmCertificateCreator {
       resource,
       certificate,
       properties.domainValidationHostedZoneIds(),
+      options,
     );
 
     return certificate;
@@ -60,16 +70,20 @@ export class SimCfnAcmCertificateCreator {
   private async requestCertificate(
     resource: SimCfnResource,
     properties: SimCfnAcmCertificatePropertyReader,
+    options: SimCfnResourceCallerOptions,
   ): Promise<SimAcmCertificate> {
-    const requestCertificateOutput = await this.acm.requestCertificate({
-      input: {
-        DomainName: properties.domainName(),
-        SubjectAlternativeNames: properties.subjectAlternativeNames(),
-        ValidationMethod: properties.validationMethod(),
-        DomainValidationOptions: properties.domainValidationOptions(),
-        Tags: properties.tags(),
+    const requestCertificateOutput = await this.acm.requestCertificate(
+      {
+        input: {
+          DomainName: properties.domainName(),
+          SubjectAlternativeNames: properties.subjectAlternativeNames(),
+          ValidationMethod: properties.validationMethod(),
+          DomainValidationOptions: properties.domainValidationOptions(),
+          Tags: properties.tags(),
+        },
       },
-    });
+      options,
+    );
 
     const certificateArn = requestCertificateOutput.CertificateArn;
     assertDefined(

--- a/src/service/acm/cfn/sim-cfn-acm-resource-factory.ts
+++ b/src/service/acm/cfn/sim-cfn-acm-resource-factory.ts
@@ -1,7 +1,9 @@
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimAcm } from "../sim-acm.js";
 import { SimCfnAcmCertificateCreator } from "./certificate/sim-cfn-acm-cert-creator.js";
@@ -56,6 +58,7 @@ export class SimAcmCfnResourceFactory implements SimCfnServiceResourceFactory {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
     if (resourceTypeName !== "Certificate") {
       throw new Error(
@@ -69,8 +72,9 @@ export class SimAcmCfnResourceFactory implements SimCfnServiceResourceFactory {
       `sim ACM certificate for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.acm.deleteCertificate({
-      input: { CertificateArn: certificate.certificateArn },
-    });
+    await this.acm.deleteCertificate(
+      { input: { CertificateArn: certificate.certificateArn } },
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/acm/cfn/validation/sim-cfn-acm-cert-validation.ts
+++ b/src/service/acm/cfn/validation/sim-cfn-acm-cert-validation.ts
@@ -5,6 +5,7 @@ import type { SimAcmCertificate } from "../../certificate/sim-acm-certificate.js
 import type { SimAcmDomainValidation } from "../../certificate/sim-acm-domain-validation.js";
 import { SimAcmDnsValidationFailed } from "../../error/sim-acm.error.js";
 import { SimCfnAcmValidationRecords } from "./sim-cfn-acm-validation-records.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnAcmCertificateValidationProperties {
   readonly acm: SimAcm;
@@ -35,13 +36,18 @@ export class SimCfnAcmCertificateValidation {
     resource: SimCfnResource,
     certificate: SimAcmCertificate,
     hostedZoneIdsByDomain: ReadonlyMap<string, string>,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const { accountId, regionName } = resource.accountRegionScope;
     const validationRecords = new SimCfnAcmValidationRecords({
       route53: this.simAws.accountRegionScope(accountId, regionName).route53(),
     });
 
-    await validationRecords.publish(certificate, hostedZoneIdsByDomain);
+    await validationRecords.publish(
+      certificate,
+      hostedZoneIdsByDomain,
+      options,
+    );
     await this.acm.settleCertificateValidation(certificate);
 
     if (certificate.status === "ISSUED") {

--- a/src/service/acm/cfn/validation/sim-cfn-acm-validation-records.ts
+++ b/src/service/acm/cfn/validation/sim-cfn-acm-validation-records.ts
@@ -3,6 +3,7 @@ import type { SimRoute53HostedZone } from "../../../route53/hosted-zone/sim-rout
 import type { SimRoute53HostedZoneId } from "../../../route53/command/create-hosted-zone/sim-route53-zone-id.js";
 import type { SimAcmCertificate } from "../../certificate/sim-acm-certificate.js";
 import type { SimAcmDomainValidation } from "../../certificate/sim-acm-domain-validation.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 const validationRecordTtl = 300;
 
@@ -30,10 +31,15 @@ export class SimCfnAcmValidationRecords {
   async publish(
     certificate: SimAcmCertificate,
     hostedZoneIdsByDomain: ReadonlyMap<string, string>,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     for (const domainValidation of certificate.domainValidationOptions) {
       // oxlint-disable-next-line no-await-in-loop -- one hosted zone at a time
-      await this.publishRecord(domainValidation, hostedZoneIdsByDomain);
+      await this.publishRecord(
+        domainValidation,
+        hostedZoneIdsByDomain,
+        options,
+      );
     }
   }
 
@@ -48,6 +54,7 @@ export class SimCfnAcmValidationRecords {
   private async publishRecord(
     domainValidation: SimAcmDomainValidation,
     hostedZoneIdsByDomain: ReadonlyMap<string, string>,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const resourceRecord = domainValidation.resourceRecord;
     const hostedZoneIdValue = hostedZoneIdsByDomain.get(
@@ -64,24 +71,27 @@ export class SimCfnAcmValidationRecords {
       return;
     }
 
-    await this.route53.changeResourceRecordSets({
-      input: {
-        HostedZoneId: hostedZone.id,
-        ChangeBatch: {
-          Changes: [
-            {
-              Action: "UPSERT",
-              ResourceRecordSet: {
-                Name: resourceRecord.name,
-                Type: resourceRecord.type,
-                TTL: validationRecordTtl,
-                ResourceRecords: [{ Value: resourceRecord.value }],
+    await this.route53.changeResourceRecordSets(
+      {
+        input: {
+          HostedZoneId: hostedZone.id,
+          ChangeBatch: {
+            Changes: [
+              {
+                Action: "UPSERT",
+                ResourceRecordSet: {
+                  Name: resourceRecord.name,
+                  Type: resourceRecord.type,
+                  TTL: validationRecordTtl,
+                  ResourceRecords: [{ Value: resourceRecord.value }],
+                },
               },
-            },
-          ],
+            ],
+          },
         },
       },
-    });
+      options,
+    );
 
     // The record mutation is scheduled, so wait for the zone to hold it before
     // the certificate is checked against DNS.

--- a/src/service/apigateway/cfn/api/sim-cfn-rest-api-creator.ts
+++ b/src/service/apigateway/cfn/api/sim-cfn-rest-api-creator.ts
@@ -7,6 +7,7 @@ import type { SimApiGateway } from "../../sim-api-gateway.js";
 import type { SimCfnRestApiImports } from "../sim-cfn-rest-api-imports.js";
 import { SimCfnRestApiImportProperties } from "./sim-cfn-rest-api-import-properties.js";
 import { SimCfnRestApiProperties } from "./sim-cfn-rest-api-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRestApiCreatorProperties {
   readonly apiGateway: SimApiGateway;
@@ -36,13 +37,19 @@ export class SimCfnRestApiCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRestApi> {
     const apiProperties = new SimCfnRestApiProperties({
       resource,
       properties,
     });
 
-    const created = await this.created(resource, properties, apiProperties);
+    const created = await this.created(
+      resource,
+      properties,
+      apiProperties,
+      options,
+    );
 
     if (apiProperties.imported()) {
       this.imports.record(created.id, resource.logicalId);
@@ -64,18 +71,19 @@ export class SimCfnRestApiCreator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
     apiProperties: SimCfnRestApiProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<SimRestApiView> {
-    if (apiProperties.imported()) {
-      return await this.apiGateway.importRestApi({
-        input: new SimCfnRestApiImportProperties({
-          resource,
-          properties,
-        }).importRestApiInput(),
-      });
+    if (!apiProperties.imported()) {
+      const input = apiProperties.createRestApiInput();
+
+      return await this.apiGateway.createRestApi({ input }, options);
     }
 
-    return await this.apiGateway.createRestApi({
-      input: apiProperties.createRestApiInput(),
-    });
+    const input = new SimCfnRestApiImportProperties({
+      resource,
+      properties,
+    }).importRestApiInput();
+
+    return await this.apiGateway.importRestApi({ input }, options);
   }
 }

--- a/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-creator.ts
+++ b/src/service/apigateway/cfn/authorizer/sim-cfn-rest-api-authorizer-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimRestApiAuthorizer } from "../../api/authorizer/sim-rest-api-authorizer.js";
 import type { SimApiGateway } from "../../sim-api-gateway.js";
 import { SimCfnRestApiAuthorizerProperties } from "./sim-cfn-rest-api-authorizer-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRestApiAuthorizerCreatorProperties {
   readonly apiGateway: SimApiGateway;
@@ -30,15 +31,17 @@ export class SimCfnRestApiAuthorizerCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRestApiAuthorizer> {
     const authorizerProperties = new SimCfnRestApiAuthorizerProperties({
       resource,
       properties,
     });
 
-    const created = await this.apiGateway.createAuthorizer({
-      input: authorizerProperties.createAuthorizerInput(),
-    });
+    const created = await this.apiGateway.createAuthorizer(
+      { input: authorizerProperties.createAuthorizerInput() },
+      options,
+    );
 
     const authorizer = this.apiGateway
       .findRestApi(authorizerProperties.restApiId())

--- a/src/service/apigateway/cfn/deployment/sim-cfn-rest-api-deployment-creator.ts
+++ b/src/service/apigateway/cfn/deployment/sim-cfn-rest-api-deployment-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimRestApiDeployment } from "../../api/deployment/sim-rest-api-deployment.js";
 import type { SimApiGateway } from "../../sim-api-gateway.js";
 import { SimCfnRestApiDeploymentProperties } from "./sim-cfn-rest-api-deployment-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRestApiDeploymentCreatorProperties {
   readonly apiGateway: SimApiGateway;
@@ -30,6 +31,7 @@ export class SimCfnRestApiDeploymentCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRestApiDeployment> {
     const deploymentProperties = new SimCfnRestApiDeploymentProperties({
       resource,
@@ -37,9 +39,10 @@ export class SimCfnRestApiDeploymentCreator {
     });
     const restApiId = deploymentProperties.restApiId();
 
-    const created = await this.apiGateway.createDeployment({
-      input: deploymentProperties.createDeploymentInput(),
-    });
+    const created = await this.apiGateway.createDeployment(
+      { input: deploymentProperties.createDeploymentInput() },
+      options,
+    );
 
     const deployment = this.apiGateway
       .findRestApi(restApiId)

--- a/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-creator.ts
+++ b/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-creator.ts
@@ -6,6 +6,7 @@ import type { SimApiGateway } from "../../sim-api-gateway.js";
 import type { SimCfnRestApiImports } from "../sim-cfn-rest-api-imports.js";
 import { SimCfnRestApiMethodIntegration } from "./sim-cfn-rest-api-method-integration.js";
 import { SimCfnRestApiMethodProperties } from "./sim-cfn-rest-api-method-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRestApiMethodCreatorProperties {
   readonly apiGateway: SimApiGateway;
@@ -38,6 +39,7 @@ export class SimCfnRestApiMethodCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRestApiMethod> {
     const methodProperties = new SimCfnRestApiMethodProperties({
       resource,
@@ -50,10 +52,11 @@ export class SimCfnRestApiMethodCreator {
       address.restApiId,
     );
 
-    await this.apiGateway.putMethod({
-      input: methodProperties.putMethodInput(),
-    });
-    await this.integration.put(methodProperties, address);
+    await this.apiGateway.putMethod(
+      { input: methodProperties.putMethodInput() },
+      options,
+    );
+    await this.integration.put(methodProperties, address, options);
 
     const method = this.apiGateway
       .findRestApi(address.restApiId)

--- a/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-integration.ts
+++ b/src/service/apigateway/cfn/method/sim-cfn-rest-api-method-integration.ts
@@ -3,6 +3,7 @@ import type {
   SimCfnRestApiMethodAddress,
   SimCfnRestApiMethodProperties,
 } from "./sim-cfn-rest-api-method-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRestApiMethodIntegrationProperties {
   readonly apiGateway: SimApiGateway;
@@ -30,15 +31,16 @@ export class SimCfnRestApiMethodIntegration {
   async put(
     methodProperties: SimCfnRestApiMethodProperties,
     address: SimCfnRestApiMethodAddress,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     try {
       const input = methodProperties.putIntegrationInput();
 
       if (input !== undefined) {
-        await this.apiGateway.putIntegration({ input });
+        await this.apiGateway.putIntegration({ input }, options);
       }
     } catch (error) {
-      await this.apiGateway.deleteMethod({ input: address });
+      await this.apiGateway.deleteMethod({ input: address }, options);
 
       throw error;
     }

--- a/src/service/apigateway/cfn/resource/sim-cfn-rest-api-resource-creator.ts
+++ b/src/service/apigateway/cfn/resource/sim-cfn-rest-api-resource-creator.ts
@@ -5,6 +5,7 @@ import type { SimRestApiResource } from "../../api/resource/sim-rest-api-resourc
 import type { SimApiGateway } from "../../sim-api-gateway.js";
 import type { SimCfnRestApiImports } from "../sim-cfn-rest-api-imports.js";
 import { SimCfnRestApiResourceProperties } from "./sim-cfn-rest-api-resource-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRestApiResourceCreatorProperties {
   readonly apiGateway: SimApiGateway;
@@ -33,6 +34,7 @@ export class SimCfnRestApiResourceCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRestApiResource> {
     const resourceProperties = new SimCfnRestApiResourceProperties({
       resource,
@@ -45,9 +47,10 @@ export class SimCfnRestApiResourceCreator {
       restApiId,
     );
 
-    const created = await this.apiGateway.createResource({
-      input: resourceProperties.createResourceInput(),
-    });
+    const created = await this.apiGateway.createResource(
+      { input: resourceProperties.createResourceInput() },
+      options,
+    );
 
     const apiResource = this.apiGateway
       .findRestApi(restApiId)

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-deleter.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-deleter.ts
@@ -4,6 +4,7 @@ import type { SimRestApi } from "../api/sim-rest-api.js";
 import type { SimApiGateway } from "../sim-api-gateway.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import { SimCfnRestApiPartDeleter } from "./sim-cfn-rest-api-part-deleter.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnApiGatewayResourceDeleterProperties {
   readonly apiGateway: SimApiGateway;
@@ -39,9 +40,15 @@ export class SimCfnApiGatewayResourceDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (resourceTypeName !== "RestApi") {
-      await this.partDeleter.delete(resourceTypeName, resource, properties);
+      await this.partDeleter.delete(
+        resourceTypeName,
+        resource,
+        properties,
+        options,
+      );
 
       return;
     }
@@ -52,8 +59,9 @@ export class SimCfnApiGatewayResourceDeleter {
       `sim REST API for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.apiGateway.deleteRestApi({
-      input: { restApiId: restApi.apiId },
-    });
+    await this.apiGateway.deleteRestApi(
+      { input: { restApiId: restApi.apiId } },
+      options,
+    );
   }
 }

--- a/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-factory.ts
+++ b/src/service/apigateway/cfn/sim-cfn-api-gateway-resource-factory.ts
@@ -14,6 +14,7 @@ import { SimCfnApiGatewayResourceDeleter } from "./sim-cfn-api-gateway-resource-
 import { simCfnApiGatewayUnsupportedReason } from "./sim-cfn-api-gateway-unsupported.js";
 import { SimCfnRestApiImports } from "./sim-cfn-rest-api-imports.js";
 import { SimCfnRestApiStageCreator } from "./stage/sim-cfn-rest-api-stage-creator.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimApiGatewayCfnResourceFactoryProperties {
   readonly apiGateway: SimApiGateway;
@@ -60,25 +61,34 @@ export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFac
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case "RestApi": {
-        return await this.apiCreator.create(resource, properties);
+        return await this.apiCreator.create(resource, properties, options);
       }
       case "Resource": {
-        return await this.resourceCreator.create(resource, properties);
+        return await this.resourceCreator.create(resource, properties, options);
       }
       case "Authorizer": {
-        return await this.authorizerCreator.create(resource, properties);
+        return await this.authorizerCreator.create(
+          resource,
+          properties,
+          options,
+        );
       }
       case "Method": {
-        return await this.methodCreator.create(resource, properties);
+        return await this.methodCreator.create(resource, properties, options);
       }
       case "Deployment": {
-        return await this.deploymentCreator.create(resource, properties);
+        return await this.deploymentCreator.create(
+          resource,
+          properties,
+          options,
+        );
       }
       case "Stage": {
-        return await this.stageCreator.create(resource, properties);
+        return await this.stageCreator.create(resource, properties, options);
       }
       default: {
         throw new Error(
@@ -101,6 +111,7 @@ export class SimApiGatewayCfnResourceFactory implements SimCfnServiceResourceFac
       resourceTypeName,
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 }

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-part-deleter.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-part-deleter.ts
@@ -1,12 +1,14 @@
 import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
-import type {
-  SimCfnTemplateValue,
-  SimCfnTemplateValueRecord,
-} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimRestApiAuthorizer } from "../api/authorizer/sim-rest-api-authorizer.js";
 import type { SimRestApiResource } from "../api/resource/sim-rest-api-resource.js";
 import type { SimRestApiStage } from "../api/stage/sim-rest-api-stage.js";
 import type { SimApiGateway } from "../sim-api-gateway.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import {
+  simCfnRestApiPart,
+  simCfnRestApiPartProperty,
+} from "./sim-cfn-rest-api-part-values.js";
 
 interface SimCfnRestApiPartDeleterProperties {
   readonly apiGateway: SimApiGateway;
@@ -41,53 +43,62 @@ export class SimCfnRestApiPartDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
-    const restApiId = this.restApiId(resource, properties);
+    const restApiId = simCfnRestApiPartProperty(
+      resource,
+      properties["RestApiId"],
+      "RestApiId",
+    );
 
     switch (resourceTypeName) {
       case "Resource": {
-        const { resourceId } = this.part<SimRestApiResource>(resource);
+        const { resourceId } = simCfnRestApiPart<SimRestApiResource>(resource);
 
-        await this.apiGateway.deleteResource({
-          input: { restApiId, resourceId },
-        });
+        await this.apiGateway.deleteResource(
+          { input: { restApiId, resourceId } },
+          options,
+        );
 
         return;
       }
       case "Authorizer": {
-        const { authorizerId } = this.part<SimRestApiAuthorizer>(resource);
+        const { authorizerId } =
+          simCfnRestApiPart<SimRestApiAuthorizer>(resource);
 
-        await this.apiGateway.deleteAuthorizer({
-          input: { restApiId, authorizerId },
-        });
+        await this.apiGateway.deleteAuthorizer(
+          { input: { restApiId, authorizerId } },
+          options,
+        );
 
         return;
       }
       case "Method": {
-        await this.apiGateway.deleteMethod({
-          input: {
-            restApiId,
-            resourceId: this.property(
-              resource,
-              properties["ResourceId"],
-              "ResourceId",
-            ),
-            httpMethod: this.property(
-              resource,
-              properties["HttpMethod"],
-              "HttpMethod",
-            ),
-          },
-        });
+        const resourceId = simCfnRestApiPartProperty(
+          resource,
+          properties["ResourceId"],
+          "ResourceId",
+        );
+        const httpMethod = simCfnRestApiPartProperty(
+          resource,
+          properties["HttpMethod"],
+          "HttpMethod",
+        );
+
+        await this.apiGateway.deleteMethod(
+          { input: { restApiId, resourceId, httpMethod } },
+          options,
+        );
 
         return;
       }
       case "Stage": {
-        const { stageName } = this.part<SimRestApiStage>(resource);
+        const { stageName } = simCfnRestApiPart<SimRestApiStage>(resource);
 
-        await this.apiGateway.deleteStage({
-          input: { restApiId, stageName },
-        });
+        await this.apiGateway.deleteStage(
+          { input: { restApiId, stageName } },
+          options,
+        );
 
         return;
       }
@@ -98,43 +109,5 @@ export class SimCfnRestApiPartDeleter {
         );
       }
     }
-  }
-
-  /**
-   * The simulated object created for this Resource.
-   */
-  private part<T extends object>(resource: SimCfnResource): T {
-    const part = resource.simResource as T | undefined;
-
-    /* v8 ignore if -- a Resource that was never created is not deleted */
-    if (part === undefined) {
-      throw new TypeError(
-        `sim REST API part for CloudFormation Resource ${resource.logicalId} is missing`,
-      );
-    }
-
-    return part;
-  }
-
-  private restApiId(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): string {
-    return this.property(resource, properties["RestApiId"], "RestApiId");
-  }
-
-  private property(
-    resource: SimCfnResource,
-    value: SimCfnTemplateValue | undefined,
-    name: string,
-  ): string {
-    /* v8 ignore if -- creation refused the Resource without this string */
-    if (typeof value !== "string") {
-      throw new TypeError(
-        `AWS::ApiGateway Resource ${resource.logicalId} requires a ${name} string to delete`,
-      );
-    }
-
-    return value;
   }
 }

--- a/src/service/apigateway/cfn/sim-cfn-rest-api-part-values.ts
+++ b/src/service/apigateway/cfn/sim-cfn-rest-api-part-values.ts
@@ -1,0 +1,38 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * The simulated object created for a REST API part Resource.
+ */
+export function simCfnRestApiPart<T extends object>(
+  resource: SimCfnResource,
+): T {
+  const part = resource.simResource as T | undefined;
+
+  /* v8 ignore if -- a Resource that was never created is not deleted */
+  if (part === undefined) {
+    throw new TypeError(
+      `sim REST API part for CloudFormation Resource ${resource.logicalId} is missing`,
+    );
+  }
+
+  return part;
+}
+
+/**
+ * A string a REST API part Resource has to carry to be addressed again.
+ */
+export function simCfnRestApiPartProperty(
+  resource: SimCfnResource,
+  value: SimCfnTemplateValue | undefined,
+  name: string,
+): string {
+  /* v8 ignore if -- creation refused the Resource without this string */
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `AWS::ApiGateway Resource ${resource.logicalId} requires a ${name} string to delete`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/apigateway/cfn/stage/sim-cfn-rest-api-stage-creator.ts
+++ b/src/service/apigateway/cfn/stage/sim-cfn-rest-api-stage-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimRestApiStage } from "../../api/stage/sim-rest-api-stage.js";
 import type { SimApiGateway } from "../../sim-api-gateway.js";
 import { SimCfnRestApiStageProperties } from "./sim-cfn-rest-api-stage-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRestApiStageCreatorProperties {
   readonly apiGateway: SimApiGateway;
@@ -28,6 +29,7 @@ export class SimCfnRestApiStageCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRestApiStage> {
     const stageProperties = new SimCfnRestApiStageProperties({
       resource,
@@ -35,9 +37,10 @@ export class SimCfnRestApiStageCreator {
     });
     const restApiId = stageProperties.restApiId();
 
-    const created = await this.apiGateway.createStage({
-      input: stageProperties.createStageInput(),
-    });
+    const created = await this.apiGateway.createStage(
+      { input: stageProperties.createStageInput() },
+      options,
+    );
 
     const stage = this.apiGateway
       .findRestApi(restApiId)

--- a/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-creator.ts
+++ b/src/service/apigatewayv2/cfn/api/sim-cfn-http-api-creator.ts
@@ -6,6 +6,7 @@ import type { SimHttpApi } from "../../api/sim-http-api.js";
 import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
 import type { SimCfnHttpApiImports } from "../sim-cfn-http-api-imports.js";
 import { SimCfnHttpApiProperties } from "./sim-cfn-http-api-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnHttpApiCreatorProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -36,13 +37,14 @@ export class SimCfnHttpApiCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimHttpApi> {
     const apiProperties = new SimCfnHttpApiProperties({
       resource,
       properties,
     });
 
-    const created = await this.created(apiProperties);
+    const created = await this.created(apiProperties, options);
 
     if (apiProperties.imported()) {
       this.imports.record(created.ApiId, resource.logicalId);
@@ -62,15 +64,18 @@ export class SimCfnHttpApiCreator {
    */
   private async created(
     apiProperties: SimCfnHttpApiProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<SimHttpApiView> {
     if (apiProperties.imported()) {
-      return await this.apiGatewayV2.importApi({
-        input: apiProperties.importApiInput(),
-      });
+      return await this.apiGatewayV2.importApi(
+        { input: apiProperties.importApiInput() },
+        options,
+      );
     }
 
-    return await this.apiGatewayV2.createApi({
-      input: apiProperties.createApiInput(),
-    });
+    return await this.apiGatewayV2.createApi(
+      { input: apiProperties.createApiInput() },
+      options,
+    );
   }
 }

--- a/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-creator.ts
+++ b/src/service/apigatewayv2/cfn/authorizer/sim-cfn-http-api-authorizer-creator.ts
@@ -5,6 +5,7 @@ import type { SimHttpApiAuthorizer } from "../../api/authorizer/sim-http-api-aut
 import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
 import type { SimCfnHttpApiImports } from "../sim-cfn-http-api-imports.js";
 import { SimCfnHttpApiAuthorizerProperties } from "./sim-cfn-http-api-authorizer-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnHttpApiAuthorizerCreatorProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -34,6 +35,7 @@ export class SimCfnHttpApiAuthorizerCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimHttpApiAuthorizer> {
     const authorizerProperties = new SimCfnHttpApiAuthorizerProperties({
       resource,
@@ -46,9 +48,10 @@ export class SimCfnHttpApiAuthorizerCreator {
       apiId,
     );
 
-    const created = await this.apiGatewayV2.createAuthorizer({
-      input: authorizerProperties.createAuthorizerInput(),
-    });
+    const created = await this.apiGatewayV2.createAuthorizer(
+      { input: authorizerProperties.createAuthorizerInput() },
+      options,
+    );
 
     const authorizer = this.apiGatewayV2
       .findApi(apiId)

--- a/src/service/apigatewayv2/cfn/domain/sim-cfn-api-mapping-creator.ts
+++ b/src/service/apigatewayv2/cfn/domain/sim-cfn-api-mapping-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimApiMapping } from "../../domain/sim-api-mapping.js";
 import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
 import { SimCfnApiMappingProperties } from "./sim-cfn-api-mapping-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnApiMappingCreatorProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -25,6 +26,7 @@ export class SimCfnApiMappingCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimApiMapping> {
     const mappingProperties = new SimCfnApiMappingProperties({
       resource,
@@ -32,9 +34,10 @@ export class SimCfnApiMappingCreator {
     });
     const domainName = mappingProperties.domainName();
 
-    const created = await this.apiGatewayV2.createApiMapping({
-      input: mappingProperties.createApiMappingInput(),
-    });
+    const created = await this.apiGatewayV2.createApiMapping(
+      { input: mappingProperties.createApiMappingInput() },
+      options,
+    );
 
     const mapping = this.apiGatewayV2
       .findDomainName(domainName)

--- a/src/service/apigatewayv2/cfn/domain/sim-cfn-http-api-domain-creator.ts
+++ b/src/service/apigatewayv2/cfn/domain/sim-cfn-http-api-domain-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimHttpApiDomainName } from "../../domain/sim-http-api-domain-name.js";
 import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
 import { SimCfnHttpApiDomainProperties } from "./sim-cfn-http-api-domain-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnHttpApiDomainCreatorProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -31,15 +32,17 @@ export class SimCfnHttpApiDomainCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimHttpApiDomainName> {
     const domainProperties = new SimCfnHttpApiDomainProperties({
       resource,
       properties,
     });
 
-    const created = await this.apiGatewayV2.createDomainName({
-      input: domainProperties.createDomainNameInput(),
-    });
+    const created = await this.apiGatewayV2.createDomainName(
+      { input: domainProperties.createDomainNameInput() },
+      options,
+    );
 
     const domain = this.apiGatewayV2.findDomainName(created.DomainName);
     assertDefined(

--- a/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-creator.ts
+++ b/src/service/apigatewayv2/cfn/integration/sim-cfn-http-api-integration-creator.ts
@@ -5,6 +5,7 @@ import type { SimHttpApiIntegration } from "../../api/integration/sim-http-api-i
 import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
 import type { SimCfnHttpApiImports } from "../sim-cfn-http-api-imports.js";
 import { SimCfnHttpApiIntegrationProperties } from "./sim-cfn-http-api-integration-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnHttpApiIntegrationCreatorProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -33,6 +34,7 @@ export class SimCfnHttpApiIntegrationCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimHttpApiIntegration> {
     const integrationProperties = new SimCfnHttpApiIntegrationProperties({
       resource,
@@ -45,9 +47,10 @@ export class SimCfnHttpApiIntegrationCreator {
       apiId,
     );
 
-    const created = await this.apiGatewayV2.createIntegration({
-      input: integrationProperties.createIntegrationInput(),
-    });
+    const created = await this.apiGatewayV2.createIntegration(
+      { input: integrationProperties.createIntegrationInput() },
+      options,
+    );
 
     const integration = this.apiGatewayV2
       .findApi(apiId)

--- a/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-route-creator.ts
+++ b/src/service/apigatewayv2/cfn/route/sim-cfn-http-api-route-creator.ts
@@ -5,6 +5,7 @@ import type { SimHttpApiRoute } from "../../api/route/sim-http-api-route.js";
 import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
 import type { SimCfnHttpApiImports } from "../sim-cfn-http-api-imports.js";
 import { SimCfnHttpApiRouteProperties } from "./sim-cfn-http-api-route-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnHttpApiRouteCreatorProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -38,6 +39,7 @@ export class SimCfnHttpApiRouteCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimHttpApiRoute> {
     const routeProperties = new SimCfnHttpApiRouteProperties({
       resource,
@@ -50,9 +52,10 @@ export class SimCfnHttpApiRouteCreator {
       apiId,
     );
 
-    const created = await this.apiGatewayV2.createRoute({
-      input: routeProperties.createRouteInput(),
-    });
+    const created = await this.apiGatewayV2.createRoute(
+      { input: routeProperties.createRouteInput() },
+      options,
+    );
 
     const route = this.apiGatewayV2
       .findApi(apiId)

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-deleter.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-deleter.ts
@@ -6,6 +6,7 @@ import type { SimApiMapping } from "../domain/sim-api-mapping.js";
 import type { SimHttpApiDomainName } from "../domain/sim-http-api-domain-name.js";
 import { SimCfnHttpApiPartDeleter } from "./sim-cfn-http-api-part-deleter.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnApiGatewayV2ResourceDeleterProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -37,11 +38,15 @@ export class SimCfnApiGatewayV2ResourceDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (resourceTypeName === "Api") {
       const api = this.deleted<SimHttpApi>(resource, "HTTP API");
 
-      await this.apiGatewayV2.deleteApi({ input: { ApiId: api.apiId } });
+      await this.apiGatewayV2.deleteApi(
+        { input: { ApiId: api.apiId } },
+        options,
+      );
 
       return;
     }
@@ -52,46 +57,47 @@ export class SimCfnApiGatewayV2ResourceDeleter {
         "HTTP API domain name",
       );
 
-      await this.apiGatewayV2.deleteDomainName({
-        input: { DomainName: domain.domainName },
-      });
+      await this.apiGatewayV2.deleteDomainName(
+        { input: { DomainName: domain.domainName } },
+        options,
+      );
 
       return;
     }
 
     if (resourceTypeName === "ApiMapping") {
-      await this.deleteApiMapping(resource, properties);
+      // A mapping is addressed by its domain as well as its own id. The domain
+      // name comes from the Resource's own property, where creation read it
+      // from, and still resolves because a mapping never outlives its domain.
+      const mapping = this.deleted<SimApiMapping>(resource, "API mapping");
+      const domainName = properties["DomainName"];
+
+      /* v8 ignore if -- creation refused the Resource without a DomainName */
+      if (typeof domainName !== "string") {
+        throw new TypeError(
+          `AWS::ApiGatewayV2::ApiMapping ${resource.logicalId} requires a DomainName string to delete`,
+        );
+      }
+
+      await this.apiGatewayV2.deleteApiMapping(
+        {
+          input: {
+            DomainName: domainName,
+            ApiMappingId: mapping.apiMappingId,
+          },
+        },
+        options,
+      );
 
       return;
     }
 
-    await this.partDeleter.delete(resourceTypeName, resource, properties);
-  }
-
-  /**
-   * Delete an API mapping, which is addressed by its domain and its own id.
-   *
-   * The domain name comes from the Resource's own property, where creation
-   * read it from, and still resolves because a mapping never outlives the
-   * domain holding it.
-   */
-  private async deleteApiMapping(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): Promise<void> {
-    const mapping = this.deleted<SimApiMapping>(resource, "API mapping");
-    const domainName = properties["DomainName"];
-
-    /* v8 ignore if -- creation refused the Resource without a DomainName */
-    if (typeof domainName !== "string") {
-      throw new TypeError(
-        `AWS::ApiGatewayV2::ApiMapping ${resource.logicalId} requires a DomainName string to delete`,
-      );
-    }
-
-    await this.apiGatewayV2.deleteApiMapping({
-      input: { DomainName: domainName, ApiMappingId: mapping.apiMappingId },
-    });
+    await this.partDeleter.delete(
+      resourceTypeName,
+      resource,
+      properties,
+      options,
+    );
   }
 
   private deleted<T extends object>(

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-factory.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-resource-factory.ts
@@ -14,16 +14,8 @@ import { SimCfnHttpApiImports } from "./sim-cfn-http-api-imports.js";
 import { SimCfnHttpApiStageCreator } from "./stage/sim-cfn-http-api-stage-creator.js";
 import { SimCfnApiGatewayV2ResourceDeleter } from "./sim-cfn-api-gateway-v2-resource-deleter.js";
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
-
-/**
- * The Resource types belonging to a WebSocket API, which is the half of API
- * Gateway v2 this simulation does not model at all.
- */
-const webSocketResourceTypeNames = new Set([
-  "Model",
-  "RouteResponse",
-  "IntegrationResponse",
-]);
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import { simCfnApiGatewayV2UnsupportedReason } from "./sim-cfn-api-gateway-v2-unsupported.js";
 
 interface SimApiGatewayV2CfnResourceFactoryProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -77,34 +69,35 @@ export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceF
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
-    const properties = context.resolvedProperties ?? resource.properties;
+    const values = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case "Api": {
-        return await this.apiCreator.create(resource, properties);
+        return await this.apiCreator.create(resource, values, options);
       }
       case "Authorizer": {
-        return await this.authorizerCreator.create(resource, properties);
+        return await this.authorizerCreator.create(resource, values, options);
       }
       case "Integration": {
-        return await this.integrationCreator.create(resource, properties);
+        return await this.integrationCreator.create(resource, values, options);
       }
       case "Route": {
-        return await this.routeCreator.create(resource, properties);
+        return await this.routeCreator.create(resource, values, options);
       }
       case "Stage": {
-        return await this.stageCreator.create(resource, properties);
+        return await this.stageCreator.create(resource, values, options);
       }
       case "DomainName": {
-        return await this.domainCreator.create(resource, properties);
+        return await this.domainCreator.create(resource, values, options);
       }
       case "ApiMapping": {
-        return await this.mappingCreator.create(resource, properties);
+        return await this.mappingCreator.create(resource, values, options);
       }
       default: {
         throw new Error(
           `Unsupported sim API Gateway v2 CloudFormation Resource ` +
-            `${resourceTypeName}${this.unsupportedReason(resourceTypeName)}`,
+            `${resourceTypeName}${simCfnApiGatewayV2UnsupportedReason(resourceTypeName)}`,
         );
       }
     }
@@ -123,18 +116,7 @@ export class SimApiGatewayV2CfnResourceFactory implements SimCfnServiceResourceF
       resourceTypeName,
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
-  }
-
-  /**
-   * Say why a Resource type is unsupported when there is more to say than that
-   * nothing creates it yet.
-   */
-  private unsupportedReason(resourceTypeName: string): string {
-    if (webSocketResourceTypeNames.has(resourceTypeName)) {
-      return ", which belongs to a WebSocket API and is not simulated";
-    }
-
-    return "";
   }
 }

--- a/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-unsupported.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-api-gateway-v2-unsupported.ts
@@ -1,0 +1,23 @@
+/**
+ * The Resource types belonging to a WebSocket API, which is the half of API
+ * Gateway v2 this simulation does not model at all.
+ */
+const webSocketResourceTypeNames = new Set([
+  "Model",
+  "RouteResponse",
+  "IntegrationResponse",
+]);
+
+/**
+ * Say why a Resource type is unsupported when there is more to say than that
+ * nothing creates it yet.
+ */
+export function simCfnApiGatewayV2UnsupportedReason(
+  resourceTypeName: string,
+): string {
+  if (webSocketResourceTypeNames.has(resourceTypeName)) {
+    return ", which belongs to a WebSocket API and is not simulated";
+  }
+
+  return "";
+}

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-part-deleter.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-part-deleter.ts
@@ -6,6 +6,7 @@ import type { SimHttpApiIntegration } from "../api/integration/sim-http-api-inte
 import type { SimHttpApiRoute } from "../api/route/sim-http-api-route.js";
 import type { SimHttpApiStage } from "../api/stage/sim-http-api-stage.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnHttpApiPartDeleterProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -37,6 +38,7 @@ export class SimCfnHttpApiPartDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const apiId = this.apiId(resource, properties);
 
@@ -44,36 +46,40 @@ export class SimCfnHttpApiPartDeleter {
       case "Authorizer": {
         const { authorizerId } = this.part<SimHttpApiAuthorizer>(resource);
 
-        await this.apiGatewayV2.deleteAuthorizer({
-          input: { ApiId: apiId, AuthorizerId: authorizerId },
-        });
+        await this.apiGatewayV2.deleteAuthorizer(
+          { input: { ApiId: apiId, AuthorizerId: authorizerId } },
+          options,
+        );
 
         return;
       }
       case "Integration": {
         const { integrationId } = this.part<SimHttpApiIntegration>(resource);
 
-        await this.apiGatewayV2.deleteIntegration({
-          input: { ApiId: apiId, IntegrationId: integrationId },
-        });
+        await this.apiGatewayV2.deleteIntegration(
+          { input: { ApiId: apiId, IntegrationId: integrationId } },
+          options,
+        );
 
         return;
       }
       case "Route": {
         const { routeId } = this.part<SimHttpApiRoute>(resource);
 
-        await this.apiGatewayV2.deleteRoute({
-          input: { ApiId: apiId, RouteId: routeId },
-        });
+        await this.apiGatewayV2.deleteRoute(
+          { input: { ApiId: apiId, RouteId: routeId } },
+          options,
+        );
 
         return;
       }
       case "Stage": {
         const { stageName } = this.part<SimHttpApiStage>(resource);
 
-        await this.apiGatewayV2.deleteStage({
-          input: { ApiId: apiId, StageName: stageName },
-        });
+        await this.apiGatewayV2.deleteStage(
+          { input: { ApiId: apiId, StageName: stageName } },
+          options,
+        );
 
         return;
       }

--- a/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-creator.ts
+++ b/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimHttpApiStage } from "../../api/stage/sim-http-api-stage.js";
 import type { SimApiGatewayV2 } from "../../sim-api-gateway-v2.js";
 import { SimCfnHttpApiStageProperties } from "./sim-cfn-http-api-stage-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnHttpApiStageCreatorProperties {
   readonly apiGatewayV2: SimApiGatewayV2;
@@ -30,6 +31,7 @@ export class SimCfnHttpApiStageCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimHttpApiStage> {
     const stageProperties = new SimCfnHttpApiStageProperties({
       resource,
@@ -37,9 +39,10 @@ export class SimCfnHttpApiStageCreator {
     });
     const apiId = stageProperties.apiId();
 
-    const created = await this.apiGatewayV2.createStage({
-      input: stageProperties.createStageInput(),
-    });
+    const created = await this.apiGatewayV2.createStage(
+      { input: stageProperties.createStageInput() },
+      options,
+    );
 
     const stage = this.apiGatewayV2
       .findApi(apiId)

--- a/src/service/athena/cfn/named-query/sim-cfn-athena-named-query-creator.ts
+++ b/src/service/athena/cfn/named-query/sim-cfn-athena-named-query-creator.ts
@@ -6,6 +6,7 @@ import type { SimAthena } from "../../sim-athena.js";
 import { simCfnAthenaResourceCreation } from "../sim-cfn-athena-resource-error.js";
 import { athenaNamedQueryResourceType } from "../sim-cfn-athena-resource-types.js";
 import { SimCfnAthenaNamedQueryProperties } from "./sim-cfn-athena-named-query-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnAthenaNamedQueryCreatorProperties {
   readonly athena: SimAthena;
@@ -33,6 +34,7 @@ export class SimCfnAthenaNamedQueryCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimAthenaNamedQuery> {
     const read = new SimCfnAthenaNamedQueryProperties({
       resource,
@@ -46,7 +48,7 @@ export class SimCfnAthenaNamedQueryCreator {
       athenaNamedQueryResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.athena.createNamedQuery({ input });
+        const created = await this.athena.createNamedQuery({ input }, options);
         const namedQuery = this.athena
           .namedQueries()
           .find((candidate) => candidate.namedQueryId === created.NamedQueryId);
@@ -65,9 +67,13 @@ export class SimCfnAthenaNamedQueryCreator {
   /**
    * Delete the named query a Resource created.
    */
-  async delete(namedQuery: SimAthenaNamedQuery): Promise<void> {
-    await this.athena.deleteNamedQuery({
-      input: { NamedQueryId: namedQuery.namedQueryId },
-    });
+  async delete(
+    namedQuery: SimAthenaNamedQuery,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.athena.deleteNamedQuery(
+      { input: { NamedQueryId: namedQuery.namedQueryId } },
+      options,
+    );
   }
 }

--- a/src/service/athena/cfn/sim-athena-cfn-resource-factory.ts
+++ b/src/service/athena/cfn/sim-athena-cfn-resource-factory.ts
@@ -3,7 +3,12 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimAthena } from "../sim-athena.js";
 import { SimCfnAthenaNamedQueryCreator } from "./named-query/sim-cfn-athena-named-query-creator.js";
@@ -28,8 +33,12 @@ interface SimCfnAthenaResourceHandler {
   create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options: SimCfnResourceCallerOptions,
   ): Promise<object>;
-  delete(resource: SimCfnResource): Promise<void>;
+  delete(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void>;
 }
 
 /**
@@ -69,6 +78,7 @@ export class SimAthenaCfnResourceFactory implements SimCfnServiceResourceFactory
     return await this.handler(resourceTypeName, "").create(
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 
@@ -78,8 +88,12 @@ export class SimAthenaCfnResourceFactory implements SimCfnServiceResourceFactory
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.handler(resourceTypeName, " deletion").delete(resource);
+    await this.handler(resourceTypeName, " deletion").delete(
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 
   private handler(
@@ -110,16 +124,17 @@ function handler<T extends object>(
     create(
       resource: SimCfnResource,
       properties: SimCfnTemplateValueRecord,
+      options: SimCfnResourceCallerOptions,
     ): Promise<T>;
-    delete(created: T): Promise<void>;
+    delete(created: T, options: SimCfnResourceCallerOptions): Promise<void>;
   },
   described: string,
 ): SimCfnAthenaResourceHandler {
   return {
-    create: async (resource, properties): Promise<T> =>
-      await creator.create(resource, properties),
-    delete: async (resource): Promise<void> => {
-      await creator.delete(created<T>(resource, described));
+    create: async (resource, properties, options): Promise<T> =>
+      await creator.create(resource, properties, options),
+    delete: async (resource, options): Promise<void> => {
+      await creator.delete(created<T>(resource, described), options);
     },
   };
 }

--- a/src/service/athena/cfn/work-group/sim-cfn-athena-work-group-creator.ts
+++ b/src/service/athena/cfn/work-group/sim-cfn-athena-work-group-creator.ts
@@ -10,6 +10,7 @@ import type {
 import { simCfnAthenaResourceCreation } from "../sim-cfn-athena-resource-error.js";
 import { athenaWorkGroupResourceType } from "../sim-cfn-athena-resource-types.js";
 import { SimCfnAthenaWorkGroupProperties } from "./sim-cfn-athena-work-group-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnAthenaWorkGroupCreatorProperties {
   readonly athena: SimAthena;
@@ -36,6 +37,7 @@ export class SimCfnAthenaWorkGroupCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimAthenaWorkGroup> {
     const read = this.read(resource, properties);
 
@@ -55,8 +57,8 @@ export class SimCfnAthenaWorkGroupCreator {
          */
         const state = workGroupStateFrom(read.state());
 
-        await this.athena.createWorkGroup({ input });
-        await this.applyState(String(input.Name), state);
+        await this.athena.createWorkGroup({ input }, options);
+        await this.applyState(String(input.Name), state, options);
 
         const workGroup = this.athena.findWorkGroup(String(input.Name));
 
@@ -77,23 +79,29 @@ export class SimCfnAthenaWorkGroupCreator {
    * Deleted recursively, so a workgroup the stack also gave named queries goes
    * with them rather than failing the stack deletion.
    */
-  async delete(workGroup: SimAthenaWorkGroup): Promise<void> {
-    await this.athena.deleteWorkGroup({
-      input: { WorkGroup: workGroup.name, RecursiveDeleteOption: true },
-    });
+  async delete(
+    workGroup: SimAthenaWorkGroup,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.athena.deleteWorkGroup(
+      { input: { WorkGroup: workGroup.name, RecursiveDeleteOption: true } },
+      options,
+    );
   }
 
   private async applyState(
     name: string,
     state: SimAthenaWorkGroupState | undefined,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (state === undefined) {
       return;
     }
 
-    await this.athena.updateWorkGroup({
-      input: { WorkGroup: name, State: state },
-    });
+    await this.athena.updateWorkGroup(
+      { input: { WorkGroup: name, State: state } },
+      options,
+    );
   }
 
   private read(

--- a/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.ts
@@ -8,12 +8,25 @@ import {
   SimCdkAssetPublications,
 } from "./sim-cdk-asset-publications.js";
 import { readSimCdkAssetBytes } from "./sim-cdk-asset-bytes.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 
 interface SimCdkAssetsPublisherProperties {
   readonly simAws: SimAws;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stackName?: string | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
+
+  /**
+   * The principal the deployment runs as, which the staging Bucket is created
+   * and written to as. A real `cdk deploy` publishes assets before
+   * CloudFormation sees the template, and it publishes them as somebody; a
+   * deployment that names a caller is what says who.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -75,14 +88,19 @@ export class SimCdkAssetsPublisher {
     }
 
     const s3 = this.stagingS3();
-    await this.ensureBucket(s3, publication.bucketName);
-    await s3.putObject({
-      input: {
-        Bucket: publication.bucketName,
-        Key: publication.objectKey,
-        Body: assetBytes,
+    const options = simCfnResourceCallerOptions(this.properties.caller);
+
+    await this.ensureBucket(s3, publication.bucketName, options);
+    await s3.putObject(
+      {
+        input: {
+          Bucket: publication.bucketName,
+          Key: publication.objectKey,
+          Body: assetBytes,
+        },
       },
-    });
+      options,
+    );
   }
 
   /**
@@ -96,13 +114,17 @@ export class SimCdkAssetsPublisher {
    * wanted, whoever created it. Anything else, such as the name already being
    * taken in another scope, is a real failure and is reported.
    */
-  private async ensureBucket(s3: SimS3, bucketName: string): Promise<void> {
+  private async ensureBucket(
+    s3: SimS3,
+    bucketName: string,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     if (s3.getSimBucketByName(bucketName) !== undefined) {
       return;
     }
 
     try {
-      await s3.createBucket({ input: { Bucket: bucketName } });
+      await s3.createBucket({ input: { Bucket: bucketName } }, options);
     } catch (error) {
       if (s3.getSimBucketByName(bucketName) === undefined) {
         throw error;

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -5,6 +5,7 @@ import type {
   BackgroundScheduler,
 } from "../../../../util/background/background.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import {
   SimCfnStack,
@@ -29,6 +30,10 @@ interface CreateStackCommandHandlerProperties {
   readonly background: BackgroundScheduler & BackgroundCompleter;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+
+  /** The principal the Stack's Resources are created as. */
+  readonly caller?: SimAwsCaller | undefined;
+
   readonly exports?: SimCfnExports | undefined;
 }
 
@@ -47,6 +52,7 @@ export class CreateStackCommandHandler implements CommandHandler<
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
   private readonly bindings: readonly SimCfnBinding[] | undefined;
+  private readonly caller: SimAwsCaller | undefined;
   private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: CreateStackCommandHandlerProperties) {
@@ -57,6 +63,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       background,
       cdkOutContext,
       bindings,
+      caller,
       exports,
     } = properties;
 
@@ -66,6 +73,7 @@ export class CreateStackCommandHandler implements CommandHandler<
     this.background = background;
     this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
+    this.caller = caller;
     this.exports = exports;
   }
 
@@ -120,6 +128,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       template,
       cdkOutContext: this.cdkOutContext,
       bindings: this.bindings,
+      caller: this.caller,
       exports: this.exports,
     });
 

--- a/src/service/cloudformation/command/update-stack/update-stack.handler.ts
+++ b/src/service/cloudformation/command/update-stack/update-stack.handler.ts
@@ -5,6 +5,7 @@ import type {
   BackgroundScheduler,
 } from "../../../../util/background/background.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type {
@@ -33,6 +34,12 @@ interface UpdateStackCommandHandlerProperties {
    */
   readonly cdkOutContext?: SimCdkOutContext | undefined;
 
+  /**
+   * The principal to apply the changed template as, for an update that names
+   * one. Left out, the Stack goes on running as whoever deployed it.
+   */
+  readonly caller?: SimAwsCaller | undefined;
+
   /** The export names published in this Account and Region. */
   readonly exports?: SimCfnExports | undefined;
 }
@@ -51,6 +58,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
+  private readonly caller: SimAwsCaller | undefined;
   private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: UpdateStackCommandHandlerProperties) {
@@ -59,6 +67,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
     this.stacks = properties.stacks;
     this.background = properties.background;
     this.cdkOutContext = properties.cdkOutContext;
+    this.caller = properties.caller;
     this.exports = properties.exports;
   }
 
@@ -112,7 +121,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
         accountRegionScope: this.accountRegionScope,
         exports: this.exports,
       }),
-      { cdkOutContext: this.cdkOutContext },
+      { cdkOutContext: this.cdkOutContext, caller: this.caller },
     );
 
     return {

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
@@ -59,7 +59,7 @@ export class SimCfnCdkOutDeployer {
     deployed: ReadonlyMap<string, SimCfnDeployedStack>,
   ): Promise<SimCfnDeployedStack> {
     const { simAws, accountRegionScope } = this.scope;
-    const { transform, ...options } = cdkOutOptionsFor(
+    const { transform, caller, ...options } = cdkOutOptionsFor(
       stack,
       plan.stackOptions,
     );
@@ -71,6 +71,7 @@ export class SimCfnCdkOutDeployer {
         templatePath: stack.templatePath,
         stackName: stack.stackName,
         ...options,
+        caller: caller ?? plan.caller,
         transform: cdkOutBoundTransform(transform, deployed),
       });
   }

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import {
   loadCdkAssemblyStacks,
   type SimCdkAssemblyStack,
@@ -29,8 +30,14 @@ export interface SimCloudFormationDeployCdkOutProperties {
   readonly stackNames?: readonly string[] | undefined;
 
   /**
-   * Bindings, parameters and a transform for individual Stacks, keyed the same
-   * way `stackNames` names them.
+   * The principal every Stack in the assembly is deployed as, which one named
+   * in `stackOptions` overrides for its own Stack.
+   */
+  readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * Bindings, parameters, a caller and a transform for individual Stacks,
+   * keyed the same way `stackNames` names them.
    */
   readonly stackOptions?: SimCfnCdkOutStackOptionsByName | undefined;
 }
@@ -42,6 +49,7 @@ export interface SimCfnCdkOutPlannedStack extends SimCdkAssemblyStack {
 
 export interface SimCfnCdkOutPlan {
   readonly stacks: readonly SimCfnCdkOutPlannedStack[];
+  readonly caller?: SimAwsCaller | undefined;
   readonly stackOptions?: SimCfnCdkOutStackOptionsByName | undefined;
 }
 
@@ -55,7 +63,7 @@ export async function planCdkOutDeployment(properties: {
   readonly request: SimCloudFormationDeployCdkOutProperties | string;
   readonly defaultRegionName: AwsRegionName;
 }): Promise<SimCfnCdkOutPlan> {
-  const { directoryPath, stackNames, stackOptions } = cdkOutDeployment(
+  const { directoryPath, stackNames, caller, stackOptions } = cdkOutDeployment(
     properties.request,
   );
 
@@ -72,6 +80,7 @@ export async function planCdkOutDeployment(properties: {
       ...stack,
       regionName: stack.regionName ?? properties.defaultRegionName,
     })),
+    caller,
     stackOptions,
   };
 }

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
@@ -1,5 +1,6 @@
 import type { SimCdkAssemblyStack } from "../cdk/sim-cdk-assembly-manifest.js";
 import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnTemplateFileTransform } from "./sim-cfn-template-file-transform.js";
@@ -31,6 +32,14 @@ export type SimCfnCdkOutTemplateTransform = (
 export interface SimCfnCdkOutStackOptions {
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+
+  /**
+   * The principal this Stack is deployed as, where the assembly's own caller
+   * is not the right one for it. A pipeline Stack deployed by one role and an
+   * application Stack deployed by another is what this is for.
+   */
+  readonly caller?: SimAwsCaller | undefined;
+
   readonly transform?: SimCfnCdkOutTemplateTransform | undefined;
 }
 
@@ -73,9 +82,9 @@ export function cdkOutBoundTransform(
 /**
  * Refuse options keyed against a Stack that is not being deployed.
  *
- * A renamed Stack would otherwise take its bindings and its transform with it
- * without saying anything, and the deployment that lost them looks like one
- * that never had them.
+ * A renamed Stack would otherwise take its bindings, its caller and its
+ * transform with it without saying anything, and the deployment that lost them
+ * looks like one that never had them.
  */
 export function assertCdkOutOptionsAreDeployed(
   optionsByName: SimCfnCdkOutStackOptionsByName | undefined,
@@ -90,11 +99,7 @@ export function assertCdkOutOptionsAreDeployed(
 
   if (unmatched.length > 0) {
     throw new Error(
-      `Options were given for ${unmatched.join(", ")}, which no Stack being deployed is named. The Stacks being deployed are ${stackNames(deploying)}.`,
+      `Options were given for ${unmatched.join(", ")}, which no Stack being deployed is named. The Stacks being deployed are ${deploying.map((stack) => stack.stackName).join(", ")}.`,
     );
   }
-}
-
-function stackNames(stacks: readonly SimCdkAssemblyStack[]): string {
-  return stacks.map((stack) => stack.stackName).join(", ");
 }

--- a/src/service/cloudformation/deploy/sim-cfn-deployment-caller.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-deployment-caller.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   assertIdentical,
+  assertMapSize,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -14,6 +15,7 @@ import {
 import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimIamUsername } from "../../iam/user/sim-iam-user.js";
 import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
 
@@ -205,6 +207,85 @@ describe("the principal a simulated CloudFormation deployment runs as", () => {
     assertNonNullable(simAws.s3().getSimBucketByName("site-uploads"));
   });
 
+  it("refuses a key the deployment may create and may not disable", async () => {
+    // Given a deploy Role that may make KMS keys and nothing else.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const maker = await deployRole(simAws, accountId, "maker", "kms:CreateKey");
+
+    // When it deploys a key the template asks to be disabled from the start.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "keys-stack",
+        template: {
+          Resources: {
+            ReportsKey: {
+              Type: "AWS::KMS::Key",
+              Properties: { Enabled: false },
+            },
+          },
+        },
+        caller: maker,
+      });
+    });
+
+    // Then disabling it was refused, rather than done as nobody in particular.
+    assertStringIncludes(error.message, "kms:DisableKey");
+  });
+
+  it("leaves a User's policies on it when the teardown may not delete it", async () => {
+    // Given a Stack holding a User with an inline policy, deployed as a Role
+    // that may not delete Users.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const maker = await deployRole(simAws, accountId, "maker", [
+      "iam:CreateUser",
+      "iam:PutUserPolicy",
+    ]);
+    const cloudFormation = simAws.cloudFormation();
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "people-stack",
+      template: {
+        Resources: {
+          Reader: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "reader",
+              Policies: [
+                {
+                  PolicyName: "ReadReports",
+                  PolicyDocument: {
+                    Version: "2012-10-17",
+                    Statement: {
+                      Effect: "Allow",
+                      Action: "s3:GetObject",
+                      Resource: "*",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      caller: maker,
+    });
+
+    // When the Stack is torn down.
+    await assertThrowsErrorAsync(async () => {
+      await stack.teardown();
+    });
+
+    // Then the User is where it was, with the policy the Stack put on it.
+    const user = simAws
+      .account(accountId)
+      .iam()
+      .users.get("reader" as SimIamUsername);
+
+    assertNonNullable(user);
+    assertMapSize(user.inlinePolicies, 1);
+  });
+
   it("deploys every Stack in a cloud assembly as the caller it is given", async () => {
     // Given an assembly of one Stack, and a Role that may not make Buckets.
     const accountId = makeSimAwsAccountId();
@@ -284,7 +365,7 @@ async function deployRole(
   simAws: SimAws,
   accountId: SimAwsAccountId,
   roleName: string,
-  action: string,
+  action: string | readonly string[],
 ): Promise<SimAwsCaller> {
   const iam = simAws.account(accountId).iam();
 

--- a/src/service/cloudformation/deploy/sim-cfn-deployment-caller.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-deployment-caller.iso.test.ts
@@ -1,0 +1,317 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import {
+  assemblyStackBucketName,
+  simCdkCloudAssemblyFactory,
+} from "../cdk/sim-cdk-cloud-assembly.factory.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+/**
+ * An organization that denies its Accounts' root principals everything, which
+ * is the shape a deployment could not be tested against while it was always
+ * decided as the root.
+ */
+const denyAccountRoot = {
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { ArnLike: { "aws:PrincipalArn": "arn:aws:iam::*:root" } },
+  },
+} as const;
+
+const reportsBucketTemplate = {
+  Resources: {
+    ReportsBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "reports-bucket" },
+    },
+  },
+};
+
+describe("the principal a simulated CloudFormation deployment runs as", () => {
+  it("creates Resources as the Role the deployment names", async () => {
+    // Given an organization denying the Account root everything, and a deploy
+    // Role the policy leaves alone.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const deployer = await deployRole(simAws, accountId, "deployer", "s3:*");
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    // When a Stack is deployed as that Role.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reports-stack",
+      template: reportsBucketTemplate,
+      caller: deployer,
+    });
+
+    // Then the Resource was created, because the deny naming the root never
+    // reached the Role the deployment ran as.
+    assertIdentical(
+      stack.getResource("ReportsBucket")?.status,
+      "CREATE_COMPLETE",
+    );
+    assertNonNullable(simAws.s3().getSimBucketByName("reports-bucket"));
+  });
+
+  it("leaves a deployment that names no caller decided as the Account root", async () => {
+    // Given the same organization, denying the Account root everything.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    // When a Stack is deployed without naming a principal.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "reports-stack",
+        template: reportsBucketTemplate,
+      });
+    });
+
+    // Then it was decided as the root, as it was before there was anything to
+    // say otherwise.
+    assertStringIncludes(error.message, `arn:aws:iam::${accountId}:root`);
+    assertStringIncludes(
+      error.message,
+      "with an explicit deny in a service control policy",
+    );
+    assertUndefined(simAws.s3().getSimBucketByName("reports-bucket"));
+  });
+
+  it("fails a Resource the principal it names is not allowed to create", async () => {
+    // Given a deploy Role that may read Buckets and not make them.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const reader = await deployRole(
+      simAws,
+      accountId,
+      "reader",
+      "s3:GetObject",
+    );
+
+    // When a Stack declaring a Bucket is deployed as it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "reports-stack",
+        template: reportsBucketTemplate,
+        caller: reader,
+      });
+    });
+
+    // Then the refusal names the Role rather than the Account root.
+    assertStringIncludes(
+      error.message,
+      `arn:aws:iam::${accountId}:role/reader is not authorized to perform: s3:CreateBucket`,
+    );
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName("reports-stack")
+        ?.getResource("ReportsBucket")?.status,
+      "CREATE_FAILED",
+    );
+  });
+
+  it("tears the Stack down as the principal it was deployed as", async () => {
+    // Given a Stack deployed as a Role, in an organization denying the root.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const deployer = await deployRole(simAws, accountId, "deployer", "*");
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.deployTemplate({
+      stackName: "reports-stack",
+      template: reportsBucketTemplate,
+      caller: deployer,
+    });
+
+    // When the Stack is deleted.
+    await cloudFormation.deleteStack(
+      { input: { StackName: "reports-stack" } },
+      { caller: deployer },
+    );
+    await cloudFormation.waitForStackDeleteComplete("reports-stack");
+
+    // Then the teardown ran as that Role too, so the Bucket has gone.
+    assertUndefined(simAws.s3().getSimBucketByName("reports-bucket"));
+  });
+
+  it("applies a template file update as the principal the deployment named", async () => {
+    // Given a Stack deployed from a template file as a Role, in an
+    // organization denying the root.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const deployer = await deployRole(simAws, accountId, "deployer", "s3:*");
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    const directory = new TemporaryDirectory();
+
+    await directory.writeFile(
+      "Site.template.json",
+      jsonStringify({ Resources: { Site: bucketResource("site-content") } }),
+    );
+
+    const templatePath = directory.join("Site.template.json");
+
+    await simAws
+      .cloudFormation()
+      .deployTemplateFile({ templatePath, caller: deployer });
+
+    // When the file is synthesized again with another Bucket in it, and
+    // applied without naming a principal of its own.
+    await directory.writeFile(
+      "Site.template.json",
+      jsonStringify({
+        Resources: {
+          Site: bucketResource("site-content"),
+          Uploads: bucketResource("site-uploads"),
+        },
+      }),
+    );
+
+    await simAws.cloudFormation().updateTemplateFile(templatePath);
+
+    // Then the update ran as the Role the Stack was deployed as, rather than
+    // falling back to the root the policy denies.
+    assertNonNullable(simAws.s3().getSimBucketByName("site-uploads"));
+  });
+
+  it("deploys every Stack in a cloud assembly as the caller it is given", async () => {
+    // Given an assembly of one Stack, and a Role that may not make Buckets.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({
+      defaultAccountId: accountId,
+      defaultRegionName: "eu-west-2",
+    });
+    const reader = await deployRole(
+      simAws,
+      accountId,
+      "reader",
+      "s3:GetObject",
+    );
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [{ artifactId: "SiteStack", regionName: "eu-west-2" }],
+    });
+
+    // When the assembly is deployed as it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployCdkOut({
+        directoryPath: directory.join("cdk.out"),
+        caller: reader,
+      });
+    });
+
+    // Then the Stack was refused as that Role rather than as the Account root.
+    assertStringIncludes(
+      error.message,
+      `arn:aws:iam::${accountId}:role/reader is not authorized to perform: s3:CreateBucket`,
+    );
+  });
+
+  it("lets a Stack's own caller override the assembly's", async () => {
+    // Given the same assembly, a Role that may not make Buckets, and one that
+    // may.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({
+      defaultAccountId: accountId,
+      defaultRegionName: "eu-west-2",
+    });
+    const reader = await deployRole(
+      simAws,
+      accountId,
+      "reader",
+      "s3:GetObject",
+    );
+    const deployer = await deployRole(simAws, accountId, "deployer", "s3:*");
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [{ artifactId: "SiteStack", regionName: "eu-west-2" }],
+    });
+
+    // When the assembly names the first and the Stack names the second.
+    await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      caller: reader,
+      stackOptions: { SiteStack: { caller: deployer } },
+    });
+
+    // Then the Stack deployed, so it ran as the caller keyed against it.
+    assertNonNullable(
+      simAws.s3().getSimBucketByName(assemblyStackBucketName("SiteStack")),
+    );
+  });
+});
+
+function bucketResource(bucketName: string): object {
+  return {
+    Type: "AWS::S3::Bucket",
+    Properties: { BucketName: bucketName },
+  };
+}
+
+/**
+ * A Role a deployment can run as, allowed the actions it is given.
+ */
+async function deployRole(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  roleName: string,
+  action: string,
+): Promise<SimAwsCaller> {
+  const iam = simAws.account(accountId).iam();
+
+  await iam.createRole({
+    input: {
+      RoleName: roleName,
+      AssumeRolePolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "sts:AssumeRole",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+        },
+      }),
+    },
+  });
+
+  await iam.putRolePolicy({
+    input: {
+      RoleName: roleName,
+      PolicyName: `${roleName}-policy`,
+      PolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: { Effect: "Allow", Action: action, Resource: "*" },
+      }),
+    },
+  });
+
+  return { kind: "arn", arn: `arn:aws:iam::${accountId}:role/${roleName}` };
+}

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -23,6 +23,7 @@ import { simCfnTemplateFileDeployment } from "./sim-cfn-template-file-deployment
 import { SimCfnTemplateFileWatches } from "../watch/sim-cfn-template-file-watches.js";
 import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type {
   BackgroundCompleter,
@@ -38,6 +39,16 @@ export interface SimCloudFormationCreateStackProperties {
   readonly template: CfnTemplateBodyRecord;
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+
+  /**
+   * The principal the deployment runs as.
+   *
+   * Every Resource is created, updated and deleted through the command an SDK
+   * caller would reach, and this is who those commands are authorized as. Left
+   * out, they are decided as the Account root, which is what a service control
+   * policy denying an Account's root principal then denies.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 
   /**
    * The synthesized CDK template file this in-memory template stands in for.
@@ -114,6 +125,7 @@ export class SimCloudFormationTemplateDeployer {
       template: properties.template,
       parameters: properties.parameters,
       bindings: properties.bindings,
+      caller: properties.caller,
       cdkOutContext: await cdkOutContextForTemplatePath(
         properties.templatePath,
       ),
@@ -181,6 +193,7 @@ export class SimCloudFormationTemplateDeployer {
     readonly template: CfnTemplateBodyRecord;
     readonly parameters?: Record<string, string> | undefined;
     readonly bindings?: readonly SimCfnBinding[] | undefined;
+    readonly caller?: SimAwsCaller | undefined;
     readonly cdkOutContext?: SimCdkOutContext | undefined;
   }): Promise<SimCfnDeployedStack> {
     await this.createStackWithContext(
@@ -198,6 +211,7 @@ export class SimCloudFormationTemplateDeployer {
       },
       properties.cdkOutContext,
       properties.bindings,
+      properties.caller,
     );
 
     const stack = this.stacks.get(
@@ -226,6 +240,7 @@ export class SimCloudFormationTemplateDeployer {
     },
     cdkOutContext?: SimCdkOutContext,
     bindings?: readonly SimCfnBinding[],
+    caller?: SimAwsCaller,
   ): Promise<SimCreateStackCommandOutput> {
     const handler = new CreateStackCommandHandler({
       simAws: this.simAws,
@@ -234,6 +249,7 @@ export class SimCloudFormationTemplateDeployer {
       background: this.background,
       cdkOutContext,
       bindings,
+      caller,
       exports: this.exports,
     });
 

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -6,6 +6,7 @@ import {
   type SimCdkOutContext,
 } from "../cdk/sim-cdk-out-context.js";
 import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import { simWatch } from "../../../watch/sim-watch-runtime.js";
 import type { SimCfnTemplateFileWatchOptions } from "../watch/sim-cfn-template-watch.type.js";
 import { simCfnTemplateFileDeployment } from "./sim-cfn-template-file-deployment.js";
@@ -21,6 +22,16 @@ export interface SimCloudFormationDeployTemplateFileProperties {
   readonly stackName?: SimCloudFormationStackName | string | undefined;
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+
+  /**
+   * The principal the deployment runs as.
+   *
+   * Every Resource is created, updated and deleted through the command an SDK
+   * caller would reach, and this is who those commands are authorized as. Left
+   * out, they are decided as the Account root, which is what a service control
+   * policy denying an Account's root principal then denies.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 
   /**
    * Adapt the parsed template before it is deployed, and again every time a
@@ -57,6 +68,7 @@ export interface SimCfnLoadedTemplateFile {
   readonly template: CfnTemplateBodyRecord;
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+  readonly caller?: SimAwsCaller | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
 }
 
@@ -73,7 +85,7 @@ export class SimCfnTemplateFileLoader {
     properties: SimCloudFormationDeployTemplateFileProperties | string,
   ): Promise<SimCfnLoadedTemplateFile> {
     const deployment = simCfnTemplateFileDeployment(properties);
-    const { templatePath, parameters, bindings } = deployment;
+    const { templatePath, parameters, bindings, caller } = deployment;
     const stackName =
       deployment.stackName ?? stackNameFromTemplatePath(templatePath);
 
@@ -95,6 +107,7 @@ export class SimCfnTemplateFileLoader {
       template,
       parameters,
       bindings,
+      caller,
       cdkOutContext,
     };
   }

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-updater.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-updater.ts
@@ -80,6 +80,7 @@ export class SimCfnTemplateFileUpdater implements SimCfnTemplateFileUpdating {
       stacks: this.stacks,
       background: this.background,
       cdkOutContext: loaded.cdkOutContext,
+      caller: loaded.caller,
     });
 
     await handler.handle({

--- a/src/service/cloudformation/resource/caller/sim-cfn-resource-caller-options.ts
+++ b/src/service/cloudformation/resource/caller/sim-cfn-resource-caller-options.ts
@@ -1,0 +1,22 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+
+/**
+ * The request options a Resource operation makes its service calls with.
+ *
+ * Every simulated service takes a caller the same way, so one shape carries the
+ * deployment's principal from the Stack down to the commands that create and
+ * delete Resources. Absent where the deployment named no caller, which leaves
+ * each service to its own default of the Account root.
+ */
+export type SimCfnResourceCallerOptions =
+  | { readonly caller: SimAwsCaller }
+  | undefined;
+
+/**
+ * The request options naming a deployment's caller, or none where it has none.
+ */
+export function simCfnResourceCallerOptions(
+  caller: SimAwsCaller | undefined,
+): SimCfnResourceCallerOptions {
+  return caller === undefined ? undefined : { caller };
+}

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -1,4 +1,5 @@
 import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimCfnServiceResourceFactory } from "./factory/sim-cfn-resource-factory.type.js";
@@ -63,6 +64,16 @@ export interface SimCloudFormationResourceCreateContext {
   readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+
+  /**
+   * The principal the deployment runs as, which every service command creating
+   * a Resource is authorized as.
+   *
+   * Left out unless the deployment named one, which leaves each service to its
+   * own omitted-caller default: the Account root, as it is everywhere else in
+   * the simulation.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -78,4 +89,7 @@ export interface SimCloudFormationResourceDeleteContext {
   readonly simAws: SimAws;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly resolvedProperties?: SimCfnTemplateValueRecord | undefined;
+
+  /** The principal the teardown runs as, as creation carries it. */
+  readonly caller?: SimAwsCaller | undefined;
 }

--- a/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-batch-creator.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-batch-creator.ts
@@ -1,4 +1,5 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
@@ -8,6 +9,7 @@ interface SimCfnStackResourceBatchCreatorProperties {
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -29,14 +31,16 @@ export class SimCfnStackResourceBatchCreator {
   private readonly resources: ReadonlyMap<string, SimCfnResource>;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
   private readonly bindings: readonly SimCfnBinding[] | undefined;
+  private readonly caller: SimAwsCaller | undefined;
 
   constructor(properties: SimCfnStackResourceBatchCreatorProperties) {
-    const { simAws, resources, cdkOutContext, bindings } = properties;
+    const { simAws, resources, cdkOutContext, bindings, caller } = properties;
 
     this.simAws = simAws;
     this.resources = resources;
     this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
+    this.caller = caller;
   }
 
   /**
@@ -53,6 +57,7 @@ export class SimCfnStackResourceBatchCreator {
           resources: this.resources,
           cdkOutContext: this.cdkOutContext,
           bindings: this.bindings,
+          caller: this.caller,
         });
       }),
     );

--- a/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-creator.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-creator.ts
@@ -1,4 +1,5 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
@@ -11,6 +12,7 @@ interface SimCfnStackResourceCreatorProperties {
   readonly stackName: string;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -35,7 +37,7 @@ export class SimCfnStackResourceCreator {
   private readonly batchCreator: SimCfnStackResourceBatchCreator;
 
   constructor(properties: SimCfnStackResourceCreatorProperties) {
-    const { simAws, resources, stackName, cdkOutContext, bindings } =
+    const { simAws, resources, stackName, cdkOutContext, bindings, caller } =
       properties;
 
     this.resources = resources;
@@ -45,6 +47,7 @@ export class SimCfnStackResourceCreator {
       resources,
       cdkOutContext,
       bindings,
+      caller,
     });
   }
 

--- a/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
@@ -1,5 +1,6 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
@@ -24,6 +25,12 @@ interface SimCfnStackResourceOperationsProperties {
   readonly stackName: SimCloudFormationStackName;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+
+  /**
+   * The principal the Stack's Resource work is authorized as. An omitted
+   * caller leaves each service to decide the request as the Account root.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -45,28 +52,45 @@ export class SimCfnStackResourceOperations {
   private readonly stackName: SimCloudFormationStackName;
   private readonly bindings: readonly SimCfnBinding[] | undefined;
   private cdkOutContext: SimCdkOutContext | undefined;
+  private caller: SimAwsCaller | undefined;
 
   constructor(properties: SimCfnStackResourceOperationsProperties) {
-    const { simAws, accountRegionScope, stackName, cdkOutContext, bindings } =
-      properties;
+    const {
+      simAws,
+      accountRegionScope,
+      stackName,
+      cdkOutContext,
+      bindings,
+      caller,
+    } = properties;
 
     this.simAws = simAws;
     this.accountRegionScope = accountRegionScope;
     this.stackName = stackName;
     this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
+    this.caller = caller;
   }
 
   /**
-   * Read Resources from a different CDK cloud assembly from now on.
+   * Take on what an update brings with it, for this and every later operation.
    *
    * A synthesis writes the template and the assets manifest beside it together,
    * so a Stack updated from a re-synthesized template needs the manifest that
    * came with it. Keeping the one the Stack was deployed from would look up the
    * asset a replaced Resource names in a manifest written before it existed.
+   *
+   * An update naming a caller runs as that one, and the Stack is torn down as
+   * it afterwards. An update that names none keeps the deployment's caller, so
+   * a Stack updated from a plain template path goes on running as whoever
+   * deployed it.
    */
-  useCdkOutContext(cdkOutContext: SimCdkOutContext): void {
-    this.cdkOutContext = cdkOutContext;
+  useUpdate(properties: {
+    readonly cdkOutContext?: SimCdkOutContext | undefined;
+    readonly caller?: SimAwsCaller | undefined;
+  }): void {
+    this.cdkOutContext = properties.cdkOutContext ?? this.cdkOutContext;
+    this.caller = properties.caller ?? this.caller;
   }
 
   /**
@@ -132,6 +156,7 @@ export class SimCfnStackResourceOperations {
       accountRegionScope: this.accountRegionScope,
       stackName: this.stackName,
       cdkOutContext: this.cdkOutContext,
+      caller: this.caller,
     }).publish();
   }
 
@@ -144,6 +169,7 @@ export class SimCfnStackResourceOperations {
       stackName: this.stackName,
       cdkOutContext: this.cdkOutContext,
       bindings: this.bindings,
+      caller: this.caller,
     });
   }
 
@@ -154,6 +180,7 @@ export class SimCfnStackResourceOperations {
       simAws: this.simAws,
       resources,
       stackName: this.stackName,
+      caller: this.caller,
     });
   }
 }

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -67,6 +67,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
       template,
       cdkOutContext,
       bindings,
+      caller,
       exports,
     } = properties;
 
@@ -91,6 +92,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
       stackName,
       cdkOutContext,
       bindings,
+      caller,
     });
     this.lifecycle = new SimCfnStackDeploymentLifecycle({
       background,
@@ -170,10 +172,9 @@ export class SimCfnStack implements SimCfnDeployedStack {
     updater.assertHasChanges();
 
     // Only once the update is going ahead, so a refused update leaves the Stack
-    // reading the cloud assembly it was deployed from.
-    if (properties.cdkOutContext !== undefined) {
-      this.operations.useCdkOutContext(properties.cdkOutContext);
-    }
+    // reading the cloud assembly it was deployed from and running as whoever
+    // deployed it.
+    this.operations.useUpdate(properties);
 
     this.cfnTemplate = template;
     this.template = template.template;

--- a/src/service/cloudformation/stack/sim-cfn-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.type.ts
@@ -1,4 +1,5 @@
 import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { Brand } from "../../../util/brand.type.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
@@ -32,6 +33,12 @@ export interface SimCfnStackUpdateProperties {
    * describes the assembly the previous template came from.
    */
   readonly cdkOutContext?: SimCdkOutContext | undefined;
+
+  /**
+   * The principal to apply the new template as, for an update that names one.
+   * The Stack goes on using it, as it does the cloud assembly.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 export interface SimCloudFormationStackProperties {
@@ -42,6 +49,13 @@ export interface SimCloudFormationStackProperties {
   readonly template: SimCfnTemplate;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
+
+  /**
+   * The principal this Stack's Resources are created, updated and deleted as.
+   * An omitted caller is the Account root, as it is everywhere else in the
+   * simulation.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 
   /**
    * The export names published in the Account and Region this Stack deploys

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-batch-deleter.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-batch-deleter.ts
@@ -1,9 +1,11 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 
 interface SimCfnStackResourceBatchDeleterProperties {
   readonly simAws: SimAws;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -19,10 +21,12 @@ interface SimCfnStackResourceBatchDeleterProperties {
 export class SimCfnStackResourceBatchDeleter {
   private readonly simAws: SimAws;
   private readonly resources: ReadonlyMap<string, SimCfnResource>;
+  private readonly caller: SimAwsCaller | undefined;
 
   constructor(properties: SimCfnStackResourceBatchDeleterProperties) {
     this.simAws = properties.simAws;
     this.resources = properties.resources;
+    this.caller = properties.caller;
   }
 
   /**
@@ -36,6 +40,7 @@ export class SimCfnStackResourceBatchDeleter {
         await resource.delete({
           simAws: this.simAws,
           resources: this.resources,
+          caller: this.caller,
         });
       }),
     );

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-deleter.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-deleter.ts
@@ -1,4 +1,5 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
 import { SimCfnStackPendingDeletions } from "./sim-cfn-stack-pending-deletions.js";
 import { SimCfnStackResourceBatchDeleter } from "./sim-cfn-stack-resource-batch-deleter.js";
@@ -7,6 +8,7 @@ interface SimCfnStackResourceDeleterProperties {
   readonly simAws: SimAws;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly stackName: string;
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -30,13 +32,14 @@ export class SimCfnStackResourceDeleter {
   private readonly batchDeleter: SimCfnStackResourceBatchDeleter;
 
   constructor(properties: SimCfnStackResourceDeleterProperties) {
-    const { simAws, resources, stackName } = properties;
+    const { simAws, resources, stackName, caller } = properties;
 
     this.resources = resources;
     this.stackName = stackName;
     this.batchDeleter = new SimCfnStackResourceBatchDeleter({
       simAws,
       resources,
+      caller,
     });
   }
 

--- a/src/service/cloudfront/cfn/cff/sim-cfn-cff-creator.ts
+++ b/src/service/cloudfront/cfn/cff/sim-cfn-cff-creator.ts
@@ -10,6 +10,10 @@ import type {
   SimCloudFrontFunctionName,
 } from "../../cff/sim-cloudfront-function.js";
 import { SimCfnCffCreateInputBuilder } from "./sim-cfn-cff-create-input-builder.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCfFunctionCreatorProperties {
   readonly cloudFront: SimCloudFront;
@@ -58,9 +62,10 @@ export class SimCfnCffCreator {
     });
     const functionInput = inputBuilder.build();
 
-    const output = await this.cloudFront.createFunction({
-      input: functionInput,
-    });
+    const output = await this.cloudFront.createFunction(
+      { input: functionInput },
+      simCfnResourceCallerOptions(context?.caller),
+    );
 
     const createdFunctionName = output.FunctionSummary
       .Name as SimCloudFrontFunctionName;
@@ -73,5 +78,26 @@ export class SimCfnCffCreator {
     );
 
     return cloudFrontFunction;
+  }
+
+  /**
+   * Delete the Function an AWS::CloudFront::Function Resource created.
+   */
+  async delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    const cloudFrontFunction = resource.simResource as
+      | SimCloudFrontFunction
+      | undefined;
+    assertDefined(
+      cloudFrontFunction,
+      `sim CloudFront Function for CloudFormation Resource ${resource.logicalId}`,
+    );
+
+    await this.cloudFront.deleteFunction(
+      { input: { Name: cloudFrontFunction.name } },
+      options,
+    );
   }
 }

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
@@ -15,6 +15,7 @@ import { simCfnCfDistroWithRunnableEdgeAssociations } from "./sim-cfn-cf-distro-
 import { simCfnCfDistroWithHeldResponseHeadersPolicies } from "./sim-cfn-cf-distro-response-headers-policy.js";
 import { simCfnCfDistroWithoutAbsentWebAcl } from "./sim-cfn-cf-distro-web-acl.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
+import { simCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCfDistroCreatorProperties {
   readonly cloudFront: SimCloudFront;
@@ -62,16 +63,19 @@ export class SimCfnCfDistroCreator {
       logicalId: resource.logicalId,
       distributionConfig: distributionConfigValue,
     });
-    const output = await this.cloudFront.createDistribution({
-      input: {
-        DistributionConfig: deployableConfig(
-          resource,
-          validator.validate(),
-          context.simAws,
-          this.cloudFront,
-        ),
+    const output = await this.cloudFront.createDistribution(
+      {
+        input: {
+          DistributionConfig: deployableConfig(
+            resource,
+            validator.validate(),
+            context.simAws,
+            this.cloudFront,
+          ),
+        },
       },
-    });
+      simCfnResourceCallerOptions(context.caller),
+    );
 
     const distributionId = output.Distribution?.Id;
     assertDefined(

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-deleter.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-deleter.ts
@@ -2,6 +2,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCloudFront } from "../../sim-cloudfront.js";
 import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCfDistroDeleterProperties {
   readonly cloudFront: SimCloudFront;
@@ -30,7 +31,10 @@ export class SimCfnCfDistroDeleter {
   /**
    * Disable and then delete the Distribution a Resource created.
    */
-  async delete(resource: SimCfnResource): Promise<void> {
+  async delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const distribution = resource.simResource as
       | SimCloudFrontDistribution
       | undefined;
@@ -39,15 +43,17 @@ export class SimCfnCfDistroDeleter {
       `sim CloudFront Distribution for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.disable(distribution);
+    await this.disable(distribution, options);
 
-    await this.cloudFront.deleteDistribution({
-      input: { Id: distribution.distributionId },
-    });
+    await this.cloudFront.deleteDistribution(
+      { input: { Id: distribution.distributionId } },
+      options,
+    );
   }
 
   private async disable(
     distribution: SimCloudFrontDistribution,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const { distributionConfig } = distribution;
     assertDefined(
@@ -55,11 +61,14 @@ export class SimCfnCfDistroDeleter {
       `sim CloudFront Distribution ${distribution.distributionId} configuration to disable`,
     );
 
-    await this.cloudFront.updateDistribution({
-      input: {
-        Id: distribution.distributionId,
-        DistributionConfig: { ...distributionConfig, Enabled: false },
+    await this.cloudFront.updateDistribution(
+      {
+        input: {
+          Id: distribution.distributionId,
+          DistributionConfig: { ...distributionConfig, Enabled: false },
+        },
       },
-    });
+      options,
+    );
   }
 }

--- a/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs-creator.ts
+++ b/src/service/cloudfront/cfn/key-value-store/sim-cfn-cf-kvs-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCloudFrontKeyValueStore } from "../../key-value-store/sim-cf-key-value-store.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
 import { SimCfnCfKeyValueStoreConfigReader } from "./sim-cfn-cf-kvs-config.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCfKeyValueStoreCreatorProperties {
   readonly cloudFront: SimCloudFront;
@@ -30,18 +31,22 @@ export class SimCfnCfKeyValueStoreCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimCloudFrontKeyValueStore> {
     const config = new SimCfnCfKeyValueStoreConfigReader({
       resource,
       properties,
     }).read();
 
-    const created = await this.cloudFront.keyValueStores().createKeyValueStore({
-      input: {
-        Name: config.name,
-        ...(config.comment !== undefined && { Comment: config.comment }),
+    const created = await this.cloudFront.keyValueStores().createKeyValueStore(
+      {
+        input: {
+          Name: config.name,
+          ...(config.comment !== undefined && { Comment: config.comment }),
+        },
       },
-    });
+      options,
+    );
 
     const store = this.cloudFront
       .keyValueStores()
@@ -63,7 +68,10 @@ export class SimCfnCfKeyValueStoreCreator {
    * anything written to it since will have moved the one creation returned.
    * Tearing a Stack down is not the place to make a caller thread that through.
    */
-  async delete(resource: SimCfnResource): Promise<void> {
+  async delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const store = resource.simResource as
       | SimCloudFrontKeyValueStore
       | undefined;
@@ -72,8 +80,11 @@ export class SimCfnCfKeyValueStoreCreator {
       return;
     }
 
-    await this.cloudFront.keyValueStores().deleteKeyValueStore({
-      input: { Name: store.name, IfMatch: store.resourceETag },
-    });
+    await this.cloudFront
+      .keyValueStores()
+      .deleteKeyValueStore(
+        { input: { Name: store.name, IfMatch: store.resourceETag } },
+        options,
+      );
   }
 }

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.iso.test.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.iso.test.ts
@@ -195,7 +195,7 @@ describe("SimCloudFrontCloudFormationResourceFactory", () => {
 
     // And when the Resource is deleted, sim CloudFront forgets it.
     resource.markCreateComplete(policy);
-    await factory.delete("ResponseHeadersPolicy", resource);
+    await factory.delete("ResponseHeadersPolicy", resource, {} as never);
 
     assertUndefined(cloudFront.getResponseHeadersPolicyById(policy.id));
   });
@@ -212,6 +212,7 @@ describe("SimCloudFrontCloudFormationResourceFactory", () => {
     await factory.delete(
       "ResponseHeadersPolicy",
       new SimCfnResource({ logicalId: "CacheHeaders" }),
+      {} as never,
     );
   });
 

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
@@ -3,21 +3,20 @@ import type { SimCloudFront } from "../sim-cloudfront.js";
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import { SimCfnCfDistroCreator } from "./distro/sim-cfn-cf-distro-creator.js";
 import { SimCfnCffCreator } from "./cff/sim-cfn-cff-creator.js";
 import { SimCfnCfDistroDeleter } from "./distro/sim-cfn-cf-distro-deleter.js";
 import { SimCfnCfResponseHeadersPolicyCreator } from "./response-headers-policy/sim-cfn-cf-rh-policy-creator.js";
 import { SimCfnCfOriginAccessControlCreator } from "./origin-access-control/sim-cfn-cf-oac-creator.js";
 import { SimCfnCfKeyValueStoreCreator } from "./key-value-store/sim-cfn-cf-kvs-creator.js";
-import type { SimCloudFrontFunction } from "../cff/sim-cloudfront-function.js";
-import { assertDefined } from "../../../util/type-guard/defined.js";
 
 /**
  * CloudFormation Resource factory for simulated CloudFront resources.
  */
 export class SimCloudFrontCloudFormationResourceFactory implements SimCfnServiceResourceFactory {
-  private readonly cloudFront: SimCloudFront;
   private readonly distroCreator: SimCfnCfDistroCreator;
   private readonly functionCreator: SimCfnCffCreator;
   private readonly distroDeleter: SimCfnCfDistroDeleter;
@@ -26,7 +25,6 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
   private readonly keyValueStoreCreator: SimCfnCfKeyValueStoreCreator;
 
   constructor(cloudFront: SimCloudFront) {
-    this.cloudFront = cloudFront;
     this.distroCreator = new SimCfnCfDistroCreator({ cloudFront });
     this.functionCreator = new SimCfnCffCreator({ cloudFront });
     this.distroDeleter = new SimCfnCfDistroDeleter({ cloudFront });
@@ -64,7 +62,11 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
         return this.originAccessControlCreator.create(resource, properties);
       }
       case "KeyValueStore": {
-        return await this.keyValueStoreCreator.create(resource, properties);
+        return await this.keyValueStoreCreator.create(
+          resource,
+          properties,
+          simCfnResourceCallerOptions(context.caller),
+        );
       }
       default: {
         throw new Error(
@@ -81,14 +83,17 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "Distribution": {
-        await this.distroDeleter.delete(resource);
+        await this.distroDeleter.delete(resource, options);
         return;
       }
       case "Function": {
-        await this.deleteFunction(resource);
+        await this.functionCreator.delete(resource, options);
         return;
       }
       case "ResponseHeadersPolicy": {
@@ -100,7 +105,7 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
         return;
       }
       case "KeyValueStore": {
-        await this.keyValueStoreCreator.delete(resource);
+        await this.keyValueStoreCreator.delete(resource, options);
         return;
       }
       default: {
@@ -109,19 +114,5 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
         );
       }
     }
-  }
-
-  private async deleteFunction(resource: SimCfnResource): Promise<void> {
-    const cloudFrontFunction = resource.simResource as
-      | SimCloudFrontFunction
-      | undefined;
-    assertDefined(
-      cloudFrontFunction,
-      `sim CloudFront Function for CloudFormation Resource ${resource.logicalId}`,
-    );
-
-    await this.cloudFront.deleteFunction({
-      input: { Name: cloudFrontFunction.name },
-    });
   }
 }

--- a/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-creator.ts
+++ b/src/service/cloudwatch/cfn/alarm/sim-cfn-alarm-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCloudWatchAlarm } from "../../alarm/sim-cloudwatch-alarm.js";
 import type { SimCloudWatch } from "../../sim-cloudwatch.js";
 import { SimCfnAlarmProperties } from "./sim-cfn-alarm-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnAlarmCreatorProperties {
   readonly cloudWatch: SimCloudWatch;
@@ -30,13 +31,17 @@ export class SimCfnAlarmCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimCloudWatchAlarm> {
     const alarmProperties = new SimCfnAlarmProperties({ resource, properties });
     const alarmName = alarmProperties.alarmName();
 
     alarmProperties.recordIgnoredProperties();
 
-    await this.#cloudWatch.putMetricAlarm({ input: alarmProperties.input() });
+    await this.#cloudWatch.putMetricAlarm(
+      { input: alarmProperties.input() },
+      options,
+    );
 
     const alarm = this.#cloudWatch.findAlarm(alarmName);
 
@@ -55,9 +60,13 @@ export class SimCfnAlarmCreator {
    * removing it, which is what lets a torn-down stack settle rather than
    * leaving an alarm waking up to read a metric nothing watches.
    */
-  async delete(alarm: SimCloudWatchAlarm): Promise<void> {
-    await this.#cloudWatch.deleteAlarms({
-      input: { AlarmNames: [alarm.name] },
-    });
+  async delete(
+    alarm: SimCloudWatchAlarm,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#cloudWatch.deleteAlarms(
+      { input: { AlarmNames: [alarm.name] } },
+      options,
+    );
   }
 }

--- a/src/service/cloudwatch/cfn/sim-cfn-alarm.iso.test.ts
+++ b/src/service/cloudwatch/cfn/sim-cfn-alarm.iso.test.ts
@@ -333,7 +333,7 @@ describe("AWS::CloudWatch::Alarm", () => {
       factory.create("Dashboard", {} as never, {} as never),
     );
     const deleted = await assertThrowsErrorAsync(async () =>
-      factory.delete("Dashboard", {} as never),
+      factory.delete("Dashboard", {} as never, {} as never),
     );
 
     // Then both are reported as unsupported, which the Stack records as a skip

--- a/src/service/cloudwatch/cfn/sim-cloudwatch-cfn-resource-factory.ts
+++ b/src/service/cloudwatch/cfn/sim-cloudwatch-cfn-resource-factory.ts
@@ -3,7 +3,9 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCloudWatchAlarm } from "../alarm/sim-cloudwatch-alarm.js";
 import type { SimCloudWatch } from "../sim-cloudwatch.js";
 import { SimCfnAlarmCreator } from "./alarm/sim-cfn-alarm-creator.js";
@@ -44,6 +46,7 @@ export class SimCloudWatchCfnResourceFactory implements SimCfnServiceResourceFac
     return this.#alarmCreator.create(
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 
@@ -51,7 +54,11 @@ export class SimCloudWatchCfnResourceFactory implements SimCfnServiceResourceFac
    * Delete a simulated CloudWatch resource created from a CloudFormation
    * Resource.
    */
-  delete(resourceTypeName: string, resource: SimCfnResource): Promise<void> {
+  delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
     requireAlarmResourceType(resourceTypeName, " deletion");
 
     const alarm = resource.simResource as SimCloudWatchAlarm | undefined;
@@ -61,7 +68,10 @@ export class SimCloudWatchCfnResourceFactory implements SimCfnServiceResourceFac
       `sim CloudWatch alarm for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    return this.#alarmCreator.delete(alarm);
+    return this.#alarmCreator.delete(
+      alarm,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }
 

--- a/src/service/cognito/cfn/client/sim-cfn-cognito-client-creator.ts
+++ b/src/service/cognito/cfn/client/sim-cfn-cognito-client-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import { SimCfnCognitoClientProperties } from "./sim-cfn-cognito-client-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCognitoClientCreatorProperties {
   readonly cognito: SimCognitoIdentityProvider;
@@ -30,15 +31,17 @@ export class SimCfnCognitoClientCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimCognitoUserPoolClient> {
     const clientProperties = new SimCfnCognitoClientProperties({
       resource,
       properties,
     });
 
-    const created = await this.cognito.createUserPoolClient({
-      input: clientProperties.createUserPoolClientInput(),
-    });
+    const created = await this.cognito.createUserPoolClient(
+      { input: clientProperties.createUserPoolClientInput() },
+      options,
+    );
 
     const clientId = created.UserPoolClient?.ClientId;
     assertDefined(

--- a/src/service/cognito/cfn/domain/sim-cfn-cognito-domain-creator.ts
+++ b/src/service/cognito/cfn/domain/sim-cfn-cognito-domain-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 import type { SimCognitoUserPoolDomain } from "../../user-pool/domain/sim-cognito-user-pool-domain.js";
 import { SimCfnCognitoDomainProperties } from "./sim-cfn-cognito-domain-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCognitoDomainCreatorProperties {
   readonly cognito: SimCognitoIdentityProvider;
@@ -31,15 +32,17 @@ export class SimCfnCognitoDomainCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimCognitoUserPoolDomain> {
     const domainProperties = new SimCfnCognitoDomainProperties({
       resource,
       properties,
     });
 
-    await this.cognito.createUserPoolDomain({
-      input: domainProperties.createUserPoolDomainInput(),
-    });
+    await this.cognito.createUserPoolDomain(
+      { input: domainProperties.createUserPoolDomainInput() },
+      options,
+    );
 
     const domain = this.cognito.findUserPoolDomainInAnyAccount(
       domainProperties.domain(),

--- a/src/service/cognito/cfn/group/sim-cfn-cognito-group-creator.ts
+++ b/src/service/cognito/cfn/group/sim-cfn-cognito-group-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 import type { SimCognitoGroup } from "../../user-pool/group/sim-cognito-group.js";
 import { SimCfnCognitoGroupProperties } from "./sim-cfn-cognito-group-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCognitoGroupCreatorProperties {
   readonly cognito: SimCognitoIdentityProvider;
@@ -29,6 +30,7 @@ export class SimCfnCognitoGroupCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimCognitoGroup> {
     const groupProperties = new SimCfnCognitoGroupProperties({
       resource,
@@ -36,9 +38,10 @@ export class SimCfnCognitoGroupCreator {
     });
     const groupName = groupProperties.groupName();
 
-    await this.cognito.createGroup({
-      input: groupProperties.createGroupInput(),
-    });
+    await this.cognito.createGroup(
+      { input: groupProperties.createGroupInput() },
+      options,
+    );
 
     const group = this.cognito
       .userPool(groupProperties.userPoolId())

--- a/src/service/cognito/cfn/idp/sim-cfn-cognito-idp-creator.ts
+++ b/src/service/cognito/cfn/idp/sim-cfn-cognito-idp-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 import type { SimCognitoUserPoolIdentityProvider } from "../../user-pool/idp/sim-cognito-user-pool-identity-provider.js";
 import { SimCfnCognitoIdpProperties } from "./sim-cfn-cognito-idp-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCognitoIdpCreatorProperties {
   readonly cognito: SimCognitoIdentityProvider;
@@ -31,6 +32,7 @@ export class SimCfnCognitoIdpCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimCognitoUserPoolIdentityProvider> {
     const providerProperties = new SimCfnCognitoIdpProperties({
       resource,
@@ -38,9 +40,10 @@ export class SimCfnCognitoIdpCreator {
     });
     const providerName = providerProperties.providerName();
 
-    await this.cognito.createIdentityProvider({
-      input: providerProperties.createIdentityProviderInput(),
-    });
+    await this.cognito.createIdentityProvider(
+      { input: providerProperties.createIdentityProviderInput() },
+      options,
+    );
 
     const provider = this.cognito
       .userPool(providerProperties.userPoolId())

--- a/src/service/cognito/cfn/sim-cfn-cognito-resource-deleter.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-resource-deleter.ts
@@ -6,6 +6,7 @@ import type { SimCognitoGroup } from "../user-pool/group/sim-cognito-group.js";
 import type { SimCognitoUserPoolDomain } from "../user-pool/domain/sim-cognito-user-pool-domain.js";
 import type { SimCognitoUserPoolIdentityProvider } from "../user-pool/idp/sim-cognito-user-pool-identity-provider.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCognitoResourceDeleterProperties {
   readonly cognito: SimCognitoIdentityProvider;
@@ -68,9 +69,10 @@ export class SimCfnCognitoResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const deletion =
-      this.deletions().get(resourceTypeName) ??
+      this.deletions(options).get(resourceTypeName) ??
       SimCfnCognitoResourceDeleter.unsupported(resourceTypeName);
 
     await deletion(resource);
@@ -79,58 +81,62 @@ export class SimCfnCognitoResourceDeleter {
   /**
    * What deletes each Resource type this service deploys.
    */
-  private deletions(): ReadonlyMap<
-    string,
-    (resource: SimCfnResource) => Promise<void>
-  > {
+  private deletions(
+    options: SimCfnResourceCallerOptions,
+  ): ReadonlyMap<string, (resource: SimCfnResource) => Promise<void>> {
     return new Map([
       [
         "UserPool",
         async (resource: SimCfnResource) => {
-          await this.deleteUserPool(resource);
+          await this.deleteUserPool(resource, options);
         },
       ],
       [
         "UserPoolClient",
         async (resource: SimCfnResource) => {
-          await this.deleteClient(resource);
+          await this.deleteClient(resource, options);
         },
       ],
       [
         "UserPoolGroup",
         async (resource: SimCfnResource) => {
-          await this.deleteGroup(resource);
+          await this.deleteGroup(resource, options);
         },
       ],
       [
         "UserPoolDomain",
         async (resource: SimCfnResource) => {
-          await this.deleteDomain(resource);
+          await this.deleteDomain(resource, options);
         },
       ],
       [
         "UserPoolIdentityProvider",
         async (resource: SimCfnResource) => {
-          await this.deleteIdentityProvider(resource);
+          await this.deleteIdentityProvider(resource, options);
         },
       ],
     ]);
   }
 
-  private async deleteDomain(resource: SimCfnResource): Promise<void> {
+  private async deleteDomain(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const domain =
       SimCfnCognitoResourceDeleter.created<SimCognitoUserPoolDomain>(
         resource,
         "domain",
       );
 
-    await this.cognito.deleteUserPoolDomain({
-      input: { UserPoolId: domain.userPoolId, Domain: domain.value },
-    });
+    await this.cognito.deleteUserPoolDomain(
+      { input: { UserPoolId: domain.userPoolId, Domain: domain.value } },
+      options,
+    );
   }
 
   private async deleteIdentityProvider(
     resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const provider =
       SimCfnCognitoResourceDeleter.created<SimCognitoUserPoolIdentityProvider>(
@@ -138,43 +144,60 @@ export class SimCfnCognitoResourceDeleter {
         "identity provider",
       );
 
-    await this.cognito.deleteIdentityProvider({
-      input: {
-        UserPoolId: provider.userPoolId,
-        ProviderName: provider.name,
+    await this.cognito.deleteIdentityProvider(
+      {
+        input: {
+          UserPoolId: provider.userPoolId,
+          ProviderName: provider.name,
+        },
       },
-    });
+      options,
+    );
   }
 
-  private async deleteUserPool(resource: SimCfnResource): Promise<void> {
+  private async deleteUserPool(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const userPool = SimCfnCognitoResourceDeleter.created<SimCognitoUserPool>(
       resource,
       "user pool",
     );
 
-    await this.cognito.deleteUserPool({ input: { UserPoolId: userPool.id } });
+    await this.cognito.deleteUserPool(
+      { input: { UserPoolId: userPool.id } },
+      options,
+    );
   }
 
-  private async deleteClient(resource: SimCfnResource): Promise<void> {
+  private async deleteClient(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const client =
       SimCfnCognitoResourceDeleter.created<SimCognitoUserPoolClient>(
         resource,
         "app client",
       );
 
-    await this.cognito.deleteUserPoolClient({
-      input: { UserPoolId: client.userPoolId, ClientId: client.id },
-    });
+    await this.cognito.deleteUserPoolClient(
+      { input: { UserPoolId: client.userPoolId, ClientId: client.id } },
+      options,
+    );
   }
 
-  private async deleteGroup(resource: SimCfnResource): Promise<void> {
+  private async deleteGroup(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const group = SimCfnCognitoResourceDeleter.created<SimCognitoGroup>(
       resource,
       "group",
     );
 
-    await this.cognito.deleteGroup({
-      input: { UserPoolId: group.userPoolId, GroupName: group.name },
-    });
+    await this.cognito.deleteGroup(
+      { input: { UserPoolId: group.userPoolId, GroupName: group.name } },
+      options,
+    );
   }
 }

--- a/src/service/cognito/cfn/sim-cfn-cognito-resource-factory.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-resource-factory.ts
@@ -2,7 +2,9 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCognitoIdentityProvider } from "../sim-cognito-identity-provider.js";
 import { SimCfnCognitoClientCreator } from "./client/sim-cfn-cognito-client-creator.js";
 import { SimCfnCognitoDomainCreator } from "./domain/sim-cfn-cognito-domain-creator.js";
@@ -50,22 +52,23 @@ export class SimCognitoCfnResourceFactory implements SimCfnServiceResourceFactor
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case "UserPool": {
-        return await this.userPoolCreator.create(resource, properties);
+        return await this.userPoolCreator.create(resource, properties, options);
       }
       case "UserPoolClient": {
-        return await this.clientCreator.create(resource, properties);
+        return await this.clientCreator.create(resource, properties, options);
       }
       case "UserPoolGroup": {
-        return await this.groupCreator.create(resource, properties);
+        return await this.groupCreator.create(resource, properties, options);
       }
       case "UserPoolDomain": {
-        return await this.domainCreator.create(resource, properties);
+        return await this.domainCreator.create(resource, properties, options);
       }
       case "UserPoolIdentityProvider": {
-        return await this.idpCreator.create(resource, properties);
+        return await this.idpCreator.create(resource, properties, options);
       }
       default: {
         throw new Error(
@@ -81,7 +84,12 @@ export class SimCognitoCfnResourceFactory implements SimCfnServiceResourceFactor
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.deleter.delete(resourceTypeName, resource);
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-creator.ts
+++ b/src/service/cognito/cfn/user-pool/sim-cfn-cognito-user-pool-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCognitoIdentityProvider } from "../../sim-cognito-identity-provider.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import { SimCfnCognitoUserPoolProperties } from "./sim-cfn-cognito-user-pool-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnCognitoUserPoolCreatorProperties {
   readonly cognito: SimCognitoIdentityProvider;
@@ -31,15 +32,17 @@ export class SimCfnCognitoUserPoolCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimCognitoUserPool> {
     const poolProperties = new SimCfnCognitoUserPoolProperties({
       resource,
       properties,
     });
 
-    const created = await this.cognito.createUserPool({
-      input: poolProperties.createUserPoolInput(),
-    });
+    const created = await this.cognito.createUserPool(
+      { input: poolProperties.createUserPoolInput() },
+      options,
+    );
 
     const userPoolId = created.UserPool?.Id;
     assertDefined(
@@ -47,7 +50,7 @@ export class SimCfnCognitoUserPoolCreator {
       `sim Cognito user pool id after CloudFormation creation for ${resource.logicalId}`,
     );
 
-    await this.setMfaConfig(poolProperties, userPoolId);
+    await this.setMfaConfig(poolProperties, userPoolId, options);
 
     return this.cognito.userPool(userPoolId);
   }
@@ -63,6 +66,7 @@ export class SimCfnCognitoUserPoolCreator {
   private async setMfaConfig(
     poolProperties: SimCfnCognitoUserPoolProperties,
     userPoolId: string,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const input = poolProperties.setUserPoolMfaConfigInput(userPoolId);
 
@@ -70,6 +74,6 @@ export class SimCfnCognitoUserPoolCreator {
       return;
     }
 
-    await this.cognito.setUserPoolMfaConfig({ input });
+    await this.cognito.setUserPoolMfaConfig({ input }, options);
   }
 }

--- a/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-creator.ts
+++ b/src/service/dynamodb/cfn/global-table/sim-cfn-dynamodb-global-table-creator.ts
@@ -3,6 +3,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
 import type { SimCfnDynamoDbTableCreator } from "../table/sim-cfn-dynamodb-table-creator.js";
 import { SimCfnDynamoDbGlobalTableProperties } from "./sim-cfn-dynamodb-global-table-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnDynamoDbGlobalTableCreatorProperties {
   readonly tableCreator: SimCfnDynamoDbTableCreator;
@@ -30,6 +31,7 @@ export class SimCfnDynamoDbGlobalTableCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimDynamoDbTable> {
     const globalTable = new SimCfnDynamoDbGlobalTableProperties({
       resource,
@@ -39,6 +41,7 @@ export class SimCfnDynamoDbGlobalTableCreator {
     return await this.tableCreator.create(
       resource,
       globalTable.tableProperties(),
+      options,
     );
   }
 }

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-deleter.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-deleter.ts
@@ -2,6 +2,7 @@ import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resou
 import type { SimDynamoDb } from "../sim-dynamodb.js";
 import type { SimDynamoDbTable } from "../table/sim-dynamodb-table.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnDynamoDbResourceDeleterProperties {
   readonly dynamoDb: SimDynamoDb;
@@ -28,6 +29,7 @@ export class SimCfnDynamoDbResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (resourceTypeName !== "Table" && resourceTypeName !== "GlobalTable") {
       throw new Error(
@@ -41,8 +43,9 @@ export class SimCfnDynamoDbResourceDeleter {
       `sim DynamoDB table for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.dynamoDb.deleteTable({
-      input: { TableName: table.tableName },
-    });
+    await this.dynamoDb.deleteTable(
+      { input: { TableName: table.tableName } },
+      options,
+    );
   }
 }

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
@@ -2,7 +2,9 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimDynamoDb } from "../sim-dynamodb.js";
 import { SimCfnDynamoDbGlobalTableCreator } from "./global-table/sim-cfn-dynamodb-global-table-creator.js";
 import { SimCfnDynamoDbTableCreator } from "./table/sim-cfn-dynamodb-table-creator.js";
@@ -47,13 +49,18 @@ export class SimDynamoDbCfnResourceFactory implements SimCfnServiceResourceFacto
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case "Table": {
-        return await this.tableCreator.create(resource, properties);
+        return await this.tableCreator.create(resource, properties, options);
       }
       case "GlobalTable": {
-        return await this.globalTableCreator.create(resource, properties);
+        return await this.globalTableCreator.create(
+          resource,
+          properties,
+          options,
+        );
       }
       default: {
         throw new Error(
@@ -69,7 +76,12 @@ export class SimDynamoDbCfnResourceFactory implements SimCfnServiceResourceFacto
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.deleter.delete(resourceTypeName, resource);
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimDynamoDb } from "../../sim-dynamodb.js";
 import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
 import { SimCfnDynamoDbTableProperties } from "./sim-cfn-dynamodb-table-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnDynamoDbTableCreatorProperties {
   readonly dynamoDb: SimDynamoDb;
@@ -31,6 +32,7 @@ export class SimCfnDynamoDbTableCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimDynamoDbTable> {
     const tableProperties = new SimCfnDynamoDbTableProperties({
       resource,
@@ -40,23 +42,27 @@ export class SimCfnDynamoDbTableCreator {
 
     const name = tableProperties.name();
 
-    await this.dynamoDb.createTable({
-      input: {
-        TableName: name,
-        KeySchema: tableProperties.keySchema(),
-        AttributeDefinitions: tableProperties.attributeDefinitions(),
-        BillingMode: tableProperties.billingMode(),
-        ProvisionedThroughput: tableProperties.provisionedThroughput(),
-        GlobalSecondaryIndexes: tableProperties.globalSecondaryIndexes(),
-        LocalSecondaryIndexes: tableProperties.localSecondaryIndexes(),
-        TableClass: tableProperties.tableClass(),
-        DeletionProtectionEnabled: tableProperties.deletionProtectionEnabled(),
-        StreamSpecification: tableProperties.streamSpecification(),
-        Tags: tableProperties.tags(),
+    await this.dynamoDb.createTable(
+      {
+        input: {
+          TableName: name,
+          KeySchema: tableProperties.keySchema(),
+          AttributeDefinitions: tableProperties.attributeDefinitions(),
+          BillingMode: tableProperties.billingMode(),
+          ProvisionedThroughput: tableProperties.provisionedThroughput(),
+          GlobalSecondaryIndexes: tableProperties.globalSecondaryIndexes(),
+          LocalSecondaryIndexes: tableProperties.localSecondaryIndexes(),
+          TableClass: tableProperties.tableClass(),
+          DeletionProtectionEnabled:
+            tableProperties.deletionProtectionEnabled(),
+          StreamSpecification: tableProperties.streamSpecification(),
+          Tags: tableProperties.tags(),
+        },
       },
-    });
+      options,
+    );
 
-    await this.applyTimeToLive(name, tableProperties);
+    await this.applyTimeToLive(name, tableProperties, options);
 
     const table = this.dynamoDb.findTable(name);
     assertDefined(
@@ -82,6 +88,7 @@ export class SimCfnDynamoDbTableCreator {
   private async applyTimeToLive(
     name: string,
     tableProperties: SimCfnDynamoDbTableProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const specification = tableProperties.timeToLiveSpecification();
 
@@ -89,8 +96,9 @@ export class SimCfnDynamoDbTableCreator {
       return;
     }
 
-    await this.dynamoDb.updateTimeToLive({
-      input: { TableName: name, TimeToLiveSpecification: specification },
-    });
+    await this.dynamoDb.updateTimeToLive(
+      { input: { TableName: name, TimeToLiveSpecification: specification } },
+      options,
+    );
   }
 }

--- a/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-creator.ts
+++ b/src/service/ecs/cfn/cluster/sim-cfn-ecs-cluster-creator.ts
@@ -3,6 +3,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimEcsCluster } from "../../cluster/sim-ecs-cluster.js";
 import type { SimEcs } from "../../sim-ecs.js";
 import { SimCfnEcsClusterProperties } from "./sim-cfn-ecs-cluster-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnEcsClusterCreatorProperties {
   readonly ecs: SimEcs;
@@ -29,6 +30,7 @@ export class SimCfnEcsClusterCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimEcsCluster> {
     const clusterProperties = new SimCfnEcsClusterProperties({
       resource,
@@ -38,7 +40,7 @@ export class SimCfnEcsClusterCreator {
 
     clusterProperties.recordIgnoredProperties();
 
-    await this.ecs.createCluster({ input });
+    await this.ecs.createCluster({ input }, options);
 
     return this.ecs.cluster(clusterProperties.clusterName());
   }
@@ -50,9 +52,13 @@ export class SimCfnEcsClusterCreator {
    * `DeleteCluster` does, so something still holding its ARN can find out what
    * became of it after the stack has gone.
    */
-  async delete(cluster: SimEcsCluster): Promise<void> {
-    await this.ecs.deleteCluster({
-      input: { cluster: cluster.clusterName },
-    });
+  async delete(
+    cluster: SimEcsCluster,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.ecs.deleteCluster(
+      { input: { cluster: cluster.clusterName } },
+      options,
+    );
   }
 }

--- a/src/service/ecs/cfn/service/sim-cfn-ecs-service-creator.ts
+++ b/src/service/ecs/cfn/service/sim-cfn-ecs-service-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimEcsService } from "../../service/sim-ecs-service.js";
 import type { SimEcs } from "../../sim-ecs.js";
 import { SimCfnEcsServiceProperties } from "./sim-cfn-ecs-service-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnEcsServiceCreatorProperties {
   readonly ecs: SimEcs;
@@ -36,6 +37,7 @@ export class SimCfnEcsServiceCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimEcsService> {
     const serviceProperties = new SimCfnEcsServiceProperties({
       resource,
@@ -45,7 +47,7 @@ export class SimCfnEcsServiceCreator {
 
     serviceProperties.recordIgnoredProperties();
 
-    const created = await this.ecs.createService({ input });
+    const created = await this.ecs.createService({ input }, options);
     const serviceArn = created.service?.serviceArn;
 
     assertDefined(
@@ -65,13 +67,19 @@ export class SimCfnEcsServiceCreator {
    * same thing: the tasks stop, and the service is left `INACTIVE` rather than
    * removed, so something holding its ARN can still find out what became of it.
    */
-  async delete(service: SimEcsService): Promise<void> {
-    await this.ecs.deleteService({
-      input: {
-        cluster: service.clusterName,
-        service: service.serviceName,
-        force: true,
+  async delete(
+    service: SimEcsService,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.ecs.deleteService(
+      {
+        input: {
+          cluster: service.clusterName,
+          service: service.serviceName,
+          force: true,
+        },
       },
-    });
+      options,
+    );
   }
 }

--- a/src/service/ecs/cfn/sim-cfn-ecs-created-resource.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-created-resource.ts
@@ -1,0 +1,19 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+
+/**
+ * The simulated resource a Resource created, which a teardown reaches it by.
+ */
+export function simCfnEcsCreatedResource<T extends object>(
+  resource: SimCfnResource,
+  described: string,
+): T {
+  const created = resource.simResource as T | undefined;
+
+  assertDefined(
+    created,
+    `sim ECS ${described} for CloudFormation Resource ${resource.logicalId}`,
+  );
+
+  return created;
+}

--- a/src/service/ecs/cfn/sim-ecs-cfn-resource-factory.ts
+++ b/src/service/ecs/cfn/sim-ecs-cfn-resource-factory.ts
@@ -1,9 +1,11 @@
-import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import { simCfnEcsCreatedResource } from "./sim-cfn-ecs-created-resource.js";
 import type { SimEcsCluster } from "../cluster/sim-ecs-cluster.js";
 import type { SimEcsService } from "../service/sim-ecs-service.js";
 import type { SimEcsTaskDefinition } from "../task-definition/sim-ecs-task-definition.js";
@@ -47,20 +49,22 @@ export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case "Cluster": {
-        return await this.clusterCreator.create(resource, properties);
+        return await this.clusterCreator.create(resource, properties, options);
       }
       case "TaskDefinition": {
         return await this.taskDefinitionCreator.create(
           resource,
           properties,
           context.bindings,
+          options,
         );
       }
       case "Service": {
-        return await this.serviceCreator.create(resource, properties);
+        return await this.serviceCreator.create(resource, properties, options);
       }
       default: {
         throw new Error(
@@ -76,11 +80,15 @@ export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "Cluster": {
         await this.clusterCreator.delete(
           simCfnEcsCreatedResource<SimEcsCluster>(resource, "cluster"),
+          options,
         );
 
         return;
@@ -91,6 +99,7 @@ export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
             resource,
             "task definition",
           ),
+          options,
         );
 
         return;
@@ -98,6 +107,7 @@ export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
       case "Service": {
         await this.serviceCreator.delete(
           simCfnEcsCreatedResource<SimEcsService>(resource, "service"),
+          options,
         );
 
         return;
@@ -110,21 +120,4 @@ export class SimEcsCfnResourceFactory implements SimCfnServiceResourceFactory {
       }
     }
   }
-}
-
-/**
- * The simulated resource a Resource created, which a teardown reaches it by.
- */
-function simCfnEcsCreatedResource<T extends object>(
-  resource: SimCfnResource,
-  described: string,
-): T {
-  const created = resource.simResource as T | undefined;
-
-  assertDefined(
-    created,
-    `sim ECS ${described} for CloudFormation Resource ${resource.logicalId}`,
-  );
-
-  return created;
 }

--- a/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
+++ b/src/service/ecs/cfn/task-definition/sim-cfn-ecs-task-definition-creator.ts
@@ -7,6 +7,7 @@ import type { SimEcsTaskDefinition } from "../../task-definition/sim-ecs-task-de
 import type { SimEcs } from "../../sim-ecs.js";
 import { SimCfnEcsContainerBindings } from "../bind/sim-cfn-ecs-container-bindings.js";
 import { SimCfnEcsTaskDefinitionProperties } from "./sim-cfn-ecs-task-definition-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnEcsTaskDefinitionCreatorProperties {
   readonly ecs: SimEcs;
@@ -46,6 +47,7 @@ export class SimCfnEcsTaskDefinitionCreator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
     bindings?: readonly SimCfnBinding[],
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimEcsTaskDefinition> {
     const taskDefinitionProperties = new SimCfnEcsTaskDefinitionProperties({
       resource,
@@ -60,7 +62,10 @@ export class SimCfnEcsTaskDefinitionCreator {
       containerNames: simCfnEcsDeclaredContainerNames(input),
     });
 
-    const registered = await this.ecs.registerTaskDefinition({ input });
+    const registered = await this.ecs.registerTaskDefinition(
+      { input },
+      options,
+    );
     const taskDefinitionArn = registered.taskDefinition?.taskDefinitionArn;
 
     assertDefined(
@@ -81,10 +86,14 @@ export class SimCfnEcsTaskDefinitionCreator {
    * is also what an update does with the revision it replaces, since sim
    * CloudFormation replaces a changed Resource rather than updating it.
    */
-  async delete(taskDefinition: SimEcsTaskDefinition): Promise<void> {
-    await this.ecs.deregisterTaskDefinition({
-      input: { taskDefinition: taskDefinition.taskDefinitionArn },
-    });
+  async delete(
+    taskDefinition: SimEcsTaskDefinition,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.ecs.deregisterTaskDefinition(
+      { input: { taskDefinition: taskDefinition.taskDefinitionArn } },
+      options,
+    );
   }
 }
 

--- a/src/service/elbv2/cfn/listener/sim-cfn-elbv2-listener-creator.ts
+++ b/src/service/elbv2/cfn/listener/sim-cfn-elbv2-listener-creator.ts
@@ -5,6 +5,7 @@ import type { SimElbV2Listener } from "../../listener/sim-elbv2-listener.js";
 import type { SimElbV2 } from "../../sim-elbv2.js";
 import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
 import { SimCfnElbV2ListenerProperties } from "./sim-cfn-elbv2-listener-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnElbV2ListenerCreatorProperties {
   readonly elbV2: SimElbV2;
@@ -36,6 +37,7 @@ export class SimCfnElbV2ListenerCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimElbV2Listener> {
     const declared = new SimCfnElbV2ListenerProperties({
       resource,
@@ -45,7 +47,7 @@ export class SimCfnElbV2ListenerCreator {
 
     declared.recordIgnoredProperties();
 
-    const created = await this.elbV2.createListener({ input });
+    const created = await this.elbV2.createListener({ input }, options);
     const listenerArn = created.Listeners?.[0]?.ListenerArn;
 
     assertDefined(
@@ -63,9 +65,13 @@ export class SimCfnElbV2ListenerCreator {
    *
    * Its rules come down with it, as they do on real ELB.
    */
-  async delete(listener: SimElbV2Listener): Promise<void> {
-    await this.elbV2.deleteListener({
-      input: { ListenerArn: listener.arn },
-    });
+  async delete(
+    listener: SimElbV2Listener,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.elbV2.deleteListener(
+      { input: { ListenerArn: listener.arn } },
+      options,
+    );
   }
 }

--- a/src/service/elbv2/cfn/load-balancer/sim-cfn-elbv2-load-balancer-creator.ts
+++ b/src/service/elbv2/cfn/load-balancer/sim-cfn-elbv2-load-balancer-creator.ts
@@ -4,6 +4,7 @@ import type { SimElbV2LoadBalancer } from "../../load-balancer/sim-elbv2-load-ba
 import type { SimElbV2 } from "../../sim-elbv2.js";
 import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
 import { SimCfnElbV2LoadBalancerProperties } from "./sim-cfn-elbv2-load-balancer-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnElbV2LoadBalancerCreatorProperties {
   readonly elbV2: SimElbV2;
@@ -34,6 +35,7 @@ export class SimCfnElbV2LoadBalancerCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimElbV2LoadBalancer> {
     const declared = new SimCfnElbV2LoadBalancerProperties({
       resource,
@@ -43,7 +45,7 @@ export class SimCfnElbV2LoadBalancerCreator {
 
     declared.recordIgnoredProperties();
 
-    await this.elbV2.createLoadBalancer({ input });
+    await this.elbV2.createLoadBalancer({ input }, options);
 
     return this.stores.loadBalancers.requireByName(declared.name());
   }
@@ -55,9 +57,13 @@ export class SimCfnElbV2LoadBalancerCreator {
    * teardown has already deleted them itself, since each of them names the
    * load balancer, so what this removes is usually the load balancer alone.
    */
-  async delete(loadBalancer: SimElbV2LoadBalancer): Promise<void> {
-    await this.elbV2.deleteLoadBalancer({
-      input: { LoadBalancerArn: loadBalancer.arn },
-    });
+  async delete(
+    loadBalancer: SimElbV2LoadBalancer,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.elbV2.deleteLoadBalancer(
+      { input: { LoadBalancerArn: loadBalancer.arn } },
+      options,
+    );
   }
 }

--- a/src/service/elbv2/cfn/rule/sim-cfn-elbv2-listener-rule-creator.ts
+++ b/src/service/elbv2/cfn/rule/sim-cfn-elbv2-listener-rule-creator.ts
@@ -5,6 +5,7 @@ import type { SimElbV2ListenerRule } from "../../listener/rule/sim-elbv2-listene
 import type { SimElbV2 } from "../../sim-elbv2.js";
 import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
 import { SimCfnElbV2ListenerRuleProperties } from "./sim-cfn-elbv2-listener-rule-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnElbV2ListenerRuleCreatorProperties {
   readonly elbV2: SimElbV2;
@@ -35,6 +36,7 @@ export class SimCfnElbV2ListenerRuleCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimElbV2ListenerRule> {
     const declared = new SimCfnElbV2ListenerRuleProperties({
       resource,
@@ -44,7 +46,7 @@ export class SimCfnElbV2ListenerRuleCreator {
 
     declared.recordIgnoredProperties();
 
-    const created = await this.elbV2.createRule({ input });
+    const created = await this.elbV2.createRule({ input }, options);
     const ruleArn = created.Rules?.[0]?.RuleArn;
 
     assertDefined(
@@ -60,7 +62,10 @@ export class SimCfnElbV2ListenerRuleCreator {
   /**
    * Delete a rule created from a ListenerRule Resource.
    */
-  async delete(rule: SimElbV2ListenerRule): Promise<void> {
-    await this.elbV2.deleteRule({ input: { RuleArn: rule.arn } });
+  async delete(
+    rule: SimElbV2ListenerRule,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.elbV2.deleteRule({ input: { RuleArn: rule.arn } }, options);
   }
 }

--- a/src/service/elbv2/cfn/sim-elbv2-cfn-resource-deleter.ts
+++ b/src/service/elbv2/cfn/sim-elbv2-cfn-resource-deleter.ts
@@ -8,6 +8,7 @@ import type { SimCfnElbV2ListenerCreator } from "./listener/sim-cfn-elbv2-listen
 import type { SimCfnElbV2LoadBalancerCreator } from "./load-balancer/sim-cfn-elbv2-load-balancer-creator.js";
 import type { SimCfnElbV2ListenerRuleCreator } from "./rule/sim-cfn-elbv2-listener-rule-creator.js";
 import type { SimCfnElbV2TargetGroupCreator } from "./target-group/sim-cfn-elbv2-target-group-creator.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimElbV2CfnResourceDeleterProperties {
   readonly loadBalancers: SimCfnElbV2LoadBalancerCreator;
@@ -47,11 +48,13 @@ export class SimElbV2CfnResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "LoadBalancer": {
         await this.loadBalancers.delete(
           simCfnElbV2Created<SimElbV2LoadBalancer>(resource, "load balancer"),
+          options,
         );
 
         return;
@@ -59,6 +62,7 @@ export class SimElbV2CfnResourceDeleter {
       case "TargetGroup": {
         await this.targetGroups.delete(
           simCfnElbV2Created<SimElbV2TargetGroup>(resource, "target group"),
+          options,
         );
 
         return;
@@ -66,6 +70,7 @@ export class SimElbV2CfnResourceDeleter {
       case "Listener": {
         await this.listeners.delete(
           simCfnElbV2Created<SimElbV2Listener>(resource, "listener"),
+          options,
         );
 
         return;
@@ -73,6 +78,7 @@ export class SimElbV2CfnResourceDeleter {
       case "ListenerRule": {
         await this.rules.delete(
           simCfnElbV2Created<SimElbV2ListenerRule>(resource, "rule"),
+          options,
         );
 
         return;

--- a/src/service/elbv2/cfn/sim-elbv2-cfn-resource-factory.ts
+++ b/src/service/elbv2/cfn/sim-elbv2-cfn-resource-factory.ts
@@ -2,6 +2,7 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimElbV2 } from "../sim-elbv2.js";
 import type { SimElbV2Stores } from "../sim-elbv2-stores.js";
@@ -10,6 +11,7 @@ import { SimCfnElbV2LoadBalancerCreator } from "./load-balancer/sim-cfn-elbv2-lo
 import { SimCfnElbV2ListenerRuleCreator } from "./rule/sim-cfn-elbv2-listener-rule-creator.js";
 import { SimCfnElbV2TargetGroupCreator } from "./target-group/sim-cfn-elbv2-target-group-creator.js";
 import { SimElbV2CfnResourceDeleter } from "./sim-elbv2-cfn-resource-deleter.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimElbV2CfnResourceFactoryProperties {
   readonly elbV2: SimElbV2;
@@ -58,19 +60,28 @@ export class SimElbV2CfnResourceFactory implements SimCfnServiceResourceFactory 
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case "LoadBalancer": {
-        return await this.loadBalancerCreator.create(resource, properties);
+        return await this.loadBalancerCreator.create(
+          resource,
+          properties,
+          options,
+        );
       }
       case "TargetGroup": {
-        return await this.targetGroupCreator.create(resource, properties);
+        return await this.targetGroupCreator.create(
+          resource,
+          properties,
+          options,
+        );
       }
       case "Listener": {
-        return await this.listenerCreator.create(resource, properties);
+        return await this.listenerCreator.create(resource, properties, options);
       }
       case "ListenerRule": {
-        return await this.ruleCreator.create(resource, properties);
+        return await this.ruleCreator.create(resource, properties, options);
       }
       default: {
         throw new Error(
@@ -86,7 +97,12 @@ export class SimElbV2CfnResourceFactory implements SimCfnServiceResourceFactory 
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.deleter.delete(resourceTypeName, resource);
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-target-group-creator.ts
+++ b/src/service/elbv2/cfn/target-group/sim-cfn-elbv2-target-group-creator.ts
@@ -5,6 +5,7 @@ import type { SimElbV2Stores } from "../../sim-elbv2-stores.js";
 import type { SimElbV2TargetGroup } from "../../target-group/sim-elbv2-target-group.js";
 import type { SimElbV2TargetDescription } from "../../target-group/sim-elbv2-target.js";
 import { SimCfnElbV2TargetGroupProperties } from "./sim-cfn-elbv2-target-group-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnElbV2TargetGroupCreatorProperties {
   readonly elbV2: SimElbV2;
@@ -35,6 +36,7 @@ export class SimCfnElbV2TargetGroupCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimElbV2TargetGroup> {
     const declared = new SimCfnElbV2TargetGroupProperties({
       resource,
@@ -44,11 +46,11 @@ export class SimCfnElbV2TargetGroupCreator {
 
     declared.recordIgnoredProperties();
 
-    await this.elbV2.createTargetGroup({ input });
+    await this.elbV2.createTargetGroup({ input }, options);
 
     const targetGroup = this.stores.targetGroups.requireByName(declared.name());
 
-    await this.registerTargets(targetGroup, declared.targets());
+    await this.registerTargets(targetGroup, declared.targets(), options);
 
     return targetGroup;
   }
@@ -60,10 +62,14 @@ export class SimCfnElbV2TargetGroupCreator {
    * a group comes down after the listeners naming it, which the teardown order
    * arranges.
    */
-  async delete(targetGroup: SimElbV2TargetGroup): Promise<void> {
-    await this.elbV2.deleteTargetGroup({
-      input: { TargetGroupArn: targetGroup.arn },
-    });
+  async delete(
+    targetGroup: SimElbV2TargetGroup,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.elbV2.deleteTargetGroup(
+      { input: { TargetGroupArn: targetGroup.arn } },
+      options,
+    );
   }
 
   /**
@@ -72,13 +78,15 @@ export class SimCfnElbV2TargetGroupCreator {
   private async registerTargets(
     targetGroup: SimElbV2TargetGroup,
     targets: readonly SimElbV2TargetDescription[] | undefined,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (targets === undefined || targets.length === 0) {
       return;
     }
 
-    await this.elbV2.registerTargets({
-      input: { TargetGroupArn: targetGroup.arn, Targets: targets },
-    });
+    await this.elbV2.registerTargets(
+      { input: { TargetGroupArn: targetGroup.arn, Targets: targets } },
+      options,
+    );
   }
 }

--- a/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-creator.ts
+++ b/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-creator.ts
@@ -6,6 +6,7 @@ import type { SimEventBridge } from "../../sim-event-bridge.js";
 import { simCfnEventBridgeResourceCreation } from "../sim-cfn-event-bridge-resource-error.js";
 import { eventBusResourceType } from "../sim-cfn-event-bridge-resource-types.js";
 import { SimCfnEventBusProperties } from "./sim-cfn-event-bus-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnEventBusCreatorProperties {
   readonly eventBridge: SimEventBridge;
@@ -32,6 +33,7 @@ export class SimCfnEventBusCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimEventBus> {
     const busProperties = new SimCfnEventBusProperties({
       resource,
@@ -47,9 +49,10 @@ export class SimCfnEventBusCreator {
       eventBusResourceType,
       resource.logicalId,
       async () => {
-        await this.eventBridge.createEventBus({
-          input: { Name: name, Description: description },
-        });
+        await this.eventBridge.createEventBus(
+          { input: { Name: name, Description: description } },
+          options,
+        );
 
         const bus = this.eventBridge.findEventBus(name);
 

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-creator.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-creator.ts
@@ -7,6 +7,7 @@ import { simCfnEventBridgeResourceCreation } from "../sim-cfn-event-bridge-resou
 import { eventRuleResourceType } from "../sim-cfn-event-bridge-resource-types.js";
 import { SimCfnEventRuleProperties } from "./sim-cfn-event-rule-properties.js";
 import type { SimCfnEventRuleTarget } from "./sim-cfn-event-rule-targets.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnEventRuleCreatorProperties {
   readonly eventBridge: SimEventBridge;
@@ -37,6 +38,7 @@ export class SimCfnEventRuleCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimEventRule> {
     const ruleProperties = new SimCfnEventRuleProperties({
       resource,
@@ -53,18 +55,21 @@ export class SimCfnEventRuleCreator {
       eventRuleResourceType,
       resource.logicalId,
       async () => {
-        await this.eventBridge.putRule({
-          input: {
-            Name: name,
-            EventBusName: busName,
-            EventPattern: ruleProperties.eventPattern(),
-            ScheduleExpression: ruleProperties.scheduleExpression(),
-            State: ruleProperties.state(),
-            Description: ruleProperties.description(),
+        await this.eventBridge.putRule(
+          {
+            input: {
+              Name: name,
+              EventBusName: busName,
+              EventPattern: ruleProperties.eventPattern(),
+              ScheduleExpression: ruleProperties.scheduleExpression(),
+              State: ruleProperties.state(),
+              Description: ruleProperties.description(),
+            },
           },
-        });
+          options,
+        );
 
-        await this.putTargets(name, busName, targets);
+        await this.putTargets(name, busName, targets, options);
 
         const rule = this.eventBridge.findRule(name, busName);
 
@@ -85,21 +90,25 @@ export class SimCfnEventRuleCreator {
     ruleName: string,
     busName: string | undefined,
     targets: readonly SimCfnEventRuleTarget[],
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (targets.length === 0) {
       return;
     }
 
-    await this.eventBridge.putTargets({
-      input: {
-        Rule: ruleName,
-        EventBusName: busName,
-        Targets: targets.map((target) => ({
-          Id: target.Id,
-          Arn: target.Arn,
-          Input: target.Input,
-        })),
+    await this.eventBridge.putTargets(
+      {
+        input: {
+          Rule: ruleName,
+          EventBusName: busName,
+          Targets: targets.map((target) => ({
+            Id: target.Id,
+            Arn: target.Arn,
+            Input: target.Input,
+          })),
+        },
       },
-    });
+      options,
+    );
   }
 }

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-deleter.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-deleter.ts
@@ -1,4 +1,5 @@
 import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimEventBridge } from "../sim-event-bridge.js";
 import { SimCfnEventBusProperties } from "./bus/sim-cfn-event-bus-properties.js";
@@ -30,14 +31,15 @@ export class SimCfnEventBridgeResourceDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "EventBus": {
-        await this.deleteBus(resource, properties);
+        await this.deleteBus(resource, properties, options);
         return;
       }
       case "Rule": {
-        await this.deleteRule(resource, properties);
+        await this.deleteRule(resource, properties, options);
         return;
       }
       default: {
@@ -56,13 +58,14 @@ export class SimCfnEventBridgeResourceDeleter {
   private async deleteBus(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const name = new SimCfnEventBusProperties({
       resource,
       properties,
     }).name();
 
-    await this.eventBridge.deleteEventBus({ input: { Name: name } });
+    await this.eventBridge.deleteEventBus({ input: { Name: name } }, options);
   }
 
   /**
@@ -71,17 +74,21 @@ export class SimCfnEventBridgeResourceDeleter {
   private async deleteRule(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const ruleProperties = new SimCfnEventRuleProperties({
       resource,
       properties,
     });
 
-    await this.eventBridge.deleteRule({
-      input: {
-        Name: ruleProperties.name(),
-        EventBusName: ruleProperties.busName(),
+    await this.eventBridge.deleteRule(
+      {
+        input: {
+          Name: ruleProperties.name(),
+          EventBusName: ruleProperties.busName(),
+        },
       },
-    });
+      options,
+    );
   }
 }

--- a/src/service/eventbridge/cfn/sim-event-bridge-cfn-resource-factory.ts
+++ b/src/service/eventbridge/cfn/sim-event-bridge-cfn-resource-factory.ts
@@ -4,6 +4,7 @@ import type {
   SimCloudFormationResourceCreateContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimEventBridge } from "../sim-event-bridge.js";
 import { SimCfnEventBusCreator } from "./bus/sim-cfn-event-bus-creator.js";
 import { SimCfnEventRuleCreator } from "./rule/sim-cfn-event-rule-creator.js";
@@ -47,12 +48,14 @@ export class SimEventBridgeCfnResourceFactory implements SimCfnServiceResourceFa
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
 
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "EventBus": {
-        return await this.busCreator.create(resource, properties);
+        return await this.busCreator.create(resource, properties, options);
       }
       case "Rule": {
-        return await this.ruleCreator.create(resource, properties);
+        return await this.ruleCreator.create(resource, properties, options);
       }
       default: {
         throw new Error(
@@ -77,6 +80,7 @@ export class SimEventBridgeCfnResourceFactory implements SimCfnServiceResourceFa
       resourceTypeName,
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 }

--- a/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-creator.ts
+++ b/src/service/firehose/cfn/delivery-stream/sim-cfn-firehose-delivery-stream-creator.ts
@@ -6,6 +6,7 @@ import type { SimFirehoseDeliveryStream } from "../../stream/sim-firehose-delive
 import { simCfnFirehoseResourceCreation } from "../sim-cfn-firehose-resource-error.js";
 import { firehoseDeliveryStreamResourceType } from "../sim-cfn-firehose-resource-types.js";
 import { SimCfnFirehoseDeliveryStreamProperties } from "./sim-cfn-firehose-delivery-stream-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnFirehoseDeliveryStreamCreatorProperties {
   readonly firehose: SimFirehose;
@@ -40,6 +41,7 @@ export class SimCfnFirehoseDeliveryStreamCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimFirehoseDeliveryStream> {
     return await simCfnFirehoseResourceCreation(
       firehoseDeliveryStreamResourceType,
@@ -51,7 +53,7 @@ export class SimCfnFirehoseDeliveryStreamCreator {
         });
         const input = streamProperties.createInput();
 
-        await this.firehose.createDeliveryStream({ input });
+        await this.firehose.createDeliveryStream({ input }, options);
 
         const deliveryStream = this.firehose.findDeliveryStream(
           streamProperties.name(),

--- a/src/service/firehose/cfn/sim-cfn-firehose-resource-deleter.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-resource-deleter.ts
@@ -3,6 +3,7 @@ import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resou
 import type { SimFirehose } from "../sim-firehose.js";
 import type { SimFirehoseDeliveryStream } from "../stream/sim-firehose-delivery-stream.js";
 import { firehoseDeliveryStreamResourceTypeName } from "./sim-cfn-firehose-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnFirehoseResourceDeleterProperties {
   readonly firehose: SimFirehose;
@@ -25,6 +26,7 @@ export class SimCfnFirehoseResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (resourceTypeName !== firehoseDeliveryStreamResourceTypeName) {
       throw new Error(
@@ -40,8 +42,9 @@ export class SimCfnFirehoseResourceDeleter {
       `sim Firehose delivery stream for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.firehose.deleteDeliveryStream({
-      input: { DeliveryStreamName: deliveryStream.name },
-    });
+    await this.firehose.deleteDeliveryStream(
+      { input: { DeliveryStreamName: deliveryStream.name } },
+      options,
+    );
   }
 }

--- a/src/service/firehose/cfn/sim-firehose-cfn-resource-factory.ts
+++ b/src/service/firehose/cfn/sim-firehose-cfn-resource-factory.ts
@@ -8,6 +8,7 @@ import type { SimFirehose } from "../sim-firehose.js";
 import { SimCfnFirehoseDeliveryStreamCreator } from "./delivery-stream/sim-cfn-firehose-delivery-stream-creator.js";
 import { SimCfnFirehoseResourceDeleter } from "./sim-cfn-firehose-resource-deleter.js";
 import { firehoseDeliveryStreamResourceTypeName } from "./sim-cfn-firehose-resource-types.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimFirehoseCfnResourceFactoryProperties {
   readonly firehose: SimFirehose;
@@ -49,6 +50,7 @@ export class SimFirehoseCfnResourceFactory implements SimCfnServiceResourceFacto
     return await this.deliveryStreamCreator.create(
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 
@@ -59,8 +61,12 @@ export class SimFirehoseCfnResourceFactory implements SimCfnServiceResourceFacto
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
-    _context: SimCloudFormationResourceDeleteContext,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.deleter.delete(resourceTypeName, resource);
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-attacher.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-attacher.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimIam } from "../../sim-iam.js";
 import type { SimIamRoleName } from "../../role/sim-iam-role.js";
 import { SimIamNoSuchEntity } from "../../error/sim-iam.error.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnIamManagedPolicyAttacherProperties {
   readonly iam: SimIam;
@@ -62,12 +63,14 @@ export class SimCfnIamManagedPolicyAttacher {
   async attach(
     policyArn: SimArn,
     roleNames: readonly SimIamRoleName[],
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await Promise.all(
       roleNames.map(async (roleName) =>
-        this.iam.attachRolePolicy({
-          input: { RoleName: roleName, PolicyArn: policyArn },
-        }),
+        this.iam.attachRolePolicy(
+          { input: { RoleName: roleName, PolicyArn: policyArn } },
+          options,
+        ),
       ),
     );
   }

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-creator.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-creator.ts
@@ -4,6 +4,7 @@ import type { SimIam } from "../../sim-iam.js";
 import type { SimIamManagedPolicy } from "../../policy/sim-iam-policy.js";
 import { SimCfnIamManagedPolicyAttacher } from "./sim-cfn-iam-managed-policy-attacher.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnIamManagedPolicyCreatorProperties {
   readonly iam: SimIam;
@@ -27,6 +28,7 @@ export class SimCfnIamManagedPolicyCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimIamManagedPolicy> {
     const roleNames = this.attacher.roleNames(resource, properties);
     const policyName = this.managedPolicyName(resource, properties);
@@ -34,14 +36,17 @@ export class SimCfnIamManagedPolicyCreator {
     const description = this.description(resource, properties);
     const policyDocument = this.policyDocument(resource, properties);
 
-    const policyCreation = await this.iam.createPolicy({
-      input: {
-        PolicyName: policyName,
-        Path: path,
-        Description: description,
-        PolicyDocument: policyDocument,
+    const policyCreation = await this.iam.createPolicy(
+      {
+        input: {
+          PolicyName: policyName,
+          Path: path,
+          Description: description,
+          PolicyDocument: policyDocument,
+        },
       },
-    });
+      options,
+    );
 
     const policy = this.iam.policies.get(policyCreation.Policy.Arn);
     assertDefined(
@@ -49,7 +54,7 @@ export class SimCfnIamManagedPolicyCreator {
       `Sim IAM Managed Policy ${policyCreation.Policy.Arn} after CloudFormation creation`,
     );
 
-    await this.attacher.attach(policy.arn, roleNames);
+    await this.attacher.attach(policy.arn, roleNames, options);
 
     return policy;
   }

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy-creator.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy-creator.ts
@@ -5,6 +5,7 @@ import {
   SimCfnIamPolicyPropertiesParser,
   type SimCfnIamPolicyProperties,
 } from "./sim-cfn-iam-policy-properties-parser.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnIamPolicyCreatorProperties {
   readonly iam: SimIam;
@@ -35,12 +36,13 @@ export class SimCfnIamPolicyCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<undefined> {
     const policyProperties = this.propsParser.parse(resource, properties);
 
     await Promise.all([
-      this.putRolePolicies(policyProperties),
-      this.putUserPolicies(policyProperties),
+      this.putRolePolicies(policyProperties, options),
+      this.putUserPolicies(policyProperties, options),
     ]);
 
     return undefined;
@@ -48,32 +50,40 @@ export class SimCfnIamPolicyCreator {
 
   private async putRolePolicies(
     policyProperties: SimCfnIamPolicyProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await Promise.all(
       policyProperties.roleNames.map(async (roleName) =>
-        this.iam.putRolePolicy({
-          input: {
-            RoleName: roleName,
-            PolicyName: policyProperties.policyName,
-            PolicyDocument: policyProperties.policyDocument,
+        this.iam.putRolePolicy(
+          {
+            input: {
+              RoleName: roleName,
+              PolicyName: policyProperties.policyName,
+              PolicyDocument: policyProperties.policyDocument,
+            },
           },
-        }),
+          options,
+        ),
       ),
     );
   }
 
   private async putUserPolicies(
     policyProperties: SimCfnIamPolicyProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await Promise.all(
       policyProperties.usernames.map(async (username) =>
-        this.iam.putUserPolicy({
-          input: {
-            UserName: username,
-            PolicyName: policyProperties.policyName,
-            PolicyDocument: policyProperties.policyDocument,
+        this.iam.putUserPolicy(
+          {
+            input: {
+              UserName: username,
+              PolicyName: policyProperties.policyName,
+              PolicyDocument: policyProperties.policyDocument,
+            },
           },
-        }),
+          options,
+        ),
       ),
     );
   }

--- a/src/service/iam/cfn/role/sim-cfn-iam-role-creator.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role-creator.ts
@@ -7,6 +7,7 @@ import {
   SimCfnIamRolePropertiesParser as SimCfnIamRolePropertiesParser,
   type SimCfnIamRoleProperties as SimCfnIamRoleProperties,
 } from "./sim-cfn-iam-role-properties-parser.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnIamRoleCreatorProperties {
   readonly iam: SimIam;
@@ -29,21 +30,25 @@ export class SimCfnIamRoleCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimIamRole> {
     const roleProperties = this.propsParser.parse(resource, properties);
 
-    await this.iam.createRole({
-      input: {
-        RoleName: roleProperties.roleName,
-        Path: roleProperties.path,
-        Description: roleProperties.description,
-        AssumeRolePolicyDocument: roleProperties.assumeRolePolicyDocument,
+    await this.iam.createRole(
+      {
+        input: {
+          RoleName: roleProperties.roleName,
+          Path: roleProperties.path,
+          Description: roleProperties.description,
+          AssumeRolePolicyDocument: roleProperties.assumeRolePolicyDocument,
+        },
       },
-    });
+      options,
+    );
 
     await Promise.all([
-      this.putInlinePolicies(roleProperties),
-      this.attachManagedPolicies(roleProperties),
+      this.putInlinePolicies(roleProperties, options),
+      this.attachManagedPolicies(roleProperties, options),
     ]);
 
     const role = this.iam.roles.get(roleProperties.roleName as SimIamRoleName);
@@ -57,31 +62,39 @@ export class SimCfnIamRoleCreator {
 
   private async putInlinePolicies(
     roleProperties: SimCfnIamRoleProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await Promise.all(
       roleProperties.inlinePolicies.map(async (inlinePolicy) =>
-        this.iam.putRolePolicy({
-          input: {
-            RoleName: roleProperties.roleName,
-            PolicyName: inlinePolicy.policyName,
-            PolicyDocument: inlinePolicy.policyDocument,
+        this.iam.putRolePolicy(
+          {
+            input: {
+              RoleName: roleProperties.roleName,
+              PolicyName: inlinePolicy.policyName,
+              PolicyDocument: inlinePolicy.policyDocument,
+            },
           },
-        }),
+          options,
+        ),
       ),
     );
   }
 
   private async attachManagedPolicies(
     roleProperties: SimCfnIamRoleProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await Promise.all(
       roleProperties.managedPolicyArns.map(async (policyArn) =>
-        this.iam.attachRolePolicy({
-          input: {
-            RoleName: roleProperties.roleName,
-            PolicyArn: policyArn,
+        this.iam.attachRolePolicy(
+          {
+            input: {
+              RoleName: roleProperties.roleName,
+              PolicyArn: policyArn,
+            },
           },
-        }),
+          options,
+        ),
       ),
     );
   }

--- a/src/service/iam/cfn/role/sim-cfn-iam-role-deleter.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role-deleter.ts
@@ -2,6 +2,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimIam } from "../../sim-iam.js";
 import type { SimIamRole } from "../../role/sim-iam-role.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnIamRoleDeleterProperties {
   readonly iam: SimIam;
@@ -30,36 +31,49 @@ export class SimCfnIamRoleDeleter {
   /**
    * Delete the Role a CloudFormation Resource created.
    */
-  async delete(resource: SimCfnResource): Promise<void> {
+  async delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const role = resource.simResource as SimIamRole | undefined;
     assertDefined(
       role,
       `sim IAM Role for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.detachPolicies(role);
-    await this.deleteInlinePolicies(role);
+    await this.detachPolicies(role, options);
+    await this.deleteInlinePolicies(role, options);
 
-    await this.iam.deleteRole({ input: { RoleName: role.roleName } });
+    await this.iam.deleteRole({ input: { RoleName: role.roleName } }, options);
   }
 
-  private async detachPolicies(role: SimIamRole): Promise<void> {
+  private async detachPolicies(
+    role: SimIamRole,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     await Promise.all(
       [...role.attachedPolicyArns].map(async (policyArn) =>
-        this.iam.detachRolePolicy({
-          input: { RoleName: role.roleName, PolicyArn: policyArn },
-        }),
+        this.iam.detachRolePolicy(
+          { input: { RoleName: role.roleName, PolicyArn: policyArn } },
+          options,
+        ),
       ),
     );
   }
 
-  private async deleteInlinePolicies(role: SimIamRole): Promise<void> {
+  private async deleteInlinePolicies(
+    role: SimIamRole,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     await Promise.all(
-      role.inlinePolicies.keys().map(async (policyName) =>
-        this.iam.deleteRolePolicy({
-          input: { RoleName: role.roleName, PolicyName: policyName },
-        }),
-      ),
+      role.inlinePolicies
+        .keys()
+        .map(async (policyName) =>
+          this.iam.deleteRolePolicy(
+            { input: { RoleName: role.roleName, PolicyName: policyName } },
+            options,
+          ),
+        ),
     );
   }
 }

--- a/src/service/iam/cfn/sim-cfn-iam-resource-deleter.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-resource-deleter.ts
@@ -6,6 +6,7 @@ import type { SimIamManagedPolicy } from "../policy/sim-iam-policy.js";
 import { SimCfnIamRoleDeleter } from "./role/sim-cfn-iam-role-deleter.js";
 import { SimCfnIamUserDeleter } from "./user/sim-cfn-iam-user-deleter.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnIamResourceDeleterProperties {
   readonly iam: SimIam;
@@ -32,22 +33,23 @@ export class SimCfnIamResourceDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "ManagedPolicy": {
-        await this.deleteManagedPolicy(resource);
+        await this.deleteManagedPolicy(resource, options);
         return;
       }
       case "Policy": {
-        await this.deleteInlinePolicy(properties);
+        await this.deleteInlinePolicy(properties, options);
         return;
       }
       case "Role": {
-        await this.roleDeleter.delete(resource);
+        await this.roleDeleter.delete(resource, options);
         return;
       }
       case "User": {
-        await this.userDeleter.delete(resource);
+        await this.userDeleter.delete(resource, options);
         return;
       }
       default: {
@@ -58,15 +60,18 @@ export class SimCfnIamResourceDeleter {
     }
   }
 
-  private async deleteManagedPolicy(resource: SimCfnResource): Promise<void> {
+  private async deleteManagedPolicy(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const policy = resource.simResource as SimIamManagedPolicy | undefined;
     assertDefined(
       policy,
       `sim IAM Managed Policy for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.detachManagedPolicy(policy.arn);
-    await this.iam.deletePolicy({ input: { PolicyArn: policy.arn } });
+    await this.detachManagedPolicy(policy.arn, options);
+    await this.iam.deletePolicy({ input: { PolicyArn: policy.arn } }, options);
   }
 
   /**
@@ -78,15 +83,19 @@ export class SimCfnIamResourceDeleter {
    * Resource is deleted. A Role declared outside the Stack keeps it. This
    * clears whatever attachments are left either way.
    */
-  private async detachManagedPolicy(policyArn: SimArn): Promise<void> {
+  private async detachManagedPolicy(
+    policyArn: SimArn,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     await Promise.all(
       this.iam.roles
         .values()
         .filter((role) => role.attachedPolicyArns.has(policyArn))
         .map(async (role) =>
-          this.iam.detachRolePolicy({
-            input: { RoleName: role.roleName, PolicyArn: policyArn },
-          }),
+          this.iam.detachRolePolicy(
+            { input: { RoleName: role.roleName, PolicyArn: policyArn } },
+            options,
+          ),
         ),
     );
   }
@@ -100,6 +109,7 @@ export class SimCfnIamResourceDeleter {
    */
   private async deleteInlinePolicy(
     properties: SimCfnTemplateValueRecord,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const policyName = properties["PolicyName"];
     const roles = properties["Roles"];
@@ -113,9 +123,10 @@ export class SimCfnIamResourceDeleter {
       roles
         .filter((roleName): roleName is string => typeof roleName === "string")
         .map(async (roleName) =>
-          this.iam.deleteRolePolicy({
-            input: { RoleName: roleName, PolicyName: policyName },
-          }),
+          this.iam.deleteRolePolicy(
+            { input: { RoleName: roleName, PolicyName: policyName } },
+            options,
+          ),
         ),
     );
   }

--- a/src/service/iam/cfn/sim-cfn-iam-resource-factory.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-resource-factory.ts
@@ -10,6 +10,7 @@ import { SimCfnIamRoleCreator } from "./role/sim-cfn-iam-role-creator.js";
 import { SimCfnIamUserCreator } from "./user/sim-cfn-iam-user-creator.js";
 import { SimCfnIamResourceDeleter } from "./sim-cfn-iam-resource-deleter.js";
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 /**
  * CloudFormation Resource factory for simulated IAM resources.
@@ -37,31 +38,26 @@ export class SimIamCloudFormationResourceFactory implements SimCfnServiceResourc
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "ManagedPolicy": {
         return await this.managedPolicyCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
+          options,
         );
       }
       case "Policy": {
-        await this.policyCreator.create(
-          resource,
-          context.resolvedProperties ?? resource.properties,
-        );
+        await this.policyCreator.create(resource, properties, options);
         return;
       }
       case "Role": {
-        return await this.roleCreator.create(
-          resource,
-          context.resolvedProperties ?? resource.properties,
-        );
+        return await this.roleCreator.create(resource, properties, options);
       }
       case "User": {
-        return await this.userCreator.create(
-          resource,
-          context.resolvedProperties ?? resource.properties,
-        );
+        return await this.userCreator.create(resource, properties, options);
       }
       default: {
         throw new Error(
@@ -83,6 +79,7 @@ export class SimIamCloudFormationResourceFactory implements SimCfnServiceResourc
       resourceTypeName,
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 }

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-creator.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-creator.ts
@@ -7,6 +7,7 @@ import {
   SimCfnIamUserPropertiesParser,
   type SimCfnIamUserProperties,
 } from "./sim-cfn-iam-user-properties-parser.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnIamUserCreatorProperties {
   readonly iam: SimIam;
@@ -29,20 +30,24 @@ export class SimCfnIamUserCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimIamUser> {
     const userProperties = this.propsParser.parse(resource, properties);
 
-    await this.iam.createUser({
-      input: {
-        UserName: userProperties.userName,
-        Path: userProperties.path,
+    await this.iam.createUser(
+      {
+        input: {
+          UserName: userProperties.userName,
+          Path: userProperties.path,
+        },
       },
-    });
+      options,
+    );
 
     await Promise.all([
-      this.putInlinePolicies(userProperties),
-      this.attachManagedPolicies(userProperties),
-      this.createLoginProfile(userProperties),
+      this.putInlinePolicies(userProperties, options),
+      this.attachManagedPolicies(userProperties, options),
+      this.createLoginProfile(userProperties, options),
     ]);
 
     const user = this.iam.users.get(userProperties.userName as SimIamUsername);
@@ -56,31 +61,39 @@ export class SimCfnIamUserCreator {
 
   private async putInlinePolicies(
     userProperties: SimCfnIamUserProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await Promise.all(
       userProperties.inlinePolicies.map(async (inlinePolicy) =>
-        this.iam.putUserPolicy({
-          input: {
-            UserName: userProperties.userName,
-            PolicyName: inlinePolicy.policyName,
-            PolicyDocument: inlinePolicy.policyDocument,
+        this.iam.putUserPolicy(
+          {
+            input: {
+              UserName: userProperties.userName,
+              PolicyName: inlinePolicy.policyName,
+              PolicyDocument: inlinePolicy.policyDocument,
+            },
           },
-        }),
+          options,
+        ),
       ),
     );
   }
 
   private async attachManagedPolicies(
     userProperties: SimCfnIamUserProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await Promise.all(
       userProperties.managedPolicyArns.map(async (policyArn) =>
-        this.iam.attachUserPolicy({
-          input: {
-            UserName: userProperties.userName,
-            PolicyArn: policyArn,
+        this.iam.attachUserPolicy(
+          {
+            input: {
+              UserName: userProperties.userName,
+              PolicyArn: policyArn,
+            },
           },
-        }),
+          options,
+        ),
       ),
     );
   }
@@ -91,6 +104,7 @@ export class SimCfnIamUserCreator {
    */
   private async createLoginProfile(
     userProperties: SimCfnIamUserProperties,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const { loginProfile } = userProperties;
 
@@ -98,12 +112,15 @@ export class SimCfnIamUserCreator {
       return;
     }
 
-    await this.iam.createLoginProfile({
-      input: {
-        UserName: userProperties.userName,
-        Password: loginProfile.password,
-        PasswordResetRequired: loginProfile.passwordResetRequired,
+    await this.iam.createLoginProfile(
+      {
+        input: {
+          UserName: userProperties.userName,
+          Password: loginProfile.password,
+          PasswordResetRequired: loginProfile.passwordResetRequired,
+        },
       },
-    });
+      options,
+    );
   }
 }

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-deleter.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-deleter.ts
@@ -2,6 +2,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimIam } from "../../sim-iam.js";
 import type { SimIamUser } from "../../user/sim-iam-user.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnIamUserDeleterProperties {
   readonly iam: SimIam;
@@ -28,7 +29,10 @@ export class SimCfnIamUserDeleter {
   /**
    * Delete the User a CloudFormation Resource created.
    */
-  async delete(resource: SimCfnResource): Promise<void> {
+  async delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const user = resource.simResource as SimIamUser | undefined;
     assertDefined(
       user,
@@ -38,6 +42,6 @@ export class SimCfnIamUserDeleter {
     user.attachedPolicyArns.clear();
     user.inlinePolicies.clear();
 
-    await this.iam.deleteUser({ input: { UserName: user.userName } });
+    await this.iam.deleteUser({ input: { UserName: user.userName } }, options);
   }
 }

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-deleter.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-deleter.ts
@@ -17,7 +17,8 @@ interface SimCfnIamUserDeleterProperties {
  * is detached and a `Policies` entry removed as part of deleting the User.
  *
  * Sim IAM serves no DeleteUserPolicy or DetachUserPolicy, so both come off the
- * User record here rather than through a command.
+ * User record here rather than through a command. A DeleteUser the caller is
+ * not allowed puts them back, leaving the User as the Stack deployed it.
  */
 export class SimCfnIamUserDeleter {
   private readonly iam: SimIam;
@@ -39,9 +40,27 @@ export class SimCfnIamUserDeleter {
       `sim IAM User for CloudFormation Resource ${resource.logicalId}`,
     );
 
+    const attachedPolicyArns = [...user.attachedPolicyArns];
+    const inlinePolicies = [...user.inlinePolicies];
+
     user.attachedPolicyArns.clear();
     user.inlinePolicies.clear();
 
-    await this.iam.deleteUser({ input: { UserName: user.userName } }, options);
+    try {
+      await this.iam.deleteUser(
+        { input: { UserName: user.userName } },
+        options,
+      );
+    } catch (error) {
+      for (const policyArn of attachedPolicyArns) {
+        user.attachedPolicyArns.add(policyArn);
+      }
+
+      for (const [policyName, document] of inlinePolicies) {
+        user.inlinePolicies.set(policyName, document);
+      }
+
+      throw error;
+    }
   }
 }

--- a/src/service/kinesis/cfn/sim-cfn-kinesis-resource-deleter.ts
+++ b/src/service/kinesis/cfn/sim-cfn-kinesis-resource-deleter.ts
@@ -2,6 +2,7 @@ import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimKinesis } from "../sim-kinesis.js";
 import type { SimKinesisStream } from "../stream/sim-kinesis-stream.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnKinesisResourceDeleterProperties {
   readonly kinesis: SimKinesis;
@@ -23,6 +24,7 @@ export class SimCfnKinesisResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (resourceTypeName !== "Stream") {
       throw new Error(
@@ -36,6 +38,9 @@ export class SimCfnKinesisResourceDeleter {
       `sim Kinesis stream for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.kinesis.deleteStream({ input: { StreamARN: stream.arn } });
+    await this.kinesis.deleteStream(
+      { input: { StreamARN: stream.arn } },
+      options,
+    );
   }
 }

--- a/src/service/kinesis/cfn/sim-kinesis-cfn-resource-factory.ts
+++ b/src/service/kinesis/cfn/sim-kinesis-cfn-resource-factory.ts
@@ -7,6 +7,7 @@ import type { SimCloudFormationResourceDeleteContext } from "../../cloudformatio
 import type { SimKinesis } from "../sim-kinesis.js";
 import { SimCfnKinesisResourceDeleter } from "./sim-cfn-kinesis-resource-deleter.js";
 import { SimCfnKinesisStreamCreator } from "./stream/sim-cfn-kinesis-stream-creator.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimKinesisCfnResourceFactoryProperties {
   readonly kinesis: SimKinesis;
@@ -51,6 +52,7 @@ export class SimKinesisCfnResourceFactory implements SimCfnServiceResourceFactor
     return await this.streamCreator.create(
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 
@@ -60,8 +62,12 @@ export class SimKinesisCfnResourceFactory implements SimCfnServiceResourceFactor
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
-    _context: SimCloudFormationResourceDeleteContext,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.deleter.delete(resourceTypeName, resource);
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-creator.ts
+++ b/src/service/kinesis/cfn/stream/sim-cfn-kinesis-stream-creator.ts
@@ -7,6 +7,7 @@ import type { SimKinesisStream } from "../../stream/sim-kinesis-stream.js";
 import { simCfnKinesisResourceCreation } from "../sim-cfn-kinesis-resource-error.js";
 import { kinesisStreamResourceType } from "../sim-cfn-kinesis-resource-types.js";
 import { SimCfnKinesisStreamProperties } from "./sim-cfn-kinesis-stream-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnKinesisStreamCreatorProperties {
   readonly kinesis: SimKinesis;
@@ -37,6 +38,7 @@ export class SimCfnKinesisStreamCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimKinesisStream> {
     const streamProperties = new SimCfnKinesisStreamProperties({
       resource,
@@ -52,18 +54,21 @@ export class SimCfnKinesisStreamCreator {
       kinesisStreamResourceType,
       resource.logicalId,
       async () => {
-        await this.kinesis.createStream({
-          input: {
-            StreamName: name,
-            ...(shardCount !== undefined && { ShardCount: shardCount }),
-            ...(streamMode !== undefined && {
-              StreamModeDetails: { StreamMode: streamMode },
-            }),
-            ...(tags !== undefined && { Tags: tags }),
+        await this.kinesis.createStream(
+          {
+            input: {
+              StreamName: name,
+              ...(shardCount !== undefined && { ShardCount: shardCount }),
+              ...(streamMode !== undefined && {
+                StreamModeDetails: { StreamMode: streamMode },
+              }),
+              ...(tags !== undefined && { Tags: tags }),
+            },
           },
-        });
+          options,
+        );
 
-        await this.applyRetention(name, retentionHours);
+        await this.applyRetention(name, retentionHours, options);
 
         const stream = this.kinesis.findStream(name);
         assertDefined(
@@ -88,6 +93,7 @@ export class SimCfnKinesisStreamCreator {
   private async applyRetention(
     name: string,
     retentionHours: number | undefined,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (
       retentionHours === undefined ||
@@ -96,8 +102,9 @@ export class SimCfnKinesisStreamCreator {
       return;
     }
 
-    await this.kinesis.increaseStreamRetentionPeriod({
-      input: { StreamName: name, RetentionPeriodHours: retentionHours },
-    });
+    await this.kinesis.increaseStreamRetentionPeriod(
+      { input: { StreamName: name, RetentionPeriodHours: retentionHours } },
+      options,
+    );
   }
 }

--- a/src/service/kms/cfn/alias/sim-cfn-kms-alias-creator.ts
+++ b/src/service/kms/cfn/alias/sim-cfn-kms-alias-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimKmsAlias } from "../../key/sim-kms-alias.js";
 import type { SimKms } from "../../sim-kms.js";
 import { SimCfnKmsAliasProperties } from "./sim-cfn-kms-alias-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnKmsAliasCreatorProperties {
   readonly kms: SimKms;
@@ -30,6 +31,7 @@ export class SimCfnKmsAliasCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimKmsAlias> {
     const aliasProperties = new SimCfnKmsAliasProperties({
       resource,
@@ -37,12 +39,15 @@ export class SimCfnKmsAliasCreator {
     });
     const aliasName = aliasProperties.aliasName();
 
-    await this.kms.createAlias({
-      input: {
-        AliasName: aliasName,
-        TargetKeyId: aliasProperties.targetKeyId(),
+    await this.kms.createAlias(
+      {
+        input: {
+          AliasName: aliasName,
+          TargetKeyId: aliasProperties.targetKeyId(),
+        },
       },
-    });
+      options,
+    );
 
     const alias = this.kms.findAlias(aliasName);
     assertDefined(

--- a/src/service/kms/cfn/key/sim-cfn-kms-key-creator.ts
+++ b/src/service/kms/cfn/key/sim-cfn-kms-key-creator.ts
@@ -57,7 +57,7 @@ export class SimCfnKmsKeyCreator {
     const key = this.kms.findKey(keyId);
     assertDefined(key, `sim KMS key ${keyId} after CloudFormation creation`);
 
-    this.applyEnabled(key, keyProperties.enabled());
+    await this.applyEnabled(keyId, keyProperties.enabled(), options);
 
     return key;
   }
@@ -66,15 +66,20 @@ export class SimCfnKmsKeyCreator {
    * Apply `Enabled: false`, which asks for a key that is disabled the moment
    * it exists.
    *
-   * CreateKey has no input for that, as the real API has none either: real
-   * CloudFormation makes the key and then disables it. The key model is
-   * disabled directly rather than through DisableKey, because CloudFormation
-   * is acting as the key's creator here and has no caller identity of its own
-   * to authorize.
+   * CreateKey has no input for that, as the real API has none either. Real
+   * CloudFormation makes the key and then disables it, and this goes through
+   * DisableKey for the same reason, so a deployment allowed to make keys and
+   * not to disable them is refused here rather than quietly disabling one.
    */
-  private applyEnabled(key: SimKmsKey, enabled: boolean): void {
-    if (!enabled) {
-      key.disable();
+  private async applyEnabled(
+    keyId: string,
+    enabled: boolean,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    if (enabled) {
+      return;
     }
+
+    await this.kms.disableKey({ input: { KeyId: keyId } }, options);
   }
 }

--- a/src/service/kms/cfn/key/sim-cfn-kms-key-creator.ts
+++ b/src/service/kms/cfn/key/sim-cfn-kms-key-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimKmsKey } from "../../key/sim-kms-key.js";
 import type { SimKms } from "../../sim-kms.js";
 import { SimCfnKmsKeyProperties } from "./sim-cfn-kms-key-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnKmsKeyCreatorProperties {
   readonly kms: SimKms;
@@ -30,18 +31,22 @@ export class SimCfnKmsKeyCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimKmsKey> {
     const keyProperties = new SimCfnKmsKeyProperties({ resource, properties });
 
-    const created = await this.kms.createKey({
-      input: {
-        Description: keyProperties.description(),
-        Policy: keyProperties.policy(),
-        KeySpec: keyProperties.keySpec(),
-        KeyUsage: keyProperties.keyUsage(),
-        Origin: keyProperties.origin(),
+    const created = await this.kms.createKey(
+      {
+        input: {
+          Description: keyProperties.description(),
+          Policy: keyProperties.policy(),
+          KeySpec: keyProperties.keySpec(),
+          KeyUsage: keyProperties.keyUsage(),
+          Origin: keyProperties.origin(),
+        },
       },
-    });
+      options,
+    );
 
     const keyId = created.KeyMetadata?.KeyId;
     assertDefined(

--- a/src/service/kms/cfn/sim-cfn-kms-resource-deleter.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-resource-deleter.ts
@@ -3,6 +3,7 @@ import type { SimKms } from "../sim-kms.js";
 import type { SimKmsKey } from "../key/sim-kms-key.js";
 import type { SimKmsAlias } from "../key/sim-kms-alias.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnKmsResourceDeleterProperties {
   readonly kms: SimKms;
@@ -29,6 +30,7 @@ export class SimCfnKmsResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "Key": {
@@ -38,7 +40,10 @@ export class SimCfnKmsResourceDeleter {
           `sim KMS Key for CloudFormation Resource ${resource.logicalId}`,
         );
 
-        await this.kms.scheduleKeyDeletion({ input: { KeyId: key.keyId } });
+        await this.kms.scheduleKeyDeletion(
+          { input: { KeyId: key.keyId } },
+          options,
+        );
 
         return;
       }
@@ -49,9 +54,10 @@ export class SimCfnKmsResourceDeleter {
           `sim KMS Alias for CloudFormation Resource ${resource.logicalId}`,
         );
 
-        await this.kms.deleteAlias({
-          input: { AliasName: alias.aliasName },
-        });
+        await this.kms.deleteAlias(
+          { input: { AliasName: alias.aliasName } },
+          options,
+        );
 
         return;
       }

--- a/src/service/kms/cfn/sim-cfn-kms-resource-factory.ts
+++ b/src/service/kms/cfn/sim-cfn-kms-resource-factory.ts
@@ -7,6 +7,8 @@ import type { SimKms } from "../sim-kms.js";
 import { SimCfnKmsAliasCreator } from "./alias/sim-cfn-kms-alias-creator.js";
 import { SimCfnKmsKeyCreator } from "./key/sim-cfn-kms-key-creator.js";
 import { SimCfnKmsResourceDeleter } from "./sim-cfn-kms-resource-deleter.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 
 interface SimKmsCfnResourceFactoryProperties {
   readonly kms: SimKms;
@@ -38,13 +40,14 @@ export class SimKmsCfnResourceFactory implements SimCfnServiceResourceFactory {
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case "Key": {
-        return await this.keyCreator.create(resource, properties);
+        return await this.keyCreator.create(resource, properties, options);
       }
       case "Alias": {
-        return await this.aliasCreator.create(resource, properties);
+        return await this.aliasCreator.create(resource, properties, options);
       }
       default: {
         throw new Error(
@@ -60,7 +63,12 @@ export class SimKmsCfnResourceFactory implements SimCfnServiceResourceFactory {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.deleter.delete(resourceTypeName, resource);
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/lambda/cfn/alias/sim-cfn-lambda-alias-creator.ts
+++ b/src/service/lambda/cfn/alias/sim-cfn-lambda-alias-creator.ts
@@ -5,6 +5,7 @@ import type { SimLambdaFunctionAlias } from "../../function/version/sim-lambda-f
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
 import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnLambdaAliasCreatorProperties {
   readonly lambda: SimLambda;
@@ -36,6 +37,7 @@ export class SimCfnLambdaAliasCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLambdaFunctionAlias> {
     const functionName = simCfnLambdaTargetFunctionName(
       this.propertyParser.requiredString(
@@ -50,22 +52,25 @@ export class SimCfnLambdaAliasCreator {
       "Name",
     );
 
-    await this.lambda.createAlias({
-      input: {
-        FunctionName: functionName,
-        Name: name,
-        FunctionVersion: this.propertyParser.requiredString(
-          resource,
-          properties["FunctionVersion"],
-          "FunctionVersion",
-        ),
-        Description: this.propertyParser.optionalString(
-          resource,
-          properties["Description"],
-          "Description",
-        ),
+    await this.lambda.createAlias(
+      {
+        input: {
+          FunctionName: functionName,
+          Name: name,
+          FunctionVersion: this.propertyParser.requiredString(
+            resource,
+            properties["FunctionVersion"],
+            "FunctionVersion",
+          ),
+          Description: this.propertyParser.optionalString(
+            resource,
+            properties["Description"],
+            "Description",
+          ),
+        },
       },
-    });
+      options,
+    );
 
     const alias = this.lambda.getSimFunctionAlias(functionName, name);
     assertDefined(

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-creator.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimLambdaEventInvokeConfig } from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaEventInvokeConfigProperties } from "./sim-cfn-lambda-event-invoke-config-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnLambdaEventInvokeConfigCreatorProperties {
   readonly lambda: SimLambda;
@@ -31,6 +32,7 @@ export class SimCfnLambdaEventInvokeConfigCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLambdaEventInvokeConfig> {
     const { functionName, qualifier, input } =
       new SimCfnLambdaEventInvokeConfigProperties({
@@ -38,7 +40,7 @@ export class SimCfnLambdaEventInvokeConfigCreator {
         properties,
       }).createInput();
 
-    await this.lambda.putFunctionEventInvokeConfig({ input });
+    await this.lambda.putFunctionEventInvokeConfig({ input }, options);
 
     const config = this.lambda.getSimEventInvokeConfig(functionName, qualifier);
 

--- a/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-remover.ts
+++ b/src/service/lambda/cfn/event-invoke-config/sim-cfn-lambda-event-invoke-config-remover.ts
@@ -2,6 +2,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimLambdaEventInvokeConfig } from "../../function/event-invoke/sim-lambda-event-invoke-config.js";
 import type { SimLambda } from "../../sim-lambda.js";
 import { simCfnLambdaCreatedResource } from "../sim-cfn-lambda-created-resource.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 /**
  * Take an AWS::Lambda::EventInvokeConfig off the function it was written on,
@@ -15,6 +16,7 @@ import { simCfnLambdaCreatedResource } from "../sim-cfn-lambda-created-resource.
 export async function simCfnLambdaRemoveEventInvokeConfig(
   lambda: SimLambda,
   resource: SimCfnResource,
+  options?: SimCfnResourceCallerOptions,
 ): Promise<void> {
   const { functionName, qualifier } =
     simCfnLambdaCreatedResource<SimLambdaEventInvokeConfig>(
@@ -26,7 +28,8 @@ export async function simCfnLambdaRemoveEventInvokeConfig(
     return;
   }
 
-  await lambda.deleteFunctionEventInvokeConfig({
-    input: { FunctionName: functionName, Qualifier: qualifier },
-  });
+  await lambda.deleteFunctionEventInvokeConfig(
+    { input: { FunctionName: functionName, Qualifier: qualifier } },
+    options,
+  );
 }

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-creator.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimLambdaEventSourceMapping } from "../../event-source/sim-lambda-event-source-mapping.js";
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaEventSourceMappingProperties } from "./sim-cfn-lambda-event-source-mapping-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnLambdaEventSourceMappingCreatorProperties {
   readonly lambda: SimLambda;
@@ -31,13 +32,17 @@ export class SimCfnLambdaEventSourceMappingCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLambdaEventSourceMapping> {
-    const created = await this.lambda.createEventSourceMapping({
-      input: new SimCfnLambdaEventSourceMappingProperties({
-        resource,
-        properties,
-      }).createInput(),
-    });
+    const created = await this.lambda.createEventSourceMapping(
+      {
+        input: new SimCfnLambdaEventSourceMappingProperties({
+          resource,
+          properties,
+        }).createInput(),
+      },
+      options,
+    );
 
     const mapping = this.lambda.getSimEventSourceMapping(created.UUID);
 

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-creator.ts
@@ -10,6 +10,7 @@ import {
   simCfnLambdaCreateFunctionInput,
   SimCfnLambdaFunctionPropertiesParser,
 } from "./sim-cfn-lambda-function-properties-parser.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnLambdaFunctionCreatorProperties {
   readonly lambda: SimLambda;
@@ -41,6 +42,7 @@ export class SimCfnLambdaFunctionCreator {
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
     bindings?: readonly SimCfnBinding[],
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLambdaFunction> {
     const functionProperties = this.propertiesParser.parse(
       resource,
@@ -62,13 +64,13 @@ export class SimCfnLambdaFunctionCreator {
       throw skipError;
     }
 
+    const input = simCfnLambdaCreateFunctionInput(
+      functionProperties,
+      codeInput.code,
+    );
+
     try {
-      await this.lambda.createFunction({
-        input: simCfnLambdaCreateFunctionInput(
-          functionProperties,
-          codeInput.code,
-        ),
-      });
+      await this.lambda.createFunction({ input }, options);
     } catch (error) {
       const assetsSkipError = this.skips.fromCreateFailure(
         resource,

--- a/src/service/lambda/cfn/permission/sim-cfn-lambda-permission-creator.ts
+++ b/src/service/lambda/cfn/permission/sim-cfn-lambda-permission-creator.ts
@@ -5,6 +5,7 @@ import type { SimLambdaPermission } from "../../function/policy/sim-lambda-permi
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
 import { simCfnLambdaTargetFunction } from "../function/sim-cfn-lambda-target-function.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnLambdaPermissionCreatorProperties {
   readonly lambda: SimLambda;
@@ -42,6 +43,7 @@ export class SimCfnLambdaPermissionCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLambdaPermission> {
     const { functionName, qualifier } = simCfnLambdaTargetFunction(
       this.propertyParser.requiredString(
@@ -51,48 +53,51 @@ export class SimCfnLambdaPermissionCreator {
       ),
     );
 
-    await this.lambda.addPermission({
-      input: {
-        FunctionName: functionName,
-        Qualifier: qualifier,
-        StatementId: resource.logicalId,
-        Action: this.propertyParser.requiredString(
-          resource,
-          properties["Action"],
-          "Action",
-        ),
-        Principal: this.propertyParser.requiredString(
-          resource,
-          properties["Principal"],
-          "Principal",
-        ),
-        FunctionUrlAuthType: this.propertyParser.optionalString(
-          resource,
-          properties["FunctionUrlAuthType"],
-          "FunctionUrlAuthType",
-        ),
-        SourceArn: this.propertyParser.optionalString(
-          resource,
-          properties["SourceArn"],
-          "SourceArn",
-        ),
-        SourceAccount: this.propertyParser.optionalString(
-          resource,
-          properties["SourceAccount"],
-          "SourceAccount",
-        ),
-        PrincipalOrgID: this.propertyParser.optionalString(
-          resource,
-          properties["PrincipalOrgID"],
-          "PrincipalOrgID",
-        ),
-        InvokedViaFunctionUrl: this.propertyParser.optionalBoolean(
-          resource,
-          properties["InvokedViaFunctionUrl"],
-          "InvokedViaFunctionUrl",
-        ),
+    await this.lambda.addPermission(
+      {
+        input: {
+          FunctionName: functionName,
+          Qualifier: qualifier,
+          StatementId: resource.logicalId,
+          Action: this.propertyParser.requiredString(
+            resource,
+            properties["Action"],
+            "Action",
+          ),
+          Principal: this.propertyParser.requiredString(
+            resource,
+            properties["Principal"],
+            "Principal",
+          ),
+          FunctionUrlAuthType: this.propertyParser.optionalString(
+            resource,
+            properties["FunctionUrlAuthType"],
+            "FunctionUrlAuthType",
+          ),
+          SourceArn: this.propertyParser.optionalString(
+            resource,
+            properties["SourceArn"],
+            "SourceArn",
+          ),
+          SourceAccount: this.propertyParser.optionalString(
+            resource,
+            properties["SourceAccount"],
+            "SourceAccount",
+          ),
+          PrincipalOrgID: this.propertyParser.optionalString(
+            resource,
+            properties["PrincipalOrgID"],
+            "PrincipalOrgID",
+          ),
+          InvokedViaFunctionUrl: this.propertyParser.optionalBoolean(
+            resource,
+            properties["InvokedViaFunctionUrl"],
+            "InvokedViaFunctionUrl",
+          ),
+        },
       },
-    });
+      options,
+    );
 
     const permission = this.lambda
       .getSimFunctionTarget(functionName, qualifier)

--- a/src/service/lambda/cfn/permission/sim-cfn-lambda-permission-revoker.ts
+++ b/src/service/lambda/cfn/permission/sim-cfn-lambda-permission-revoker.ts
@@ -3,6 +3,7 @@ import type { SimLambda } from "../../sim-lambda.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import { simCfnLambdaCreatedResource } from "../sim-cfn-lambda-created-resource.js";
 import { simCfnLambdaTargetFunction } from "../function/sim-cfn-lambda-target-function.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 /**
  * Take an AWS::Lambda::Permission back off what it was granted on.
@@ -15,6 +16,7 @@ import { simCfnLambdaTargetFunction } from "../function/sim-cfn-lambda-target-fu
 export async function simCfnLambdaRevokePermission(
   lambda: SimLambda,
   resource: SimCfnResource,
+  options?: SimCfnResourceCallerOptions,
 ): Promise<void> {
   const permission = simCfnLambdaCreatedResource<SimLambdaPermission>(
     resource,
@@ -24,11 +26,14 @@ export async function simCfnLambdaRevokePermission(
     permission.resourceArn,
   );
 
-  await lambda.removePermission({
-    input: {
-      FunctionName: functionName,
-      Qualifier: qualifier,
-      StatementId: permission.statementId,
+  await lambda.removePermission(
+    {
+      input: {
+        FunctionName: functionName,
+        Qualifier: qualifier,
+        StatementId: permission.statementId,
+      },
     },
-  });
+    options,
+  );
 }

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-deleter.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-deleter.ts
@@ -4,10 +4,11 @@ import type { SimLambdaFunction } from "../function/sim-lambda-function.js";
 import type { SimLambdaFunctionUrl } from "../function/url/sim-lambda-function-url.js";
 import type { SimLambdaEventSourceMapping } from "../event-source/sim-lambda-event-source-mapping.js";
 import type { SimLambdaFunctionAlias } from "../function/version/sim-lambda-function-alias.js";
-import { simCfnLambdaCreatedResource } from "./sim-cfn-lambda-created-resource.js";
+import { simCfnLambdaCreatedResource as created } from "./sim-cfn-lambda-created-resource.js";
 import { simCfnLambdaRemoveEventInvokeConfig } from "./event-invoke-config/sim-cfn-lambda-event-invoke-config-remover.js";
 import { simCfnLambdaRevokePermission } from "./permission/sim-cfn-lambda-permission-revoker.js";
 import { simCfnLambdaTargetFunctionName } from "./function/sim-cfn-lambda-target-function.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnLambdaResourceDeleterProperties {
   readonly lambda: SimLambda;
@@ -33,26 +34,49 @@ export class SimCfnLambdaResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "Function": {
-        await this.deleteFunction(resource);
+        const { name } = created<SimLambdaFunction>(resource, "function");
+
+        await this.lambda.deleteFunction(
+          { input: { FunctionName: name } },
+          options,
+        );
         return;
       }
       case "Url": {
-        await this.deleteFunctionUrl(resource);
+        const url = created<SimLambdaFunctionUrl>(resource, "Function URL");
+
+        await this.lambda.deleteFunctionUrlConfig(
+          { input: { FunctionName: url.functionName } },
+          options,
+        );
         return;
       }
       case "EventSourceMapping": {
-        await this.deleteEventSourceMapping(resource);
+        const { uuid } = created<SimLambdaEventSourceMapping>(
+          resource,
+          "event source mapping",
+        );
+
+        await this.lambda.deleteEventSourceMapping(
+          { input: { UUID: uuid } },
+          options,
+        );
         return;
       }
       case "EventInvokeConfig": {
-        await simCfnLambdaRemoveEventInvokeConfig(this.lambda, resource);
+        await simCfnLambdaRemoveEventInvokeConfig(
+          this.lambda,
+          resource,
+          options,
+        );
         return;
       }
       case "Permission": {
-        await simCfnLambdaRevokePermission(this.lambda, resource);
+        await simCfnLambdaRevokePermission(this.lambda, resource, options);
         return;
       }
       case "Version": {
@@ -64,7 +88,18 @@ export class SimCfnLambdaResourceDeleter {
         return;
       }
       case "Alias": {
-        await this.deleteAlias(resource);
+        // The version the alias pointed at is left where it is.
+        const alias = created<SimLambdaFunctionAlias>(resource, "alias");
+
+        await this.lambda.deleteAlias(
+          {
+            input: {
+              FunctionName: simCfnLambdaTargetFunctionName(alias.arn),
+              Name: alias.name,
+            },
+          },
+          options,
+        );
         return;
       }
       default: {
@@ -73,57 +108,5 @@ export class SimCfnLambdaResourceDeleter {
         );
       }
     }
-  }
-
-  private async deleteFunction(resource: SimCfnResource): Promise<void> {
-    const simFunction = simCfnLambdaCreatedResource<SimLambdaFunction>(
-      resource,
-      "function",
-    );
-
-    await this.lambda.deleteFunction({
-      input: { FunctionName: simFunction.name },
-    });
-  }
-
-  private async deleteFunctionUrl(resource: SimCfnResource): Promise<void> {
-    const functionUrl = simCfnLambdaCreatedResource<SimLambdaFunctionUrl>(
-      resource,
-      "Function URL",
-    );
-
-    await this.lambda.deleteFunctionUrlConfig({
-      input: { FunctionName: functionUrl.functionName },
-    });
-  }
-
-  private async deleteEventSourceMapping(
-    resource: SimCfnResource,
-  ): Promise<void> {
-    const mapping = simCfnLambdaCreatedResource<SimLambdaEventSourceMapping>(
-      resource,
-      "event source mapping",
-    );
-
-    await this.lambda.deleteEventSourceMapping({
-      input: { UUID: mapping.uuid },
-    });
-  }
-
-  /**
-   * Drop an alias, leaving the version it pointed at where it is.
-   */
-  private async deleteAlias(resource: SimCfnResource): Promise<void> {
-    const alias = simCfnLambdaCreatedResource<SimLambdaFunctionAlias>(
-      resource,
-      "alias",
-    );
-
-    await this.lambda.deleteAlias({
-      input: {
-        FunctionName: simCfnLambdaTargetFunctionName(alias.arn),
-        Name: alias.name,
-      },
-    });
   }
 }

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.ts
@@ -1,7 +1,9 @@
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type { SimLambda } from "../sim-lambda.js";
 import { SimCfnLambdaAliasCreator } from "./alias/sim-cfn-lambda-alias-creator.js";
@@ -49,49 +51,47 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "Function": {
         return await this.functionCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
           context.bindings,
+          options,
         );
       }
       case "Url": {
-        return await this.urlCreator.create(
-          resource,
-          context.resolvedProperties ?? resource.properties,
-        );
+        return await this.urlCreator.create(resource, properties, options);
       }
       case "EventSourceMapping": {
         return await this.eventSourceMappingCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
+          options,
         );
       }
       case "EventInvokeConfig": {
         return await this.eventInvokeConfigCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
+          options,
         );
       }
       case "Permission": {
         return await this.permissionCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
+          options,
         );
       }
       case "Version": {
-        return await this.versionCreator.create(
-          resource,
-          context.resolvedProperties ?? resource.properties,
-        );
+        return await this.versionCreator.create(resource, properties, options);
       }
       case "Alias": {
-        return await this.aliasCreator.create(
-          resource,
-          context.resolvedProperties ?? resource.properties,
-        );
+        return await this.aliasCreator.create(resource, properties, options);
       }
       default: {
         throw new Error(
@@ -107,7 +107,12 @@ export class SimLambdaCloudFormationResourceFactory implements SimCfnServiceReso
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.deleter.delete(resourceTypeName, resource);
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/lambda/cfn/url/sim-cfn-lambda-url-creator.ts
+++ b/src/service/lambda/cfn/url/sim-cfn-lambda-url-creator.ts
@@ -9,6 +9,7 @@ import type {
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
 import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnLambdaUrlCreatorProperties {
   readonly lambda: SimLambda;
@@ -35,6 +36,7 @@ export class SimCfnLambdaUrlCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLambdaFunctionUrl> {
     const targetFunctionArn = this.propertyParser.requiredString(
       resource,
@@ -43,21 +45,24 @@ export class SimCfnLambdaUrlCreator {
     );
     const functionName = simCfnLambdaTargetFunctionName(targetFunctionArn);
 
-    await this.lambda.createFunctionUrlConfig({
-      input: {
-        FunctionName: functionName,
-        AuthType: this.propertyParser.requiredString(
-          resource,
-          properties["AuthType"],
-          "AuthType",
-        ) as SimLambdaFunctionUrlAuthType,
-        InvokeMode: this.propertyParser.optionalString(
-          resource,
-          properties["InvokeMode"],
-          "InvokeMode",
-        ) as SimLambdaFunctionUrlInvokeMode | undefined,
+    await this.lambda.createFunctionUrlConfig(
+      {
+        input: {
+          FunctionName: functionName,
+          AuthType: this.propertyParser.requiredString(
+            resource,
+            properties["AuthType"],
+            "AuthType",
+          ) as SimLambdaFunctionUrlAuthType,
+          InvokeMode: this.propertyParser.optionalString(
+            resource,
+            properties["InvokeMode"],
+            "InvokeMode",
+          ) as SimLambdaFunctionUrlInvokeMode | undefined,
+        },
       },
-    });
+      options,
+    );
 
     const functionUrl = this.lambda.getSimFunctionUrl(functionName);
     assertDefined(

--- a/src/service/lambda/cfn/version/sim-cfn-lambda-version-creator.ts
+++ b/src/service/lambda/cfn/version/sim-cfn-lambda-version-creator.ts
@@ -5,6 +5,7 @@ import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
 import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnLambdaVersionCreatorProperties {
   readonly lambda: SimLambda;
@@ -37,6 +38,7 @@ export class SimCfnLambdaVersionCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLambdaFunction> {
     const functionName = simCfnLambdaTargetFunctionName(
       this.propertyParser.requiredString(
@@ -46,16 +48,19 @@ export class SimCfnLambdaVersionCreator {
       ),
     );
 
-    const published = await this.lambda.publishVersion({
-      input: {
-        FunctionName: functionName,
-        Description: this.propertyParser.optionalString(
-          resource,
-          properties["Description"],
-          "Description",
-        ),
+    const published = await this.lambda.publishVersion(
+      {
+        input: {
+          FunctionName: functionName,
+          Description: this.propertyParser.optionalString(
+            resource,
+            properties["Description"],
+            "Description",
+          ),
+        },
       },
-    });
+      options,
+    );
 
     const version = this.lambda.getSimFunctionTarget(
       functionName,

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-creator.ts
@@ -3,6 +3,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimLogsDelivery } from "../../delivery/sim-logs-delivery.js";
 import type { SimLogs } from "../../sim-logs.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import { simCfnDeliveryInput } from "./sim-cfn-delivery-input.js";
 import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
 import { deliveryUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
@@ -41,6 +42,7 @@ export class SimCfnDeliveryCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLogsDelivery> {
     const reader = new SimCfnDeliveryProperties({
       resource,
@@ -52,9 +54,10 @@ export class SimCfnDeliveryCreator {
 
     reader.recordIgnoredProperties();
 
-    const created = await this.#logs.createDelivery({
-      input: simCfnDeliveryInput(reader),
-    });
+    const created = await this.#logs.createDelivery(
+      { input: simCfnDeliveryInput(reader) },
+      options,
+    );
     const delivery = this.#logs.findDelivery(created.delivery?.id ?? "");
 
     assertDefined(
@@ -68,7 +71,10 @@ export class SimCfnDeliveryCreator {
   /**
    * Delete a delivery created from a CloudFormation Resource.
    */
-  async delete(delivery: SimLogsDelivery): Promise<void> {
-    await this.#logs.deleteDelivery({ input: { id: delivery.id } });
+  async delete(
+    delivery: SimLogsDelivery,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#logs.deleteDelivery({ input: { id: delivery.id } }, options);
   }
 }

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-destination-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-destination-creator.ts
@@ -3,6 +3,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimLogsDeliveryDestination } from "../../delivery/sim-logs-delivery-destination.js";
 import type { SimLogs } from "../../sim-logs.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
 import { deliveryDestinationUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
 
@@ -39,6 +40,7 @@ export class SimCfnDeliveryDestinationCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLogsDeliveryDestination> {
     const reader = new SimCfnDeliveryProperties({
       resource,
@@ -51,17 +53,20 @@ export class SimCfnDeliveryDestinationCreator {
 
     reader.recordIgnoredProperties();
 
-    await this.#logs.putDeliveryDestination({
-      input: {
-        name,
-        outputFormat: reader.optionalString("OutputFormat"),
-        deliveryDestinationConfiguration: {
-          destinationResourceArn: reader.requiredString(
-            "DestinationResourceArn",
-          ),
+    await this.#logs.putDeliveryDestination(
+      {
+        input: {
+          name,
+          outputFormat: reader.optionalString("OutputFormat"),
+          deliveryDestinationConfiguration: {
+            destinationResourceArn: reader.requiredString(
+              "DestinationResourceArn",
+            ),
+          },
         },
       },
-    });
+      options,
+    );
 
     const destination = this.#logs.findDeliveryDestination(name);
 
@@ -76,9 +81,13 @@ export class SimCfnDeliveryDestinationCreator {
   /**
    * Delete a delivery destination created from a CloudFormation Resource.
    */
-  async delete(destination: SimLogsDeliveryDestination): Promise<void> {
-    await this.#logs.deleteDeliveryDestination({
-      input: { name: destination.name },
-    });
+  async delete(
+    destination: SimLogsDeliveryDestination,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#logs.deleteDeliveryDestination(
+      { input: { name: destination.name } },
+      options,
+    );
   }
 }

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-source-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-source-creator.ts
@@ -3,6 +3,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimLogsDeliverySource } from "../../delivery/sim-logs-delivery-source.js";
 import type { SimLogs } from "../../sim-logs.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
 import { deliverySourceUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
 
@@ -34,6 +35,7 @@ export class SimCfnDeliverySourceCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimLogsDeliverySource> {
     const reader = new SimCfnDeliveryProperties({
       resource,
@@ -46,13 +48,16 @@ export class SimCfnDeliverySourceCreator {
 
     reader.recordIgnoredProperties();
 
-    await this.#logs.putDeliverySource({
-      input: {
-        name,
-        resourceArn: reader.requiredString("ResourceArn"),
-        logType: reader.requiredString("LogType"),
+    await this.#logs.putDeliverySource(
+      {
+        input: {
+          name,
+          resourceArn: reader.requiredString("ResourceArn"),
+          logType: reader.requiredString("LogType"),
+        },
       },
-    });
+      options,
+    );
 
     const source = this.#logs.findDeliverySource(name);
 
@@ -67,7 +72,13 @@ export class SimCfnDeliverySourceCreator {
   /**
    * Delete a delivery source created from a CloudFormation Resource.
    */
-  async delete(source: SimLogsDeliverySource): Promise<void> {
-    await this.#logs.deleteDeliverySource({ input: { name: source.name } });
+  async delete(
+    source: SimLogsDeliverySource,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#logs.deleteDeliverySource(
+      { input: { name: source.name } },
+      options,
+    );
   }
 }

--- a/src/service/logs/cfn/sim-cfn-log-group.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-log-group.iso.test.ts
@@ -191,7 +191,7 @@ describe("AWS::Logs::LogGroup", () => {
       factory.create("MetricFilter", {} as never, {} as never),
     );
     const deleted = await assertThrowsErrorAsync(async () =>
-      factory.delete("MetricFilter", {} as never),
+      factory.delete("MetricFilter", {} as never, {} as never),
     );
 
     // Then both are reported as unsupported, which the Stack records as a

--- a/src/service/logs/cfn/sim-logs-cfn-resource-deleter.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-deleter.ts
@@ -9,6 +9,7 @@ import type { SimCfnDeliveryDestinationCreator } from "./delivery/sim-cfn-delive
 import type { SimCfnDeliverySourceCreator } from "./delivery/sim-cfn-delivery-source-creator.js";
 import type { SimCfnLogGroupCreator } from "./group/sim-cfn-log-group-creator.js";
 import { unsupportedSimLogsResourceType } from "./sim-logs-cfn-unsupported-resource.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimLogsCfnResourceDeleterProperties {
   readonly logGroups: SimCfnLogGroupCreator;
@@ -36,6 +37,7 @@ export class SimLogsCfnResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "LogGroup": {
@@ -46,6 +48,7 @@ export class SimLogsCfnResourceDeleter {
       case "DeliverySource": {
         await this.#creators.deliverySources.delete(
           created<SimLogsDeliverySource>(resource),
+          options,
         );
 
         return;
@@ -53,6 +56,7 @@ export class SimLogsCfnResourceDeleter {
       case "DeliveryDestination": {
         await this.#creators.deliveryDestinations.delete(
           created<SimLogsDeliveryDestination>(resource),
+          options,
         );
 
         return;
@@ -60,6 +64,7 @@ export class SimLogsCfnResourceDeleter {
       case "Delivery": {
         await this.#creators.deliveries.delete(
           created<SimLogsDelivery>(resource),
+          options,
         );
 
         return;

--- a/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
@@ -2,7 +2,9 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimLogs } from "../sim-logs.js";
 import { SimCfnDeliveryCreator } from "./delivery/sim-cfn-delivery-creator.js";
 import { SimCfnDeliveryDestinationCreator } from "./delivery/sim-cfn-delivery-destination-creator.js";
@@ -59,19 +61,24 @@ export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const values = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case "LogGroup": {
         return this.#logGroups.create(resource, values);
       }
       case "DeliverySource": {
-        return await this.#deliverySources.create(resource, values);
+        return await this.#deliverySources.create(resource, values, options);
       }
       case "DeliveryDestination": {
-        return await this.#deliveryDestinations.create(resource, values);
+        return await this.#deliveryDestinations.create(
+          resource,
+          values,
+          options,
+        );
       }
       case "Delivery": {
-        return await this.#deliveries.create(resource, values);
+        return await this.#deliveries.create(resource, values, options);
       }
       default: {
         throw unsupportedSimLogsResourceType(resourceTypeName, "");
@@ -86,7 +93,12 @@ export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.#deleter.delete(resourceTypeName, resource);
+    await this.#deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/personalize/cfn/sim-cfn-personalize-dataset-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-dataset-creator.ts
@@ -7,6 +7,7 @@ import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
 import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
 import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
 import { personalizeDatasetResourceType } from "./sim-cfn-personalize-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 const readProperties = new Set([
   "Name",
@@ -49,6 +50,7 @@ export class SimCfnPersonalizeDatasetCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimPersonalizeDataset> {
     const read = new SimCfnPersonalizeProperties({
       resourceType: personalizeDatasetResourceType,
@@ -70,7 +72,10 @@ export class SimCfnPersonalizeDatasetCreator {
       personalizeDatasetResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.#personalize.createDataset({ input });
+        const created = await this.#personalize.createDataset(
+          { input },
+          options,
+        );
 
         return simCfnPersonalizeCreated(
           this.#resources.datasets,
@@ -82,9 +87,13 @@ export class SimCfnPersonalizeDatasetCreator {
   }
 
   /** Delete a dataset an AWS::Personalize::Dataset Resource made. */
-  async delete(dataset: SimPersonalizeDataset): Promise<void> {
-    await this.#personalize.deleteDataset({
-      input: { datasetArn: dataset.arn },
-    });
+  async delete(
+    dataset: SimPersonalizeDataset,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#personalize.deleteDataset(
+      { input: { datasetArn: dataset.arn } },
+      options,
+    );
   }
 }

--- a/src/service/personalize/cfn/sim-cfn-personalize-dataset-group-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-dataset-group-creator.ts
@@ -7,6 +7,7 @@ import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
 import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
 import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
 import { personalizeDatasetGroupResourceType } from "./sim-cfn-personalize-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 const readProperties = new Set(["Name", "Domain", "KmsKeyArn", "RoleArn"]);
 
@@ -41,6 +42,7 @@ export class SimCfnPersonalizeDatasetGroupCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimPersonalizeDatasetGroup> {
     const read = new SimCfnPersonalizeProperties({
       resourceType: personalizeDatasetGroupResourceType,
@@ -62,7 +64,10 @@ export class SimCfnPersonalizeDatasetGroupCreator {
       personalizeDatasetGroupResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.#personalize.createDatasetGroup({ input });
+        const created = await this.#personalize.createDatasetGroup(
+          { input },
+          options,
+        );
 
         return simCfnPersonalizeCreated(
           this.#resources.datasetGroups,
@@ -74,9 +79,13 @@ export class SimCfnPersonalizeDatasetGroupCreator {
   }
 
   /** Delete a dataset group an AWS::Personalize::DatasetGroup Resource made. */
-  async delete(datasetGroup: SimPersonalizeDatasetGroup): Promise<void> {
-    await this.#personalize.deleteDatasetGroup({
-      input: { datasetGroupArn: datasetGroup.arn },
-    });
+  async delete(
+    datasetGroup: SimPersonalizeDatasetGroup,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#personalize.deleteDatasetGroup(
+      { input: { datasetGroupArn: datasetGroup.arn } },
+      options,
+    );
   }
 }

--- a/src/service/personalize/cfn/sim-cfn-personalize-event-tracker-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-event-tracker-creator.ts
@@ -7,6 +7,7 @@ import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
 import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
 import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
 import { personalizeEventTrackerResourceType } from "./sim-cfn-personalize-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 const readProperties = new Set(["Name", "DatasetGroupArn"]);
 
@@ -37,6 +38,7 @@ export class SimCfnPersonalizeEventTrackerCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimPersonalizeEventTracker> {
     const read = new SimCfnPersonalizeProperties({
       resourceType: personalizeEventTrackerResourceType,
@@ -55,7 +57,10 @@ export class SimCfnPersonalizeEventTrackerCreator {
       personalizeEventTrackerResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.#personalize.createEventTracker({ input });
+        const created = await this.#personalize.createEventTracker(
+          { input },
+          options,
+        );
 
         return simCfnPersonalizeCreated(
           this.#resources.eventTrackers,
@@ -67,9 +72,13 @@ export class SimCfnPersonalizeEventTrackerCreator {
   }
 
   /** Delete a tracker an AWS::Personalize::EventTracker Resource made. */
-  async delete(eventTracker: SimPersonalizeEventTracker): Promise<void> {
-    await this.#personalize.deleteEventTracker({
-      input: { eventTrackerArn: eventTracker.arn },
-    });
+  async delete(
+    eventTracker: SimPersonalizeEventTracker,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#personalize.deleteEventTracker(
+      { input: { eventTrackerArn: eventTracker.arn } },
+      options,
+    );
   }
 }

--- a/src/service/personalize/cfn/sim-cfn-personalize-resource-refusals.iso.test.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-resource-refusals.iso.test.ts
@@ -146,7 +146,11 @@ describe("simulated Personalize CloudFormation refusals", () => {
       await simAws
         .personalize()
         .cfnResourceFactory()
-        .delete("MetricAttribution", deployedResourceObject(resource));
+        .delete(
+          "MetricAttribution",
+          deployedResourceObject(resource),
+          {} as never,
+        );
     });
 
     assertStringIncludes(

--- a/src/service/personalize/cfn/sim-cfn-personalize-schema-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-schema-creator.ts
@@ -7,6 +7,7 @@ import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
 import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
 import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
 import { personalizeSchemaResourceType } from "./sim-cfn-personalize-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 const readProperties = new Set(["Name", "Schema", "Domain"]);
 
@@ -35,6 +36,7 @@ export class SimCfnPersonalizeSchemaCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimPersonalizeSchema> {
     const read = new SimCfnPersonalizeProperties({
       resourceType: personalizeSchemaResourceType,
@@ -54,7 +56,10 @@ export class SimCfnPersonalizeSchemaCreator {
       personalizeSchemaResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.#personalize.createSchema({ input });
+        const created = await this.#personalize.createSchema(
+          { input },
+          options,
+        );
 
         return simCfnPersonalizeCreated(
           this.#resources.schemas,
@@ -66,7 +71,13 @@ export class SimCfnPersonalizeSchemaCreator {
   }
 
   /** Delete a schema an AWS::Personalize::Schema Resource made. */
-  async delete(schema: SimPersonalizeSchema): Promise<void> {
-    await this.#personalize.deleteSchema({ input: { schemaArn: schema.arn } });
+  async delete(
+    schema: SimPersonalizeSchema,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#personalize.deleteSchema(
+      { input: { schemaArn: schema.arn } },
+      options,
+    );
   }
 }

--- a/src/service/personalize/cfn/sim-cfn-personalize-solution-creator.ts
+++ b/src/service/personalize/cfn/sim-cfn-personalize-solution-creator.ts
@@ -7,6 +7,7 @@ import { simCfnPersonalizeCreated } from "./sim-cfn-personalize-created.js";
 import { SimCfnPersonalizeProperties } from "./sim-cfn-personalize-properties.js";
 import { simCfnPersonalizeResourceCreation } from "./sim-cfn-personalize-resource-error.js";
 import { personalizeSolutionResourceType } from "./sim-cfn-personalize-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 const readProperties = new Set([
   "Name",
@@ -51,6 +52,7 @@ export class SimCfnPersonalizeSolutionCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimPersonalizeSolution> {
     const read = new SimCfnPersonalizeProperties({
       resourceType: personalizeSolutionResourceType,
@@ -74,7 +76,10 @@ export class SimCfnPersonalizeSolutionCreator {
       personalizeSolutionResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.#personalize.createSolution({ input });
+        const created = await this.#personalize.createSolution(
+          { input },
+          options,
+        );
 
         return simCfnPersonalizeCreated(
           this.#resources.solutions,
@@ -86,9 +91,13 @@ export class SimCfnPersonalizeSolutionCreator {
   }
 
   /** Delete a solution an AWS::Personalize::Solution Resource made. */
-  async delete(solution: SimPersonalizeSolution): Promise<void> {
-    await this.#personalize.deleteSolution({
-      input: { solutionArn: solution.arn },
-    });
+  async delete(
+    solution: SimPersonalizeSolution,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#personalize.deleteSolution(
+      { input: { solutionArn: solution.arn } },
+      options,
+    );
   }
 }

--- a/src/service/personalize/cfn/sim-personalize-cfn-resource-factory.ts
+++ b/src/service/personalize/cfn/sim-personalize-cfn-resource-factory.ts
@@ -3,7 +3,12 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimPersonalizeResources } from "../resource/sim-personalize-resources.js";
 import type { SimPersonalize } from "../sim-personalize.js";
@@ -36,8 +41,12 @@ interface SimCfnPersonalizeResourceHandler {
   create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options: SimCfnResourceCallerOptions,
   ): Promise<object>;
-  delete(resource: SimCfnResource): Promise<void>;
+  delete(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void>;
 }
 
 /**
@@ -95,6 +104,7 @@ export class SimPersonalizeCfnResourceFactory implements SimCfnServiceResourceFa
     return await this.handler(resourceTypeName, "").create(
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 
@@ -105,8 +115,12 @@ export class SimPersonalizeCfnResourceFactory implements SimCfnServiceResourceFa
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.handler(resourceTypeName, " deletion").delete(resource);
+    await this.handler(resourceTypeName, " deletion").delete(
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 
   private handler(
@@ -137,16 +151,17 @@ function handler<T extends object>(
     create(
       resource: SimCfnResource,
       properties: SimCfnTemplateValueRecord,
+      options: SimCfnResourceCallerOptions,
     ): Promise<T>;
-    delete(created: T): Promise<void>;
+    delete(created: T, options: SimCfnResourceCallerOptions): Promise<void>;
   },
   described: string,
 ): SimCfnPersonalizeResourceHandler {
   return {
-    create: async (resource, properties): Promise<T> =>
-      await creator.create(resource, properties),
-    delete: async (resource): Promise<void> => {
-      await creator.delete(created<T>(resource, described));
+    create: async (resource, properties, options): Promise<T> =>
+      await creator.create(resource, properties, options),
+    delete: async (resource, options): Promise<void> => {
+      await creator.delete(created<T>(resource, described), options);
     },
   };
 }

--- a/src/service/route53/cfn/dnssec/sim-cfn-r53-ksk-creator.ts
+++ b/src/service/route53/cfn/dnssec/sim-cfn-r53-ksk-creator.ts
@@ -8,6 +8,7 @@ import type { SimRoute53 } from "../../sim-route53.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { normalizeSimRoute53HostedZoneId } from "../../command/create-hosted-zone/sim-route53-zone-id.js";
 import { simCfnRoute53String } from "./sim-cfn-r53-dnssec-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 const resourceType = "AWS::Route53::KeySigningKey";
 
@@ -35,6 +36,7 @@ export class SimCfnRoute53KskCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRoute53KeySigningKey> {
     const hostedZoneId = this.string(
       resource,
@@ -43,19 +45,22 @@ export class SimCfnRoute53KskCreator {
     );
     const name = this.string(resource, properties["Name"], "Name");
 
-    await this.route53.createKeySigningKey({
-      input: {
-        CallerReference: resource.logicalId,
-        HostedZoneId: hostedZoneId,
-        KeyManagementServiceArn: this.string(
-          resource,
-          properties["KeyManagementServiceArn"],
-          "KeyManagementServiceArn",
-        ),
-        Name: name,
-        Status: this.string(resource, properties["Status"], "Status"),
+    await this.route53.createKeySigningKey(
+      {
+        input: {
+          CallerReference: resource.logicalId,
+          HostedZoneId: hostedZoneId,
+          KeyManagementServiceArn: this.string(
+            resource,
+            properties["KeyManagementServiceArn"],
+            "KeyManagementServiceArn",
+          ),
+          Name: name,
+          Status: this.string(resource, properties["Status"], "Status"),
+        },
       },
-    });
+      options,
+    );
 
     const keySigningKey = this.route53.hostedZones
       .get(normalizeSimRoute53HostedZoneId(hostedZoneId))
@@ -80,6 +85,7 @@ export class SimCfnRoute53KskCreator {
   async delete(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const input = {
       HostedZoneId: this.string(
@@ -90,8 +96,8 @@ export class SimCfnRoute53KskCreator {
       Name: this.string(resource, properties["Name"], "Name"),
     };
 
-    await this.route53.deactivateKeySigningKey({ input });
-    await this.route53.deleteKeySigningKey({ input });
+    await this.route53.deactivateKeySigningKey({ input }, options);
+    await this.route53.deleteKeySigningKey({ input }, options);
   }
 
   private string(

--- a/src/service/route53/cfn/dnssec/sim-cfn-r53-zone-signing-creator.ts
+++ b/src/service/route53/cfn/dnssec/sim-cfn-r53-zone-signing-creator.ts
@@ -5,6 +5,7 @@ import { normalizeSimRoute53HostedZoneId } from "../../command/create-hosted-zon
 import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
 import type { SimRoute53 } from "../../sim-route53.js";
 import { simCfnRoute53String } from "./sim-cfn-r53-dnssec-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 const resourceType = "AWS::Route53::DNSSEC";
 
@@ -33,12 +34,14 @@ export class SimCfnRoute53ZoneSigningCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRoute53HostedZone> {
     const hostedZoneId = this.hostedZoneId(resource, properties);
 
-    await this.route53.enableHostedZoneDnssec({
-      input: { HostedZoneId: hostedZoneId },
-    });
+    await this.route53.enableHostedZoneDnssec(
+      { input: { HostedZoneId: hostedZoneId } },
+      options,
+    );
 
     const hostedZone = this.route53.hostedZones.get(
       normalizeSimRoute53HostedZoneId(hostedZoneId),
@@ -57,10 +60,12 @@ export class SimCfnRoute53ZoneSigningCreator {
   async delete(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
-    await this.route53.disableHostedZoneDnssec({
-      input: { HostedZoneId: this.hostedZoneId(resource, properties) },
-    });
+    await this.route53.disableHostedZoneDnssec(
+      { input: { HostedZoneId: this.hostedZoneId(resource, properties) } },
+      options,
+    );
   }
 
   private hostedZoneId(

--- a/src/service/route53/cfn/hosted-zone/sim-cfn-r53-zone-creator.ts
+++ b/src/service/route53/cfn/hosted-zone/sim-cfn-r53-zone-creator.ts
@@ -4,6 +4,7 @@ import { assertIsSimRoute53HostedZoneId } from "../../command/create-hosted-zone
 import type { SimRoute53HostedZone } from "../../hosted-zone/sim-route53-hosted-zone.js";
 import type { SimRoute53 } from "../../sim-route53.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRoute53HostedZoneCreatorProperties {
   readonly route53: SimRoute53;
@@ -25,6 +26,7 @@ export class SimCfnRoute53HostedZoneCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRoute53HostedZone> {
     const name = properties["Name"];
 
@@ -57,13 +59,16 @@ export class SimCfnRoute53HostedZoneCreator {
             ),
           };
 
-    const hostedZoneCreation = await this.route53.createHostedZone({
-      input: {
-        Name: name,
-        CallerReference: resource.logicalId,
-        HostedZoneConfig: route53HostedZoneConfig,
+    const hostedZoneCreation = await this.route53.createHostedZone(
+      {
+        input: {
+          Name: name,
+          CallerReference: resource.logicalId,
+          HostedZoneConfig: route53HostedZoneConfig,
+        },
       },
-    });
+      options,
+    );
 
     const hostedZoneId = hostedZoneCreation.HostedZone?.Id;
     assertIsSimRoute53HostedZoneId(hostedZoneId);

--- a/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.ts
+++ b/src/service/route53/cfn/record-set/apply/sim-cfn-r53-record-set-applicator.ts
@@ -8,6 +8,7 @@ import type { SimRoute53 } from "../../../sim-route53.js";
 import { assertDefined } from "../../../../../util/type-guard/defined.js";
 import { SimCfnRoute53RecordSetBuilder } from "../build/sim-cfn-r53-record-set-builder.js";
 import { SimCfnRoute53RecordSetHostedZoneResolver } from "../resolve/sim-cfn-r53-rec-set-zone-resolver.js";
+import type { SimCfnResourceCallerOptions } from "../../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRoute53RecordSetApplicatorProperties {
   readonly route53: SimRoute53;
@@ -33,6 +34,7 @@ export class SimCfnRoute53RecordSetApplicator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimRoute53Record> {
     // The record set is built first because resolving the Hosted Zone can
     // register one, and a RecordSet that turns out to be unbuildable or of a
@@ -51,19 +53,22 @@ export class SimCfnRoute53RecordSetApplicator {
       properties,
     );
 
-    await this.route53.changeResourceRecordSets({
-      input: {
-        HostedZoneId: hostedZoneId,
-        ChangeBatch: {
-          Changes: [
-            {
-              Action: "CREATE",
-              ResourceRecordSet: recordSet,
-            },
-          ],
+    await this.route53.changeResourceRecordSets(
+      {
+        input: {
+          HostedZoneId: hostedZoneId,
+          ChangeBatch: {
+            Changes: [
+              {
+                Action: "CREATE",
+                ResourceRecordSet: recordSet,
+              },
+            ],
+          },
         },
       },
-    });
+      options,
+    );
 
     const hostedZone = this.route53.hostedZones.get(hostedZoneId);
     assertDefined(hostedZone, "Sim Route53 Hosted Zone after update");
@@ -77,5 +82,42 @@ export class SimCfnRoute53RecordSetApplicator {
     assertDefined(record, "Sim Route53 Record after update");
 
     return record;
+  }
+
+  /**
+   * Remove the Record Set a Resource created.
+   *
+   * Route53 only takes changes, so this is a ChangeResourceRecordSets carrying
+   * a DELETE change built from the same template properties that created it.
+   */
+  async delete(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    const hostedZoneId = this.hostedZoneResolver.hostedZoneId(
+      resource,
+      properties,
+    );
+    const recordSet = new SimCfnRoute53RecordSetBuilder(
+      resource,
+      properties,
+    ).build();
+
+    await this.route53.changeResourceRecordSets(
+      {
+        input: {
+          HostedZoneId: hostedZoneId,
+          ChangeBatch: {
+            Changes: [{ Action: "DELETE", ResourceRecordSet: recordSet }],
+          },
+        },
+      },
+      options,
+    );
+
+    await this.route53.hostedZones
+      .get(hostedZoneId)
+      ?.waitForSynchronizationComplete();
   }
 }

--- a/src/service/route53/cfn/sim-cfn-route53-resource-deleter.ts
+++ b/src/service/route53/cfn/sim-cfn-route53-resource-deleter.ts
@@ -2,14 +2,15 @@ import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resou
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimRoute53 } from "../sim-route53.js";
 import type { SimRoute53HostedZone } from "../hosted-zone/sim-route53-hosted-zone.js";
-import { SimCfnRoute53RecordSetBuilder } from "./record-set/build/sim-cfn-r53-record-set-builder.js";
-import { SimCfnRoute53RecordSetHostedZoneResolver } from "./record-set/resolve/sim-cfn-r53-rec-set-zone-resolver.js";
+import type { SimCfnRoute53RecordSetApplicator } from "./record-set/apply/sim-cfn-r53-record-set-applicator.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimCfnRoute53KskCreator } from "./dnssec/sim-cfn-r53-ksk-creator.js";
 import type { SimCfnRoute53ZoneSigningCreator } from "./dnssec/sim-cfn-r53-zone-signing-creator.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnRoute53ResourceDeleterProperties {
   readonly route53: SimRoute53;
+  readonly recordSetCreator: SimCfnRoute53RecordSetApplicator;
   readonly keySigningKeyCreator: SimCfnRoute53KskCreator;
   readonly zoneSigningCreator: SimCfnRoute53ZoneSigningCreator;
 }
@@ -30,17 +31,15 @@ interface SimCfnRoute53ResourceDeleterProperties {
  */
 export class SimCfnRoute53ResourceDeleter {
   private readonly route53: SimRoute53;
+  private readonly recordSetCreator: SimCfnRoute53RecordSetApplicator;
   private readonly keySigningKeyCreator: SimCfnRoute53KskCreator;
   private readonly zoneSigningCreator: SimCfnRoute53ZoneSigningCreator;
-  private readonly hostedZoneResolver: SimCfnRoute53RecordSetHostedZoneResolver;
 
   constructor(properties: SimCfnRoute53ResourceDeleterProperties) {
     this.route53 = properties.route53;
+    this.recordSetCreator = properties.recordSetCreator;
     this.keySigningKeyCreator = properties.keySigningKeyCreator;
     this.zoneSigningCreator = properties.zoneSigningCreator;
-    this.hostedZoneResolver = new SimCfnRoute53RecordSetHostedZoneResolver({
-      route53: this.route53,
-    });
   }
 
   /**
@@ -50,22 +49,23 @@ export class SimCfnRoute53ResourceDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "HostedZone": {
-        await this.deleteHostedZone(resource);
+        await this.deleteHostedZone(resource, options);
         return;
       }
       case "RecordSet": {
-        await this.deleteRecordSet(resource, properties);
+        await this.recordSetCreator.delete(resource, properties, options);
         return;
       }
       case "KeySigningKey": {
-        await this.keySigningKeyCreator.delete(resource, properties);
+        await this.keySigningKeyCreator.delete(resource, properties, options);
         return;
       }
       case "DNSSEC": {
-        await this.zoneSigningCreator.delete(resource, properties);
+        await this.zoneSigningCreator.delete(resource, properties, options);
         return;
       }
       default: {
@@ -76,40 +76,19 @@ export class SimCfnRoute53ResourceDeleter {
     }
   }
 
-  private async deleteHostedZone(resource: SimCfnResource): Promise<void> {
+  private async deleteHostedZone(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const hostedZone = resource.simResource as SimRoute53HostedZone | undefined;
     assertDefined(
       hostedZone,
       `sim Route53 Hosted Zone for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.route53.deleteHostedZone({ input: { Id: hostedZone.id } });
-  }
-
-  private async deleteRecordSet(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): Promise<void> {
-    const hostedZoneId = this.hostedZoneResolver.hostedZoneId(
-      resource,
-      properties,
+    await this.route53.deleteHostedZone(
+      { input: { Id: hostedZone.id } },
+      options,
     );
-    const recordSet = new SimCfnRoute53RecordSetBuilder(
-      resource,
-      properties,
-    ).build();
-
-    await this.route53.changeResourceRecordSets({
-      input: {
-        HostedZoneId: hostedZoneId,
-        ChangeBatch: {
-          Changes: [{ Action: "DELETE", ResourceRecordSet: recordSet }],
-        },
-      },
-    });
-
-    await this.route53.hostedZones
-      .get(hostedZoneId)
-      ?.waitForSynchronizationComplete();
   }
 }

--- a/src/service/route53/cfn/sim-cfn-route53-resource-factory.ts
+++ b/src/service/route53/cfn/sim-cfn-route53-resource-factory.ts
@@ -10,6 +10,7 @@ import { SimCfnRoute53KskCreator } from "./dnssec/sim-cfn-r53-ksk-creator.js";
 import { SimCfnRoute53ZoneSigningCreator } from "./dnssec/sim-cfn-r53-zone-signing-creator.js";
 import { SimCfnRoute53ResourceDeleter } from "./sim-cfn-route53-resource-deleter.js";
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimRoute53CloudFormationResourceFactoryProperties {
   readonly route53?: SimRoute53 | undefined;
@@ -36,6 +37,7 @@ export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceRes
     this.zoneSigningCreator = new SimCfnRoute53ZoneSigningCreator({ route53 });
     this.deleter = new SimCfnRoute53ResourceDeleter({
       route53,
+      recordSetCreator: this.recordSetCreator,
       keySigningKeyCreator: this.keySigningKeyCreator,
       zoneSigningCreator: this.zoneSigningCreator,
     });
@@ -49,29 +51,36 @@ export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceRes
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
+    const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "HostedZone": {
         return await this.hostedZoneCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
+          options,
         );
       }
       case "RecordSet": {
         return await this.recordSetCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
+          options,
         );
       }
       case "KeySigningKey": {
         return await this.keySigningKeyCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
+          options,
         );
       }
       case "DNSSEC": {
         return await this.zoneSigningCreator.create(
           resource,
-          context.resolvedProperties ?? resource.properties,
+          properties,
+          options,
         );
       }
       default: {
@@ -94,6 +103,7 @@ export class SimRoute53CloudFormationResourceFactory implements SimCfnServiceRes
       resourceTypeName,
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 }

--- a/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy-creator.ts
+++ b/src/service/s3/cfn/bucket-policy/sim-cfn-s3-bucket-policy-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import type { SimS3 } from "../../sim-s3.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnS3BucketPolicyCreatorProperties {
   readonly simS3: SimS3;
@@ -35,16 +36,20 @@ export class SimCfnS3BucketPolicyCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimS3Bucket> {
     const bucketName = this.bucketNameForResource(resource, properties);
     const policyDocument = this.policyDocumentForResource(resource, properties);
 
-    await this.simS3.putBucketPolicy({
-      input: {
-        Bucket: bucketName,
-        Policy: jsonStringify(policyDocument),
+    await this.simS3.putBucketPolicy(
+      {
+        input: {
+          Bucket: bucketName,
+          Policy: jsonStringify(policyDocument),
+        },
       },
-    });
+      options,
+    );
 
     const bucket = this.simS3.getSimBucketByName(bucketName);
     assertDefined(

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-configurator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-configurator.ts
@@ -5,12 +5,14 @@ import { SimCfnS3BucketLifecycleConfiguration } from "./lifecycle/sim-cfn-s3-buc
 import { SimCfnS3BucketNotificationConfiguration } from "./notification/sim-cfn-s3-bucket-notification-configuration.js";
 import { SimCfnS3BucketPublicAccessConfiguration } from "./public-access/sim-cfn-s3-bucket-public-access-configuration.js";
 import { SimCfnS3BucketWebsiteConfiguration } from "./website/sim-cfn-s3-bucket-website-configuration.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnS3BucketConfiguratorProperties {
   readonly simS3: SimS3;
   readonly resource: SimCfnResource;
   readonly properties: SimCfnTemplateValueRecord;
   readonly bucketName: string;
+  readonly options?: SimCfnResourceCallerOptions;
 }
 
 /**
@@ -25,12 +27,14 @@ export class SimCfnS3BucketConfigurator {
   private readonly resource: SimCfnResource;
   private readonly properties: SimCfnTemplateValueRecord;
   private readonly bucketName: string;
+  private readonly options: SimCfnResourceCallerOptions;
 
   constructor(properties: SimCfnS3BucketConfiguratorProperties) {
     this.simS3 = properties.simS3;
     this.resource = properties.resource;
     this.properties = properties.properties;
     this.bucketName = properties.bucketName;
+    this.options = properties.options;
   }
 
   /**
@@ -57,9 +61,10 @@ export class SimCfnS3BucketConfigurator {
       return;
     }
 
-    await this.simS3.putBucketWebsite({
-      input: { Bucket: this.bucketName, WebsiteConfiguration: config },
-    });
+    await this.simS3.putBucketWebsite(
+      { input: { Bucket: this.bucketName, WebsiteConfiguration: config } },
+      this.options,
+    );
   }
 
   private async configurePublicAccess(): Promise<void> {
@@ -72,12 +77,15 @@ export class SimCfnS3BucketConfigurator {
       return;
     }
 
-    await this.simS3.putPublicAccessBlock({
-      input: {
-        Bucket: this.bucketName,
-        PublicAccessBlockConfiguration: config,
+    await this.simS3.putPublicAccessBlock(
+      {
+        input: {
+          Bucket: this.bucketName,
+          PublicAccessBlockConfiguration: config,
+        },
       },
-    });
+      this.options,
+    );
   }
 
   private async configureLifecycle(): Promise<void> {
@@ -90,9 +98,10 @@ export class SimCfnS3BucketConfigurator {
       return;
     }
 
-    await this.simS3.putBucketLifecycleConfiguration({
-      input: { Bucket: this.bucketName, LifecycleConfiguration: config },
-    });
+    await this.simS3.putBucketLifecycleConfiguration(
+      { input: { Bucket: this.bucketName, LifecycleConfiguration: config } },
+      this.options,
+    );
   }
 
   private async configureNotifications(): Promise<void> {
@@ -106,11 +115,9 @@ export class SimCfnS3BucketConfigurator {
       this.resource.logicalId,
     ).read(declared);
 
-    await this.simS3.putBucketNotificationConfiguration({
-      input: {
-        Bucket: this.bucketName,
-        NotificationConfiguration: config,
-      },
-    });
+    await this.simS3.putBucketNotificationConfiguration(
+      { input: { Bucket: this.bucketName, NotificationConfiguration: config } },
+      this.options,
+    );
   }
 }

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
@@ -6,6 +6,7 @@ import { validateS3BucketName } from "../../bucket/validate/validate-s3-bucket-n
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimCfnS3BucketConfigurator } from "./sim-cfn-s3-bucket-configurator.js";
 import { SimCfnS3BucketPropertyRules } from "./sim-cfn-s3-bucket-property-rules.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnS3BucketCreatorProperties {
   readonly simS3: SimS3;
@@ -32,6 +33,7 @@ export class SimCfnS3BucketCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimS3Bucket> {
     new SimCfnS3BucketPropertyRules({
       logicalId: resource.logicalId,
@@ -42,7 +44,7 @@ export class SimCfnS3BucketCreator {
     const bucketName = this.bucketNameForResource(resource, properties);
     validateS3BucketName(bucketName);
 
-    await this.simS3.createBucket({ input: { Bucket: bucketName } });
+    await this.simS3.createBucket({ input: { Bucket: bucketName } }, options);
 
     const bucket = this.simS3.getSimBucketByName(bucketName);
     assertDefined(
@@ -55,6 +57,7 @@ export class SimCfnS3BucketCreator {
       resource,
       properties,
       bucketName,
+      options,
     }).configure();
 
     return bucket;

--- a/src/service/s3/cfn/sim-cfn-s3-resource-deleter.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-deleter.ts
@@ -2,6 +2,7 @@ import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resou
 import type { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
 import type { SimS3 } from "../sim-s3.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnS3ResourceDeleterProperties {
   readonly simS3: SimS3;
@@ -30,19 +31,22 @@ export class SimCfnS3ResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "Bucket": {
-        await this.simS3.deleteBucket({
-          input: { Bucket: this.bucketName(resource) },
-        });
+        await this.simS3.deleteBucket(
+          { input: { Bucket: this.bucketName(resource) } },
+          options,
+        );
 
         return;
       }
       case "BucketPolicy": {
-        await this.simS3.deleteBucketPolicy({
-          input: { Bucket: this.bucketName(resource) },
-        });
+        await this.simS3.deleteBucketPolicy(
+          { input: { Bucket: this.bucketName(resource) } },
+          options,
+        );
 
         return;
       }

--- a/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-factory.ts
@@ -1,12 +1,14 @@
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimS3 } from "../sim-s3.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimCfnS3BucketCreator } from "./bucket/sim-cfn-s3-bucket-creator.js";
 import { SimCfnS3BucketPolicyCreator } from "./bucket-policy/sim-cfn-s3-bucket-policy-creator.js";
 import { SimCfnS3ResourceDeleter } from "./sim-cfn-s3-resource-deleter.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 /**
  * CloudFormation Resource factory for simulated S3 resources.
@@ -30,17 +32,21 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "Bucket": {
         return await this.bucketCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
+          options,
         );
       }
       case "BucketPolicy": {
         return await this.bucketPolicyCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
+          options,
         );
       }
       default: {
@@ -57,7 +63,12 @@ export class SimS3CloudFormationResourceFactory implements SimCfnServiceResource
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.deleter.delete(resourceTypeName, resource);
+    await this.deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/scheduler/cfn/sim-scheduler-cfn-resource-factory.ts
+++ b/src/service/scheduler/cfn/sim-scheduler-cfn-resource-factory.ts
@@ -13,6 +13,7 @@ import {
 } from "./sim-cfn-scheduler-resource-lookup.js";
 import { SimCfnScheduleProperties } from "./sim-cfn-schedule-properties.js";
 import { simCfnSchedulerResourceCreation } from "./sim-cfn-scheduler-resource-error.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimSchedulerCfnResourceFactoryProperties {
   readonly scheduler: SimScheduler;
@@ -52,7 +53,10 @@ export class SimSchedulerCfnResourceFactory implements SimCfnServiceResourceFact
     return await simCfnSchedulerResourceCreation(
       resource.logicalId,
       async () => {
-        await this.scheduler.createSchedule({ input });
+        await this.scheduler.createSchedule(
+          { input },
+          simCfnResourceCallerOptions(context.caller),
+        );
 
         const schedule = createdSchedule(this.scheduler, input);
 
@@ -82,12 +86,15 @@ export class SimSchedulerCfnResourceFactory implements SimCfnServiceResourceFact
       context.resolvedProperties ?? resource.properties,
     );
 
-    await this.scheduler.deleteSchedule({
-      input: {
-        Name: properties.name(),
-        GroupName: properties.scheduleInput().GroupName,
+    await this.scheduler.deleteSchedule(
+      {
+        input: {
+          Name: properties.name(),
+          GroupName: properties.scheduleInput().GroupName,
+        },
       },
-    });
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 
   private read(

--- a/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-creator.ts
+++ b/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimSecretsManagerSecret } from "../../secret/sim-secrets-manager-secret.js";
 import type { SimSecretsManager } from "../../sim-secrets-manager.js";
 import { SimCfnSecretsManagerSecretProperties } from "./sim-cfn-secrets-manager-secret-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSecretsManagerSecretCreatorProperties {
   readonly secretsManager: SimSecretsManager;
@@ -29,21 +30,25 @@ export class SimCfnSecretsManagerSecretCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSecretsManagerSecret> {
     const secretProperties = new SimCfnSecretsManagerSecretProperties({
       resource,
       properties,
     });
 
-    const created = await this.secretsManager.createSecret({
-      input: {
-        Name: secretProperties.name(),
-        Description: secretProperties.description(),
-        KmsKeyId: secretProperties.kmsKeyId(),
-        SecretString: secretProperties.secretString(),
-        Tags: secretProperties.tags(),
+    const created = await this.secretsManager.createSecret(
+      {
+        input: {
+          Name: secretProperties.name(),
+          Description: secretProperties.description(),
+          KmsKeyId: secretProperties.kmsKeyId(),
+          SecretString: secretProperties.secretString(),
+          Tags: secretProperties.tags(),
+        },
       },
-    });
+      options,
+    );
 
     assertDefined(
       created.ARN,

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-resource-factory.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-resource-factory.ts
@@ -2,7 +2,9 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimSecretsManager } from "../sim-secrets-manager.js";
 import { SimCfnSecretsManagerSecretCreator } from "./secret/sim-cfn-secrets-manager-secret-creator.js";
 import type { SimSecretsManagerSecret } from "../secret/sim-secrets-manager-secret.js";
@@ -44,6 +46,7 @@ export class SimSecretsManagerCfnResourceFactory implements SimCfnServiceResourc
         return await this.secretCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
+          simCfnResourceCallerOptions(context.caller),
         );
       }
       default: {
@@ -66,6 +69,7 @@ export class SimSecretsManagerCfnResourceFactory implements SimCfnServiceResourc
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
     if (resourceTypeName !== "Secret") {
       throw new Error(
@@ -79,8 +83,9 @@ export class SimSecretsManagerCfnResourceFactory implements SimCfnServiceResourc
       `sim Secrets Manager secret for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.secretsManager.deleteSecret({
-      input: { SecretId: secret.arn.value },
-    });
+    await this.secretsManager.deleteSecret(
+      { input: { SecretId: secret.arn.value } },
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/ses/cfn/configuration-set/sim-cfn-ses-configuration-set-creator.ts
+++ b/src/service/ses/cfn/configuration-set/sim-cfn-ses-configuration-set-creator.ts
@@ -6,6 +6,7 @@ import type { SimSesV2 } from "../../sim-ses-v2.js";
 import { simCfnSesResourceCreation } from "../sim-cfn-ses-resource-error.js";
 import { sesConfigurationSetResourceType } from "../sim-cfn-ses-resource-types.js";
 import { SimCfnSesConfigurationSetProperties } from "./sim-cfn-ses-configuration-set-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSesConfigurationSetCreatorProperties {
   readonly ses: SimSesV2;
@@ -32,6 +33,7 @@ export class SimCfnSesConfigurationSetCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSesConfigurationSet> {
     const setProperties = new SimCfnSesConfigurationSetProperties({
       resource,
@@ -45,7 +47,7 @@ export class SimCfnSesConfigurationSetCreator {
       sesConfigurationSetResourceType,
       resource.logicalId,
       async () => {
-        await this.#ses.createConfigurationSet({ input });
+        await this.#ses.createConfigurationSet({ input }, options);
 
         const name = input.ConfigurationSetName;
 
@@ -70,9 +72,15 @@ export class SimCfnSesConfigurationSetCreator {
    * Delete a configuration set created from an AWS::SES::ConfigurationSet
    * Resource.
    */
-  async delete(configurationSet: SimSesConfigurationSet): Promise<void> {
-    await this.#ses.deleteConfigurationSet({
-      input: { ConfigurationSetName: configurationSet.configurationSetName },
-    });
+  async delete(
+    configurationSet: SimSesConfigurationSet,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#ses.deleteConfigurationSet(
+      {
+        input: { ConfigurationSetName: configurationSet.configurationSetName },
+      },
+      options,
+    );
   }
 }

--- a/src/service/ses/cfn/identity/sim-cfn-ses-identity-creator.ts
+++ b/src/service/ses/cfn/identity/sim-cfn-ses-identity-creator.ts
@@ -6,6 +6,7 @@ import type { SimSesV2 } from "../../sim-ses-v2.js";
 import { simCfnSesResourceCreation } from "../sim-cfn-ses-resource-error.js";
 import { sesEmailIdentityResourceType } from "../sim-cfn-ses-resource-types.js";
 import { SimCfnSesIdentityProperties } from "./sim-cfn-ses-identity-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSesIdentityCreatorProperties {
   readonly ses: SimSesV2;
@@ -43,6 +44,7 @@ export class SimCfnSesIdentityCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSesIdentity> {
     const identityProperties = new SimCfnSesIdentityProperties({
       resource,
@@ -58,9 +60,10 @@ export class SimCfnSesIdentityCreator {
       sesEmailIdentityResourceType,
       resource.logicalId,
       async () => {
-        await this.#ses.createEmailIdentity({
-          input: { EmailIdentity: emailIdentity },
-        });
+        await this.#ses.createEmailIdentity(
+          { input: { EmailIdentity: emailIdentity } },
+          options,
+        );
 
         const identity = this.#ses.findIdentity(emailIdentity);
 
@@ -79,9 +82,13 @@ export class SimCfnSesIdentityCreator {
   /**
    * Delete an identity created from an AWS::SES::EmailIdentity Resource.
    */
-  async delete(identity: SimSesIdentity): Promise<void> {
-    await this.#ses.deleteEmailIdentity({
-      input: { EmailIdentity: identity.emailIdentity },
-    });
+  async delete(
+    identity: SimSesIdentity,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#ses.deleteEmailIdentity(
+      { input: { EmailIdentity: identity.emailIdentity } },
+      options,
+    );
   }
 }

--- a/src/service/ses/cfn/sim-cfn-ses-resource-refusals.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-resource-refusals.iso.test.ts
@@ -78,7 +78,7 @@ describe("simulated SES CloudFormation refusals", () => {
       await simAws
         .sesV2()
         .cfnResourceFactory()
-        .delete("ReceiptRule", deployedResourceObject(resource));
+        .delete("ReceiptRule", deployedResourceObject(resource), {} as never);
     });
 
     assertStringIncludes(

--- a/src/service/ses/cfn/sim-ses-cfn-resource-factory.ts
+++ b/src/service/ses/cfn/sim-ses-cfn-resource-factory.ts
@@ -3,7 +3,12 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimSesV2 } from "../sim-ses-v2.js";
 import { SimCfnSesConfigurationSetCreator } from "./configuration-set/sim-cfn-ses-configuration-set-creator.js";
@@ -30,8 +35,12 @@ interface SimCfnSesResourceHandler {
   create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options: SimCfnResourceCallerOptions,
   ): Promise<object>;
-  delete(resource: SimCfnResource): Promise<void>;
+  delete(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void>;
 }
 
 /**
@@ -78,6 +87,7 @@ export class SimSesCfnResourceFactory implements SimCfnServiceResourceFactory {
     return await this.handler(resourceTypeName, "").create(
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 
@@ -87,8 +97,12 @@ export class SimSesCfnResourceFactory implements SimCfnServiceResourceFactory {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.handler(resourceTypeName, " deletion").delete(resource);
+    await this.handler(resourceTypeName, " deletion").delete(
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 
   private handler(
@@ -119,16 +133,17 @@ function handler<T extends object>(
     create(
       resource: SimCfnResource,
       properties: SimCfnTemplateValueRecord,
+      options: SimCfnResourceCallerOptions,
     ): Promise<T>;
-    delete(created: T): Promise<void>;
+    delete(created: T, options: SimCfnResourceCallerOptions): Promise<void>;
   },
   described: string,
 ): SimCfnSesResourceHandler {
   return {
-    create: async (resource, properties): Promise<T> =>
-      await creator.create(resource, properties),
-    delete: async (resource): Promise<void> => {
-      await creator.delete(created<T>(resource, described));
+    create: async (resource, properties, options): Promise<T> =>
+      await creator.create(resource, properties, options),
+    delete: async (resource, options): Promise<void> => {
+      await creator.delete(created<T>(resource, described), options);
     },
   };
 }

--- a/src/service/ses/cfn/template/sim-cfn-ses-template-creator.ts
+++ b/src/service/ses/cfn/template/sim-cfn-ses-template-creator.ts
@@ -6,6 +6,7 @@ import type { SimSesTemplate } from "../../template/sim-ses-template.js";
 import { simCfnSesResourceCreation } from "../sim-cfn-ses-resource-error.js";
 import { sesTemplateResourceType } from "../sim-cfn-ses-resource-types.js";
 import { SimCfnSesTemplateProperties } from "./sim-cfn-ses-template-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSesTemplateCreatorProperties {
   readonly ses: SimSesV2;
@@ -33,6 +34,7 @@ export class SimCfnSesTemplateCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSesTemplate> {
     const templateProperties = new SimCfnSesTemplateProperties({
       resource,
@@ -47,9 +49,10 @@ export class SimCfnSesTemplateCreator {
       sesTemplateResourceType,
       resource.logicalId,
       async () => {
-        await this.#ses.createEmailTemplate({
-          input: { TemplateName: templateName, TemplateContent: content },
-        });
+        await this.#ses.createEmailTemplate(
+          { input: { TemplateName: templateName, TemplateContent: content } },
+          options,
+        );
 
         const template = this.#ses.findTemplate(templateName);
 
@@ -66,9 +69,13 @@ export class SimCfnSesTemplateCreator {
   /**
    * Delete a template created from an AWS::SES::Template Resource.
    */
-  async delete(template: SimSesTemplate): Promise<void> {
-    await this.#ses.deleteEmailTemplate({
-      input: { TemplateName: template.templateName },
-    });
+  async delete(
+    template: SimSesTemplate,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#ses.deleteEmailTemplate(
+      { input: { TemplateName: template.templateName } },
+      options,
+    );
   }
 }

--- a/src/service/sns/cfn/sim-cfn-sns-resource-deleter.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-resource-deleter.ts
@@ -4,11 +4,12 @@ import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/va
 import type { SimSns } from "../sim-sns.js";
 import type { SimSnsSubscription } from "../subscription/sim-sns-subscription.js";
 import type { SimSnsTopic } from "../topic/sim-sns-topic.js";
-import { simSnsPolicyAttributeName } from "../topic/sim-sns-topic-attribute-names.js";
-import { simCfnSnsPolicyTopicArns } from "./topic-policy/sim-cfn-sns-topic-policy-properties.js";
+import type { SimCfnSnsTopicPolicyCreator } from "./topic-policy/sim-cfn-sns-topic-policy-creator.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSnsResourceDeleterProperties {
   readonly sns: SimSns;
+  readonly topicPolicyCreator: SimCfnSnsTopicPolicyCreator;
 }
 
 /**
@@ -26,9 +27,11 @@ interface SimCfnSnsResourceDeleterProperties {
  */
 export class SimCfnSnsResourceDeleter {
   private readonly sns: SimSns;
+  private readonly topicPolicyCreator: SimCfnSnsTopicPolicyCreator;
 
   constructor(properties: SimCfnSnsResourceDeleterProperties) {
     this.sns = properties.sns;
+    this.topicPolicyCreator = properties.topicPolicyCreator;
   }
 
   /**
@@ -38,18 +41,19 @@ export class SimCfnSnsResourceDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "Topic": {
-        await this.deleteTopic(resource);
+        await this.deleteTopic(resource, options);
         return;
       }
       case "Subscription": {
-        await this.unsubscribe(resource);
+        await this.unsubscribe(resource, options);
         return;
       }
       case "TopicPolicy": {
-        await this.clearTopicPolicy(resource, properties);
+        await this.topicPolicyCreator.delete(resource, properties, options);
         return;
       }
       default: {
@@ -60,50 +64,35 @@ export class SimCfnSnsResourceDeleter {
     }
   }
 
-  private async deleteTopic(resource: SimCfnResource): Promise<void> {
+  private async deleteTopic(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const topic = resource.simResource as SimSnsTopic | undefined;
     assertDefined(
       topic,
       `sim SNS topic for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.sns.deleteTopic({ input: { TopicArn: topic.arn.value } });
+    await this.sns.deleteTopic(
+      { input: { TopicArn: topic.arn.value } },
+      options,
+    );
   }
 
-  private async unsubscribe(resource: SimCfnResource): Promise<void> {
+  private async unsubscribe(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const subscription = resource.simResource as SimSnsSubscription | undefined;
     assertDefined(
       subscription,
       `sim SNS subscription for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.sns.unsubscribe({
-      input: { SubscriptionArn: subscription.arn.value },
-    });
-  }
-
-  /**
-   * Take the policy back off every topic the Resource named.
-   *
-   * The Resource points at only the first of them, so the topics are read from
-   * the template the same way creation read them.
-   */
-  private async clearTopicPolicy(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): Promise<void> {
-    const topicArns = simCfnSnsPolicyTopicArns(resource.logicalId, properties);
-
-    await Promise.all(
-      topicArns.map(async (topicArn) =>
-        this.sns.setTopicAttributes({
-          input: {
-            TopicArn: topicArn,
-            AttributeName: simSnsPolicyAttributeName,
-            AttributeValue: "",
-          },
-        }),
-      ),
+    await this.sns.unsubscribe(
+      { input: { SubscriptionArn: subscription.arn.value } },
+      options,
     );
   }
 }

--- a/src/service/sns/cfn/sim-sns-cfn-resource-factory.ts
+++ b/src/service/sns/cfn/sim-sns-cfn-resource-factory.ts
@@ -9,6 +9,7 @@ import { SimCfnSnsResourceDeleter } from "./sim-cfn-sns-resource-deleter.js";
 import { SimCfnSnsSubscriptionCreator } from "./subscription/sim-cfn-sns-subscription-creator.js";
 import { SimCfnSnsTopicCreator } from "./topic/sim-cfn-sns-topic-creator.js";
 import { SimCfnSnsTopicPolicyCreator } from "./topic-policy/sim-cfn-sns-topic-policy-creator.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimSnsCfnResourceFactoryProperties {
   readonly sns: SimSns;
@@ -31,7 +32,10 @@ export class SimSnsCfnResourceFactory implements SimCfnServiceResourceFactory {
     this.topicPolicyCreator = new SimCfnSnsTopicPolicyCreator({
       sns: properties.sns,
     });
-    this.deleter = new SimCfnSnsResourceDeleter({ sns: properties.sns });
+    this.deleter = new SimCfnSnsResourceDeleter({
+      sns: properties.sns,
+      topicPolicyCreator: this.topicPolicyCreator,
+    });
   }
 
   /**
@@ -48,15 +52,25 @@ export class SimSnsCfnResourceFactory implements SimCfnServiceResourceFactory {
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
 
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "Topic": {
-        return await this.topicCreator.create(resource, properties);
+        return await this.topicCreator.create(resource, properties, options);
       }
       case "Subscription": {
-        return await this.subscriptionCreator.create(resource, properties);
+        return await this.subscriptionCreator.create(
+          resource,
+          properties,
+          options,
+        );
       }
       case "TopicPolicy": {
-        return await this.topicPolicyCreator.create(resource, properties);
+        return await this.topicPolicyCreator.create(
+          resource,
+          properties,
+          options,
+        );
       }
       default: {
         throw new Error(
@@ -78,6 +92,7 @@ export class SimSnsCfnResourceFactory implements SimCfnServiceResourceFactory {
       resourceTypeName,
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 }

--- a/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-creator.ts
+++ b/src/service/sns/cfn/subscription/sim-cfn-sns-subscription-creator.ts
@@ -2,6 +2,7 @@ import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimSns } from "../../sim-sns.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimSnsSubscription } from "../../subscription/sim-sns-subscription.js";
 import { simCfnSnsResourceCreation } from "../sim-cfn-sns-resource-error.js";
 import { snsSubscriptionResourceType } from "../sim-cfn-sns-resource-types.js";
@@ -33,6 +34,7 @@ export class SimCfnSnsSubscriptionCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSnsSubscription> {
     const input = new SimCfnSnsSubscriptionProperties({
       resource,
@@ -43,7 +45,7 @@ export class SimCfnSnsSubscriptionCreator {
       snsSubscriptionResourceType,
       resource.logicalId,
       async () => {
-        const subscribed = await this.sns.subscribe({ input });
+        const subscribed = await this.sns.subscribe({ input }, options);
 
         const arn = subscribed.SubscriptionArn;
         assertDefined(

--- a/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-creator.ts
+++ b/src/service/sns/cfn/topic-policy/sim-cfn-sns-topic-policy-creator.ts
@@ -3,6 +3,7 @@ import { jsonStringify } from "../../../../util/type-guard/json.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimSns } from "../../sim-sns.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimSnsTopic } from "../../topic/sim-sns-topic.js";
 import { simSnsPolicyAttributeName } from "../../topic/sim-sns-topic-attribute-names.js";
 import { parseSnsTopicArn } from "../../topic/sim-sns-topic-arn.js";
@@ -43,6 +44,7 @@ export class SimCfnSnsTopicPolicyCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSnsTopic> {
     const { logicalId } = resource;
     const topicArns = simCfnSnsPolicyTopicArns(logicalId, properties);
@@ -56,7 +58,7 @@ export class SimCfnSnsTopicPolicyCreator {
       async () => {
         const topics = await Promise.all(
           topicArns.map(async (topicArn) =>
-            this.policyApplied(topicArn, policy),
+            this.policyApplied(topicArn, policy, options),
           ),
         );
 
@@ -72,19 +74,52 @@ export class SimCfnSnsTopicPolicyCreator {
   }
 
   /**
+   * Take the policy back off every topic the Resource named.
+   *
+   * The Resource points at only the first of them, so the topics are read from
+   * the template the same way creation read them.
+   */
+  async delete(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    const topicArns = simCfnSnsPolicyTopicArns(resource.logicalId, properties);
+
+    await Promise.all(
+      topicArns.map(async (topicArn) =>
+        this.sns.setTopicAttributes(
+          {
+            input: {
+              TopicArn: topicArn,
+              AttributeName: simSnsPolicyAttributeName,
+              AttributeValue: "",
+            },
+          },
+          options,
+        ),
+      ),
+    );
+  }
+
+  /**
    * Set the policy on one topic and hand back the topic it was set on.
    */
   private async policyApplied(
     topicArn: string,
     policy: string,
+    options: SimCfnResourceCallerOptions,
   ): Promise<SimSnsTopic> {
-    await this.sns.setTopicAttributes({
-      input: {
-        TopicArn: topicArn,
-        AttributeName: simSnsPolicyAttributeName,
-        AttributeValue: policy,
+    await this.sns.setTopicAttributes(
+      {
+        input: {
+          TopicArn: topicArn,
+          AttributeName: simSnsPolicyAttributeName,
+          AttributeValue: policy,
+        },
       },
-    });
+      options,
+    );
 
     const parts = parseSnsTopicArn(topicArn);
     assertDefined(parts, `topic ARN ${topicArn} SetTopicAttributes accepted`);

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-creator.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-creator.ts
@@ -2,6 +2,7 @@ import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimSns } from "../../sim-sns.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimSnsTopic } from "../../topic/sim-sns-topic.js";
 import { simCfnSnsResourceCreation } from "../sim-cfn-sns-resource-error.js";
 import { snsTopicResourceType } from "../sim-cfn-sns-resource-types.js";
@@ -33,6 +34,7 @@ export class SimCfnSnsTopicCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSnsTopic> {
     const topicProperties = new SimCfnSnsTopicProperties({
       resource,
@@ -46,9 +48,10 @@ export class SimCfnSnsTopicCreator {
       snsTopicResourceType,
       resource.logicalId,
       async () => {
-        await this.sns.createTopic({
-          input: { Name: name, Attributes: attributes },
-        });
+        await this.sns.createTopic(
+          { input: { Name: name, Attributes: attributes } },
+          options,
+        );
 
         const topic = this.sns.findTopic(name);
         assertDefined(
@@ -56,7 +59,7 @@ export class SimCfnSnsTopicCreator {
           `sim SNS topic ${name} after CloudFormation creation`,
         );
 
-        await this.subscribeInline(topic, inline);
+        await this.subscribeInline(topic, inline, options);
 
         return topic;
       },
@@ -74,16 +77,20 @@ export class SimCfnSnsTopicCreator {
   private async subscribeInline(
     topic: SimSnsTopic,
     subscriptions: readonly SimCfnSnsInlineSubscription[],
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     for (const subscription of subscriptions) {
       // oxlint-disable-next-line no-await-in-loop -- one entry at a time, so a refused entry leaves the earlier ones subscribed
-      await this.sns.subscribe({
-        input: {
-          TopicArn: topic.arn.value,
-          Protocol: subscription.protocol,
-          Endpoint: subscription.endpoint,
+      await this.sns.subscribe(
+        {
+          input: {
+            TopicArn: topic.arn.value,
+            Protocol: subscription.protocol,
+            Endpoint: subscription.endpoint,
+          },
         },
-      });
+        options,
+      );
     }
   }
 }

--- a/src/service/sqs/cfn/queue-policy/sim-cfn-sqs-queue-policy-creator.ts
+++ b/src/service/sqs/cfn/queue-policy/sim-cfn-sqs-queue-policy-creator.ts
@@ -6,6 +6,7 @@ import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
 import { simSqsQueuePolicyAttributeName } from "../../queue/sim-sqs-queue-attribute-specs.js";
 import { SimSqsQueueUrl } from "../../queue/sim-sqs-queue-url.js";
 import type { SimSqs } from "../../sim-sqs.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSqsQueuePolicyCreatorProperties {
   readonly sqs: SimSqs;
@@ -37,6 +38,7 @@ export class SimCfnSqsQueuePolicyCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSqsQueue> {
     const queueUrls = this.queueUrlsForResource(resource, properties);
     const policy = jsonStringify(
@@ -44,7 +46,9 @@ export class SimCfnSqsQueuePolicyCreator {
     );
 
     const queues = await Promise.all(
-      queueUrls.map(async (queueUrl) => this.policyApplied(queueUrl, policy)),
+      queueUrls.map(async (queueUrl) =>
+        this.policyApplied(queueUrl, policy, options),
+      ),
     );
 
     const first = queues[0];
@@ -62,13 +66,17 @@ export class SimCfnSqsQueuePolicyCreator {
   private async policyApplied(
     queueUrl: string,
     policy: string,
+    options: SimCfnResourceCallerOptions,
   ): Promise<SimSqsQueue> {
-    await this.sqs.setQueueAttributes({
-      input: {
-        QueueUrl: queueUrl,
-        Attributes: { [simSqsQueuePolicyAttributeName]: policy },
+    await this.sqs.setQueueAttributes(
+      {
+        input: {
+          QueueUrl: queueUrl,
+          Attributes: { [simSqsQueuePolicyAttributeName]: policy },
+        },
       },
-    });
+      options,
+    );
 
     const parts = SimSqsQueueUrl.parse(queueUrl);
     assertDefined(parts, `queue URL ${queueUrl} SetQueueAttributes accepted`);

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-creator.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimSqs } from "../../sim-sqs.js";
 import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
 import { SimCfnSqsQueueProperties } from "./sim-cfn-sqs-queue-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSqsQueueCreatorProperties {
   readonly sqs: SimSqs;
@@ -30,6 +31,7 @@ export class SimCfnSqsQueueCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSqsQueue> {
     const queueProperties = new SimCfnSqsQueueProperties({
       resource,
@@ -37,9 +39,10 @@ export class SimCfnSqsQueueCreator {
     });
     const name = queueProperties.name();
 
-    await this.sqs.createQueue({
-      input: { QueueName: name, Attributes: queueProperties.attributes() },
-    });
+    await this.sqs.createQueue(
+      { input: { QueueName: name, Attributes: queueProperties.attributes() } },
+      options,
+    );
 
     const queue = this.sqs.findQueue(name);
     assertDefined(queue, `sim SQS queue ${name} after CloudFormation creation`);

--- a/src/service/sqs/cfn/sim-cfn-sqs-resource-deleter.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-resource-deleter.ts
@@ -4,6 +4,7 @@ import type { SimSqs } from "../sim-sqs.js";
 import type { SimSqsQueue } from "../queue/sim-sqs-queue.js";
 import { simSqsQueuePolicyAttributeName } from "../queue/sim-sqs-queue-attribute-specs.js";
 import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSqsResourceDeleterProperties {
   readonly sqs: SimSqs;
@@ -31,14 +32,15 @@ export class SimCfnSqsResourceDeleter {
     resourceTypeName: string,
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     switch (resourceTypeName) {
       case "Queue": {
-        await this.deleteQueue(resource);
+        await this.deleteQueue(resource, options);
         return;
       }
       case "QueuePolicy": {
-        await this.clearQueuePolicy(properties);
+        await this.clearQueuePolicy(properties, options);
         return;
       }
       default: {
@@ -49,14 +51,17 @@ export class SimCfnSqsResourceDeleter {
     }
   }
 
-  private async deleteQueue(resource: SimCfnResource): Promise<void> {
+  private async deleteQueue(
+    resource: SimCfnResource,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     const queue = resource.simResource as SimSqsQueue | undefined;
     assertDefined(
       queue,
       `sim SQS queue for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.sqs.deleteQueue({ input: { QueueUrl: queue.url } });
+    await this.sqs.deleteQueue({ input: { QueueUrl: queue.url } }, options);
   }
 
   /**
@@ -67,6 +72,7 @@ export class SimCfnSqsResourceDeleter {
    */
   private async clearQueuePolicy(
     properties: SimCfnTemplateValueRecord,
+    options: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const queues = properties["Queues"];
 
@@ -79,12 +85,15 @@ export class SimCfnSqsResourceDeleter {
       queues
         .filter((queueUrl): queueUrl is string => typeof queueUrl === "string")
         .map(async (queueUrl) =>
-          this.sqs.setQueueAttributes({
-            input: {
-              QueueUrl: queueUrl,
-              Attributes: { [simSqsQueuePolicyAttributeName]: "" },
+          this.sqs.setQueueAttributes(
+            {
+              input: {
+                QueueUrl: queueUrl,
+                Attributes: { [simSqsQueuePolicyAttributeName]: "" },
+              },
             },
-          }),
+            options,
+          ),
         ),
     );
   }

--- a/src/service/sqs/cfn/sim-sqs-cfn-resource-factory.ts
+++ b/src/service/sqs/cfn/sim-sqs-cfn-resource-factory.ts
@@ -8,6 +8,7 @@ import { SimCfnSqsQueueCreator } from "./queue/sim-cfn-sqs-queue-creator.js";
 import { SimCfnSqsQueuePolicyCreator } from "./queue-policy/sim-cfn-sqs-queue-policy-creator.js";
 import { SimCfnSqsResourceDeleter } from "./sim-cfn-sqs-resource-deleter.js";
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimSqsCfnResourceFactoryProperties {
   readonly sqs: SimSqs;
@@ -41,17 +42,21 @@ export class SimSqsCfnResourceFactory implements SimCfnServiceResourceFactory {
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
+    const options = simCfnResourceCallerOptions(context.caller);
+
     switch (resourceTypeName) {
       case "Queue": {
         return await this.queueCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
+          options,
         );
       }
       case "QueuePolicy": {
         return await this.queuePolicyCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
+          options,
         );
       }
       default: {
@@ -74,6 +79,7 @@ export class SimSqsCfnResourceFactory implements SimCfnServiceResourceFactory {
       resourceTypeName,
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 }

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-creator.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimSsmParameter } from "../../parameter/sim-ssm-parameter.js";
 import type { SimSsm } from "../../sim-ssm.js";
 import { SimCfnSsmParameterProperties } from "./sim-cfn-ssm-parameter-properties.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnSsmParameterCreatorProperties {
   readonly ssm: SimSsm;
@@ -36,6 +37,7 @@ export class SimCfnSsmParameterCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimSsmParameter> {
     const parameterProperties = new SimCfnSsmParameterProperties({
       resource,
@@ -43,19 +45,22 @@ export class SimCfnSsmParameterCreator {
     });
     const name = parameterProperties.name();
 
-    await this.ssm.putParameter({
-      input: {
-        Name: name,
-        Type: parameterProperties.type(),
-        Value: parameterProperties.value(),
-        Description: parameterProperties.description(),
-        Tier: parameterProperties.tier(),
-        AllowedPattern: parameterProperties.allowedPattern(),
-        DataType: parameterProperties.dataType(),
-        Policies: parameterProperties.policies(),
-        Tags: parameterProperties.tags(),
+    await this.ssm.putParameter(
+      {
+        input: {
+          Name: name,
+          Type: parameterProperties.type(),
+          Value: parameterProperties.value(),
+          Description: parameterProperties.description(),
+          Tier: parameterProperties.tier(),
+          AllowedPattern: parameterProperties.allowedPattern(),
+          DataType: parameterProperties.dataType(),
+          Policies: parameterProperties.policies(),
+          Tags: parameterProperties.tags(),
+        },
       },
-    });
+      options,
+    );
 
     const parameter = this.ssm.findParameter(name);
     assertDefined(

--- a/src/service/ssm/cfn/sim-cfn-ssm-resource-factory.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-resource-factory.ts
@@ -2,7 +2,9 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimSsm } from "../sim-ssm.js";
 import { SimCfnSsmParameterCreator } from "./parameter/sim-cfn-ssm-parameter-creator.js";
 import type { SimSsmParameter } from "../parameter/sim-ssm-parameter.js";
@@ -43,6 +45,7 @@ export class SimSsmCfnResourceFactory implements SimCfnServiceResourceFactory {
         return await this.parameterCreator.create(
           resource,
           context.resolvedProperties ?? resource.properties,
+          simCfnResourceCallerOptions(context.caller),
         );
       }
       default: {
@@ -59,6 +62,7 @@ export class SimSsmCfnResourceFactory implements SimCfnServiceResourceFactory {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
     if (resourceTypeName !== "Parameter") {
       throw new Error(
@@ -72,6 +76,9 @@ export class SimSsmCfnResourceFactory implements SimCfnServiceResourceFactory {
       `sim SSM Parameter for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.ssm.deleteParameter({ input: { Name: parameter.name.value } });
+    await this.ssm.deleteParameter(
+      { input: { Name: parameter.name.value } },
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/stepfunctions/cfn/sim-cfn-step-functions-resource-deleter.ts
+++ b/src/service/stepfunctions/cfn/sim-cfn-step-functions-resource-deleter.ts
@@ -3,6 +3,7 @@ import type { SimStateMachine } from "../machine/sim-state-machine.js";
 import type { SimStepFunctions } from "../sim-step-functions.js";
 import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
 import { stateMachineResourceTypeName } from "./sim-cfn-step-functions-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnStepFunctionsResourceDeleterProperties {
   readonly stepFunctions: SimStepFunctions;
@@ -26,6 +27,7 @@ export class SimCfnStepFunctionsResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     if (resourceTypeName !== stateMachineResourceTypeName) {
       throw new Error(
@@ -40,8 +42,9 @@ export class SimCfnStepFunctionsResourceDeleter {
       `sim state machine for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    await this.#stepFunctions.deleteStateMachine({
-      input: { stateMachineArn: stateMachine.arn },
-    });
+    await this.#stepFunctions.deleteStateMachine(
+      { input: { stateMachineArn: stateMachine.arn } },
+      options,
+    );
   }
 }

--- a/src/service/stepfunctions/cfn/sim-step-functions-cfn-resource-factory.ts
+++ b/src/service/stepfunctions/cfn/sim-step-functions-cfn-resource-factory.ts
@@ -9,6 +9,7 @@ import type {
 import { SimCfnStateMachineCreator } from "./state-machine/sim-cfn-state-machine-creator.js";
 import { SimCfnStepFunctionsResourceDeleter } from "./sim-cfn-step-functions-resource-deleter.js";
 import { stateMachineResourceTypeName } from "./sim-cfn-step-functions-resource-types.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimStepFunctionsCfnResourceFactoryProperties {
   readonly stepFunctions: SimStepFunctions;
@@ -58,6 +59,7 @@ export class SimStepFunctionsCfnResourceFactory implements SimCfnServiceResource
     return await this.#stateMachineCreator.create(
       resource,
       context.resolvedProperties ?? resource.properties,
+      simCfnResourceCallerOptions(context.caller),
     );
   }
 
@@ -68,8 +70,12 @@ export class SimStepFunctionsCfnResourceFactory implements SimCfnServiceResource
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
-    _context: SimCloudFormationResourceDeleteContext,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.#deleter.delete(resourceTypeName, resource);
+    await this.#deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/stepfunctions/cfn/state-machine/sim-cfn-state-machine-creator.ts
+++ b/src/service/stepfunctions/cfn/state-machine/sim-cfn-state-machine-creator.ts
@@ -7,6 +7,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import { SimCfnStateMachineProperties } from "./sim-cfn-state-machine-properties.js";
 import { simCfnStepFunctionsResourceCommand } from "../sim-cfn-step-functions-resource-error.js";
 import { stateMachineResourceType } from "../sim-cfn-step-functions-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnStateMachineCreatorProperties {
   readonly stepFunctions: SimStepFunctions;
@@ -40,6 +41,7 @@ export class SimCfnStateMachineCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimStateMachine> {
     const stateMachineProperties = new SimCfnStateMachineProperties({
       resource,
@@ -56,15 +58,18 @@ export class SimCfnStateMachineCreator {
       stateMachineResourceType,
       resource.logicalId,
       async () => {
-        await this.#stepFunctions.createStateMachine({
-          input: {
-            name,
-            definition,
-            roleArn,
-            tags,
-            ...(type !== undefined && { type }),
+        await this.#stepFunctions.createStateMachine(
+          {
+            input: {
+              name,
+              definition,
+              roleArn,
+              tags,
+              ...(type !== undefined && { type }),
+            },
           },
-        });
+          options,
+        );
 
         const stateMachine = this.#stepFunctions.findStateMachine(name);
         assertDefined(

--- a/src/service/wafv2/cfn/association/sim-cfn-waf-association-creator.ts
+++ b/src/service/wafv2/cfn/association/sim-cfn-waf-association-creator.ts
@@ -7,6 +7,7 @@ import { wafWebAclAssociationResourceType } from "../sim-cfn-waf-resource-types.
 import { SimCfnWafAssociationConfig } from "./sim-cfn-waf-association-config.js";
 import { simCfnWafAssociationSkipError } from "./sim-cfn-waf-association-skip.js";
 import { SimWafCfnWebAclAssociation } from "./sim-cfn-waf-web-acl-association.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnWafAssociationCreatorProperties {
   readonly wafV2: SimWafV2;
@@ -40,6 +41,7 @@ export class SimCfnWafAssociationCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimWafCfnWebAclAssociation> {
     const config = new SimCfnWafAssociationConfig({ resource, properties });
     const association = new SimWafCfnWebAclAssociation({
@@ -60,12 +62,15 @@ export class SimCfnWafAssociationCreator {
       wafWebAclAssociationResourceType,
       resource.logicalId,
       async () => {
-        await this.#wafV2.associateWebAcl({
-          input: {
-            ResourceArn: association.resourceArn,
-            WebACLArn: association.webAclArn,
+        await this.#wafV2.associateWebAcl(
+          {
+            input: {
+              ResourceArn: association.resourceArn,
+              WebACLArn: association.webAclArn,
+            },
           },
-        });
+          options,
+        );
 
         return association;
       },
@@ -88,15 +93,17 @@ export class SimCfnWafAssociationCreator {
   async delete(
     resource: SimCfnResource,
     association: SimWafCfnWebAclAssociation,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await simCfnWafResourceCommand(
       wafWebAclAssociationResourceType,
       resource.logicalId,
       async () => {
         try {
-          await this.#wafV2.disassociateWebAcl({
-            input: { ResourceArn: association.resourceArn },
-          });
+          await this.#wafV2.disassociateWebAcl(
+            { input: { ResourceArn: association.resourceArn } },
+            options,
+          );
         } catch (error) {
           if (!(error instanceof SimWafUnavailableEntityException)) {
             throw error;

--- a/src/service/wafv2/cfn/ip-set/sim-cfn-waf-ip-set-creator.ts
+++ b/src/service/wafv2/cfn/ip-set/sim-cfn-waf-ip-set-creator.ts
@@ -6,6 +6,7 @@ import type { SimWafV2 } from "../../sim-wafv2.js";
 import { simCfnWafResourceCommand } from "../sim-cfn-waf-resource-error.js";
 import { wafIpSetResourceType } from "../sim-cfn-waf-resource-types.js";
 import { SimCfnWafIpSetConfig } from "./sim-cfn-waf-ip-set-config.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnWafIpSetCreatorProperties {
   readonly wafV2: SimWafV2;
@@ -32,6 +33,7 @@ export class SimCfnWafIpSetCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimWafIpSet> {
     const input = new SimCfnWafIpSetConfig({
       resource,
@@ -42,7 +44,7 @@ export class SimCfnWafIpSetCreator {
       wafIpSetResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.#wafV2.createIpSet({ input });
+        const created = await this.#wafV2.createIpSet({ input }, options);
         const arn = created.Summary?.ARN;
 
         assertDefined(
@@ -67,19 +69,26 @@ export class SimCfnWafIpSetCreator {
   /**
    * Delete the IP set an AWS::WAFv2::IPSet Resource created.
    */
-  async delete(resource: SimCfnResource, ipSet: SimWafIpSet): Promise<void> {
+  async delete(
+    resource: SimCfnResource,
+    ipSet: SimWafIpSet,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     await simCfnWafResourceCommand(
       wafIpSetResourceType,
       resource.logicalId,
       async () =>
-        await this.#wafV2.deleteIpSet({
-          input: {
-            Name: ipSet.name,
-            Scope: ipSet.scope,
-            Id: ipSet.id,
-            LockToken: ipSet.lockToken,
+        await this.#wafV2.deleteIpSet(
+          {
+            input: {
+              Name: ipSet.name,
+              Scope: ipSet.scope,
+              Id: ipSet.id,
+              LockToken: ipSet.lockToken,
+            },
           },
-        }),
+          options,
+        ),
     );
   }
 }

--- a/src/service/wafv2/cfn/regex-pattern-set/sim-cfn-waf-regex-set-creator.ts
+++ b/src/service/wafv2/cfn/regex-pattern-set/sim-cfn-waf-regex-set-creator.ts
@@ -6,6 +6,7 @@ import type { SimWafV2 } from "../../sim-wafv2.js";
 import { simCfnWafResourceCommand } from "../sim-cfn-waf-resource-error.js";
 import { wafRegexPatternSetResourceType } from "../sim-cfn-waf-resource-types.js";
 import { SimCfnWafRegexPatternSetConfig } from "./sim-cfn-waf-regex-set-config.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnWafRegexPatternSetCreatorProperties {
   readonly wafV2: SimWafV2;
@@ -32,6 +33,7 @@ export class SimCfnWafRegexPatternSetCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimWafRegexPatternSet> {
     const input = new SimCfnWafRegexPatternSetConfig({
       resource,
@@ -42,7 +44,10 @@ export class SimCfnWafRegexPatternSetCreator {
       wafRegexPatternSetResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.#wafV2.createRegexPatternSet({ input });
+        const created = await this.#wafV2.createRegexPatternSet(
+          { input },
+          options,
+        );
         const arn = created.Summary?.ARN;
 
         assertDefined(
@@ -70,19 +75,23 @@ export class SimCfnWafRegexPatternSetCreator {
   async delete(
     resource: SimCfnResource,
     patternSet: SimWafRegexPatternSet,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     await simCfnWafResourceCommand(
       wafRegexPatternSetResourceType,
       resource.logicalId,
       async () =>
-        await this.#wafV2.deleteRegexPatternSet({
-          input: {
-            Name: patternSet.name,
-            Scope: patternSet.scope,
-            Id: patternSet.id,
-            LockToken: patternSet.lockToken,
+        await this.#wafV2.deleteRegexPatternSet(
+          {
+            input: {
+              Name: patternSet.name,
+              Scope: patternSet.scope,
+              Id: patternSet.id,
+              LockToken: patternSet.lockToken,
+            },
           },
-        }),
+          options,
+        ),
     );
   }
 }

--- a/src/service/wafv2/cfn/sim-cfn-waf-resource-deleter.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-resource-deleter.ts
@@ -14,6 +14,7 @@ import {
   wafWebAclAssociationResourceTypeName,
   wafWebAclResourceTypeName,
 } from "./sim-cfn-waf-resource-types.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 /**
  * Deletes the simulated WAFv2 resources a CloudFormation Stack created.
@@ -36,6 +37,7 @@ export class SimCfnWafResourceDeleter {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<void> {
     const creators = this.#creators;
 
@@ -44,6 +46,7 @@ export class SimCfnWafResourceDeleter {
         await creators.webAcl.delete(
           resource,
           created<SimWafWebAcl>(resource, "web ACL"),
+          options,
         );
         return;
       }
@@ -51,6 +54,7 @@ export class SimCfnWafResourceDeleter {
         await creators.association.delete(
           resource,
           created<SimWafCfnWebAclAssociation>(resource, "web ACL association"),
+          options,
         );
         return;
       }
@@ -58,6 +62,7 @@ export class SimCfnWafResourceDeleter {
         await creators.ipSet.delete(
           resource,
           created<SimWafIpSet>(resource, "IP set"),
+          options,
         );
         return;
       }
@@ -65,6 +70,7 @@ export class SimCfnWafResourceDeleter {
         await creators.regexPatternSet.delete(
           resource,
           created<SimWafRegexPatternSet>(resource, "regex pattern set"),
+          options,
         );
         return;
       }

--- a/src/service/wafv2/cfn/sim-waf-cfn-resource-factory.ts
+++ b/src/service/wafv2/cfn/sim-waf-cfn-resource-factory.ts
@@ -2,6 +2,7 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimWafV2 } from "../sim-wafv2.js";
 import {
@@ -16,6 +17,7 @@ import {
   wafWebAclAssociationResourceTypeName,
   wafWebAclResourceTypeName,
 } from "./sim-cfn-waf-resource-types.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimWafCfnResourceFactoryProperties {
   readonly wafV2: SimWafV2;
@@ -56,19 +58,24 @@ export class SimWafCfnResourceFactory implements SimCfnServiceResourceFactory {
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
     const creators = this.#creators;
+    const options = simCfnResourceCallerOptions(context.caller);
 
     switch (resourceTypeName) {
       case wafWebAclResourceTypeName: {
-        return await creators.webAcl.create(resource, properties);
+        return await creators.webAcl.create(resource, properties, options);
       }
       case wafWebAclAssociationResourceTypeName: {
-        return await creators.association.create(resource, properties);
+        return await creators.association.create(resource, properties, options);
       }
       case wafIpSetResourceTypeName: {
-        return await creators.ipSet.create(resource, properties);
+        return await creators.ipSet.create(resource, properties, options);
       }
       case wafRegexPatternSetResourceTypeName: {
-        return await creators.regexPatternSet.create(resource, properties);
+        return await creators.regexPatternSet.create(
+          resource,
+          properties,
+          options,
+        );
       }
       default: {
         throw unsupportedSimWafResourceType(resourceTypeName, "");
@@ -82,7 +89,12 @@ export class SimWafCfnResourceFactory implements SimCfnServiceResourceFactory {
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    await this.#deleter.delete(resourceTypeName, resource);
+    await this.#deleter.delete(
+      resourceTypeName,
+      resource,
+      simCfnResourceCallerOptions(context.caller),
+    );
   }
 }

--- a/src/service/wafv2/cfn/web-acl/sim-cfn-waf-web-acl-creator.ts
+++ b/src/service/wafv2/cfn/web-acl/sim-cfn-waf-web-acl-creator.ts
@@ -7,6 +7,7 @@ import { simCfnWafResourceCommand } from "../sim-cfn-waf-resource-error.js";
 import { wafWebAclResourceType } from "../sim-cfn-waf-resource-types.js";
 import { simCfnWafEvaluatableRules } from "./sim-cfn-waf-evaluatable-rules.js";
 import { SimCfnWafWebAclConfig } from "./sim-cfn-waf-web-acl-config.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimCfnWafWebAclCreatorProperties {
   readonly wafV2: SimWafV2;
@@ -43,6 +44,7 @@ export class SimCfnWafWebAclCreator {
   async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): Promise<SimWafWebAcl> {
     const input = new SimCfnWafWebAclConfig({
       resource,
@@ -57,9 +59,10 @@ export class SimCfnWafWebAclCreator {
       wafWebAclResourceType,
       resource.logicalId,
       async () => {
-        const created = await this.#wafV2.createWebAcl({
-          input: deployable,
-        });
+        const created = await this.#wafV2.createWebAcl(
+          { input: deployable },
+          options,
+        );
         const arn = created.Summary?.ARN;
 
         assertDefined(
@@ -89,19 +92,26 @@ export class SimCfnWafWebAclCreator {
    * it holds. A template that associates without naming it keeps that refusal,
    * which says which resources are still pointing at the ACL.
    */
-  async delete(resource: SimCfnResource, webAcl: SimWafWebAcl): Promise<void> {
+  async delete(
+    resource: SimCfnResource,
+    webAcl: SimWafWebAcl,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
     await simCfnWafResourceCommand(
       wafWebAclResourceType,
       resource.logicalId,
       async () =>
-        await this.#wafV2.deleteWebAcl({
-          input: {
-            Name: webAcl.name,
-            Scope: webAcl.scope,
-            Id: webAcl.id,
-            LockToken: webAcl.lockToken,
+        await this.#wafV2.deleteWebAcl(
+          {
+            input: {
+              Name: webAcl.name,
+              Scope: webAcl.scope,
+              Id: webAcl.id,
+              LockToken: webAcl.lockToken,
+            },
           },
-        }),
+          options,
+        ),
     );
   }
 }


### PR DESCRIPTION
Sim CloudFormation created every Resource through the owning service's command with no caller, which IAM decided as the Account root, so a service control policy denying an Account's root principal failed every stack in that organization. A `caller` option on `deployTemplate`, `deployTemplateFile` and `deployCdkOut` now says which principal a deployment runs as, and `stackOptions` carries one per Stack in a cloud assembly. The Stack keeps that principal for its updates and its teardown, and staged CDK assets are published as it. An omitted caller still reaches each service with none. A deployment that names nobody is decided as the Account root, as it was before. Several files under `src/service/*/cfn/` were reorganised to stay under the FTA threshold once the extra argument was threaded through them.

Resolves #1072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CloudFormation deployments, updates, deletions, and CDK assembly deployments can now run under a specified IAM principal.
  * CDK deployments support assembly-wide callers with per-stack overrides.
  * Caller identity is consistently enforced across supported simulated AWS resources, including API Gateway, S3, IAM, Lambda, and more.
  * Unauthorized operations now reflect the configured principal.

* **Documentation**
  * Added deployment guidance and examples for IAM callers, authorization failures, and root-principal behavior.

* **Tests**
  * Added coverage for caller propagation, authorization, overrides, and staged CDK assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->