### PR TITLE
fix: give every sim ECS container its Region

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -439,7 +439,9 @@ request routed to the container, and is covered under
 The container definition's `environment` is visible through `process.env` for the length of the run,
 along with any `RunTask` container override and the region variables a real task agent sets. This
 works the same way it does for a sim Lambda function handler, through Node.js asynchronous context
-tracking. A container that declares nothing reads the host environment untouched.
+tracking. The host process environment is underneath, and what the test process set stays readable.
+Every container gets the region variables, whatever its definition declares, and an SDK client the
+container builds reads `AWS_REGION` to find the region its task runs in.
 
 ```typescript sim-ecs-run-task-environment
 /**

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -143,10 +143,16 @@ containers keeps the `RunTask` caller's context, so leaving it would attribute a
 to whoever started the task.
 
 `SimEcsContainerEnvironment` merges the container definition's `environment` with its resolved
-secrets, any `RunTask` override and the Region variables, and applies them through
-`simProcessEnvironment`, the shared `process.env` patch under `util/process/`. It is shared with
-simulated Lambda because it patches a process global: two of them would each install a getter, and
-the second would capture whatever the first was reporting as its host environment.
+secrets, any `RunTask` override and the Region variables, lays them over the host process
+environment, and applies the result through `simProcessEnvironment`, the shared `process.env` patch
+under `util/process/`. It is shared with simulated Lambda because it patches a process global: two
+of them would each install a getter, and the second would capture whatever the first was reporting
+as its host environment.
+
+The host variables are read for each run. A variable the test process sets between two runs reaches
+the second of them. Every container gets the Region variables, whatever its definition
+declares. Without them an SDK client the container builds resolves its Region from the machine the
+test happens to run on, and its calls land in a Region the simulated task knows nothing about.
 
 ## Container secrets
 

--- a/src/service/ecs/command/run-task/run-task-environment.iso.test.ts
+++ b/src/service/ecs/command/run-task/run-task-environment.iso.test.ts
@@ -159,18 +159,20 @@ describe("The environment a simulated ECS container runs with", () => {
     assertIdentical(observed, "eu-west-2");
   });
 
-  it("leaves the host environment alone for a container declaring nothing", async () => {
-    // Given a container with no environment of its own.
+  it("gives a container declaring nothing the host environment and the Region", async () => {
+    // Given a container with no environment of its own, in a known Region.
     const simAws = new SimAws();
-    const ecs = simAws.ecs();
-    await simEcsClusterFactory.make({}, simAws);
+    const ecs = simAws.account("222222222222").region("eu-west-2").ecs();
+    await ecs.createCluster({ input: {} });
     process.env["YULIN_ECS_HOST_VARIABLE"] = "host";
-    let observed: string | undefined;
+    process.env["AWS_REGION"] = "ap-south-1";
+    const observed: Record<string, string | undefined> = {};
     ecs.bindContainer({
       family: "checkout",
       containerName: "app",
       run: () => {
-        observed = process.env["YULIN_ECS_HOST_VARIABLE"];
+        observed["host"] = process.env["YULIN_ECS_HOST_VARIABLE"];
+        observed["region"] = process.env["AWS_REGION"];
       },
     });
     await ecs.registerTaskDefinition(
@@ -184,10 +186,14 @@ describe("The environment a simulated ECS container runs with", () => {
     await ecs.runTask(new RunTaskCommand({ taskDefinition: "checkout" }));
     await simAws.backgroundTasksComplete();
 
-    // Then it read the host environment, since there was nothing of its own to
-    // give it.
-    assertIdentical(observed, "host");
-
     delete process.env["YULIN_ECS_HOST_VARIABLE"];
+    delete process.env["AWS_REGION"];
+
+    // Then it read the host environment it would have read anyway, with the
+    // task's own Region over the top rather than the one the machine running
+    // the test is configured for. A client the container builds is reached by
+    // the same variable, so it talks to the Region the task runs in.
+    assertIdentical(observed["host"], "host");
+    assertIdentical(observed["region"], "eu-west-2");
   });
 });

--- a/src/service/ecs/task/run/sim-ecs-container-environment.ts
+++ b/src/service/ecs/task/run/sim-ecs-container-environment.ts
@@ -25,8 +25,9 @@ interface SimEcsContainerEnvironmentProperties {
  * The variables are applied to `process.env` for the length of the run, in the
  * same way a sim Lambda function's are: a bound handler is an ordinary closure
  * with no sandbox of its own, so asynchronous context tracking is what gives
- * it an environment. A container declaring nothing is left reading the host
- * environment untouched.
+ * it an environment. They are laid over the host process environment, so a
+ * container still reads what the test process set, and a container declaring
+ * nothing of its own still runs in its task's Region.
  */
 export class SimEcsContainerEnvironment {
   private readonly regionName: string;
@@ -60,30 +61,26 @@ export class SimEcsContainerEnvironment {
   }
 
   /**
-   * Whether this container has an environment of its own at all.
-   */
-  get hasVariables(): boolean {
-    return (
-      this.declared.length > 0 ||
-      this.overridden.length > 0 ||
-      Object.keys(this.secrets).length > 0
-    );
-  }
-
-  /**
    * Run a container's handler with this environment applied to process.env.
    *
-   * A container with nothing of its own is left reading the host environment
-   * untouched, Region variables included. Giving it only the Region ones would
-   * take away everything the test process set, which is where an in-process
-   * handler's configuration usually comes from.
+   * The host process environment is underneath, because that is where an
+   * in-process handler's configuration usually comes from. It is read for each
+   * run, so a variable the test process sets between two runs reaches the
+   * second of them.
+   *
+   * The container's own variables are laid over it, the Region ones included.
+   * A real task agent sets those whatever the definition declares, and without
+   * them a client the handler builds resolves its Region from the machine the
+   * test happens to run on.
    */
   async runWith<T>(run: () => Promise<T>): Promise<T> {
-    if (!this.hasVariables) {
-      return await run();
-    }
-
-    return await simProcessEnvironment.run(this.variables(), run);
+    return await simProcessEnvironment.run(
+      {
+        ...simProcessEnvironment.definedHostVariables(),
+        ...this.variables(),
+      },
+      run,
+    );
   }
 
   /**


### PR DESCRIPTION
Two ECS tests fail on `main` for anyone whose machine has an AWS Region configured that is not
us-east-1. A simulated container declaring no environment of its own ran with the host process
environment untouched. An SDK client it built then resolved its Region from `~/.aws/config`, and its
`PutParameter` landed in eu-west-2 while the test read the parameter back in us-east-1. The
container reported success first, because sim IAM authorized the write against the same global
registry either way.

Every container now runs with its own variables laid over the host environment, the Region ones
included. That is what a real task agent gives a container whatever its definition declares, and it
matches what sim Lambda already does through `SimLambdaHostBackedVariables`. Both tests have failed
this way since they were written. The recent sim IAM Region work did not cause it.

One thing left for a reviewer. Outside a simulated container an intercepted client still takes its
Region from the host environment. That is worth a separate look.