### PR TITLE
fix: supply aws:SourceArn assuming a service role

### DIFF
--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -703,6 +703,11 @@ The role is the whole of the decision. It has to trust `events.amazonaws.com` in
 the target runs. A role that may not becomes a recorded
 [delivery failure](#reading-back-a-failed-delivery), and the caller who put the event sees no error.
 
+The trust policy may carry the condition AWS recommends against the confused deputy problem. The
+rule's ARN is supplied as `aws:SourceArn` and the account it belongs to as `aws:SourceAccount`, the
+same pair a queue or topic policy is conditioned on for the other target types. A role scoped to one
+rule is assumable for that rule and for no other.
+
 Which containers actually run is [simulated ECS](https://yulinsim.dev/services/ecs/)'s answer, and never the rule's. A
 container with a binding runs its handler, and a container without one is recorded as not simulated.
 A target naming a task definition with nothing bound therefore records a task that never started,

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -175,6 +175,12 @@ Two things therefore have to be right, and they are fixed in different places:
 - A policy **on the role** has to allow the action on the target, being `lambda:InvokeFunction`,
   `sqs:SendMessage`, `sns:Publish` or `ecs:RunTask`.
 
+A trust policy may also carry the condition AWS recommends against the confused deputy problem. The
+schedule's group ARN is supplied as `aws:SourceArn`, and the Account the schedule is in as
+`aws:SourceAccount`. A role scoped to one schedule group is assumable by schedules in that group and
+by nothing else. CDK writes that condition into the execution roles it generates for a schedule
+target, so a role taken from a synthesized template works here unchanged.
+
 When either is missing the target goes uninvoked and no error is thrown, exactly as on AWS, where the
 failure goes to CloudWatch and nowhere the caller can see. `advanceBy(...)` still returns normally. A
 test asserting on a failed invocation reads `deliveryFailures`:
@@ -795,7 +801,3 @@ Resources of the same stack.
   for each of them, in this process and one after another.
 - `KmsKeyArn` is refused, and `ClientToken` is accepted and ignored. Nothing here retries, so it has
   no request to make idempotent.
-- A schedule's execution role is assumed with no `aws:SourceArn` condition key supplied. AWS
-  recommends scoping that key to a schedule group ARN in the role's trust policy, against the
-  confused deputy problem, and a trust policy carrying that condition admits nothing here. Every
-  firing of a schedule using such a role is recorded in `deliveryFailures`.

--- a/src/service/cloudfront/edge/sim-aws-cf-edge-functions.ts
+++ b/src/service/cloudfront/edge/sim-aws-cf-edge-functions.ts
@@ -3,8 +3,8 @@ import type { SimLambdaFunctionTarget } from "../../lambda/function/version/sim-
 import {
   assumeSimServiceRole,
   type SimServiceRoleRefusals,
-  simServiceRoleTarget,
 } from "../../sts/service-role/sim-service-role.js";
+import { simServiceRoleTarget } from "../../sts/service-role/sim-service-role-target.js";
 import { SimCloudFrontInvalidLambdaFunctionAssociation } from "../error/sim-cloudfront.error.js";
 import { edgeFunctionArnParts } from "./sim-cf-edge-function-arn.js";
 import type { SimCfEdgeFunctions } from "./sim-cf-edge-functions.js";

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-task.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-task.ts
@@ -40,7 +40,10 @@ export class SimEventBridgeDeliveryTask {
       role.accountId,
       arn.regionName,
     );
-    const caller = await assumeEventBridgeTargetRole(role, roleScope);
+    const caller = await assumeEventBridgeTargetRole(role, roleScope, {
+      arn: request.ruleArn,
+      accountId: request.ruleOwnerAccountId,
+    });
 
     await new SimEcsTargetRun({
       scope: this.simAws.accountRegionScope(arn.accountId, arn.regionName),

--- a/src/service/eventbridge/delivery/sim-event-bridge-target-role.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-target-role.iso.test.ts
@@ -1,0 +1,188 @@
+import { RegisterTaskDefinitionCommand } from "@aws-sdk/client-ecs";
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simEcsClusterFactory } from "../../ecs/cluster/sim-ecs-cluster.factory.js";
+
+const clusterArn = "arn:aws:ecs:us-east-1:888888888888:cluster/default";
+
+const roleArn = "arn:aws:iam::888888888888:role/EventsRole";
+
+const ruleArn = "arn:aws:events:us-east-1:888888888888:rule/orders";
+
+/**
+ * A simulation with a cluster, and a role that trusts EventBridge under the
+ * condition given and may run any task.
+ *
+ * The condition is what each test here varies. Everything else matches the
+ * arrangement the other ECS target tests use.
+ */
+async function simulationWithTrustCondition(
+  condition: object | undefined,
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simEcsClusterFactory.make({}, simAws);
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "EventsRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "events.amazonaws.com" },
+          Action: "sts:AssumeRole",
+          ...(condition !== undefined && { Condition: condition }),
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "EventsRole",
+      PolicyName: "RunTasks",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: { Effect: "Allow", Action: "ecs:RunTask", Resource: "*" },
+      }),
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * The confused deputy condition AWS documents for a rule's role, written the
+ * way its own example writes it.
+ */
+function sourceCondition(arn: string): object {
+  return {
+    ArnLike: { "aws:SourceArn": arn },
+    StringEquals: { "aws:SourceAccount": "888888888888" },
+  };
+}
+
+/**
+ * A rule with an ECS target on it, and a container bound to count its runs.
+ */
+async function ruleRunningTask(simAws: SimAws): Promise<() => number> {
+  let runs = 0;
+
+  simAws.ecs().bindContainer({
+    family: "nightly-import",
+    containerName: "app",
+    run: () => {
+      runs += 1;
+    },
+  });
+
+  await simAws.ecs().registerTaskDefinition(
+    new RegisterTaskDefinitionCommand({
+      family: "nightly-import",
+      containerDefinitions: [{ name: "app", image: "nightly-import:1" }],
+    }),
+  );
+
+  await simAws.eventBridge().putRule(
+    new PutRuleCommand({
+      Name: "orders",
+      EventPattern: JSON.stringify({ source: ["orders.service"] }),
+    }),
+  );
+
+  await simAws.eventBridge().putTargets(
+    new PutTargetsCommand({
+      Rule: "orders",
+      Targets: [
+        {
+          Id: "import",
+          Arn: clusterArn,
+          RoleArn: roleArn,
+          EcsParameters: { TaskDefinitionArn: "nightly-import" },
+        },
+      ],
+    }),
+  );
+
+  return () => runs;
+}
+
+/**
+ * Put one matching event and settle everything it caused.
+ */
+async function putOrderEvent(simAws: SimAws): Promise<void> {
+  await simAws.eventBridge().putEvents(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "orders.service",
+          DetailType: "OrderPlaced",
+          Detail: JSON.stringify({ orderId: "order-1" }),
+        },
+      ],
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+}
+
+describe("EventBridge target role source", () => {
+  it("assumes a role scoped to the rule's ARN", async () => {
+    // Given a role carrying the confused deputy condition AWS documents for a
+    // role a rule uses.
+    const simAws = await simulationWithTrustCondition(sourceCondition(ruleArn));
+    const runs = await ruleRunningTask(simAws);
+
+    // When an event the rule matches is put.
+    await putOrderEvent(simAws);
+
+    // Then the task ran. The rule's ARN and Account were supplied, so the
+    // condition matched.
+    assertIdentical(runs(), 1);
+    assertArrayLength(simAws.eventBridge().deliveryFailures, 0);
+  });
+
+  it("refuses a role scoped to a different rule's ARN", async () => {
+    // Given a role scoped to some other rule.
+    const simAws = await simulationWithTrustCondition(
+      sourceCondition("arn:aws:events:us-east-1:888888888888:rule/refunds"),
+    );
+    const runs = await ruleRunningTask(simAws);
+
+    // When an event this rule matches is put.
+    await putOrderEvent(simAws);
+
+    // Then no task ran and the delivery is a recorded failure.
+    assertIdentical(runs(), 0);
+    assertArrayLength(simAws.eventBridge().deliveryFailures, 1);
+    assertStringIncludes(
+      String(simAws.eventBridge().deliveryFailures[0]?.error),
+      "does not allow events.amazonaws.com to assume it",
+    );
+  });
+
+  it("assumes a role whose trust policy carries no condition", async () => {
+    // Given a role that trusts EventBridge unconditionally.
+    const simAws = await simulationWithTrustCondition(undefined);
+    const runs = await ruleRunningTask(simAws);
+
+    // When an event the rule matches is put.
+    await putOrderEvent(simAws);
+
+    // Then the task ran. Supplying the keys does not require them to be used.
+    assertIdentical(runs(), 1);
+  });
+});

--- a/src/service/eventbridge/delivery/sim-event-bridge-target-role.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-target-role.ts
@@ -3,9 +3,12 @@ import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-reg
 import {
   assumeSimServiceRole,
   type SimServiceRoleRefusals,
+} from "../../sts/service-role/sim-service-role.js";
+import {
   type SimServiceRoleTarget,
   simServiceRoleTarget,
-} from "../../sts/service-role/sim-service-role.js";
+} from "../../sts/service-role/sim-service-role-target.js";
+import type { SimServiceRoleSource } from "../../sts/service-role/sim-service-role-source.js";
 import { SimEventBridgeDeliveryNotPermitted } from "../error/sim-event-bridge-delivery.error.js";
 import { simEventBridgeServicePrincipal } from "./sim-event-bridge-delivery.js";
 
@@ -48,16 +51,22 @@ const refusals: SimServiceRoleRefusals = {
  * policy, but there is no resource policy on a task definition for a rule to be
  * admitted by, so running a task is a call the rule makes as a role of the
  * account instead. Real EventBridge requires the role for that reason.
+ *
+ * The rule is the `aws:SourceArn` AWS documents for the trust policy condition
+ * it recommends against the confused deputy problem. It is the same rule ARN a
+ * queue or topic policy is conditioned on for the other target types.
  */
 export async function assumeEventBridgeTargetRole(
   target: SimEventBridgeTargetRole,
   scope: SimAwsAccountRegionContainer,
+  source: SimServiceRoleSource,
 ): Promise<SimAwsCaller> {
   return await assumeSimServiceRole({
     target,
     servicePrincipal: simEventBridgeServicePrincipal,
     sessionName,
     scope,
+    source,
     refusals,
   });
 }

--- a/src/service/scheduler/delivery/sim-aws-scheduler-delivery-targets.ts
+++ b/src/service/scheduler/delivery/sim-aws-scheduler-delivery-targets.ts
@@ -50,7 +50,11 @@ export class SimAwsSchedulerDeliveryTargets implements SimSchedulerDeliveryTarge
       arn.regionName,
     );
 
-    const caller = await assumeSchedulerExecutionRole(role, roleScope);
+    const caller = await assumeSchedulerExecutionRole(
+      role,
+      roleScope,
+      request.schedule,
+    );
 
     await this.invoke(arn.service, { request, caller });
   }

--- a/src/service/scheduler/delivery/sim-scheduler-execution-role.iso.test.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-execution-role.iso.test.ts
@@ -1,0 +1,196 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateScheduleCommand,
+  CreateScheduleGroupCommand,
+} from "@aws-sdk/client-scheduler";
+import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+const startedAt = "2026-07-26T09:00:00.000Z";
+
+const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+const queueArn = "arn:aws:sqs:us-east-1:888888888888:reports";
+
+const queueUrl = "https://sqs.us-east-1.amazonaws.com/888888888888/reports";
+
+const defaultGroupArn =
+  "arn:aws:scheduler:us-east-1:888888888888:schedule-group/default";
+
+/**
+ * A simulation whose execution role trusts Scheduler under the condition given,
+ * and which may send to one queue.
+ *
+ * The condition is the whole point of each test here, so it is what varies.
+ * Everything else is the same arrangement the other delivery tests use.
+ */
+async function simulationWithTrustCondition(
+  condition: object | undefined,
+): Promise<SimAws> {
+  const simAws = new SimAws({ clock: new SimFixedClock(new Date(startedAt)) });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SchedulerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "scheduler.amazonaws.com" },
+          Action: "sts:AssumeRole",
+          ...(condition !== undefined && { Condition: condition }),
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SchedulerRole",
+      PolicyName: "Send",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "sqs:SendMessage",
+          Resource: queueArn,
+        },
+      }),
+    }),
+  );
+
+  await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: "reports" }));
+
+  return simAws;
+}
+
+/**
+ * The confused deputy condition AWS recommends, scoped to one group ARN.
+ */
+function sourceCondition(groupArn: string): object {
+  return {
+    StringEquals: {
+      "aws:SourceAccount": "888888888888",
+      "aws:SourceArn": groupArn,
+    },
+  };
+}
+
+/**
+ * A one-time schedule an hour out, so one advance fires it exactly once.
+ */
+async function fireSchedule(simAws: SimAws, groupName?: string): Promise<void> {
+  await simAws.scheduler().createSchedule(
+    new CreateScheduleCommand({
+      Name: "nightly-report",
+      GroupName: groupName,
+      ScheduleExpression: "at(2026-07-26T10:00:00)",
+      FlexibleTimeWindow: { Mode: "OFF" },
+      Target: { Arn: queueArn, RoleArn: roleArn, Input: "reports" },
+    }),
+  );
+
+  await simAws.clock().advanceBy({ hours: 2 });
+}
+
+/**
+ * What the queue received, as the message bodies on it.
+ */
+async function delivered(
+  simAws: SimAws,
+): Promise<readonly (string | undefined)[]> {
+  const received = await simAws
+    .sqs()
+    .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+  return (received.Messages ?? []).map((message) => message.Body);
+}
+
+describe("Scheduler execution role source", () => {
+  it("assumes a role scoped to the default group's ARN", async () => {
+    // Given a role carrying the confused deputy condition AWS recommends, which
+    // is what CDK writes into an execution role it generates.
+    const simAws = await simulationWithTrustCondition(
+      sourceCondition(defaultGroupArn),
+    );
+
+    // When a schedule in that group fires.
+    await fireSchedule(simAws);
+
+    // Then the target ran. The group ARN and the schedule's Account were
+    // supplied, so the condition matched.
+    const messages = await delivered(simAws);
+
+    assertIdentical(messages[0], "reports");
+    assertArrayLength(simAws.scheduler().deliveryFailures, 0);
+  });
+
+  it("assumes a role scoped to a named group's ARN", async () => {
+    // Given a group of its own, and a role scoped to that group rather than to
+    // default.
+    const simAws = await simulationWithTrustCondition(
+      sourceCondition(
+        "arn:aws:scheduler:us-east-1:888888888888:schedule-group/analytics",
+      ),
+    );
+
+    await simAws
+      .scheduler()
+      .createScheduleGroup(
+        new CreateScheduleGroupCommand({ Name: "analytics" }),
+      );
+
+    // When a schedule in that group fires.
+    await fireSchedule(simAws, "analytics");
+
+    // Then the target ran, so the group the schedule is actually in is the one
+    // supplied rather than default.
+    const messages = await delivered(simAws);
+
+    assertIdentical(messages[0], "reports");
+  });
+
+  it("refuses a role scoped to a different group's ARN", async () => {
+    // Given a role scoped to a group the schedule is not in.
+    const simAws = await simulationWithTrustCondition(
+      sourceCondition(
+        "arn:aws:scheduler:us-east-1:888888888888:schedule-group/analytics",
+      ),
+    );
+
+    // When a schedule in default fires.
+    await fireSchedule(simAws);
+
+    // Then nothing was delivered and the firing is a recorded failure, which is
+    // the confused deputy guard doing its job rather than a simulator gap.
+    assertArrayLength(await delivered(simAws), 0);
+    assertArrayLength(simAws.scheduler().deliveryFailures, 1);
+    assertStringIncludes(
+      String(simAws.scheduler().deliveryFailures[0]?.error),
+      "does not allow scheduler.amazonaws.com to assume it",
+    );
+  });
+
+  it("assumes a role whose trust policy carries no condition", async () => {
+    // Given a role that trusts Scheduler unconditionally.
+    const simAws = await simulationWithTrustCondition(undefined);
+
+    // When a schedule fires.
+    await fireSchedule(simAws);
+
+    // Then the target ran. Supplying the keys does not require them to be used.
+    const messages = await delivered(simAws);
+
+    assertIdentical(messages[0], "reports");
+  });
+});

--- a/src/service/scheduler/delivery/sim-scheduler-execution-role.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-execution-role.ts
@@ -3,10 +3,13 @@ import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-reg
 import {
   assumeSimServiceRole,
   type SimServiceRoleRefusals,
+} from "../../sts/service-role/sim-service-role.js";
+import {
   type SimServiceRoleTarget,
   simServiceRoleTarget,
-} from "../../sts/service-role/sim-service-role.js";
+} from "../../sts/service-role/sim-service-role-target.js";
 import { SimSchedulerDeliveryNotPermitted } from "../error/sim-scheduler-delivery.error.js";
+import type { SimSchedulerSchedule } from "../schedule/sim-scheduler-schedule.js";
 import { simSchedulerServicePrincipal } from "./sim-scheduler-delivery.js";
 
 /**
@@ -53,16 +56,23 @@ const refusals: SimServiceRoleRefusals = {
  * function as the `events.amazonaws.com` service principal and the target's own
  * resource policy decides; a schedule assumes a role, and the role's policies
  * decide.
+ *
+ * The schedule comes along because its group ARN is the `aws:SourceArn` AWS
+ * documents for the trust policy condition it recommends against the confused
+ * deputy problem. A schedule ARN is not accepted there, and CDK writes the
+ * group ARN into the execution roles it generates.
  */
 export async function assumeSchedulerExecutionRole(
   target: SimSchedulerExecutionRoleTarget,
   scope: SimAwsAccountRegionContainer,
+  schedule: SimSchedulerSchedule,
 ): Promise<SimAwsCaller> {
   return await assumeSimServiceRole({
     target,
     servicePrincipal: simSchedulerServicePrincipal,
     sessionName,
     scope,
+    source: { arn: schedule.groupArn, accountId: schedule.accountId },
     refusals,
   });
 }

--- a/src/service/scheduler/schedule/sim-scheduler-schedule.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-schedule.ts
@@ -1,6 +1,7 @@
 import type { SimSchedule } from "../../../util/schedule/sim-schedule.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimSchedulerTarget } from "../target/sim-scheduler-target.js";
+import { schedulerScheduleGroupArn } from "../group/sim-scheduler-schedule-group-arn.js";
 import { schedulerScheduleArn } from "./sim-scheduler-schedule-arn.js";
 import type { SimSchedulerScheduleName } from "./sim-scheduler-schedule-name.js";
 import type { SimSchedulerScheduleState } from "./sim-scheduler-schedule-state.js";
@@ -39,6 +40,22 @@ export class SimSchedulerSchedule {
   public readonly name: SimSchedulerScheduleName;
   public readonly groupName: string;
   public readonly arn: string;
+
+  /**
+   * The ARN of the group this schedule is in.
+   *
+   * Kept beside the schedule's own ARN because it is a different resource path
+   * and the two are easy to confuse. This is the one AWS recommends as the
+   * `aws:SourceArn` of an execution role's trust policy.
+   */
+  public readonly groupArn: string;
+
+  /**
+   * The Account this schedule is in, supplied as `aws:SourceAccount` when its
+   * execution role is assumed.
+   */
+  public readonly accountId: string;
+
   public readonly target: SimSchedulerTarget;
   public readonly actionAfterCompletion: SimSchedulerActionAfterCompletion;
   public readonly description: string | undefined;
@@ -60,6 +77,11 @@ export class SimSchedulerSchedule {
       properties.name.value,
       properties.accountRegionScope,
     );
+    this.groupArn = schedulerScheduleGroupArn(
+      properties.groupName,
+      properties.accountRegionScope,
+    );
+    this.accountId = properties.accountRegionScope.accountId;
     this.schedule = properties.schedule;
     this.target = properties.target;
     this.actionAfterCompletion = properties.actionAfterCompletion;

--- a/src/service/stepfunctions/task/sim-states-execution-role.ts
+++ b/src/service/stepfunctions/task/sim-states-execution-role.ts
@@ -3,9 +3,11 @@ import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-reg
 import {
   assumeSimServiceRole,
   type SimServiceRoleRefusals,
+} from "../../sts/service-role/sim-service-role.js";
+import {
   type SimServiceRoleTarget,
   simServiceRoleTarget,
-} from "../../sts/service-role/sim-service-role.js";
+} from "../../sts/service-role/sim-service-role-target.js";
 import { SimStatesTaskFailure } from "../error/sim-step-functions.error.js";
 
 /**

--- a/src/service/sts/service-role/sim-service-role-source.ts
+++ b/src/service/sts/service-role/sim-service-role-source.ts
@@ -1,0 +1,48 @@
+import type { SimIamConditionValue } from "../../iam/policy/sim-iam-policy.js";
+
+/**
+ * The resource a service says it is assuming a role for, as `aws:SourceArn`.
+ */
+export const simServiceRoleSourceArnConditionKey = "aws:SourceArn";
+
+/**
+ * The Account owning that resource, as `aws:SourceAccount`.
+ */
+export const simServiceRoleSourceAccountConditionKey = "aws:SourceAccount";
+
+/**
+ * Which of its own resources a service is assuming a role on behalf of.
+ *
+ * AWS recommends conditioning a service role's trust policy on these two
+ * against the confused deputy problem, so that a role trusting
+ * `scheduler.amazonaws.com` is assumable for one schedule group rather than by
+ * Scheduler at large. Which resource counts is the service's own answer, and
+ * differs between services: Scheduler names a schedule group and EventBridge
+ * names a rule.
+ */
+export interface SimServiceRoleSource {
+  readonly arn: string;
+  readonly accountId: string;
+}
+
+/**
+ * The request-time values a trust policy statement's conditions are matched
+ * against.
+ *
+ * A service that states no source supplies neither key, so a trust policy
+ * conditioned on either fails to match instead of matching an empty string.
+ * That is the safe direction. A role scoped to one schedule group should refuse
+ * an assume request that says nothing about which group it is for.
+ */
+export function simServiceRoleConditionContext(
+  source: SimServiceRoleSource | undefined,
+): Readonly<Record<string, SimIamConditionValue>> {
+  if (source === undefined) {
+    return {};
+  }
+
+  return {
+    [simServiceRoleSourceArnConditionKey]: source.arn,
+    [simServiceRoleSourceAccountConditionKey]: source.accountId,
+  };
+}

--- a/src/service/sts/service-role/sim-service-role-target.ts
+++ b/src/service/sts/service-role/sim-service-role-target.ts
@@ -1,0 +1,45 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { IamRoleArnParser } from "../../iam/role/arn/sim-iam-role-arn-parser.js";
+
+/**
+ * Which IAM a role ARN belongs to, and what the role is called there.
+ */
+export interface SimServiceRoleTarget {
+  readonly accountId: SimAwsAccountId;
+  readonly roleName: string;
+  readonly roleArn: string;
+}
+
+/**
+ * Read the Account and name out of a role ARN a service will assume.
+ *
+ * The ARN is checked for being a role ARN where the request that carried it was
+ * written, so this is reading a known shape rather than validating an unknown
+ * one.
+ */
+export function simServiceRoleTarget(roleArn: string): SimServiceRoleTarget {
+  const parts = new IamRoleArnParser().parse(roleArn);
+
+  return { accountId: parts.accountId, roleName: parts.roleName, roleArn };
+}
+
+/**
+ * The caller one assumed service-role session makes.
+ *
+ * It carries both principals. The request is attributed to the session, as it
+ * is on AWS, while the policies that apply are the role's. That is exactly the
+ * split `SimResolvedCaller` exists for.
+ */
+export function simServiceRoleCaller(
+  target: SimServiceRoleTarget,
+  sessionName: string,
+): SimAwsCaller {
+  const session = `arn:aws:sts::${target.accountId}:assumed-role/${target.roleName}/${sessionName}`;
+
+  return {
+    kind: "resolved",
+    principal: { kind: "arn", arn: session },
+    identityPolicyPrincipal: { kind: "arn", arn: target.roleArn },
+  };
+}

--- a/src/service/sts/service-role/sim-service-role.ts
+++ b/src/service/sts/service-role/sim-service-role.ts
@@ -1,19 +1,16 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
-import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
-import { IamRoleArnParser } from "../../iam/role/arn/sim-iam-role-arn-parser.js";
 import type { SimIam } from "../../iam/sim-iam.js";
 import { AssumeRoleTrustPolicyAuthorizer } from "../auth-z/assume-role-trust-policy-authorizer.js";
-
-/**
- * Which IAM a role ARN belongs to, and what the role is called there.
- */
-export interface SimServiceRoleTarget {
-  readonly accountId: SimAwsAccountId;
-  readonly roleName: string;
-  readonly roleArn: string;
-}
+import {
+  simServiceRoleConditionContext,
+  type SimServiceRoleSource,
+} from "./sim-service-role-source.js";
+import {
+  simServiceRoleCaller,
+  type SimServiceRoleTarget,
+} from "./sim-service-role-target.js";
 
 /**
  * How a service says that it could not assume a role, in its own words.
@@ -55,20 +52,16 @@ export interface SimServiceRoleAssumption {
    */
   readonly scope: SimAwsAccountRegionContainer;
 
+  /**
+   * Which of the service's own resources the role is assumed for.
+   *
+   * A service that states one has its trust policy evaluated with
+   * `aws:SourceArn` and `aws:SourceAccount` in hand, which is what a role
+   * carrying AWS's confused deputy condition needs to be assumable at all.
+   */
+  readonly source?: SimServiceRoleSource | undefined;
+
   readonly refusals: SimServiceRoleRefusals;
-}
-
-/**
- * Read the Account and name out of a role ARN a service will assume.
- *
- * The ARN is checked for being a role ARN where the request that carried it was
- * written, so this is reading a known shape rather than validating an unknown
- * one.
- */
-export function simServiceRoleTarget(roleArn: string): SimServiceRoleTarget {
-  const parts = new IamRoleArnParser().parse(roleArn);
-
-  return { accountId: parts.accountId, roleName: parts.roleName, roleArn };
 }
 
 /**
@@ -87,7 +80,8 @@ export function simServiceRoleTarget(roleArn: string): SimServiceRoleTarget {
 export async function assumeSimServiceRole(
   assumption: SimServiceRoleAssumption,
 ): Promise<SimAwsCaller> {
-  const { target, servicePrincipal, sessionName, scope, refusals } = assumption;
+  const { target, servicePrincipal, sessionName, scope, source, refusals } =
+    assumption;
   const iam = scope.iam();
   const role = await roleOrRefuse(target, iam, refusals);
 
@@ -98,6 +92,7 @@ export async function assumeSimServiceRole(
       targetIam: iam,
       region: scope.accountRegionScope.regionName,
       caller: { kind: "service", service: servicePrincipal },
+      conditionContext: simServiceRoleConditionContext(source),
     });
   } catch (error) {
     if (error instanceof SimIamAccessDenied) {
@@ -107,14 +102,7 @@ export async function assumeSimServiceRole(
     throw error;
   }
 
-  return {
-    kind: "resolved",
-    principal: {
-      kind: "arn",
-      arn: `arn:aws:sts::${target.accountId}:assumed-role/${target.roleName}/${sessionName}`,
-    },
-    identityPolicyPrincipal: { kind: "arn", arn: target.roleArn },
-  };
+  return simServiceRoleCaller(target, sessionName);
 }
 
 /**


### PR DESCRIPTION
Simulated Scheduler and EventBridge assumed a role without supplying `aws:SourceArn` or `aws:SourceAccount`. A trust policy carrying the confused deputy condition AWS recommends therefore admitted nothing, and every firing was recorded as a delivery failure. A schedule now supplies its schedule group ARN and a rule supplies its own ARN, which is what AWS documents for each and what CDK writes into the execution roles it generates. Step Functions and CloudFront assume their roles through the same helper and still supply no source, so nothing changes for them.

`assumeSimServiceRole` takes an optional source and passes both condition keys to the trust policy evaluation. The target shape, the ARN parsing and the assumed-role caller move to `sim-service-role-target.ts`, which keeps `sim-service-role.ts` under the FTA complexity cap that the added tokens pushed it over.

Two tests fail on this branch, and both fail identically on a clean checkout of `main` at 50f4d239, so they are not from this change: `sim-ecs-serving-container-context.iso.test.ts` and `sim-ecs-queue-consumer-iam.iso.test.ts`. Vitest suppresses the coverage report while tests fail, so the coverage thresholds are unverifiable until those are fixed. Lint, FTA, the project type check and the docs examples all pass.

Resolves https://github.com/KensioSoftware/yulin/issues/1085


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - EventBridge ECS deliveries now support IAM trust policies scoped by source rule ARN and account.
  - Scheduler execution-role assumptions now support trust policies scoped by schedule group ARN and account.
  - Service-role assumptions now honor source resource conditions for improved authorization control.

- **Documentation**
  - Updated EventBridge and Scheduler guidance with supported trust-policy conditions and configuration examples.
  - Removed outdated Scheduler documentation stating that these conditions caused delivery failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->