### PR TITLE
feat: hash and encode binary in sim Athena

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -938,6 +938,11 @@ Current documented limitations:
 - Three classes of expression the engine accepts are ones real Athena refuses. `1 / 0` answers
   null, `CAST('abc' AS INTEGER)` answers 0, and `1 || 'x'` answers `'1x'`. Each of them fails a
   real query.
+- A column of text reaching `sha256` or any of the other byte-only functions is hashed as its UTF-8
+  bytes. Athena refuses the argument and fails the query, and a test writing one gets an answer
+  where real Athena would have given an error. SQLite has no analysis to refuse the argument with,
+  and a Glue `binary` column arrives here as text, so refusing it would turn down a query Athena
+  runs.
 - `try_cast` runs as a plain cast. `try_cast('abc' AS integer)` therefore answers 0 where real
   Athena answers null, which is the same forgiving direction as the cast above. Reading the
   statement without the rewrite would turn the whole query down.

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -380,11 +380,23 @@ its declared result.
 | JSON          | `json_extract`, `json_extract_scalar`, `json_parse`, `json_size`                                                                                                                                      |
 | Array and map | `array_agg`, `cardinality`, `contains`, `element_at`, `array_join`, `slice`                                                                                                                           |
 | String        | `regexp_like`, `regexp_extract`, `regexp_replace`, `split_part`, `strpos`                                                                                                                             |
+| Binary        | `md5`, `sha1`, `sha256`, `sha512`, `xxhash64`, `murmur3`, `crc32`, `to_hex`, `from_hex`, `to_base64`, `from_base64`, `to_utf8`, `from_utf8`                                                           |
 | URL           | `url_extract_host`, `url_extract_path`, `url_extract_protocol`, `url_extract_port`, `url_extract_query`, `url_extract_fragment`, `url_extract_parameter`, `url_decode`, `url_encode`                  |
 | Approximate   | `approx_distinct`, `approx_percentile`                                                                                                                                                                |
 
 `substr` and `format` are SQLite's own. Both count from one and take the same `%s` and `%d` a
 statement writes, so shadowing either would replace something that works.
+
+The hashing functions answer with bytes and `to_hex` writes those bytes in the upper case Trino
+writes them in. Node carries every digest here apart from xxHash64 and MurmurHash3, and both of
+those are written out by hand against their published vectors. Trino refuses text where a
+`varbinary` is wanted, and SQLite has no analysis to refuse it with. A column reaching `sha256`
+with no `to_utf8` around it is hashed as its UTF-8 bytes.
+
+`count(DISTINCT <expression>)` runs. The parser's Athena grammar takes a column after `DISTINCT`
+and refuses everything else. The call is rewritten onto an aggregate of the simulator's own before
+the statement is read. A plain `count(DISTINCT <column>)` is left alone and SQLite counts it. A
+call written inside a string literal is left alone as well.
 
 `current_date` and `current_timestamp` read the simulator's clock. A test that froze time gets the
 instant it froze, and the same test answers the same way on every machine. Athena reads both at the
@@ -912,6 +924,15 @@ Current documented limitations:
   down, since JavaScript can turn no flag on part way through one.
 - The date and time functions work on the ISO-8601 text a JSON or CSV object carries. A column
   written any other way gets whatever slicing that text comes to.
+- A `varbinary` in a result row reads as its bytes decoded as UTF-8. A digest read that way loses
+  whatever in it was no UTF-8. A query answering with one wants `to_hex` or `to_base64` around it.
+- `from_hex` and `from_base64` turn the query down over text the encoding cannot carry. Trino fails
+  the query, and reading as much of the text as parses would answer with bytes nobody wrote.
+- `from_utf8` with a replacement named turns the query down where the bytes already carry the
+  replacement character. Trino writes the replacement only where a sequence was broken, and nothing
+  survives decoding to tell one of those apart from a character the bytes held.
+- `spooky_hash_v2_32` and `spooky_hash_v2_64` are absent, and so are the other Trino hashes with no
+  entry in the table above.
 - `approx_distinct` and `approx_percentile` are computed exactly. The simulation is more accurate
   than AWS here, and at the scale a test seeds the difference cannot show.
 - Three classes of expression the engine accepts are ones real Athena refuses. `1 / 0` answers

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -253,6 +253,18 @@ that SQLite reads as its own JSON operator. Registering the name would leave the
 as that operator and answer something. Leaving it absent makes SQLite refuse the statement, which
 is a refusal rather than a wrong answer.
 
+`sim-athena-binary-shims.ts` holds the hashing functions and the encodings that carry bytes in and
+out of them. A `varbinary` lives in SQLite as a blob. A digest travels as bytes, and two rows
+carrying the same digest count as one value. Node has every digest apart from xxHash64 and
+MurmurHash3, and `sim-athena-xxhash64.ts` and `sim-athena-murmur3.ts` write those two out. Both are
+checked against published vectors and against the worked example in Trino's own documentation.
+
+`sim-athena-count-distinct.ts` works on the statement text before `astify` reads it. The parser's
+Athena grammar takes a column after `DISTINCT` and refuses anything else, and
+`count(DISTINCT concat(a, b))` never gets that far. The rewrite turns that call into
+`count_distinct(...)`, registered by `sim-athena-aggregate-shims.ts`. A plain column is left alone (SQLite counts one natively), and a call written inside a
+string literal is left alone as well.
+
 `sim-athena-timestamp-text.ts` is what keeps a timestamp's shape. A value arrives as text and has
 to leave as text written the same way, so an instant is rendered back through the value it came
 from. A value carrying a numeric UTC offset is refused for the same reason. Rendering

--- a/src/service/athena/engine/sim-athena-aggregate-shims.ts
+++ b/src/service/athena/engine/sim-athena-aggregate-shims.ts
@@ -1,5 +1,12 @@
 import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
 
+import { countDistinctShim } from "./sim-athena-count-distinct.js";
+import {
+  countedDistinctValues,
+  noDistinctValues,
+  withDistinctValue,
+} from "./sim-athena-distinct-values.js";
+
 /** What `approx_percentile` carries between rows. */
 interface SimAthenaPercentileState {
   readonly values: number[];
@@ -7,31 +14,29 @@ interface SimAthenaPercentileState {
 }
 
 /**
- * Trino's two approximate aggregates, computed exactly.
+ * Trino's two approximate aggregates, computed exactly, and the exact count
+ * behind `count(DISTINCT <expression>)`.
  *
- * Real Athena answers both from a sketch and this answers from the values
- * themselves, so the simulation is the more accurate of the two. At the scale
- * a test seeds that difference cannot show, and the alternative is a query
- * that refuses to run at all.
+ * Real Athena answers the approximate pair from a sketch and this answers from
+ * the values themselves, so the simulation is the more accurate of the two. At
+ * the scale a test seeds that difference cannot show, and the alternative is a
+ * query that refuses to run at all.
+ *
+ * `count_distinct` is nobody's function to write. It is what the SQL rewrite
+ * turns `count(DISTINCT <expression>)` into, because the parser's Athena
+ * grammar takes a column after `DISTINCT` and nothing else.
  *
  * The state travels as JSON because SQLite carries an aggregate's accumulator
  * as one of its own values rather than as an object.
  */
 export function simAthenaInstallAggregateShims(database: DatabaseSync): void {
-  database.aggregate("approx_distinct", {
-    start: "[]",
-    step: (accumulator: string, value: SQLOutputValue) => {
-      const seen = new Set(JSON.parse(accumulator) as unknown[]);
-
-      if (value !== null) {
-        seen.add(typeof value === "bigint" ? String(value) : value);
-      }
-
-      return JSON.stringify([...seen]);
-    },
-    result: (accumulator: string) =>
-      (JSON.parse(accumulator) as unknown[]).length,
-  });
+  for (const name of ["approx_distinct", countDistinctShim]) {
+    database.aggregate(name, {
+      start: noDistinctValues,
+      step: withDistinctValue,
+      result: countedDistinctValues,
+    });
+  }
 
   database.aggregate("approx_percentile", {
     start: () => JSON.stringify({ values: [], percentile: 0.5 }),

--- a/src/service/athena/engine/sim-athena-binary-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-binary-shims.iso.test.ts
@@ -1,0 +1,293 @@
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredExpression } from "./sim-athena-shim.fixture.js";
+
+/**
+ * The bytes Trino's own worked example for `murmur3` hashes, written as hex.
+ *
+ * Trino writes it as `from_base64('aaaaaa')`, and the two are the same four
+ * bytes.
+ */
+const murmurVector = "'69A69A69'";
+
+/** Eighty bytes, which is two whole stripes of the xxHash64 body and a tail. */
+const longDigits = `'${"1234567890".repeat(8)}'`;
+
+/** Forty-three bytes, which is two whole blocks of the MurmurHash3 body and a tail. */
+const longWords = "'The quick brown fox jumps over the lazy dog'";
+
+describe("Trino's hashing functions on SQLite", () => {
+  it("answers the published digest for each algorithm", async () => {
+    // Given the letter `a`, which every one of these has a published digest
+    // for.
+    // When each is hashed and read back as hex.
+    // Then the digest is the published one, and `to_hex` writes it in the
+    // upper case Trino writes it in.
+    assertIdentical(
+      await anAnsweredExpression("to_hex(md5(to_utf8('a')))"),
+      "0CC175B9C0F1B6A831C399E269772661",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_hex(sha1(to_utf8('a')))"),
+      "86F7E437FAA5A7FCE15D1DDCB9EAEAEA377667B8",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_hex(sha256(to_utf8('a')))"),
+      "CA978112CA1BBDCAFAC231B39A23DC4DA786EFF8147C4E72B9807785AFEE48BB",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_hex(sha512(to_utf8('')))"),
+      "CF83E1357EEFB8BDF1542850D66D8007D620E4050B5715DC83F4A921D36CE9CE" +
+        "47D0D13C5D85F2B0FF8318D2877EEC2F63B931BD47417A81A538327AF927DA3E",
+    );
+  });
+
+  it("answers the published digest for the two hashes Node has not got", async () => {
+    // Given the vectors xxHash publishes and the ones Trino's own tests
+    // assert on. Neither hash has an implementation in Node, and both are
+    // written out by hand here.
+    // When each is hashed.
+    // Then the answer is the published one, and a test asserting on one of
+    // these digests asserts on what real Athena would have answered.
+    assertIdentical(
+      await anAnsweredExpression("to_hex(xxhash64(to_utf8('')))"),
+      "EF46DB3751D8E999",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_hex(xxhash64(to_utf8('abc')))"),
+      "44BC2CF5AD770999",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_hex(xxhash64(to_utf8('hashme')))"),
+      "F9D96E0E1165E892",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_hex(murmur3(to_utf8('')))"),
+      "00000000000000000000000000000000",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_hex(murmur3(to_utf8('hashme')))"),
+      "93192FE805BE23041C8318F67EC4F2BC",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`to_hex(murmur3(from_hex(${murmurVector})))`),
+      "BA5855635569B42F4920372CA0E396EF",
+      "the one worked example in Trino's documentation",
+    );
+  });
+
+  it("answers over values long enough to go round the block loop", async () => {
+    // Given values that fill the body of each hash and leave a tail behind
+    // it. The digits are a published xxHash64 vector, and the words are what
+    // Austin Appleby's own MurmurHash3 answers with.
+    // When each is hashed.
+    // Then the answer is the published one. Every value above is short enough
+    // to stay in the tail, and the loop reading the body would go untried.
+    assertIdentical(
+      await anAnsweredExpression(`to_hex(xxhash64(to_utf8(${longDigits})))`),
+      "E04A477F19EE145D",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`to_hex(murmur3(to_utf8(${longWords})))`),
+      "6C1B07BC7BBC4BE347939AC4A93C437A",
+    );
+  });
+
+  it("reads a tail eight bytes at a time, then four, then one", async () => {
+    // Given values whose length leaves a different tail behind the body.
+    // When each is hashed.
+    // Then each answer is the published one. Twenty-six bytes leave three
+    // whole words and two bytes, and fourteen leave one word, one half word
+    // and two bytes.
+    assertIdentical(
+      await anAnsweredExpression(
+        "to_hex(xxhash64(to_utf8('abcdefghijklmnopqrstuvwxyz')))",
+      ),
+      "CFE1F278FA89835C",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_hex(xxhash64(to_utf8('message digest')))"),
+      "066ED728FCEEB3BE",
+    );
+  });
+
+  it("counts a checksum rather than hashing to bytes", async () => {
+    // Given a value.
+    // When its CRC-32 is taken.
+    // Then the answer is a whole number, where every other hash here answers
+    // with bytes. Trino's `crc32` is the one that returns a bigint.
+    assertIdentical(
+      await anAnsweredExpression("crc32(to_utf8('hello'))"),
+      907_060_870,
+    );
+    assertIdentical(await anAnsweredExpression("crc32(to_utf8(''))"), 0);
+  });
+
+  it("hashes text that reached it without a to_utf8 around it", async () => {
+    // Given a value of text passed straight to a hash.
+    // When it is hashed.
+    // Then the answer is the hash of its UTF-8 bytes, which is what the
+    // missing `to_utf8` would have produced. Trino refuses text where a
+    // varbinary is wanted, and SQLite has no analysis to refuse it with.
+    assertIdentical(
+      await anAnsweredExpression("to_hex(sha256('a'))"),
+      await anAnsweredExpression("to_hex(sha256(to_utf8('a')))"),
+    );
+  });
+
+  it("answers null wherever the value is null", async () => {
+    // Given a null reaching each function.
+    // When it is hashed or encoded.
+    // Then the answer is null, the way every Trino function answers a null
+    // argument.
+    const calls = [
+      "md5(NULL)",
+      "sha256(NULL)",
+      "xxhash64(NULL)",
+      "murmur3(NULL)",
+      "crc32(NULL)",
+      "to_hex(NULL)",
+      "from_hex(NULL)",
+      "to_base64(NULL)",
+      "from_base64(NULL)",
+      "to_utf8(NULL)",
+      "from_utf8(NULL)",
+    ];
+    const answered = await Promise.all(calls.map(anAnsweredExpression));
+
+    for (const [index, call] of calls.entries()) {
+      assertIdentical(answered.at(index), null, call);
+    }
+  });
+});
+
+describe("Trino's binary encodings on SQLite", () => {
+  it("carries a digest as bytes rather than as text", async () => {
+    // Given a digest.
+    // When SQLite is asked what it is holding.
+    // Then it is a blob, so a varbinary has somewhere to live and two rows
+    // carrying the same digest are one value.
+    assertIdentical(
+      await anAnsweredExpression("typeof(sha256(to_utf8('a')))"),
+      "blob",
+    );
+    assertIdentical(await anAnsweredExpression("typeof(to_utf8(''))"), "blob");
+  });
+
+  it("reads bytes back out of hex and base64", async () => {
+    // Given text in each encoding.
+    // When it is read back and decoded.
+    // Then the round trip reaches the value it started from, and either case
+    // of hex reads.
+    assertIdentical(
+      await anAnsweredExpression("from_utf8(from_hex('72616E'))"),
+      "ran",
+    );
+    assertIdentical(
+      await anAnsweredExpression("from_utf8(from_hex('72616e'))"),
+      "ran",
+    );
+    assertIdentical(
+      await anAnsweredExpression("to_base64(to_utf8('rain'))"),
+      "cmFpbg==",
+    );
+    assertIdentical(
+      await anAnsweredExpression("from_utf8(from_base64('cmFpbg=='))"),
+      "rain",
+    );
+    assertIdentical(
+      await anAnsweredExpression("from_utf8(from_base64('cmFpbg'))"),
+      "rain",
+      "Trino takes base64 written without its padding",
+    );
+  });
+
+  it("keeps an empty value as an empty value", async () => {
+    // Given an empty string encoded, and empty text decoded.
+    // When each is read back.
+    // Then the answer is empty rather than null. SQLite reads some empty byte
+    // arrays as SQL NULL, and a digest over an empty column would otherwise
+    // answer nothing at all.
+    assertIdentical(await anAnsweredExpression("to_hex(to_utf8(''))"), "");
+    assertIdentical(await anAnsweredExpression("from_utf8(from_hex(''))"), "");
+    assertIdentical(await anAnsweredExpression("to_base64(to_utf8(''))"), "");
+  });
+
+  it("refuses text the encoding cannot carry", async () => {
+    // Given text that is no hex and text that is no base64.
+    // When each is read back.
+    // Then the statement raises and the query falls back. Trino fails the
+    // query, and reading as much of the text as parses would answer with
+    // bytes nobody wrote.
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("from_hex('zz')"),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("from_hex('ABC')"),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("from_base64('not base64!')"),
+    );
+  });
+});
+
+describe("reading bytes back as text", () => {
+  /** A byte that opens a two byte sequence, followed by one that cannot close it. */
+  const brokenUtf8 = "from_hex('61C328')";
+
+  it("writes a replacement character where the bytes were no UTF-8", async () => {
+    // Given bytes carrying a sequence no decoder can read.
+    // When they are read back with no replacement named.
+    // Then the broken sequence reads as U+FFFD, which is what Trino writes.
+    assertIdentical(
+      await anAnsweredExpression(`from_utf8(${brokenUtf8})`),
+      "a\u{FFFD}(",
+    );
+  });
+
+  it("writes the replacement a call names instead", async () => {
+    // Given the same bytes and a replacement of one character, and of none.
+    // When each is read back.
+    // Then the named replacement is written, and an empty one takes the
+    // broken sequence out altogether.
+    assertIdentical(
+      await anAnsweredExpression(`from_utf8(${brokenUtf8}, '?')`),
+      "a?(",
+    );
+    assertIdentical(
+      await anAnsweredExpression(`from_utf8(${brokenUtf8}, '')`),
+      "a(",
+    );
+  });
+
+  it("tells a replacement left out from one written as NULL", async () => {
+    // Given a call leaving the replacement out and a call writing it as NULL.
+    // When each runs.
+    // Then the absent one reads the bytes and the NULL answers null.
+    assertIdentical(
+      await anAnsweredExpression("from_utf8(to_utf8('rain'))"),
+      "rain",
+    );
+    assertIdentical(
+      await anAnsweredExpression("from_utf8(to_utf8('rain'), NULL)"),
+      null,
+    );
+  });
+
+  it("refuses a replacement it cannot apply faithfully", async () => {
+    // Given a replacement longer than one character, and bytes already
+    // carrying a replacement character of their own.
+    // When each is read back with a replacement named.
+    // Then the statement raises and the query falls back. Trino takes a
+    // replacement of one character or none, and there is nothing left after
+    // decoding to tell a character the bytes carried from one the decoder
+    // wrote.
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression(`from_utf8(${brokenUtf8}, '??')`),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("from_utf8(to_utf8('a\u{FFFD}b'), '?')"),
+    );
+  });
+});

--- a/src/service/athena/engine/sim-athena-binary-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-binary-shims.iso.test.ts
@@ -230,6 +230,22 @@ describe("Trino's binary encodings on SQLite", () => {
       anAnsweredExpression("from_base64('not base64!')"),
     );
   });
+
+  it("refuses base64 whose padding could never have been written", async () => {
+    // Given text padded to a length no encoder produces, and text one
+    // character over a multiple of four.
+    // When each is read back.
+    // Then the statement raises. `Buffer` decodes all four of these and
+    // answers with bytes nobody wrote.
+    await Promise.all(
+      ["=", "A=", "AAAA=", "A"].map(async (text) =>
+        assertThrowsErrorAsync(
+          async () => anAnsweredExpression(`from_base64('${text}')`),
+          text,
+        ),
+      ),
+    );
+  });
 });
 
 describe("reading bytes back as text", () => {

--- a/src/service/athena/engine/sim-athena-binary-shims.ts
+++ b/src/service/athena/engine/sim-athena-binary-shims.ts
@@ -1,0 +1,92 @@
+import { createHash } from "node:crypto";
+import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
+import { crc32 } from "node:zlib";
+
+import { simAthenaMurmur3 } from "./sim-athena-murmur3.js";
+import {
+  simAthenaDecodedText,
+  simAthenaFromUtf8,
+} from "./sim-athena-binary-text.js";
+import {
+  shimBytes,
+  shimText,
+  simAthenaScalarShim,
+} from "./sim-athena-shim-registry.js";
+import { simAthenaXxHash64 } from "./sim-athena-xxhash64.js";
+
+/** The `node:crypto` digest each Trino hashing function is spelled with. */
+const digests: ReadonlyMap<string, string> = new Map([
+  ["md5", "md5"],
+  ["sha1", "sha1"],
+  ["sha256", "sha256"],
+  ["sha512", "sha512"],
+]);
+
+/**
+ * Trino's hashing functions and the encodings that carry bytes in and out of
+ * them.
+ *
+ * A `varbinary` is held as a SQLite blob, so a digest travels as bytes the way
+ * it does in Athena and a `to_hex` around it reads the same. Trino refuses text
+ * where a `varbinary` is wanted and SQLite has no analysis to refuse it with,
+ * so a column reaching one of these without a `to_utf8` around it is hashed as
+ * its UTF-8 bytes.
+ *
+ * `spooky_hash_v2_32` and `spooky_hash_v2_64` are absent. Nothing an access log
+ * query reaches for spells either, and a name registered for one would have to
+ * carry a third hash written out by hand.
+ */
+export function simAthenaInstallBinaryShims(database: DatabaseSync): void {
+  for (const [name, algorithm] of digests) {
+    simAthenaScalarShim(database, name, (value) =>
+      overBytes(
+        value,
+        (bytes) => new Uint8Array(createHash(algorithm).update(bytes).digest()),
+      ),
+    );
+  }
+
+  simAthenaScalarShim(database, "xxhash64", (value) =>
+    overBytes(value, simAthenaXxHash64),
+  );
+  simAthenaScalarShim(database, "murmur3", (value) =>
+    overBytes(value, simAthenaMurmur3),
+  );
+  simAthenaScalarShim(database, "crc32", (value) =>
+    overBytes(value, (bytes) => crc32(bytes)),
+  );
+
+  simAthenaScalarShim(database, "to_hex", (value) =>
+    overBytes(value, (bytes) =>
+      Buffer.from(bytes).toString("hex").toUpperCase(),
+    ),
+  );
+  simAthenaScalarShim(database, "to_base64", (value) =>
+    overBytes(value, (bytes) => Buffer.from(bytes).toString("base64")),
+  );
+  simAthenaScalarShim(database, "from_hex", (value) =>
+    simAthenaDecodedText(shimText(value), "hex"),
+  );
+  simAthenaScalarShim(database, "from_base64", (value) =>
+    simAthenaDecodedText(shimText(value), "base64"),
+  );
+
+  simAthenaScalarShim(database, "to_utf8", (value) => {
+    const text = shimText(value);
+
+    return text === undefined ? null : new TextEncoder().encode(text);
+  });
+  simAthenaScalarShim(database, "from_utf8", (...values) =>
+    simAthenaFromUtf8(shimBytes(values.at(0)), values),
+  );
+}
+
+/** One binary function over its argument, answering null where it is null. */
+function overBytes<T>(
+  value: SQLOutputValue | undefined,
+  read: (bytes: Uint8Array) => T,
+): T | null {
+  const bytes = shimBytes(value);
+
+  return bytes === undefined ? null : read(bytes);
+}

--- a/src/service/athena/engine/sim-athena-binary-text.ts
+++ b/src/service/athena/engine/sim-athena-binary-text.ts
@@ -1,0 +1,98 @@
+import type { SQLOutputValue } from "node:sqlite";
+
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+import { isExplicitNull } from "./sim-athena-shim-registry.js";
+
+/** What each encoding will read back, in either case and padded or not. */
+const shapes: ReadonlyMap<string, RegExp> = new Map([
+  ["hex", /^[\dA-Fa-f]*$/u],
+  ["base64", /^[\d+/A-Za-z]*={0,2}$/u],
+]);
+
+/** One character or none, counted in code points the way Trino counts them. */
+const oneCharacter = /^.?$/u;
+
+/** The character a UTF-8 decoder writes where the bytes were no UTF-8. */
+const replacementCharacter = "\u{FFFD}";
+
+/** The bytes that encode that character, which are valid UTF-8 themselves. */
+const encodedReplacement = Buffer.from([0xef, 0xbf, 0xbd]);
+
+/**
+ * One encoded string read back to bytes, or null where it is null.
+ *
+ * Trino fails the query over text the encoding cannot carry, and `Buffer` reads
+ * as much of it as it can and drops the rest. Raising here turns the query down
+ * instead, which is nearer to Trino's answer than bytes nobody wrote.
+ */
+export function simAthenaDecodedText(
+  text: string | undefined,
+  encoding: "base64" | "hex",
+): Uint8Array | null {
+  if (text === undefined) {
+    return null;
+  }
+
+  const even = encoding === "base64" || text.length % 2 === 0;
+
+  if (!even || shapes.get(encoding)?.test(text) !== true) {
+    throw new SimAthenaSetUpError(`from_${encoding} takes ${encoding} text`);
+  }
+
+  return new Uint8Array(Buffer.from(text, encoding));
+}
+
+/**
+ * Bytes read back as text, with whatever was no UTF-8 replaced.
+ *
+ * Trino writes `U+FFFD` where a call named no replacement, which is what a
+ * decoder writes anyway. A call naming one has that written instead, and the
+ * replacement has to be a single character or empty, as Trino's does.
+ *
+ * Bytes carrying `U+FFFD` of their own leave nothing to tell the two apart
+ * once the decoder has run, so a call naming a replacement over those raises
+ * rather than replacing text that was never broken.
+ */
+export function simAthenaFromUtf8(
+  bytes: Uint8Array | undefined,
+  values: readonly SQLOutputValue[],
+): string | null {
+  if (bytes === undefined) {
+    return null;
+  }
+
+  const decoded = new TextDecoder().decode(bytes);
+
+  if (values.length < 2) {
+    return decoded;
+  }
+
+  if (isExplicitNull(values, 1)) {
+    return null;
+  }
+
+  const replacement = replacementFor(bytes, values);
+
+  return decoded.replaceAll(replacementCharacter, () => replacement);
+}
+
+function replacementFor(
+  bytes: Uint8Array,
+  values: readonly SQLOutputValue[],
+): string {
+  const replacement = String(values.at(1));
+
+  if (!oneCharacter.test(replacement)) {
+    throw new SimAthenaSetUpError(
+      "from_utf8 takes a replacement of one character or none",
+    );
+  }
+
+  if (Buffer.from(bytes).includes(encodedReplacement)) {
+    throw new SimAthenaSetUpError(
+      "from_utf8 cannot tell a replacement character it decoded from one the bytes carried",
+    );
+  }
+
+  return replacement;
+}

--- a/src/service/athena/engine/sim-athena-binary-text.ts
+++ b/src/service/athena/engine/sim-athena-binary-text.ts
@@ -9,6 +9,12 @@ const shapes: ReadonlyMap<string, RegExp> = new Map([
   ["base64", /^[\d+/A-Za-z]*={0,2}$/u],
 ]);
 
+/** Whether the length of this text is one the encoding could have written. */
+const lengths: ReadonlyMap<string, (text: string) => boolean> = new Map([
+  ["hex", (text: string) => text.length % 2 === 0],
+  ["base64", isBase64Length],
+]);
+
 /** One character or none, counted in code points the way Trino counts them. */
 const oneCharacter = /^.?$/u;
 
@@ -33,13 +39,35 @@ export function simAthenaDecodedText(
     return null;
   }
 
-  const even = encoding === "base64" || text.length % 2 === 0;
+  const read =
+    shapes.get(encoding)?.test(text) === true &&
+    lengths.get(encoding)?.(text) === true;
 
-  if (!even || shapes.get(encoding)?.test(text) !== true) {
+  if (!read) {
     throw new SimAthenaSetUpError(`from_${encoding} takes ${encoding} text`);
   }
 
   return new Uint8Array(Buffer.from(text, encoding));
+}
+
+/**
+ * Whether base64 of this length decodes, padding and all.
+ *
+ * Base64 carries three bytes in every four characters, and a length one over a
+ * multiple of four is a length no encoder could have written. Padding fills the
+ * last four out, so text carrying any has to be a multiple of four long.
+ * `Buffer` takes `A=` and `AAAA=` and answers with bytes nobody wrote.
+ */
+function isBase64Length(text: string): boolean {
+  let padding = 0;
+
+  while (text.charAt(text.length - padding - 1) === "=") {
+    padding += 1;
+  }
+
+  const body = text.length - padding;
+
+  return body % 4 !== 1 && (padding === 0 || text.length % 4 === 0);
 }
 
 /**

--- a/src/service/athena/engine/sim-athena-count-distinct.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-count-distinct.iso.test.ts
@@ -1,0 +1,64 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAthenaCountDistinct } from "./sim-athena-count-distinct.js";
+
+describe("rewriting a count over a distinct expression", () => {
+  it("rewrites an expression and leaves a plain column alone", () => {
+    // Given a count over an expression and a count over a column.
+    // When each is rewritten.
+    // Then the expression becomes a call the parser's Athena grammar takes,
+    // and the column is left for SQLite to count natively.
+    assertIdentical(
+      simAthenaCountDistinct("SELECT count(DISTINCT concat(a, b)) FROM t"),
+      "SELECT count_distinct(concat(a, b)) FROM t",
+    );
+    assertIdentical(
+      simAthenaCountDistinct("SELECT COUNT( DISTINCT  t.c ) FROM t"),
+      "SELECT COUNT( DISTINCT  t.c ) FROM t",
+    );
+    assertIdentical(
+      simAthenaCountDistinct(
+        "SELECT count(DISTINCT lower(a)), count(DISTINCT upper(b)) FROM t",
+      ),
+      "SELECT count_distinct(lower(a)), count_distinct(upper(b)) FROM t",
+    );
+  });
+
+  it("leaves a call written inside quotes alone", () => {
+    // Given the text of a call sitting inside a string literal, inside a
+    // delimited identifier, and inside a literal carrying a doubled quote.
+    // When each is rewritten.
+    // Then nothing changes. Rewriting inside a literal would change the value
+    // a comparison is made against, and rewriting inside an identifier would
+    // name a different column.
+    for (const sql of [
+      `SELECT a FROM t WHERE b = 'count(DISTINCT f(x))'`,
+      `SELECT "count(DISTINCT f(x))" FROM t`,
+      `SELECT a FROM t WHERE b = 'it''s count(DISTINCT f(x))'`,
+    ]) {
+      assertIdentical(simAthenaCountDistinct(sql), sql, sql);
+    }
+  });
+
+  it("passes over a parenthesis that quotes carry", () => {
+    // Given a call whose argument names a column with a parenthesis in it.
+    // When it is rewritten.
+    // Then the call is read to its own closing parenthesis. Counting the one
+    // inside the identifier would cut the argument short and write a
+    // statement nobody could run.
+    assertIdentical(
+      simAthenaCountDistinct(`SELECT count(DISTINCT lower("a)b")) FROM t`),
+      `SELECT count_distinct(lower("a)b")) FROM t`,
+    );
+  });
+
+  it("leaves a call the statement never closes alone", () => {
+    // Given a statement with a parenthesis left open.
+    // When it is rewritten.
+    // Then nothing changes, and the parser refuses the statement as written.
+    const sql = "SELECT count(DISTINCT lower(x) FROM t";
+
+    assertIdentical(simAthenaCountDistinct(sql), sql);
+  });
+});

--- a/src/service/athena/engine/sim-athena-count-distinct.ts
+++ b/src/service/athena/engine/sim-athena-count-distinct.ts
@@ -20,6 +20,7 @@ const namePart = /^(?:"[^"]*"|[A-Za-z_]\w*)$/u;
  * own, which counts the distinct values the same way.
  */
 export function simAthenaCountDistinct(sql: string): string {
+  const quoted = quotedPositions(sql);
   let rewritten = "";
   let read = 0;
 
@@ -30,9 +31,9 @@ export function simAthenaCountDistinct(sql: string): string {
     match !== null;
     match = opening.exec(sql)
   ) {
-    const closes = closingParenthesis(sql, opening.lastIndex);
+    const closes = closingParenthesis(sql, opening.lastIndex, quoted);
 
-    if (closes === undefined || isQuoted(sql, match.index)) {
+    if (closes === undefined || quoted.at(match.index) === true) {
       continue;
     }
 
@@ -61,23 +62,40 @@ function isColumnReference(argument: string): boolean {
 }
 
 /**
- * Whether this position sits inside a string literal.
+ * Whether the character at each position sits inside quotes.
  *
- * A literal is free to carry the text of a call, and rewriting inside one would
- * quietly change the value a comparison is made against. SQL escapes a quote
- * inside a literal by doubling it, which counts here as one literal ending and
- * another starting, so the count stays even either way.
+ * Both of SQL's quotes are tracked. A single quote opens a string literal and a
+ * double quote opens a delimited identifier, and either is free to carry the
+ * text of a call. Rewriting inside a literal would change the value a
+ * comparison is made against, and rewriting inside an identifier would name a
+ * different column.
+ *
+ * SQL escapes a quote inside either by doubling it, which reads here as one
+ * quoted run ending and another starting. The positions in between land the
+ * same way whichever reading is taken.
  */
-function isQuoted(sql: string, at: number): boolean {
-  let quotes = 0;
+function quotedPositions(sql: string): readonly boolean[] {
+  const inside: boolean[] = [];
+  let quote: string | undefined;
 
-  for (let read = 0; read < at; read += 1) {
-    if (sql.at(read) === "'") {
-      quotes += 1;
+  for (const character of quotableCharacters(sql)) {
+    if (quote === undefined && (character === "'" || character === '"')) {
+      quote = character;
+    } else if (quote === character) {
+      quote = undefined;
     }
+
+    inside.push(quote !== undefined);
   }
 
-  return quotes % 2 === 1;
+  return inside;
+}
+
+/** Each character of the statement, by position rather than by code point. */
+function* quotableCharacters(sql: string): Generator<string> {
+  for (let at = 0; at < sql.length; at += 1) {
+    yield sql.charAt(at);
+  }
 }
 
 /**
@@ -85,22 +103,21 @@ function isQuoted(sql: string, at: number): boolean {
  * statement never closes it.
  *
  * Depth is counted so that a call carrying calls of its own is read whole, and
- * a string literal is skipped so that a parenthesis inside one is not counted.
- * SQL escapes a quote inside a literal by doubling it, which reads here as one
- * literal ending and another starting.
+ * a parenthesis inside quotes is passed over so that it is not counted.
  */
-function closingParenthesis(sql: string, from: number): number | undefined {
+function closingParenthesis(
+  sql: string,
+  from: number,
+  quoted: readonly boolean[],
+): number | undefined {
   let depth = 0;
-  let quoted = false;
 
   for (let at = from; at < sql.length; at += 1) {
-    const character = sql.at(at);
+    const character = quoted.at(at) === true ? "" : sql.charAt(at);
 
-    if (character === "'") {
-      quoted = !quoted;
-    } else if (!quoted && character === "(") {
+    if (character === "(") {
       depth += 1;
-    } else if (!quoted && character === ")") {
+    } else if (character === ")") {
       if (depth === 0) {
         return at;
       }

--- a/src/service/athena/engine/sim-athena-count-distinct.ts
+++ b/src/service/athena/engine/sim-athena-count-distinct.ts
@@ -1,0 +1,113 @@
+/** The name the rewrite calls, which the aggregate shims register. */
+export const countDistinctShim = "count_distinct";
+
+/** Where one `count(DISTINCT` opens, however the statement spaced it. */
+const opening = /\bcount\s*\(\s*DISTINCT\b/giu;
+
+/** One name in a column reference, quoted or bare. */
+const namePart = /^(?:"[^"]*"|[A-Za-z_]\w*)$/u;
+
+/**
+ * `count(DISTINCT <expression>)`, written as a call the parser will take.
+ *
+ * The parser's Athena grammar takes a column after `DISTINCT` and nothing else,
+ * so `count(DISTINCT concat(a, b))` is refused outright and the whole query
+ * falls back. SQLite takes the same expression happily, and so does Athena, so
+ * the gap is the grammar rather than the engine.
+ *
+ * A plain column is left alone, since that already parses and SQLite counts it
+ * natively. Everything else becomes a call to one aggregate of the simulator's
+ * own, which counts the distinct values the same way.
+ */
+export function simAthenaCountDistinct(sql: string): string {
+  let rewritten = "";
+  let read = 0;
+
+  opening.lastIndex = 0;
+
+  for (
+    let match = opening.exec(sql);
+    match !== null;
+    match = opening.exec(sql)
+  ) {
+    const closes = closingParenthesis(sql, opening.lastIndex);
+
+    if (closes === undefined || isQuoted(sql, match.index)) {
+      continue;
+    }
+
+    const argument = sql.slice(opening.lastIndex, closes).trim();
+
+    if (isColumnReference(argument)) {
+      continue;
+    }
+
+    rewritten += `${sql.slice(read, match.index)}${countDistinctShim}(${argument})`;
+    read = closes + 1;
+    opening.lastIndex = read;
+  }
+
+  return rewritten + sql.slice(read);
+}
+
+/**
+ * Whether this argument is a column the grammar would have taken as it stands.
+ *
+ * A quoted name carrying a dot of its own reads here as two names and fails
+ * this. The call is then rewritten, and the rewrite answers the same way.
+ */
+function isColumnReference(argument: string): boolean {
+  return argument.split(".").every((part) => namePart.test(part.trim()));
+}
+
+/**
+ * Whether this position sits inside a string literal.
+ *
+ * A literal is free to carry the text of a call, and rewriting inside one would
+ * quietly change the value a comparison is made against. SQL escapes a quote
+ * inside a literal by doubling it, which counts here as one literal ending and
+ * another starting, so the count stays even either way.
+ */
+function isQuoted(sql: string, at: number): boolean {
+  let quotes = 0;
+
+  for (let read = 0; read < at; read += 1) {
+    if (sql.at(read) === "'") {
+      quotes += 1;
+    }
+  }
+
+  return quotes % 2 === 1;
+}
+
+/**
+ * Where the parenthesis that opened this call closes, or nothing where the
+ * statement never closes it.
+ *
+ * Depth is counted so that a call carrying calls of its own is read whole, and
+ * a string literal is skipped so that a parenthesis inside one is not counted.
+ * SQL escapes a quote inside a literal by doubling it, which reads here as one
+ * literal ending and another starting.
+ */
+function closingParenthesis(sql: string, from: number): number | undefined {
+  let depth = 0;
+  let quoted = false;
+
+  for (let at = from; at < sql.length; at += 1) {
+    const character = sql.at(at);
+
+    if (character === "'") {
+      quoted = !quoted;
+    } else if (!quoted && character === "(") {
+      depth += 1;
+    } else if (!quoted && character === ")") {
+      if (depth === 0) {
+        return at;
+      }
+
+      depth -= 1;
+    }
+  }
+
+  return undefined;
+}

--- a/src/service/athena/engine/sim-athena-distinct-values.ts
+++ b/src/service/athena/engine/sim-athena-distinct-values.ts
@@ -1,0 +1,59 @@
+import type { SQLOutputValue } from "node:sqlite";
+
+/**
+ * The values one aggregate has seen, as SQLite will carry them between rows.
+ *
+ * SQLite holds an accumulator as one of its own values rather than as an
+ * object, so the set travels as the JSON text of its keys.
+ */
+export type SimAthenaDistinctValues = string;
+
+/** An empty accumulator, which is what an aggregate over no rows answers from. */
+export const noDistinctValues: SimAthenaDistinctValues = "[]";
+
+/**
+ * This value with one more added, where it is not null.
+ *
+ * Trino and SQLite both leave a null out of a distinct count, so a null row
+ * adds nothing.
+ */
+export function withDistinctValue(
+  accumulator: SimAthenaDistinctValues,
+  value: SQLOutputValue,
+): SimAthenaDistinctValues {
+  if (value === null) {
+    return accumulator;
+  }
+
+  const seen = new Set(JSON.parse(accumulator) as string[]);
+
+  seen.add(keyOf(value));
+
+  return JSON.stringify([...seen]);
+}
+
+/** How many distinct values this accumulator saw. */
+export function countedDistinctValues(
+  accumulator: SimAthenaDistinctValues,
+): number {
+  return (JSON.parse(accumulator) as string[]).length;
+}
+
+/**
+ * One value as the key that tells it apart from the others.
+ *
+ * The tag is what keeps the number `1` and the text `'1'` apart, which is how
+ * SQLite keeps them apart too. A whole number arrives as a `bigint` or as a
+ * `number` by its size alone, so both take the same tag and the same spelling.
+ * Bytes are keyed by their hex, since a digest is a blob here and two rows
+ * carrying the same digest are one value.
+ */
+function keyOf(value: Exclude<SQLOutputValue, null>): string {
+  if (typeof value === "string") {
+    return `s:${value}`;
+  }
+
+  return value instanceof Uint8Array
+    ? `b:${Buffer.from(value).toString("hex")}`
+    : `n:${String(value)}`;
+}

--- a/src/service/athena/engine/sim-athena-hash-words.ts
+++ b/src/service/athena/engine/sim-athena-hash-words.ts
@@ -1,0 +1,27 @@
+/**
+ * The 64-bit arithmetic both hand-written hashes are built on.
+ *
+ * Neither xxHash64 nor MurmurHash3 has an implementation in Node, and both are
+ * defined over 64-bit words. A BigInt carries as many bits as it is given, so
+ * every operation masks its answer back down to the width the algorithm works
+ * in.
+ */
+
+/** Every bit of one 64-bit word. */
+export const hashWord = (1n << 64n) - 1n;
+
+/** One word rotated left, with the bits carried off the top brought back in. */
+export function rotateWord(value: bigint, by: number): bigint {
+  return ((value << BigInt(by)) | (value >> BigInt(64 - by))) & hashWord;
+}
+
+/** Whatever bytes are left over, read as the low end of a word. */
+export function partialWord(bytes: Uint8Array): bigint {
+  let value = 0n;
+
+  for (const [index, byte] of bytes.entries()) {
+    value |= BigInt(byte) << BigInt(8 * index);
+  }
+
+  return value;
+}

--- a/src/service/athena/engine/sim-athena-murmur3-mixing.ts
+++ b/src/service/athena/engine/sim-athena-murmur3-mixing.ts
@@ -1,0 +1,64 @@
+import {
+  hashWord as word,
+  rotateWord as rotate,
+} from "./sim-athena-hash-words.js";
+
+/** The two accumulators MurmurHash3 carries, the low half first. */
+export type SimAthenaMurmurHalves = readonly [bigint, bigint];
+
+const constant1 = 0x87_c3_7b_91_11_42_53_d5n;
+const constant2 = 0x4c_f5_ad_43_27_45_93_7fn;
+
+/** Two words scrambled into the keys one round mixes in. */
+export function murmurKeys(low: bigint, high: bigint): SimAthenaMurmurHalves {
+  return [
+    scramble(low, constant1, 31, constant2),
+    scramble(high, constant2, 33, constant1),
+  ];
+}
+
+/**
+ * Both accumulators taken through one round, the low half leading.
+ *
+ * The high half is crossed with the low half the round has just written, which
+ * is what carries a block into every later one.
+ */
+export function murmurRound(
+  halves: SimAthenaMurmurHalves,
+  keys: SimAthenaMurmurHalves,
+): SimAthenaMurmurHalves {
+  const low = mixed(halves[0] ^ keys[0], halves[1], 27, 0x52_dc_e7_29n);
+
+  return [low, mixed(halves[1] ^ keys[1], low, 31, 0x38_49_5a_b5n)];
+}
+
+/** Each accumulator with the other added into it, the low half first. */
+export function murmurCrossed(
+  halves: SimAthenaMurmurHalves,
+): SimAthenaMurmurHalves {
+  const low = (halves[0] + halves[1]) & word;
+
+  return [low, (halves[1] + low) & word];
+}
+
+/** The final mix, which spreads every bit of one half over its word. */
+export function murmurAvalanche(value: bigint): bigint {
+  let spread = ((value ^ (value >> 33n)) * 0xff_51_af_d7_ed_55_8c_cdn) & word;
+
+  spread = ((spread ^ (spread >> 33n)) * 0xc4_ce_b9_fe_1a_85_ec_53n) & word;
+
+  return spread ^ (spread >> 33n);
+}
+
+function scramble(
+  value: bigint,
+  before: bigint,
+  by: number,
+  after: bigint,
+): bigint {
+  return (rotate((value * before) & word, by) * after) & word;
+}
+
+function mixed(half: bigint, other: bigint, by: number, added: bigint): bigint {
+  return ((rotate(half, by) + other) * 5n + added) & word;
+}

--- a/src/service/athena/engine/sim-athena-murmur3.ts
+++ b/src/service/athena/engine/sim-athena-murmur3.ts
@@ -1,0 +1,76 @@
+import { partialWord } from "./sim-athena-hash-words.js";
+import {
+  murmurAvalanche,
+  murmurCrossed,
+  murmurKeys,
+  murmurRound,
+  type SimAthenaMurmurHalves,
+} from "./sim-athena-murmur3-mixing.js";
+
+/** How many bytes one round of the body reads. */
+const block = 16;
+
+/**
+ * The 128-bit MurmurHash3 of these bytes, seeded with zero, as Trino's
+ * `murmur3` seeds it.
+ *
+ * This is the x64 variant, which answers differently from the x86 one of the
+ * same width. Trino writes each half of the answer little-endian, which is what
+ * makes `to_hex(murmur3(from_hex('69A69A69')))` read as
+ * `BA5855635569B42F4920372CA0E396EF`. That is the one worked example Trino's
+ * own documentation carries.
+ */
+export function simAthenaMurmur3(bytes: Uint8Array): Uint8Array {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const body = bytes.length - (bytes.length % block);
+  let halves: SimAthenaMurmurHalves = [0n, 0n];
+
+  for (let at = 0; at < body; at += block) {
+    halves = murmurRound(
+      halves,
+      murmurKeys(view.getBigUint64(at, true), view.getBigUint64(at + 8, true)),
+    );
+  }
+
+  return written(finish(halves, bytes.subarray(body), bytes.length));
+}
+
+/**
+ * Whatever the body left over, then the final mix over both accumulators.
+ *
+ * The tail bytes are read low to high, which is the little-endian read of a
+ * partial word. Neither half is rotated for them and neither is crossed with
+ * the other, and a tail short enough to leave a half empty scrambles a zero
+ * into it, which changes nothing.
+ */
+function finish(
+  halves: SimAthenaMurmurHalves,
+  tail: Uint8Array,
+  length: number,
+): SimAthenaMurmurHalves {
+  const keys = murmurKeys(
+    partialWord(tail.subarray(0, 8)),
+    partialWord(tail.subarray(8)),
+  );
+  const counted = BigInt(length);
+  const carried = murmurCrossed([
+    halves[0] ^ keys[0] ^ counted,
+    halves[1] ^ keys[1] ^ counted,
+  ]);
+
+  return murmurCrossed([
+    murmurAvalanche(carried[0]),
+    murmurAvalanche(carried[1]),
+  ]);
+}
+
+/** Both halves as bytes, each one written little-endian, as Trino writes them. */
+function written(halves: SimAthenaMurmurHalves): Uint8Array {
+  const digest = new Uint8Array(block);
+  const view = new DataView(digest.buffer);
+
+  view.setBigUint64(0, halves[0], true);
+  view.setBigUint64(8, halves[1], true);
+
+  return digest;
+}

--- a/src/service/athena/engine/sim-athena-shim-registry.ts
+++ b/src/service/athena/engine/sim-athena-shim-registry.ts
@@ -17,11 +17,23 @@ export function simAthenaScalarShim(
   name: string,
   implementation: SimAthenaScalarShim,
 ): void {
-  database.function(
-    name,
-    { varargs: true, deterministic: true },
-    implementation,
+  database.function(name, { varargs: true, deterministic: true }, (...values) =>
+    withEmptyBytes(implementation(...values)),
   );
+}
+
+/**
+ * One answer, with an empty `varbinary` written so that SQLite keeps it.
+ *
+ * `node:sqlite` reads a zero length typed array as SQL NULL where its backing
+ * store carries no pointer, and `TextEncoder` answers with exactly that over an
+ * empty string. Copying those bytes gives the empty blob back, and `to_utf8('')`
+ * then answers the empty `varbinary` Trino answers with rather than a null.
+ */
+function withEmptyBytes(answered: SQLInputValue): SQLInputValue {
+  return answered instanceof Uint8Array && answered.length === 0
+    ? Buffer.alloc(0)
+    : answered;
 }
 
 /**
@@ -56,4 +68,24 @@ export function shimNumber(
   const parsed = Number(value);
 
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * One argument as bytes, or nothing where it is null.
+ *
+ * The binary functions take a `varbinary`, and Trino refuses text where one is
+ * wanted rather than converting it. SQLite has no such analysis to run, so a
+ * column of text reaching `sha256` without a `to_utf8` around it is hashed as
+ * its UTF-8 bytes, which is what the missing call would have produced.
+ */
+export function shimBytes(
+  value: SQLOutputValue | undefined,
+): Uint8Array | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  return value instanceof Uint8Array
+    ? value
+    : new TextEncoder().encode(String(value));
 }

--- a/src/service/athena/engine/sim-athena-shims.ts
+++ b/src/service/athena/engine/sim-athena-shims.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 
 import { simAthenaInstallAggregateShims } from "./sim-athena-aggregate-shims.js";
 import { simAthenaInstallArrayShims } from "./sim-athena-array-shims.js";
+import { simAthenaInstallBinaryShims } from "./sim-athena-binary-shims.js";
 import { simAthenaInstallClockShims } from "./sim-athena-clock-shims.js";
 import { simAthenaInstallDateArithmeticShims } from "./sim-athena-date-arithmetic-shims.js";
 import { simAthenaInstallDateShims } from "./sim-athena-date-shims.js";
@@ -30,6 +31,7 @@ export function simAthenaInstallShims(
   simAthenaInstallJsonDocumentShims(database);
   simAthenaInstallArrayShims(database);
   simAthenaInstallStringShims(database);
+  simAthenaInstallBinaryShims(database);
   simAthenaInstallRegexpShims(database);
   simAthenaInstallUrlShims(database);
   simAthenaInstallAggregateShims(database);

--- a/src/service/athena/engine/sim-athena-sql-rewrites.ts
+++ b/src/service/athena/engine/sim-athena-sql-rewrites.ts
@@ -1,3 +1,5 @@
+import { simAthenaCountDistinct } from "./sim-athena-count-distinct.js";
+
 /** What a statement asks for, once the parser's grammar has been worked around. */
 export interface SimAthenaParserSql {
   readonly sql: string;
@@ -18,14 +20,16 @@ const withOrdinality = /\s+WITH\s+ORDINALITY\b/giu;
 /**
  * The statement as the parser's Athena grammar will take it.
  *
- * The two rewrites close a gap in that grammar rather than a gap in SQLite.
+ * Every rewrite here closes a gap in that grammar rather than a gap in SQLite.
  * `try_cast` becomes a plain cast, which changes meaning in the forgiving
  * direction, since SQLite already answers with a value where a cast fails
  * rather than failing the query. Trino writes `OFFSET` before `LIMIT` and every
- * other dialect writes it after.
+ * other dialect writes it after. `count(DISTINCT <expression>)` becomes a call
+ * to an aggregate of the simulator's own, since the grammar takes a column
+ * after `DISTINCT` and nothing else.
  */
 export function simAthenaSqlForParser(sql: string): SimAthenaParserSql {
-  const rewritten = sql
+  const rewritten = simAthenaCountDistinct(sql)
     .replaceAll(/\btry_cast\s*\(/giu, "CAST(")
     .replaceAll(
       /\bOFFSET\s+(\d+)\s+LIMIT\s+(\d+)/giu,

--- a/src/service/athena/engine/sim-athena-xxhash64.ts
+++ b/src/service/athena/engine/sim-athena-xxhash64.ts
@@ -1,0 +1,118 @@
+import {
+  hashWord as word,
+  rotateWord as rotate,
+} from "./sim-athena-hash-words.js";
+
+const prime1 = 11_400_714_785_074_694_791n;
+const prime2 = 14_029_467_366_897_019_727n;
+const prime3 = 1_609_587_929_392_839_161n;
+const prime4 = 9_650_029_242_287_828_579n;
+const prime5 = 2_870_177_450_012_600_261n;
+
+/** How many bytes one round of the four-lane body reads. */
+const stripe = 32;
+
+/**
+ * The xxHash64 of these bytes, seeded with zero, as Trino's `xxhash64` seeds
+ * it.
+ *
+ * Trino answers with the eight bytes of the hash written big-endian, which is
+ * what makes `to_hex(xxhash64(to_utf8('hello')))` read as `26C7827D889F6DA3`.
+ */
+export function simAthenaXxHash64(bytes: Uint8Array): Uint8Array {
+  const digest = new Uint8Array(8);
+
+  new DataView(digest.buffer).setBigUint64(0, hashOf(bytes), false);
+
+  return digest;
+}
+
+function hashOf(bytes: Uint8Array): bigint {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const body = bytes.length - (bytes.length % stripe);
+  let hash = bytes.length < stripe ? prime5 : mixedLanes(view, body);
+
+  hash = (hash + BigInt(bytes.length)) & word;
+
+  return avalanche(tail(view, bytes, hash, body));
+}
+
+/**
+ * The four lanes the body is read into, mixed back down to one word.
+ *
+ * Each lane takes every fourth eight bytes, which is what lets the real
+ * implementation read four of them at once.
+ */
+function mixedLanes(view: DataView, body: number): bigint {
+  let lanes = [
+    { value: (prime1 + prime2) & word, rotation: 1 },
+    { value: prime2, rotation: 7 },
+    { value: 0n, rotation: 12 },
+    { value: -prime1 & word, rotation: 18 },
+  ];
+
+  for (let at = 0; at < body; at += stripe) {
+    lanes = lanes.map((lane, index) => ({
+      ...lane,
+      value: round(lane.value, view.getBigUint64(at + index * 8, true)),
+    }));
+  }
+
+  let hash = lanes.reduce(
+    (sum, lane) => (sum + rotate(lane.value, lane.rotation)) & word,
+    0n,
+  );
+
+  for (const lane of lanes) {
+    hash = ((hash ^ round(0n, lane.value)) * prime1 + prime4) & word;
+  }
+
+  return hash;
+}
+
+/**
+ * Whatever the body left over, read eight bytes at a time, then four, then one.
+ */
+function tail(
+  view: DataView,
+  bytes: Uint8Array,
+  hash: bigint,
+  body: number,
+): bigint {
+  let mixed = hash;
+  let at = body;
+
+  for (; at + 8 <= bytes.length; at += 8) {
+    const lane = round(0n, view.getBigUint64(at, true));
+
+    mixed = (rotate(mixed ^ lane, 27) * prime1 + prime4) & word;
+  }
+
+  if (at + 4 <= bytes.length) {
+    const lane = (BigInt(view.getUint32(at, true)) * prime1) & word;
+
+    mixed = (rotate(mixed ^ lane, 23) * prime2 + prime3) & word;
+    at += 4;
+  }
+
+  for (; at < bytes.length; at += 1) {
+    const lane = (BigInt(view.getUint8(at)) * prime5) & word;
+
+    mixed = (rotate(mixed ^ lane, 11) * prime1) & word;
+  }
+
+  return mixed;
+}
+
+/** The final mix, which spreads every bit of the accumulator over the word. */
+function avalanche(hash: bigint): bigint {
+  let mixed = ((hash ^ (hash >> 33n)) * prime2) & word;
+
+  mixed = ((mixed ^ (mixed >> 29n)) * prime3) & word;
+
+  return mixed ^ (mixed >> 32n);
+}
+
+function round(lane: bigint, input: bigint): bigint {
+  return (rotate((lane + input * prime2) & word, 31) * prime1) & word;
+}

--- a/src/service/athena/sim-athena-engine-functions.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-functions.iso.test.ts
@@ -124,3 +124,131 @@ describe("the Trino functions a query reaches for", () => {
     assertObjectEquals(answered.rows, [["declared"]]);
   });
 });
+
+const visits = [
+  { c_ip: "198.51.100.7", cs_user_agent: "Firefox" },
+  { c_ip: "198.51.100.7", cs_user_agent: "Firefox" },
+  { c_ip: "198.51.100.7", cs_user_agent: "Safari" },
+  { c_ip: "203.0.113.4", cs_user_agent: "Safari" },
+];
+
+/** A simulation holding the access log rows, with the engine on. */
+async function aVisitSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "visits",
+    columns: [
+      { Name: "c_ip", Type: "string" },
+      { Name: "cs_user_agent", Type: "string" },
+    ],
+  });
+
+  await aSeededJson(simulation.simAws, "visits/part-0.json", visits);
+  await simulation.simAws.athena().engine().enable();
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["fallback"], rows: [["declared"]] });
+
+  return simulation;
+}
+
+describe("counting unique visitors from a salted digest", () => {
+  it("hashes each visitor and counts the digests", async () => {
+    // Given four rows carrying three distinct address and agent pairs.
+    const simulation = await aVisitSimulation();
+
+    // When they are counted the way an analytics query counts a visitor,
+    // hashing the pair behind a salt so no address is kept.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(DISTINCT to_hex(sha256(to_utf8(" +
+        "concat('pepper', '|', c_ip, '|', cs_user_agent))))) AS visitors " +
+        "FROM rainlytics.visits",
+    );
+
+    // Then the engine answers it, and three distinct pairs come to three
+    // distinct digests.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["3"]]);
+  });
+
+  it("counts a distinct expression as well as a distinct column", async () => {
+    // Given the same rows.
+    const simulation = await aVisitSimulation();
+
+    // When each of the three shapes of count is asked for.
+    const column = await anAnsweredQuery(
+      simulation,
+      "SELECT count(DISTINCT c_ip) AS v FROM rainlytics.visits",
+    );
+    const expression = await anAnsweredQuery(
+      simulation,
+      "SELECT count(DISTINCT concat(c_ip, '|', cs_user_agent)) AS v " +
+        "FROM rainlytics.visits",
+    );
+    const approximate = await anAnsweredQuery(
+      simulation,
+      "SELECT approx_distinct(concat(c_ip, '|', cs_user_agent)) AS v " +
+        "FROM rainlytics.visits",
+    );
+
+    // Then all three run. The parser's Athena grammar takes a column after
+    // DISTINCT and nothing else, so the middle one is rewritten onto an
+    // aggregate of the simulator's own rather than turned down.
+    assertObjectEquals(column.rows, [["2"]]);
+    assertObjectEquals(expression.rows, [["3"]]);
+    assertObjectEquals(approximate.rows, [["3"]]);
+  });
+
+  it("counts distinct digests by their bytes", async () => {
+    // Given the same rows.
+    const simulation = await aVisitSimulation();
+
+    // When the digests are counted without a `to_hex` around them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(DISTINCT sha256(to_utf8(concat(c_ip, cs_user_agent)))) " +
+        "AS visitors FROM rainlytics.visits",
+    );
+
+    // Then the count is the same three. A digest is a blob here, and two rows
+    // carrying the same bytes are one value.
+    assertObjectEquals(answered.rows, [["3"]]);
+  });
+
+  it("turns down a statement whose parentheses do not close", async () => {
+    // Given the same rows.
+    const simulation = await aVisitSimulation();
+
+    // When a query leaves a parenthesis open.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(DISTINCT lower(c_ip) FROM rainlytics.visits",
+    );
+
+    // Then the declaration answers it. The rewrite finds no closing
+    // parenthesis, leaves the call as it was written, and the parser refuses
+    // the statement.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("leaves a count written inside a string literal alone", async () => {
+    // Given the same rows.
+    const simulation = await aVisitSimulation();
+
+    // When a query compares a column against text that reads like one of
+    // these calls.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT count(DISTINCT lower(c_ip)) AS v FROM rainlytics.visits " +
+        "WHERE cs_user_agent <> 'count(DISTINCT lower(x))'",
+    );
+
+    // Then the rewrite reaches the call and not the literal, so the
+    // comparison is still made against the text somebody wrote.
+    assertObjectEquals(answered.rows, [["2"]]);
+  });
+});


### PR DESCRIPTION
The simulated Athena engine had no shim for Trino's hashing functions or for the binary encodings
that feed them, so `to_hex(sha256(to_utf8(...)))` fell back to whatever a test had declared. The
engine now carries `md5`, `sha1`, `sha256`, `sha512`, `xxhash64`, `murmur3` and `crc32`, along with
`to_hex`, `from_hex`, `to_base64`, `from_base64`, `to_utf8` and `from_utf8`. A `varbinary` lives in
SQLite as a blob, so a digest travels as bytes and two rows carrying the same digest count as one
value. Node has every digest apart from xxHash64 and MurmurHash3, and both of those are written out
by hand and checked against published vectors, against Trino's own tests and against Austin
Appleby's reference implementation.

`count(DISTINCT <expression>)` runs as well. The parser's Athena grammar takes a column after
`DISTINCT` and refuses anything else, so that call is rewritten onto an aggregate of the simulator's
own before the statement is read. A plain column is left alone and SQLite counts it, and a call
written inside a string literal is left alone as well.

Two things the issue did not ask for are in here. `to_base64` and `from_base64` complete the
encoding row of Trino's binary functions table, and they are what Trino's own worked example for
`murmur3` is written in terms of. `simAthenaScalarShim` now copies a zero length byte array on its
way back to SQLite, because `node:sqlite` reads the empty array `TextEncoder` returns as SQL NULL
and `to_utf8('')` would otherwise answer null.

A `varbinary` in a result row still reads as its bytes decoded as UTF-8, which loses whatever in a
digest was no UTF-8. Athena's own rendering of a bare `varbinary` is not documented anywhere I could
check, so that is left as it was and written down as a limitation, with `to_hex` and `to_base64` as
the way to read one.

Resolves #1082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Athena-compatible binary hashing, checksum, encoding, decoding, and UTF-8 conversion support.
  * Added support for exact and approximate distinct counts, including expressions.
  * Preserved empty binary results and improved null and invalid-input handling.
* **Bug Fixes**
  * Improved compatibility with Trino-compatible hash outputs and invalid UTF-8 behavior.
* **Documentation**
  * Documented supported binary functions, distinct-count behavior, encoding rules, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->