### PR TITLE
fix: advance simulated time by a bare number

### DIFF
--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -73,8 +73,9 @@ clock stopped.
 ## Advancing time
 
 `advanceBy(...)` takes a duration written as any combination of `days`, `hours`, `minutes`,
-`seconds` and `milliseconds`, which add together. Durations are never negative, since time passing
-only runs forwards. `setTo(...)` is the explicit way to move a clock back.
+`seconds` and `milliseconds`, which add together. A bare number counts milliseconds, as it does for
+`setTimeout`, and `advanceBy(3_600_000)` moves an hour. Durations are never negative, since time
+passing only runs forwards. `setTo(...)` is the explicit way to move a clock back.
 
 Advancing moves the clock, and it runs whatever the passage of time should have caused. Work
 scheduled for an instant inside the interval is dispatched in due order, each task running with the

--- a/src/util/clock/sim-clock-control.iso.test.ts
+++ b/src/util/clock/sim-clock-control.iso.test.ts
@@ -65,6 +65,17 @@ describe("SimClockControl", () => {
     expect(control.isFrozen).toBe(true);
   });
 
+  it("advances simulated time by a number of milliseconds", async () => {
+    // Given control over a simulation's clock
+    const { control } = simulatedTime();
+
+    // When time is advanced by a bare number
+    await control.advanceBy(20 * 60 * 1000);
+
+    // Then the number counted as milliseconds, and time moved by it
+    expect(control.now()).toStrictEqual(new Date("2026-07-26T09:20:00.000Z"));
+  });
+
   it("measures an advance from where the clock stood when it started", async () => {
     // Given a simulation on a host clock that moves while an advance runs, and
     // work due now that buffers for an hour once it runs

--- a/src/util/clock/sim-clock-control.ts
+++ b/src/util/clock/sim-clock-control.ts
@@ -113,8 +113,12 @@ export class SimClockControl implements SimClock {
    * The duration is measured from a frozen instant. Advancing by exactly a
    * buffering interval or a schedule period lands on the due instant every
    * time, whatever the host clock does while the advance runs.
+   *
+   * A bare number counts milliseconds, as it does for `setTimeout`.
    */
-  async advanceBy(duration: SimDuration | SimDurationInput): Promise<void> {
+  async advanceBy(
+    duration: SimDuration | SimDurationInput | number,
+  ): Promise<void> {
     this.clock.freeze();
 
     const milliseconds = SimDuration.of(duration).toMilliseconds();

--- a/src/util/clock/sim-controllable-clock.ts
+++ b/src/util/clock/sim-controllable-clock.ts
@@ -74,8 +74,10 @@ export class SimControllableClock implements SimClock {
 
   /**
    * Move simulated time forward by a duration, and stop there.
+   *
+   * A bare number counts milliseconds, as it does for `setTimeout`.
    */
-  advanceBy(duration: SimDuration | SimDurationInput): void {
+  advanceBy(duration: SimDuration | SimDurationInput | number): void {
     const milliseconds = SimDuration.of(duration).toMilliseconds();
 
     this.setTo(new Date(this.now().getTime() + milliseconds));

--- a/src/util/clock/sim-duration.iso.test.ts
+++ b/src/util/clock/sim-duration.iso.test.ts
@@ -43,6 +43,24 @@ describe("SimDuration", () => {
     expect(SimDuration.ofMilliseconds(250).toMilliseconds()).toBe(250);
   });
 
+  it("reads a bare number as milliseconds", () => {
+    // Given a duration written as a bare number, as setTimeout takes one
+    const duration = SimDuration.of(3_600_000);
+
+    // When it is measured
+    // Then the number counted as milliseconds
+    expect(duration.toMilliseconds()).toBe(60 * 60 * 1000);
+  });
+
+  it("refuses a bare number that cannot describe elapsed time", () => {
+    // Given durations written as numbers that are negative or not finite
+    // When they are built
+    // Then they are refused as their millisecond components would be
+    expect(() => SimDuration.of(-1)).toThrow(SimInvalidDuration);
+    expect(() => SimDuration.of(-1)).toThrow(/milliseconds/);
+    expect(() => SimDuration.of(NaN)).toThrow(SimInvalidDuration);
+  });
+
   it("passes an existing duration through", () => {
     // Given a duration that has already been built
     const duration = SimDuration.of({ seconds: 30 });

--- a/src/util/clock/sim-duration.ts
+++ b/src/util/clock/sim-duration.ts
@@ -76,11 +76,19 @@ export class SimDuration {
   }
 
   /**
-   * Build a duration from the components a caller wrote, or pass one through.
+   * Build a duration from the components a caller wrote, from a plain number of
+   * milliseconds, or pass an existing duration through.
+   *
+   * A bare number counts milliseconds, as it does for `setTimeout`. That is what
+   * a caller reaching for `advanceBy(1000)` has in mind.
    */
-  static of(duration: SimDuration | SimDurationInput): SimDuration {
+  static of(duration: SimDuration | SimDurationInput | number): SimDuration {
     if (duration instanceof this) {
       return duration;
+    }
+
+    if (typeof duration === "number") {
+      return this.ofMilliseconds(duration);
     }
 
     return new this(totalMilliseconds(duration));


### PR DESCRIPTION
`SimDuration.of` read `days`, `hours`, `minutes`, `seconds` and `milliseconds` off whatever it was
given. A bare number carries none of them, and `advanceBy(3_600_000)` moved the clock nowhere while
reporting success. `of` now reads a bare number as milliseconds and hands it to `ofMilliseconds`,
and both `advanceBy` methods accept one. The issue's other option was to refuse anything that is not
a duration. Accepting the number makes the reported call do what its author meant and matches
`setTimeout`, while refusing it would change the exported constructor of `SimInvalidDuration` and
drop the documented zero from `SimDuration.of({})` to catch a misspelled key that TypeScript already
flags in a checked file.

Resolves #1077

@coderabbitai ignore
