### PR TITLE
fix: authorize the ssm dynamic reference read

### DIFF
--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -440,6 +440,10 @@ Real CloudFormation makes no dependency out of a dynamic reference, and neither 
 parameter another resource of the same stack creates is only there in time when the template says
 `DependsOn`.
 
+The parameter is read with `GetParameter`, as the caller deploying the stack. A policy denying that
+read fails the resource holding the reference, the way it fails a real deployment. A stack deployed
+without a caller reads as the account root.
+
 A `SecureString` parameter is read through `{{resolve:ssm-secure:...}}`, which the next section
 covers. `{{resolve:secretsmanager:...}}` reads a secret, and
 [simulated Secrets Manager](https://yulinsim.dev/services/secretsmanager/#reading-a-secret-with-a-dynamic-reference)

--- a/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
+++ b/src/service/cloudformation/resource/resolve/property/sim-cfn-resource-property-resolver.ts
@@ -9,6 +9,7 @@ import type { SimCfnPseudoParameters } from "../../../parameters/pseudo/sim-cfn-
 import type { SimCfnExports } from "../../../export/sim-cfn-exports.js";
 import type { SimAwsAccountRegionScope } from "../../../../aws/sim-aws-account-region-scope.js";
 import { makeSimCfnDynamicReferences } from "../../../template/dynamic/make-sim-cfn-dynamic-references.js";
+import { hasSimCfnDynamicReferenceIn } from "../../../template/dynamic/sim-cfn-dynamic-reference-scan.js";
 import type { SimCfnDynamicReferences } from "../../../template/dynamic/sim-cfn-dynamic-references.js";
 import type { SimCfnPropertyIgnorer } from "../../ignore/sim-cfn-ignored-property.type.js";
 
@@ -63,10 +64,13 @@ export class SimCfnResourcePropertyResolver {
    * {@link SimCfnTemplateValueResolver}. If no Parameters are available, an empty
    * Parameter resolver is used so Resource Refs can still resolve.
    *
-   * Resolution itself is synchronous, and the awaiting happens around it. A
-   * dynamic reference naming a service that has to be waited on resolves to a
-   * marker while the properties resolve, and the values replace the markers
-   * here.
+   * Resolution itself is synchronous, and the awaiting happens around it.
+   * Properties holding a dynamic reference are resolved twice: the first pass
+   * reads the references and leaves them as the template wrote them, and the
+   * second finds the answers waiting, so an intrinsic function reading a
+   * reference's value gets the value rather than a marker. A reference the
+   * first pass never reached resolves to a marker instead, and the values
+   * replace the markers here.
    *
    * Resource Refs are read from the creation context. If a referenced Resource
    * is unexpectedly absent, the Ref is preserved as `{ Ref: logicalId }` rather
@@ -107,13 +111,17 @@ export class SimCfnResourcePropertyResolver {
       },
     });
 
-    const resolved = resolver.resolveRecord(properties);
-
     if (dynamicReferences === undefined) {
-      return resolved;
+      return resolver.resolveRecord(properties);
     }
 
-    return await dynamicReferences.settle(resolved);
+    if (hasSimCfnDynamicReferenceIn(properties)) {
+      await dynamicReferences.prefetch(() => {
+        resolver.resolveRecord(properties);
+      });
+    }
+
+    return await dynamicReferences.settle(resolver.resolveRecord(properties));
   }
 
   /**

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-caller.iso.test.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-caller.iso.test.ts
@@ -31,6 +31,20 @@ const denyAccountRoot = {
   },
 } as const;
 
+/**
+ * An organization denying every read of a parameter, whatever principal makes
+ * it, which is the policy a real deployment fails a Stack against.
+ */
+const denyEveryParameterRead = {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyEverySsmRead",
+    Effect: "Deny",
+    Action: "ssm:GetParameter*",
+    Resource: "*",
+  },
+} as const;
+
 interface DeploymentAccount {
   readonly simAws: SimAws;
   readonly accountId: SimAwsAccountId;
@@ -166,6 +180,62 @@ describe("the principal a CloudFormation dynamic reference is resolved as", () =
 
     assertNonNullable(user?.loginProfile, "the deployed User's login profile");
     assertIdentical(user.loginProfile.password, "hunter2");
+  });
+
+  it("reads a plain ssm reference as that Role too", async () => {
+    // Given a parameter stored in the clear, the same deploy Role, and the
+    // same organization.
+    const { simAws, accountId } = deploymentAccount();
+    const deployer = await deployRole(simAws, "deployer", ["*"]);
+
+    await simAws.ssm().putParameter({
+      input: { Name: "/site/origin", Type: "String", Value: "edge.internal" },
+    });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyAccountRoot);
+
+    // When a Stack reading it is deployed as the Role.
+    await deployReading(simAws, "{{resolve:ssm:/site/origin}}", deployer);
+
+    // Then the parameter was read as the Role rather than as the root.
+    assertIdentical(readParameter(simAws), "edge.internal");
+  });
+
+  it("fails the Resource where the deployment may not read an ssm reference", async () => {
+    // Given a parameter, a deploy Role allowed everything, and an organization
+    // denying every Parameter Store read.
+    const { simAws, accountId } = deploymentAccount();
+    const deployer = await deployRole(simAws, "deployer", ["*"]);
+
+    await simAws.ssm().putParameter({
+      input: { Name: "/site/origin", Type: "String", Value: "edge.internal" },
+    });
+
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(accountId, denyEveryParameterRead);
+
+    // When a Stack reading that parameter is deployed as the Role.
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployReading(simAws, "{{resolve:ssm:/site/origin}}", deployer);
+    });
+
+    // Then the Resource failed on the read, rather than being created with a
+    // value the deny should have kept from it.
+    assertStringIncludes(
+      error.message,
+      `arn:aws:iam::${accountId}:role/deployer is not authorized to perform: ssm:GetParameter`,
+    );
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName("site-stack")
+        ?.getResource("EdgeToken")?.status,
+      "CREATE_FAILED",
+    );
+    assertUndefined(readParameter(simAws));
   });
 
   it("leaves a deployment that names no caller reading as the Account root", async () => {

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-resolvers.ts
@@ -49,8 +49,8 @@ export const simCfnDynamicReferenceResolvers: ReadonlyMap<
 > = new Map([
   [
     "ssm",
-    ({ scopedAws }): SimCfnDynamicReferenceResolver =>
-      scopedAws.ssm().cfnDynamicReferenceResolver(),
+    ({ scopedAws, caller }): SimCfnDynamicReferenceResolver =>
+      scopedAws.ssm().cfnDynamicReferenceResolver(caller),
   ],
   [
     "ssm-secure",

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-scan.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-reference-scan.ts
@@ -1,3 +1,4 @@
+import type { SimCfnTemplateValue } from "../value/sim-cfn-template-value.js";
 import type { SimCfnDynamicReference } from "./sim-cfn-dynamic-reference.type.js";
 
 /**
@@ -30,6 +31,35 @@ type SimCfnDynamicReferenceSubstitution = (
  */
 export function hasSimCfnDynamicReference(text: string): boolean {
   return text.includes(dynamicReferenceOpening);
+}
+
+/**
+ * Whether anything in a template value was written as a dynamic reference.
+ *
+ * The opening is written literally in every template but a contrived one, so
+ * this answers whether a Resource's properties are worth reading references
+ * out of before they are resolved. A template building the opening itself,
+ * out of an `Fn::Join` over its characters, is answered no and reads its
+ * references while resolving instead.
+ */
+export function hasSimCfnDynamicReferenceIn(
+  value: SimCfnTemplateValue,
+): boolean {
+  if (typeof value === "string") {
+    return hasSimCfnDynamicReference(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasSimCfnDynamicReferenceIn(entry));
+  }
+
+  if (value !== null && typeof value === "object") {
+    return Object.values(value).some((entry) =>
+      hasSimCfnDynamicReferenceIn(entry),
+    );
+  }
+
+  return false;
 }
 
 /**

--- a/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-dynamic-references.ts
@@ -4,7 +4,9 @@ import { currentSimCfnValuePath } from "../value/sim-cfn-value-path.js";
 import { SimCfnAwaitedDynamicReferences } from "./sim-cfn-awaited-dynamic-references.js";
 import { fillSimCfnDynamicReferencePlaceholders } from "./sim-cfn-dynamic-reference-placeholder.js";
 import { substituteSimCfnDynamicReferences } from "./sim-cfn-dynamic-reference-scan.js";
+import { SimCfnPrefetchedDynamicReferences } from "./sim-cfn-prefetched-dynamic-references.js";
 import type {
+  SimCfnDynamicReference,
   SimCfnDynamicReferenceResolution,
   SimCfnDynamicReferenceResolver,
 } from "./sim-cfn-dynamic-reference.type.js";
@@ -29,8 +31,9 @@ interface SimCfnDynamicReferencesProperties {
  * what the ones this simulation has yet to implement do.
  *
  * One of these belongs to a single Resource's property resolution. That is
- * what lets it hold the references still being read. `substitute` runs while
- * the properties resolve, and `settle` finishes them afterwards.
+ * what lets it hold the references still being read. `prefetch` reads them
+ * ahead of resolution, `substitute` runs while the properties resolve, and
+ * `settle` finishes whatever the prefetch pass never reached.
  */
 export class SimCfnDynamicReferences {
   private readonly resolvers: ReadonlyMap<
@@ -44,10 +47,31 @@ export class SimCfnDynamicReferences {
 
   private readonly awaited = new SimCfnAwaitedDynamicReferences();
 
+  private readonly prefetched = new SimCfnPrefetchedDynamicReferences();
+
   constructor(properties: SimCfnDynamicReferencesProperties) {
     this.resolvers = properties.resolvers;
     this.propertyIgnorer = properties.propertyIgnorer;
     this.resourceType = properties.resourceType;
+  }
+
+  /**
+   * Read every reference the properties hold, before resolving them for real.
+   *
+   * A service that has to be waited on cannot answer during resolution, which
+   * is synchronous, so an `Fn::Split` over a reference would otherwise split
+   * something that is not the value yet. Resolving the properties twice is
+   * what avoids that: this pass leaves every reference as the template wrote
+   * it and only collects what the services answer, and the pass after it finds
+   * the answers already here.
+   *
+   * Nothing is recorded here and no failure escapes. A template this pass
+   * cannot resolve is resolved again straight afterwards, and that is the pass
+   * whose failure the Resource reports. A reference the pass never reached, or
+   * one whose service refused it, is left to `substitute` and `settle`.
+   */
+  async prefetch(resolve: () => void): Promise<void> {
+    await this.prefetched.read(resolve);
   }
 
   /**
@@ -65,17 +89,7 @@ export class SimCfnDynamicReferences {
         return;
       }
 
-      const path = currentSimCfnValuePath();
-      const resolution = resolver.resolve(reference, {
-        resourceType: this.resourceType,
-        propertyPath: path,
-      });
-
-      if (resolution instanceof Promise) {
-        return this.awaited.hold(resolution, path);
-      }
-
-      return this.answer(resolution, path);
+      return this.substituted(resolver, reference);
     });
   }
 
@@ -103,6 +117,43 @@ export class SimCfnDynamicReferences {
     );
 
     return fillSimCfnDynamicReferencePlaceholders(properties, values);
+  }
+
+  /**
+   * What one reference is replaced with, given the service answering it.
+   */
+  private substituted(
+    resolver: SimCfnDynamicReferenceResolver,
+    reference: SimCfnDynamicReference,
+  ): string {
+    const path = currentSimCfnValuePath();
+    const key = `${path} ${reference.text}`;
+    const prefetched = this.prefetched.answerFor(key);
+
+    if (prefetched !== undefined) {
+      return this.answer(prefetched, path);
+    }
+
+    if (this.prefetched.isHeld(key)) {
+      return reference.text;
+    }
+
+    const resolution = resolver.resolve(reference, {
+      resourceType: this.resourceType,
+      propertyPath: path,
+    });
+
+    if (this.prefetched.isReading) {
+      this.prefetched.hold(key, resolution);
+
+      return reference.text;
+    }
+
+    if (resolution instanceof Promise) {
+      return this.awaited.hold(resolution, path);
+    }
+
+    return this.answer(resolution, path);
   }
 
   /**

--- a/src/service/cloudformation/template/dynamic/sim-cfn-prefetched-dynamic-references.ts
+++ b/src/service/cloudformation/template/dynamic/sim-cfn-prefetched-dynamic-references.ts
@@ -1,0 +1,112 @@
+import type { SimCfnDynamicReferenceResolution } from "./sim-cfn-dynamic-reference.type.js";
+
+/**
+ * One reference, once the pass reading it ahead of resolution has answered.
+ */
+interface SimCfnPrefetchedDynamicReference {
+  readonly key: string;
+  readonly resolution: SimCfnDynamicReferenceResolution;
+}
+
+/**
+ * The references of one property resolution that were read before it ran.
+ *
+ * A service that has to be waited on cannot answer while the properties
+ * resolve, because resolution is synchronous, so properties holding a
+ * reference are resolved twice. The first pass leaves every reference as the
+ * template wrote it and keeps what the services answer here. The second finds
+ * the answers waiting, so an `Fn::Split` over a reference splits the value
+ * rather than something standing in for it.
+ *
+ * A read that failed is not kept. The resolution pass asks its service again,
+ * and the failure reaches the Resource from there, which is what fails a
+ * Resource holding a reference the deployment may not read.
+ */
+export class SimCfnPrefetchedDynamicReferences {
+  private readonly answers = new Map<
+    string,
+    SimCfnDynamicReferenceResolution
+  >();
+
+  private reads:
+    | Map<string, Promise<SimCfnDynamicReferenceResolution>>
+    | undefined;
+
+  /** Whether the pass running now is the one reading references ahead. */
+  get isReading(): boolean {
+    return this.reads !== undefined;
+  }
+
+  /**
+   * What one reference was already answered with, where it was.
+   */
+  answerFor(key: string): SimCfnDynamicReferenceResolution | undefined {
+    return this.answers.get(key);
+  }
+
+  /**
+   * Whether the pass running now has already started reading one reference.
+   *
+   * A property holding the same reference twice would otherwise read it twice.
+   */
+  isHeld(key: string): boolean {
+    return this.reads?.has(key) === true;
+  }
+
+  /**
+   * Keep one reference's answer for the resolution pass to use.
+   */
+  hold(
+    key: string,
+    resolution:
+      | SimCfnDynamicReferenceResolution
+      | Promise<SimCfnDynamicReferenceResolution>,
+  ): void {
+    this.reads?.set(key, Promise.resolve(resolution));
+  }
+
+  /**
+   * Run one pass over the properties, keeping what its references answer.
+   *
+   * Nothing the pass throws escapes. The resolution pass after it resolves the
+   * same properties, and that is the pass whose failure the Resource reports.
+   */
+  async read(pass: () => void): Promise<void> {
+    const reads = new Map<string, Promise<SimCfnDynamicReferenceResolution>>();
+    this.reads = reads;
+
+    try {
+      pass();
+    } catch {
+      // The resolution pass after this one is the one that reports it.
+    } finally {
+      this.reads = undefined;
+    }
+
+    const answers = await Promise.all(
+      reads
+        .entries()
+        .map(async ([key, read]) => await prefetchedReference(key, read)),
+    );
+
+    for (const answer of answers) {
+      if (answer !== undefined) {
+        this.answers.set(answer.key, answer.resolution);
+      }
+    }
+  }
+}
+
+/**
+ * What one read answered, or nothing where it failed.
+ */
+async function prefetchedReference(
+  key: string,
+  read: Promise<SimCfnDynamicReferenceResolution>,
+): Promise<SimCfnPrefetchedDynamicReference | undefined> {
+  try {
+    return { key, resolution: await read };
+  } catch {
+    return undefined;
+  }
+}

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -149,9 +149,10 @@ There is no resource policy support, so cross-account access to a parameter cann
 - Every deployment of an `AWS::SSM::Parameter` is a create, because sim CloudFormation has no stack
   updates. A name another stack already used is refused rather than overwritten.
 - `{{resolve:ssm:...}}` dynamic references resolve here. `cfn/dynamic/` holds the resolver the
-  CloudFormation engine reaches through `SimSsm.cfnDynamicReferenceResolver()`. A reference this
-  store cannot answer resolves to a stand-in value and is recorded, which is the same best-effort
-  answer an unsupported property gets.
+  CloudFormation engine reaches through `SimSsm.cfnDynamicReferenceResolver()`. The parameter is
+  read through `GetParameter` as the caller deploying the Stack, and a policy denying that read
+  fails the Resource. A reference this store cannot answer resolves to a stand-in value and is
+  recorded, which is the same best-effort answer an unsupported property gets.
 - An `AWS::SSM::Parameter::Value<...>` template parameter is read here too.
   `cfn/parameter/sim-cfn-ssm-parameter-value-reader.ts` holds the reader the CloudFormation engine
   reaches through `SimSsm.cfnParameterValueReader()`, and a name this store cannot answer gets the

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference-resolver.ts
@@ -1,26 +1,45 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import {
+  simCfnResourceCallerOptions,
+  type SimCfnResourceCallerOptions,
+} from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type {
   SimCfnDynamicReference,
   SimCfnDynamicReferenceResolution,
   SimCfnDynamicReferenceResolver,
 } from "../../../cloudformation/template/dynamic/sim-cfn-dynamic-reference.type.js";
-import { SimSsmParameterVersionNotFound } from "../../error/sim-ssm.error.js";
-import type { SimSsmParameter } from "../../parameter/sim-ssm-parameter.js";
+import type { SimSsmParameterOutput } from "../../command/parameter/parameter.command.js";
+import { SimSsmError } from "../../error/sim-ssm.error.js";
 import type { SimSsm } from "../../sim-ssm.js";
 import { parseSimCfnSsmReferenceBody } from "./sim-cfn-ssm-reference-body.js";
 import { simCfnSsmReferenceStandIn } from "./sim-cfn-ssm-reference-stand-in.js";
 
+/** The parameter type a plain `ssm` reference leaves to `ssm-secure`. */
+const secureString = "SecureString";
+
 interface SimCfnSsmDynamicReferenceResolverProperties {
   readonly ssm: SimSsm;
+
+  /** The principal the deployment runs as, which the parameter is read as. */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
  * Answers `{{resolve:ssm:...}}` references from the simulated Parameter Store.
  *
- * A reference is read as the caller deploying the Stack would read it, at the
- * point the Resource holding it is created. Real CloudFormation makes no
- * dependency out of a dynamic reference, so a parameter another Resource of
- * the same Stack creates is only there in time if the template says
- * `DependsOn`.
+ * The parameter is read the way `GetParameter` reads it, as the principal the
+ * deployment names, so a caller that may not read it is denied here and the
+ * Resource fails. That is the failure a real deployment hits, where the read
+ * runs under the Stack's execution role. A deployment naming no principal
+ * reads as the Account root, which is Parameter Store's own default. Reading
+ * through the Command means waiting on it, so the answer comes back as a
+ * promise for the CloudFormation engine to wait on.
+ *
+ * A reference is read at the point the Resource holding it is created. Real
+ * CloudFormation makes no dependency out of a dynamic reference, so a
+ * parameter another Resource of the same Stack creates is only there in time
+ * if the template says `DependsOn`.
  *
  * Anything Parameter Store cannot answer becomes a stand-in value carrying a
  * reason. A template naming parameters a test never created still deploys, and
@@ -29,14 +48,21 @@ interface SimCfnSsmDynamicReferenceResolverProperties {
 export class SimCfnSsmDynamicReferenceResolver implements SimCfnDynamicReferenceResolver {
   private readonly ssm: SimSsm;
 
+  private readonly callerOptions: SimCfnResourceCallerOptions;
+
   constructor(properties: SimCfnSsmDynamicReferenceResolverProperties) {
     this.ssm = properties.ssm;
+    this.callerOptions = simCfnResourceCallerOptions(properties.caller);
   }
 
   /**
    * Resolve one reference to the parameter value it names.
    */
-  resolve(reference: SimCfnDynamicReference): SimCfnDynamicReferenceResolution {
+  resolve(
+    reference: SimCfnDynamicReference,
+  ):
+    | SimCfnDynamicReferenceResolution
+    | Promise<SimCfnDynamicReferenceResolution> {
     const parsed = parseSimCfnSsmReferenceBody(reference.body);
 
     if (parsed === undefined) {
@@ -48,18 +74,51 @@ export class SimCfnSsmDynamicReferenceResolver implements SimCfnDynamicReference
       );
     }
 
-    const { name, version } = parsed;
-    const parameter = this.ssm.findParameter(name);
+    return this.parameterValue(reference, parsed.name, parsed.version);
+  }
 
-    if (parameter === undefined) {
+  /**
+   * Read the version the reference selects, or the current one.
+   */
+  private async parameterValue(
+    reference: SimCfnDynamicReference,
+    name: string,
+    version: string | undefined,
+  ): Promise<SimCfnDynamicReferenceResolution> {
+    const selector = version === undefined ? name : `${name}:${version}`;
+
+    try {
+      const read = await this.ssm.getParameter(
+        { input: { Name: selector } },
+        this.callerOptions,
+      );
+
+      assertDefined(read.Parameter, `the parameter read for '${name}'`);
+
+      return this.readValue(reference, name, read.Parameter);
+    } catch (error) {
+      if (!(error instanceof SimSsmError)) {
+        throw error;
+      }
+
       return simCfnSsmReferenceStandIn(
         reference,
         name,
-        `and simulated Parameter Store holds no parameter '${name}'`,
+        `and simulated Parameter Store could not read it (${error.message})`,
       );
     }
+  }
 
-    if (parameter.type.value === "SecureString") {
+  /**
+   * The value the read reports, unless it is a ciphertext this reference has
+   * no business handing to a Resource.
+   */
+  private readValue(
+    reference: SimCfnDynamicReference,
+    name: string,
+    parameter: SimSsmParameterOutput,
+  ): SimCfnDynamicReferenceResolution {
+    if (parameter.Type === secureString) {
       return simCfnSsmReferenceStandIn(
         reference,
         name,
@@ -68,35 +127,8 @@ export class SimCfnSsmDynamicReferenceResolver implements SimCfnDynamicReference
       );
     }
 
-    return this.parameterValue(reference, parameter, name, version);
-  }
+    assertDefined(parameter.Value, `the value read for '${name}'`);
 
-  /**
-   * Read the version the reference selects, or the current one.
-   */
-  private parameterValue(
-    reference: SimCfnDynamicReference,
-    parameter: SimSsmParameter,
-    name: string,
-    version: string | undefined,
-  ): SimCfnDynamicReferenceResolution {
-    if (version === undefined) {
-      return { value: parameter.currentVersion.value.value };
-    }
-
-    try {
-      return { value: parameter.versionNumbered(Number(version)).value.value };
-    } catch (error) {
-      /* v8 ignore next 3 -- defensive: only a missing version reaches here */
-      if (!(error instanceof SimSsmParameterVersionNotFound)) {
-        throw error;
-      }
-
-      return simCfnSsmReferenceStandIn(
-        reference,
-        name,
-        `and '${name}' has no version ${version}`,
-      );
-    }
+    return { value: parameter.Value };
   }
 }

--- a/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference.iso.test.ts
+++ b/src/service/ssm/cfn/dynamic/sim-cfn-ssm-dynamic-reference.iso.test.ts
@@ -127,6 +127,23 @@ describe("SSM CloudFormation dynamic references", () => {
     assertIdentical(readValue(simAws), "prod-db.internal");
   });
 
+  it("resolves a reference an Fn::Join built out of its own text", async () => {
+    // Given a parameter, and a template writing the reference in pieces rather
+    // than as one string.
+    const simAws = simAwsInEuWest2();
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/db-host", Type: "String", Value: "db.internal" },
+    });
+
+    // When the pieces are joined.
+    await deployReading(simAws, {
+      "Fn::Join": ["", ["{{", "resolve:ssm:/myapp/db-host}}"]],
+    });
+
+    // Then the joined string is read as a reference, as it is on AWS.
+    assertIdentical(readValue(simAws), "db.internal");
+  });
+
   it("hands a StringList parameter to Fn::Split as one comma-separated string", async () => {
     // Given a StringList parameter.
     const simAws = simAwsInEuWest2();

--- a/src/service/ssm/sim-ssm.ts
+++ b/src/service/ssm/sim-ssm.ts
@@ -208,9 +208,15 @@ export class SimSsm {
 
   /**
    * Get the resolver for `{{resolve:ssm:...}}` dynamic references.
+   *
+   * The caller is the principal the deployment holding the reference runs as,
+   * which the parameter is read as. Left out where the deployment named none,
+   * leaving the read as the Account root.
    */
-  cfnDynamicReferenceResolver(): SimCfnSsmDynamicReferenceResolver {
-    return new SimCfnSsmDynamicReferenceResolver({ ssm: this });
+  cfnDynamicReferenceResolver(
+    caller?: SimAwsCaller,
+  ): SimCfnSsmDynamicReferenceResolver {
+    return new SimCfnSsmDynamicReferenceResolver({ ssm: this, caller });
   }
 
   /**


### PR DESCRIPTION
A `{{resolve:ssm:...}}` reference read its parameter through `SimSsm.findParameter`, the simulator's own accessor for tests seeding and inspecting state. No IAM check ran, and a policy denying the read was never consulted. The resolver calls `getParameter` as the principal the deployment names, the way the two resolvers beside it already do, and a denied read now fails the Resource holding the reference. Reading through the Command means waiting on it, and an intrinsic function such as `Fn::Split` would then have been handed a marker in place of the value. Properties holding a dynamic reference are resolved twice for that reason. The first pass reads the references and leaves them as the template wrote them, and the second finds the answers waiting.

Resolves #1096