### PR TITLE
feat: model schedule groups in sim Scheduler

### DIFF
--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -718,8 +718,9 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-// An execution role policy is often written against this, since it covers
-// every schedule the group will ever hold.
+// An identity policy granting `scheduler:` actions on the group names this
+// ARN. So does the `aws:SourceArn` condition AWS recommends in a schedule
+// execution role's trust policy, which the simulation does not supply.
 console.log(stack.output("GroupArn"));
 // "arn:aws:scheduler:us-east-1:888888888888:schedule-group/reporting-pr-412"
 ```
@@ -794,6 +795,7 @@ Resources of the same stack.
   for each of them, in this process and one after another.
 - `KmsKeyArn` is refused, and `ClientToken` is accepted and ignored. Nothing here retries, so it has
   no request to make idempotent.
-- `AWS::Scheduler::ScheduleGroup` is absent as a CloudFormation resource type.
-  `AWS::Scheduler::Schedule` is there, under
-  [deploying from a template](#deploying-from-a-cloudformation-template).
+- A schedule's execution role is assumed with no `aws:SourceArn` condition key supplied. AWS
+  recommends scoping that key to a schedule group ARN in the role's trust policy, against the
+  confused deputy problem, and a trust policy carrying that condition admits nothing here. Every
+  firing of a schedule using such a role is recorded in `deliveryFailures`.

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -432,6 +432,73 @@ A listing carries less than a describe, as it does on AWS. It has the target's A
 and no expression at all. Code reading `ScheduleExpression` off a listing gets
 `undefined` from AWS, and gets `undefined` here too.
 
+## Schedule groups
+
+Every account and region starts with a `default` group. A schedule naming no group goes in it.
+
+A schedule's name is unique within its group, and the group is in the schedule's ARN. Two
+deployments of one construct into the same account and region collide on schedule names unless each
+one brings its own group.
+
+```typescript sim-scheduler-schedule-group
+/**
+ * A schedule group scoping the names of one deployment's schedules.
+ */
+
+import {
+  CreateScheduleCommand,
+  CreateScheduleGroupCommand,
+  ListSchedulesCommand,
+} from "@aws-sdk/client-scheduler";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const scheduler = simAws.scheduler();
+
+const group = await scheduler.createScheduleGroup(
+  new CreateScheduleGroupCommand({ Name: "reporting-pr-412" }),
+);
+
+console.log(group.ScheduleGroupArn);
+// "arn:aws:scheduler:us-east-1:888888888888:schedule-group/reporting-pr-412"
+
+const created = await scheduler.createSchedule(
+  new CreateScheduleCommand({
+    Name: "pageviews-hourly",
+    GroupName: "reporting-pr-412",
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: {
+      Arn: "arn:aws:lambda:us-east-1:888888888888:function:report",
+      RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+    },
+  }),
+);
+
+// The group is in the schedule's ARN. The same schedule name is free in every
+// other group, including default.
+console.log(created.ScheduleArn);
+// ".../schedule/reporting-pr-412/pageviews-hourly"
+
+const listed = await scheduler.listSchedules(
+  new ListSchedulesCommand({ GroupName: "reporting-pr-412" }),
+);
+
+console.log(listed.Schedules?.length); // 1
+```
+
+A `GroupName` for a group that has yet to be created raises `ResourceNotFoundException`, and so
+does a listing for one. Real Scheduler answers the same way. A schedule quietly moved into `default`
+would carry an ARN naming a group it had never been put in.
+
+`GetScheduleGroup` reports a group's ARN, state and timestamps. `ListScheduleGroups` reports them
+all in creation order, narrowed by `NamePrefix` and paged by `MaxResults` and `NextToken`.
+
+`DeleteScheduleGroup` deletes the schedules in the group along with it, as AWS does. It refuses the
+`default` group, which comes with the account. Losing that group would leave every request naming
+no group with nowhere to go.
+
 ## Permissions
 
 Every operation is authorized against the schedule ARN, which carries the group:
@@ -608,6 +675,67 @@ A property this simulation leaves out is refused at deploy time, naming the Reso
 schedule that behaves differently from the one declared would be worse. Tearing the stack down
 removes the schedules it created, and no schedule fires afterwards.
 
+### Deploying a schedule group
+
+`AWS::Scheduler::ScheduleGroup` deploys too, so a stack can bring the group its schedules go in.
+
+```typescript sim-scheduler-cfn-schedule-group
+/**
+ * A stack deploying its own schedule group, with a schedule in it.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reporting-stack",
+  template: {
+    Resources: {
+      ReportGroup: {
+        Type: "AWS::Scheduler::ScheduleGroup",
+        Properties: { Name: "reporting-pr-412" },
+      },
+      HourlyReport: {
+        Type: "AWS::Scheduler::Schedule",
+        Properties: {
+          Name: "pageviews-hourly",
+          GroupName: { Ref: "ReportGroup" },
+          ScheduleExpression: "rate(1 hour)",
+          FlexibleTimeWindow: { Mode: "OFF" },
+          Target: {
+            Arn: "arn:aws:sqs:us-east-1:888888888888:reports",
+            RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+          },
+        },
+      },
+    },
+    Outputs: {
+      GroupArn: { Value: { "Fn::GetAtt": ["ReportGroup", "Arn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// An execution role policy is often written against this, since it covers
+// every schedule the group will ever hold.
+console.log(stack.output("GroupArn"));
+// "arn:aws:scheduler:us-east-1:888888888888:schedule-group/reporting-pr-412"
+```
+
+`Ref` returns the group's **name** and `Fn::GetAtt` answers `Arn`, `State`, `CreationDate` and
+`LastModificationDate`. A group the template leaves unnamed gets one generated from the stack name
+and the logical ID.
+
+`Tags` on a group are recorded as an ignored property and the group deploys without them. The CDK
+puts a stack's tags on every taggable Resource in it, so a template gains them without asking.
+Failing the whole stack over a tag would refuse a deployment for a property the simulation ignores
+anyway. Read the record back from `stack.getResource("<logicalId>")?.ignoredProperties`.
+
+Tearing the stack down removes the group. Its schedules go with it, whether or not they are
+Resources of the same stack.
+
 ## Available functionality
 
 - `CreateSchedule`, `GetSchedule`, `UpdateSchedule`, `DeleteSchedule` and `ListSchedules`.
@@ -618,7 +746,10 @@ removes the schedules it created, and no schedule fires afterwards.
 - ECS targets, running a simulated task as the execution role, with the task definition and
   `TaskCount` from `EcsParameters` and container overrides from the target's `Input`.
 - `ActionAfterCompletion`, and `deliveryFailures` for invocations that did not happen.
-- The `default` schedule group in every account and region, without one being created.
+- `CreateScheduleGroup`, `GetScheduleGroup`, `DeleteScheduleGroup` and `ListScheduleGroups`, over
+  the `default` group every account and region starts with and any group created beside it.
+- `AWS::Scheduler::Schedule` and `AWS::Scheduler::ScheduleGroup` deployed from a CloudFormation
+  template.
 - Creation and modification timestamps from the simulation's clock, and prefix-narrowed,
   state-narrowed, paged listings.
 - IAM authorization against the schedule ARN.
@@ -633,9 +764,13 @@ removes the schedules it created, and no schedule fires afterwards.
 - An invocation is attempted once. There is no retry and no dead letter queue. A target that throws
   is recorded as a failure, and never redelivered. A failed invocation never rejects
   `advanceBy(...)`, and is read from `deliveryFailures`.
-- Schedule groups are absent as a manageable resource. Every schedule is in `default`, and a
-  `GroupName` naming any other group is refused. Putting it quietly in `default` would give it an
-  ARN naming the wrong group.
+- A schedule group carries no tags. `CreateScheduleGroup` refuses `Tags`, since the simulation
+  stores them nowhere. A template's `Tags` are recorded as an ignored property and the group still
+  deploys.
+- A schedule group is `ACTIVE` or gone. Deleting one removes its schedules in the same call, where
+  real Scheduler holds the group in `DELETING` until they have gone.
+- The `default` schedule group cannot be deleted. AWS leaves the answer to that request
+  undocumented.
 - `FlexibleTimeWindow` with `Mode: "FLEXIBLE"` is refused. Real Scheduler invokes the target at an
   unpredictable moment inside the window, and firing at the exact due time instead would let a test
   rely on timing AWS leaves unpromised.

--- a/docs/services/scheduler/sim-scheduler-cfn-schedule-group.example.ts
+++ b/docs/services/scheduler/sim-scheduler-cfn-schedule-group.example.ts
@@ -1,0 +1,42 @@
+/**
+ * A stack deploying its own schedule group, with a schedule in it.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "reporting-stack",
+  template: {
+    Resources: {
+      ReportGroup: {
+        Type: "AWS::Scheduler::ScheduleGroup",
+        Properties: { Name: "reporting-pr-412" },
+      },
+      HourlyReport: {
+        Type: "AWS::Scheduler::Schedule",
+        Properties: {
+          Name: "pageviews-hourly",
+          GroupName: { Ref: "ReportGroup" },
+          ScheduleExpression: "rate(1 hour)",
+          FlexibleTimeWindow: { Mode: "OFF" },
+          Target: {
+            Arn: "arn:aws:sqs:us-east-1:888888888888:reports",
+            RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+          },
+        },
+      },
+    },
+    Outputs: {
+      GroupArn: { Value: { "Fn::GetAtt": ["ReportGroup", "Arn"] } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+// An execution role policy is often written against this, since it covers
+// every schedule the group will ever hold.
+console.log(stack.output("GroupArn"));
+// "arn:aws:scheduler:us-east-1:888888888888:schedule-group/reporting-pr-412"

--- a/docs/services/scheduler/sim-scheduler-cfn-schedule-group.example.ts
+++ b/docs/services/scheduler/sim-scheduler-cfn-schedule-group.example.ts
@@ -36,7 +36,8 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 await stack.waitForDeployComplete();
 
-// An execution role policy is often written against this, since it covers
-// every schedule the group will ever hold.
+// An identity policy granting `scheduler:` actions on the group names this
+// ARN. So does the `aws:SourceArn` condition AWS recommends in a schedule
+// execution role's trust policy, which the simulation does not supply.
 console.log(stack.output("GroupArn"));
 // "arn:aws:scheduler:us-east-1:888888888888:schedule-group/reporting-pr-412"

--- a/docs/services/scheduler/sim-scheduler-schedule-group.example.ts
+++ b/docs/services/scheduler/sim-scheduler-schedule-group.example.ts
@@ -1,0 +1,45 @@
+/**
+ * A schedule group scoping the names of one deployment's schedules.
+ */
+
+import {
+  CreateScheduleCommand,
+  CreateScheduleGroupCommand,
+  ListSchedulesCommand,
+} from "@aws-sdk/client-scheduler";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const scheduler = simAws.scheduler();
+
+const group = await scheduler.createScheduleGroup(
+  new CreateScheduleGroupCommand({ Name: "reporting-pr-412" }),
+);
+
+console.log(group.ScheduleGroupArn);
+// "arn:aws:scheduler:us-east-1:888888888888:schedule-group/reporting-pr-412"
+
+const created = await scheduler.createSchedule(
+  new CreateScheduleCommand({
+    Name: "pageviews-hourly",
+    GroupName: "reporting-pr-412",
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: {
+      Arn: "arn:aws:lambda:us-east-1:888888888888:function:report",
+      RoleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+    },
+  }),
+);
+
+// The group is in the schedule's ARN. The same schedule name is free in every
+// other group, including default.
+console.log(created.ScheduleArn);
+// ".../schedule/reporting-pr-412/pageviews-hourly"
+
+const listed = await scheduler.listSchedules(
+  new ListSchedulesCommand({ GroupName: "reporting-pr-412" }),
+);
+
+console.log(listed.Schedules?.length); // 1

--- a/src/service/cloudformation/resource/cfn/scheduler/sim-scheduler-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/scheduler/sim-scheduler-cfn-value-adapter.ts
@@ -1,3 +1,4 @@
+import { SimSchedulerScheduleGroup } from "../../../../scheduler/group/sim-scheduler-schedule-group.js";
 import { SimSchedulerSchedule } from "../../../../scheduler/schedule/sim-scheduler-schedule.js";
 import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
 import type {
@@ -38,6 +39,57 @@ class SimSchedulerScheduleCfn implements SimCfnResourceValueAdapter {
 }
 
 /**
+ * CloudFormation-facing values for a simulated schedule group.
+ *
+ * `Arn` is the one worth having. A schedule's execution role is often written
+ * against the group's ARN, since a policy naming the group covers every
+ * schedule that will ever go in it.
+ */
+class SimSchedulerScheduleGroupCfn implements SimCfnResourceValueAdapter {
+  private readonly group: SimSchedulerScheduleGroup;
+
+  constructor(properties: { readonly group: SimSchedulerScheduleGroup }) {
+    this.group = properties.group;
+  }
+
+  /**
+   * AWS::Scheduler::ScheduleGroup Ref returns the group's name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.group.name;
+  }
+
+  /**
+   * AWS::Scheduler::ScheduleGroup attributes.
+   *
+   * The two dates come back as ISO strings. A template value is JSON, so there
+   * is nowhere for a `Date` to go, and every other date CloudFormation hands
+   * back is a string too.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Arn": {
+        return this.group.arn;
+      }
+      case "State": {
+        return this.group.state;
+      }
+      case "CreationDate": {
+        return this.group.creationDate.toISOString();
+      }
+      case "LastModificationDate": {
+        return this.group.lastModificationDate.toISOString();
+      }
+      default: {
+        throw new Error(
+          `Unsupported AWS::Scheduler::ScheduleGroup attribute ${attributeName}`,
+        );
+      }
+    }
+  }
+}
+
+/**
  * The CloudFormation-facing value adapter for a simulated Scheduler Resource.
  */
 export function schedulerValueAdapter(
@@ -48,6 +100,13 @@ export function schedulerValueAdapter(
     properties.simResource instanceof SimSchedulerSchedule
   ) {
     return new SimSchedulerScheduleCfn({ schedule: properties.simResource });
+  }
+
+  if (
+    properties.type === "AWS::Scheduler::ScheduleGroup" &&
+    properties.simResource instanceof SimSchedulerScheduleGroup
+  ) {
+    return new SimSchedulerScheduleGroupCfn({ group: properties.simResource });
   }
 
   return undefined;

--- a/src/service/cloudformation/resource/cfn/scheduler/sim-scheduler-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/scheduler/sim-scheduler-cfn-value-adapter.ts
@@ -41,9 +41,9 @@ class SimSchedulerScheduleCfn implements SimCfnResourceValueAdapter {
 /**
  * CloudFormation-facing values for a simulated schedule group.
  *
- * `Arn` is the one worth having. A schedule's execution role is often written
- * against the group's ARN, since a policy naming the group covers every
- * schedule that will ever go in it.
+ * `Arn` is the one worth having. An identity policy granting `scheduler:`
+ * actions on the group names it, and so does the `aws:SourceArn` condition AWS
+ * recommends in a schedule execution role's trust policy.
  */
 class SimSchedulerScheduleGroupCfn implements SimCfnResourceValueAdapter {
   private readonly group: SimSchedulerScheduleGroup;

--- a/src/service/scheduler/README.md
+++ b/src/service/scheduler/README.md
@@ -1,7 +1,8 @@
 # Simulated EventBridge Scheduler implementation
 
-This directory contains the simulated EventBridge Scheduler service implementation. Schedules, their
-targets, the five commands that manage them, and firing a schedule as simulated time advances.
+This directory contains the simulated EventBridge Scheduler service implementation. Schedules, the
+groups they go in, their targets, the commands that manage them, and firing a schedule as simulated
+time advances.
 
 The guiding decision is that this is a separate service from simulated EventBridge rather than a
 corner of it. The two look similar from a distance and differ in every detail that matters: a
@@ -32,9 +33,10 @@ from it; a schedule has exactly one and cannot be created without it, so it is a
 policy written without the group matches nothing.
 
 `SimSchedulerScheduleName` validates a schedule name and a group name, which AWS constrains
-identically. `requestedScheduleGroupName` is where the one-group decision lives: a request naming
-any group but `default` is refused as unsimulated rather than quietly moved, because a schedule moved
-into `default` would carry an ARN naming a group it is not in.
+identically. `requestedScheduleGroupName` reads the group a schedule request names and defaults it
+to `default`. Whether that group exists is asked separately, by `SimSchedulerScheduleAccess`, after
+the caller has been authorized. A caller with no permission therefore learns nothing about which
+groups an account has.
 
 `SimSchedulerTarget` requires both `Arn` and `RoleArn`, as AWS does, and validates the role ARN when
 the schedule is written rather than when it first falls due. A schedule that could never invoke
@@ -45,6 +47,23 @@ the same three services today and they are answering different questions: EventB
 its rules cannot deliver to, and this refuses one that Scheduler's much larger real target list does
 not reach here. Sharing would tie two services' supported-target sets together, and those sets are
 not the same on real AWS.
+
+## Schedule groups
+
+`group/` holds the group model. `SimSchedulerScheduleGroup` is a name, an ARN and two timestamps, and
+`schedulerScheduleGroupArn` builds the `schedule-group/<name>` path, which is a different resource
+from a schedule's `schedule/<group>/<name>`. An IAM policy naming one does not match the other.
+
+`SimSchedulerScheduleGroupStore` builds its own groups rather than taking them from a writer, which
+is the opposite of how schedules are handled. A schedule is read out of a request carrying a dozen
+properties, and reading it in one place is what keeps Create and Update agreeing. A group is a name
+and two timestamps. The store also seeds `default` when it is constructed, because every Account has
+that group without anyone creating one.
+
+Deleting a group deletes its schedules, as AWS does. `SimSchedulerScheduleStore.removeGroup` is where
+that happens, since how the schedules of a group are found is the store's own business.
+`SimSchedulerGroupAccess.requireDeletable` refuses `default`. AWS does not document what it answers
+for that request, and a simulation that let the group go would have no way of getting it back.
 
 ## Schedule expressions
 
@@ -133,6 +152,20 @@ role's permission to run it is ECS's answer rather than a second one kept here. 
 and its `Input`, which is the task's overrides, are read by `src/service/ecs/target/`, shared with
 EventBridge because a rule target says the same things about a task in the same words.
 
+## CloudFormation
+
+`cfn/` creates `AWS::Scheduler::Schedule` and `AWS::Scheduler::ScheduleGroup`, one creator class
+each, dispatched by `SimSchedulerCfnResourceFactory`. Both go through the ordinary Scheduler
+commands, so what a template may ask for is decided once by the service rather than again here.
+`simCfnSchedulerResourceError` is what keeps a refusal from reading as an unsupported Resource. Sim
+CloudFormation steps over one of those, and a schedule stepped over would leave a Stack looking
+deployed while nothing ever fired.
+
+`simCfnSchedulerResourceDeletion` swallows a not-found on the way down. A group takes its schedules
+with it, so a schedule whose template named its group as a string rather than by `Ref` declares no
+dependency on it and may find itself already deleted when its own turn comes. Real CloudFormation
+treats a Resource that has already gone as deleted.
+
 ## Authorization
 
 `SimSchedulerAuthorizer` authorizes the caller against the schedule ARN. It is deliberately not
@@ -142,12 +175,16 @@ the command that created the schedule.
 
 ## Divergences
 
-Four, all deliberate.
+Five, all deliberate.
 
-Schedule groups are **refused rather than simulated**. A `GroupName` other than `default` fails, where
-real AWS creates the schedule in whichever group is named. Accepting the name and using `default`
-anyway would produce a schedule whose ARN named a group it was not in, and refusing is the smaller
-lie.
+A schedule group is **`ACTIVE` or gone**. Real Scheduler holds a group in `DELETING` while the
+schedules in it are removed, and reaching that state needs a deletion that takes time. Deleting a
+group here removes its schedules in the same call, so nothing is ever seen in `DELETING`.
+
+Group **tags are refused** by `CreateScheduleGroup` and **recorded as ignored** by CloudFormation.
+The two answers differ because the requests do. An SDK caller asking for a tag meant to ask for it.
+The CDK puts a Stack's tags on every taggable Resource in it, and failing a Stack over a tag nothing
+reads would refuse a template nobody wrote that way.
 
 `ClientToken` is **accepted and ignored**, on `CreateSchedule`, `UpdateSchedule` and
 `DeleteSchedule`. It exists to make a retried request idempotent, nothing here retries, and refusing

--- a/src/service/scheduler/cfn/sim-cfn-schedule-creator.ts
+++ b/src/service/scheduler/cfn/sim-cfn-schedule-creator.ts
@@ -1,0 +1,99 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSchedulerSchedule } from "../schedule/sim-scheduler-schedule.js";
+import type { SimScheduler } from "../sim-scheduler.js";
+import { SimCfnScheduleProperties } from "./sim-cfn-schedule-properties.js";
+import { createdSchedule } from "./sim-cfn-scheduler-resource-lookup.js";
+import {
+  schedulerScheduleResourceType,
+  simCfnSchedulerResourceCreation,
+  simCfnSchedulerResourceDeletion,
+} from "./sim-cfn-scheduler-resource-error.js";
+
+/**
+ * Creates simulated schedules from AWS::Scheduler::Schedule Resources.
+ *
+ * The schedule goes through the ordinary CreateSchedule command rather than
+ * being constructed directly, so a schedule a template deployed is the same
+ * thing an SDK caller would have got, down to the refusals.
+ */
+export class SimCfnScheduleCreator {
+  private readonly scheduler: SimScheduler;
+
+  constructor(properties: { readonly scheduler: SimScheduler }) {
+    this.scheduler = properties.scheduler;
+  }
+
+  /**
+   * Create a schedule from an AWS::Scheduler::Schedule Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<SimSchedulerSchedule> {
+    const properties = this.read(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+    const input = properties.scheduleInput();
+
+    return await simCfnSchedulerResourceCreation(
+      schedulerScheduleResourceType,
+      resource.logicalId,
+      async () => {
+        await this.scheduler.createSchedule(
+          { input },
+          simCfnResourceCallerOptions(context.caller),
+        );
+
+        const schedule = createdSchedule(this.scheduler, input);
+
+        assertDefined(
+          schedule,
+          `sim Scheduler schedule ${String(input.Name)} after ` +
+            `CloudFormation creation`,
+        );
+
+        return schedule;
+      },
+    );
+  }
+
+  /**
+   * Delete the schedule a Resource created.
+   */
+  async delete(
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    const properties = this.read(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+
+    await simCfnSchedulerResourceDeletion(async () => {
+      await this.scheduler.deleteSchedule(
+        {
+          input: {
+            Name: properties.name(),
+            GroupName: properties.scheduleInput().GroupName,
+          },
+        },
+        simCfnResourceCallerOptions(context.caller),
+      );
+    });
+  }
+
+  private read(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnScheduleProperties {
+    return new SimCfnScheduleProperties({ resource, properties });
+  }
+}

--- a/src/service/scheduler/cfn/sim-cfn-schedule-group-creator.ts
+++ b/src/service/scheduler/cfn/sim-cfn-schedule-group-creator.ts
@@ -1,0 +1,99 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimSchedulerScheduleGroup } from "../group/sim-scheduler-schedule-group.js";
+import type { SimScheduler } from "../sim-scheduler.js";
+import { SimCfnScheduleGroupProperties } from "./sim-cfn-schedule-group-properties.js";
+import {
+  schedulerScheduleGroupResourceType,
+  simCfnSchedulerResourceCreation,
+  simCfnSchedulerResourceDeletion,
+} from "./sim-cfn-scheduler-resource-error.js";
+
+/**
+ * Creates simulated schedule groups from AWS::Scheduler::ScheduleGroup
+ * Resources.
+ *
+ * A group is worth deploying for one reason. A schedule's name is unique
+ * within its group, and a construct deployed twice into one Account and Region
+ * collides on schedule names unless each deployment brings its own group.
+ */
+export class SimCfnScheduleGroupCreator {
+  private readonly scheduler: SimScheduler;
+
+  constructor(properties: { readonly scheduler: SimScheduler }) {
+    this.scheduler = properties.scheduler;
+  }
+
+  /**
+   * Create a group from an AWS::Scheduler::ScheduleGroup Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<SimSchedulerScheduleGroup> {
+    const properties = this.read(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+    const name = properties.name();
+
+    properties.recordIgnoredProperties();
+
+    return await simCfnSchedulerResourceCreation(
+      schedulerScheduleGroupResourceType,
+      resource.logicalId,
+      async () => {
+        await this.scheduler.createScheduleGroup(
+          { input: { Name: name } },
+          simCfnResourceCallerOptions(context.caller),
+        );
+
+        const group = this.scheduler.findScheduleGroup(name);
+
+        assertDefined(
+          group,
+          `sim Scheduler schedule group ${name} after CloudFormation creation`,
+        );
+
+        return group;
+      },
+    );
+  }
+
+  /**
+   * Delete the group a Resource created, and the schedules still in it.
+   *
+   * Real Scheduler deletes a group's schedules with it, so a stack whose
+   * schedules come down alongside their group has nothing left over either
+   * way.
+   */
+  async delete(
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    const properties = this.read(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+
+    await simCfnSchedulerResourceDeletion(async () => {
+      await this.scheduler.deleteScheduleGroup(
+        { input: { Name: properties.name() } },
+        simCfnResourceCallerOptions(context.caller),
+      );
+    });
+  }
+
+  private read(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnScheduleGroupProperties {
+    return new SimCfnScheduleGroupProperties({ resource, properties });
+  }
+}

--- a/src/service/scheduler/cfn/sim-cfn-schedule-group-properties.ts
+++ b/src/service/scheduler/cfn/sim-cfn-schedule-group-properties.ts
@@ -1,0 +1,96 @@
+import { SimCfnGeneratedResourceName } from "../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  schedulerScheduleGroupResourceType,
+  simCfnSchedulerResourceError,
+} from "./sim-cfn-scheduler-resource-error.js";
+
+const maximumNameLength = 64;
+
+/**
+ * The properties an AWS::Scheduler::ScheduleGroup Resource is read for.
+ */
+const readNames = new Set(["Name", "Tags"]);
+
+/**
+ * Why a group is deployed without its tags, rather than the tags failing it.
+ *
+ * Every other unmodelled Scheduler input is refused, and this one is not, for
+ * two reasons. Nothing a simulation runs reads a schedule group tag, so a group
+ * without them behaves exactly as the template's does. And the CDK propagates a
+ * Stack's tags onto every taggable Resource in it, so refusing them would fail
+ * any tagged Stack that happened to contain a group, over a property nobody
+ * writing that Stack asked the group for.
+ */
+const tagsReason =
+  "Tags is a real AWS::Scheduler::ScheduleGroup property no simulated " +
+  "service reads, so the group is created without them";
+
+/**
+ * Reads AWS::Scheduler::ScheduleGroup properties.
+ *
+ * A group is a name, which is the whole of the Resource beyond its tags.
+ */
+export class SimCfnScheduleGroupProperties {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: {
+    readonly resource: SimCfnResource;
+    readonly properties: SimCfnTemplateValueRecord;
+  }) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * The group name.
+   *
+   * An unnamed group is named after the stack and the logical ID, as real
+   * CloudFormation names one.
+   */
+  name(): string {
+    const name = this.properties["Name"];
+
+    if (name === undefined) {
+      return new SimCfnGeneratedResourceName({
+        stackName: this.resource.stackName,
+        logicalId: this.resource.logicalId,
+        maximumLength: maximumNameLength,
+      }).value;
+    }
+
+    if (typeof name !== "string") {
+      throw simCfnSchedulerResourceError(
+        schedulerScheduleGroupResourceType,
+        this.resource.logicalId,
+        "Name must be a string",
+      );
+    }
+
+    return name;
+  }
+
+  /**
+   * Record the properties the group is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    for (const name of Object.keys(this.properties)) {
+      if (name === "Tags") {
+        this.resource.ignoreProperty(name, tagsReason);
+
+        continue;
+      }
+
+      if (!readNames.has(name)) {
+        this.resource.ignoreProperty(
+          name,
+          `${name} is not an ${schedulerScheduleGroupResourceType} property ` +
+            `simulated Scheduler knows about, so the group is created ` +
+            `without it`,
+        );
+      }
+    }
+  }
+}

--- a/src/service/scheduler/cfn/sim-cfn-schedule-properties.ts
+++ b/src/service/scheduler/cfn/sim-cfn-schedule-properties.ts
@@ -10,7 +10,10 @@ import type {
   SimSchedulerRequestTarget,
   SimSchedulerScheduleInput,
 } from "../command/schedule/schedule.command.js";
-import { simCfnSchedulerResourceError } from "./sim-cfn-scheduler-resource-error.js";
+import {
+  schedulerScheduleResourceType,
+  simCfnSchedulerResourceError,
+} from "./sim-cfn-scheduler-resource-error.js";
 
 const maximumNameLength = 64;
 
@@ -131,17 +134,9 @@ export class SimCfnScheduleProperties {
   }
 
   private dateProperty(name: string): Date | undefined {
-    const value = this.properties.get(name);
+    const value = this.stringProperty(name);
 
-    if (value === undefined) {
-      return undefined;
-    }
-
-    if (typeof value !== "string") {
-      throw this.propertyError(`${name} must be a string`);
-    }
-
-    return new Date(value);
+    return value === undefined ? undefined : new Date(value);
   }
 
   private stringProperty(name: string): string | undefined {
@@ -159,6 +154,10 @@ export class SimCfnScheduleProperties {
   }
 
   private propertyError(reason: string): Error {
-    return simCfnSchedulerResourceError(this.resource.logicalId, reason);
+    return simCfnSchedulerResourceError(
+      schedulerScheduleResourceType,
+      this.resource.logicalId,
+      reason,
+    );
   }
 }

--- a/src/service/scheduler/cfn/sim-cfn-scheduler-resource-error.ts
+++ b/src/service/scheduler/cfn/sim-cfn-scheduler-resource-error.ts
@@ -1,9 +1,15 @@
-import { SimSchedulerError } from "../error/sim-scheduler.error.js";
+import {
+  SimSchedulerError,
+  SimSchedulerResourceNotFoundException,
+} from "../error/sim-scheduler.error.js";
 
 /**
- * The CloudFormation Resource type simulated Scheduler creates.
+ * The CloudFormation Resource types simulated Scheduler creates.
  */
 export const schedulerScheduleResourceType = "AWS::Scheduler::Schedule";
+
+export const schedulerScheduleGroupResourceType =
+  "AWS::Scheduler::ScheduleGroup";
 
 /**
  * Build the error a Resource of a simulated Scheduler type is refused with.
@@ -14,14 +20,14 @@ export const schedulerScheduleResourceType = "AWS::Scheduler::Schedule";
  * while nothing ever fired. So a refusal here says the Resource is invalid.
  */
 export function simCfnSchedulerResourceError(
+  resourceType: string,
   logicalId: string,
   reason: string,
   cause?: unknown,
 ): Error {
-  return new Error(
-    `Invalid ${schedulerScheduleResourceType} Resource ${logicalId}: ${reason}`,
-    { cause },
-  );
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
 }
 
 /**
@@ -34,6 +40,7 @@ export function simCfnSchedulerResourceError(
  * so a refusal the CloudFormation layer decided keeps its own wording.
  */
 export async function simCfnSchedulerResourceCreation<T>(
+  resourceType: string,
   logicalId: string,
   create: () => Promise<T>,
 ): Promise<T> {
@@ -41,9 +48,35 @@ export async function simCfnSchedulerResourceCreation<T>(
     return await create();
   } catch (error) {
     if (error instanceof SimSchedulerError) {
-      throw simCfnSchedulerResourceError(logicalId, error.message, error);
+      throw simCfnSchedulerResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
     }
 
     throw error;
+  }
+}
+
+/**
+ * Remove the resource one Resource created, leaving one that has already gone.
+ *
+ * Real CloudFormation treats deleting a Resource that has already gone as
+ * done rather than as a failure, and a Scheduler teardown reaches that case. A
+ * schedule group takes its schedules with it. A schedule whose template named
+ * its group as a string rather than by `Ref` declares no dependency on it, and
+ * may find itself already deleted by the time its own turn comes.
+ */
+export async function simCfnSchedulerResourceDeletion(
+  remove: () => Promise<void>,
+): Promise<void> {
+  try {
+    await remove();
+  } catch (error) {
+    if (!(error instanceof SimSchedulerResourceNotFoundException)) {
+      throw error;
+    }
   }
 }

--- a/src/service/scheduler/cfn/sim-cfn-scheduler-resource-lookup.ts
+++ b/src/service/scheduler/cfn/sim-cfn-scheduler-resource-lookup.ts
@@ -3,6 +3,11 @@ import type { SimSchedulerSchedule } from "../schedule/sim-scheduler-schedule.js
 import type { SimScheduler } from "../sim-scheduler.js";
 
 /**
+ * The `AWS::Scheduler::*` Resource types this service creates.
+ */
+export type SimSchedulerCfnResourceTypeName = "Schedule" | "ScheduleGroup";
+
+/**
  * Find the schedule a Resource just created, in whichever group it went into.
  *
  * The group is left out of the lookup when the template named none, so the
@@ -25,15 +30,21 @@ export function createdSchedule(
 }
 
 /**
- * Refuse a Resource type this service does not create.
+ * Read the Resource type a request names, refusing one this service does not
+ * create.
  *
- * Schedule groups are the other `AWS::Scheduler::*` type, and are reported as
- * unsupported rather than quietly treated as deployed.
+ * A schedule and a schedule group are the whole of `AWS::Scheduler::*`, so
+ * anything else is a type AWS has added since, reported as unsupported rather
+ * than quietly treated as deployed.
  */
-export function refuseUnknownType(resourceTypeName: string): void {
-  if (resourceTypeName !== "Schedule") {
-    throw new Error(
-      `Unsupported sim Scheduler CloudFormation Resource ${resourceTypeName}`,
-    );
+export function schedulerResourceTypeName(
+  resourceTypeName: string,
+): SimSchedulerCfnResourceTypeName {
+  if (resourceTypeName === "Schedule" || resourceTypeName === "ScheduleGroup") {
+    return resourceTypeName;
   }
+
+  throw new Error(
+    `Unsupported sim Scheduler CloudFormation Resource ${resourceTypeName}`,
+  );
 }

--- a/src/service/scheduler/cfn/sim-cfn-scheduler-schedule-group.iso.test.ts
+++ b/src/service/scheduler/cfn/sim-cfn-scheduler-schedule-group.iso.test.ts
@@ -1,0 +1,268 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:report";
+
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+/**
+ * A simulation with a function to invoke and a role allowed to invoke it.
+ */
+async function simAwsWithRole(): Promise<{
+  readonly simAws: SimAws;
+  readonly runs: unknown[];
+}> {
+  const simAws = new SimAws({
+    clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+  });
+  const runs: unknown[] = [];
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "report",
+      Role: "arn:aws:iam::888888888888:role/ReportRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput(() => {
+          runs.push(1);
+          return { ok: true };
+        }),
+      },
+    },
+  });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SchedulerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "scheduler.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SchedulerRole",
+      PolicyName: "InvokeReport",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "lambda:InvokeFunction",
+          Resource: functionArn,
+        },
+      }),
+    }),
+  );
+
+  return { simAws, runs };
+}
+
+/**
+ * A group and a schedule that names it by Ref, which is what CDK writes.
+ */
+function groupedSchedule(
+  groupProperties: Record<string, SimCfnTemplateValue> = {},
+): Record<string, SimCfnTemplateValue> {
+  return {
+    ReportGroup: {
+      Type: "AWS::Scheduler::ScheduleGroup",
+      Properties: { Name: "analytics", ...groupProperties },
+    },
+    HourlyReport: {
+      Type: "AWS::Scheduler::Schedule",
+      Properties: {
+        Name: "hourly-report",
+        GroupName: { Ref: "ReportGroup" },
+        ScheduleExpression: "rate(1 hour)",
+        FlexibleTimeWindow: { Mode: "OFF" },
+        Target: { Arn: functionArn, RoleArn: roleArn },
+      },
+    },
+  };
+}
+
+describe("Scheduler CloudFormation ScheduleGroup deployment", () => {
+  it("deploys a group and puts the stack's schedule in it", async () => {
+    // Given a template declaring a group and a schedule that names it.
+    const { simAws, runs } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: { Resources: groupedSchedule() },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the schedule is in the group, with the group in its ARN, and it
+    // fires as any other schedule does.
+    const schedule = simAws
+      .scheduler()
+      .findSchedule("hourly-report", "analytics");
+
+    assertNonNullable(simAws.scheduler().findScheduleGroup("analytics"));
+    assertNonNullable(schedule);
+    assertIdentical(
+      schedule.arn,
+      "arn:aws:scheduler:us-east-1:888888888888:schedule/analytics/hourly-report",
+    );
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    assertArrayLength(runs, 3);
+  });
+
+  it("resolves the group's ARN through Fn::GetAtt", async () => {
+    // Given a template reading the group's ARN back out, which is how an
+    // execution role policy names every schedule the group will ever hold.
+    const { simAws } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: {
+        Resources: groupedSchedule(),
+        Outputs: {
+          GroupArn: { Value: { "Fn::GetAtt": ["ReportGroup", "Arn"] } },
+          GroupName: { Value: { Ref: "ReportGroup" } },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the attribute is the group's own schedule-group ARN, and a Ref is
+    // its name.
+    assertIdentical(
+      stack.output("GroupArn"),
+      "arn:aws:scheduler:us-east-1:888888888888:schedule-group/analytics",
+    );
+    assertIdentical(stack.output("GroupName"), "analytics");
+  });
+
+  it("names an unnamed group after the stack and logical id", async () => {
+    const { simAws } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: {
+        Resources: {
+          ReportGroup: { Type: "AWS::Scheduler::ScheduleGroup" },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    const [, generated] = simAws.scheduler().allScheduleGroups;
+
+    assertNonNullable(generated);
+    assertStringIncludes(generated.name, "reporting-stack");
+  });
+
+  it("deploys a tagged group, recording the tags it was created without", async () => {
+    // Given a group carrying tags, which is what CDK puts on one when the
+    // stack is tagged.
+    const { simAws } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: {
+        Resources: groupedSchedule({
+          Tags: [{ Key: "team", Value: "analytics" }],
+        }),
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the group is there, and the omission is on the record rather than
+    // having failed a stack over a property nothing reads.
+    const ignored = stack
+      .getResource("ReportGroup")
+      ?.ignoredProperties.find((property) => property.path === "Tags");
+
+    assertNonNullable(simAws.scheduler().findScheduleGroup("analytics"));
+    assertNonNullable(ignored);
+    assertStringIncludes(ignored.reason, "no simulated service reads");
+  });
+
+  it("tears down a stack whose schedule names its group by name", async () => {
+    // Given a template naming the group as a string, so nothing tells
+    // CloudFormation the schedule depends on it and the group may come down
+    // first, taking the schedule with it.
+    const { simAws } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: {
+        Resources: {
+          ReportGroup: {
+            Type: "AWS::Scheduler::ScheduleGroup",
+            Properties: { Name: "analytics" },
+          },
+          HourlyReport: {
+            Type: "AWS::Scheduler::Schedule",
+            Properties: {
+              Name: "hourly-report",
+              GroupName: "analytics",
+              ScheduleExpression: "rate(1 hour)",
+              FlexibleTimeWindow: { Mode: "OFF" },
+              Target: { Arn: functionArn, RoleArn: roleArn },
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then the teardown finished rather than failing on a schedule that had
+    // already gone with its group.
+    assertUndefined(simAws.scheduler().findScheduleGroup("analytics"));
+    assertArrayLength(simAws.scheduler().allSchedules, 0);
+  });
+
+  it("removes the group and its schedules when the stack comes down", async () => {
+    // Given a deployed group holding a schedule.
+    const { simAws, runs } = await simAwsWithRole();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reporting-stack",
+      template: { Resources: groupedSchedule() },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the stack is torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then both are gone, and time passing fires nothing.
+    assertUndefined(simAws.scheduler().findScheduleGroup("analytics"));
+    assertUndefined(
+      simAws.scheduler().findSchedule("hourly-report", "analytics"),
+    );
+
+    await simAws.clock().advanceBy({ hours: 3 });
+
+    assertArrayLength(runs, 0);
+  });
+});

--- a/src/service/scheduler/cfn/sim-scheduler-cfn-resource-factory.ts
+++ b/src/service/scheduler/cfn/sim-scheduler-cfn-resource-factory.ts
@@ -1,19 +1,13 @@
-import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
-import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimScheduler } from "../sim-scheduler.js";
-import {
-  createdSchedule,
-  refuseUnknownType,
-} from "./sim-cfn-scheduler-resource-lookup.js";
-import { SimCfnScheduleProperties } from "./sim-cfn-schedule-properties.js";
-import { simCfnSchedulerResourceCreation } from "./sim-cfn-scheduler-resource-error.js";
-import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import { SimCfnScheduleCreator } from "./sim-cfn-schedule-creator.js";
+import { SimCfnScheduleGroupCreator } from "./sim-cfn-schedule-group-creator.js";
+import { schedulerResourceTypeName } from "./sim-cfn-scheduler-resource-lookup.js";
 
 interface SimSchedulerCfnResourceFactoryProperties {
   readonly scheduler: SimScheduler;
@@ -22,85 +16,47 @@ interface SimSchedulerCfnResourceFactoryProperties {
 /**
  * CloudFormation Resource factory for simulated Scheduler resources.
  *
- * There is one type, and the schedule goes through the ordinary CreateSchedule
- * command rather than being constructed directly, so a schedule a template
- * deployed is the same thing an SDK caller would have got, down to the
- * refusals.
+ * Two types, a schedule and the group it goes in, both created through the
+ * ordinary Scheduler commands rather than constructed directly.
  */
 export class SimSchedulerCfnResourceFactory implements SimCfnServiceResourceFactory {
-  private readonly scheduler: SimScheduler;
+  private readonly scheduleCreator: SimCfnScheduleCreator;
+  private readonly groupCreator: SimCfnScheduleGroupCreator;
 
   constructor(properties: SimSchedulerCfnResourceFactoryProperties) {
-    this.scheduler = properties.scheduler;
+    this.scheduleCreator = new SimCfnScheduleCreator(properties);
+    this.groupCreator = new SimCfnScheduleGroupCreator(properties);
   }
 
   /**
-   * Create a simulated schedule from a CloudFormation Resource.
+   * Create a simulated Scheduler resource from a CloudFormation Resource.
    */
   async create(
     resourceTypeName: string,
     resource: SimCfnResource,
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
-    refuseUnknownType(resourceTypeName);
+    if (schedulerResourceTypeName(resourceTypeName) === "ScheduleGroup") {
+      return await this.groupCreator.create(resource, context);
+    }
 
-    const properties = this.read(
-      resource,
-      context.resolvedProperties ?? resource.properties,
-    );
-    const input = properties.scheduleInput();
-
-    return await simCfnSchedulerResourceCreation(
-      resource.logicalId,
-      async () => {
-        await this.scheduler.createSchedule(
-          { input },
-          simCfnResourceCallerOptions(context.caller),
-        );
-
-        const schedule = createdSchedule(this.scheduler, input);
-
-        assertDefined(
-          schedule,
-          `sim Scheduler schedule ${String(input.Name)} after ` +
-            `CloudFormation creation`,
-        );
-
-        return schedule;
-      },
-    );
+    return await this.scheduleCreator.create(resource, context);
   }
 
   /**
-   * Delete the schedule a Resource created.
+   * Delete the resource a Resource created.
    */
   async delete(
     resourceTypeName: string,
     resource: SimCfnResource,
     context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
-    refuseUnknownType(resourceTypeName);
+    if (schedulerResourceTypeName(resourceTypeName) === "ScheduleGroup") {
+      await this.groupCreator.delete(resource, context);
 
-    const properties = this.read(
-      resource,
-      context.resolvedProperties ?? resource.properties,
-    );
+      return;
+    }
 
-    await this.scheduler.deleteSchedule(
-      {
-        input: {
-          Name: properties.name(),
-          GroupName: properties.scheduleInput().GroupName,
-        },
-      },
-      simCfnResourceCallerOptions(context.caller),
-    );
-  }
-
-  private read(
-    resource: SimCfnResource,
-    properties: SimCfnTemplateValueRecord,
-  ): SimCfnScheduleProperties {
-    return new SimCfnScheduleProperties({ resource, properties });
+    await this.scheduleCreator.delete(resource, context);
   }
 }

--- a/src/service/scheduler/command/authorize/sim-scheduler-auth-z.iso.test.ts
+++ b/src/service/scheduler/command/authorize/sim-scheduler-auth-z.iso.test.ts
@@ -1,6 +1,7 @@
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import {
   CreateScheduleCommand,
+  CreateScheduleGroupCommand,
   GetScheduleCommand,
   ListSchedulesCommand,
 } from "@aws-sdk/client-scheduler";
@@ -129,6 +130,42 @@ describe("Scheduler IAM authorization", () => {
     // missing, which is the order every command in the simulation uses.
     assertInstanceOf(error, SimSchedulerAccessDeniedException);
     assertStringIncludes(error.message, "scheduler:GetSchedule");
+  });
+
+  it("authorizes a group command against the group's own ARN", async () => {
+    // Given a Role allowed to create one group, named by its schedule-group
+    // ARN, which is a different resource path from a schedule's.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "scheduler:CreateScheduleGroup",
+      Resource:
+        "arn:aws:scheduler:us-east-1:888888888888:schedule-group/analytics",
+    });
+
+    // When it creates that group, and then another.
+    const created = await simAws
+      .scheduler()
+      .createScheduleGroup(
+        new CreateScheduleGroupCommand({ Name: "analytics" }),
+        { caller },
+      );
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .scheduler()
+        .createScheduleGroup(
+          new CreateScheduleGroupCommand({ Name: "billing" }),
+          { caller },
+        );
+    });
+
+    // Then only the one its policy names is allowed.
+    assertIdentical(
+      created.ScheduleGroupArn,
+      "arn:aws:scheduler:us-east-1:888888888888:schedule-group/analytics",
+    );
+    assertInstanceOf(error, SimSchedulerAccessDeniedException);
+    assertStringIncludes(error.message, "scheduler:CreateScheduleGroup");
   });
 
   it("authorizes a listing against every schedule rather than one", async () => {

--- a/src/service/scheduler/command/authorize/sim-scheduler-authorizer.ts
+++ b/src/service/scheduler/command/authorize/sim-scheduler-authorizer.ts
@@ -7,8 +7,8 @@ import type { SimSchedulerRequestOptions } from "../sim-scheduler-request-option
 /**
  * The resource an action with no resource type authorizes against.
  *
- * `ListSchedules` names no schedule, so IAM evaluates it against `*` and only a
- * policy whose Resource is `*` allows it.
+ * `ListSchedules` and `ListScheduleGroups` name nothing, so IAM evaluates them
+ * against `*` and only a policy whose Resource is `*` allows them.
  */
 const noResource = "*";
 
@@ -22,7 +22,8 @@ interface SimSchedulerAuthorizerProperties {
  * The resource is the schedule ARN, which carries its group:
  * `arn:aws:scheduler:<region>:<account>:schedule/<group>/<name>`. A policy
  * written without the group in it matches nothing here, as it matches nothing
- * on real AWS.
+ * on real AWS. A group command authorizes against the group's own ARN, which
+ * is a different resource path: `schedule-group/<name>`.
  *
  * This is the caller's own authorization to manage schedules, and is a separate
  * question from whether a schedule's execution role may invoke its target. The
@@ -38,33 +39,16 @@ export class SimSchedulerAuthorizer {
   }
 
   /**
-   * Ensure the caller may perform an action on a schedule, named by its ARN.
+   * Ensure the caller may perform an action on a resource, named by its ARN.
    *
-   * The schedule need not exist: `CreateSchedule` authorizes against the ARN
-   * the schedule is about to have.
+   * The resource need not exist: `CreateSchedule` authorizes against the ARN
+   * the schedule is about to have, and `CreateScheduleGroup` against the
+   * group's.
    */
-  authorizeSchedule(
-    action: string,
-    scheduleArn: string,
-    options?: SimSchedulerRequestOptions,
-  ): SimAwsResolvedCaller {
-    return this.authorizeResource(action, scheduleArn, options);
-  }
-
-  /**
-   * Ensure the caller may perform an action naming no particular schedule.
-   */
-  authorizeAnySchedule(
-    action: string,
-    options?: SimSchedulerRequestOptions,
-  ): SimAwsResolvedCaller {
-    return this.authorizeResource(action, noResource, options);
-  }
-
-  private authorizeResource(
+  authorizeResource(
     action: string,
     resource: string,
-    options: SimSchedulerRequestOptions | undefined,
+    options?: SimSchedulerRequestOptions,
   ): SimAwsResolvedCaller {
     const decision = this.iam.authorize({
       action,
@@ -84,5 +68,15 @@ export class SimSchedulerAuthorizer {
     }
 
     return decision.caller;
+  }
+
+  /**
+   * Ensure the caller may perform an action naming no particular resource.
+   */
+  authorizeAnyResource(
+    action: string,
+    options?: SimSchedulerRequestOptions,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(action, noResource, options);
   }
 }

--- a/src/service/scheduler/command/group/group.command.ts
+++ b/src/service/scheduler/command/group/group.command.ts
@@ -1,0 +1,106 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One tag a request asks to put on a schedule group.
+ *
+ * Read only so the group commands can refuse them. Nothing here stores a tag,
+ * and a group carrying one it never got would be worse than the refusal.
+ */
+export interface SimSchedulerTag {
+  readonly Key?: string | undefined;
+  readonly Value?: string | undefined;
+}
+
+/**
+ * Minimal structural sim Scheduler CreateScheduleGroup command.
+ *
+ * https://docs.aws.amazon.com/scheduler/latest/APIReference/API_CreateScheduleGroup.html
+ */
+export interface SimCreateScheduleGroupCommand {
+  readonly input: SimCreateScheduleGroupCommandInput;
+}
+
+export interface SimCreateScheduleGroupCommandInput {
+  readonly Name?: string | undefined;
+  readonly Tags?: readonly SimSchedulerTag[] | undefined;
+  readonly ClientToken?: string | undefined;
+}
+
+export interface SimCreateScheduleGroupCommandOutput {
+  readonly ScheduleGroupArn?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Scheduler GetScheduleGroup command.
+ *
+ * https://docs.aws.amazon.com/scheduler/latest/APIReference/API_GetScheduleGroup.html
+ */
+export interface SimGetScheduleGroupCommand {
+  readonly input: SimGetScheduleGroupCommandInput;
+}
+
+export interface SimGetScheduleGroupCommandInput {
+  readonly Name?: string | undefined;
+}
+
+export interface SimGetScheduleGroupCommandOutput {
+  readonly Arn?: string | undefined;
+  readonly Name?: string | undefined;
+  readonly State?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly LastModificationDate?: Date | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim Scheduler DeleteScheduleGroup command.
+ *
+ * https://docs.aws.amazon.com/scheduler/latest/APIReference/API_DeleteScheduleGroup.html
+ */
+export interface SimDeleteScheduleGroupCommand {
+  readonly input: SimDeleteScheduleGroupCommandInput;
+}
+
+export interface SimDeleteScheduleGroupCommandInput {
+  readonly Name?: string | undefined;
+  readonly ClientToken?: string | undefined;
+}
+
+export interface SimDeleteScheduleGroupCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * One schedule group as a listing reports it, which is all of it.
+ */
+export interface SimSchedulerListedScheduleGroup {
+  readonly Arn: string;
+  readonly Name: string;
+  readonly State: string;
+  readonly CreationDate: Date;
+  readonly LastModificationDate: Date;
+}
+
+/**
+ * Minimal structural sim Scheduler ListScheduleGroups command.
+ *
+ * https://docs.aws.amazon.com/scheduler/latest/APIReference/API_ListScheduleGroups.html
+ */
+export interface SimListScheduleGroupsCommand {
+  readonly input: SimListScheduleGroupsCommandInput;
+}
+
+export interface SimListScheduleGroupsCommandInput {
+  readonly NamePrefix?: string | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimListScheduleGroupsCommandOutput {
+  readonly ScheduleGroups?:
+    | readonly SimSchedulerListedScheduleGroup[]
+    | undefined;
+  readonly NextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/scheduler/command/group/sim-scheduler-described-group.ts
+++ b/src/service/scheduler/command/group/sim-scheduler-described-group.ts
@@ -1,0 +1,40 @@
+import type { SimSchedulerScheduleGroup } from "../../group/sim-scheduler-schedule-group.js";
+import type {
+  SimGetScheduleGroupCommandOutput,
+  SimSchedulerListedScheduleGroup,
+} from "./group.command.js";
+
+/**
+ * One group as `GetScheduleGroup` reports it.
+ */
+export function describedScheduleGroup(
+  group: SimSchedulerScheduleGroup,
+): Omit<SimGetScheduleGroupCommandOutput, "$metadata"> {
+  return {
+    Arn: group.arn,
+    Name: group.name,
+    State: group.state,
+    CreationDate: group.creationDate,
+    LastModificationDate: group.lastModificationDate,
+  };
+}
+
+/**
+ * One group as a listing reports it.
+ *
+ * A group has nothing a describe carries and a listing does not, unlike a
+ * schedule, so these two agree on everything. They are written apart anyway
+ * because the AWS shapes are separate and only one of them has required
+ * fields.
+ */
+export function listedScheduleGroup(
+  group: SimSchedulerScheduleGroup,
+): SimSchedulerListedScheduleGroup {
+  return {
+    Arn: group.arn,
+    Name: group.name,
+    State: group.state,
+    CreationDate: group.creationDate,
+    LastModificationDate: group.lastModificationDate,
+  };
+}

--- a/src/service/scheduler/command/group/sim-scheduler-group-access.ts
+++ b/src/service/scheduler/command/group/sim-scheduler-group-access.ts
@@ -1,0 +1,109 @@
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { schedulerScheduleGroupArn } from "../../group/sim-scheduler-schedule-group-arn.js";
+import type { SimSchedulerScheduleGroup } from "../../group/sim-scheduler-schedule-group.js";
+import type { SimSchedulerScheduleGroupStore } from "../../group/sim-scheduler-schedule-group-store.js";
+import { SimSchedulerValidationException } from "../../error/sim-scheduler.error.js";
+import {
+  defaultScheduleGroupName,
+  requiredScheduleGroupName,
+} from "../../schedule/sim-scheduler-schedule-name.js";
+import type { SimSchedulerAuthorizer } from "../authorize/sim-scheduler-authorizer.js";
+import type { SimSchedulerRequestOptions } from "../sim-scheduler-request-options.js";
+
+interface SimSchedulerGroupAccessProperties {
+  readonly groups: SimSchedulerScheduleGroupStore;
+  readonly authorizer: SimSchedulerAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * How a request reaches the schedule group it names.
+ *
+ * The same shape as `SimSchedulerScheduleAccess`, and for the same reason. The
+ * caller is authorized before the group is looked up, and a caller with no
+ * permission is refused whether or not the group is there.
+ */
+export class SimSchedulerGroupAccess {
+  private readonly groups: SimSchedulerScheduleGroupStore;
+  private readonly authorizer: SimSchedulerAuthorizer;
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimSchedulerGroupAccessProperties) {
+    this.groups = properties.groups;
+    this.authorizer = properties.authorizer;
+    this.accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Read the group name a request names, and authorize the action on it.
+   *
+   * The group need not exist: `CreateScheduleGroup` authorizes against the ARN
+   * the group is about to have.
+   */
+  authorized(
+    action: string,
+    name: string | undefined,
+    options?: SimSchedulerRequestOptions,
+  ): string {
+    const groupName = requiredScheduleGroupName(name);
+
+    this.authorizer.authorizeResource(action, this.arnFor(groupName), options);
+
+    return groupName;
+  }
+
+  /**
+   * Resolve the group a request names, authorizing the action first.
+   */
+  require(
+    action: string,
+    name: string | undefined,
+    options?: SimSchedulerRequestOptions,
+  ): SimSchedulerScheduleGroup {
+    return this.groups.require(this.authorized(action, name, options));
+  }
+
+  /**
+   * Resolve the group a request wants deleted, which `default` is never one
+   * of.
+   *
+   * AWS leaves the answer for the `default` group undocumented, and a
+   * simulation that let it go would have no way of getting it back. It comes
+   * with the Account rather than being created, and every request naming no
+   * group wants it.
+   */
+  requireDeletable(
+    action: string,
+    name: string | undefined,
+    options?: SimSchedulerRequestOptions,
+  ): SimSchedulerScheduleGroup {
+    const groupName = this.authorized(action, name, options);
+
+    if (groupName === defaultScheduleGroupName) {
+      throw new SimSchedulerValidationException(
+        `The ${defaultScheduleGroupName} schedule group comes with the ` +
+          `Account and cannot be deleted.`,
+      );
+    }
+
+    return this.groups.require(groupName);
+  }
+
+  /**
+   * Let a listing through, which names no group.
+   *
+   * `ListScheduleGroups` authorizes against every group in the Account rather
+   * than against each one it is about to report, and does not filter the
+   * listing by what the caller can reach.
+   */
+  authorizeListing(action: string, options?: SimSchedulerRequestOptions): void {
+    this.authorizer.authorizeAnyResource(action, options);
+  }
+
+  /**
+   * The ARN a group of this name has, or would have.
+   */
+  private arnFor(groupName: string): string {
+    return schedulerScheduleGroupArn(groupName, this.accountRegionScope);
+  }
+}

--- a/src/service/scheduler/command/group/sim-scheduler-group-commands.iso.test.ts
+++ b/src/service/scheduler/command/group/sim-scheduler-group-commands.iso.test.ts
@@ -1,0 +1,279 @@
+import {
+  CreateScheduleCommand,
+  CreateScheduleGroupCommand,
+  DeleteScheduleGroupCommand,
+  GetScheduleGroupCommand,
+  ListScheduleGroupsCommand,
+} from "@aws-sdk/client-scheduler";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  SimSchedulerConflictException,
+  SimSchedulerResourceNotFoundException,
+  SimSchedulerUnsimulatedInputException,
+  SimSchedulerValidationException,
+} from "../../error/sim-scheduler.error.js";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:reconcile";
+
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+/**
+ * A schedule in a group, so each test names only what it is about.
+ */
+function schedule(
+  name: string,
+  groupName: string,
+): ConstructorParameters<typeof CreateScheduleCommand>[0] {
+  return {
+    Name: name,
+    GroupName: groupName,
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: { Arn: functionArn, RoleArn: roleArn },
+  };
+}
+
+describe("Scheduler schedule group commands", () => {
+  it("creates a group and reports its own ARN", async () => {
+    // Given a simulation with no groups of its own.
+    const simAws = new SimAws();
+
+    // When one is created.
+    const created = await simAws
+      .scheduler()
+      .createScheduleGroup(
+        new CreateScheduleGroupCommand({ Name: "analytics" }),
+      );
+
+    // Then its ARN is a schedule-group ARN, which is a different resource
+    // path from the schedule/<group>/<name> a schedule carries.
+    assertIdentical(
+      created.ScheduleGroupArn,
+      "arn:aws:scheduler:us-east-1:888888888888:schedule-group/analytics",
+    );
+  });
+
+  it("comes with the default group nobody created", async () => {
+    // Given a simulation nothing has been asked of.
+    const simAws = new SimAws();
+
+    // When its groups are listed.
+    const listed = await simAws
+      .scheduler()
+      .listScheduleGroups(new ListScheduleGroupsCommand({}));
+
+    // Then default is already there, as it is in every Account.
+    const groups = listed.ScheduleGroups ?? [];
+
+    assertArrayLength(groups, 1);
+    assertIdentical(groups[0].Name, "default");
+    assertIdentical(groups[0].State, "ACTIVE");
+  });
+
+  it("describes a group as the simulation's clock stamped it", async () => {
+    // Given a group created at a known instant.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-07-26T09:00:00.000Z")),
+    });
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(
+        new CreateScheduleGroupCommand({ Name: "analytics" }),
+      );
+
+    // When it is described.
+    const described = await simAws
+      .scheduler()
+      .getScheduleGroup(new GetScheduleGroupCommand({ Name: "analytics" }));
+
+    // Then it comes back stamped from the simulation's own clock.
+    assertIdentical(described.State, "ACTIVE");
+    assertIdentical(
+      described.CreationDate?.toISOString(),
+      "2026-07-26T09:00:00.000Z",
+    );
+    assertIdentical(
+      described.LastModificationDate?.toISOString(),
+      "2026-07-26T09:00:00.000Z",
+    );
+  });
+
+  it("refuses to create a group that already exists", async () => {
+    // Given a group that has been created.
+    const simAws = new SimAws();
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(
+        new CreateScheduleGroupCommand({ Name: "analytics" }),
+      );
+
+    // When the same request is made again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .scheduler()
+        .createScheduleGroup(
+          new CreateScheduleGroupCommand({ Name: "analytics" }),
+        );
+    });
+
+    // Then it conflicts rather than replacing it.
+    assertInstanceOf(error, SimSchedulerConflictException);
+  });
+
+  it("refuses group tags rather than dropping them", async () => {
+    // Given a group asking to be tagged, which is what AWS says groups are
+    // for, and what nothing here reads back.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.scheduler().createScheduleGroup(
+        new CreateScheduleGroupCommand({
+          Name: "analytics",
+          Tags: [{ Key: "team", Value: "analytics" }],
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSchedulerUnsimulatedInputException);
+    assertStringIncludes(error.message, "Schedule group tags");
+  });
+
+  it("narrows a listing by name prefix, in creation order", async () => {
+    // Given three groups beside the default one, created in this order.
+    const simAws = new SimAws();
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(
+        new CreateScheduleGroupCommand({ Name: "reporting-live" }),
+      );
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(
+        new CreateScheduleGroupCommand({ Name: "reporting-test" }),
+      );
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(new CreateScheduleGroupCommand({ Name: "billing" }));
+
+    // When the reporting ones are listed.
+    const listed = await simAws
+      .scheduler()
+      .listScheduleGroups(
+        new ListScheduleGroupsCommand({ NamePrefix: "reporting-" }),
+      );
+
+    // Then only those two come back, in the order they were created.
+    const groups = listed.ScheduleGroups ?? [];
+
+    assertArrayLength(groups, 2);
+    assertIdentical(groups[0].Name, "reporting-live");
+    assertIdentical(groups[1].Name, "reporting-test");
+  });
+
+  it("deletes a group and the schedules still in it", async () => {
+    // Given a group holding a schedule.
+    const simAws = new SimAws();
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(
+        new CreateScheduleGroupCommand({ Name: "analytics" }),
+      );
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(schedule("rollup", "analytics")),
+      );
+
+    // When the group is deleted.
+    await simAws
+      .scheduler()
+      .deleteScheduleGroup(
+        new DeleteScheduleGroupCommand({ Name: "analytics" }),
+      );
+
+    // Then the schedule went with it, as it does on AWS, rather than the
+    // deletion being refused for the group not being empty.
+    assertUndefined(simAws.scheduler().findScheduleGroup("analytics"));
+    assertUndefined(simAws.scheduler().findSchedule("rollup", "analytics"));
+  });
+
+  it("leaves the schedules of other groups alone", async () => {
+    // Given a schedule of the same name in two groups.
+    const simAws = new SimAws();
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(new CreateScheduleGroupCommand({ Name: "live" }));
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(new CreateScheduleGroupCommand({ Name: "test" }));
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(schedule("rollup", "live")));
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(schedule("rollup", "test")));
+
+    // When one group goes.
+    await simAws
+      .scheduler()
+      .deleteScheduleGroup(new DeleteScheduleGroupCommand({ Name: "test" }));
+
+    // Then the other group's schedule of that name is untouched, which is the
+    // whole reason for having a group per deployment.
+    assertNonNullable(simAws.scheduler().findSchedule("rollup", "live"));
+    assertUndefined(simAws.scheduler().findSchedule("rollup", "test"));
+  });
+
+  it("refuses to delete the default group", async () => {
+    // Given a simulation with only the group every Account comes with.
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .scheduler()
+        .deleteScheduleGroup(
+          new DeleteScheduleGroupCommand({ Name: "default" }),
+        );
+    });
+
+    // Then it is refused: nothing here could create it again, and every
+    // request naming no group wants it.
+    assertInstanceOf(error, SimSchedulerValidationException);
+    assertStringIncludes(error.message, "cannot be deleted");
+  });
+
+  it("refuses a group that is not there", async () => {
+    const simAws = new SimAws();
+
+    const missing = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .scheduler()
+        .getScheduleGroup(new GetScheduleGroupCommand({ Name: "analytics" }));
+    });
+
+    assertInstanceOf(missing, SimSchedulerResourceNotFoundException);
+  });
+});

--- a/src/service/scheduler/command/group/sim-scheduler-group-commands.iso.test.ts
+++ b/src/service/scheduler/command/group/sim-scheduler-group-commands.iso.test.ts
@@ -152,6 +152,22 @@ describe("Scheduler schedule group commands", () => {
     assertStringIncludes(error.message, "Schedule group tags");
   });
 
+  it("takes an empty tag list, which asks for nothing", async () => {
+    // Given a request carrying an empty list, which some clients send for an
+    // untagged group.
+    const simAws = new SimAws();
+
+    await simAws.scheduler().createScheduleGroup(
+      new CreateScheduleGroupCommand({
+        Name: "analytics",
+        Tags: [],
+      }),
+    );
+
+    // Then the group is created, since there was nothing to drop.
+    assertNonNullable(simAws.scheduler().findScheduleGroup("analytics"));
+  });
+
   it("narrows a listing by name prefix, in creation order", async () => {
     // Given three groups beside the default one, created in this order.
     const simAws = new SimAws();

--- a/src/service/scheduler/command/group/sim-scheduler-group-commands.ts
+++ b/src/service/scheduler/command/group/sim-scheduler-group-commands.ts
@@ -1,0 +1,141 @@
+import { SimSchedulerConflictException } from "../../error/sim-scheduler.error.js";
+import type { SimSchedulerScheduleGroupStore } from "../../group/sim-scheduler-schedule-group-store.js";
+import type { SimSchedulerScheduleStore } from "../../schedule/sim-scheduler-schedule-store.js";
+import { SimSchedulerPage } from "../sim-scheduler-page.js";
+import type { SimSchedulerRequestOptions } from "../sim-scheduler-request-options.js";
+import type { SimSchedulerGroupAccess } from "./sim-scheduler-group-access.js";
+import { narrowedScheduleGroups } from "./sim-scheduler-listed-groups.js";
+import { refuseUnsimulatedGroupInput } from "./sim-scheduler-unsimulated-group-input.js";
+import {
+  describedScheduleGroup,
+  listedScheduleGroup,
+} from "./sim-scheduler-described-group.js";
+import type {
+  SimCreateScheduleGroupCommand,
+  SimCreateScheduleGroupCommandOutput,
+  SimDeleteScheduleGroupCommand,
+  SimDeleteScheduleGroupCommandOutput,
+  SimGetScheduleGroupCommand,
+  SimGetScheduleGroupCommandOutput,
+  SimListScheduleGroupsCommand,
+  SimListScheduleGroupsCommandOutput,
+} from "./group.command.js";
+
+interface SimSchedulerGroupCommandsProperties {
+  readonly groups: SimSchedulerScheduleGroupStore;
+  readonly schedules: SimSchedulerScheduleStore;
+  readonly access: SimSchedulerGroupAccess;
+}
+
+/**
+ * The commands that manage schedule groups.
+ *
+ * All four in one handler, unlike schedules, where creating and updating are
+ * their own. A group is a name. There is no request to read into a resource,
+ * and no update at all, since `Name` is the only thing a group has and AWS
+ * replaces the group to change it.
+ */
+export class SimSchedulerGroupCommands {
+  private readonly groups: SimSchedulerScheduleGroupStore;
+  private readonly schedules: SimSchedulerScheduleStore;
+  private readonly access: SimSchedulerGroupAccess;
+
+  constructor(properties: SimSchedulerGroupCommandsProperties) {
+    this.groups = properties.groups;
+    this.schedules = properties.schedules;
+    this.access = properties.access;
+  }
+
+  /**
+   * Create a schedule group.
+   */
+  createScheduleGroup(
+    command: SimCreateScheduleGroupCommand,
+    options?: SimSchedulerRequestOptions,
+  ): SimCreateScheduleGroupCommandOutput {
+    const input = command.input;
+
+    refuseUnsimulatedGroupInput(input);
+
+    const groupName = this.access.authorized(
+      "scheduler:CreateScheduleGroup",
+      input.Name,
+      options,
+    );
+
+    if (this.groups.find(groupName) !== undefined) {
+      throw new SimSchedulerConflictException(
+        `Schedule group ${groupName} already exists.`,
+      );
+    }
+
+    return {
+      $metadata: {},
+      ScheduleGroupArn: this.groups.create(groupName).arn,
+    };
+  }
+
+  /**
+   * Describe a schedule group.
+   */
+  getScheduleGroup(
+    command: SimGetScheduleGroupCommand,
+    options?: SimSchedulerRequestOptions,
+  ): SimGetScheduleGroupCommandOutput {
+    const group = this.access.require(
+      "scheduler:GetScheduleGroup",
+      command.input.Name,
+      options,
+    );
+
+    return { $metadata: {}, ...describedScheduleGroup(group) };
+  }
+
+  /**
+   * Delete a schedule group, and the schedules in it.
+   *
+   * AWS deletes the schedules with the group rather than refusing a group that
+   * still holds some, and leaves the group in a `DELETING` state until they
+   * have gone. Here they go in the same call, so nothing is ever seen in that
+   * state.
+   */
+  deleteScheduleGroup(
+    command: SimDeleteScheduleGroupCommand,
+    options?: SimSchedulerRequestOptions,
+  ): SimDeleteScheduleGroupCommandOutput {
+    const group = this.access.requireDeletable(
+      "scheduler:DeleteScheduleGroup",
+      command.input.Name,
+      options,
+    );
+
+    this.schedules.removeGroup(group.name);
+    this.groups.remove(group);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * List the schedule groups of this scope, in creation order.
+   */
+  listScheduleGroups(
+    command: SimListScheduleGroupsCommand,
+    options?: SimSchedulerRequestOptions,
+  ): SimListScheduleGroupsCommandOutput {
+    const input = command.input;
+
+    this.access.authorizeListing("scheduler:ListScheduleGroups", options);
+
+    const page = new SimSchedulerPage(
+      narrowedScheduleGroups(this.groups.all, input).map(listedScheduleGroup),
+      input.MaxResults,
+      input.NextToken,
+    );
+
+    return {
+      $metadata: {},
+      ScheduleGroups: page.items,
+      NextToken: page.nextToken,
+    };
+  }
+}

--- a/src/service/scheduler/command/group/sim-scheduler-listed-groups.ts
+++ b/src/service/scheduler/command/group/sim-scheduler-listed-groups.ts
@@ -1,0 +1,18 @@
+import type { SimSchedulerScheduleGroup } from "../../group/sim-scheduler-schedule-group.js";
+import type { SimListScheduleGroupsCommandInput } from "./group.command.js";
+
+/**
+ * The groups a listing reports, narrowed by what it asked for.
+ */
+export function narrowedScheduleGroups(
+  groups: readonly SimSchedulerScheduleGroup[],
+  input: SimListScheduleGroupsCommandInput,
+): readonly SimSchedulerScheduleGroup[] {
+  const prefix = input.NamePrefix;
+
+  if (prefix === undefined) {
+    return groups;
+  }
+
+  return groups.filter((group) => group.name.startsWith(prefix));
+}

--- a/src/service/scheduler/command/group/sim-scheduler-unsimulated-group-input.ts
+++ b/src/service/scheduler/command/group/sim-scheduler-unsimulated-group-input.ts
@@ -1,0 +1,22 @@
+import { SimSchedulerUnsimulatedInputException } from "../../error/sim-scheduler.error.js";
+import type { SimCreateScheduleGroupCommandInput } from "./group.command.js";
+
+/**
+ * Refuse the group request inputs this simulation does not model.
+ *
+ * Tagging is most of what AWS says a group is for, and nothing here reads a
+ * tag back, so a group created without them would look tagged to whoever
+ * asked and untagged to everything else. A template is treated differently:
+ * the CDK puts a Stack's tags on a group without being asked, and failing a
+ * Stack over them would be a refusal nobody wrote.
+ */
+export function refuseUnsimulatedGroupInput(
+  input: SimCreateScheduleGroupCommandInput,
+): void {
+  if (input.Tags !== undefined) {
+    throw new SimSchedulerUnsimulatedInputException(
+      "Schedule group tags are not simulated, so CreateScheduleGroup " +
+        "refuses them rather than dropping them",
+    );
+  }
+}

--- a/src/service/scheduler/command/group/sim-scheduler-unsimulated-group-input.ts
+++ b/src/service/scheduler/command/group/sim-scheduler-unsimulated-group-input.ts
@@ -6,14 +6,17 @@ import type { SimCreateScheduleGroupCommandInput } from "./group.command.js";
  *
  * Tagging is most of what AWS says a group is for, and nothing here reads a
  * tag back, so a group created without them would look tagged to whoever
- * asked and untagged to everything else. A template is treated differently:
- * the CDK puts a Stack's tags on a group without being asked, and failing a
- * Stack over them would be a refusal nobody wrote.
+ * asked and untagged to everything else. An empty list asks for no tags, so
+ * there is nothing to drop and nothing to refuse.
+ *
+ * A template is treated differently. The CDK puts a Stack's tags on a group
+ * without being asked, and failing a Stack over them would be a refusal nobody
+ * wrote.
  */
 export function refuseUnsimulatedGroupInput(
   input: SimCreateScheduleGroupCommandInput,
 ): void {
-  if (input.Tags !== undefined) {
+  if (input.Tags !== undefined && input.Tags.length > 0) {
     throw new SimSchedulerUnsimulatedInputException(
       "Schedule group tags are not simulated, so CreateScheduleGroup " +
         "refuses them rather than dropping them",

--- a/src/service/scheduler/command/schedule/sim-scheduler-create-schedule.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-create-schedule.ts
@@ -49,6 +49,7 @@ export class SimSchedulerCreateSchedule {
     const requested = this.access.requested(input);
 
     this.access.authorize("scheduler:CreateSchedule", requested, options);
+    this.access.requireGroup(requested.groupName);
 
     if (
       this.schedules.find(requested.groupName, requested.name.value) !==

--- a/src/service/scheduler/command/schedule/sim-scheduler-schedule-access.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-schedule-access.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimSchedulerScheduleGroupStore } from "../../group/sim-scheduler-schedule-group-store.js";
 import { schedulerScheduleArn } from "../../schedule/sim-scheduler-schedule-arn.js";
 import {
   requestedScheduleGroupName,
@@ -19,6 +20,7 @@ export interface SimSchedulerRequestedSchedule {
 
 interface SimSchedulerScheduleAccessProperties {
   readonly schedules: SimSchedulerScheduleStore;
+  readonly groups: SimSchedulerScheduleGroupStore;
   readonly authorizer: SimSchedulerAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
@@ -37,11 +39,13 @@ interface SimSchedulerScheduleRequest {
  */
 export class SimSchedulerScheduleAccess {
   private readonly schedules: SimSchedulerScheduleStore;
+  private readonly groups: SimSchedulerScheduleGroupStore;
   private readonly authorizer: SimSchedulerAuthorizer;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
 
   constructor(properties: SimSchedulerScheduleAccessProperties) {
     this.schedules = properties.schedules;
+    this.groups = properties.groups;
     this.authorizer = properties.authorizer;
     this.accountRegionScope = properties.accountRegionScope;
   }
@@ -67,7 +71,23 @@ export class SimSchedulerScheduleAccess {
     requested: SimSchedulerRequestedSchedule,
     options?: SimSchedulerRequestOptions,
   ): void {
-    this.authorizer.authorizeSchedule(action, this.arnFor(requested), options);
+    this.authorizer.authorizeResource(action, this.arnFor(requested), options);
+  }
+
+  /**
+   * Ensure the group a request names is there, which AWS requires of every
+   * request naming one.
+   *
+   * Real Scheduler refuses a schedule whose `GroupName` names no group rather
+   * than creating it in `default`, and so does this. The group is in a
+   * schedule's ARN, and a schedule quietly moved would carry an ARN naming a
+   * group it had never been put in.
+   *
+   * Asked after the caller is authorized, so a caller with no permission
+   * learns nothing about which groups exist.
+   */
+  requireGroup(groupName: string): void {
+    this.groups.require(groupName);
   }
 
   /**
@@ -81,6 +101,7 @@ export class SimSchedulerScheduleAccess {
     const requested = this.requested(request);
 
     this.authorize(action, requested, options);
+    this.requireGroup(requested.groupName);
 
     return this.schedules.require(requested.groupName, requested.name.value);
   }
@@ -97,9 +118,13 @@ export class SimSchedulerScheduleAccess {
     requested: string | undefined,
     options?: SimSchedulerRequestOptions,
   ): string {
-    this.authorizer.authorizeAnySchedule(action, options);
+    this.authorizer.authorizeAnyResource(action, options);
 
-    return requestedScheduleGroupName(requested);
+    const groupName = requestedScheduleGroupName(requested);
+
+    this.requireGroup(groupName);
+
+    return groupName;
   }
 
   /**

--- a/src/service/scheduler/command/schedule/sim-scheduler-schedule-validation.iso.test.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-schedule-validation.iso.test.ts
@@ -11,6 +11,7 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import {
+  SimSchedulerResourceNotFoundException,
   SimSchedulerUnsimulatedInputException,
   SimSchedulerValidationException,
 } from "../../error/sim-scheduler.error.js";
@@ -70,11 +71,13 @@ describe("Scheduler schedule validation", () => {
     assertStringIncludes(error.message, "does not promise");
   });
 
-  it("refuses a schedule group other than the default one", async () => {
+  it("refuses a schedule whose group has not been created", async () => {
+    // Given a schedule asking for a group nothing created, which is what real
+    // Scheduler answers with a not-found rather than putting it in default.
     const error = await refusedSchedule({ GroupName: "reporting" });
 
-    assertInstanceOf(error, SimSchedulerUnsimulatedInputException);
-    assertStringIncludes(error.message, "Schedule groups are not simulated");
+    assertInstanceOf(error, SimSchedulerResourceNotFoundException);
+    assertStringIncludes(error.message, "Schedule group reporting");
   });
 
   it("refuses a timezone rather than running the schedule in UTC anyway", async () => {

--- a/src/service/scheduler/command/sim-scheduler-command.types.ts
+++ b/src/service/scheduler/command/sim-scheduler-command.types.ts
@@ -17,3 +17,19 @@ export type {
   SimUpdateScheduleCommand,
   SimUpdateScheduleCommandOutput,
 } from "./schedule/schedule.command.js";
+export type {
+  SimCreateScheduleGroupCommand,
+  SimCreateScheduleGroupCommandInput,
+  SimCreateScheduleGroupCommandOutput,
+  SimDeleteScheduleGroupCommand,
+  SimDeleteScheduleGroupCommandInput,
+  SimDeleteScheduleGroupCommandOutput,
+  SimGetScheduleGroupCommand,
+  SimGetScheduleGroupCommandInput,
+  SimGetScheduleGroupCommandOutput,
+  SimListScheduleGroupsCommand,
+  SimListScheduleGroupsCommandInput,
+  SimListScheduleGroupsCommandOutput,
+  SimSchedulerListedScheduleGroup,
+  SimSchedulerTag,
+} from "./group/group.command.js";

--- a/src/service/scheduler/command/sim-scheduler-commands.ts
+++ b/src/service/scheduler/command/sim-scheduler-commands.ts
@@ -4,9 +4,12 @@ import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-
 import type { SimSchedulerDeliveryTargets } from "../delivery/sim-scheduler-delivery.js";
 import { SimSchedulerNoDeliveryTargets } from "../delivery/sim-scheduler-no-delivery-targets.js";
 import { SimSchedulerTargetDelivery } from "../delivery/sim-scheduler-target-delivery.js";
+import type { SimSchedulerScheduleGroupStore } from "../group/sim-scheduler-schedule-group-store.js";
 import { SimSchedulerSchedules } from "../schedule/sim-scheduler-schedules.js";
 import type { SimSchedulerScheduleStore } from "../schedule/sim-scheduler-schedule-store.js";
 import { SimSchedulerAuthorizer } from "./authorize/sim-scheduler-authorizer.js";
+import { SimSchedulerGroupAccess } from "./group/sim-scheduler-group-access.js";
+import { SimSchedulerGroupCommands } from "./group/sim-scheduler-group-commands.js";
 import { SimSchedulerCreateSchedule } from "./schedule/sim-scheduler-create-schedule.js";
 import { SimSchedulerScheduleAccess } from "./schedule/sim-scheduler-schedule-access.js";
 import { SimSchedulerScheduleCommands } from "./schedule/sim-scheduler-schedule-commands.js";
@@ -15,6 +18,7 @@ import { SimSchedulerUpdateSchedule } from "./schedule/sim-scheduler-update-sche
 
 interface SimSchedulerCommandsProperties {
   readonly schedules: SimSchedulerScheduleStore;
+  readonly groups: SimSchedulerScheduleGroupStore;
   readonly iam: SimIamInterServiceAuthZ;
   readonly background: BackgroundScheduler;
   readonly deliveryTargets?: SimSchedulerDeliveryTargets | undefined;
@@ -31,14 +35,16 @@ export class SimSchedulerCommands {
   public readonly scheduleCreation: SimSchedulerCreateSchedule;
   public readonly scheduleUpdate: SimSchedulerUpdateSchedule;
   public readonly schedules: SimSchedulerScheduleCommands;
+  public readonly groups: SimSchedulerGroupCommands;
   public readonly delivery: SimSchedulerTargetDelivery;
   public readonly firing: SimSchedulerSchedules;
 
   constructor(properties: SimSchedulerCommandsProperties) {
-    const { schedules, accountRegionScope, background } = properties;
+    const { schedules, groups, accountRegionScope, background } = properties;
     const authorizer = new SimSchedulerAuthorizer({ iam: properties.iam });
     const access = new SimSchedulerScheduleAccess({
       schedules,
+      groups,
       authorizer,
       accountRegionScope,
     });
@@ -70,5 +76,14 @@ export class SimSchedulerCommands {
       firing: this.firing,
     });
     this.schedules = new SimSchedulerScheduleCommands({ schedules, access });
+    this.groups = new SimSchedulerGroupCommands({
+      groups,
+      schedules,
+      access: new SimSchedulerGroupAccess({
+        groups,
+        authorizer,
+        accountRegionScope,
+      }),
+    });
   }
 }

--- a/src/service/scheduler/group/sim-scheduler-grouped-schedules.iso.test.ts
+++ b/src/service/scheduler/group/sim-scheduler-grouped-schedules.iso.test.ts
@@ -1,0 +1,151 @@
+import {
+  CreateScheduleCommand,
+  CreateScheduleGroupCommand,
+  GetScheduleCommand,
+  ListSchedulesCommand,
+} from "@aws-sdk/client-scheduler";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimSchedulerResourceNotFoundException } from "../error/sim-scheduler.error.js";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:reconcile";
+
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+/**
+ * A schedule in a group, so each test names only what it is about.
+ */
+function schedule(
+  name: string,
+  groupName?: string,
+): ConstructorParameters<typeof CreateScheduleCommand>[0] {
+  return {
+    Name: name,
+    GroupName: groupName,
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: { Arn: functionArn, RoleArn: roleArn },
+  };
+}
+
+/**
+ * A simulation with one group of its own beside `default`.
+ */
+async function simAwsWithGroup(groupName: string): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .scheduler()
+    .createScheduleGroup(new CreateScheduleGroupCommand({ Name: groupName }));
+
+  return simAws;
+}
+
+describe("Scheduler schedules in a group", () => {
+  it("puts the group in the schedule's ARN", async () => {
+    // Given a group of its own.
+    const simAws = await simAwsWithGroup("analytics");
+
+    // When a schedule goes in it.
+    const created = await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(schedule("rollup", "analytics")),
+      );
+
+    // Then the ARN names the group it is actually in, which is why a schedule
+    // could not be quietly moved into default.
+    assertIdentical(
+      created.ScheduleArn,
+      "arn:aws:scheduler:us-east-1:888888888888:schedule/analytics/rollup",
+    );
+  });
+
+  it("keeps a name unique per group rather than per Account", async () => {
+    // Given two groups, as two deployments of one construct would have.
+    const simAws = await simAwsWithGroup("live");
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(new CreateScheduleGroupCommand({ Name: "test" }));
+
+    // When both create a schedule of the same name.
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(schedule("rollup", "live")));
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(schedule("rollup", "test")));
+
+    // Then neither collided, which is the whole reason groups exist.
+    assertArrayLength(simAws.scheduler().allSchedules, 2);
+  });
+
+  it("lists only the schedules of the group asked for", async () => {
+    // Given a schedule in a group and another in default.
+    const simAws = await simAwsWithGroup("analytics");
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(schedule("rollup", "analytics")),
+      );
+
+    await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(schedule("reconcile")));
+
+    // When one group is listed.
+    const listed = await simAws
+      .scheduler()
+      .listSchedules(new ListSchedulesCommand({ GroupName: "analytics" }));
+
+    // Then the other group's schedule is not in it.
+    const schedules = listed.Schedules ?? [];
+
+    assertArrayLength(schedules, 1);
+    assertIdentical(schedules[0].Name, "rollup");
+    assertIdentical(schedules[0].GroupName, "analytics");
+  });
+
+  it("does not find a grouped schedule in the default group", async () => {
+    // Given a schedule in a group of its own.
+    const simAws = await simAwsWithGroup("analytics");
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(schedule("rollup", "analytics")),
+      );
+
+    // When it is read without naming the group.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .scheduler()
+        .getSchedule(new GetScheduleCommand({ Name: "rollup" }));
+    });
+
+    // Then it is not there, because a schedule belongs to one group.
+    assertInstanceOf(error, SimSchedulerResourceNotFoundException);
+  });
+
+  it("refuses a listing for a group that does not exist", async () => {
+    const simAws = new SimAws();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .scheduler()
+        .listSchedules(new ListSchedulesCommand({ GroupName: "analytics" }));
+    });
+
+    assertInstanceOf(error, SimSchedulerResourceNotFoundException);
+  });
+});

--- a/src/service/scheduler/group/sim-scheduler-schedule-group-arn.ts
+++ b/src/service/scheduler/group/sim-scheduler-schedule-group-arn.ts
@@ -5,8 +5,9 @@ import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-
  *
  * `arn:aws:scheduler:<region>:<account>:schedule-group/<name>`. That is a
  * different resource path from a schedule's `schedule/<group>/<name>`. An
- * execution role is often written against this one, since a policy naming the
- * group covers every schedule that will ever be put in it.
+ * identity policy granting `scheduler:` actions on the group names this one,
+ * and so does the `aws:SourceArn` condition AWS recommends in a schedule
+ * execution role's trust policy.
  */
 export function schedulerScheduleGroupArn(
   groupName: string,

--- a/src/service/scheduler/group/sim-scheduler-schedule-group-arn.ts
+++ b/src/service/scheduler/group/sim-scheduler-schedule-group-arn.ts
@@ -1,0 +1,19 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The ARN of one simulated schedule group.
+ *
+ * `arn:aws:scheduler:<region>:<account>:schedule-group/<name>`. That is a
+ * different resource path from a schedule's `schedule/<group>/<name>`. An
+ * execution role is often written against this one, since a policy naming the
+ * group covers every schedule that will ever be put in it.
+ */
+export function schedulerScheduleGroupArn(
+  groupName: string,
+  scope: SimAwsAccountRegionScope,
+): string {
+  return (
+    `arn:aws:scheduler:${scope.regionName}:${scope.accountId}:` +
+    `schedule-group/${groupName}`
+  );
+}

--- a/src/service/scheduler/group/sim-scheduler-schedule-group-store.ts
+++ b/src/service/scheduler/group/sim-scheduler-schedule-group-store.ts
@@ -1,0 +1,86 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimSchedulerResourceNotFoundException } from "../error/sim-scheduler.error.js";
+import { defaultScheduleGroupName } from "../schedule/sim-scheduler-schedule-name.js";
+import { SimSchedulerScheduleGroup } from "./sim-scheduler-schedule-group.js";
+
+interface SimSchedulerScheduleGroupStoreProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly clock: SimClock;
+}
+
+/**
+ * The schedule groups of one simulated Scheduler scope.
+ *
+ * This store builds its own groups rather than taking them from a writer, which
+ * is the opposite of how schedules are handled. A schedule is read out of a
+ * request carrying a dozen properties, and reading it in one place is what
+ * keeps Create and Update agreeing. A group is a name and two timestamps. A
+ * writer beside this would be a class that exists to call a constructor.
+ */
+export class SimSchedulerScheduleGroupStore {
+  private readonly groups = new Map<string, SimSchedulerScheduleGroup>();
+  private readonly accountRegionScope: SimAwsAccountRegionScope;
+  private readonly clock: SimClock;
+
+  constructor(properties: SimSchedulerScheduleGroupStoreProperties) {
+    this.accountRegionScope = properties.accountRegionScope;
+    this.clock = properties.clock;
+
+    this.create(defaultScheduleGroupName);
+  }
+
+  /**
+   * Every group in this scope, in creation order.
+   *
+   * `default` is always the first of them. Every Account has it without anyone
+   * creating one, so this scope starts with it too.
+   */
+  get all(): readonly SimSchedulerScheduleGroup[] {
+    return this.groups.values().toArray();
+  }
+
+  /**
+   * Create a group, stamped from the simulation's clock.
+   */
+  create(groupName: string): SimSchedulerScheduleGroup {
+    const group = new SimSchedulerScheduleGroup({
+      name: groupName,
+      accountRegionScope: this.accountRegionScope,
+      createdAt: this.clock.now(),
+    });
+
+    this.groups.set(groupName, group);
+
+    return group;
+  }
+
+  /**
+   * Find a group by name.
+   */
+  find(groupName: string): SimSchedulerScheduleGroup | undefined {
+    return this.groups.get(groupName);
+  }
+
+  /**
+   * Resolve a group by name, or refuse.
+   */
+  require(groupName: string): SimSchedulerScheduleGroup {
+    const found = this.find(groupName);
+
+    if (found === undefined) {
+      throw new SimSchedulerResourceNotFoundException(
+        `Schedule group ${groupName} does not exist.`,
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Forget a deleted group.
+   */
+  remove(group: SimSchedulerScheduleGroup): void {
+    this.groups.delete(group.name);
+  }
+}

--- a/src/service/scheduler/group/sim-scheduler-schedule-group.ts
+++ b/src/service/scheduler/group/sim-scheduler-schedule-group.ts
@@ -1,0 +1,45 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { schedulerScheduleGroupArn } from "./sim-scheduler-schedule-group-arn.js";
+
+/**
+ * The state a schedule group is in.
+ *
+ * Real Scheduler also has `DELETING`, which a group sits in while the schedules
+ * it holds are being removed. No group here is ever in it. Deleting a group
+ * removes its schedules in the same call, and a group is `ACTIVE` or gone.
+ */
+const activeState = "ACTIVE";
+
+interface SimSchedulerScheduleGroupProperties {
+  readonly name: string;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly createdAt: Date;
+}
+
+/**
+ * One simulated EventBridge Scheduler schedule group.
+ *
+ * A group is a namespace and a tagging handle. It carries no settings, and a
+ * schedule in it behaves exactly as one in `default` would. What it changes is
+ * identity. A schedule's name is unique within its group rather than within the
+ * Account, and the group is in the schedule's ARN. Two deployments of the same
+ * construct into one Account and Region collide on schedule names unless each
+ * one has its own group.
+ */
+export class SimSchedulerScheduleGroup {
+  public readonly name: string;
+  public readonly arn: string;
+  public readonly creationDate: Date;
+  public readonly lastModificationDate: Date;
+  public readonly state = activeState;
+
+  constructor(properties: SimSchedulerScheduleGroupProperties) {
+    this.name = properties.name;
+    this.arn = schedulerScheduleGroupArn(
+      properties.name,
+      properties.accountRegionScope,
+    );
+    this.creationDate = properties.createdAt;
+    this.lastModificationDate = properties.createdAt;
+  }
+}

--- a/src/service/scheduler/index.ts
+++ b/src/service/scheduler/index.ts
@@ -5,6 +5,8 @@ export {
   type SimSchedulerActionAfterCompletion,
 } from "./schedule/sim-scheduler-schedule.js";
 export { schedulerScheduleArn } from "./schedule/sim-scheduler-schedule-arn.js";
+export { SimSchedulerScheduleGroup } from "./group/sim-scheduler-schedule-group.js";
+export { schedulerScheduleGroupArn } from "./group/sim-scheduler-schedule-group-arn.js";
 export {
   defaultScheduleGroupName,
   SimSchedulerScheduleName,

--- a/src/service/scheduler/schedule/sim-scheduler-schedule-name.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-schedule-name.ts
@@ -1,7 +1,4 @@
-import {
-  SimSchedulerUnsimulatedInputException,
-  SimSchedulerValidationException,
-} from "../error/sim-scheduler.error.js";
+import { SimSchedulerValidationException } from "../error/sim-scheduler.error.js";
 
 const maximumNameLength = 64;
 
@@ -12,13 +9,11 @@ const maximumNameLength = 64;
 const allowedName = /^[0-9a-zA-Z\-_.]+$/u;
 
 /**
- * The one schedule group this simulation has.
+ * The schedule group a request naming none goes to.
  *
- * Every Account has a `default` group without one being created, and named
- * groups are a resource of their own with their own commands. Nothing here
- * creates one, so a schedule asking for another group is refused rather than
- * quietly put in `default`, where it would have the wrong ARN and be found by
- * a listing that should not see it.
+ * Every Account has a `default` group without one being created, which is why
+ * this is a name every scope already has rather than one the first request
+ * makes up.
  */
 export const defaultScheduleGroupName = "default";
 
@@ -69,25 +64,21 @@ export class SimSchedulerScheduleName {
 /**
  * The name of the schedule group a request names.
  *
- * A request naming no group gets `default`, as AWS does. One naming any other
- * group is refused: schedule groups are not simulated, and a schedule quietly
- * moved into `default` would carry an ARN naming a group it is not in.
+ * A request naming no group gets `default`, as AWS does. Whether the group is
+ * there is a separate question, asked once the caller has been authorized, so
+ * nothing here reaches a store.
  */
 export function requestedScheduleGroupName(value: string | undefined): string {
   if (value === undefined) {
     return defaultScheduleGroupName;
   }
 
-  const groupName = readName("GroupName", value);
+  return readName("GroupName", value);
+}
 
-  if (groupName !== defaultScheduleGroupName) {
-    throw new SimSchedulerUnsimulatedInputException(
-      `Schedule groups are not simulated, so a schedule goes in the ` +
-        `${defaultScheduleGroupName} group. GroupName '${groupName}' is ` +
-        `refused rather than put in ${defaultScheduleGroupName}, where its ` +
-        `ARN would name a group it is not in.`,
-    );
-  }
-
-  return groupName;
+/**
+ * The name of the schedule group a group command names, which is required.
+ */
+export function requiredScheduleGroupName(value: string | undefined): string {
+  return readName("Name", value);
 }

--- a/src/service/scheduler/schedule/sim-scheduler-schedule-store.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-schedule-store.ts
@@ -63,6 +63,20 @@ export class SimSchedulerScheduleStore {
   }
 
   /**
+   * Forget every schedule of one group.
+   *
+   * Deleting a group takes its schedules with it, as it does on AWS, and how
+   * to find them is this store's own business rather than the command's.
+   */
+  removeGroup(groupName: string): void {
+    for (const schedule of this.all) {
+      if (schedule.groupName === groupName) {
+        this.remove(schedule);
+      }
+    }
+  }
+
+  /**
    * Forget a deleted schedule.
    */
   remove(schedule: SimSchedulerSchedule): void {

--- a/src/service/scheduler/sdk/sim-scheduler-sdk-command-router.ts
+++ b/src/service/scheduler/sdk/sim-scheduler-sdk-command-router.ts
@@ -4,6 +4,12 @@ import {
   type SimSdkCommandRouter,
 } from "../../../sdk/index.js";
 import type {
+  SimCreateScheduleGroupCommand,
+  SimDeleteScheduleGroupCommand,
+  SimGetScheduleGroupCommand,
+  SimListScheduleGroupsCommand,
+} from "../command/group/group.command.js";
+import type {
   SimCreateScheduleCommand,
   SimDeleteScheduleCommand,
   SimGetScheduleCommand,
@@ -57,6 +63,38 @@ export class SimSchedulerSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simScheduler.listSchedules(
             command as SimListSchedulesCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateScheduleGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simScheduler.createScheduleGroup(
+            command as SimCreateScheduleGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetScheduleGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simScheduler.getScheduleGroup(
+            command as SimGetScheduleGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteScheduleGroupCommand",
+        async (command, context): Promise<unknown> =>
+          await simScheduler.deleteScheduleGroup(
+            command as SimDeleteScheduleGroupCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListScheduleGroupsCommand",
+        async (command, context): Promise<unknown> =>
+          await simScheduler.listScheduleGroups(
+            command as SimListScheduleGroupsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/scheduler/sdk/sim-scheduler-sdk-routing.iso.test.ts
+++ b/src/service/scheduler/sdk/sim-scheduler-sdk-routing.iso.test.ts
@@ -1,7 +1,11 @@
 import {
   CreateScheduleCommand,
+  CreateScheduleGroupCommand,
   DeleteScheduleCommand,
+  DeleteScheduleGroupCommand,
   GetScheduleCommand,
+  GetScheduleGroupCommand,
+  ListScheduleGroupsCommand,
   ListSchedulesCommand,
   SchedulerClient,
   UpdateScheduleCommand,
@@ -84,5 +88,34 @@ describe("Scheduler SDK interception", () => {
     // Then each was handled by the simulation rather than reaching AWS.
     assertArrayLength(listed.Schedules ?? [], 1);
     assertArrayLength(afterDelete.Schedules ?? [], 0);
+  });
+
+  it("routes every schedule group command", async () => {
+    // Given an intercepted client.
+    using simSdk = new SimSdk();
+    simSdk.intercept(SchedulerClient);
+
+    const client = new SchedulerClient({ region: "eu-west-2" });
+
+    // When a group is created, read, listed and deleted.
+    await client.send(new CreateScheduleGroupCommand({ Name: "analytics" }));
+
+    const described = await client.send(
+      new GetScheduleGroupCommand({ Name: "analytics" }),
+    );
+    const listed = await client.send(new ListScheduleGroupsCommand({}));
+
+    await client.send(new DeleteScheduleGroupCommand({ Name: "analytics" }));
+
+    const afterDelete = await client.send(new ListScheduleGroupsCommand({}));
+
+    // Then each reached the simulation, in the client's own Region, and the
+    // listing keeps the default group the deletion did not touch.
+    assertIdentical(
+      described.Arn,
+      "arn:aws:scheduler:eu-west-2:888888888888:schedule-group/analytics",
+    );
+    assertArrayLength(listed.ScheduleGroups ?? [], 2);
+    assertArrayLength(afterDelete.ScheduleGroups ?? [], 1);
   });
 });

--- a/src/service/scheduler/sim-scheduler-inspection.ts
+++ b/src/service/scheduler/sim-scheduler-inspection.ts
@@ -1,3 +1,5 @@
+import type { SimSchedulerScheduleGroup } from "./group/sim-scheduler-schedule-group.js";
+import type { SimSchedulerScheduleGroupStore } from "./group/sim-scheduler-schedule-group-store.js";
 import { defaultScheduleGroupName } from "./schedule/sim-scheduler-schedule-name.js";
 import type { SimSchedulerSchedule } from "./schedule/sim-scheduler-schedule.js";
 import type { SimSchedulerScheduleStore } from "./schedule/sim-scheduler-schedule-store.js";
@@ -13,6 +15,7 @@ import type { SimSchedulerScheduleStore } from "./schedule/sim-scheduler-schedul
  */
 export abstract class SimSchedulerInspection {
   protected abstract readonly scheduleStore: SimSchedulerScheduleStore;
+  protected abstract readonly groupStore: SimSchedulerScheduleGroupStore;
 
   /**
    * Find a schedule by name, in a group.
@@ -32,5 +35,22 @@ export abstract class SimSchedulerInspection {
    */
   get allSchedules(): readonly SimSchedulerSchedule[] {
     return this.scheduleStore.all;
+  }
+
+  /**
+   * Find a schedule group by name.
+   */
+  findScheduleGroup(groupName: string): SimSchedulerScheduleGroup | undefined {
+    return this.groupStore.find(groupName);
+  }
+
+  /**
+   * Every schedule group this scope holds, in creation order.
+   *
+   * `default` is always the first of them, since every Account has it without
+   * anyone creating one.
+   */
+  get allScheduleGroups(): readonly SimSchedulerScheduleGroup[] {
+    return this.groupStore.all;
   }
 }

--- a/src/service/scheduler/sim-scheduler.ts
+++ b/src/service/scheduler/sim-scheduler.ts
@@ -12,6 +12,7 @@ import type { SimSchedulerDeliveryTargets } from "./delivery/sim-scheduler-deliv
 import type { SimSchedulerDeliveryFailure } from "./delivery/sim-scheduler-delivery-failures.js";
 import { SimSchedulerCommands } from "./command/sim-scheduler-commands.js";
 import type { SimSchedulerRequestOptions } from "./command/sim-scheduler-request-options.js";
+import { SimSchedulerScheduleGroupStore } from "./group/sim-scheduler-schedule-group-store.js";
 import { SimSchedulerScheduleStore } from "./schedule/sim-scheduler-schedule-store.js";
 import { SimSchedulerCfnResourceFactory } from "./cfn/sim-scheduler-cfn-resource-factory.js";
 import { SimSchedulerSdkCommandRouter } from "./sdk/sim-scheduler-sdk-command-router.js";
@@ -45,6 +46,7 @@ interface SimSchedulerProperties {
  */
 export class SimScheduler extends SimSchedulerInspection {
   protected readonly scheduleStore = new SimSchedulerScheduleStore();
+  protected readonly groupStore: SimSchedulerScheduleGroupStore;
   private readonly commands: SimSchedulerCommands;
   private readonly background: BackgroundScheduler;
   private readonly sdkRouter = new SimSchedulerSdkCommandRouter(this);
@@ -63,8 +65,13 @@ export class SimScheduler extends SimSchedulerInspection {
     const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
 
     this.background = background;
+    this.groupStore = new SimSchedulerScheduleGroupStore({
+      accountRegionScope,
+      clock: background,
+    });
     this.commands = new SimSchedulerCommands({
       schedules: this.scheduleStore,
+      groups: this.groupStore,
       iam,
       background,
       deliveryTargets: properties.deliveryTargets,
@@ -135,6 +142,50 @@ export class SimScheduler extends SimSchedulerInspection {
   ): Promise<simSchedulerCommands.SimListSchedulesCommandOutput> {
     await this.background.sequence();
     return this.commands.schedules.listSchedules(command, options);
+  }
+
+  /**
+   * Handle a CreateScheduleGroup Command from the SDK.
+   */
+  async createScheduleGroup(
+    command: simSchedulerCommands.SimCreateScheduleGroupCommand,
+    options?: SimSchedulerRequestOptions,
+  ): Promise<simSchedulerCommands.SimCreateScheduleGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.groups.createScheduleGroup(command, options);
+  }
+
+  /**
+   * Handle a GetScheduleGroup Command from the SDK.
+   */
+  async getScheduleGroup(
+    command: simSchedulerCommands.SimGetScheduleGroupCommand,
+    options?: SimSchedulerRequestOptions,
+  ): Promise<simSchedulerCommands.SimGetScheduleGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.groups.getScheduleGroup(command, options);
+  }
+
+  /**
+   * Handle a DeleteScheduleGroup Command from the SDK.
+   */
+  async deleteScheduleGroup(
+    command: simSchedulerCommands.SimDeleteScheduleGroupCommand,
+    options?: SimSchedulerRequestOptions,
+  ): Promise<simSchedulerCommands.SimDeleteScheduleGroupCommandOutput> {
+    await this.background.sequence();
+    return this.commands.groups.deleteScheduleGroup(command, options);
+  }
+
+  /**
+   * Handle a ListScheduleGroups Command from the SDK.
+   */
+  async listScheduleGroups(
+    command: simSchedulerCommands.SimListScheduleGroupsCommand,
+    options?: SimSchedulerRequestOptions,
+  ): Promise<simSchedulerCommands.SimListScheduleGroupsCommandOutput> {
+    await this.background.sequence();
+    return this.commands.groups.listScheduleGroups(command, options);
   }
 
   /**


### PR DESCRIPTION
Simulated Scheduler models a schedule group as a resource of its own. A template creates one through `AWS::Scheduler::ScheduleGroup` and the SDK through `CreateScheduleGroup`, with `GetScheduleGroup`, `ListScheduleGroups` and `DeleteScheduleGroup` beside it. A schedule whose `GroupName` names a group that has yet to be created is refused with `ResourceNotFoundException`, in place of the blanket refusal of any group but `default`. Deleting a group deletes the schedules in it, which is what the API reference documents rather than the refusal the issue described. `Fn::GetAtt` on the Resource answers `Arn`, `State`, `CreationDate` and `LastModificationDate`. Group tags are refused on the SDK command and recorded as an ignored property by CloudFormation, since the CDK puts a stack's tags on the group without being asked.

Resolves #1078


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated EventBridge Scheduler schedule-group support, including create, retrieve, list, and delete operations.
  * Schedules can now be associated with specific groups, with group-scoped names and ARNs.
  * Added CloudFormation support for deploying schedule groups and schedules.
  * Added IAM authorization for group-specific resources.
  * Added examples demonstrating schedule-group usage and CloudFormation deployment.

* **Documentation**
  * Updated Scheduler documentation with group lifecycle, tagging limitations, deletion behavior, and default-group protection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->