### PR TITLE
fix: ship the Oxlint config in the package root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,10 @@ scripts/input/*
 .cache-loader
 src/docs/docs/api/*.mdx
 
+# The published Oxlint config fragment, written into the package root by the
+# build so that a consumer's `extends` path does not go through `dist/`.
+/cffjs2.oxlintrc.json
+
 # Misc
 .DS_Store
 

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -53,9 +53,7 @@ places.
 
 ```json
 {
-  "extends": [
-    "./node_modules/@kensio/yulin/dist/config/oxlint/cffjs2.oxlintrc.json"
-  ],
+  "extends": ["./node_modules/@kensio/yulin/cffjs2.oxlintrc.json"],
   "rules": {
     "no-console": "error"
   }
@@ -63,8 +61,9 @@ places.
 ```
 
 Oxlint's `extends` takes a file path rather than a package name. The path into `node_modules` is
-written out in full. The fragment brings its own `overrides` entry scoped to `**/*.cff.js` and the
-JS plugin the rules live in, and leaves every other file to your own rules.
+written out in full. The file sits in the package root. A build that moves what it emits under
+`dist/` leaves the path alone. The fragment brings its own `overrides` entry scoped to `**/*.cff.js`
+and the JS plugin the rules live in, and leaves every other file to your own rules.
 
 The plugin is loaded through Oxlint's JS plugin support, which needs Oxlint 1.77 or later.
 
@@ -134,9 +133,7 @@ In Oxlint, the same thing goes in an `overrides` entry after the `extends`:
 
 ```json
 {
-  "extends": [
-    "./node_modules/@kensio/yulin/dist/config/oxlint/cffjs2.oxlintrc.json"
-  ],
+  "extends": ["./node_modules/@kensio/yulin/cffjs2.oxlintrc.json"],
   "overrides": [
     {
       "files": ["**/*.cff.js"],
@@ -151,7 +148,7 @@ In Oxlint, the same thing goes in an `overrides` entry after the `extends`:
 ## Available functionality
 
 - A flat ESLint config at `@kensio/yulin/eslint`, exported as `cloudFrontFunctionsJs2`
-- An Oxlint config fragment at `dist/config/oxlint/cffjs2.oxlintrc.json`, with the object it is
+- An Oxlint config fragment at `cffjs2.oxlintrc.json` in the package root, with the object it is
   generated from exported as `cloudFrontFunctionsJs2Oxlint` from `@kensio/yulin/oxlint`
 - Nine `cff-js2` rules, one per restriction, shared by both linters
 - Scoping to `**/*.cff.js`, leaving a repository's own rules untouched elsewhere

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "yulin": "./dist/cli/yulin.js"
   },
   "scripts": {
-    "clean": "rm -rf ./dist/ ./*.tsbuildinfo",
+    "clean": "rm -rf ./dist/ ./*.tsbuildinfo ./cffjs2.oxlintrc.json",
     "build": "pnpm clean && tsc -p tsconfig.build.json && pnpm oxlint:config",
     "oxlint:config": "pnpm tsx scripts/mts/write-oxlint-config.mts",
     "build:check": "tsc -p tsconfig.json --noEmit",
@@ -140,7 +140,7 @@
       "import": "./dist/config/oxlint/index.js",
       "types": "./dist/config/oxlint/index.d.ts"
     },
-    "./oxlint/cffjs2.oxlintrc.json": "./dist/config/oxlint/cffjs2.oxlintrc.json",
+    "./oxlint/cffjs2.oxlintrc.json": "./cffjs2.oxlintrc.json",
     "./package.json": "./package.json",
     "./organizations": {
       "import": "./dist/service/organizations/index.js",
@@ -213,6 +213,7 @@
   },
   "files": [
     "dist",
+    "cffjs2.oxlintrc.json",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/mts/verify-pack-consumer.mts
+++ b/scripts/mts/verify-pack-consumer.mts
@@ -8,9 +8,10 @@
  */
 
 import { execa } from "execa";
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { isFile } from "./verify-pack-files.mjs";
 import type {
   ImportResult,
   PackageManifest,
@@ -147,16 +148,6 @@ export async function findMissingTypes(
   }
 
   return missing;
-}
-
-async function isFile(filePath: string): Promise<boolean> {
-  try {
-    const entry = await stat(filePath);
-
-    return entry.isFile();
-  } catch {
-    return false;
-  }
 }
 
 /** Imports each subpath in a child process running inside the consumer. */

--- a/scripts/mts/verify-pack-files.mts
+++ b/scripts/mts/verify-pack-files.mts
@@ -1,0 +1,110 @@
+/**
+ * The checks for what the package publishes as files rather than as modules.
+ *
+ * An export naming a JSON file is not something the import check can reach,
+ * and the Oxlint config fragment is named by path from a consumer's own config
+ * rather than imported at all. Both are checked against the installed tarball.
+ */
+
+import { readFile, stat } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import type { FileExport, PackageManifest } from "./verify-pack.type.mjs";
+
+/** The Oxlint config fragment, as it sits in the published package root. */
+const oxlintConfigFileName = "cffjs2.oxlintrc.json";
+
+/**
+ * Resolves every string-valued export the way a consumer would.
+ *
+ * These are files rather than modules, so the import check cannot reach them,
+ * and a target that no longer exists in the tarball shows up nowhere else.
+ */
+export function assertFileExportsResolve(
+  consumerDirectory: string,
+  fileExports: readonly FileExport[],
+): void {
+  const consumerRequire = createRequire(
+    path.join(consumerDirectory, "resolve-file-exports.cjs"),
+  );
+
+  const unresolvable = fileExports.filter((fileExport) => {
+    try {
+      consumerRequire.resolve(fileExport.specifier);
+
+      return false;
+    } catch {
+      return true;
+    }
+  });
+
+  if (unresolvable.length > 0) {
+    throw new Error(
+      `Export subpaths naming a file the tarball does not have:\n${unresolvable
+        .map(
+          (fileExport) => `  ${fileExport.specifier} -> ${fileExport.target}`,
+        )
+        .join("\n")}`,
+    );
+  }
+
+  console.log(
+    `All ${String(fileExports.length)} file export subpaths resolve from the tarball.`,
+  );
+}
+
+/**
+ * Checks the Oxlint config at the path a consumer writes into `extends`.
+ *
+ * Oxlint has no package-name resolution there, so a consumer names this file
+ * through `node_modules` and Oxlint resolves the plugin inside it against that
+ * same location. Both halves are checked in the tarball, because a consumer
+ * running Oxlint is the only other place either would be noticed.
+ */
+export async function assertOxlintConfigExtendable(
+  consumerDirectory: string,
+  manifest: PackageManifest,
+): Promise<void> {
+  const configPath = path.join(
+    consumerDirectory,
+    "node_modules",
+    manifest.name,
+    oxlintConfigFileName,
+  );
+
+  if (!(await isFile(configPath))) {
+    throw new Error(
+      `The tarball has no ${oxlintConfigFileName} in its package root, so a consumer's Oxlint \`extends\` has nothing to name.`,
+    );
+  }
+
+  const config = JSON.parse(await readFile(configPath, "utf8")) as {
+    readonly jsPlugins: readonly { readonly specifier: string }[];
+  };
+
+  for (const plugin of config.jsPlugins) {
+    if (
+      !(await isFile(path.resolve(path.dirname(configPath), plugin.specifier)))
+    ) {
+      throw new Error(
+        `${oxlintConfigFileName} names a plugin at ${plugin.specifier}, which is not in the tarball.`,
+      );
+    }
+  }
+
+  console.log(
+    "Oxlint config sits in the package root and finds its own plugin.",
+  );
+}
+
+/** Whether a path exists and is a file, rather than a directory or absent. */
+export async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const entry = await stat(filePath);
+
+    return entry.isFile();
+  } catch {
+    return false;
+  }
+}

--- a/scripts/mts/verify-pack.mts
+++ b/scripts/mts/verify-pack.mts
@@ -26,7 +26,12 @@ import {
   findMissingTypes,
   importSubpaths,
 } from "./verify-pack-consumer.mjs";
+import {
+  assertFileExportsResolve,
+  assertOxlintConfigExtendable,
+} from "./verify-pack-files.mjs";
 import type {
+  FileExport,
   ImportResult,
   PackageManifest,
   Subpath,
@@ -80,6 +85,7 @@ const requiredExports = new Map<string, readonly string[]>([
 async function main(): Promise<void> {
   const manifest = await readManifest();
   const subpaths = collectSubpaths(manifest);
+  const fileExports = collectFileExports(manifest);
 
   const workDirectory = await mkdtemp(
     path.join(os.tmpdir(), "yulin-verify-pack-"),
@@ -104,6 +110,8 @@ async function main(): Promise<void> {
 
     report(results, missingTypes);
 
+    assertFileExportsResolve(consumerDirectory, fileExports);
+    await assertOxlintConfigExtendable(consumerDirectory, manifest);
     await assertTypesUsable(consumerDirectory);
   } finally {
     await rm(workDirectory, { recursive: true, force: true });
@@ -114,6 +122,27 @@ async function readManifest(): Promise<PackageManifest> {
   const raw = await readFile(path.join(projectRoot, "package.json"), "utf8");
 
   return JSON.parse(raw) as PackageManifest;
+}
+
+/**
+ * Every export subpath that names a file rather than a module.
+ *
+ * `collectSubpaths` passes over these, because importing a JSON file is not
+ * what a consumer does with one. They are resolved instead.
+ */
+function collectFileExports(manifest: PackageManifest): readonly FileExport[] {
+  const fileExports: FileExport[] = [];
+
+  for (const [key, target] of Object.entries(manifest.exports)) {
+    if (typeof target === "string") {
+      fileExports.push({
+        specifier: `${manifest.name}${key.slice(1)}`,
+        target,
+      });
+    }
+  }
+
+  return fileExports;
 }
 
 /** Every importable export subpath, excluding plain file exports. */

--- a/scripts/mts/verify-pack.type.mts
+++ b/scripts/mts/verify-pack.type.mts
@@ -13,6 +13,14 @@ export type ExportTarget =
   | string
   | { readonly import: string; readonly types: string };
 
+/** A string-valued export: a file the package publishes under a name. */
+export interface FileExport {
+  /** Specifier a consumer would resolve, e.g. `@kensio/yulin/package.json`. */
+  readonly specifier: string;
+  /** Package-relative path the export points at. */
+  readonly target: string;
+}
+
 export interface Subpath {
   /** Specifier a consumer would import, e.g. `@kensio/yulin/s3`. */
   readonly specifier: string;

--- a/scripts/mts/write-oxlint-config.mts
+++ b/scripts/mts/write-oxlint-config.mts
@@ -1,29 +1,28 @@
 #!/usr/bin/env -S pnpm tsx
 
 /**
- * Writes the published `.oxlintrc.json` into `dist/` from the same rule
- * definitions the ESLint config uses.
+ * Writes the published `.oxlintrc.json` into the package root from the same
+ * rule definitions the ESLint config uses.
  *
  * Oxlint reads JSON, and TypeScript does not emit JSON, so the file has to be
  * produced rather than compiled. Generating it here rather than committing a
  * second copy is what stops the two published configs from drifting: a rule
  * added to the plugin reaches both, or neither.
+ *
+ * It sits in the package root because a consumer extends it by writing its
+ * path into `node_modules` in full, Oxlint having no package-name resolution
+ * in `extends`. A path through `dist/` would put the build's layout in every
+ * consumer's config file.
  */
 
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { cloudFrontFunctionsJs2Oxlint } from "../../src/config/oxlint/index.js";
 
 const projectRoot = path.resolve(import.meta.dirname, "../..");
 
-const outputPath = path.join(
-  projectRoot,
-  "dist",
-  "config",
-  "oxlint",
-  "cffjs2.oxlintrc.json",
-);
+const outputPath = path.join(projectRoot, "cffjs2.oxlintrc.json");
 
 /**
  * Oxlint resolves a plugin specifier against the config file, and finds out it
@@ -38,15 +37,13 @@ async function assertPluginsResolve(): Promise<void> {
       await stat(pluginPath);
     } catch {
       throw new Error(
-        `${outputPath} names a plugin at ${plugin.specifier}, which does not exist in dist/ (looked for ${pluginPath}).`,
+        `${outputPath} names a plugin at ${plugin.specifier}, which the build did not emit (looked for ${pluginPath}).`,
       );
     }
   }
 }
 
 async function main(): Promise<void> {
-  await mkdir(path.dirname(outputPath), { recursive: true });
-
   await writeFile(
     outputPath,
     `${JSON.stringify(cloudFrontFunctionsJs2Oxlint, undefined, 2)}\n`,

--- a/src/config/oxlint/cffjs2.oxlint.config.ts
+++ b/src/config/oxlint/cffjs2.oxlint.config.ts
@@ -19,12 +19,13 @@ export interface OxlintConfig {
 }
 
 /**
- * Where the built plugin sits, relative to the built config that names it.
+ * Where the built plugin sits, relative to the published config that names it.
  *
  * Oxlint resolves a plugin specifier against the config file's own location,
- * so this path is the one inside `dist/`, not the one in the source tree.
+ * and the config is written to the package root, so this path goes down into
+ * `dist/` rather than across the source tree.
  */
-const pluginSpecifier = "../lint/cff-js2-oxlint-plugin.js";
+const pluginSpecifier = "./dist/config/lint/cff-js2-oxlint-plugin.js";
 
 /**
  * Oxlint's half of the CloudFront Functions JS2 lint setup.


### PR DESCRIPTION
@coderabbitai ignore

The CloudFront Functions JS2 Oxlint fragment is written to `cffjs2.oxlintrc.json` in the package root rather than into `dist/`, and the `./oxlint/cffjs2.oxlintrc.json` export points there. Oxlint resolves an `extends` entry as a filesystem path and never as a package specifier, so what a consumer writes is the path through `node_modules` in full, and a path through `dist/` put the build's own layout in every consumer's config file. The plugin specifier inside the fragment now goes down into `dist/` from the root, which is where Oxlint looks for it. `verify-pack` resolves the string-valued exports the way a consumer would and checks the fragment sits in the tarball with its plugin reachable beside it, neither of which the import check could reach.

Resolves #1093