### PR TITLE
fix: resolve dynamic references as the caller

### DIFF
--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -122,11 +122,15 @@ export class SimCfnResourcePropertyResolver {
    * Absent where the caller has no simulation to read from, which is how the
    * resolver is used on its own in tests. A reference then stays in the
    * property as the template wrote it.
+   *
+   * The principal the operation runs as goes with the simulation, so a
+   * reference is read as the deployment's own caller rather than as the
+   * Account root.
    */
   private dynamicReferences(
     context: SimCfnResourceResolveContext,
   ): SimCfnDynamicReferences | undefined {
-    const { simAws } = context;
+    const { simAws, caller } = context;
 
     if (simAws === undefined || this.accountRegionScope === undefined) {
       return undefined;
@@ -134,6 +138,7 @@ export class SimCfnResourcePropertyResolver {
 
     return makeSimCfnDynamicReferences({
       simAws,
+      caller,
       accountRegionScope: this.accountRegionScope,
       propertyIgnorer: this.propertyIgnorer,
       resourceType: this.resourceType,

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -56,6 +56,16 @@ export interface SimCfnResourceResolveContext {
    * another service rather than from the template. A dynamic reference is one.
    */
   readonly simAws?: SimAws | undefined;
+
+  /**
+   * The principal the operation runs as, which a value read out of another
+   * service is authorized as. Real CloudFormation reads a dynamic reference
+   * under the Stack's execution role rather than as the Account root.
+   *
+   * Left out unless the deployment named one, which leaves each service to its
+   * own omitted-caller default of the Account root.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 export interface SimCloudFormationResourceCreateContext {

--- a/src/service/cloudformation/template/dynamic/make-sim-cfn-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/make-sim-cfn-dynamic-references.ts
@@ -1,4 +1,5 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnPropertyIgnorer } from "../../resource/ignore/sim-cfn-ignored-property.type.js";
 import { SimCfnDynamicReferences } from "./sim-cfn-dynamic-references.js";
@@ -7,6 +8,7 @@ import { simCfnDynamicReferenceResolvers } from "./sim-cfn-dynamic-reference-res
 interface MakeSimCfnDynamicReferencesProperties {
   readonly simAws: SimAws;
   readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly caller?: SimAwsCaller | undefined;
   readonly propertyIgnorer?: SimCfnPropertyIgnorer | undefined;
   readonly resourceType?: string | undefined;
 }
@@ -17,7 +19,7 @@ interface MakeSimCfnDynamicReferencesProperties {
 export function makeSimCfnDynamicReferences(
   properties: MakeSimCfnDynamicReferencesProperties,
 ): SimCfnDynamicReferences {
-  const { simAws, accountRegionScope, propertyIgnorer, resourceType } =
+  const { simAws, accountRegionScope, caller, propertyIgnorer, resourceType } =
     properties;
 
   const scopedAws = simAws.accountRegionScope(
@@ -33,7 +35,7 @@ export function makeSimCfnDynamicReferences(
         .entries()
         .map(([service, resolver]) => [
           service,
-          resolver({ simAws, scopedAws }),
+          resolver({ simAws, scopedAws, caller }),
         ]),
     ),
   });

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-caller.iso.test.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-caller.iso.test.ts
@@ -1,0 +1,254 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamUser } from "../../../iam/user/sim-iam-user.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import type { SimCfnDeployedStack } from "../../stack/sim-cfn-deployed-stack.type.js";
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
+
+/**
+ * An organization denying its Accounts' root principals everything, which a
+ * reference resolved as the root fails against and one resolved as a Role
+ * deploying the Stack does not.
+ */
+const denyAccountRoot = {
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { ArnLike: { "aws:PrincipalArn": "arn:aws:iam::*:root" } },
+  },
+} as const;
+
+interface DeploymentAccount {
+  readonly simAws: SimAws;
+  readonly accountId: SimAwsAccountId;
+}
+
+function deploymentAccount(): DeploymentAccount {
+  const accountId = makeSimAwsAccountId();
+
+  return { accountId, simAws: new SimAws({ defaultAccountId: accountId }) };
+}
+
+/**
+ * A Role a deployment can run as, allowed the actions it is given.
+ */
+async function deployRole(
+  simAws: SimAws,
+  roleName: string,
+  actions: readonly string[],
+): Promise<SimAwsCaller> {
+  const role = await simIamRoleWithPolicyFactory.make(
+    { roleName, actions },
+    simAws,
+  );
+
+  return { kind: "arn", arn: role.Arn };
+}
+
+/**
+ * Deploy a parameter holding the value under test, so that whatever the
+ * reference resolved to can be read back out of the simulation.
+ */
+async function deployReading(
+  simAws: SimAws,
+  value: SimCfnTemplateValue,
+  caller?: SimAwsCaller,
+): Promise<SimCfnDeployedStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "site-stack",
+    template: {
+      Resources: {
+        EdgeToken: {
+          Type: "AWS::SSM::Parameter",
+          Properties: {
+            Name: "/site/edge-token",
+            Type: "String",
+            Value: value,
+          },
+        },
+      },
+    },
+    ...(caller !== undefined && { caller }),
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+function readParameter(simAws: SimAws): string | undefined {
+  return simAws.ssm().findParameter("/site/edge-token")?.currentVersion.value
+    .value;
+}
+
+describe("the principal a CloudFormation dynamic reference is resolved as", () => {
+  it("reads a secretsmanager reference as the Role the deployment names", async () => {
+    // Given a secret, a deploy Role allowed everything, and an organization
+    // denying the Account root.
+    const { simAws, accountId } = deploymentAccount();
+    const deployer = await deployRole(simAws, "deployer", ["*"]);
+
+    await simAws.secretsManager().createSecret({
+      input: { Name: "site/edge-token", SecretString: "s3cret" },
+    });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    // When a Stack reading that secret is deployed as the Role.
+    await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:site/edge-token}}",
+      deployer,
+    );
+
+    // Then the reference was read as the Role, so the deny naming the root
+    // never reached it.
+    assertIdentical(readParameter(simAws), "s3cret");
+  });
+
+  it("reads an ssm-secure reference as that Role too", async () => {
+    // Given a SecureString parameter, the same deploy Role, and the same
+    // organization.
+    const { simAws, accountId } = deploymentAccount();
+    const deployer = await deployRole(simAws, "deployer", ["*"]);
+
+    await simAws.ssm().putParameter({
+      input: {
+        Name: "/site/console-password",
+        Type: "SecureString",
+        Value: "hunter2",
+      },
+    });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    // When a Stack reading it into a console User's password is deployed as
+    // the Role.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "console-stack",
+      template: {
+        Resources: {
+          ConsoleUser: {
+            Type: "AWS::IAM::User",
+            Properties: {
+              UserName: "ConsoleUser",
+              LoginProfile: {
+                Password: "{{resolve:ssm-secure:/site/console-password}}",
+              },
+            },
+          },
+        },
+      },
+      caller: deployer,
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the parameter was decrypted as the Role rather than as the root.
+    const user = stack.getResource("ConsoleUser")?.simResource as
+      | SimIamUser
+      | undefined;
+
+    assertNonNullable(user?.loginProfile, "the deployed User's login profile");
+    assertIdentical(user.loginProfile.password, "hunter2");
+  });
+
+  it("leaves a deployment that names no caller reading as the Account root", async () => {
+    // Given the same secret and organization, and no deploy Role.
+    const { simAws, accountId } = deploymentAccount();
+
+    await simAws.secretsManager().createSecret({
+      input: { Name: "site/edge-token", SecretString: "s3cret" },
+    });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    // When a Stack reading the secret is deployed without naming a principal.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployReading(simAws, "{{resolve:secretsmanager:site/edge-token}}");
+    });
+
+    // Then the read was decided as the root, as it was before there was
+    // anything to say otherwise.
+    assertStringIncludes(error.message, `arn:aws:iam::${accountId}:root`);
+    assertStringIncludes(error.message, "secretsmanager:GetSecretValue");
+    assertUndefined(readParameter(simAws));
+  });
+
+  it("fails the Resource when the Role it names may not read the reference", async () => {
+    // Given a secret, and a deploy Role that may write parameters and not read
+    // secrets.
+    const { simAws, accountId } = deploymentAccount();
+    const writer = await deployRole(simAws, "writer", ["ssm:*"]);
+
+    await simAws.secretsManager().createSecret({
+      input: { Name: "site/edge-token", SecretString: "s3cret" },
+    });
+
+    // When a Stack reading that secret is deployed as it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployReading(
+        simAws,
+        "{{resolve:secretsmanager:site/edge-token}}",
+        writer,
+      );
+    });
+
+    // Then the refusal names the Role rather than the Account root.
+    assertStringIncludes(
+      error.message,
+      `arn:aws:iam::${accountId}:role/writer is not authorized to perform: secretsmanager:GetSecretValue`,
+    );
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName("site-stack")
+        ?.getResource("EdgeToken")?.status,
+      "CREATE_FAILED",
+    );
+  });
+
+  it("resolves a reference for teardown as the principal the Stack was deployed as", async () => {
+    // Given a Stack whose properties hold a secret reference, deployed as a
+    // Role in an organization denying the root.
+    const { simAws, accountId } = deploymentAccount();
+    const deployer = await deployRole(simAws, "deployer", ["*"]);
+
+    await simAws.secretsManager().createSecret({
+      input: { Name: "site/edge-token", SecretString: "s3cret" },
+    });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    const stack = await deployReading(
+      simAws,
+      "{{resolve:secretsmanager:site/edge-token}}",
+      deployer,
+    );
+
+    // When the Stack is torn down, which resolves its properties again.
+    await stack.teardown();
+
+    // Then the reference was read as that Role, so the parameter has gone.
+    assertUndefined(readParameter(simAws));
+  });
+});

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
@@ -1,4 +1,5 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
 import { SimCfnSecretsManagerDynamicReferenceResolver } from "../../../secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-resolver.js";
 import type { SimCfnDynamicReferenceResolver } from "./sim-cfn-dynamic-reference.type.js";
@@ -14,6 +15,16 @@ import type { SimCfnDynamicReferenceResolver } from "./sim-cfn-dynamic-reference
 interface SimCfnDynamicReferenceSimulation {
   readonly simAws: SimAws;
   readonly scopedAws: SimAwsAccountRegionContainer;
+
+  /**
+   * The principal the deployment runs as, which the reference is read as. Real
+   * CloudFormation resolves a dynamic reference under the Stack's execution
+   * role, so a Stack deployed as a Role reads what that Role may read.
+   *
+   * Left out unless the deployment named one, which leaves each service to its
+   * own omitted-caller default of the Account root.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -43,18 +54,19 @@ export const simCfnDynamicReferenceResolvers: ReadonlyMap<
   ],
   [
     "ssm-secure",
-    ({ scopedAws }): SimCfnDynamicReferenceResolver =>
-      scopedAws.ssm().cfnSecureDynamicReferenceResolver(),
+    ({ scopedAws, caller }): SimCfnDynamicReferenceResolver =>
+      scopedAws.ssm().cfnSecureDynamicReferenceResolver(caller),
   ],
   [
     "secretsmanager",
-    ({ simAws, scopedAws }): SimCfnDynamicReferenceResolver =>
+    ({ simAws, scopedAws, caller }): SimCfnDynamicReferenceResolver =>
       new SimCfnSecretsManagerDynamicReferenceResolver({
         secretsManager: scopedAws.secretsManager(),
         secretsManagerIn: (scope) =>
           simAws
             .accountRegionScope(scope.accountId, scope.regionName)
             .secretsManager(),
+        caller,
       }),
   ],
 ]);

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-resolver.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-dynamic-reference-resolver.ts
@@ -1,4 +1,9 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type {
   SimCfnDynamicReference,
   SimCfnDynamicReferenceResolution,
@@ -6,10 +11,10 @@ import type {
 } from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
 import { SimSecretsManagerError } from "../../error/sim-secrets-manager.error.js";
 import type { SimSecretsManager } from "../../sim-secrets-manager.js";
-import { simCfnSecretsManagerJsonKeyValue } from "./sim-cfn-secrets-manager-json-key.js";
+import { simCfnSecretsManagerReferenceStandIn } from "./sim-cfn-secrets-manager-reference-stand-in.js";
+import { simCfnSecretsManagerReferenceValue } from "./sim-cfn-secrets-manager-reference-value.js";
 import {
   parseSimCfnSecretsManagerReference,
-  type SimCfnSecretsManagerReference,
   SimCfnSecretsManagerReferenceProblem,
 } from "./sim-cfn-secrets-manager-reference-body.js";
 
@@ -21,17 +26,21 @@ interface SimCfnSecretsManagerDynamicReferenceResolverProperties {
   readonly secretsManagerIn: (
     scope: SimAwsAccountRegionScope,
   ) => SimSecretsManager;
+
+  /** The principal the deployment runs as, which the secret is read as. */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
  * Answers `{{resolve:secretsmanager:...}}` references from simulated Secrets
  * Manager.
  *
- * The secret is read as the caller deploying the Stack would read it, at the
- * point the Resource holding the reference is created. Real CloudFormation
- * makes no dependency out of a dynamic reference, so a secret another Resource
- * of the same Stack creates is only there in time if the template says
- * `DependsOn`.
+ * The secret is read as the principal the deployment names, at the point the
+ * Resource holding the reference is created. A deployment naming none reads as
+ * the Account root, which is Secrets Manager's own default. Real
+ * CloudFormation makes no dependency out of a dynamic reference, so a secret
+ * another Resource of the same Stack creates is only there in time if the
+ * template says `DependsOn`.
  *
  * Reading goes through the ordinary GetSecretValue command, which decrypts the
  * version through simulated KMS, so the answer comes back as a promise. That
@@ -49,11 +58,14 @@ export class SimCfnSecretsManagerDynamicReferenceResolver implements SimCfnDynam
     scope: SimAwsAccountRegionScope,
   ) => SimSecretsManager;
 
+  private readonly callerOptions: SimCfnResourceCallerOptions;
+
   constructor(
     properties: SimCfnSecretsManagerDynamicReferenceResolverProperties,
   ) {
     this.secretsManager = properties.secretsManager;
     this.secretsManagerIn = properties.secretsManagerIn;
+    this.callerOptions = simCfnResourceCallerOptions(properties.caller);
   }
 
   /**
@@ -68,10 +80,20 @@ export class SimCfnSecretsManagerDynamicReferenceResolver implements SimCfnDynam
       const parsed = parseSimCfnSecretsManagerReference(reference.body);
       secretId = parsed.secretId;
 
-      return { value: await this.read(parsed) };
+      return {
+        value: await simCfnSecretsManagerReferenceValue(
+          this.secretsManagerFor(parsed.scope),
+          parsed,
+          this.callerOptions,
+        ),
+      };
     } catch (error) {
       if (error instanceof SimCfnSecretsManagerReferenceProblem) {
-        return this.standIn(reference, secretId, error.message);
+        return simCfnSecretsManagerReferenceStandIn(
+          reference,
+          secretId,
+          error.message,
+        );
       }
 
       /* v8 ignore next 3 -- defensive: only Secrets Manager reaches here */
@@ -79,7 +101,7 @@ export class SimCfnSecretsManagerDynamicReferenceResolver implements SimCfnDynam
         throw error;
       }
 
-      return this.standIn(
+      return simCfnSecretsManagerReferenceStandIn(
         reference,
         secretId,
         `and simulated Secrets Manager could not read it (${error.message})`,
@@ -88,56 +110,14 @@ export class SimCfnSecretsManagerDynamicReferenceResolver implements SimCfnDynam
   }
 
   /**
-   * Read the version the reference selects, or the current one.
+   * The Secrets Manager a reference reads from: the Stack's own, or the one a
+   * full secret ARN names.
    */
-  private async read(
-    reference: SimCfnSecretsManagerReference,
-  ): Promise<string> {
-    const { secretId, scope, jsonKey, versionStage, versionId } = reference;
-    const secretsManager =
-      scope === undefined ? this.secretsManager : this.secretsManagerIn(scope);
-
-    const read = await secretsManager.getSecretValue({
-      input: {
-        SecretId: secretId,
-        VersionStage: versionStage,
-        VersionId: versionId,
-      },
-    });
-
-    const secretString = read.SecretString;
-
-    if (secretString === undefined) {
-      throw new SimCfnSecretsManagerReferenceProblem(
-        `and '${secretId}' holds a binary value, which a dynamic reference ` +
-          `cannot read`,
-      );
-    }
-
-    if (jsonKey === undefined) {
-      return secretString;
-    }
-
-    return simCfnSecretsManagerJsonKeyValue(secretString, secretId, jsonKey);
-  }
-
-  /**
-   * The value a reference Secrets Manager could not answer resolves to.
-   *
-   * The shape follows the `ssm` references beside it, and CDK before them,
-   * which fills an unresolved context lookup with `dummy-value-for-<name>`. A
-   * test reading one back sees where it came from.
-   */
-  private standIn(
-    reference: SimCfnDynamicReference,
-    secretId: string,
-    reason: string,
-  ): SimCfnDynamicReferenceResolution {
-    return {
-      value: `dummy-value-for-${secretId}`,
-      reason:
-        `holds ${reference.text}, ${reason}, so the Resource is created ` +
-        `with a stand-in value`,
-    };
+  private secretsManagerFor(
+    scope: SimAwsAccountRegionScope | undefined,
+  ): SimSecretsManager {
+    return scope === undefined
+      ? this.secretsManager
+      : this.secretsManagerIn(scope);
   }
 }

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-reference-stand-in.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-reference-stand-in.ts
@@ -1,0 +1,24 @@
+import type {
+  SimCfnDynamicReference,
+  SimCfnDynamicReferenceResolution,
+} from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
+
+/**
+ * The value a reference Secrets Manager could not answer resolves to.
+ *
+ * The shape follows the `ssm` references beside it, and CDK before them, which
+ * fills an unresolved context lookup with `dummy-value-for-<name>`. A test
+ * reading one back sees where it came from.
+ */
+export function simCfnSecretsManagerReferenceStandIn(
+  reference: SimCfnDynamicReference,
+  secretId: string,
+  reason: string,
+): SimCfnDynamicReferenceResolution {
+  return {
+    value: `dummy-value-for-${secretId}`,
+    reason:
+      `holds ${reference.text}, ${reason}, so the Resource is created ` +
+      `with a stand-in value`,
+  };
+}

--- a/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-reference-value.ts
+++ b/src/service/secretsmanager/cfn/dynamic/sim-cfn-secrets-manager-reference-value.ts
@@ -1,0 +1,49 @@
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimSecretsManager } from "../../sim-secrets-manager.js";
+import { simCfnSecretsManagerJsonKeyValue } from "./sim-cfn-secrets-manager-json-key.js";
+import {
+  type SimCfnSecretsManagerReference,
+  SimCfnSecretsManagerReferenceProblem,
+} from "./sim-cfn-secrets-manager-reference-body.js";
+
+/**
+ * The secret value one parsed reference names.
+ *
+ * The version the reference selects, or the current one, read through the
+ * ordinary GetSecretValue command as the principal the deployment named. That
+ * decrypts the version through simulated KMS, which is why reading a secret
+ * has to be waited on.
+ */
+export async function simCfnSecretsManagerReferenceValue(
+  secretsManager: SimSecretsManager,
+  reference: SimCfnSecretsManagerReference,
+  callerOptions: SimCfnResourceCallerOptions,
+): Promise<string> {
+  const { secretId, jsonKey, versionStage, versionId } = reference;
+
+  const read = await secretsManager.getSecretValue(
+    {
+      input: {
+        SecretId: secretId,
+        VersionStage: versionStage,
+        VersionId: versionId,
+      },
+    },
+    callerOptions,
+  );
+
+  const secretString = read.SecretString;
+
+  if (secretString === undefined) {
+    throw new SimCfnSecretsManagerReferenceProblem(
+      `and '${secretId}' holds a binary value, which a dynamic reference ` +
+        `cannot read`,
+    );
+  }
+
+  if (jsonKey === undefined) {
+    return secretString;
+  }
+
+  return simCfnSecretsManagerJsonKeyValue(secretString, secretId, jsonKey);
+}

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-resolver.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-secure-dynamic-reference-resolver.ts
@@ -1,4 +1,9 @@
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type {
   SimCfnDynamicReference,
   SimCfnDynamicReferenceResolution,
@@ -16,6 +21,9 @@ import {
 
 interface SimCfnSsmSecureDynamicReferenceResolverProperties {
   readonly ssm: SimSsm;
+
+  /** The principal the deployment runs as, which the parameter is read as. */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -23,11 +31,12 @@ interface SimCfnSsmSecureDynamicReferenceResolverProperties {
  * Store.
  *
  * The parameter is read the way `GetParameter` with `WithDecryption` reads it,
- * as the caller deploying the Stack, so the value comes back decrypted through
- * the simulated KMS key it was written under. A caller the key does not admit
- * is denied here, which is the failure a real deployment hits. Decrypting
- * cannot be done synchronously, so the answer comes back as a promise for the
- * CloudFormation engine to wait on.
+ * as the principal the deployment names, so the value comes back decrypted
+ * through the simulated KMS key it was written under. A caller the key does
+ * not admit is denied here, which is the failure a real deployment hits. A
+ * deployment naming no principal reads as the Account root, which is Parameter
+ * Store's own default. Decrypting cannot be done synchronously, so the answer
+ * comes back as a promise for the CloudFormation engine to wait on.
  *
  * A reference the template had no business writing fails the Resource, which
  * `sim-cfn-ssm-secure-refusals.ts` holds the rules for. Everything else
@@ -38,8 +47,11 @@ interface SimCfnSsmSecureDynamicReferenceResolverProperties {
 export class SimCfnSsmSecureDynamicReferenceResolver implements SimCfnDynamicReferenceResolver {
   private readonly ssm: SimSsm;
 
+  private readonly callerOptions: SimCfnResourceCallerOptions;
+
   constructor(properties: SimCfnSsmSecureDynamicReferenceResolverProperties) {
     this.ssm = properties.ssm;
+    this.callerOptions = simCfnResourceCallerOptions(properties.caller);
   }
 
   /**
@@ -82,9 +94,10 @@ export class SimCfnSsmSecureDynamicReferenceResolver implements SimCfnDynamicRef
     const selector = version === undefined ? name : `${name}:${version}`;
 
     try {
-      const read = await this.ssm.getParameter({
-        input: { Name: selector, WithDecryption: true },
-      });
+      const read = await this.ssm.getParameter(
+        { input: { Name: selector, WithDecryption: true } },
+        this.callerOptions,
+      );
 
       const parameter = read.Parameter;
 

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -215,9 +215,15 @@ export class SimSsm {
 
   /**
    * Get the resolver for `{{resolve:ssm-secure:...}}` dynamic references.
+   *
+   * The caller is the principal the deployment holding the reference runs as,
+   * which the parameter is read as. Left out where the deployment named none,
+   * leaving the read as the Account root.
    */
-  cfnSecureDynamicReferenceResolver(): SimCfnSsmSecureDynamicReferenceResolver {
-    return new SimCfnSsmSecureDynamicReferenceResolver({ ssm: this });
+  cfnSecureDynamicReferenceResolver(
+    caller?: SimAwsCaller,
+  ): SimCfnSsmSecureDynamicReferenceResolver {
+    return new SimCfnSsmSecureDynamicReferenceResolver({ ssm: this, caller });
   }
 
   /**


### PR DESCRIPTION
A `{{resolve:secretsmanager:...}}` or `{{resolve:ssm-secure:...}}` reference was read as the Account root whatever principal the deployment named, because the caller added in #1072 reached Resource creation and stopped one type short of property resolution. `SimCfnResourceResolveContext` carries it now, and the Secrets Manager and Parameter Store resolvers read the secret and the parameter as the principal the deployment names, at creation and again at teardown. A Stack under an SCP denying the root then deploys when it names a Role the policy allows, and a deployment naming no caller still reads as the Account root. The `{{resolve:ssm:...}}` resolver is left alone for #1096, with the caller reaching its factory entry to build on. Reading a secret and building a stand-in value moved into their own modules, which the extra plumbing made necessary to keep the Secrets Manager resolver under the FTA threshold.

Resolves #1095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secure CloudFormation dynamic references now resolve using the deployment’s specified caller.
  * Supports caller-aware access for Secrets Manager secrets and SSM SecureString parameters.
  * Secret references can return raw values or selected JSON fields, with clear stand-ins for unresolved references.
* **Bug Fixes**
  * Unauthorized callers now receive caller-specific access errors.
  * Deployments without an explicit caller continue using the account root.
  * Stack teardown consistently re-resolves references under the original deployment caller.
* **Tests**
  * Added coverage for authorized, unauthorized, and callerless dynamic-reference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->