### PR TITLE
feat: report IAM statements left unevaluated

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -317,15 +317,17 @@ request value is there to satisfy it.
 ### Statements left unevaluated
 
 An operator from outside the list above fails closed. The statement holding it matches nothing, and
-a `Deny` written that way allows the request it was meant to stop. `decision.unevaluatedStatements`
-reports each of those statements, with the policy it came from (`policy`), how that policy reached
-the request (`sourceType`), the statement as its document declared it (`statement`), and the
-operator that stopped the simulator reading it (`reason`).
+a `Deny` written that way stops nothing. The request then goes through on whatever else allows it,
+which is how a guardrail comes to report a healthy Allow. `decision.unevaluatedStatements` reports
+each of those statements, with the policy it came from (`policy`), how that policy reached the
+request (`sourceType`), the statement as its document declared it (`statement`), and the operator
+the simulator could not evaluate (`reason`).
 
-A statement reaches the list once everything else about it has matched. Its Principal, Action and
-Resource applied to the request, and the condition block was the only part left to read. A decision
-reached over policies the simulator read in full reports an empty list, and a test asserting on a
-guardrail can say so.
+Every operator in a condition block is read, and an unsupported one leaves the rest of the block
+evaluated as usual. A statement reaches the list once everything else about it has matched. Its
+Principal, Action and Resource applied to the request, and the unsupported operator was the only
+thing standing between the statement and the request. A decision reached over policies the
+simulator read in full reports an empty list, and a test asserting on a guardrail can say so.
 
 ```typescript sim-iam-unevaluated-statements
 /**

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -85,7 +85,9 @@ The decision exposes `value` (`"Allow"`, `"ExplicitDeny"`, or `"ImplicitDeny"`),
 flags `isAllowed`, `isDenied`, `isExplicitDeny`, and `isImplicitDeny`, the matching
 `allowStatements` and `explicitDenyStatements`, and the resolved `caller` for diagnostics. The
 matching Allows are also available per side as `identityAllowStatements` and
-`resourceAllowStatements`. A cross-Account denial is best read from those.
+`resourceAllowStatements`. A cross-Account denial is best read from those. Statements the simulator
+could not evaluate are reported by `unevaluatedStatements`, covered under
+[Statements left unevaluated](#statements-left-unevaluated).
 
 If the caller is omitted, authorization defaults to the root principal of the Account owning the
 sim IAM instance. That principal is allowed within its own Account. An explicit
@@ -311,6 +313,57 @@ match, leaving the request implicitly denied unless another statement allows it.
 matches instead, as AWS documents. With no value in the request there is none for the policy value
 to equal. A `ForAnyValue:` operator answers false for an absent key whatever it wraps, because no
 request value is there to satisfy it.
+
+### Statements left unevaluated
+
+An operator from outside the list above fails closed. The statement holding it matches nothing, and
+a `Deny` written that way allows the request it was meant to stop. `decision.unevaluatedStatements`
+reports each of those statements, with the policy it came from (`policy`), how that policy reached
+the request (`sourceType`), the statement as its document declared it (`statement`), and the
+operator that stopped the simulator reading it (`reason`).
+
+A statement reaches the list once everything else about it has matched. Its Principal, Action and
+Resource applied to the request, and the condition block was the only part left to read. A decision
+reached over policies the simulator read in full reports an empty list, and a test asserting on a
+guardrail can say so.
+
+```typescript sim-iam-unevaluated-statements
+/**
+ * Reporting simulated IAM statements that could not be evaluated.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+simAws.organizations().attachServiceControlPolicy(
+  "123456789012",
+  {
+    Version: "2012-10-17",
+    Statement: {
+      Sid: "DenyBucketCreationAfterFreeze",
+      Effect: "Deny",
+      Action: "s3:CreateBucket",
+      Resource: "*",
+      Condition: {
+        DateGreaterThan: { "aws:CurrentTime": "2026-01-01T00:00:00Z" },
+      },
+    },
+  },
+  { policyName: "BucketGuardrail" },
+);
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::123456789012-reports",
+});
+
+const [unevaluated] = decision.unevaluatedStatements;
+
+console.log(decision.isAllowed); // true
+console.log(unevaluated?.policy); // "BucketGuardrail"
+console.log(unevaluated?.reason); // "unsupported condition operator DateGreaterThan"
+```
 
 ## Users and access keys
 
@@ -1118,7 +1171,8 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
   `DeleteLoginProfile`. `DeleteUserCommand` refuses a User that still holds a policy, and
   CloudFormation teardown clears a User's policies before deleting it
 - Only the condition operators listed above are supported. A statement using any other operator
-  fails closed, matching no request
+  fails closed, matching no request. `decision.unevaluatedStatements` names those statements, and a
+  test can assert that a decision was reached over policies read in full
 - A positive `ForAllValues:` condition fails to match a request carrying no value for the key, and
   fails to match an empty value set. AWS matches both, and the negated form here matches both
 - Signature age is deliberately not enforced. `X-Amz-Date` must be present, well formed, and agree

--- a/docs/services/iam/sim-iam-unevaluated-statements.example.ts
+++ b/docs/services/iam/sim-iam-unevaluated-statements.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Reporting simulated IAM statements that could not be evaluated.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+simAws.organizations().attachServiceControlPolicy(
+  "123456789012",
+  {
+    Version: "2012-10-17",
+    Statement: {
+      Sid: "DenyBucketCreationAfterFreeze",
+      Effect: "Deny",
+      Action: "s3:CreateBucket",
+      Resource: "*",
+      Condition: {
+        DateGreaterThan: { "aws:CurrentTime": "2026-01-01T00:00:00Z" },
+      },
+    },
+  },
+  { policyName: "BucketGuardrail" },
+);
+
+const decision = simAws.account("123456789012").iam().authorize({
+  action: "s3:CreateBucket",
+  resource: "arn:aws:s3:::123456789012-reports",
+});
+
+const [unevaluated] = decision.unevaluatedStatements;
+
+console.log(decision.isAllowed); // true
+console.log(unevaluated?.policy); // "BucketGuardrail"
+console.log(unevaluated?.reason); // "unsupported condition operator DateGreaterThan"

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-match.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-match.ts
@@ -1,0 +1,27 @@
+/**
+ * What reading one statement's condition block told the simulator.
+ *
+ * A condition block either matched the request or it did not, and separately
+ * from that it may have held an operator sim IAM has no implementation for.
+ * The two facts travel together because a statement carrying an unread
+ * operator does not match, and a caller that only reads `matched` cannot tell
+ * that apart from a condition the simulator read and rejected.
+ */
+export interface SimIamConditionMatch {
+  /**
+   * Whether the whole condition block matched the request.
+   *
+   * An operator the simulator cannot evaluate fails closed. A block holding
+   * one never matches.
+   */
+  readonly matched: boolean;
+
+  /**
+   * The operator keywords sim IAM has no implementation for.
+   *
+   * These are reported only where every other operator in the block matched.
+   * A block ruled out by an operator the simulator did read needs nothing
+   * said about it: the statement would not have matched either way.
+   */
+  readonly unsupportedOperators: readonly string[];
+}

--- a/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
@@ -2,6 +2,7 @@ import type {
   SimIamConditionValue,
   SimIamPolicyDocumentCondition,
 } from "../../../policy/sim-iam-policy.js";
+import type { SimIamConditionMatch } from "./sim-iam-condition-match.js";
 import type { SimIamConditionOperator } from "./sim-iam-condition-operator.js";
 import { SimIamConditionOperatorParser } from "./sim-iam-condition-operator-parser.js";
 
@@ -12,11 +13,17 @@ import { SimIamConditionOperatorParser } from "./sim-iam-condition-operator-pars
  * key lookup. Individual condition operators encapsulate value validation,
  * comparison, and set semantics.
  *
- * An unsupported operator fails closed by making the condition non-matching. A
- * context key the request carries no value for is left to the operator, which
- * answers for itself whether an absent key matches it.
+ * An unsupported operator fails closed by making the condition non-matching,
+ * and is named in the result so the decision can report the statement as one
+ * it never read. A context key the request carries no value for is left to the
+ * operator, which answers for itself whether an absent key matches it.
  */
 export class SimIamPolicyConditionMatcher {
+  private static readonly noCondition: SimIamConditionMatch = {
+    matched: true,
+    unsupportedOperators: [],
+  };
+
   private readonly conditionContext: ReadonlyMap<string, SimIamConditionValue>;
 
   constructor(
@@ -35,28 +42,42 @@ export class SimIamPolicyConditionMatcher {
    * Match every operator and every key in a condition block.
    *
    * Separate operators and separate keys use logical AND semantics.
+   *
+   * Every operator in the block is read. Stopping at the first that fails
+   * would leave the operators the simulator could not evaluate depending on
+   * the order the policy happens to list them in.
    */
-  matches(condition: SimIamPolicyDocumentCondition | undefined): boolean {
+  matches(
+    condition: SimIamPolicyDocumentCondition | undefined,
+  ): SimIamConditionMatch {
     if (condition === undefined) {
-      return true;
+      return SimIamPolicyConditionMatcher.noCondition;
     }
 
-    return Object.entries(condition).every(([keyword, keyValues]) =>
-      this.operatorMatches(keyword, keyValues),
-    );
+    const unsupportedOperators: string[] = [];
+    let matched = true;
+
+    for (const [keyword, keyValues] of Object.entries(condition)) {
+      const operator = this.operatorParser.parse(keyword);
+
+      if (operator === undefined) {
+        unsupportedOperators.push(keyword);
+        continue;
+      }
+
+      matched = this.operatorMatches(operator, keyValues) && matched;
+    }
+
+    return {
+      matched: matched && unsupportedOperators.length === 0,
+      unsupportedOperators: matched ? unsupportedOperators : [],
+    };
   }
 
   private operatorMatches(
-    keyword: string,
+    operator: SimIamConditionOperator,
     keyValues: Readonly<Record<string, SimIamConditionValue>>,
   ): boolean {
-    const operator = this.operatorParser.parse(keyword);
-
-    /* v8 ignore if -- defensive */
-    if (operator === undefined) {
-      return false;
-    }
-
     return Object.entries(keyValues).every(([key, expected]) =>
       this.entryMatches(operator, key, expected),
     );

--- a/src/service/iam/authorize/match/sim-iam-policy-statement-matcher.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-statement-matcher.ts
@@ -6,7 +6,8 @@ import type { SimIamParsedPolicyStatement } from "../../policy/parse/sim-iam-doc
 import { simIamWildcardMatch } from "../sim-iam-wildcard.js";
 import { SimIamPolicyConditionMatcher } from "./condition/sim-iam-policy-condition-matcher.js";
 import { SimIamPolicyPrincipalMatcher } from "./sim-iam-policy-principal-matcher.js";
-import type { SimIamPrincipalMatch } from "./sim-iam-principal-match.js";
+import { SimIamPrincipalMatch } from "./sim-iam-principal-match.js";
+import { SimIamUnevaluatedStatements } from "../unevaluated/sim-iam-unevaluated-statements.js";
 
 /**
  * Matches one parsed IAM policy statement against one authorization request.
@@ -25,16 +26,30 @@ import type { SimIamPrincipalMatch } from "./sim-iam-principal-match.js";
  * - Action and NotAction;
  * - Resource and NotResource;
  * - supported IAM string conditions.
+ *
+ * One matcher reads every policy of one request, and it is also where the
+ * statements the simulator could not evaluate are collected. A statement is
+ * recorded only once everything else about it has matched. Each entry is a
+ * statement that would have applied to this request had its condition been
+ * readable.
  */
 export class SimIamPolicyStatementMatcher {
   private readonly conditionMatcher: SimIamPolicyConditionMatcher;
   private readonly principalMatcher: SimIamPolicyPrincipalMatcher;
+  private readonly unevaluated = new SimIamUnevaluatedStatements();
 
   constructor(private readonly context: SimIamAuthZContext) {
     this.conditionMatcher = new SimIamPolicyConditionMatcher(
       context.conditionContext,
     );
     this.principalMatcher = new SimIamPolicyPrincipalMatcher(context);
+  }
+
+  /**
+   * The statements read so far that the simulator could not evaluate.
+   */
+  get unevaluatedStatements(): SimIamUnevaluatedStatements {
+    return this.unevaluated;
   }
 
   /**
@@ -50,12 +65,36 @@ export class SimIamPolicyStatementMatcher {
   ): SimIamPrincipalMatch {
     const principal = this.principalMatcher.matches(policy, statement);
 
-    return principal.when(
-      principal.matched &&
-        this.actionMatches(statement) &&
-        this.resourceMatches(policy, statement) &&
-        this.conditionMatcher.matches(statement.condition),
-    );
+    if (
+      !principal.matched ||
+      !this.actionMatches(statement) ||
+      !this.resourceMatches(policy, statement)
+    ) {
+      return SimIamPrincipalMatch.none();
+    }
+
+    return principal.when(this.conditionMatches(policy, statement));
+  }
+
+  /**
+   * Check the statement's condition block, recording it as unevaluated where
+   * an operator stopped the simulator reading it.
+   */
+  private conditionMatches(
+    policy: SimIamAuthZPolicySource,
+    statement: SimIamParsedPolicyStatement,
+  ): boolean {
+    const condition = this.conditionMatcher.matches(statement.condition);
+
+    for (const operator of condition.unsupportedOperators) {
+      this.unevaluated.record(
+        policy,
+        statement.source,
+        `unsupported condition operator ${operator}`,
+      );
+    }
+
+    return condition.matched;
   }
 
   /**

--- a/src/service/iam/authorize/sim-iam-decision.ts
+++ b/src/service/iam/authorize/sim-iam-decision.ts
@@ -6,6 +6,7 @@ import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resol
 import { SimIamPolicyEvaluation } from "./allow/sim-iam-policy-evaluation.js";
 import { SimIamScpGate } from "./scp/sim-iam-scp-gate.js";
 import { SimIamPolicyDecisionValue } from "./sim-iam-decision-value.js";
+import type { SimIamUnevaluatedStatement } from "./unevaluated/sim-iam-unevaluated-statement.type.js";
 
 export { SimIamPolicyDecisionValue } from "./sim-iam-decision-value.js";
 
@@ -37,6 +38,7 @@ export class SimIamPolicyDecision {
   private readonly request: SimIamAuthZContext;
   private readonly policies: SimIamPolicyEvaluation;
   private readonly scpGate: SimIamScpGate;
+  private readonly statementMatcher: SimIamPolicyStatementMatcher;
 
   constructor(
     request: SimIamAuthZContext,
@@ -45,6 +47,7 @@ export class SimIamPolicyDecision {
     const statementMatcher = new SimIamPolicyStatementMatcher(request);
 
     this.request = request;
+    this.statementMatcher = statementMatcher;
     this.policies = new SimIamPolicyEvaluation({
       policies: [...request.identityPolicies, ...request.resourcePolicies],
       policyDocumentParser,
@@ -165,6 +168,19 @@ export class SimIamPolicyDecision {
    */
   get allowStatements(): readonly SimIamPolicyDocumentStatement[] {
     return this.policies.allowStatements.all;
+  }
+
+  /**
+   * The statements the simulator could not evaluate, and why.
+   *
+   * Sim IAM fails closed on a condition operator it has no implementation
+   * for, and a statement holding one matches nothing. A Deny that would have
+   * stopped the request in a real account leaves an ordinary Allow here. A
+   * decision reached over policies the simulator read in full reports
+   * nothing.
+   */
+  get unevaluatedStatements(): readonly SimIamUnevaluatedStatement[] {
+    return this.statementMatcher.unevaluatedStatements.all;
   }
 
   /**

--- a/src/service/iam/authorize/unevaluated/sim-iam-unevaluated-statement.type.ts
+++ b/src/service/iam/authorize/unevaluated/sim-iam-unevaluated-statement.type.ts
@@ -1,0 +1,35 @@
+import type { SimIamPolicyDocumentStatement } from "../../policy/sim-iam-policy.js";
+import type { SimIamAuthZPolicySourceType } from "../context/sim-iam-auth-z-context.js";
+
+/**
+ * One policy statement an authorization decision could not evaluate.
+ *
+ * The statement applied to the request as far as the simulator could tell:
+ * its Principal, Action and Resource all matched, and only its Condition was
+ * left undecided. Sim IAM fails closed, and the statement matched nothing. A
+ * Deny that would have stopped the request in a real account lets it through
+ * here.
+ *
+ * That is why this is recorded. A decision reporting an ordinary Allow over a
+ * statement nothing could read is an allow for the wrong reason, and a test
+ * asserting on it needs somewhere to find that out.
+ */
+export interface SimIamUnevaluatedStatement {
+  /**
+   * The policy the statement came from.
+   *
+   * This is the policy's name, falling back to the ARN of the resource
+   * holding it, and then to how the policy reached the request, since a
+   * resource policy supplied by a service need not name itself.
+   */
+  readonly policy: string;
+
+  /** Where the policy came from, e.g. `service-control`. */
+  readonly sourceType: SimIamAuthZPolicySourceType;
+
+  /** The statement, as its policy document declared it. */
+  readonly statement: SimIamPolicyDocumentStatement;
+
+  /** Why the simulator could not tell whether the statement matched. */
+  readonly reason: string;
+}

--- a/src/service/iam/authorize/unevaluated/sim-iam-unevaluated-statements.iso.test.ts
+++ b/src/service/iam/authorize/unevaluated/sim-iam-unevaluated-statements.iso.test.ts
@@ -1,0 +1,286 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+
+const denyAfterFreeze = {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyBucketCreationAfterFreeze",
+    Effect: "Deny",
+    Action: "s3:CreateBucket",
+    Resource: "*",
+    Condition: {
+      DateGreaterThan: { "aws:CurrentTime": "2026-01-01T00:00:00Z" },
+    },
+  },
+} as const;
+
+describe("Sim IAM statements it could not evaluate", () => {
+  it("reports a service control policy statement holding an operator it cannot read", () => {
+    // Given an organization denying Bucket creation past a date, under a
+    // condition operator sim IAM has no implementation for.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAfterFreeze, {
+        policyName: "BucketGuardrail",
+      });
+
+    // When the Account root asks to create a Bucket.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    // Then the guardrail let it through, and the decision says which
+    // statement went unread and what stopped it.
+    assertTrue(decision.isAllowed);
+    assertArrayLength(decision.unevaluatedStatements, 1);
+
+    const [unevaluated] = decision.unevaluatedStatements;
+
+    assertIdentical(unevaluated.policy, "BucketGuardrail");
+    assertIdentical(unevaluated.sourceType, "service-control");
+    assertIdentical(unevaluated.statement.Sid, "DenyBucketCreationAfterFreeze");
+    assertIdentical(
+      unevaluated.reason,
+      "unsupported condition operator DateGreaterThan",
+    );
+  });
+
+  it("counts one guardrail attached at two levels once", () => {
+    // Given the same guardrail attached both to the organizational unit an
+    // Account sits in and to the Account itself.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const organizations = simAws.organizations();
+    const workloads = organizations.createOrganizationalUnit("Workloads");
+
+    organizations.moveAccount(accountId, workloads);
+    organizations.attachServiceControlPolicy(workloads, denyAfterFreeze, {
+      policyName: "BucketGuardrail",
+    });
+    organizations.attachServiceControlPolicy(accountId, denyAfterFreeze, {
+      policyName: "BucketGuardrail",
+    });
+
+    // When the Account root asks to create a Bucket.
+    const decision = simAws
+      .account(accountId)
+      .iam()
+      .authorize({
+        action: "s3:CreateBucket",
+        resource: `arn:aws:s3:::${accountId}-reports`,
+      });
+
+    // Then the statement going unread is reported once for the request,
+    // however many levels reached it.
+    assertArrayLength(decision.unevaluatedStatements, 1);
+  });
+
+  it("reports nothing for policies it read in full", () => {
+    // Given a Bucket policy whose condition sim IAM supports.
+    const simAws = new SimAws();
+
+    // When a request satisfies it.
+    const decision = simAws
+      .account("123456789012")
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: "arn:aws:s3:::reports-bucket/summary.csv",
+        caller: { kind: "anonymous" },
+        conditionContext: { "aws:SourceVpce": "vpce-1a2b3c4d" },
+        resourcePolicies: [
+          {
+            policyName: "ReportsBucketPolicy",
+            document: {
+              Version: "2012-10-17",
+              Statement: {
+                Effect: "Allow",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::reports-bucket/*",
+                Condition: {
+                  StringEquals: { "aws:SourceVpce": "vpce-1a2b3c4d" },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+    // Then the decision was reached over everything the policy said.
+    assertTrue(decision.isAllowed);
+    assertArrayLength(decision.unevaluatedStatements, 0);
+  });
+
+  it("says nothing about a statement another operator ruled out", () => {
+    // Given a statement whose condition block holds an operator sim IAM
+    // cannot read alongside one it can, listed first so that reading in order
+    // would reach the unsupported one.
+    const simAws = new SimAws();
+
+    // When the supported operator does not match the request.
+    const decision = simAws
+      .account("123456789012")
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: "arn:aws:s3:::reports-bucket/summary.csv",
+        caller: { kind: "anonymous" },
+        conditionContext: { "aws:SourceVpce": "vpce-99999999" },
+        resourcePolicies: [
+          {
+            policyName: "ReportsBucketPolicy",
+            document: {
+              Version: "2012-10-17",
+              Statement: {
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::reports-bucket/*",
+                Condition: {
+                  DateGreaterThan: {
+                    "aws:CurrentTime": "2026-01-01T00:00:00Z",
+                  },
+                  StringEquals: { "aws:SourceVpce": "vpce-1a2b3c4d" },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+    // Then nothing is reported, because the statement would not have applied
+    // to this request whatever the unread operator said.
+    assertTrue(decision.isDenied);
+    assertArrayLength(decision.unevaluatedStatements, 0);
+  });
+
+  it("says nothing about a statement the request never reached", () => {
+    // Given a statement about another action, holding an operator sim IAM
+    // cannot read.
+    const simAws = new SimAws();
+
+    // When a request the statement says nothing about is authorized.
+    const decision = simAws
+      .account("123456789012")
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: "arn:aws:s3:::reports-bucket/summary.csv",
+        caller: { kind: "anonymous" },
+        resourcePolicies: [
+          {
+            policyName: "ReportsBucketPolicy",
+            document: {
+              Version: "2012-10-17",
+              Statement: {
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:DeleteObject",
+                Resource: "arn:aws:s3:::reports-bucket/*",
+                Condition: {
+                  DateGreaterThan: {
+                    "aws:CurrentTime": "2026-01-01T00:00:00Z",
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+    // Then the condition was beside the point, and nothing is reported.
+    assertArrayLength(decision.unevaluatedStatements, 0);
+  });
+
+  it("names an unnamed resource policy by the resource holding it", () => {
+    // Given a Bucket policy supplied by a service without a name of its own.
+    const simAws = new SimAws();
+
+    // When it holds a statement sim IAM cannot read.
+    const decision = simAws
+      .account("123456789012")
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: "arn:aws:s3:::reports-bucket/summary.csv",
+        caller: { kind: "anonymous" },
+        resourcePolicies: [
+          {
+            resourceArn: "arn:aws:s3:::reports-bucket",
+            document: {
+              Version: "2012-10-17",
+              Statement: {
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::reports-bucket/*",
+                Condition: {
+                  DateGreaterThan: {
+                    "aws:CurrentTime": "2026-01-01T00:00:00Z",
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+    // Then the resource it belongs to is what the report calls it.
+    assertArrayLength(decision.unevaluatedStatements, 1);
+    assertIdentical(
+      decision.unevaluatedStatements[0].policy,
+      "arn:aws:s3:::reports-bucket",
+    );
+  });
+
+  it("falls back to how a policy reached the request", () => {
+    // Given a policy naming neither itself nor a resource.
+    const simAws = new SimAws();
+
+    // When it holds a statement sim IAM cannot read.
+    const decision = simAws
+      .account("123456789012")
+      .iam()
+      .authorize({
+        action: "s3:GetObject",
+        resource: "arn:aws:s3:::reports-bucket/summary.csv",
+        caller: { kind: "anonymous" },
+        resourcePolicies: [
+          {
+            document: {
+              Version: "2012-10-17",
+              Statement: {
+                Effect: "Deny",
+                Principal: "*",
+                Action: "s3:GetObject",
+                Resource: "arn:aws:s3:::reports-bucket/*",
+                Condition: {
+                  DateGreaterThan: {
+                    "aws:CurrentTime": "2026-01-01T00:00:00Z",
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+    // Then the report says which side of the decision it came from.
+    assertArrayLength(decision.unevaluatedStatements, 1);
+    assertIdentical(decision.unevaluatedStatements[0].policy, "resource");
+  });
+});

--- a/src/service/iam/authorize/unevaluated/sim-iam-unevaluated-statements.ts
+++ b/src/service/iam/authorize/unevaluated/sim-iam-unevaluated-statements.ts
@@ -1,0 +1,58 @@
+import type { SimIamPolicyDocumentStatement } from "../../policy/sim-iam-policy.js";
+import type { SimIamAuthZPolicySource } from "../context/sim-iam-auth-z-context.js";
+import type { SimIamUnevaluatedStatement } from "./sim-iam-unevaluated-statement.type.js";
+
+/**
+ * The statements one authorization decision could not evaluate.
+ *
+ * Sim IAM implements the condition operators multi-service tests need and
+ * fails closed on the rest, which leaves a statement it cannot read matching
+ * nothing. On a Deny that reads as an allow, and the decision otherwise looks
+ * healthy. Collecting the skips here is what lets a decision say that it
+ * reached its answer without reading everything the policies said.
+ *
+ * A statement recorded twice is kept once. One policy attached at two levels
+ * of an organization is one statement going unread, however many levels
+ * reached it.
+ */
+export class SimIamUnevaluatedStatements {
+  private readonly records: SimIamUnevaluatedStatement[] = [];
+
+  /**
+   * Every statement left unevaluated, in the order they were reached.
+   */
+  get all(): readonly SimIamUnevaluatedStatement[] {
+    return this.records;
+  }
+
+  /**
+   * Record a statement the simulator could not decide.
+   */
+  record(
+    policy: SimIamAuthZPolicySource,
+    statement: SimIamPolicyDocumentStatement,
+    reason: string,
+  ): void {
+    const already = this.records.some(
+      (record) => record.statement === statement && record.reason === reason,
+    );
+
+    if (already) {
+      return;
+    }
+
+    this.records.push({
+      policy: this.policyName(policy),
+      sourceType: policy.sourceType,
+      statement,
+      reason,
+    });
+  }
+
+  /**
+   * What to call the policy a statement came from.
+   */
+  private policyName(policy: SimIamAuthZPolicySource): string {
+    return policy.policyName ?? policy.resourceArn ?? policy.sourceType;
+  }
+}


### PR DESCRIPTION
Sim IAM fails closed on a condition operator it has no implementation for and recorded the skip
nowhere. A Deny written that way allowed the request it was meant to stop, and the decision reported
an ordinary Allow. The condition matcher now names the operators it could not read, and
`decision.unevaluatedStatements` reports each statement one of them stopped, with the policy the
statement came from and the reason. A statement is recorded only once its Principal, Action and
Resource have matched, and every existing decision value is unchanged.

The report follows `decision.serviceControlPolicy`, not `stack.ignoredProperties`. A CloudFormation
Resource is created once and carries its ignored properties from then on, while this belongs to one
authorization attempt and dies with it. `authorize(...)` already answers with a decision object
holding the statements it matched, and the statements it could not match are the same kind of answer
about the same request. The entry shape is borrowed from `SimCfnIgnoredProperty` all the same, down
to the free-text `reason` and keeping one record for a statement reached twice.

The issue also asks whether an unevaluable `Deny` should deny the request. It should not, and this
PR leaves the decision values alone. Denying would turn every unimplemented operator into a
different wrong answer, and a harder one to debug. A request a real account allows would start
failing in a simulation, in a service test that never mentions IAM. Whether the statement matches is
genuinely unknown, and a decision that guesses either way is wrong half the time. Reporting says so
and lets the test decide. A test that wants the strict reading can assert
`decision.unevaluatedStatements` is empty, which is the assertion the SCP in the issue needed.

Condition operators are still evaluated as one AND block, with one change. Every operator in the
block is now read. Stopping at the first that fails would leave the reported set depending on the
order the policy lists its operators in. An unsupported operator alongside one that
already rules the statement out reports nothing.

Resolves #1071


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - IAM authorization results now report policy statements that could not be evaluated because of unsupported condition operators.
  - Added details including the originating policy, statement, source type, and evaluation reason.
  - Duplicate reports are consolidated while preserving evaluation order.
  - Added an example demonstrating this diagnostic information.

- **Documentation**
  - Updated IAM authorization guidance with fail-closed behavior, reported metadata, limitations, and examples.

- **Tests**
  - Added coverage for unsupported conditions, policy sources, deduplication, exclusions, and fallback policy names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->