### PR TITLE
fix: patch the clients a static factory builds

### DIFF
--- a/src/sdk/module/sim-sdk-module-client-interceptor.iso.test.ts
+++ b/src/sdk/module/sim-sdk-module-client-interceptor.iso.test.ts
@@ -18,6 +18,29 @@ import { SimSdkModuleClientInterceptor } from "./sim-sdk-module-client-intercept
 class FakeSdkClient {
   constructor(readonly clientConfiguration?: { region?: string }) {}
 
+  /**
+   * A static factory, as `DynamoDBDocumentClient.from` is: it constructs
+   * from the class binding it closes over, never through a wrapper.
+   */
+  static from(clientConfiguration?: { region?: string }): FakeSdkClient {
+    return new FakeSdkClient(clientConfiguration);
+  }
+
+  /**
+   * A static factory building through the class it was called on, which is
+   * the intercepted one when the call went through interception.
+   */
+  static build(this: typeof FakeSdkClient): FakeSdkClient {
+    return new this();
+  }
+
+  /**
+   * A static that returns something other than a client.
+   */
+  static describe(): string {
+    return "fake-sdk-client";
+  }
+
   send(command: object): Promise<unknown> {
     return Promise.resolve({ realSend: command });
   }
@@ -96,6 +119,52 @@ describe("SimSdkModuleClientInterceptor", () => {
       realSend: object;
     };
     assertIdentical(directResult.realSend, command);
+  });
+
+  it("send-patches the clients a static factory builds", async () => {
+    // Given a module whose client class export has been intercepted.
+    const { interceptor, sends } = makeInterceptor();
+    const intercepted = interceptor.interceptModule(fakeModuleExports()) as {
+      FakeSdkClient: typeof FakeSdkClient;
+    };
+
+    // When a client comes from the class's own static factory, which
+    // constructs the real class rather than the intercepted one.
+    const client = intercepted.FakeSdkClient.from();
+    const command = new FakeSdkCommand({ TableName: "table" });
+    const result = await client.send(command);
+
+    // Then that client's send went to the simulated send handler too.
+    assertIdentical(result, "sim-send-result");
+    assertArrayLength(sends, 1);
+    const recordedSend = sends[0];
+    assertNonNullable(recordedSend);
+    assertIdentical(recordedSend.client, client);
+
+    // And a static returning something that is not a client is untouched.
+    assertIdentical(intercepted.FakeSdkClient.describe(), "fake-sdk-client");
+
+    // And the factory built the real class, so instanceof still holds.
+    assertInstanceOf(client, FakeSdkClient);
+    assertFalse(Object.hasOwn(FakeSdkClient.from(), "send"));
+  });
+
+  it("leaves a factory's already-patched client alone", async () => {
+    // Given a module whose client class export has been intercepted.
+    const { interceptor, sends } = makeInterceptor();
+    const intercepted = interceptor.interceptModule(fakeModuleExports()) as {
+      FakeSdkClient: typeof FakeSdkClient;
+    };
+
+    // When a static factory builds through the intercepted class itself, so
+    // the construct trap has already patched what it returns.
+    const client = intercepted.FakeSdkClient.build();
+    const result = await client.send(new FakeSdkCommand({}));
+
+    // Then the one patch stands, rather than a second being rejected as a
+    // double interception.
+    assertIdentical(result, "sim-send-result");
+    assertArrayLength(sends, 1);
   });
 
   it("passes non-client exports through by identity", () => {

--- a/src/sdk/module/sim-sdk-module-client-interceptor.ts
+++ b/src/sdk/module/sim-sdk-module-client-interceptor.ts
@@ -1,5 +1,6 @@
 import type { AwsRegionName } from "../../service/aws/sim-aws-region.js";
 import { installSendPatch, type SimSdkSendHandler } from "../send-patch.js";
+import { SimSdkStaticClientFactories } from "./sim-sdk-static-client-factory.js";
 
 /**
  * An SDK client class: a constructable whose instances have a send method.
@@ -73,6 +74,11 @@ export class SimSdkModuleClientInterceptor {
    *
    * Reflect.construct with the incoming new target preserves subclassing and
    * instanceof against the real class.
+   *
+   * The class's own static methods are wrapped as well, so a client built by
+   * a static factory such as `DynamoDBDocumentClient.from` is patched too.
+   * Such a factory constructs from the class binding it closes over rather
+   * than through this proxy, so the construct trap never sees it.
    */
   private wrapClientClass(
     clientClass: SimSdkClientConstructor,
@@ -80,6 +86,7 @@ export class SimSdkModuleClientInterceptor {
     const sendHandler = this.sendHandler;
     const configureArguments = (constructorArguments: unknown[]): unknown[] =>
       this.regionDefaultedArguments(constructorArguments);
+    const staticFactories = new SimSdkStaticClientFactories(sendHandler);
 
     return new Proxy(clientClass, {
       construct(
@@ -94,6 +101,18 @@ export class SimSdkModuleClientInterceptor {
         ) as object;
         installSendPatch(instance, sendHandler);
         return instance;
+      },
+
+      get(
+        target: SimSdkClientConstructor,
+        property: string | symbol,
+        receiver: unknown,
+      ): unknown {
+        const value: unknown = Reflect.get(target, property, receiver);
+        if (typeof value !== "function" || !Object.hasOwn(target, property)) {
+          return value;
+        }
+        return staticFactories.wrap(value);
       },
     });
   }

--- a/src/sdk/module/sim-sdk-static-client-factory.ts
+++ b/src/sdk/module/sim-sdk-static-client-factory.ts
@@ -1,0 +1,81 @@
+import {
+  hasSendPatch,
+  installSendPatch,
+  type SimSdkSendHandler,
+} from "../send-patch.js";
+
+/**
+ * A static method of an SDK client class, called through a wrapper.
+ */
+type SimSdkStaticMethod = (...arguments_: unknown[]) => unknown;
+
+/**
+ * The wrapped static methods of one intercepted SDK client class.
+ *
+ * A static factory such as `DynamoDBDocumentClient.from` constructs from the
+ * class binding it closes over rather than through the class the calling code
+ * holds, so the client it builds is never seen by the interception's construct
+ * trap. Wrapping the method send-patches that client on the way back out.
+ *
+ * Each method is wrapped once, so the class keeps handing out the same
+ * function for the same static.
+ */
+export class SimSdkStaticClientFactories {
+  private readonly sendHandler: SimSdkSendHandler;
+  private readonly wrappers = new WeakMap<object, unknown>();
+
+  constructor(sendHandler: SimSdkSendHandler) {
+    this.sendHandler = sendHandler;
+  }
+
+  /**
+   * The patching wrapper for one static method.
+   */
+  wrap(method: object): unknown {
+    const wrapped = this.wrappers.get(method) ?? this.wrapMethod(method);
+    this.wrappers.set(method, wrapped);
+    return wrapped;
+  }
+
+  /**
+   * A Proxy rather than a plain function keeps the method's own identity
+   * surface, such as its name, length and any properties hung off it.
+   */
+  private wrapMethod(method: object): unknown {
+    const sendHandler = this.sendHandler;
+    return new Proxy(method as SimSdkStaticMethod, {
+      apply(
+        target: SimSdkStaticMethod,
+        thisArgument: unknown,
+        callArguments: unknown[],
+      ): unknown {
+        const result: unknown = Reflect.apply(
+          target,
+          thisArgument,
+          callArguments,
+        );
+        if (isUnpatchedClient(result)) {
+          installSendPatch(result, sendHandler);
+        }
+        return result;
+      },
+    });
+  }
+}
+
+/**
+ * Whether a static method's return value is a client still to be patched.
+ *
+ * A factory building through the intercepted class itself has already been
+ * patched by the construct trap, so patching again is skipped rather than
+ * rejected as a double interception.
+ */
+function isUnpatchedClient(value: unknown): value is object {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (typeof (value as { send?: unknown }).send !== "function") {
+    return false;
+  }
+  return !hasSendPatch(value);
+}

--- a/src/sdk/send-patch.ts
+++ b/src/sdk/send-patch.ts
@@ -101,6 +101,18 @@ export function installSendPatch(
 }
 
 /**
+ * Whether a simulated send patch is currently installed on a target.
+ *
+ * Only an own patched send counts, which is the property installSendPatch
+ * writes, so an instance inheriting a patched send from a patched prototype
+ * reports false.
+ */
+export function hasSendPatch(target: object): boolean {
+  const send: unknown = Object.getOwnPropertyDescriptor(target, "send")?.value;
+  return typeof send === "function" && installedSends.has(send);
+}
+
+/**
  * Name a patch target for diagnostics: the client's class name for instances
  * and prototypes alike, when it has one.
  */

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-sdk-document-client.iso.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-sdk-document-client.iso.test.ts
@@ -1,0 +1,219 @@
+import { CreateTableCommand, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../../iam/policy/sim-iam-policy-document.factory.js";
+import type { SimLambda } from "../../../sim-lambda.js";
+import { makeLambdaCodeZip } from "../make-lambda-code-zip.js";
+
+/**
+ * A handler writing one order through the document client the AWS SDK
+ * documentation builds, whose static factory constructs the client itself
+ * rather than through the class the function code holds.
+ */
+const factoryHandlerSource = `
+const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+const { DynamoDBDocumentClient, PutCommand } = require("@aws-sdk/lib-dynamodb");
+
+exports.handler = async (event) => {
+  const documents = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+  await documents.send(
+    new PutCommand({
+      TableName: event.tableName,
+      Item: { orderId: event.orderId, total: 42 },
+    }),
+  );
+  return event.orderId;
+};
+`;
+
+/**
+ * A handler writing one order through each of the other two client shapes:
+ * the document client constructed directly, and the plain client.
+ */
+const constructedHandlerSource = `
+const { DynamoDBClient, PutItemCommand } = require("@aws-sdk/client-dynamodb");
+const { DynamoDBDocumentClient, PutCommand } = require("@aws-sdk/lib-dynamodb");
+
+exports.handler = async (event) => {
+  const client = new DynamoDBClient({});
+  const documents = new DynamoDBDocumentClient(client);
+  await documents.send(
+    new PutCommand({
+      TableName: event.tableName,
+      Item: { orderId: "constructed", total: 1 },
+    }),
+  );
+  await client.send(
+    new PutItemCommand({
+      TableName: event.tableName,
+      Item: { orderId: { S: "plain" }, total: { N: "2" } },
+    }),
+  );
+  return "both";
+};
+`;
+
+function parsePayload(payload: Uint8Array | undefined): unknown {
+  assertNonNullable(payload);
+  return JSON.parse(Buffer.from(payload).toString()) as unknown;
+}
+
+/**
+ * A simulation holding an orders table, and a role that may write to it when
+ * the write permission is granted.
+ */
+async function simAwsWithOrders(
+  writable: boolean,
+): Promise<{ simAws: SimAws; simLambda: SimLambda; roleArn: string }> {
+  const simAws = new SimAws();
+  const creation = await simAws.dynamoDb().createTable(
+    new CreateTableCommand({
+      TableName: "orders",
+      AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+      KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  const tableArn = creation.TableDescription?.TableArn;
+  assertNonNullable(tableArn);
+
+  const roleCreation = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "OrderWriterRole",
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  if (writable) {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "OrderWriterRole",
+        PolicyName: "WriteOrders",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "dynamodb:PutItem", Resource: tableArn },
+        }),
+      }),
+    );
+  }
+
+  return { simAws, simLambda: simAws.lambda(), roleArn: roleCreation.Role.Arn };
+}
+
+async function orderTotal(
+  simAws: SimAws,
+  orderId: string,
+): Promise<string | undefined> {
+  const read = await simAws.dynamoDb().getItem(
+    new GetItemCommand({
+      TableName: "orders",
+      Key: { orderId: { S: orderId } },
+    }),
+  );
+  return read.Item?.["total"]?.N;
+}
+
+describe("Sim Lambda function code using the DynamoDB document client", () => {
+  it("writes to sim DynamoDB through a document client built by from", async () => {
+    // Given a function that builds its document client with the static
+    // factory, and a role allowed to write the table.
+    const { simAws, simLambda, roleArn } = await simAwsWithOrders(true);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "order-writer",
+        Role: roleArn,
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(factoryHandlerSource) },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({
+        FunctionName: "order-writer",
+        Payload: JSON.stringify({ tableName: "orders", orderId: "order-1" }),
+      }),
+    );
+
+    // Then the write reached the simulated table as the execution role.
+    assertIdentical(output.StatusCode, 200);
+    assertUndefined(output.FunctionError);
+    assertIdentical(parsePayload(output.Payload), "order-1");
+    assertIdentical(await orderTotal(simAws, "order-1"), "42");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("denies the document client write the execution role cannot make", async () => {
+    // Given the same function with a role holding no DynamoDB permissions.
+    const { simAws, simLambda, roleArn } = await simAwsWithOrders(false);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "denied-order-writer",
+        Role: roleArn,
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(factoryHandlerSource) },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({
+        FunctionName: "denied-order-writer",
+        Payload: JSON.stringify({ tableName: "orders", orderId: "order-2" }),
+      }),
+    );
+
+    // Then simulated IAM denied the write, so the factory client is
+    // authorized like any other.
+    assertIdentical(output.FunctionError, "Unhandled");
+    const errorDocument = parsePayload(output.Payload) as {
+      errorMessage: string;
+    };
+    assertStringIncludes(errorDocument.errorMessage, "dynamodb:PutItem");
+    assertUndefined(await orderTotal(simAws, "order-2"));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("keeps the constructed document client and the plain client writing", async () => {
+    // Given a function writing through both of the shapes the construct trap
+    // already sees.
+    const { simAws, simLambda, roleArn } = await simAwsWithOrders(true);
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "both-writers",
+        Role: roleArn,
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(constructedHandlerSource) },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simLambda.invoke(
+      new InvokeCommand({
+        FunctionName: "both-writers",
+        Payload: JSON.stringify({ tableName: "orders" }),
+      }),
+    );
+
+    // Then both writes reached the simulated table.
+    assertUndefined(output.FunctionError);
+    assertIdentical(await orderTotal(simAws, "constructed"), "1");
+    assertIdentical(await orderTotal(simAws, "plain"), "2");
+
+    await simAws.backgroundTasksComplete();
+  });
+});


### PR DESCRIPTION
Function code reaching DynamoDB through `DynamoDBDocumentClient.from` left the simulation for the host credential chain and failed on its security token. Interception proxies each client class with a construct trap. The static factory builds from the class binding it closes over, which the trap never sees, and the client it returns keeps the real SDK send. The proxy now wraps the class's own static methods as well and patches any client they hand back.

Resolves #1108