### PR TITLE
fix: refuse IAM statement values of the wrong type

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -762,6 +762,11 @@ resource. Every entry names a Role or a User in the Stack's Account. An entry na
 principal fails the resource, and so does a policy naming no principal at all. A `Groups` property
 still fails the resource.
 
+A statement value of the wrong type fails the resource too. A `Ref` or an `Fn::GetAtt` naming a
+Resource the template leaves out survives resolution and reaches IAM as an object where `Action` or
+`Resource` takes a string. The put refuses it with `MalformedPolicyDocument`, naming the Role or
+User, the policy and the statement holding it.
+
 An `AWS::IAM::ManagedPolicy` also carries `Roles`, and attaches itself to each Role it names as it
 is created (the attachment `AttachRolePolicy` records). A name no simulated Role in the Account
 answers to fails the resource. Deleting the stack takes the policy back off the Roles still

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy-validation.iso.test.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy-validation.iso.test.ts
@@ -6,11 +6,25 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamMalformedPolicyDocument } from "../../error/sim-iam.error.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimIamCloudFormationResourceFactory } from "../sim-cfn-iam-resource-factory.js";
 import { SimCfnIamPolicyCreator } from "./sim-cfn-iam-policy-creator.js";
+
+const assumeRolePolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: {
+        Service: "athena.amazonaws.com",
+      },
+      Action: "sts:AssumeRole",
+    },
+  ],
+};
 
 const validPolicyDocument = {
   Version: "2012-10-17",
@@ -196,6 +210,59 @@ describe("IAM CloudFormation Policy validation", () => {
         Groups: ["SomeGroup"],
       },
       "Groups are not simulated",
+    );
+  });
+
+  it("rejects a PolicyDocument holding an unresolved intrinsic", async () => {
+    // Given a template whose Policy statement names a Resource that the
+    // template never declares, which leaves the Fn::GetAtt unresolved and
+    // stored in the document as written.
+    const simAws = new SimAws();
+
+    // When the template is deployed through sim CloudFormation.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "dangling-intrinsic-stack",
+        template: {
+          Resources: {
+            QueryRole: {
+              Type: "AWS::IAM::Role",
+              Properties: {
+                RoleName: "QueryRole",
+                AssumeRolePolicyDocument: assumeRolePolicyDocument,
+              },
+            },
+            QueryPolicy: {
+              Type: "AWS::IAM::Policy",
+              Properties: {
+                PolicyName: "RunQueries",
+                Roles: [{ Ref: "QueryRole" }],
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [
+                    {
+                      Effect: "Allow",
+                      Action: "athena:StartQueryExecution",
+                      Resource: { "Fn::GetAtt": ["DoesNotExist", "Arn"] },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the deployment fails on the policy holding it, and the message
+    // names the Role, the policy and the statement.
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource QueryPolicy creation failed: Role " +
+        '"QueryRole" policy "RunQueries" statement 1: Resource must be a ' +
+        "string or an array of strings, but holds " +
+        '{"Fn::GetAtt":["DoesNotExist","Arn"]}',
     );
   });
 });

--- a/src/service/iam/command/policy/create-policy/create-policy-input-resolver.ts
+++ b/src/service/iam/command/policy/create-policy/create-policy-input-resolver.ts
@@ -43,7 +43,10 @@ export class CreatePolicyInputResolver {
       throw new Error("PolicyName is required");
     }
 
-    this.policyDocValidator.validateOptional(command.input.PolicyDocument);
+    this.policyDocValidator.validateOptional(command.input.PolicyDocument, {
+      attachedTo: "Policy",
+      name: policyName,
+    });
 
     const path = normalisePolicyPath(command.input.Path);
     const arn = makeSimPolicyArn({

--- a/src/service/iam/command/policy/put-role-policy/put-role-policy.handler.ts
+++ b/src/service/iam/command/policy/put-role-policy/put-role-policy.handler.ts
@@ -58,7 +58,11 @@ export class PutRolePolicyCommandHandler implements CommandHandler<
     }
 
     const policyDocument = command.input.PolicyDocument;
-    this.policyDocValidator.validateRequired(policyDocument);
+    this.policyDocValidator.validateRequired(policyDocument, {
+      attachedTo: "Role",
+      name: roleName,
+      policyName,
+    });
 
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();

--- a/src/service/iam/command/policy/put-role-policy/put-role-policy.iso.test.ts
+++ b/src/service/iam/command/policy/put-role-policy/put-role-policy.iso.test.ts
@@ -194,7 +194,7 @@ describe("IAM PutRolePolicyCommand", () => {
     assertInstanceOf(error, SimIamMalformedPolicyDocument);
     assertIdentical(
       error.message,
-      "IAM policy statement must define either Action or NotAction",
+      'Role "ApplicationRole" policy "InvalidPolicy" statement 1: must define either Action or NotAction',
     );
   });
 
@@ -240,7 +240,58 @@ describe("IAM PutRolePolicyCommand", () => {
     assertInstanceOf(error, SimIamMalformedPolicyDocument);
     assertIdentical(
       error.message,
-      "IAM policy statement must define either Resource or NotResource",
+      'Role "ApplicationRole" policy "InvalidPolicy" statement 1: must define either Resource or NotResource',
+    );
+  });
+
+  it("throws when a policy statement Resource is not a string or a list", async () => {
+    // Given an IAM Role exists.
+    const simAws = new SimAws();
+    const accountId = makeSimAwsAccountId();
+    const simIam = simAws.account(accountId).iam();
+
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "ApplicationRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Statement: {
+            Effect: "Allow",
+            Action: "sts:AssumeRole",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          },
+        }),
+      }),
+    );
+
+    // When an inline policy statement holds an unresolved CloudFormation
+    // intrinsic where its Resource ARN belongs.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.putRolePolicy(
+        new PutRolePolicyCommand({
+          RoleName: "ApplicationRole",
+          PolicyName: "InvalidPolicy",
+          PolicyDocument: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Action: "athena:StartQueryExecution",
+                Resource: { "Fn::GetAtt": ["DoesNotExist", "Arn"] },
+              },
+            ],
+          }),
+        }),
+      ),
+    );
+
+    // Then the document is rejected at the put, where the Role, the policy and
+    // the statement can all be named.
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+    assertIdentical(
+      error.message,
+      'Role "ApplicationRole" policy "InvalidPolicy" statement 1: Resource ' +
+        "must be a string or an array of strings, but holds " +
+        '{"Fn::GetAtt":["DoesNotExist","Arn"]}',
     );
   });
 });

--- a/src/service/iam/command/policy/put-user-policy/put-user-policy.handler.ts
+++ b/src/service/iam/command/policy/put-user-policy/put-user-policy.handler.ts
@@ -53,7 +53,11 @@ export class PutUserPolicyCommandHandler implements CommandHandler<
     assertDefined(policyName, "PutUserPolicyCommand.input.PolicyName");
     const policyDocument = command.input.PolicyDocument;
 
-    this.policyDocValidator.validateRequired(policyDocument);
+    this.policyDocValidator.validateRequired(policyDocument, {
+      attachedTo: "User",
+      name: username,
+      policyName,
+    });
 
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();

--- a/src/service/iam/command/policy/put-user-policy/put-user-policy.iso.test.ts
+++ b/src/service/iam/command/policy/put-user-policy/put-user-policy.iso.test.ts
@@ -168,7 +168,7 @@ describe("IAM PutUserPolicyCommand", () => {
     assertInstanceOf(error, SimIamMalformedPolicyDocument);
     assertIdentical(
       error.message,
-      "IAM policy statement must define either Action or NotAction",
+      'User "ApplicationUser" policy "InvalidPolicy" statement 1: must define either Action or NotAction',
     );
   });
 });

--- a/src/service/iam/policy/parse/sim-iam-document-parser.iso.test.ts
+++ b/src/service/iam/policy/parse/sim-iam-document-parser.iso.test.ts
@@ -1,5 +1,11 @@
-import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
+import { SimIamMalformedPolicyDocument } from "../../error/sim-iam.error.js";
 import type { SimIamPolicyDocument } from "../sim-iam-policy.js";
 import { SimIamPolicyDocumentParser } from "./sim-iam-document-parser.js";
 
@@ -50,5 +56,35 @@ describe("SimIamPolicyDocumentParser", () => {
     assertArrayLength(parsed.statements, 1);
     assertIdentical(parsed.statements[0].actions?.[0], "s3:GetObject");
     assertIdentical(parsed.statements[0].actions[1], "s3:ListBucket");
+  });
+
+  it("reports a malformed policy when a statement field holds an object", () => {
+    // Given a stored policy document whose Resource holds an unresolved
+    // CloudFormation intrinsic in place of an ARN.
+    const parser = new SimIamPolicyDocumentParser();
+    const policy = {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "athena:StartQueryExecution",
+          Resource: { "Fn::GetAtt": ["DoesNotExist", "Arn"] },
+        },
+      ],
+    } as unknown as SimIamPolicyDocument;
+
+    // When the policy document is parsed.
+    const error = assertThrowsError(() => {
+      parser.parse(policy);
+    });
+
+    // Then the malformed document is reported, naming the statement and the
+    // value it holds.
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+    assertIdentical(
+      error.message,
+      "IAM policy statement 1: Resource must be a string or an array of " +
+        'strings, but holds {"Fn::GetAtt":["DoesNotExist","Arn"]}',
+    );
   });
 });

--- a/src/service/iam/policy/parse/sim-iam-document-parser.ts
+++ b/src/service/iam/policy/parse/sim-iam-document-parser.ts
@@ -5,6 +5,8 @@ import type {
   SimIamPolicyDocumentStatement,
 } from "../sim-iam-policy.js";
 import { simIamPolicyDocumentStatements } from "../sim-iam-pol-document-statements.js";
+import { simIamStatementLabel } from "../sim-iam-statement-label.js";
+import { simIamStatementStrings } from "../sim-iam-statement-strings.js";
 
 export interface SimIamParsedPolicyDocument {
   readonly statements: readonly SimIamParsedPolicyStatement[];
@@ -28,6 +30,10 @@ export interface SimIamParsedPolicyStatement {
  *
  * IAM policy JSON commonly allows either a single value or an array. The decision
  * engine should not need to care which source shape was used.
+ *
+ * A document stored without validation can hold a value of the wrong type in
+ * one of those fields. Parsing it reports a malformed policy naming the
+ * statement.
  */
 export class SimIamPolicyDocumentParser {
   /**
@@ -35,40 +41,37 @@ export class SimIamPolicyDocumentParser {
    */
   parse(policy: SimIamPolicyDocument): SimIamParsedPolicyDocument {
     return {
-      statements: simIamPolicyDocumentStatements(policy).map((statement) =>
-        this.parseStatement(statement),
+      statements: simIamPolicyDocumentStatements(policy).map(
+        (statement, index) => this.parseStatement(statement, index),
       ),
     };
   }
 
   private parseStatement(
     statement: SimIamPolicyDocumentStatement,
+    index: number,
   ): SimIamParsedPolicyStatement {
+    const label = simIamStatementLabel(index);
+
     return {
       source: statement,
       sid: statement.Sid,
       effect: statement.Effect,
-      actions: this.stringList(statement.Action),
-      notActions: this.stringList(statement.NotAction),
-      resources: this.stringList(statement.Resource),
-      notResources: this.stringList(statement.NotResource),
+      actions: simIamStatementStrings(statement.Action, label, "Action"),
+      notActions: simIamStatementStrings(
+        statement.NotAction,
+        label,
+        "NotAction",
+      ),
+      resources: simIamStatementStrings(statement.Resource, label, "Resource"),
+      notResources: simIamStatementStrings(
+        statement.NotResource,
+        label,
+        "NotResource",
+      ),
       principal: statement.Principal,
       notPrincipal: statement.NotPrincipal,
       condition: statement.Condition,
     };
-  }
-
-  private stringList(
-    value: string | readonly string[] | undefined,
-  ): readonly string[] | undefined {
-    if (value === undefined) {
-      return undefined;
-    }
-
-    if (typeof value === "string") {
-      return [value];
-    }
-
-    return [...value];
   }
 }

--- a/src/service/iam/policy/sim-iam-statement-label.ts
+++ b/src/service/iam/policy/sim-iam-statement-label.ts
@@ -1,0 +1,45 @@
+/**
+ * What a policy document is attached to, for naming it when one of its
+ * statements is rejected.
+ */
+export interface SimIamPolicyDocumentSubject {
+  /**
+   * The kind of thing the document is attached to, such as `Role` or `Bucket`.
+   */
+  readonly attachedTo: string;
+
+  /**
+   * The name of the thing the document is attached to.
+   */
+  readonly name: string;
+
+  /**
+   * The policy's own name, for a document stored under one.
+   */
+  readonly policyName?: string | undefined;
+}
+
+/**
+ * Name one statement of a policy document, for a message about what is wrong
+ * with it.
+ *
+ * A malformed statement usually arrives from a CloudFormation template. The
+ * reader chasing one back needs the document it came from as well as the fault
+ * in it. Statements carry no names of their own. The position in the document
+ * stands in for one.
+ */
+export function simIamStatementLabel(
+  index: number,
+  subject?: SimIamPolicyDocumentSubject,
+): string {
+  const statement = `statement ${index + 1}`;
+
+  if (subject === undefined) {
+    return `IAM policy ${statement}`;
+  }
+
+  const policy =
+    subject.policyName === undefined ? "" : ` policy "${subject.policyName}"`;
+
+  return `${subject.attachedTo} "${subject.name}"${policy} ${statement}`;
+}

--- a/src/service/iam/policy/sim-iam-statement-strings.ts
+++ b/src/service/iam/policy/sim-iam-statement-strings.ts
@@ -1,0 +1,42 @@
+import { SimIamMalformedPolicyDocument } from "../error/sim-iam.error.js";
+
+/**
+ * Read a statement field holding either one string or a list of strings.
+ *
+ * Action, NotAction, Resource and NotResource each take either shape, and
+ * anything else is a malformed document. An unresolved CloudFormation intrinsic
+ * is the usual way one arrives. The IAM policy parsers store `PolicyDocument`
+ * whole, and a `Ref` or `Fn::GetAtt` nested inside a statement is kept as
+ * written. Refusing it here keeps it out of evaluation, where the same value
+ * surfaces as a `TypeError` naming no policy.
+ */
+export function simIamStatementStrings(
+  value: unknown,
+  label: string,
+  field: string,
+): readonly string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (isStringArray(value)) {
+    return [...value];
+  }
+
+  throw new SimIamMalformedPolicyDocument(
+    `${label}: ${field} must be a string or an array of strings, but holds ${JSON.stringify(
+      value,
+    )}`,
+  );
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return (
+    Array.isArray(value) &&
+    (value as readonly unknown[]).every((entry) => typeof entry === "string")
+  );
+}

--- a/src/service/iam/validate/sim-iam-policy-document-validator.iso.test.ts
+++ b/src/service/iam/validate/sim-iam-policy-document-validator.iso.test.ts
@@ -1,4 +1,5 @@
 import {
+  assertIdentical,
   assertInstanceOf,
   assertStringIncludes,
   assertThrowsError,
@@ -117,7 +118,7 @@ describe("SimIamPolicyDocumentValidator", () => {
     assertInstanceOf(error, SimIamMalformedPolicyDocument);
     assertStringIncludes(
       error.message,
-      'IAM policy statement Effect must be either "Allow" or "Deny"',
+      'IAM policy statement 1: Effect must be either "Allow" or "Deny"',
     );
   });
 
@@ -143,7 +144,7 @@ describe("SimIamPolicyDocumentValidator", () => {
     assertInstanceOf(error, SimIamMalformedPolicyDocument);
     assertStringIncludes(
       error.message,
-      'IAM policy statement Effect must be either "Allow" or "Deny"',
+      'IAM policy statement 1: Effect must be either "Allow" or "Deny"',
     );
   });
 
@@ -168,7 +169,7 @@ describe("SimIamPolicyDocumentValidator", () => {
     assertInstanceOf(error, SimIamMalformedPolicyDocument);
     assertStringIncludes(
       error.message,
-      "IAM policy statement must define either Action or NotAction",
+      "IAM policy statement 1: must define either Action or NotAction",
     );
   });
 
@@ -193,7 +194,109 @@ describe("SimIamPolicyDocumentValidator", () => {
     assertInstanceOf(error, SimIamMalformedPolicyDocument);
     assertStringIncludes(
       error.message,
-      "IAM policy statement must define either Resource or NotResource",
+      "IAM policy statement 1: must define either Resource or NotResource",
+    );
+  });
+
+  it("rejects a statement field holding an object", () => {
+    // Given an IAM policy statement whose Resource holds an unresolved
+    // CloudFormation intrinsic in place of an ARN.
+    const validator: SimIamPolicyDocumentValidator =
+      new SimIamPolicyDocumentValidator();
+    const policyDocument = JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "athena:StartQueryExecution",
+        Resource: { "Fn::GetAtt": ["DoesNotExist", "Arn"] },
+      },
+    });
+
+    // When the policy document is validated for a Role's inline policy.
+    const error = assertThrowsError(() => {
+      validator.validateRequired(policyDocument, {
+        attachedTo: "Role",
+        name: "QueryRole",
+        policyName: "RunQueries",
+      });
+    });
+
+    // Then the document is rejected naming the Role, the policy, the statement
+    // and the value it holds.
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+    assertIdentical(
+      error.message,
+      'Role "QueryRole" policy "RunQueries" statement 1: Resource must be a ' +
+        "string or an array of strings, but holds " +
+        '{"Fn::GetAtt":["DoesNotExist","Arn"]}',
+    );
+  });
+
+  it("rejects a statement field holding an array of anything else", () => {
+    // Given an IAM policy statement whose Action list holds an object among
+    // its action names.
+    const validator: SimIamPolicyDocumentValidator =
+      new SimIamPolicyDocumentValidator();
+    const policyDocument = JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ["s3:GetObject", { Ref: "ExtraAction" }],
+          Resource: "arn:aws:s3:::example-bucket/*",
+        },
+      ],
+    });
+
+    // When the policy document is validated.
+    const error = assertThrowsError(() => {
+      validator.validateRequired(policyDocument);
+    });
+
+    // Then the document is rejected naming the field and what it holds.
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+    assertIdentical(
+      error.message,
+      "IAM policy statement 1: Action must be a string or an array of " +
+        'strings, but holds ["s3:GetObject",{"Ref":"ExtraAction"}]',
+    );
+  });
+
+  it("names the statement a malformed value is in", () => {
+    // Given an IAM policy document whose second statement is the malformed one.
+    const validator: SimIamPolicyDocumentValidator =
+      new SimIamPolicyDocumentValidator();
+    const policyDocument = JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::example-bucket/*",
+        },
+        {
+          Effect: "Allow",
+          Action: { Ref: "QueryAction" },
+          Resource: "*",
+        },
+      ],
+    });
+
+    // When the policy document is validated for a User's inline policy.
+    const error = assertThrowsError(() => {
+      validator.validateRequired(policyDocument, {
+        attachedTo: "User",
+        name: "Analyst",
+        policyName: "RunQueries",
+      });
+    });
+
+    // Then the rejection names the statement the malformed value is in.
+    assertInstanceOf(error, SimIamMalformedPolicyDocument);
+    assertIdentical(
+      error.message,
+      'User "Analyst" policy "RunQueries" statement 2: Action must be a ' +
+        'string or an array of strings, but holds {"Ref":"QueryAction"}',
     );
   });
 });

--- a/src/service/iam/validate/sim-iam-policy-document-validator.ts
+++ b/src/service/iam/validate/sim-iam-policy-document-validator.ts
@@ -1,10 +1,23 @@
 import { jsonParse, type JSONString } from "../../../util/type-guard/json.js";
 import { SimIamMalformedPolicyDocument } from "../error/sim-iam.error.js";
 import { simIamPolicyDocumentStatements } from "../policy/sim-iam-pol-document-statements.js";
-import type { SimIamPolicyDocument } from "../policy/sim-iam-policy.js";
+import type {
+  SimIamPolicyDocument,
+  SimIamPolicyDocumentStatement,
+} from "../policy/sim-iam-policy.js";
+import {
+  simIamStatementLabel,
+  type SimIamPolicyDocumentSubject,
+} from "../policy/sim-iam-statement-label.js";
+import { simIamStatementStrings } from "../policy/sim-iam-statement-strings.js";
 
 /**
  * Performs basic IAM policy document validation shared by IAM policy commands.
+ *
+ * A caller can say what the document is attached to, and a rejection names it.
+ * Malformed documents usually arrive from a CloudFormation template, and the
+ * failure has to carry enough for a reader to find the template that wrote
+ * it.
  */
 export class SimIamPolicyDocumentValidator {
   /**
@@ -12,12 +25,13 @@ export class SimIamPolicyDocumentValidator {
    */
   validateRequired(
     policyDocument: string | undefined,
+    subject?: SimIamPolicyDocumentSubject,
   ): asserts policyDocument is JSONString<SimIamPolicyDocument> {
     if (policyDocument === undefined || policyDocument.length === 0) {
       throw new Error("PolicyDocument is required");
     }
 
-    this.validate(policyDocument);
+    this.validate(policyDocument, subject);
   }
 
   /**
@@ -25,47 +39,69 @@ export class SimIamPolicyDocumentValidator {
    */
   validateOptional(
     policyDocument: string | undefined,
+    subject?: SimIamPolicyDocumentSubject,
   ): asserts policyDocument is JSONString<SimIamPolicyDocument> | undefined {
     if (policyDocument === undefined || policyDocument.length === 0) {
       return;
     }
 
-    this.validate(policyDocument);
+    this.validate(policyDocument, subject);
   }
 
   private validate(
     policyDocument: string,
+    subject: SimIamPolicyDocumentSubject | undefined,
   ): asserts policyDocument is JSONString<SimIamPolicyDocument> {
     const parsedPolicyDocument = jsonParse(
       policyDocument as JSONString<SimIamPolicyDocument>,
     );
 
-    this.validateParsed(parsedPolicyDocument);
+    this.validateParsed(parsedPolicyDocument, subject);
   }
 
-  private validateParsed(policyDocument: SimIamPolicyDocument): void {
-    for (const statement of simIamPolicyDocumentStatements(policyDocument)) {
-      // oxlint-disable-next-line typescript/no-unnecessary-condition
-      if (statement.Effect !== "Allow" && statement.Effect !== "Deny") {
-        throw new SimIamMalformedPolicyDocument(
-          'IAM policy statement Effect must be either "Allow" or "Deny"',
-        );
-      }
+  private validateParsed(
+    policyDocument: SimIamPolicyDocument,
+    subject: SimIamPolicyDocumentSubject | undefined,
+  ): void {
+    const statements = simIamPolicyDocumentStatements(policyDocument);
 
-      if (statement.Action === undefined && statement.NotAction === undefined) {
-        throw new SimIamMalformedPolicyDocument(
-          "IAM policy statement must define either Action or NotAction",
-        );
-      }
-
-      if (
-        statement.Resource === undefined &&
-        statement.NotResource === undefined
-      ) {
-        throw new SimIamMalformedPolicyDocument(
-          "IAM policy statement must define either Resource or NotResource",
-        );
-      }
+    for (const [index, statement] of statements.entries()) {
+      this.validateStatement(statement, simIamStatementLabel(index, subject));
     }
+  }
+
+  private validateStatement(
+    statement: SimIamPolicyDocumentStatement,
+    label: string,
+  ): void {
+    // oxlint-disable-next-line typescript/no-unnecessary-condition
+    if (statement.Effect !== "Allow" && statement.Effect !== "Deny") {
+      throw new SimIamMalformedPolicyDocument(
+        `${label}: Effect must be either "Allow" or "Deny"`,
+      );
+    }
+
+    if (statement.Action === undefined && statement.NotAction === undefined) {
+      throw new SimIamMalformedPolicyDocument(
+        `${label}: must define either Action or NotAction`,
+      );
+    }
+
+    if (
+      statement.Resource === undefined &&
+      statement.NotResource === undefined
+    ) {
+      throw new SimIamMalformedPolicyDocument(
+        `${label}: must define either Resource or NotResource`,
+      );
+    }
+
+    // Read for the types alone. A field of the wrong type throws while the
+    // document is still beside the call that wrote it. Left to the first
+    // authorization, the same fault names no policy at all.
+    simIamStatementStrings(statement.Action, label, "Action");
+    simIamStatementStrings(statement.NotAction, label, "NotAction");
+    simIamStatementStrings(statement.Resource, label, "Resource");
+    simIamStatementStrings(statement.NotResource, label, "NotResource");
   }
 }

--- a/src/service/s3/command/put-bucket-policy/put-bucket-policy.handler.ts
+++ b/src/service/s3/command/put-bucket-policy/put-bucket-policy.handler.ts
@@ -62,7 +62,10 @@ export class PutBucketPolicyCommandHandler implements CommandHandler<
   ): Promise<SimPutBucketPolicyCommandOutput> {
     assertDefined(command.input.Bucket, "PutBucketPolicyCommand.input.Bucket");
     assertDefined(command.input.Policy, "PutBucketPolicyCommand.input.Policy");
-    this.policyValidator.validateRequired(command.input.Policy);
+    this.policyValidator.validateRequired(command.input.Policy, {
+      attachedTo: "Bucket",
+      name: command.input.Bucket,
+    });
 
     const bucketName = command.input.Bucket as SimS3BucketName;
     const bucket = requireSimS3Bucket(this.buckets, bucketName);


### PR DESCRIPTION
An IAM policy statement whose `Action` or `Resource` held an object crashed authorization with a `TypeError` from the document parser, in place of an allow or a deny. Validation now checks the types of `Action`, `NotAction`, `Resource` and `NotResource`, and `putRolePolicy` refuses a wrong-typed value with `MalformedPolicyDocument` naming the Role, the policy, the statement and the value it holds. The parser refuses one the same way, for a document that reached it by another route. An unresolved CloudFormation intrinsic is the common way in, and a template whose statement holds a `Ref` or an `Fn::GetAtt` naming a Resource it leaves out now fails on the policy holding it.

Resolves #1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IAM policy validation for incorrectly typed fields, including unresolved CloudFormation values.
  * Error messages now identify the affected resource, policy, statement number, field, and invalid value.
  * Applied contextual validation improvements to role, user, standalone, and bucket policies.
  * Prevented malformed policies from being created with unclear or generic errors.
* **Documentation**
  * Documented policy creation failures caused by invalid statement types and unresolved intrinsic values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->