### PR TITLE
fix: serialise the delivery failure message

### DIFF
--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -973,6 +973,9 @@ console.log(failure?.message);
 A target that names nothing reads differently from one whose policy said no, because a policy saying
 no is a modelled outcome a test may be asking for on purpose.
 
+`JSON.stringify` on a failure carries the message alongside the rule, the target and the event it
+names.
+
 ## Permissions
 
 Most operations are authorized by simulated IAM against the bus ARN. The two that name no bus

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -235,6 +235,9 @@ console.log(failure?.message);
 //  allow scheduler.amazonaws.com to assume it, ..."
 ```
 
+`JSON.stringify` on a failure carries the message alongside the schedule, the target, the role and
+the instant it names.
+
 ### One-time schedules and what happens after
 
 An `at(...)` schedule fires once and then stops. By default it stays in the Account afterwards, which

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-failure.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-failure.iso.test.ts
@@ -1,4 +1,4 @@
-import { assertIdentical } from "@kensio/smartass";
+import { assertIdentical, assertObjectMatches } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimEventBridgeDeliveryFailures } from "./sim-event-bridge-delivery-failures.js";
 
@@ -21,5 +21,34 @@ describe("EventBridge delivery failure", () => {
     // know what a target threw.
     assertIdentical(failures.all[0]?.message, "the queue said no");
     assertIdentical(failures.all[1]?.message, "the queue said no, rudely");
+  });
+
+  it("carries the message into JSON", () => {
+    // Given a delivery that failed with an Error, whose own message property
+    // is not enumerable and so does not serialise on its own.
+    const failures = new SimEventBridgeDeliveryFailures();
+
+    failures.record({
+      ruleName: "orders",
+      ruleArn: "arn:aws:events:us-east-1:888888888888:rule/orders",
+      targetId: "queue",
+      targetArn: "arn:aws:sqs:us-east-1:888888888888:orders",
+      eventId: "0f2c9d6e",
+      error: new Error("the queue said no"),
+    });
+
+    // When the failure is serialised. That is the first thing to reach for
+    // when a target received nothing.
+    const serialised = JSON.stringify(failures.all[0]);
+    const read: unknown = JSON.parse(serialised);
+
+    // Then the message is there alongside the fields naming the delivery.
+    assertObjectMatches(read, {
+      ruleName: "orders",
+      targetId: "queue",
+      targetArn: "arn:aws:sqs:us-east-1:888888888888:orders",
+      eventId: "0f2c9d6e",
+      message: "the queue said no",
+    });
   });
 });

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-failures.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-failures.ts
@@ -8,6 +8,14 @@ interface SimEventBridgeDeliveryFailureProperties {
 }
 
 /**
+ * A failed delivery as it serialises. Every property the failure holds, plus
+ * the message the getter reads off the error.
+ */
+export interface SimEventBridgeDeliveryFailureJson extends SimEventBridgeDeliveryFailureProperties {
+  readonly message: string;
+}
+
+/**
  * One event a rule could not get to one of its targets.
  */
 export class SimEventBridgeDeliveryFailure {
@@ -36,6 +44,26 @@ export class SimEventBridgeDeliveryFailure {
     }
 
     return String(this.error);
+  }
+
+  /**
+   * The failure as JSON.stringify renders it, message included.
+   *
+   * Serialising a failure is the first thing to reach for when a target
+   * received nothing. The message is a getter on the prototype and would be
+   * left out. An Error keeps its own message on a non-enumerable property and
+   * prints as `{}`.
+   */
+  toJSON(): SimEventBridgeDeliveryFailureJson {
+    return {
+      ruleName: this.ruleName,
+      ruleArn: this.ruleArn,
+      targetId: this.targetId,
+      targetArn: this.targetArn,
+      eventId: this.eventId,
+      message: this.message,
+      error: this.error,
+    };
   }
 }
 

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-failure.iso.test.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-failure.iso.test.ts
@@ -1,0 +1,68 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSchedulerDeliveryFailures } from "./sim-scheduler-delivery-failures.js";
+
+const recorded = {
+  scheduleName: "probe",
+  scheduleArn:
+    "arn:aws:scheduler:us-east-1:888888888888:schedule/default/probe",
+  targetArn: "arn:aws:lambda:us-east-1:888888888888:function:reconcile",
+  roleArn: "arn:aws:iam::888888888888:role/SchedulerRole",
+  at: new Date("2026-07-26T10:00:00.000Z"),
+};
+
+describe("Scheduler delivery failure", () => {
+  it("reads a message off whatever the invocation threw", () => {
+    // Given invocations that failed with an Error and with something else.
+    const failures = new SimSchedulerDeliveryFailures();
+
+    failures.record({ ...recorded, error: new Error("the role said no") });
+    failures.record({ ...recorded, error: "the role said no, rudely" });
+
+    // Then both read as a message. A test asserting on one does not have to
+    // know what a target threw, and the error it threw is still there to look
+    // at.
+    const [thrown, rude] = failures.all;
+
+    assertNonNullable(thrown);
+    assertNonNullable(rude);
+    assertIdentical(thrown.message, "the role said no");
+    assertIdentical(rude.message, "the role said no, rudely");
+    assertIdentical(rude.error, "the role said no, rudely");
+  });
+
+  it("carries the message into JSON", () => {
+    // Given an invocation that failed with an Error, whose own message
+    // property is not enumerable and so does not serialise on its own.
+    const failures = new SimSchedulerDeliveryFailures();
+
+    failures.record({
+      ...recorded,
+      error: new Error(
+        "arn:aws:iam::888888888888:role/SchedulerRole is not a simulated " +
+          "IAM role",
+      ),
+    });
+
+    // When the failure is serialised. That is the first thing to reach for
+    // when a schedule did not do what a test expected.
+    const serialised = JSON.stringify(failures.all[0]);
+    const read: unknown = JSON.parse(serialised);
+
+    // Then the message is there alongside the fields naming the invocation.
+    assertObjectMatches(read, {
+      scheduleName: "probe",
+      scheduleArn: recorded.scheduleArn,
+      targetArn: recorded.targetArn,
+      roleArn: recorded.roleArn,
+      at: "2026-07-26T10:00:00.000Z",
+      message:
+        "arn:aws:iam::888888888888:role/SchedulerRole is not a simulated " +
+        "IAM role",
+    });
+  });
+});

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-failures.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-failures.ts
@@ -8,6 +8,14 @@ interface SimSchedulerDeliveryFailureProperties {
 }
 
 /**
+ * A failed invocation as it serialises. Every property the failure holds, plus
+ * the message the getter reads off the error.
+ */
+export interface SimSchedulerDeliveryFailureJson extends SimSchedulerDeliveryFailureProperties {
+  readonly message: string;
+}
+
+/**
  * One invocation a schedule could not make.
  */
 export class SimSchedulerDeliveryFailure {
@@ -46,6 +54,26 @@ export class SimSchedulerDeliveryFailure {
     }
 
     return String(this.error);
+  }
+
+  /**
+   * The failure as JSON.stringify renders it, message included.
+   *
+   * Serialising a failure is the first thing to reach for when a schedule did
+   * not do what a test expected. The message is a getter on the prototype and
+   * would be left out. An Error keeps its own message on a non-enumerable
+   * property and prints as `{}`.
+   */
+  toJSON(): SimSchedulerDeliveryFailureJson {
+    return {
+      scheduleName: this.scheduleName,
+      scheduleArn: this.scheduleArn,
+      targetArn: this.targetArn,
+      roleArn: this.roleArn,
+      at: this.at,
+      message: this.message,
+      error: this.error,
+    };
   }
 }
 

--- a/src/service/scheduler/index.ts
+++ b/src/service/scheduler/index.ts
@@ -23,7 +23,10 @@ export {
   simSchedulerServicePrincipal,
   type SimSchedulerDeliveryTargets,
 } from "./delivery/sim-scheduler-delivery.js";
-export { SimSchedulerDeliveryFailure } from "./delivery/sim-scheduler-delivery-failures.js";
+export {
+  SimSchedulerDeliveryFailure,
+  type SimSchedulerDeliveryFailureJson,
+} from "./delivery/sim-scheduler-delivery-failures.js";
 export {
   SimSchedulerDeliveryNotPermitted,
   SimSchedulerTargetNotFound,


### PR DESCRIPTION
`JSON.stringify` on a Scheduler or EventBridge delivery failure returned the schedule, the target and the role with the cause hollowed out. The message is a getter on the prototype and an `Error` keeps its own message on a non-enumerable own property, so neither reached the output. Both failures now answer `toJSON` with the message alongside the fields they already printed. The getter and the `error` property are unchanged.

Resolves #1091

@coderabbitai ignore