### PR TITLE
feat: name every missing sim Lambda SDK package

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -597,6 +597,12 @@ real runtime's `AWS_REGION` provides. An explicit region on the client wins. The
 takes precedence. A package bundled under the archive's `node_modules/` is used as it stands, and
 reaches the simulation through the transport below.
 
+An `@aws-sdk/*` package the project has not installed is refused when the function code requires
+it. The message names every other AWS SDK package the code imports and the project is missing too.
+One install then covers the set. (The archive is the only place to read what a third-party function
+imports.) Packages bundled under the archive's `node_modules/` are left out of that list, along with
+anything only a bundled dependency imports.
+
 ### Function code that bundles the SDK
 
 Some deployment packages inline the SDK rather than relying on the runtime to provide it. CDK's

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -198,6 +198,13 @@ as-is, uninstrumented. Interception is per client instance (`function/code/vm/sd
 fail with `Runtime.ImportModuleError` and guidance to wire a `vmSdkModuleProvider` or bundle the
 package.
 
+A package the host cannot resolve is refused with `SimLambdaSdkPackagesNotInstalledError`.
+`sdk/sim-lambda-provided-sdk-module.ts` catches that one error type, reads `@aws-sdk/*` specifiers
+out of the archive's own JavaScript files, drops the ones the archive bundles, and asks the
+provider's `unresolvedModules` which of the rest the host is missing too. The refusal names them
+all, and one install covers the set. Resolution stays lazy. An archive that runs is never read for
+this, and a package reached only through a bundled dependency is refused on its own.
+
 Note that the `vm` context is a namespacing convenience, not a security boundary: function code
 runs in-process with the same trust as the test suite itself, in keeping with the simulator's
 in-process, Docker-free design. Do not run untrusted code through the simulator.

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-function.factory.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-function.factory.ts
@@ -8,6 +8,7 @@ import {
   type LambdaCodeZipFiles,
   makeLambdaCodeZip,
 } from "./make-lambda-code-zip.js";
+import type { SimLambdaVmSdkModuleProvider } from "./vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import { SimLambdaVmZipCode } from "./sim-lambda-vm-zip-code.js";
 
 /**
@@ -24,6 +25,13 @@ export interface SimLambdaVmZipFunctionInput {
   readonly code: string | LambdaCodeZipFiles;
   readonly handlerName: string;
   readonly memorySizeMb: number;
+
+  /**
+   * What provides the modules the archive does not bundle, as the real
+   * runtime provides the AWS SDK. Left out, the code has none, and an SDK
+   * require is refused for want of one.
+   */
+  readonly sdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
 }
 
 /**
@@ -67,6 +75,7 @@ export const simLambdaVmZipFunctionFactory = new MappedFactory<
         archive,
         handlerName: input.handlerName,
         environment,
+        sdkModuleProvider: input.sdkModuleProvider,
       }),
     });
   },

--- a/src/service/lambda/function/code/vm/sdk/sim-lambda-provided-sdk-module.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-lambda-provided-sdk-module.ts
@@ -1,0 +1,111 @@
+import { assertDefined } from "../../../../../../util/type-guard/defined.js";
+import type { SimZipArchive } from "../../../../../../util/zip/zip-archive.js";
+import { SimLambdaVmModuleResolver } from "../sim-lambda-vm-module-resolver.js";
+import { SimLambdaSdkPackagesNotInstalledError } from "./sim-lambda-sdk-packages-not-installed.error.js";
+import type { SimLambdaVmSdkModuleProvider } from "./sim-lambda-vm-sdk-module-provider.js";
+
+/**
+ * The archive entries worth reading specifiers out of.
+ */
+const javaScriptFilePattern = /\.[cm]?js$/;
+
+/**
+ * A quoted `@aws-sdk/*` specifier, however a file asks for it. A `require`
+ * call, a dynamic `import`, and a static import's `from` clause all match.
+ */
+const awsSdkImportPattern =
+  /(?:\b(?:require|import)\s*\(|\b(?:from|import)\b)\s*["'](@aws-sdk\/[^"']+)["']/g;
+
+/**
+ * What the archive holds and who provides for what it does not. Between them
+ * that is enough to tell an absent package from one already accounted for.
+ */
+interface SimLambdaMissingSdkPackagesContext {
+  readonly archive: SimZipArchive;
+  readonly sdkModuleProvider: SimLambdaVmSdkModuleProvider;
+}
+
+/**
+ * The module the runtime provides for a specifier the archive does not
+ * bundle, or undefined for a specifier the provider does not serve.
+ *
+ * A package the project has not installed is refused here naming every other
+ * AWS SDK package the function code imports and the project is missing too.
+ */
+export function provideSdkModule(
+  specifier: string,
+  context: SimLambdaMissingSdkPackagesContext,
+): unknown {
+  try {
+    return context.sdkModuleProvider.provideModule(specifier);
+  } catch (error) {
+    throw everyMissingSdkPackage(error, context);
+  }
+}
+
+/**
+ * The refusal to raise for a package the project has not installed, naming
+ * every other AWS SDK package the function code imports and the project is
+ * missing too. Any other error stands as it is.
+ *
+ * The runtime provides a package when the code requires it, so on its own a
+ * refusal only ever names the one the code reached. A function importing two
+ * absent packages would then cost two runs and two installs, and the archive
+ * is the only place to read what a third-party function imports. So the
+ * archive is read here, once a package has already turned out to be missing,
+ * and one install covers the set. An archive that runs is never read.
+ */
+function everyMissingSdkPackage(
+  error: unknown,
+  context: SimLambdaMissingSdkPackagesContext,
+): unknown {
+  if (!(error instanceof SimLambdaSdkPackagesNotInstalledError)) {
+    return error;
+  }
+
+  const resolver = new SimLambdaVmModuleResolver(context.archive);
+  const candidates = archiveAwsSdkImports(context.archive).filter(
+    (specifier) =>
+      !error.specifiers.includes(specifier) &&
+      !resolver.bundlesPackage(specifier),
+  );
+  const missing =
+    context.sdkModuleProvider.unresolvedModules?.(candidates) ?? [];
+  if (missing.length === 0) {
+    return error;
+  }
+  return new SimLambdaSdkPackagesNotInstalledError(
+    [...error.specifiers, ...missing],
+    { cause: error.cause },
+  );
+}
+
+/**
+ * The AWS SDK packages a function code archive's own files import, in the
+ * order they appear.
+ *
+ * Bundled dependencies are left out. What a package under `node_modules/`
+ * imports is that package's own business, resolved from the bundle beside it,
+ * and reading a vendored tree to name one more install is a poor trade.
+ */
+function archiveAwsSdkImports(archive: SimZipArchive): readonly string[] {
+  const specifiers = new Set<string>();
+  for (const filePath of archive.filePaths()) {
+    if (!isFunctionCodeFile(filePath)) {
+      continue;
+    }
+    const source = archive.file(filePath).toString();
+    for (const match of source.matchAll(awsSdkImportPattern)) {
+      const specifier = match[1];
+      assertDefined(specifier, "Matched import has no specifier");
+      specifiers.add(specifier);
+    }
+  }
+  return specifiers.values().toArray();
+}
+
+function isFunctionCodeFile(filePath: string): boolean {
+  return (
+    javaScriptFilePattern.test(filePath) && !filePath.includes("node_modules/")
+  );
+}

--- a/src/service/lambda/function/code/vm/sdk/sim-lambda-sdk-packages-not-installed.error.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-lambda-sdk-packages-not-installed.error.ts
@@ -1,0 +1,33 @@
+/**
+ * AWS SDK packages the sim Lambda runtime was asked to provide and the
+ * consuming project has not installed.
+ *
+ * The real Lambda runtime provides these packages from the execution
+ * environment rather than from the deployment package, so the simulated
+ * runtime provides them from the host project. The fix is the same for every
+ * one of them, which is why they are named together: install them, or bundle
+ * them into the function code archive.
+ */
+export class SimLambdaSdkPackagesNotInstalledError extends Error {
+  public override readonly name = "SimLambdaSdkPackagesNotInstalledError";
+
+  constructor(
+    readonly specifiers: readonly string[],
+    options?: ErrorOptions,
+  ) {
+    super(notInstalledMessage(specifiers), options);
+  }
+}
+
+function notInstalledMessage(specifiers: readonly string[]): string {
+  const [subject, object] =
+    specifiers.length > 1
+      ? ["the packages are", "them"]
+      : ["the package is", "it"];
+  return (
+    `Cannot provide ${specifiers.join(", ")} to sim Lambda function code: ` +
+    `${subject} not installed. Install ${object} in your project, as the ` +
+    `real Lambda runtime provides ${object}, or bundle ${object} into the ` +
+    "function code archive."
+  );
+}

--- a/src/service/lambda/function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.ts
@@ -19,6 +19,16 @@ export const awsSdkPackagePrefix = "@aws-sdk/";
  */
 export interface SimLambdaVmSdkModuleProvider {
   provideModule(specifier: string): unknown;
+
+  /**
+   * Which of the given specifiers this provider serves and cannot resolve.
+   *
+   * The module system asks once a package has turned out to be missing. The
+   * refusal then names every package the project has to install, where on
+   * its own it would name only the one the function code reached first. A
+   * provider that does not answer is asked for one specifier at a time.
+   */
+  unresolvedModules?(specifiers: readonly string[]): readonly string[];
 }
 
 /**

--- a/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.iso.test.ts
@@ -2,6 +2,7 @@ import http from "node:http";
 import https from "node:https";
 import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import {
+  assertArrayEquals,
   assertFalse,
   assertIdentical,
   assertNonNullable,
@@ -115,6 +116,54 @@ describe("SimSdkLambdaVmModuleProvider", () => {
 
     assertStringIncludes(error.message, "@aws-sdk/client-unknown");
     assertStringIncludes(error.message, "not installed");
+  });
+
+  it("names the packages the host cannot resolve", () => {
+    // Given a provider whose host has one of the packages and not the other.
+    const provider = new SimSdkLambdaVmModuleProvider({
+      simAws: new SimAws(),
+      requireModule: (specifier) => {
+        if (specifier === "@aws-sdk/client-present") {
+          return { presentExport: true };
+        }
+        throw makeModuleNotFoundError(specifier);
+      },
+    });
+
+    // When the provider is asked which of a set it cannot resolve.
+    const unresolved = provider.unresolvedModules([
+      "@aws-sdk/client-present",
+      "@aws-sdk/client-unknown",
+      "left-pad",
+    ]);
+
+    // Then only the AWS SDK package it serves and cannot resolve is named:
+    // a package it does not serve at all is nothing for it to report.
+    assertArrayEquals(unresolved, ["@aws-sdk/client-unknown"]);
+  });
+
+  it("counts an already-provided package as resolved", () => {
+    // Given a provider that has already provided a package.
+    const provider = new SimSdkLambdaVmModuleProvider({ simAws: new SimAws() });
+    provider.provideModule("@aws-sdk/client-s3");
+
+    // When it is asked whether that package is missing, then it is not.
+    assertArrayEquals(provider.unresolvedModules(["@aws-sdk/client-s3"]), []);
+  });
+
+  it("counts a package that fails to initialize as installed", () => {
+    // Given a provider whose host resolves the package and the package
+    // throws while it initializes.
+    const provider = new SimSdkLambdaVmModuleProvider({
+      simAws: new SimAws(),
+      requireModule: () => {
+        throw new Error("boom during package initialization");
+      },
+    });
+
+    // When it is asked whether the package is missing, then it is not: the
+    // package is there, and its own error belongs to the code requiring it.
+    assertArrayEquals(provider.unresolvedModules(["@aws-sdk/client-s3"]), []);
   });
 
   it("propagates installed-package initialization failures unchanged", () => {

--- a/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.ts
+++ b/src/service/lambda/function/code/vm/sdk/sim-sdk-lambda-vm-module-provider.ts
@@ -1,5 +1,3 @@
-import { createRequire } from "node:module";
-import path from "node:path";
 import { SimSdkModuleClientInterceptor } from "../../../../../../sdk/module/sim-sdk-module-client-interceptor.js";
 import { SimSdkCommandDispatcher } from "../../../../../../sdk/sim-sdk-command-dispatcher.js";
 import type { AwsRegionName } from "../../../../../aws/sim-aws-region.js";
@@ -12,11 +10,14 @@ import {
 } from "../../../outbound/sim-lambda-http-module.js";
 import type { SimLambdaOutboundHttp } from "../../../outbound/sim-lambda-outbound-http.js";
 import {
+  isModuleNotFoundError,
+  requireHostModule,
+} from "../sim-lambda-host-modules.js";
+import { SimLambdaSdkPackagesNotInstalledError } from "./sim-lambda-sdk-packages-not-installed.error.js";
+import {
   awsSdkPackagePrefix,
   type SimLambdaVmSdkModuleProvider,
 } from "./sim-lambda-vm-sdk-module-provider.js";
-
-const hostRequire = createRequire(import.meta.url);
 
 interface SimSdkLambdaVmModuleProviderProperties {
   readonly simAws: SimAws;
@@ -97,6 +98,33 @@ export class SimSdkLambdaVmModuleProvider implements SimLambdaVmSdkModuleProvide
     return module;
   }
 
+  /**
+   * Which of the given specifiers this provider serves and the host cannot
+   * resolve.
+   *
+   * Resolution only. A package that resolves and then throws while it
+   * initializes is installed, and that error belongs to the function code
+   * requiring it rather than to a report of what is missing.
+   */
+  unresolvedModules(specifiers: readonly string[]): readonly string[] {
+    return specifiers.filter(
+      (specifier) =>
+        specifier.startsWith(awsSdkPackagePrefix) && !this.resolves(specifier),
+    );
+  }
+
+  private resolves(specifier: string): boolean {
+    if (this.providedModules.has(specifier)) {
+      return true;
+    }
+    try {
+      this.requireModule(specifier);
+      return true;
+    } catch (error) {
+      return !isModuleNotFoundError(error);
+    }
+  }
+
   private hostModuleExports(specifier: string): object {
     let moduleExports: unknown;
     try {
@@ -107,13 +135,9 @@ export class SimSdkLambdaVmModuleProvider implements SimLambdaVmSdkModuleProvide
       if (!isModuleNotFoundError(error)) {
         throw error;
       }
-      throw new Error(
-        `Cannot provide ${specifier} to sim Lambda function code: the ` +
-          "package is not installed. Install it in your project, as the " +
-          "real Lambda runtime provides it, or bundle it into the function " +
-          "code archive.",
-        { cause: error },
-      );
+      throw new SimLambdaSdkPackagesNotInstalledError([specifier], {
+        cause: error,
+      });
     }
 
     if (typeof moduleExports !== "object" || moduleExports === null) {
@@ -124,34 +148,4 @@ export class SimSdkLambdaVmModuleProvider implements SimLambdaVmSdkModuleProvide
     }
     return moduleExports;
   }
-}
-
-/**
- * Require an AWS SDK package from the host.
- *
- * The packages are installed by the consuming project, as they are provided
- * by the real Lambda runtime rather than by this package. Requiring from
- * this module's context covers hoisted installs; the working-directory
- * fallback covers stricter package layouts.
- */
-function requireHostModule(specifier: string): unknown {
-  try {
-    return hostRequire(specifier);
-  } catch {
-    /* v8 ignore next 4 -- only reachable in consumer package layouts where
-       this package's own require context cannot see the SDK packages. */
-    return createRequire(path.join(process.cwd(), "package.json"))(specifier);
-  }
-}
-
-/**
- * Whether an error is a Node.js module resolution failure, as opposed to an
- * error thrown while a resolved module initializes.
- */
-function isModuleNotFoundError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error.code === "MODULE_NOT_FOUND" || error.code === "ERR_MODULE_NOT_FOUND")
-  );
 }

--- a/src/service/lambda/function/code/vm/sim-lambda-host-modules.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-host-modules.ts
@@ -1,0 +1,35 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const hostRequire = createRequire(import.meta.url);
+
+/**
+ * Require from the host a module the real Lambda runtime provides without it
+ * being bundled: a Node.js built-in, or an AWS SDK package.
+ *
+ * The SDK packages are installed by the consuming project, as the real
+ * runtime provides them rather than this package. Requiring from this
+ * module's context covers hoisted installs; the working-directory fallback
+ * covers stricter package layouts.
+ */
+export function requireHostModule(specifier: string): unknown {
+  try {
+    return hostRequire(specifier);
+  } catch {
+    /* v8 ignore next 4 -- only reachable in consumer package layouts where
+       this package's own require context cannot see the SDK packages. */
+    return createRequire(path.join(process.cwd(), "package.json"))(specifier);
+  }
+}
+
+/**
+ * Whether an error is a Node.js module resolution failure, as opposed to an
+ * error thrown while a resolved module initializes.
+ */
+export function isModuleNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "MODULE_NOT_FOUND" || error.code === "ERR_MODULE_NOT_FOUND")
+  );
+}

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-missing-sdk-packages.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-missing-sdk-packages.iso.test.ts
@@ -1,0 +1,122 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertStringNotIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimLambdaRuntimeError } from "../../../error/sim-lambda-runtime.error.js";
+import type { LambdaCodeZipFiles } from "../make-lambda-code-zip.js";
+import { simLambdaVmZipFunctionFactory } from "../sim-lambda-vm-zip-function.factory.js";
+import { SimSdkLambdaVmModuleProvider } from "./sdk/sim-sdk-lambda-vm-module-provider.js";
+
+/**
+ * Package names no project installs, so the host resolves neither of them
+ * however this suite is installed.
+ */
+const absentAlpha = "@aws-sdk/client-absent-alpha";
+const absentBeta = "@aws-sdk/client-absent-beta";
+
+function coldStartError(code: string | LambdaCodeZipFiles): Promise<Error> {
+  const simFunction = simLambdaVmZipFunctionFactory.make({
+    code,
+    sdkModuleProvider: new SimSdkLambdaVmModuleProvider({
+      simAws: new SimAws(),
+    }),
+  });
+  return assertThrowsErrorAsync(async () => simFunction.invoke({}));
+}
+
+describe("sim Lambda function code importing uninstalled AWS SDK packages", () => {
+  it("names every package the project has not installed", async () => {
+    // Given function code importing two AWS SDK packages the project does
+    // not have.
+    const error = await coldStartError(`
+      const alpha = require("${absentAlpha}");
+      const beta = require("${absentBeta}");
+      exports.handler = async () => ({ alpha, beta });
+    `);
+
+    // Then the cold start is refused once, naming both, so one install
+    // covers the set rather than one package costing one run.
+    assertInstanceOf(error, SimLambdaRuntimeError);
+    assertIdentical(error.name, "Runtime.ImportModuleError");
+    assertIdentical(
+      error.message,
+      `Cannot provide ${absentAlpha}, ${absentBeta} to sim Lambda function ` +
+        "code: the packages are not installed. Install them in your " +
+        "project, as the real Lambda runtime provides them, or bundle them " +
+        "into the function code archive.",
+    );
+  });
+
+  it("keeps the singular wording for one package", async () => {
+    // Given function code importing a single absent AWS SDK package.
+    const error = await coldStartError(`
+      const alpha = require("${absentAlpha}");
+      exports.handler = async () => alpha;
+    `);
+
+    // Then the message reads as it always has for the one.
+    assertIdentical(
+      error.message,
+      `Cannot provide ${absentAlpha} to sim Lambda function code: the ` +
+        "package is not installed. Install it in your project, as the real " +
+        "Lambda runtime provides it, or bundle it into the function code " +
+        "archive.",
+    );
+  });
+
+  it("leaves out packages the project has installed", async () => {
+    // Given function code importing an absent package before one the
+    // project does have.
+    const error = await coldStartError(`
+      const alpha = require("${absentAlpha}");
+      const s3 = require("@aws-sdk/client-s3");
+      exports.handler = async () => ({ alpha, s3 });
+    `);
+
+    // Then only the one to install is named.
+    assertStringIncludes(error.message, absentAlpha);
+    assertStringNotIncludes(error.message, "@aws-sdk/client-s3");
+  });
+
+  it("leaves out packages the archive bundles", async () => {
+    // Given an archive bundling one AWS SDK package and importing another it
+    // does not have.
+    const error = await coldStartError({
+      "index.js": `
+        const bundled = require("@aws-sdk/client-bundled");
+        const beta = require("${absentBeta}");
+        exports.handler = async () => ({ bundled, beta });
+      `,
+      "node_modules/@aws-sdk/client-bundled/index.js":
+        "module.exports = { bundled: true };",
+    });
+
+    // Then the bundled package is not something to install: the archive
+    // takes precedence over anything the runtime provides.
+    assertStringIncludes(error.message, absentBeta);
+    assertStringNotIncludes(error.message, "@aws-sdk/client-bundled");
+  });
+
+  it("reports what a bundled dependency imports as it reaches it", async () => {
+    // Given an archive whose bundled dependency imports an absent package,
+    // which nothing in the function's own code mentions.
+    const error = await coldStartError({
+      "index.js": `
+        const helper = require("helper");
+        exports.handler = async () => helper;
+      `,
+      "node_modules/helper/index.js": `module.exports = require("${absentAlpha}");`,
+    });
+
+    // Then it is named on its own. A vendored tree is not read to find one
+    // more install; what a bundled package imports is its own business.
+    assertStringIncludes(error.message, absentAlpha);
+    assertStringIncludes(error.message, "the package is not installed");
+  });
+});

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-module-resolver.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-module-resolver.ts
@@ -26,6 +26,21 @@ export class SimLambdaVmModuleResolver {
     return this.resolvePackage(specifier);
   }
 
+  /**
+   * Whether the archive bundles a bare specifier itself.
+   *
+   * The archive takes precedence over anything the runtime provides, so a
+   * specifier it resolves is never asked of the module provider.
+   */
+  bundlesPackage(specifier: string): boolean {
+    try {
+      this.resolvePackage(specifier);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private resolveCandidates(basePath: string, specifier: string): string {
     const candidates = [
       basePath,

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-modules.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-modules.ts
@@ -1,7 +1,9 @@
-import { createRequire, isBuiltin } from "node:module";
+import { isBuiltin } from "node:module";
 import path from "node:path";
 import vm from "node:vm";
 import type { SimZipArchive } from "../../../../../util/zip/zip-archive.js";
+import { requireHostModule } from "./sim-lambda-host-modules.js";
+import { provideSdkModule } from "./sdk/sim-lambda-provided-sdk-module.js";
 import type { SimLambdaVmSdkModuleProvider } from "./sdk/sim-lambda-vm-sdk-module-provider.js";
 import { loadJsonModule } from "./sim-lambda-vm-json-module.js";
 import type {
@@ -16,8 +18,6 @@ import { userCodeSyntaxError } from "./sim-lambda-vm-syntax-error.js";
  * bounded like real Lambda bounds its init phase.
  */
 const moduleEvaluationTimeoutMs = 5000;
-
-const hostRequire = createRequire(import.meta.url);
 
 interface SimLambdaVmModulesProperties {
   readonly archive: SimZipArchive;
@@ -51,7 +51,7 @@ export class SimLambdaVmModules {
     if (isBuiltin(specifier)) {
       return (
         this.properties.sdkModuleProvider.provideModule(specifier) ??
-        hostRequire(specifier)
+        requireHostModule(specifier)
       );
     }
 
@@ -78,7 +78,7 @@ export class SimLambdaVmModules {
    * original archive resolution error is reported.
    */
   private provideModule(specifier: string, archiveError: unknown): unknown {
-    const provided = this.properties.sdkModuleProvider.provideModule(specifier);
+    const provided = provideSdkModule(specifier, this.properties);
     if (provided === undefined) {
       throw archiveError;
     }


### PR DESCRIPTION
A packaged Lambda importing two AWS SDK packages the project has not installed was refused one at a time, costing two runs and two installs. The refusal now reads the archive's own JavaScript files for `@aws-sdk/*` specifiers, drops the ones the archive bundles and the ones the host resolves, and names what is left alongside the package the code reached. One install covers the set. Reading happens only after a package has turned out to be missing. An archive that runs is never scanned, a package reached only through a bundled dependency is still refused on its own, and a function importing a single absent package keeps the message it had.

Resolves #1092