### PR TITLE
build: ship the usage docs in the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,10 @@ src/docs/docs/api/*.mdx
 # build so that a consumer's `extends` path does not go through `dist/`.
 /cffjs2.oxlintrc.json
 
+# The published index of the documentation pages, written into the package root
+# by the build from the links in docs/README.md.
+/llms.txt
+
 # Misc
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ npm i -D @kensio/yulin
 - [ACM](https://yulinsim.dev/services/acm/ "Simulated ACM docs")
 - [API Gateway HTTP APIs](https://yulinsim.dev/services/apigatewayv2/ "Simulated API Gateway HTTP API docs")
 - [API Gateway REST APIs](https://yulinsim.dev/services/apigateway/ "Simulated API Gateway REST API docs")
+- [Athena](https://yulinsim.dev/services/athena/ "Simulated Amazon Athena docs")
+- [Bedrock](https://yulinsim.dev/services/bedrock/ "Simulated Amazon Bedrock docs")
 - [CloudFormation](https://yulinsim.dev/services/cloudformation/ "Simulated CloudFormation docs")
 - [CloudFront](https://yulinsim.dev/services/cloudfront/ "Simulated CloudFront docs")
 - [CloudWatch metrics](https://yulinsim.dev/services/cloudwatch/ "Simulated CloudWatch metrics docs")
@@ -29,12 +31,16 @@ npm i -D @kensio/yulin
 - [DynamoDB](https://yulinsim.dev/services/dynamodb/ "Simulated DynamoDB docs")
 - [ECR](https://yulinsim.dev/services/ecr/ "Simulated ECR docs")
 - [ECS](https://yulinsim.dev/services/ecs/ "Simulated ECS docs")
+- [Elastic Load Balancing](https://yulinsim.dev/services/elbv2/ "Simulated Application Load Balancer docs")
 - [EventBridge](https://yulinsim.dev/services/eventbridge/ "Simulated EventBridge docs")
 - [Glue](https://yulinsim.dev/services/glue/ "Simulated Glue Data Catalog docs")
 - [IAM](https://yulinsim.dev/services/iam/ "Simulated IAM docs")
+- [Kinesis Data Firehose](https://yulinsim.dev/services/firehose/ "Simulated Kinesis Data Firehose docs")
+- [Kinesis Data Streams](https://yulinsim.dev/services/kinesis/ "Simulated Kinesis Data Streams docs")
 - [KMS](https://yulinsim.dev/services/kms/ "Simulated KMS docs")
 - [Lambda](https://yulinsim.dev/services/lambda/ "Simulated Lambda docs")
 - [CloudWatch Logs](https://yulinsim.dev/services/logs/ "Simulated CloudWatch Logs docs")
+- [Organizations](https://yulinsim.dev/services/organizations/ "Simulated Organizations service control policies docs")
 - [Personalize](https://yulinsim.dev/services/personalize/ "Simulated Amazon Personalize docs")
 - [Rekognition](https://yulinsim.dev/services/rekognition/ "Simulated Rekognition docs")
 - [Route53](https://yulinsim.dev/services/route53/ "Simulated Route53 docs")
@@ -54,9 +60,16 @@ npm i -D @kensio/yulin
 - [AI skill](https://yulinsim.dev/ai-skill/ "Yulin AI skill docs")
 - [The AWS CLI](https://yulinsim.dev/cli/ "The AWS CLI against simulated AWS docs")
 - [AWS SDK interception](https://yulinsim.dev/sdk/ "Simulated AWS SDK docs")
+- [Event factories](https://yulinsim.dev/factories/ "Test factories for AWS event shapes docs")
+- [Linting CloudFront Functions JS2](https://yulinsim.dev/lint/ "CloudFront Functions JS2 lint config docs")
+- [Non-AWS dependencies](https://yulinsim.dev/non-aws-dependencies/ "Dependencies Yulin does not simulate docs")
 - [Serving on localhost](https://yulinsim.dev/serve/ "Serving simulated AWS on localhost docs")
 - [Simulated time](https://yulinsim.dev/time/ "Simulated time docs")
 - [Terraform](https://yulinsim.dev/terraform/ "Deploying Terraform into simulated AWS docs")
+
+Every page listed above also ships inside the package as markdown, documenting the version
+installed. `node_modules/@kensio/yulin/llms.txt` indexes them, and a coding agent with no network
+reach can read them from there.
 
 ## Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [SNS](https://yulinsim.dev/services/sns/ "Simulated SNS usage docs")
 - [SQS](https://yulinsim.dev/services/sqs/ "Simulated SQS usage docs")
 - [SSM Parameter Store](https://yulinsim.dev/services/ssm/ "Simulated SSM Parameter Store usage docs")
+- [Step Functions](https://yulinsim.dev/services/stepfunctions/ "Simulated Step Functions usage docs")
 - [STS](https://yulinsim.dev/services/sts/ "Simulated STS usage docs")
 - [WAFv2](https://yulinsim.dev/services/wafv2/ "Simulated WAFv2 usage docs")
 

--- a/docs/ai-skill/README.md
+++ b/docs/ai-skill/README.md
@@ -57,6 +57,13 @@ The skill sends the AI agent to these docs for anything API-shaped, and
 plain markdown by appending `llms.txt` to its URL, one file per guide and one per simulated service.
 That index works with or without the skill installed.
 
+The same pages ship inside the package. An installed project holds them under
+`node_modules/@kensio/yulin/docs/`, indexed by `node_modules/@kensio/yulin/llms.txt`, and they
+document the version in that package rather than the current release. An agent with no network
+reach has them, and so does one working on a project held a few versions back. Ripgrep and most
+editor search skip `node_modules` by default. An agent finds these files when something names the
+path for it.
+
 The skill lives at
 [kensio.ai/skills/yulin-aws-simulation](https://kensio.ai/skills/yulin-aws-simulation), versioned
 separately from Yulin and licensed Apache-2.0.

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "yulin": "./dist/cli/yulin.js"
   },
   "scripts": {
-    "clean": "rm -rf ./dist/ ./*.tsbuildinfo ./cffjs2.oxlintrc.json",
-    "build": "pnpm clean && tsc -p tsconfig.build.json && pnpm oxlint:config",
+    "clean": "rm -rf ./dist/ ./*.tsbuildinfo ./cffjs2.oxlintrc.json ./llms.txt",
+    "build": "pnpm clean && tsc -p tsconfig.build.json && pnpm oxlint:config && pnpm docs:index",
     "oxlint:config": "pnpm tsx scripts/mts/write-oxlint-config.mts",
+    "docs:index": "pnpm tsx scripts/mts/write-llms-index.mts",
     "build:check": "tsc -p tsconfig.json --noEmit",
     "prepack": "pnpm build",
     "verify:pack": "pnpm tsx scripts/mts/verify-pack.mts",
@@ -27,7 +28,7 @@
     "examples:tsc": "tsc -p docs/tsconfig.json",
     "examples:tsc:cdk": "tsc -p docs/tsconfig.cdk.json",
     "examples:lint": "oxlint --type-aware --max-warnings=0 docs",
-    "examples:check": "pnpm examples:extract && pnpm examples:tsc && pnpm examples:tsc:cdk && pnpm examples:lint",
+    "examples:check": "pnpm docs:index && pnpm examples:extract && pnpm examples:tsc && pnpm examples:tsc:cdk && pnpm examples:lint",
     "fta": "./scripts/sh/fta.sh",
     "check": "pnpm fmt && pnpm fta && pnpm build:check && pnpm examples:check && pnpm test:coverage",
     "tf:init": "./scripts/sh/tf-init.sh"
@@ -213,7 +214,9 @@
   },
   "files": [
     "dist",
+    "docs/**/README.md",
     "cffjs2.oxlintrc.json",
+    "llms.txt",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/mts/documentation-readmes.mts
+++ b/scripts/mts/documentation-readmes.mts
@@ -1,0 +1,33 @@
+/**
+ * Finding the documentation pages on disk.
+ *
+ * Two scripts walk the same tree. The example extractor reads every page for
+ * its fenced TypeScript blocks, and the `llms.txt` writer checks every page has
+ * a link pointing at it.
+ */
+
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+/** Every `README.md` under a directory, at any depth. */
+export async function findReadmes(
+  directory: string,
+): Promise<readonly string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const readmePaths: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      readmePaths.push(...(await findReadmes(entryPath)));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name === "README.md") {
+      readmePaths.push(entryPath);
+    }
+  }
+
+  return readmePaths;
+}

--- a/scripts/mts/extract-documentation-examples.mts
+++ b/scripts/mts/extract-documentation-examples.mts
@@ -1,7 +1,9 @@
 #!/usr/bin/env -S pnpm tsx
 
-import { readdir, readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+
+import { findReadmes } from "./documentation-readmes.mjs";
 
 const projectRoot = path.resolve(import.meta.dirname, "../..");
 const documentationDirectory = path.join(projectRoot, "docs");
@@ -31,26 +33,6 @@ async function main(): Promise<void> {
       await writeFile(outputPath, `${example.code.trimEnd()}\n`, "utf8");
     }
   }
-}
-
-async function findReadmes(directory: string): Promise<readonly string[]> {
-  const entries = await readdir(directory, { withFileTypes: true });
-  const readmePaths: string[] = [];
-
-  for (const entry of entries) {
-    const entryPath = path.join(directory, entry.name);
-
-    if (entry.isDirectory()) {
-      readmePaths.push(...(await findReadmes(entryPath)));
-      continue;
-    }
-
-    if (entry.isFile() && entry.name === "README.md") {
-      readmePaths.push(entryPath);
-    }
-  }
-
-  return readmePaths;
 }
 
 function extractTypescriptExamples(

--- a/scripts/mts/verify-pack-files.mts
+++ b/scripts/mts/verify-pack-files.mts
@@ -3,7 +3,9 @@
  *
  * An export naming a JSON file is not something the import check can reach,
  * and the Oxlint config fragment is named by path from a consumer's own config
- * rather than imported at all. Both are checked against the installed tarball.
+ * rather than imported at all. The documentation is read by a person or a
+ * coding agent and never resolved by anything. All three are checked against
+ * the installed tarball.
  */
 
 import { readFile, stat } from "node:fs/promises";
@@ -14,6 +16,9 @@ import type { FileExport, PackageManifest } from "./verify-pack.type.mjs";
 
 /** The Oxlint config fragment, as it sits in the published package root. */
 const oxlintConfigFileName = "cffjs2.oxlintrc.json";
+
+/** The documentation index, as it sits in the published package root. */
+const documentationIndexFileName = "llms.txt";
 
 /**
  * Resolves every string-valued export the way a consumer would.
@@ -95,6 +100,62 @@ export async function assertOxlintConfigExtendable(
 
   console.log(
     "Oxlint config sits in the package root and finds its own plugin.",
+  );
+}
+
+/**
+ * Checks the documentation the package ships against its own index.
+ *
+ * The pages reach the tarball through a glob in `files`, and a glob that stops
+ * matching publishes a package whose index points at nothing. Every entry in
+ * `llms.txt` is looked up in the installed package, which covers the index and
+ * the pages together.
+ */
+export async function assertDocumentationPublished(
+  consumerDirectory: string,
+  manifest: PackageManifest,
+): Promise<void> {
+  const packageRoot = path.join(
+    consumerDirectory,
+    "node_modules",
+    manifest.name,
+  );
+  const indexPath = path.join(packageRoot, documentationIndexFileName);
+
+  if (!(await isFile(indexPath))) {
+    throw new Error(
+      `The tarball has no ${documentationIndexFileName} in its package root, so the documentation it ships has no index.`,
+    );
+  }
+
+  const index = await readFile(indexPath, "utf8");
+  const pages = index
+    .matchAll(/^- \[[^\]]+]\(([^\s)]+)\)/gm)
+    .map(([, page]) => page ?? "")
+    .toArray();
+
+  if (pages.length === 0) {
+    throw new Error(
+      `${documentationIndexFileName} lists no pages, so the tarball ships an index of nothing.`,
+    );
+  }
+
+  const missing: string[] = [];
+
+  for (const page of pages) {
+    if (!(await isFile(path.join(packageRoot, page)))) {
+      missing.push(page);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `${documentationIndexFileName} names pages the tarball does not have:\n${missing.map((page) => `  ${page}`).join("\n")}`,
+    );
+  }
+
+  console.log(
+    `All ${String(pages.length)} documentation pages named by ${documentationIndexFileName} are in the tarball.`,
   );
 }
 

--- a/scripts/mts/verify-pack-tarball.mts
+++ b/scripts/mts/verify-pack-tarball.mts
@@ -1,0 +1,114 @@
+/**
+ * The checks against the packed tarball itself, before anything installs it.
+ *
+ * What the tarball holds and what it weighs are properties of the archive, and
+ * both are read straight out of it with `tar`.
+ */
+
+import { execa } from "execa";
+import { stat } from "node:fs/promises";
+
+/** Build artefacts that must never be published. */
+const forbiddenTarballEntries = [
+  ".tsbuildinfo",
+  "/dist-hidden/",
+  "/node_modules/",
+];
+
+/**
+ * What the tarball is allowed to weigh, unpacked and in files.
+ *
+ * Yulin gains about a megabyte and five hundred files a week, a simulated
+ * service at a time, so these are a ratchet rather than a fixed ceiling: raise
+ * them in the change that earns the growth. They sit far enough above the
+ * package to leave a couple of months of ordinary work alone, and close enough
+ * to catch a single change that alters what the build emits for every module.
+ *
+ * File count is the tighter of the two. Yulin is thousands of small modules
+ * rather than a few large ones, and a consumer feels that in how long an
+ * install takes to unpack far more than it feels the megabytes.
+ *
+ * The unpacked limit went from 20 MiB to 24 MiB when the documentation pages
+ * joined the package. They add about two megabytes across 45 pages and an
+ * index, taking the tarball to 17.83 MiB, and the gap above it is back to
+ * what it was.
+ */
+const maximumUnpackedBytes = 24 * 1024 * 1024;
+const maximumFileCount = 12_000;
+
+/** Fails when the tarball carries a build artefact that must not ship. */
+export async function assertTarballHygiene(tarballPath: string): Promise<void> {
+  const { stdout } = await execa("tar", ["tzf", tarballPath]);
+  const entries = stdout.split("\n");
+
+  const offenders = entries.filter((entry) =>
+    forbiddenTarballEntries.some((forbidden) => entry.includes(forbidden)),
+  );
+
+  if (offenders.length > 0) {
+    throw new Error(
+      `Tarball contains build artefacts that must not be published:\n${offenders.join("\n")}`,
+    );
+  }
+
+  console.log(`Tarball is clean (${String(entries.length)} entries).`);
+}
+
+/**
+ * Fails the verification when the tarball outgrows what the package is allowed
+ * to ship, and reports what it weighs either way.
+ *
+ * A publish that suddenly carries far more than the last one is worth seeing
+ * before it goes out, whether it came from a change to what the build emits or
+ * from a directory that should never have been packed.
+ */
+export async function assertTarballSize(tarballPath: string): Promise<void> {
+  const { size } = await stat(tarballPath);
+  const { stdout } = await execa("tar", ["tzvf", tarballPath]);
+
+  const entries = stdout.split("\n");
+  const unpacked = entries.reduce(
+    (total, entry) => total + entrySize(entry),
+    0,
+  );
+
+  console.log(
+    `Tarball is ${formatBytes(size)} packed, ${formatBytes(unpacked)} unpacked, in ${String(entries.length)} files.`,
+  );
+
+  const breaches = [
+    unpacked > maximumUnpackedBytes
+      ? `unpacked size is ${formatBytes(unpacked)}, over the ${formatBytes(maximumUnpackedBytes)} limit`
+      : undefined,
+    entries.length > maximumFileCount
+      ? `file count is ${String(entries.length)}, over the ${String(maximumFileCount)} limit`
+      : undefined,
+  ].filter((breach) => breach !== undefined);
+
+  if (breaches.length > 0) {
+    throw new Error(
+      `Tarball is too large to publish:\n${breaches.join("\n")}\n` +
+        "Either stop shipping what it gained, or raise the limit in this script deliberately.",
+    );
+  }
+}
+
+/**
+ * Size of one `tar tzvf` entry, whichever of BSD tar and GNU tar produced it.
+ *
+ * The two put the size in different columns, but in both it is the last
+ * whole-number field before the modification date.
+ */
+function entrySize(entry: string): number {
+  const fields = entry.trim().split(/\s+/).slice(0, 5);
+  const sizes = fields.filter((field) => /^\d+$/.test(field));
+  const size = sizes.at(-1);
+
+  return size === undefined ? 0 : Number(size);
+}
+
+function formatBytes(bytes: number): string {
+  const mib = bytes / 1024 / 1024;
+
+  return `${mib.toFixed(2)} MiB (${bytes.toLocaleString("en-GB")} bytes)`;
+}

--- a/scripts/mts/verify-pack.mts
+++ b/scripts/mts/verify-pack.mts
@@ -15,7 +15,7 @@
  */
 
 import { execa } from "execa";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -31,6 +31,10 @@ import {
   assertFileExportsResolve,
   assertOxlintConfigExtendable,
 } from "./verify-pack-files.mjs";
+import {
+  assertTarballHygiene,
+  assertTarballSize,
+} from "./verify-pack-tarball.mjs";
 import type {
   FileExport,
   ImportResult,
@@ -39,34 +43,6 @@ import type {
 } from "./verify-pack.type.mjs";
 
 const projectRoot = path.resolve(import.meta.dirname, "../..");
-
-/** Build artefacts that must never be published. */
-const forbiddenTarballEntries = [
-  ".tsbuildinfo",
-  "/dist-hidden/",
-  "/node_modules/",
-];
-
-/**
- * What the tarball is allowed to weigh, unpacked and in files.
- *
- * Yulin gains about a megabyte and five hundred files a week, a simulated
- * service at a time, so these are a ratchet rather than a fixed ceiling: raise
- * them in the change that earns the growth. They sit far enough above the
- * package to leave a couple of months of ordinary work alone, and close enough
- * to catch a single change that alters what the build emits for every module.
- *
- * File count is the tighter of the two. Yulin is thousands of small modules
- * rather than a few large ones, and a consumer feels that in how long an
- * install takes to unpack far more than it feels the megabytes.
- *
- * The unpacked limit went from 20 MiB to 24 MiB when the documentation pages
- * joined the package. They add about two megabytes across 45 pages and an
- * index, taking the tarball to 17.83 MiB, and the gap above it is back to
- * what it was.
- */
-const maximumUnpackedBytes = 24 * 1024 * 1024;
-const maximumFileCount = 12_000;
 
 /**
  * Exports a consumer imports by name, keyed by export subpath.
@@ -191,82 +167,6 @@ async function pack(destination: string): Promise<string> {
   assertDefined(entry, "npm pack produced no tarball");
 
   return path.join(destination, entry.filename);
-}
-
-async function assertTarballHygiene(tarballPath: string): Promise<void> {
-  const { stdout } = await execa("tar", ["tzf", tarballPath]);
-  const entries = stdout.split("\n");
-
-  const offenders = entries.filter((entry) =>
-    forbiddenTarballEntries.some((forbidden) => entry.includes(forbidden)),
-  );
-
-  if (offenders.length > 0) {
-    throw new Error(
-      `Tarball contains build artefacts that must not be published:\n${offenders.join("\n")}`,
-    );
-  }
-
-  console.log(`Tarball is clean (${String(entries.length)} entries).`);
-}
-
-/**
- * Fails the verification when the tarball outgrows what the package is allowed
- * to ship, and reports what it weighs either way.
- *
- * A publish that suddenly carries far more than the last one is worth seeing
- * before it goes out, whether it came from a change to what the build emits or
- * from a directory that should never have been packed.
- */
-async function assertTarballSize(tarballPath: string): Promise<void> {
-  const { size } = await stat(tarballPath);
-  const { stdout } = await execa("tar", ["tzvf", tarballPath]);
-
-  const entries = stdout.split("\n");
-  const unpacked = entries.reduce(
-    (total, entry) => total + entrySize(entry),
-    0,
-  );
-
-  console.log(
-    `Tarball is ${formatBytes(size)} packed, ${formatBytes(unpacked)} unpacked, in ${String(entries.length)} files.`,
-  );
-
-  const breaches = [
-    unpacked > maximumUnpackedBytes
-      ? `unpacked size is ${formatBytes(unpacked)}, over the ${formatBytes(maximumUnpackedBytes)} limit`
-      : undefined,
-    entries.length > maximumFileCount
-      ? `file count is ${String(entries.length)}, over the ${String(maximumFileCount)} limit`
-      : undefined,
-  ].filter((breach) => breach !== undefined);
-
-  if (breaches.length > 0) {
-    throw new Error(
-      `Tarball is too large to publish:\n${breaches.join("\n")}\n` +
-        "Either stop shipping what it gained, or raise the limit in this script deliberately.",
-    );
-  }
-}
-
-/**
- * Size of one `tar tzvf` entry, whichever of BSD tar and GNU tar produced it.
- *
- * The two put the size in different columns, but in both it is the last
- * whole-number field before the modification date.
- */
-function entrySize(entry: string): number {
-  const fields = entry.trim().split(/\s+/).slice(0, 5);
-  const sizes = fields.filter((field) => /^\d+$/.test(field));
-  const size = sizes.at(-1);
-
-  return size === undefined ? 0 : Number(size);
-}
-
-function formatBytes(bytes: number): string {
-  const mib = bytes / 1024 / 1024;
-
-  return `${mib.toFixed(2)} MiB (${bytes.toLocaleString("en-GB")} bytes)`;
 }
 
 function report(

--- a/scripts/mts/verify-pack.mts
+++ b/scripts/mts/verify-pack.mts
@@ -27,6 +27,7 @@ import {
   importSubpaths,
 } from "./verify-pack-consumer.mjs";
 import {
+  assertDocumentationPublished,
   assertFileExportsResolve,
   assertOxlintConfigExtendable,
 } from "./verify-pack-files.mjs";
@@ -58,8 +59,13 @@ const forbiddenTarballEntries = [
  * File count is the tighter of the two. Yulin is thousands of small modules
  * rather than a few large ones, and a consumer feels that in how long an
  * install takes to unpack far more than it feels the megabytes.
+ *
+ * The unpacked limit went from 20 MiB to 24 MiB when the documentation pages
+ * joined the package. They add about two megabytes across 45 pages and an
+ * index, taking the tarball to 17.83 MiB, and the gap above it is back to
+ * what it was.
  */
-const maximumUnpackedBytes = 20 * 1024 * 1024;
+const maximumUnpackedBytes = 24 * 1024 * 1024;
 const maximumFileCount = 12_000;
 
 /**
@@ -112,6 +118,7 @@ async function main(): Promise<void> {
 
     assertFileExportsResolve(consumerDirectory, fileExports);
     await assertOxlintConfigExtendable(consumerDirectory, manifest);
+    await assertDocumentationPublished(consumerDirectory, manifest);
     await assertTypesUsable(consumerDirectory);
   } finally {
     await rm(workDirectory, { recursive: true, force: true });

--- a/scripts/mts/write-llms-index.mts
+++ b/scripts/mts/write-llms-index.mts
@@ -1,0 +1,199 @@
+#!/usr/bin/env -S pnpm tsx
+
+/**
+ * Writes the published `llms.txt` into the package root from the links in
+ * `docs/README.md`.
+ *
+ * The package carries its documentation as markdown, and this index is how a
+ * reader finds one page without opening every one of them. It sits in the
+ * package root because that is where the same file sits on the website, and
+ * because a coding agent hunting for one has a single path to try.
+ *
+ * Generating it from `docs/README.md` keeps the repository to one list of
+ * pages. A page added there reaches the index, and a page nothing links to
+ * fails this script.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { findReadmes } from "./documentation-readmes.mjs";
+
+const projectRoot = path.resolve(import.meta.dirname, "../..");
+const documentationDirectory = path.join(projectRoot, "docs");
+const outputPath = path.join(projectRoot, "llms.txt");
+
+/** The website, and the prefix every link in `docs/README.md` carries. */
+const siteOrigin = "https://yulinsim.dev/";
+
+/** The list this index is generated from, and the one page it leaves out. */
+const indexPage = "docs/README.md";
+
+const preamble = `# Yulin
+
+> AWS system behaviour simulation for isolated unit testing.
+
+The pages below ship with the package as markdown, and they document the version
+installed. Paths are relative to the package root, which an installed project
+has at \`node_modules/@kensio/yulin/\`.
+
+The same pages are on the web at ${siteOrigin} for whichever release is current.
+`;
+
+interface DocumentationLink {
+  readonly title: string;
+  readonly filePath: string;
+  readonly description: string | undefined;
+}
+
+interface DocumentationSection {
+  readonly heading: string;
+  readonly links: DocumentationLink[];
+}
+
+async function main(): Promise<void> {
+  const markdown = await readFile(path.join(projectRoot, indexPage), "utf8");
+  const sections = parseSections(markdown);
+
+  await assertIndexIsComplete(sections);
+
+  await writeFile(outputPath, render(sections), "utf8");
+
+  // This runs inside `prepack`, where `npm pack --json` gives its own output
+  // on stdout, and anything said there would be parsed as part of it.
+  console.error(`Wrote ${path.relative(projectRoot, outputPath)}.`);
+}
+
+/** The `##` sections of `docs/README.md`, and the doc links under each one. */
+function parseSections(markdown: string): readonly DocumentationSection[] {
+  const sections: DocumentationSection[] = [];
+  const linkPattern = /^- \[([^\]]+)]\(([^)]+)\)/;
+
+  for (const line of markdown.split("\n")) {
+    const heading = /^## (.+)$/.exec(line)?.[1];
+
+    if (heading !== undefined) {
+      sections.push({ heading, links: [] });
+      continue;
+    }
+
+    const match = linkPattern.exec(line);
+    const section = sections.at(-1);
+
+    if (match === null || section === undefined) {
+      continue;
+    }
+
+    const [, title, target] = match;
+
+    if (title === undefined || target === undefined) {
+      continue;
+    }
+
+    const { url, description } = splitLinkTarget(target);
+    const filePath = toDocumentationPath(url);
+
+    if (filePath !== undefined) {
+      section.links.push({ title, filePath, description });
+    }
+  }
+
+  return sections.filter((section) => section.links.length > 0);
+}
+
+/**
+ * Splits what a markdown link holds into the URL and the title attribute.
+ *
+ * The two are separated by a space, and the title attribute is in quotes. A
+ * link written without one gives `undefined` for it.
+ */
+function splitLinkTarget(target: string): {
+  readonly url: string;
+  readonly description: string | undefined;
+} {
+  const separator = target.indexOf(" ");
+
+  if (separator === -1) {
+    return { url: target, description: undefined };
+  }
+
+  const title = target.slice(separator + 1).trim();
+  const quoted = title.startsWith('"') && title.endsWith('"');
+
+  return {
+    url: target.slice(0, separator),
+    description: quoted ? title.slice(1, -1) : title,
+  };
+}
+
+/**
+ * The package-relative page a website URL stands for.
+ *
+ * A link pointing anywhere else, such as the specification the AI skill page
+ * cites, gives `undefined` and stays out of the index.
+ */
+function toDocumentationPath(url: string): string | undefined {
+  if (!url.startsWith(siteOrigin)) {
+    return undefined;
+  }
+
+  const slug = url.slice(siteOrigin.length).replace(/\/$/, "");
+
+  return slug === "" ? undefined : `docs/${slug}/README.md`;
+}
+
+/**
+ * Checks the index against the documentation tree in both directions.
+ *
+ * A link naming a page the package lacks publishes a dead path. A page nothing
+ * links to is one an agent reading the index never finds. Both go wrong at the
+ * moment a service is documented, and both are silent everywhere else.
+ */
+async function assertIndexIsComplete(
+  sections: readonly DocumentationSection[],
+): Promise<void> {
+  const linked = new Set(
+    sections.flatMap((section) => section.links.map((link) => link.filePath)),
+  );
+
+  const readmePaths = await findReadmes(documentationDirectory);
+  const onDisk = new Set(
+    readmePaths.map((readmePath) =>
+      path.relative(projectRoot, readmePath).split(path.sep).join("/"),
+    ),
+  );
+
+  onDisk.delete(indexPage);
+
+  const unlinked = onDisk.difference(linked);
+  const absent = linked.difference(onDisk);
+
+  if (unlinked.size > 0 || absent.size > 0) {
+    throw new Error(
+      [
+        `${indexPage} and the documentation tree disagree.`,
+        ...[...unlinked].map((page) => `  nothing links to ${page}`),
+        ...[...absent].map((page) => `  linked, but the tree has no ${page}`),
+      ].join("\n"),
+    );
+  }
+}
+
+function render(sections: readonly DocumentationSection[]): string {
+  const rendered = sections.map(
+    (section) =>
+      `## ${section.heading}\n\n${section.links.map(renderLink).join("\n")}\n`,
+  );
+
+  return [preamble, ...rendered].join("\n");
+}
+
+function renderLink(link: DocumentationLink): string {
+  const entry = `- [${link.title}](${link.filePath})`;
+
+  return link.description === undefined
+    ? entry
+    : `${entry}: ${link.description}`;
+}
+
+await main();


### PR DESCRIPTION
The 45 documentation pages now go into the tarball, indexed by an llms.txt written into the package root from the links in docs/README.md. An agent working in a project holds the docs for the version installed, and reaches them with no network. The tarball grows about two megabytes to 17.83 MiB, and the pack verification limit moves to 24 MiB to keep the same headroom above it. Generating the index also caught two lists that had drifted. docs/README.md was missing Step Functions, and the root README was missing nine pages.

@coderabbitai ignore