### PR TITLE
feat: name a default caller for a simulation

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -80,7 +80,9 @@ Each sent Command resolves its own simulated Account and Region scope:
 The resolved caller reaches the simulated service, and simulated [IAM](https://yulinsim.dev/services/iam/)
 authorization applies to it exactly as it does for direct sim service use. A caller without
 permission for a Command is denied, as on real AWS. Where no caller can be identified, Commands run
-as the simulation's default Account root.
+as the simulation's `defaultCaller`, and as the default Account root where the simulation was given
+none. See
+[Name the caller a simulation uses by default](https://yulinsim.dev/services/iam/#name-the-caller-a-simulation-uses-by-default).
 
 `runAs` runs a function with an ambient simulated caller, such as an IAM Role. Commands sent during
 the run are attributed to that caller, with no changes to the client or the code under test:

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -595,6 +595,10 @@ console.log(decision.caller.arn); // "arn:aws:iam::123456789012:role/Administrat
 console.log(decision.isAllowed); // true
 ```
 
+`defaultCaller` takes a principal or a caller resolved elsewhere, such as an assumed-role session
+carrying the Role its policies come from. Credentials are the one caller it refuses. Only the
+Account that issued a key can authenticate it, and a default is held for a whole simulation.
+
 The default reaches a direct sim service call, an intercepted SDK Command, a CloudFormation
 deployment and STS. Three things outrank it, each of them a caller stated for the request in hand.
 An operation's own `caller` wins, as does the ambient caller of a `runAs` block and the `caller` a

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -89,9 +89,11 @@ matching Allows are also available per side as `identityAllowStatements` and
 could not evaluate are reported by `unevaluatedStatements`, covered under
 [Statements left unevaluated](#statements-left-unevaluated).
 
-If the caller is omitted, authorization defaults to the root principal of the Account owning the
-sim IAM instance. That principal is allowed within its own Account. An explicit
-`{ kind: "anonymous" }` caller suppresses the fallback and is evaluated without identity policies.
+If the caller is omitted, authorization defaults to the simulation's own
+[default caller](#name-the-caller-a-simulation-uses-by-default), and to the root principal of the
+Account owning the sim IAM instance where the simulation has none. That root principal is allowed
+within its own Account. An explicit `{ kind: "anonymous" }` caller suppresses both fallbacks and is
+evaluated without identity policies.
 
 Resource policies live with the service that owns the target resource, such as an S3 Bucket policy,
 and are supplied with the authorization request.
@@ -528,6 +530,82 @@ The resolved caller ARN is the STS assumed-role session ARN, such as
 the derived `aws:PrincipalArn` come from the underlying Role. A caller that the trust policy does
 not allow is denied the assume request, session credentials require their session token, and
 expired sessions are rejected.
+
+## Name the caller a simulation uses by default
+
+Every simulated operation takes a `caller`, and a call that gives none is decided as the root
+principal of the Account it reaches. `defaultCaller` on `SimAws` names a principal for those calls,
+such as the Role an operator would be reading the account through.
+
+```typescript sim-iam-default-caller
+/**
+ * Naming who a call that states no caller comes from.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  defaultAccountId: "123456789012",
+  defaultCaller: {
+    kind: "arn",
+    arn: "arn:aws:iam::123456789012:role/Administrator",
+  },
+});
+
+// The Role is created as the Account root. A simulation with a default caller
+// attributes these commands to it, and it holds no policy until they are done.
+const root = simAws.account().rootPrincipal;
+const simIam = simAws.iam();
+
+await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "Administrator",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::123456789012:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+  { caller: root },
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Administrator",
+    PolicyName: "Administer",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+    }),
+  }),
+  { caller: root },
+);
+
+const decision = simAws.iam().authorize({
+  action: "s3:GetObject",
+  resource: "arn:aws:s3:::reports-bucket/summary.csv",
+});
+
+console.log(decision.caller.arn); // "arn:aws:iam::123456789012:role/Administrator"
+console.log(decision.isAllowed); // true
+```
+
+The default reaches a direct sim service call, an intercepted SDK Command, a CloudFormation
+deployment and STS. Three things outrank it, each of them a caller stated for the request in hand.
+An operation's own `caller` wins, as does the ambient caller of a `runAs` block and the `caller` a
+deployment is given.
+
+A simulation told no `defaultCaller` decides an unattributed call as the Account root, which is what
+every simulation did before the option existed. The root keeps its unrestricted access either way,
+and a test about root behaviour reaches it as `simAws.account().rootPrincipal`.
+
+The reason to name one is a service control policy denying the Account root.
+[Simulated Organizations](https://yulinsim.dev/services/organizations/) covers that case, where
+every unattributed read is otherwise denied on a message about the root.
 
 ## Callers of HTTP requests
 

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -92,7 +92,8 @@ could not evaluate are reported by `unevaluatedStatements`, covered under
 If the caller is omitted, authorization defaults to the simulation's own
 [default caller](#name-the-caller-a-simulation-uses-by-default), and to the root principal of the
 Account owning the sim IAM instance where the simulation has none. That root principal is allowed
-within its own Account. An explicit `{ kind: "anonymous" }` caller suppresses both fallbacks and is
+within its own Account, subject to any service control policy over that Account. An explicit
+`{ kind: "anonymous" }` caller suppresses both fallbacks and is
 evaluated without identity policies.
 
 Resource policies live with the service that owns the target resource, such as an S3 Bucket policy,
@@ -600,8 +601,9 @@ An operation's own `caller` wins, as does the ambient caller of a `runAs` block 
 deployment is given.
 
 A simulation told no `defaultCaller` decides an unattributed call as the Account root, which is what
-every simulation did before the option existed. The root keeps its unrestricted access either way,
-and a test about root behaviour reaches it as `simAws.account().rootPrincipal`.
+every simulation did before the option existed. The root keeps the identity access sim IAM gives it
+either way, and a test about root behaviour reaches it as `simAws.account().rootPrincipal`. A
+service control policy denying that root still overrides the access.
 
 The reason to name one is a service control policy denying the Account root.
 [Simulated Organizations](https://yulinsim.dev/services/organizations/) covers that case, where

--- a/docs/services/iam/sim-iam-default-caller.example.ts
+++ b/docs/services/iam/sim-iam-default-caller.example.ts
@@ -1,0 +1,54 @@
+/**
+ * Naming who a call that states no caller comes from.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  defaultAccountId: "123456789012",
+  defaultCaller: {
+    kind: "arn",
+    arn: "arn:aws:iam::123456789012:role/Administrator",
+  },
+});
+
+// The Role is created as the Account root. A simulation with a default caller
+// attributes these commands to it, and it holds no policy until they are done.
+const root = simAws.account().rootPrincipal;
+const simIam = simAws.iam();
+
+await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "Administrator",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::123456789012:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+  { caller: root },
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Administrator",
+    PolicyName: "Administer",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+    }),
+  }),
+  { caller: root },
+);
+
+const decision = simAws.iam().authorize({
+  action: "s3:GetObject",
+  resource: "arn:aws:s3:::reports-bucket/summary.csv",
+});
+
+console.log(decision.caller.arn); // "arn:aws:iam::123456789012:role/Administrator"
+console.log(decision.isAllowed); // true

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -372,9 +372,9 @@ console.log(identity.Arn); // "arn:aws:iam::123456789012:role/Administrator"
 Setup runs before the policy is attached, for the same reason the deploy Role above does. The Role a
 simulation reads as has to exist and hold a policy, and creating it is itself a call.
 
-The account root keeps the unrestricted access sim IAM gives it. Naming a default caller says who an
-unattributed call comes from and leaves the root's own access alone. A test about root behaviour
-names `simAws.account().rootPrincipal` and gets it.
+Naming a default caller says who an unattributed call comes from, and leaves the root's own identity
+access where it was. A test about root behaviour names `simAws.account().rootPrincipal` and gets the
+root. Under the policy above that call is denied, which is what the statement is written to do.
 
 ## Write an allow list instead of a deny list
 

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -288,6 +288,94 @@ console.log(stack.getResource("ReportsBucket")?.status); // "CREATE_COMPLETE"
 The Role is created before the policy is attached. Creating it afterwards is a call the policy
 denies the root, and the account root is who a bare `createRole` runs as.
 
+## Name the caller the rest of a test reads as
+
+A deployment names its own principal. Every other call in the test still names none, and each one is
+the account root. Under a policy denying that root, a test reading back what a stack made is denied
+on every read.
+
+`defaultCaller` on `SimAws` says who those calls are. A test then reads the account as the person or
+role that would really be looking at it, and an explicit `caller` still wins wherever one is given.
+
+```typescript sim-organizations-scp-default-caller
+/**
+ * Reading an account whose organization denies its root principal.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const administratorArn = "arn:aws:iam::123456789012:role/Administrator";
+
+const simAws = new SimAws({
+  defaultAccountId: "123456789012",
+  defaultCaller: { kind: "arn", arn: administratorArn },
+});
+
+// The Role is created as the account root, because a simulation with a default
+// caller attributes these two commands to a Role that has no policy yet.
+const root = simAws.account().rootPrincipal;
+const simIam = simAws.iam();
+
+await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "Administrator",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::123456789012:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+  { caller: root },
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Administrator",
+    PolicyName: "Administer",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+    }),
+  }),
+  { caller: root },
+);
+
+simAws.organizations().attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyRootPrincipal",
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { ArnLike: { "aws:PrincipalArn": "arn:aws:iam::*:root" } },
+  },
+});
+
+await simAws.ssm().putParameter({
+  input: { Name: "/reports/bucket", Type: "String", Value: "reports-bucket" },
+});
+
+const read = await simAws
+  .ssm()
+  .getParameter({ input: { Name: "/reports/bucket" } });
+
+const identity = await simAws.sts().getCallerIdentity({});
+
+console.log(read.Parameter?.Value); // "reports-bucket"
+console.log(identity.Arn); // "arn:aws:iam::123456789012:role/Administrator"
+```
+
+Setup runs before the policy is attached, for the same reason the deploy Role above does. The Role a
+simulation reads as has to exist and hold a policy, and creating it is itself a call.
+
+The account root keeps the unrestricted access sim IAM gives it. Naming a default caller says who an
+unattributed call comes from and leaves the root's own access alone. A test about root behaviour
+names `simAws.account().rootPrincipal` and gets it.
+
 ## Write an allow list instead of a deny list
 
 `detachFullAwsAccess` takes AWS's own policy off an account. What remains has to allow an action

--- a/docs/services/organizations/sim-organizations-scp-default-caller.example.ts
+++ b/docs/services/organizations/sim-organizations-scp-default-caller.example.ts
@@ -1,0 +1,69 @@
+/**
+ * Reading an account whose organization denies its root principal.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const administratorArn = "arn:aws:iam::123456789012:role/Administrator";
+
+const simAws = new SimAws({
+  defaultAccountId: "123456789012",
+  defaultCaller: { kind: "arn", arn: administratorArn },
+});
+
+// The Role is created as the account root, because a simulation with a default
+// caller attributes these two commands to a Role that has no policy yet.
+const root = simAws.account().rootPrincipal;
+const simIam = simAws.iam();
+
+await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "Administrator",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::123456789012:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+  { caller: root },
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Administrator",
+    PolicyName: "Administer",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+    }),
+  }),
+  { caller: root },
+);
+
+simAws.organizations().attachServiceControlPolicy("123456789012", {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "DenyRootPrincipal",
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { ArnLike: { "aws:PrincipalArn": "arn:aws:iam::*:root" } },
+  },
+});
+
+await simAws.ssm().putParameter({
+  input: { Name: "/reports/bucket", Type: "String", Value: "reports-bucket" },
+});
+
+const read = await simAws
+  .ssm()
+  .getParameter({ input: { Name: "/reports/bucket" } });
+
+const identity = await simAws.sts().getCallerIdentity({});
+
+console.log(read.Parameter?.Value); // "reports-bucket"
+console.log(identity.Arn); // "arn:aws:iam::123456789012:role/Administrator"

--- a/src/serve/http/sim-aws-http-caller.iso.test.ts
+++ b/src/serve/http/sim-aws-http-caller.iso.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { signAwsRequest } from "../../../test/sigv4/sign-aws-request.js";
 import { createSigner } from "../../../test/sigv4/sim-signer.js";
 import { SimAws } from "../../service/aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../service/iam/role/sim-iam-role-with-policy.factory.js";
 import { makeLambdaZipFileInput } from "../../service/lambda/function/code/lambda-zip-file-input.js";
 import { simAwsCallerHeaderName } from "../../service/iam/request/sim-aws-caller-header.js";
 import {
@@ -60,6 +61,35 @@ describe("The caller of a served simulated AWS request", () => {
 
     // Then the simulator reports the caller as anonymous, not the Account
     // root, which is what an omitted in-process caller would have meant
+    expect(response.headers.get(simAwsCallerHeaderName)).toBe("anonymous");
+    expect(response.headers.get(simAwsAuthHeaderName)).toBe("none");
+  });
+
+  it("keeps an unauthenticated request anonymous under a default caller", async () => {
+    // Given a simulation that names a default caller for its own calls, which
+    // is what the Function below is then created as
+    const simAws = new SimAws({
+      defaultCaller: {
+        kind: "arn",
+        arn: "arn:aws:iam::888888888888:role/Administrator",
+      },
+    });
+    await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Administrator",
+        actions: ["*"],
+        caller: simAws.account().rootPrincipal,
+      },
+      simAws,
+    );
+    const url = await serveHeaderEcho(simAws);
+
+    // When a request arrives over HTTP carrying no identity
+    const response = await new SimAwsHttp({ simAws }).fetch(url);
+
+    // Then it is still anonymous. The default is a convenience for calls made
+    // inside the process, and applying it here would hand that Role to anyone
+    // who could reach the port
     expect(response.headers.get(simAwsCallerHeaderName)).toBe("anonymous");
     expect(response.headers.get(simAwsAuthHeaderName)).toBe("none");
   });

--- a/src/service/aws/caller/sim-aws-caller-resolver.ts
+++ b/src/service/aws/caller/sim-aws-caller-resolver.ts
@@ -29,41 +29,71 @@ export interface SimAwsResolvedCaller {
 }
 
 /**
+ * What resolving a caller needs beyond the caller itself.
+ */
+export interface SimAwsCallerResolverProperties {
+  /**
+   * Authenticates a caller that presents credentials.
+   */
+  readonly credentialIdentityResolver?:
+    | SimAwsCredentialIdentityResolver
+    | undefined;
+
+  /**
+   * The caller a request naming none of its own is attributed to.
+   *
+   * A simulation sets this to say who its unattributed calls come from. It is
+   * consulted ahead of the operation default. A simulation that names no
+   * default caller keeps the Account root fallback.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
+}
+
+/**
  * Resolves caller input at a simulated AWS operation boundary.
  *
- * An omitted caller resolves to the supplied operation default. Explicit
- * anonymity is preserved. Credential callers are authenticated before a
- * resolved caller is returned, and a caller already resolved elsewhere is
- * taken as it stands.
+ * An omitted caller resolves to the simulation's default caller, and to the
+ * supplied operation default where there is none. Explicit anonymity is
+ * preserved. Credential callers are authenticated before a resolved caller is
+ * returned, and a caller already resolved elsewhere is taken as it stands.
  */
 export class SimAwsCallerResolver {
   private readonly credentialIdentityResolver?:
     | SimAwsCredentialIdentityResolver
     | undefined;
 
-  constructor(credentialIdentityResolver?: SimAwsCredentialIdentityResolver) {
-    this.credentialIdentityResolver = credentialIdentityResolver;
+  private readonly defaultCaller?: SimAwsCaller | undefined;
+
+  constructor(properties: SimAwsCallerResolverProperties = {}) {
+    this.credentialIdentityResolver = properties.credentialIdentityResolver;
+    this.defaultCaller = properties.defaultCaller;
   }
 
   /**
    * Resolve and normalize a simulated AWS caller.
+   *
+   * The request's own caller is used where it has one. A request without one
+   * falls back to the simulation's default caller, and then to the operation
+   * default the call site supplies.
    */
   resolve(
     caller: SimAwsCaller | undefined,
     defaultPrincipal: SimAwsPrincipal,
   ): SimAwsResolvedCaller {
-    if (caller?.kind === "resolved") {
-      return this.normalized(caller.principal, caller.identityPolicyPrincipal);
+    const stated = caller ?? this.defaultCaller;
+
+    if (stated?.kind === "resolved") {
+      return this.normalized(stated.principal, stated.identityPolicyPrincipal);
     }
 
-    if (caller?.kind === "credentials") {
+    if (stated?.kind === "credentials") {
       assertDefined(
         this.credentialIdentityResolver,
         "Simulated credential callers require an IAM credential resolver",
       );
 
       const identity = this.credentialIdentityResolver.resolveCredentials(
-        caller.credentials,
+        stated.credentials,
       );
 
       return this.normalized(
@@ -72,7 +102,7 @@ export class SimAwsCallerResolver {
       );
     }
 
-    const principal = caller ?? defaultPrincipal;
+    const principal = stated ?? defaultPrincipal;
     return this.normalized(principal, principal);
   }
 

--- a/src/service/aws/caller/sim-aws-caller-resolver.ts
+++ b/src/service/aws/caller/sim-aws-caller-resolver.ts
@@ -1,6 +1,7 @@
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import type {
   SimAwsCaller,
+  SimAwsDefaultCaller,
   SimAwsPrincipal,
   SimCredentialCaller,
 } from "./sim-aws-caller.js";
@@ -46,7 +47,7 @@ export interface SimAwsCallerResolverProperties {
    * consulted ahead of the operation default. A simulation that names no
    * default caller keeps the Account root fallback.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 }
 
 /**
@@ -62,7 +63,7 @@ export class SimAwsCallerResolver {
     | SimAwsCredentialIdentityResolver
     | undefined;
 
-  private readonly defaultCaller?: SimAwsCaller | undefined;
+  private readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 
   constructor(properties: SimAwsCallerResolverProperties = {}) {
     this.credentialIdentityResolver = properties.credentialIdentityResolver;

--- a/src/service/aws/caller/sim-aws-caller.ts
+++ b/src/service/aws/caller/sim-aws-caller.ts
@@ -65,3 +65,13 @@ export type SimAwsCaller =
   | SimAwsPrincipal
   | SimCredentialCaller
   | SimResolvedCaller;
+
+/**
+ * Caller a simulation attributes a request that names none of its own to.
+ *
+ * A principal, or a caller something else has already resolved. Credentials
+ * are left out because the Account that issued a key is the only thing able to
+ * authenticate it, while a default is held for a whole simulation. A key from
+ * one Account would fail wherever another Account decided the request.
+ */
+export type SimAwsDefaultCaller = SimAwsPrincipal | SimResolvedCaller;

--- a/src/service/aws/caller/sim-aws-default-caller.iso.test.ts
+++ b/src/service/aws/caller/sim-aws-default-caller.iso.test.ts
@@ -154,6 +154,45 @@ describe("Simulated AWS default caller", () => {
     assertStringIncludes(error.message, `User: ${bystander.Arn}`);
   });
 
+  it("takes a resolved caller, applying the Role behind a session", async () => {
+    // Given a Role, and a default caller standing for a session of it.
+    const accountId = makeSimAwsAccountId();
+    const roleArn = `arn:aws:iam::${accountId}:role/Operator`;
+    const simAws = new SimAws({
+      defaultAccountId: accountId,
+      defaultCaller: {
+        kind: "resolved",
+        principal: {
+          kind: "arn",
+          arn: `arn:aws:sts::${accountId}:assumed-role/Operator/session`,
+        },
+        identityPolicyPrincipal: { kind: "arn", arn: roleArn },
+      },
+    });
+
+    await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Operator",
+        actions: ["ssm:GetParameter"],
+        caller: simAws.account().rootPrincipal,
+      },
+      simAws,
+    );
+
+    // When a call is made without naming a caller.
+    const decision = simAws
+      .iam()
+      .authorize({ action: "ssm:GetParameter", resource: "*" });
+
+    // Then the session made the request and the Role's policies allowed it.
+    assertIdentical(
+      decision.caller.arn,
+      `arn:aws:sts::${accountId}:assumed-role/Operator/session`,
+    );
+    assertIdentical(decision.caller.identityPolicyArn, roleArn);
+    assertTrue(decision.isAllowed);
+  });
+
   it("keeps the Account root's own unrestricted access", async () => {
     // Given a simulation whose default caller is an operator Role.
     const { simAws, root } = await simAwsWithOperator();

--- a/src/service/aws/caller/sim-aws-default-caller.iso.test.ts
+++ b/src/service/aws/caller/sim-aws-default-caller.iso.test.ts
@@ -1,0 +1,205 @@
+import { CreateBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+import { makeSimAwsAccountId } from "../sim-aws-account.js";
+import { SimAws } from "../sim-aws.js";
+import type { SimAwsPrincipal } from "./sim-aws-caller.js";
+
+const denyTheRoot = {
+  Version: "2012-10-17",
+  Statement: {
+    Sid: "NotAsRoot",
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { ArnLike: { "aws:PrincipalArn": "arn:aws:iam::*:root" } },
+  },
+} as const;
+
+/**
+ * A simulation whose unattributed calls are an operator Role allowed anything.
+ *
+ * The Role is created as the Account root, because the simulation attributes
+ * the two commands that create it to the operator otherwise, and the operator
+ * has nothing allowing them until the second of the two has run.
+ */
+async function simAwsWithOperator(): Promise<{
+  simAws: SimAws;
+  operatorArn: string;
+  root: SimAwsPrincipal;
+}> {
+  const accountId = makeSimAwsAccountId();
+  const operatorArn = `arn:aws:iam::${accountId}:role/Operator`;
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultCaller: { kind: "arn", arn: operatorArn },
+  });
+  const root = simAws.account().rootPrincipal;
+
+  await simIamRoleWithPolicyFactory.make(
+    { roleName: "Operator", actions: ["*"], caller: root },
+    simAws,
+  );
+
+  return { simAws, operatorArn, root };
+}
+
+describe("Simulated AWS default caller", () => {
+  it("decides a call naming no caller as the default caller", async () => {
+    // Given a simulation whose default caller is an operator Role.
+    const { simAws, operatorArn } = await simAwsWithOperator();
+
+    // When a call is made without naming one.
+    const decision = simAws
+      .iam()
+      .authorize({ action: "ssm:GetParameter", resource: "*" });
+
+    // Then it was decided as the operator.
+    assertIdentical(decision.caller.arn, operatorArn);
+  });
+
+  it("reads an Account whose organization denies its root principal", async () => {
+    // Given such a simulation, under a policy denying the Account root.
+    const { simAws } = await simAwsWithOperator();
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(simAws.defaultAccountId, denyTheRoot);
+
+    // When a test writes and reads a parameter without naming a caller.
+    await simAws.ssm().putParameter({
+      input: { Name: "/myapp/db-host", Type: "String", Value: "db.internal" },
+    });
+    const read = await simAws
+      .ssm()
+      .getParameter({ input: { Name: "/myapp/db-host" } });
+
+    // Then the policy left both alone.
+    assertIdentical(read.Parameter?.Value, "db.internal");
+  });
+
+  it("denies the same read once the caller is named as the root", async () => {
+    // Given the same simulation and policy.
+    const { simAws, root } = await simAwsWithOperator();
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(simAws.defaultAccountId, denyTheRoot);
+
+    // When a call names the Account root itself.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .ssm()
+        .putParameter(
+          { input: { Name: "/myapp/db-host", Type: "String", Value: "x" } },
+          { caller: root },
+        );
+    });
+
+    // Then the policy denied it, so the default caller is what the reads above
+    // were decided as rather than the policy failing to apply.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "ssm:PutParameter");
+  });
+
+  it("lets an explicit caller override the default", async () => {
+    // Given a simulation with a default caller, and a Role allowed nothing.
+    const { simAws, root } = await simAwsWithOperator();
+    const bystander = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Bystander", actions: [], caller: root },
+      simAws,
+    );
+
+    // When a call names that Role.
+    const decision = simAws.iam().authorize({
+      action: "ssm:GetParameter",
+      resource: "*",
+      caller: { kind: "arn", arn: bystander.Arn },
+    });
+
+    // Then the named caller decided it, and the default granted it nothing.
+    assertIdentical(decision.caller.arn, bystander.Arn);
+    assertTrue(decision.isDenied);
+  });
+
+  it("lets a run-as caller override the default", async () => {
+    // Given a simulation with a default caller, and an intercepted client.
+    const { simAws, root } = await simAwsWithOperator();
+    const bystander = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Bystander", actions: [], caller: root },
+      simAws,
+    );
+
+    const s3 = new S3Client({ region: "eu-west-1" });
+    new SimSdk({ simAws }).intercept(s3);
+
+    // When a Command is sent inside a run as that Role.
+    const error = await simAws.runAs(
+      { kind: "arn", arn: bystander.Arn },
+      async () =>
+        await assertThrowsErrorAsync(async () => {
+          await s3.send(new CreateBucketCommand({ Bucket: "reports-bucket" }));
+        }),
+    );
+
+    // Then the ambient caller decided it rather than the default.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, `User: ${bystander.Arn}`);
+  });
+
+  it("keeps the Account root's own unrestricted access", async () => {
+    // Given a simulation whose default caller is an operator Role.
+    const { simAws, root } = await simAwsWithOperator();
+
+    // When the Account root is named as the caller.
+    const decision = simAws.iam().authorize({
+      action: "ssm:GetParameter",
+      resource: "*",
+      caller: root,
+    });
+
+    // Then it still holds the access AWS gives it, which naming a default
+    // caller neither moves nor takes away.
+    assertTrue(decision.isAllowed);
+  });
+
+  it("decides a call naming no caller as the Account root without a default", () => {
+    // Given a simulation told nothing about who its callers are.
+    const simAws = new SimAws();
+
+    // When a call is made without naming one.
+    const decision = simAws
+      .iam()
+      .authorize({ action: "ssm:GetParameter", resource: "*" });
+
+    // Then it was decided as the Account root, as it always has been.
+    assertIdentical(
+      decision.caller.arn,
+      `arn:aws:iam::${simAws.defaultAccountId}:root`,
+    );
+    assertTrue(decision.isAllowed);
+  });
+
+  it("suppresses the default for an explicitly anonymous caller", async () => {
+    // Given a simulation whose default caller is an operator Role.
+    const { simAws } = await simAwsWithOperator();
+
+    // When a call states that it has no identity.
+    const decision = simAws.iam().authorize({
+      action: "ssm:GetParameter",
+      resource: "*",
+      caller: { kind: "anonymous" },
+    });
+
+    // Then it stayed anonymous and the operator's policies were not applied.
+    assertIdentical(decision.caller.principal.kind, "anonymous");
+    assertTrue(decision.isDenied);
+  });
+});

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
+import type { SimAwsCaller } from "../caller/sim-aws-caller.js";
 import {
   simAwsEventBridgeDeliveryTargets,
   simAwsRekognitionImages,
@@ -51,6 +52,11 @@ interface SimAwsAccountRegionServiceBuilderProperties {
   readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
   readonly accountServices: SimAwsAccountServiceCache;
   readonly messageLog: SimAwsMessageLog;
+
+  /**
+   * The caller this simulation attributes a request naming none to.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -83,6 +89,7 @@ export class SimAwsAccountRegionServiceBuilder {
   private readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
   private readonly accountServices: SimAwsAccountServiceCache;
   private readonly messageLog: SimAwsMessageLog;
+  private readonly defaultCaller?: SimAwsCaller | undefined;
 
   constructor(properties: SimAwsAccountRegionServiceBuilderProperties) {
     this.simAws = properties.simAws;
@@ -92,6 +99,7 @@ export class SimAwsAccountRegionServiceBuilder {
     this.lambdaUrlRegistry = properties.lambdaUrlRegistry;
     this.accountServices = properties.accountServices;
     this.messageLog = properties.messageLog;
+    this.defaultCaller = properties.defaultCaller;
   }
 
   /** Create simulated ACM for an Account Region scope. */
@@ -318,6 +326,7 @@ export class SimAwsAccountRegionServiceBuilder {
       accountRegionScope: scope.accountRegionScope,
       background: this.background,
       iamResolver: this.iamRegistry,
+      defaultCaller: this.defaultCaller,
     });
   }
 

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -4,7 +4,7 @@ import type {
 } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
-import type { SimAwsCaller } from "../caller/sim-aws-caller.js";
+import type { SimAwsDefaultCaller } from "../caller/sim-aws-caller.js";
 import {
   simAwsEventBridgeDeliveryTargets,
   simAwsRekognitionImages,
@@ -56,7 +56,7 @@ interface SimAwsAccountRegionServiceBuilderProperties {
   /**
    * The caller this simulation attributes a request naming none to.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 }
 
 /**
@@ -89,7 +89,7 @@ export class SimAwsAccountRegionServiceBuilder {
   private readonly lambdaUrlRegistry: SimLambdaUrlRegistry;
   private readonly accountServices: SimAwsAccountServiceCache;
   private readonly messageLog: SimAwsMessageLog;
-  private readonly defaultCaller?: SimAwsCaller | undefined;
+  private readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 
   constructor(properties: SimAwsAccountRegionServiceBuilderProperties) {
     this.simAws = properties.simAws;

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -4,7 +4,7 @@ import type {
 } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
-import type { SimAwsCaller } from "../caller/sim-aws-caller.js";
+import type { SimAwsDefaultCaller } from "../caller/sim-aws-caller.js";
 import type { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
 import type { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import { makeSimCfS3OriginResolver } from "../../cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.js";
@@ -44,7 +44,7 @@ interface SimAwsAccountServiceCacheProperties {
   /**
    * The caller this simulation attributes a request naming none to.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 }
 
 /**
@@ -76,7 +76,7 @@ export class SimAwsAccountServiceCache {
   private readonly iamRegistry: SimIamRegistry;
   private readonly accessKeyRegistry: SimIamAccessKeyRegistry;
   private readonly scpResolver: SimIamServiceControlPolicyResolver;
-  private readonly defaultCaller?: SimAwsCaller | undefined;
+  private readonly defaultCaller?: SimAwsDefaultCaller | undefined;
   private readonly route53Registry: SimRoute53Registry;
   private readonly kmsRegistry: SimKmsRegistry;
   private readonly serviceHosts: SimAwsServiceHosts;

--- a/src/service/aws/factory/sim-aws-account-service-cache.ts
+++ b/src/service/aws/factory/sim-aws-account-service-cache.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
+import type { SimAwsCaller } from "../caller/sim-aws-caller.js";
 import type { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
 import type { SimCloudFrontRegistry } from "../../cloudfront/registry/sim-cloud-front-registry.js";
 import { makeSimCfS3OriginResolver } from "../../cloudfront/origin/s3/sim-cf-s3-origin-resolver-factory.js";
@@ -39,6 +40,11 @@ interface SimAwsAccountServiceCacheProperties {
   readonly iamRegistry: SimIamRegistry;
   readonly accessKeyRegistry: SimIamAccessKeyRegistry;
   readonly scpResolver: SimIamServiceControlPolicyResolver;
+
+  /**
+   * The caller this simulation attributes a request naming none to.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -70,6 +76,7 @@ export class SimAwsAccountServiceCache {
   private readonly iamRegistry: SimIamRegistry;
   private readonly accessKeyRegistry: SimIamAccessKeyRegistry;
   private readonly scpResolver: SimIamServiceControlPolicyResolver;
+  private readonly defaultCaller?: SimAwsCaller | undefined;
   private readonly route53Registry: SimRoute53Registry;
   private readonly kmsRegistry: SimKmsRegistry;
   private readonly serviceHosts: SimAwsServiceHosts;
@@ -91,6 +98,7 @@ export class SimAwsAccountServiceCache {
     this.cloudFrontRegistry = properties.cloudFrontRegistry;
     this.iamRegistry = properties.iamRegistry;
     this.scpResolver = properties.scpResolver;
+    this.defaultCaller = properties.defaultCaller;
     this.accessKeyRegistry = properties.accessKeyRegistry;
     this.route53Registry = properties.route53Registry;
     this.kmsRegistry = properties.kmsRegistry;
@@ -160,6 +168,9 @@ export class SimAwsAccountServiceCache {
           // What the Account's organization allows it to do is decided outside
           // the Account, so IAM asks simulated Organizations about it.
           scpResolver: this.scpResolver,
+          // Who a request naming no caller comes from is decided for the
+          // whole simulation. Every Account in it applies the same default.
+          defaultCaller: this.defaultCaller,
           // Access keys are indexed simulation-wide as they are issued, so a
           // signed request naming only a key id can be traced to this Account.
           credentialRegistry: new SimIamCredentialRegistry({

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
+import type { SimAwsCaller } from "../caller/sim-aws-caller.js";
 import type { SimAcm } from "../../acm/sim-acm.js";
 import type { SimApiGateway } from "../../apigateway/index.js";
 import type { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
@@ -53,6 +54,11 @@ import { SimAwsMessageLog } from "../message/sim-aws-message-log.js";
 interface SimAwsServiceFactoryProperties {
   readonly simAws: SimAws;
   readonly background: BackgroundScheduler & BackgroundCompleter;
+
+  /**
+   * The caller this simulation attributes a call naming none to.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -158,10 +164,16 @@ export class SimAwsServiceFactory {
       iamRegistry: this.iamRegistry,
       accessKeyRegistry: this.requestAuth.accessKeyRegistry,
       scpResolver: this.organizations,
+      // Simulated IAM applies this wherever a request names no caller of its
+      // own, in place of the Account root it would otherwise be decided as.
+      defaultCaller: properties.defaultCaller,
     });
     this.accountRegionServices = new SimAwsAccountRegionServiceBuilder({
       simAws: properties.simAws,
       background: properties.background,
+      // STS reports and evaluates the same default. An unattributed
+      // GetCallerIdentity answers with the principal everything else uses.
+      defaultCaller: properties.defaultCaller,
       registries: this.registries,
       iamRegistry: this.iamRegistry,
       lambdaUrlRegistry: this.lambdaUrlRegistry,

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -4,7 +4,7 @@ import type {
 } from "../../../util/background/background.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import type { SimAws } from "../sim-aws.js";
-import type { SimAwsCaller } from "../caller/sim-aws-caller.js";
+import type { SimAwsDefaultCaller } from "../caller/sim-aws-caller.js";
 import type { SimAcm } from "../../acm/sim-acm.js";
 import type { SimApiGateway } from "../../apigateway/index.js";
 import type { SimApiGatewayV2 } from "../../apigatewayv2/index.js";
@@ -58,7 +58,7 @@ interface SimAwsServiceFactoryProperties {
   /**
    * The caller this simulation attributes a call naming none to.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 }
 
 /**

--- a/src/service/aws/sim-aws-properties.ts
+++ b/src/service/aws/sim-aws-properties.ts
@@ -5,6 +5,7 @@ import type {
 import type { SimClock } from "../../util/clock/sim-clock.js";
 import type { SimIamSigV4ExpectedScope } from "../iam/sigv4/sim-iam-sigv4-expected-scope.js";
 import type { SimAwsAccountId } from "./sim-aws-account.js";
+import type { SimAwsCaller } from "./caller/sim-aws-caller.js";
 import type { AwsRegionName } from "./sim-aws-region.js";
 
 /**
@@ -33,6 +34,22 @@ export interface SimAwsProperties {
    */
   readonly defaultAccountId?: SimAwsAccountId | string;
   readonly defaultRegionName?: AwsRegionName;
+
+  /**
+   * The principal this simulation attributes a call naming no caller to.
+   *
+   * Every simulated operation takes a `caller`, and one is set for a
+   * deployment through `deployTemplate` and `deployCdkOut`. This says who the
+   * calls that name none are, such as the role an operator reads the account
+   * through. An explicit caller always wins, as does the ambient caller of a
+   * `runAs` block.
+   *
+   * Left out, a call naming no caller is decided as the root principal of the
+   * Account it reaches. A service control policy denying that root then denies
+   * the call. That is the reason to name a default.
+   */
+  readonly defaultCaller?: SimAwsCaller;
+
   readonly background?: BackgroundScheduler & BackgroundCompleter;
   /**
    * Clock this simulation's timestamps start from, defaulting to the real

--- a/src/service/aws/sim-aws-properties.ts
+++ b/src/service/aws/sim-aws-properties.ts
@@ -5,7 +5,7 @@ import type {
 import type { SimClock } from "../../util/clock/sim-clock.js";
 import type { SimIamSigV4ExpectedScope } from "../iam/sigv4/sim-iam-sigv4-expected-scope.js";
 import type { SimAwsAccountId } from "./sim-aws-account.js";
-import type { SimAwsCaller } from "./caller/sim-aws-caller.js";
+import type { SimAwsDefaultCaller } from "./caller/sim-aws-caller.js";
 import type { AwsRegionName } from "./sim-aws-region.js";
 
 /**
@@ -48,7 +48,7 @@ export interface SimAwsProperties {
    * Account it reaches. A service control policy denying that root then denies
    * the call. That is the reason to name a default.
    */
-  readonly defaultCaller?: SimAwsCaller;
+  readonly defaultCaller?: SimAwsDefaultCaller;
 
   readonly background?: BackgroundScheduler & BackgroundCompleter;
   /**

--- a/src/service/aws/sim-aws.ts
+++ b/src/service/aws/sim-aws.ts
@@ -69,6 +69,7 @@ export class SimAws extends SimAwsServiceAccessors {
       defaultAccountId = DEFAULT_SIM_AWS_ACCOUNT_ID,
       defaultRegionName = DEFAULT_SIM_AWS_REGION_NAME,
       clock,
+      defaultCaller,
       background: suppliedBackground,
     } = properties;
 
@@ -85,6 +86,7 @@ export class SimAws extends SimAwsServiceAccessors {
     this.serviceFactory = new SimAwsServiceFactory({
       simAws: this,
       background,
+      defaultCaller,
     });
     this.iamRegistry = this.serviceFactory.iamRegistry;
     this.scopes = new SimAwsScopeRegistry({ simAws: this });

--- a/src/service/cloudformation/deploy/sim-cfn-deploy-default-caller.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-deploy-default-caller.iso.test.ts
@@ -1,0 +1,132 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+
+/**
+ * An organization denying its Accounts' root principals everything.
+ */
+const denyAccountRoot = {
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Deny",
+    Action: "*",
+    Resource: "*",
+    Condition: { ArnLike: { "aws:PrincipalArn": "arn:aws:iam::*:root" } },
+  },
+} as const;
+
+const reportsBucketTemplate = {
+  Resources: {
+    ReportsBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "reports-bucket" },
+    },
+  },
+};
+
+/**
+ * A simulation whose unattributed calls are an operator Role.
+ *
+ * The Role is created as the Account root, which the policy under test is
+ * attached after.
+ */
+async function simAwsWithOperator(
+  actions: readonly string[],
+): Promise<{ simAws: SimAws; operatorArn: string }> {
+  const accountId = makeSimAwsAccountId();
+  const operatorArn = `arn:aws:iam::${accountId}:role/Operator`;
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultCaller: { kind: "arn", arn: operatorArn },
+  });
+
+  await simIamRoleWithPolicyFactory.make(
+    { roleName: "Operator", actions, caller: simAws.account().rootPrincipal },
+    simAws,
+  );
+
+  return { simAws, operatorArn };
+}
+
+describe("a simulated CloudFormation deployment under a default caller", () => {
+  it("creates Resources as the default caller when it names none", async () => {
+    // Given a simulation whose default caller may create Buckets, under an
+    // organization denying the Account root everything.
+    const { simAws } = await simAwsWithOperator(["s3:*"]);
+    simAws
+      .organizations()
+      .attachServiceControlPolicy(simAws.defaultAccountId, denyAccountRoot);
+
+    // When a Stack naming no caller of its own is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reports-stack",
+      template: reportsBucketTemplate,
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the default caller carried the deployment past the policy.
+    assertNonNullable(
+      simAws.s3().getSimBucketByName("reports-bucket"),
+      "the deployed Bucket",
+    );
+  });
+
+  it("fails a Resource the default caller may not create", async () => {
+    // Given a simulation whose default caller may do nothing with S3.
+    const { simAws, operatorArn } = await simAwsWithOperator(["ssm:*"]);
+
+    // When a Stack naming no caller of its own is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "reports-stack",
+        template: reportsBucketTemplate,
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the deployment was decided as the default caller, and says so.
+    assertStringIncludes(error.message, `User: ${operatorArn}`);
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName("reports-stack")
+        ?.getResource("ReportsBucket")?.status,
+      "CREATE_FAILED",
+    );
+  });
+
+  it("lets the deployment's own caller override the default", async () => {
+    // Given a simulation whose default caller may do nothing with S3, and a
+    // deploy Role that may.
+    const { simAws } = await simAwsWithOperator(["ssm:*"]);
+    const deployer = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Deployer",
+        actions: ["s3:*"],
+        caller: simAws.account().rootPrincipal,
+      },
+      simAws,
+    );
+
+    // When a Stack naming that Role is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reports-stack",
+      template: reportsBucketTemplate,
+      caller: { kind: "arn", arn: deployer.Arn },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Role the deployment named created the Bucket.
+    assertNonNullable(
+      simAws.s3().getSimBucketByName("reports-bucket"),
+      "the deployed Bucket",
+    );
+  });
+});

--- a/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
@@ -15,22 +15,48 @@ export interface SimIamAuthZCallerContext {
 }
 
 /**
+ * What building a caller context needs beyond the request's own caller.
+ */
+export interface SimIamAuthZCallerContextBuilderProperties {
+  /**
+   * The root principal of the Account deciding the request.
+   *
+   * This is both the last fallback for a request that names no caller and the
+   * principal holding the Account's intrinsic unrestricted access. The default
+   * caller stands apart from it. Naming a default says who an unattributed
+   * call comes from, and leaves the root's own access where AWS puts it.
+   */
+  readonly accountRootPrincipal: SimAwsPrincipal;
+
+  readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
+
+  /**
+   * The caller this simulation attributes an unattributed request to.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
+}
+
+/**
  * Resolves the caller and any policy sources implied by that caller.
  *
- * The configured default principal represents the simulated account root. It is
- * used only when the request omits a caller. An explicit anonymous caller does
- * not fall back to root.
+ * A request that omits a caller is decided as the simulation's default caller,
+ * and as the Account root where the simulation named none. An explicit
+ * anonymous caller falls back to neither.
  */
 export class SimIamAuthZCallerContextBuilder {
   private readonly callerResolver: SimAwsCallerResolver;
-  private readonly defaultCallerPrincipal: SimAwsPrincipal;
+  private readonly accountRootPrincipal: SimAwsPrincipal;
+  private readonly accountRootArn?: string | undefined;
 
-  constructor(
-    defaultCallerPrincipal: SimAwsPrincipal,
-    credentialIdentityResolver: SimAwsCredentialIdentityResolver,
-  ) {
-    this.defaultCallerPrincipal = defaultCallerPrincipal;
-    this.callerResolver = new SimAwsCallerResolver(credentialIdentityResolver);
+  constructor(properties: SimIamAuthZCallerContextBuilderProperties) {
+    const root = properties.accountRootPrincipal;
+
+    this.accountRootPrincipal = root;
+    this.accountRootArn = root.kind === "arn" ? root.arn : undefined;
+    this.callerResolver = new SimAwsCallerResolver({
+      credentialIdentityResolver: properties.credentialIdentityResolver,
+      defaultCaller: properties.defaultCaller,
+    });
   }
 
   /**
@@ -40,7 +66,7 @@ export class SimIamAuthZCallerContextBuilder {
   build(caller: SimAwsCaller | undefined): SimIamAuthZCallerContext {
     const resolvedCaller = this.callerResolver.resolve(
       caller,
-      this.defaultCallerPrincipal,
+      this.accountRootPrincipal,
     );
 
     return {
@@ -50,17 +76,18 @@ export class SimIamAuthZCallerContextBuilder {
   }
 
   /**
-   * Give the configured account-root principal unrestricted identity access.
+   * Give the Account's root principal unrestricted identity access.
+   *
+   * The comparison names the root principal explicitly, so a simulation with a
+   * default caller keeps this access on the root where AWS has it.
    */
   private rootPolicySources(
     caller: SimAwsResolvedCaller,
   ): readonly SimIamAuthZPolicySource[] {
-    const defaultCaller = this.callerResolver.resolve(
-      this.defaultCallerPrincipal,
-      this.defaultCallerPrincipal,
-    );
-
-    if (defaultCaller.arn === undefined || caller.arn !== defaultCaller.arn) {
+    if (
+      this.accountRootArn === undefined ||
+      caller.arn !== this.accountRootArn
+    ) {
       return [];
     }
 

--- a/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-caller-context-builder.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type {
   SimAwsCaller,
+  SimAwsDefaultCaller,
   SimAwsPrincipal,
 } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimIamAuthZPolicySource } from "./sim-iam-auth-z-context.js";
@@ -33,7 +34,7 @@ export interface SimIamAuthZCallerContextBuilderProperties {
   /**
    * The caller this simulation attributes an unattributed request to.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 }
 
 /**

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -3,6 +3,7 @@ import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import { makeSimAwsAccountRootPrincipal } from "../../../aws/caller/sim-aws-account-root-principal.js";
 import type {
   SimAwsCaller,
+  SimAwsDefaultCaller,
   SimAwsPrincipal,
 } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
@@ -125,8 +126,7 @@ interface SimIamAuthZContextBuilderProperties {
   readonly users: ReadonlyMap<SimIamUsername, SimIamUser>;
   readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
 
-  /** The caller this simulation attributes a request naming none to. */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 
   /**
    * Resolves other Accounts' IAM in the same simulation, for the identity side

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -125,6 +125,9 @@ interface SimIamAuthZContextBuilderProperties {
   readonly users: ReadonlyMap<SimIamUsername, SimIamUser>;
   readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
 
+  /** The caller this simulation attributes a request naming none to. */
+  readonly defaultCaller?: SimAwsCaller | undefined;
+
   /**
    * Resolves other Accounts' IAM in the same simulation, for the identity side
    * of a cross-Account request.
@@ -177,10 +180,13 @@ export class SimIamAuthZContextBuilder {
   private readonly scpSourceBuilder: SimIamAuthZScpSourceBuilder;
 
   constructor(properties: SimIamAuthZContextBuilderProperties) {
-    this.callerContextBuilder = new SimIamAuthZCallerContextBuilder(
-      makeSimAwsAccountRootPrincipal(properties.accountId),
-      properties.credentialIdentityResolver,
-    );
+    this.callerContextBuilder = new SimIamAuthZCallerContextBuilder({
+      accountRootPrincipal: makeSimAwsAccountRootPrincipal(
+        properties.accountId,
+      ),
+      credentialIdentityResolver: properties.credentialIdentityResolver,
+      defaultCaller: properties.defaultCaller,
+    });
     this.identityPolicyCoordinator = new SimIamAuthZIdentityPolicyCoordinator({
       policies: properties.policies,
       roles: properties.roles,

--- a/src/service/iam/authorize/sim-iam-account-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-account-auth-z.ts
@@ -1,7 +1,10 @@
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimArn } from "../../aws/arn.js";
 import type { SimAwsCredentialIdentityResolver } from "../../aws/caller/sim-aws-caller-resolver.js";
-import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsPrincipal,
+} from "../../aws/caller/sim-aws-caller.js";
 import type { SimIamManagedPolicy } from "../policy/sim-iam-policy.js";
 import type { SimIamRole, SimIamRoleName } from "../role/sim-iam-role.js";
 import type { SimIamUser, SimIamUsername } from "../user/sim-iam-user.js";
@@ -19,6 +22,13 @@ interface SimIamAccountAuthZProperties {
   readonly roles: Map<SimIamRoleName, SimIamRole>;
   readonly users: Map<SimIamUsername, SimIamUser>;
   readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
+
+  /**
+   * The caller this simulation attributes a request naming none to.
+   *
+   * Left out, such a request is decided as this Account's root principal.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
 
   /**
    * Resolves other Accounts' IAM in the same simulation.
@@ -42,9 +52,10 @@ interface SimIamAccountAuthZProperties {
  * Evaluates IAM authorization attempts against one simulated Account's IAM
  * state.
  *
- * If the caller is omitted, authorization defaults to the root principal of
- * the owning sim Account. An explicit anonymous caller suppresses that
- * fallback and is evaluated without identity policies.
+ * If the caller is omitted, authorization defaults to the simulation's default
+ * caller, and to the root principal of the owning sim Account where the
+ * simulation has none. An explicit anonymous caller suppresses both and is
+ * evaluated without identity policies.
  */
 export class SimIamAccountAuthZ implements SimIamAccountIdentityPolicies {
   private readonly properties: SimIamAccountAuthZProperties;
@@ -83,6 +94,7 @@ export class SimIamAccountAuthZ implements SimIamAccountIdentityPolicies {
       roles: this.properties.roles,
       users: this.properties.users,
       credentialIdentityResolver: this.properties.credentialIdentityResolver,
+      defaultCaller: this.properties.defaultCaller,
       iamResolver: this.properties.iamResolver,
       scpResolver: this.properties.scpResolver,
     });

--- a/src/service/iam/authorize/sim-iam-account-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-account-auth-z.ts
@@ -2,7 +2,7 @@ import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimArn } from "../../aws/arn.js";
 import type { SimAwsCredentialIdentityResolver } from "../../aws/caller/sim-aws-caller-resolver.js";
 import type {
-  SimAwsCaller,
+  SimAwsDefaultCaller,
   SimAwsPrincipal,
 } from "../../aws/caller/sim-aws-caller.js";
 import type { SimIamManagedPolicy } from "../policy/sim-iam-policy.js";
@@ -28,7 +28,7 @@ interface SimIamAccountAuthZProperties {
    *
    * Left out, such a request is decided as this Account's root principal.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 
   /**
    * Resolves other Accounts' IAM in the same simulation.

--- a/src/service/iam/authorize/sim-iam-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-authorizer.ts
@@ -7,7 +7,7 @@ import {
 } from "./context/sim-iam-auth-z-context-builder.js";
 import { SimIamPolicyDecision } from "./sim-iam-decision.js";
 import type {
-  SimAwsCaller,
+  SimAwsDefaultCaller,
   SimAwsPrincipal,
 } from "../../aws/caller/sim-aws-caller.js";
 import type { SimIamUser, SimIamUsername } from "../user/sim-iam-user.js";
@@ -24,7 +24,7 @@ interface SimIamAuthorizerProperties {
   readonly roles: ReadonlyMap<SimIamRoleName, SimIamRole>;
   readonly users: ReadonlyMap<SimIamUsername, SimIamUser>;
   readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
   readonly iamResolver?: SimIamAccountResolver | undefined;
   readonly scpResolver?: SimIamServiceControlPolicyResolver | undefined;
 }

--- a/src/service/iam/authorize/sim-iam-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-authorizer.ts
@@ -6,7 +6,10 @@ import {
   type SimIamAuthorizationInput,
 } from "./context/sim-iam-auth-z-context-builder.js";
 import { SimIamPolicyDecision } from "./sim-iam-decision.js";
-import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsPrincipal,
+} from "../../aws/caller/sim-aws-caller.js";
 import type { SimIamUser, SimIamUsername } from "../user/sim-iam-user.js";
 import type { SimAwsCredentialIdentityResolver } from "../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
@@ -21,6 +24,7 @@ interface SimIamAuthorizerProperties {
   readonly roles: ReadonlyMap<SimIamRoleName, SimIamRole>;
   readonly users: ReadonlyMap<SimIamUsername, SimIamUser>;
   readonly credentialIdentityResolver: SimAwsCredentialIdentityResolver;
+  readonly defaultCaller?: SimAwsCaller | undefined;
   readonly iamResolver?: SimIamAccountResolver | undefined;
   readonly scpResolver?: SimIamServiceControlPolicyResolver | undefined;
 }
@@ -43,6 +47,7 @@ export class SimIamAuthorizer implements SimIamAccountIdentityPolicies {
       roles: properties.roles,
       users: properties.users,
       credentialIdentityResolver: properties.credentialIdentityResolver,
+      defaultCaller: properties.defaultCaller,
       iamResolver: properties.iamResolver,
       scpResolver: properties.scpResolver,
     });

--- a/src/service/iam/role/sim-iam-role-with-policy.factory.ts
+++ b/src/service/iam/role/sim-iam-role-with-policy.factory.ts
@@ -1,5 +1,6 @@
 import { AsyncMappedFactory } from "@kensio/part-factory";
 import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimCreateRoleCommandOutput } from "../command/role/create-role/create-role.command.js";
 import { simIamPolicyDocumentFactory } from "../policy/sim-iam-policy-document.factory.js";
 
@@ -15,6 +16,15 @@ export interface SimIamRoleWithPolicyInput {
   readonly policyName: string;
   readonly actions: readonly string[];
   readonly resource: string;
+
+  /**
+   * The principal creating the Role.
+   *
+   * A simulation given a default caller attributes these two commands to it,
+   * and a Role being created for that caller has no policies to allow them
+   * yet. Naming the Account root here is how such a test bootstraps.
+   */
+  readonly caller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -51,33 +61,42 @@ export const simIamRoleWithPolicyFactory = new AsyncMappedFactory<
     policyName: "ApplicationPolicy",
     actions: [],
     resource: "*",
+    caller: undefined,
   }),
   async (input, simAws) => {
     const simIam = simAws.iam();
+    const options =
+      input.caller === undefined ? undefined : { caller: input.caller };
 
-    const creation = await simIam.createRole({
-      input: {
-        RoleName: input.roleName,
-        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Principal: {
-              AWS: `arn:aws:iam::${simAws.defaultAccountId}:root`,
+    const creation = await simIam.createRole(
+      {
+        input: {
+          RoleName: input.roleName,
+          AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+            Statement: {
+              Principal: {
+                AWS: `arn:aws:iam::${simAws.defaultAccountId}:root`,
+              },
+              Action: "sts:AssumeRole",
             },
-            Action: "sts:AssumeRole",
-          },
-        }),
+          }),
+        },
       },
-    });
+      options,
+    );
 
-    await simIam.putRolePolicy({
-      input: {
-        RoleName: input.roleName,
-        PolicyName: input.policyName,
-        PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: input.actions, Resource: input.resource },
-        }),
+    await simIam.putRolePolicy(
+      {
+        input: {
+          RoleName: input.roleName,
+          PolicyName: input.policyName,
+          PolicyDocument: simIamPolicyDocumentFactory.make({
+            Statement: { Action: input.actions, Resource: input.resource },
+          }),
+        },
       },
-    });
+      options,
+    );
 
     return creation.Role;
   },

--- a/src/service/iam/sim-iam-account-parts.ts
+++ b/src/service/iam/sim-iam-account-parts.ts
@@ -5,7 +5,7 @@ import {
 import type { SimArn } from "../aws/arn.js";
 import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
-import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import type { SimAwsDefaultCaller } from "../aws/caller/sim-aws-caller.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimIamAccountAuthZ } from "./authorize/sim-iam-account-auth-z.js";
 import type { SimIamInterServiceAuthZ } from "./authorize/sim-iam-inter-service-auth-z.js";
@@ -39,7 +39,7 @@ export interface SimIamProperties {
    * A SimAws passes on what it was built with. Left out, such a request is
    * decided as the Account root, which is what a standalone SimIam does.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 
   /**
    * Resolves the IAM of other Accounts in the same simulation.

--- a/src/service/iam/sim-iam-account-parts.ts
+++ b/src/service/iam/sim-iam-account-parts.ts
@@ -5,6 +5,7 @@ import {
 import type { SimArn } from "../aws/arn.js";
 import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimIamAccountAuthZ } from "./authorize/sim-iam-account-auth-z.js";
 import type { SimIamInterServiceAuthZ } from "./authorize/sim-iam-inter-service-auth-z.js";
@@ -31,6 +32,14 @@ export interface SimIamProperties {
   readonly credentialRegistry?: SimIamCredentialRegistry;
   readonly sessionCredentialGenerator?: SimIamSessionCredentialGenerator;
   readonly userCredentialGenerator?: SimIamUserCredentialGenerator;
+
+  /**
+   * The caller this simulation attributes a request naming none to.
+   *
+   * A SimAws passes on what it was built with. Left out, such a request is
+   * decided as the Account root, which is what a standalone SimIam does.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
 
   /**
    * Resolves the IAM of other Accounts in the same simulation.
@@ -103,6 +112,7 @@ export class SimIamAccountParts {
       roles: this.roles,
       users: this.users,
       credentialIdentityResolver: credentialRegistry,
+      defaultCaller: properties.defaultCaller,
       iamResolver: properties.iamResolver,
       scpResolver: properties.scpResolver,
     });

--- a/src/service/sts/auth-z/assume-role-source-account-auth-z.ts
+++ b/src/service/sts/auth-z/assume-role-source-account-auth-z.ts
@@ -2,7 +2,6 @@ import type { SimIamAccountResolver } from "../../iam/registry/sim-iam-account-r
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
-import { makeSimAwsAccountRootPrincipal } from "../../aws/caller/sim-aws-account-root-principal.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 
 interface AssumeRoleSourceAccountAuthorizerProperties {
@@ -38,8 +37,8 @@ export interface AssumeRoleSourceAuthorizationInput {
  * trust authorization is a separate responsibility and must be performed even
  * when the source and target Account are the same.
  *
- * When no caller principal is supplied, Sim IAM applies its normal default
- * caller behavior for the source Account.
+ * When no caller principal is supplied, sim IAM applies its own default caller
+ * behaviour for the source Account.
  */
 export class AssumeRoleSourcePrincipalAuthorizer {
   private readonly sourceAccountId: SimAwsAccountId;
@@ -60,15 +59,15 @@ export class AssumeRoleSourcePrincipalAuthorizer {
    */
   authorize(input: AssumeRoleSourceAuthorizationInput): void {
     const sourceIam = this.iamResolver.iamForAccount(this.sourceAccountId);
-    const callerPrincipal =
-      input.callerPrincipal ??
-      makeSimAwsAccountRootPrincipal(this.sourceAccountId);
 
+    // A request with no caller principal of its own is left for sim IAM to
+    // attribute. The simulation's default caller reaches this decision the way
+    // it reaches every other one.
     const decision = sourceIam.authorize({
       action: "sts:AssumeRole",
       resource: input.roleArn,
       region: this.regionName,
-      caller: callerPrincipal,
+      caller: input.callerPrincipal,
     });
 
     if (
@@ -76,7 +75,7 @@ export class AssumeRoleSourcePrincipalAuthorizer {
       (decision.isImplicitDeny && Boolean(input.identityPolicyAllowRequired))
     ) {
       throw new SimIamAccessDenied({
-        principal: callerPrincipal,
+        principal: decision.caller.principal,
         action: "sts:AssumeRole",
         resource: input.roleArn,
       });

--- a/src/service/sts/command/assume-role/assume-role.handler.ts
+++ b/src/service/sts/command/assume-role/assume-role.handler.ts
@@ -28,6 +28,11 @@ interface AssumeRoleCommandHandlerProperties {
 
   readonly iamResolver: SimIamAccountResolver;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * The caller this simulation attributes a request naming none to.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -44,7 +49,7 @@ export class AssumeRoleCommandHandler implements CommandHandler<
   SimAssumeRoleCommandOutput
 > {
   private readonly background: BackgroundScheduler;
-  private readonly callerResolver = new SimAwsCallerResolver();
+  private readonly callerResolver: SimAwsCallerResolver;
   private readonly requestParser = new SimStsAssumeRoleRequestParser();
   private readonly authorizationCoordinator: AssumeRoleAuthorizationCoordinator;
   private readonly sessionCreator: SimStsAssumeRoleSessionCreator;
@@ -60,6 +65,11 @@ export class AssumeRoleCommandHandler implements CommandHandler<
 
     this.sourceAccountId = sourceAccountId;
     this.background = background;
+    this.callerResolver = new SimAwsCallerResolver({
+      credentialIdentityResolver:
+        iamResolver.findIamForAccount(sourceAccountId)?.credentials,
+      defaultCaller: properties.defaultCaller,
+    });
     this.authorizationCoordinator = new AssumeRoleAuthorizationCoordinator({
       sourceAccountId,
       iamResolver,

--- a/src/service/sts/command/assume-role/assume-role.handler.ts
+++ b/src/service/sts/command/assume-role/assume-role.handler.ts
@@ -15,7 +15,10 @@ import { SimStsAssumeRoleSessionCreator } from "../../assume/sim-sts-assume-role
 import { SimStsAssumeRoleRequestParser } from "../../assume/sim-sts-assume-role-request-parser.js";
 import { SimAwsCallerResolver } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsDefaultCaller,
+} from "../../../aws/caller/sim-aws-caller.js";
 import { AssumeRoleAuthorizationCoordinator } from "../../auth-z/assume-role-auth-z-coordinator.js";
 
 interface AssumeRoleCommandHandlerProperties {
@@ -32,7 +35,7 @@ interface AssumeRoleCommandHandlerProperties {
   /**
    * The caller this simulation attributes a request naming none to.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 }
 
 /**
@@ -66,8 +69,6 @@ export class AssumeRoleCommandHandler implements CommandHandler<
     this.sourceAccountId = sourceAccountId;
     this.background = background;
     this.callerResolver = new SimAwsCallerResolver({
-      credentialIdentityResolver:
-        iamResolver.findIamForAccount(sourceAccountId)?.credentials,
       defaultCaller: properties.defaultCaller,
     });
     this.authorizationCoordinator = new AssumeRoleAuthorizationCoordinator({

--- a/src/service/sts/command/get-caller-identity/get-caller-identity.handler.ts
+++ b/src/service/sts/command/get-caller-identity/get-caller-identity.handler.ts
@@ -1,6 +1,9 @@
 import type { CommandHandler } from "../../../../command/command-handler.js";
 import { SimAwsCallerResolver } from "../../../aws/caller/sim-aws-caller-resolver.js";
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsDefaultCaller,
+} from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { makeSimAwsAccountRootPrincipal } from "../../../aws/caller/sim-aws-account-root-principal.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
@@ -18,7 +21,7 @@ interface GetCallerIdentityCommandHandlerProperties {
   /**
    * The caller this simulation attributes a request naming none to.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 }
 
 /**
@@ -43,9 +46,6 @@ export class GetCallerIdentityCommandHandler implements CommandHandler<
     this.sourceAccountId = properties.sourceAccountId;
     this.iamResolver = properties.iamResolver;
     this.callerResolver = new SimAwsCallerResolver({
-      credentialIdentityResolver: properties.iamResolver.findIamForAccount(
-        properties.sourceAccountId,
-      )?.credentials,
       defaultCaller: properties.defaultCaller,
     });
   }

--- a/src/service/sts/command/get-caller-identity/get-caller-identity.handler.ts
+++ b/src/service/sts/command/get-caller-identity/get-caller-identity.handler.ts
@@ -14,6 +14,11 @@ import { simStsCallerUserId } from "./sim-sts-caller-user-id.js";
 interface GetCallerIdentityCommandHandlerProperties {
   readonly sourceAccountId: SimAwsAccountId;
   readonly iamResolver: SimIamAccountResolver;
+
+  /**
+   * The caller this simulation attributes a request naming none to.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -30,13 +35,19 @@ export class GetCallerIdentityCommandHandler implements CommandHandler<
   SimGetCallerIdentityCommand,
   SimGetCallerIdentityCommandOutput
 > {
-  private readonly callerResolver = new SimAwsCallerResolver();
+  private readonly callerResolver: SimAwsCallerResolver;
   private readonly sourceAccountId: SimAwsAccountId;
   private readonly iamResolver: SimIamAccountResolver;
 
   constructor(properties: GetCallerIdentityCommandHandlerProperties) {
     this.sourceAccountId = properties.sourceAccountId;
     this.iamResolver = properties.iamResolver;
+    this.callerResolver = new SimAwsCallerResolver({
+      credentialIdentityResolver: properties.iamResolver.findIamForAccount(
+        properties.sourceAccountId,
+      )?.credentials,
+      defaultCaller: properties.defaultCaller,
+    });
   }
 
   /**

--- a/src/service/sts/sim-sts-default-caller.iso.test.ts
+++ b/src/service/sts/sim-sts-default-caller.iso.test.ts
@@ -1,0 +1,100 @@
+import { assertIdentical, assertStringStartsWith } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../aws/sim-aws-account.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../iam/role/sim-iam-role-with-policy.factory.js";
+
+/**
+ * A simulation whose unattributed calls are an operator Role allowed anything.
+ *
+ * The Role is created as the Account root, because the simulation attributes
+ * the commands that create it to the operator otherwise, and the operator has
+ * nothing allowing them until the last of those commands has run.
+ */
+async function simAwsWithOperator(): Promise<{
+  simAws: SimAws;
+  operatorArn: string;
+}> {
+  const accountId = makeSimAwsAccountId();
+  const operatorArn = `arn:aws:iam::${accountId}:role/Operator`;
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultCaller: { kind: "arn", arn: operatorArn },
+  });
+
+  await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "Operator",
+      actions: ["*"],
+      caller: simAws.account().rootPrincipal,
+    },
+    simAws,
+  );
+
+  return { simAws, operatorArn };
+}
+
+describe("Simulated STS under a default caller", () => {
+  it("reports the default caller from GetCallerIdentity", async () => {
+    // Given a simulation whose default caller is an operator Role.
+    const { simAws, operatorArn } = await simAwsWithOperator();
+
+    // When a request that names no caller asks who it is.
+    const identity = await simAws.sts().getCallerIdentity({});
+
+    // Then STS answers with the operator rather than the Account root.
+    assertIdentical(identity.Arn, operatorArn);
+    assertIdentical(identity.Account, simAws.defaultAccountId);
+  });
+
+  it("reports the Account root where the simulation names no default", async () => {
+    // Given a simulation told nothing about who its callers are.
+    const simAws = new SimAws();
+
+    // When a request that names no caller asks who it is.
+    const identity = await simAws.sts().getCallerIdentity({});
+
+    // Then STS answers with the Account root, as it always has.
+    assertIdentical(
+      identity.Arn,
+      `arn:aws:iam::${simAws.defaultAccountId}:root`,
+    );
+  });
+
+  it("assumes a Role as the default caller", async () => {
+    // Given a simulation whose default caller may assume a Role that trusts it.
+    const { simAws, operatorArn } = await simAwsWithOperator();
+    const root = simAws.account().rootPrincipal;
+
+    await simAws.iam().createRole(
+      {
+        input: {
+          RoleName: "Reporting",
+          AssumeRolePolicyDocument: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Principal: { AWS: operatorArn },
+              Action: "sts:AssumeRole",
+            },
+          }),
+        },
+      },
+      { caller: root },
+    );
+
+    // When a request naming no caller assumes it.
+    const session = await simAws.sts().assumeRole({
+      input: {
+        RoleArn: `arn:aws:iam::${simAws.defaultAccountId}:role/Reporting`,
+        RoleSessionName: "reporting",
+      },
+    });
+
+    // Then the trust policy matched the operator, so the session exists.
+    assertStringStartsWith(
+      session.AssumedRoleUser?.Arn ?? "",
+      `arn:aws:sts::${simAws.defaultAccountId}:assumed-role/Reporting/`,
+    );
+  });
+});

--- a/src/service/sts/sim-sts.ts
+++ b/src/service/sts/sim-sts.ts
@@ -16,7 +16,10 @@ import { GetCallerIdentityCommandHandler } from "./command/get-caller-identity/g
 import { SimIamRegistry } from "../iam/registry/sim-iam-registry.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
-import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import type {
+  SimAwsCaller,
+  SimAwsDefaultCaller,
+} from "../aws/caller/sim-aws-caller.js";
 import { SimStsSdkCommandRouter } from "./sdk/sim-sts-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
 
@@ -31,7 +34,7 @@ interface SimStsProperties {
    * Left out, such a request is the source Account's root principal, which is
    * the identity GetCallerIdentity then reports.
    */
-  readonly defaultCaller?: SimAwsCaller | undefined;
+  readonly defaultCaller?: SimAwsDefaultCaller | undefined;
 }
 
 /**
@@ -45,7 +48,7 @@ export class SimSts {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly background: BackgroundScheduler;
   private readonly iamResolver: SimIamAccountResolver;
-  private readonly defaultCaller?: SimAwsCaller | undefined;
+  private readonly defaultCaller?: SimAwsDefaultCaller | undefined;
   private readonly sdkRouter = new SimStsSdkCommandRouter(this);
 
   constructor(properties: SimStsProperties = {}) {

--- a/src/service/sts/sim-sts.ts
+++ b/src/service/sts/sim-sts.ts
@@ -24,6 +24,14 @@ interface SimStsProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
   readonly iamResolver?: SimIamAccountResolver;
   readonly background?: BackgroundScheduler;
+
+  /**
+   * The caller this simulation attributes a request naming none to.
+   *
+   * Left out, such a request is the source Account's root principal, which is
+   * the identity GetCallerIdentity then reports.
+   */
+  readonly defaultCaller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -37,6 +45,7 @@ export class SimSts {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly background: BackgroundScheduler;
   private readonly iamResolver: SimIamAccountResolver;
+  private readonly defaultCaller?: SimAwsCaller | undefined;
   private readonly sdkRouter = new SimStsSdkCommandRouter(this);
 
   constructor(properties: SimStsProperties = {}) {
@@ -44,6 +53,7 @@ export class SimSts {
       properties.accountRegionScope ?? simAwsAccountRegionScopeFactory.make();
     this.iamResolver = properties.iamResolver ?? new SimIamRegistry();
     this.background = properties.background ?? new BackgroundTasks();
+    this.defaultCaller = properties.defaultCaller;
   }
 
   /**
@@ -60,6 +70,7 @@ export class SimSts {
       regionName: this.accountRegionScope.regionName,
       iamResolver: this.iamResolver,
       background: this.background,
+      defaultCaller: this.defaultCaller,
     });
     return await handler.handle(command, options);
   }
@@ -76,6 +87,7 @@ export class SimSts {
     const handler = new GetCallerIdentityCommandHandler({
       sourceAccountId: this.accountRegionScope.accountId,
       iamResolver: this.iamResolver,
+      defaultCaller: this.defaultCaller,
     });
 
     return await handler.handle(command, options);


### PR DESCRIPTION
Every simulated operation takes a caller, and a call that omits one was decided as the root principal of the Account it reached. A service control policy denying that root then denied every unattributed read, leaving such a policy and a test that reads through `simAws` mutually exclusive. `SimAws` now takes a `defaultCaller` naming who those calls come from, and IAM authorization, STS and the CloudFormation deployment path all apply it. An explicit caller, a `runAs` caller and a deployment caller each still win, and a simulation given no default keeps the Account root fallback.

Resolves #1105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable default caller support for simulated AWS requests without an explicit caller.
  * Explicit callers, `runAs`, and anonymous requests retain their existing precedence and behavior.
  * Default caller attribution now applies consistently across IAM, STS, CloudFormation, and Organizations scenarios.
  * Added examples demonstrating authorization, caller identity, role assumption, and SCP behavior.

* **Documentation**
  * Expanded SDK and service documentation with caller resolution rules, configuration guidance, and usage examples.

* **Tests**
  * Added coverage for default caller resolution, root fallback, overrides, authorization, CloudFormation deployments, STS, and policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->