### PR TITLE
fix: chain a Role from an assumed-role session

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -458,6 +458,10 @@ Simulated STS issues temporary credentials for IAM Roles with `AssumeRoleCommand
 request is evaluated against the Role's trust policy, and the returned credentials resolve to an
 assumed-role session principal whose permissions come from the underlying Role's policies.
 
+A session carries two ARNs, the session's own and the Role's, and a resource policy naming either
+one applies to it. A Bucket policy naming a Role therefore covers every session of that Role, as it
+does in AWS, and `aws:PrincipalArn` holds the Role's ARN throughout.
+
 ```typescript sim-iam-sts-assume-role
 /**
  * Assuming a simulated IAM Role through simulated STS.

--- a/docs/services/sts/README.md
+++ b/docs/services/sts/README.md
@@ -153,6 +153,20 @@ Cross-Account assumption works the same way. Create the source and target Roles 
 simulated Accounts of the same `SimAws` instance, and call `assumeRole` on the source Account's
 `sts()`. The issued session belongs to the target Role's Account.
 
+## Role chaining
+
+A process that assumes a Role and then assumes a second one from that session is chaining Roles. The
+caller of the second request is the session, and the Role it holds the permissions of is what both
+sides of the decision are written against. The trust policy of the target names that Role, and the
+identity policy allowing `sts:AssumeRole` belongs to it.
+
+Both ARNs of a session are matched against a `Principal`, so a trust policy naming either the Role
+or one particular session admits it. AWS recommends naming the Role, and a session name is often
+decided at run time rather than written into a policy.
+
+Chaining over a served endpoint works the same way. Credentials from the first request sign the
+second, and the caller they resolve to carries the Role along with the session.
+
 ## ExternalId
 
 A trust policy can require an external ID through the `sts:ExternalId` condition key. The

--- a/src/service/aws/caller/sim-aws-resolved-caller.ts
+++ b/src/service/aws/caller/sim-aws-resolved-caller.ts
@@ -1,0 +1,36 @@
+import type { SimAwsPrincipal, SimResolvedCaller } from "./sim-aws-caller.js";
+import {
+  SimAwsCallerResolver,
+  type SimAwsResolvedCaller,
+} from "./sim-aws-caller-resolver.js";
+
+/**
+ * State an already-resolved caller as the caller of another request.
+ *
+ * A resolver answers with a SimAwsResolvedCaller, and a service that goes on
+ * to ask IAM about the same caller has to pass one back in. Both principals
+ * travel together, so an assumed-role session keeps the Role its policies come
+ * from instead of arriving as a session ARN that owns none.
+ */
+export function simAwsCallerFor(
+  caller: SimAwsResolvedCaller,
+): SimResolvedCaller {
+  return {
+    kind: "resolved",
+    principal: caller.principal,
+    identityPolicyPrincipal: caller.identityPolicyPrincipal,
+  };
+}
+
+/**
+ * Resolve a principal that needs nothing authenticated.
+ *
+ * A service principal, or an ARN something else has already established, is
+ * its own answer. This is the short way to the SimAwsResolvedCaller that an
+ * authorization boundary asks for.
+ */
+export function simAwsResolvedCallerOf(
+  principal: SimAwsPrincipal,
+): SimAwsResolvedCaller {
+  return new SimAwsCallerResolver().resolve(principal, principal);
+}

--- a/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
@@ -115,6 +115,12 @@ export class SimIamPolicyPrincipalMatcher {
    * The wildcard matches both authenticated and anonymous requests. Other AWS
    * forms require an ARN-based caller. Account delegation forms compare against
    * the account ID derived by the caller resolver.
+   *
+   * A pattern is compared against two ARNs, because an assumed-role session
+   * has two. The session ARN is the caller, and the Role behind it is the
+   * identity whose policies apply. AWS matches a policy naming either one, and
+   * recommends naming the Role. The two ARNs are the same for every caller
+   * that is not a session, so one comparison happens in that case.
    */
   private awsPatternMatches(pattern: string): SimIamPrincipalMatch {
     if (pattern === "*") {
@@ -135,9 +141,18 @@ export class SimIamPolicyPrincipalMatcher {
     }
 
     return SimIamPrincipalMatch.direct().when(
-      simIamWildcardMatch(pattern, caller.arn, {
-        caseSensitive: true,
-      }),
+      this.arnMatches(pattern, caller.arn) ||
+        this.arnMatches(pattern, caller.identityPolicyArn),
+    );
+  }
+
+  /**
+   * Whether a principal pattern names one of the caller's ARNs.
+   */
+  private arnMatches(pattern: string, arn: string | undefined): boolean {
+    return (
+      arn !== undefined &&
+      simIamWildcardMatch(pattern, arn, { caseSensitive: true })
     );
   }
 

--- a/src/service/iam/authorize/match/sim-iam-session-principal.iso.test.ts
+++ b/src/service/iam/authorize/match/sim-iam-session-principal.iso.test.ts
@@ -1,0 +1,106 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+
+/**
+ * Which ARN of an assumed-role session a resource policy names.
+ *
+ * A session has two: the session itself, and the Role it holds the permissions
+ * of. AWS matches a policy naming either, and its own guidance is to name the
+ * Role. Both are covered here because naming the Role is the common case and
+ * naming one session is the precise one.
+ */
+describe("A resource policy naming an assumed-role session", () => {
+  it("matches a policy naming the Role behind the session", () => {
+    // Given a session of a Role, and a policy naming that Role.
+    const { simAws, session, roleArn } = sessionCaller();
+
+    // When the session reads the resource the policy is on.
+    const decision = simAws.iam().authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::reports/summary.csv",
+      caller: session,
+      resourcePolicies: [bucketPolicyFor(roleArn)],
+    });
+
+    // Then the Role the session holds carried the grant.
+    assertIdentical(decision.value, "Allow");
+  });
+
+  it("matches a policy naming that session in particular", () => {
+    // Given a session of a Role, and a policy naming the session itself.
+    const { simAws, session, sessionArn } = sessionCaller();
+
+    // When the session reads the resource the policy is on.
+    const decision = simAws.iam().authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::reports/summary.csv",
+      caller: session,
+      resourcePolicies: [bucketPolicyFor(sessionArn)],
+    });
+
+    // Then the session ARN matched.
+    assertIdentical(decision.value, "Allow");
+  });
+
+  it("leaves a policy naming another Role alone", () => {
+    // Given a session of a Role, and a policy naming a different Role.
+    const { simAws, session, accountId } = sessionCaller();
+
+    // When the session reads the resource the policy is on.
+    const decision = simAws.iam().authorize({
+      action: "s3:GetObject",
+      resource: "arn:aws:s3:::reports/summary.csv",
+      caller: session,
+      resourcePolicies: [
+        bucketPolicyFor(`arn:aws:iam::${accountId}:role/Other`),
+      ],
+    });
+
+    // Then neither of the session's two ARNs matched it.
+    assertIdentical(decision.value, "ImplicitDeny");
+  });
+});
+
+function bucketPolicyFor(principalArn: string) {
+  return {
+    sourceType: "resource" as const,
+    policyName: "BucketPolicy",
+    resourceArn: "arn:aws:s3:::reports",
+    document: {
+      Version: "2012-10-17" as const,
+      Statement: {
+        Effect: "Allow" as const,
+        Principal: { AWS: principalArn },
+        Action: "s3:GetObject",
+        Resource: "arn:aws:s3:::reports/*",
+      },
+    },
+  };
+}
+
+function sessionCaller(): {
+  simAws: SimAws;
+  session: SimAwsCaller;
+  roleArn: string;
+  sessionArn: string;
+  accountId: string;
+} {
+  const accountId = makeSimAwsAccountId();
+  const roleArn = `arn:aws:iam::${accountId}:role/Reporting`;
+  const sessionArn = `arn:aws:sts::${accountId}:assumed-role/Reporting/one`;
+
+  return {
+    simAws: new SimAws({ defaultAccountId: accountId }),
+    session: {
+      kind: "resolved",
+      principal: { kind: "arn", arn: sessionArn },
+      identityPolicyPrincipal: { kind: "arn", arn: roleArn },
+    },
+    roleArn,
+    sessionArn,
+    accountId,
+  };
+}

--- a/src/service/sts/assume/sim-sts-assume-role-chain.iso.test.ts
+++ b/src/service/sts/assume/sim-sts-assume-role-chain.iso.test.ts
@@ -1,0 +1,179 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+
+/**
+ * Chaining one Role into another, which is what a process does when it assumes
+ * a Role and then assumes a second one from that session.
+ *
+ * The caller of the second request is a session, and the Role behind it is
+ * what both sides of the decision are written against. The trust policy of the
+ * target names that Role, and the identity policy allowing the action belongs
+ * to it.
+ */
+describe("Assuming a Role from an assumed-role session", () => {
+  it("matches a trust policy naming the Role behind the session", async () => {
+    // Given RoleA allowed to assume, and RoleB trusting RoleA.
+    const { simAws, accountId, session } = await chainableRoles();
+
+    // When a session of RoleA assumes RoleB.
+    const assumed = await simAws.sts().assumeRole(
+      {
+        input: {
+          RoleArn: `arn:aws:iam::${accountId}:role/RoleB`,
+          RoleSessionName: "second",
+        },
+      },
+      { caller: session },
+    );
+
+    // Then the session it hands back belongs to RoleB.
+    assertStringStartsWith(
+      assumed.AssumedRoleUser?.Arn ?? "",
+      `arn:aws:sts::${accountId}:assumed-role/RoleB/`,
+    );
+  });
+
+  it("refuses a session whose Role the trust policy leaves out", async () => {
+    // Given RoleB trusting RoleA, and a session of some other Role.
+    const { simAws, accountId } = await chainableRoles();
+
+    const error = await assertThrowsErrorAsync(async () => {
+      // When a session of RoleC assumes RoleB.
+      await simAws.sts().assumeRole(
+        {
+          input: {
+            RoleArn: `arn:aws:iam::${accountId}:role/RoleB`,
+            RoleSessionName: "second",
+          },
+        },
+        {
+          caller: {
+            kind: "resolved",
+            principal: {
+              kind: "arn",
+              arn: `arn:aws:sts::${accountId}:assumed-role/RoleC/other`,
+            },
+            identityPolicyPrincipal: {
+              kind: "arn",
+              arn: `arn:aws:iam::${accountId}:role/RoleC`,
+            },
+          },
+        },
+      );
+    });
+
+    // Then the trust policy refused it, naming the session that asked.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "sts:AssumeRole");
+  });
+
+  it("refuses a session whose Role may not assume the target", async () => {
+    // Given RoleA trusted by RoleB, with nothing allowing it the action.
+    const { simAws, accountId, session } = await chainableRoles({
+      allowChaining: false,
+    });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      // When a session of RoleA assumes RoleB.
+      await simAws.sts().assumeRole(
+        {
+          input: {
+            RoleArn: `arn:aws:iam::${accountId}:role/RoleB`,
+            RoleSessionName: "second",
+          },
+        },
+        { caller: session },
+      );
+    });
+
+    // Then the identity side refused it, so the Role's own policies decided
+    // the request rather than the session's absence of any.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "sts:AssumeRole");
+  });
+});
+
+/**
+ * RoleA, RoleB trusting RoleA, and a caller standing for a session of RoleA.
+ */
+async function chainableRoles(
+  options: { allowChaining?: boolean } = {},
+): Promise<{
+  simAws: SimAws;
+  accountId: string;
+  session: SimAwsCaller;
+}> {
+  const { allowChaining = true } = options;
+  const accountId = makeSimAwsAccountId();
+  const simAws = new SimAws({ defaultAccountId: accountId });
+  const simIam = simAws.iam();
+  const roleA = `arn:aws:iam::${accountId}:role/RoleA`;
+
+  await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: "RoleA",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  if (allowChaining) {
+    await simIam.putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "RoleA",
+        PolicyName: "Chain",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "sts:AssumeRole",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+  }
+
+  await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: "RoleB",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: roleA },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  return {
+    simAws,
+    accountId,
+    session: {
+      kind: "resolved",
+      principal: {
+        kind: "arn",
+        arn: `arn:aws:sts::${accountId}:assumed-role/RoleA/first`,
+      },
+      identityPolicyPrincipal: { kind: "arn", arn: roleA },
+    },
+  };
+}

--- a/src/service/sts/assume/sim-sts-assume-role-deny.iso.test.ts
+++ b/src/service/sts/assume/sim-sts-assume-role-deny.iso.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
+import { simAwsResolvedCallerOf } from "../../aws/caller/sim-aws-resolved-caller.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
 import { AssumeRoleTrustPolicyAuthorizer } from "../auth-z/assume-role-trust-policy-authorizer.js";
@@ -304,7 +305,7 @@ describe("STS AssumeRole denial", () => {
         // @ts-expect-error TS2322 -- testing invalid role
         role,
         targetIam: simIam,
-        caller,
+        caller: simAwsResolvedCallerOf(caller),
       });
     });
 

--- a/src/service/sts/auth-z/assume-role-auth-z-coordinator.ts
+++ b/src/service/sts/auth-z/assume-role-auth-z-coordinator.ts
@@ -1,7 +1,5 @@
-import type {
-  SimArnPrincipal,
-  SimAwsPrincipal,
-} from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimGetRoleCommandOutput } from "../../iam/command/role/get-role/get-role.command.js";
@@ -22,7 +20,15 @@ interface AssumeRoleAuthorizationCoordinatorProperties {
 interface AssumeRoleAuthorizationInput {
   readonly roleArn: string;
   readonly roleArnParts: IamRoleArnParts;
-  readonly caller: SimArnPrincipal;
+
+  /**
+   * The caller as the request boundary resolved it.
+   *
+   * Both sides of an AssumeRole decision need the identity whose policies
+   * apply, which is the Role behind an assumed-role session. Passing the
+   * resolved caller whole is what carries it here.
+   */
+  readonly caller: SimAwsResolvedCaller;
   readonly conditionContext?:
     | Readonly<Record<string, SimIamConditionValue>>
     | undefined;
@@ -75,9 +81,9 @@ export class AssumeRoleAuthorizationCoordinator {
 
     this.sourcePrincipalAuthorizer.authorize({
       roleArn: input.roleArn,
-      callerPrincipal: input.caller,
+      caller: input.caller,
       identityPolicyAllowRequired: !this.hasDirectSameAccountUserGrant(
-        input.caller,
+        input.caller.principal,
         input.roleArnParts.accountId,
         targetAuthorization.trust.isDirectPrincipalGrant,
       ),

--- a/src/service/sts/auth-z/assume-role-source-account-auth-z.ts
+++ b/src/service/sts/auth-z/assume-role-source-account-auth-z.ts
@@ -1,7 +1,8 @@
 import type { SimIamAccountResolver } from "../../iam/registry/sim-iam-account-resolver.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
-import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
+import { simAwsCallerFor } from "../../aws/caller/sim-aws-resolved-caller.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 
 interface AssumeRoleSourceAccountAuthorizerProperties {
@@ -16,7 +17,14 @@ interface AssumeRoleSourceAccountAuthorizerProperties {
 
 export interface AssumeRoleSourceAuthorizationInput {
   readonly roleArn: string;
-  readonly callerPrincipal?: SimAwsPrincipal | undefined;
+
+  /**
+   * The caller as the request boundary resolved it.
+   *
+   * The identity policies deciding this are the ones held by the Role behind
+   * an assumed-role session, so the resolved caller travels here whole.
+   */
+  readonly caller?: SimAwsResolvedCaller | undefined;
 
   /**
    * Whether the caller must have an identity-policy Allow for sts:AssumeRole.
@@ -60,14 +68,15 @@ export class AssumeRoleSourcePrincipalAuthorizer {
   authorize(input: AssumeRoleSourceAuthorizationInput): void {
     const sourceIam = this.iamResolver.iamForAccount(this.sourceAccountId);
 
-    // A request with no caller principal of its own is left for sim IAM to
-    // attribute. The simulation's default caller reaches this decision the way
-    // it reaches every other one.
+    // A request with no caller of its own is left for sim IAM to attribute.
+    // The simulation's default caller reaches this decision the way it reaches
+    // every other one.
     const decision = sourceIam.authorize({
       action: "sts:AssumeRole",
       resource: input.roleArn,
       region: this.regionName,
-      caller: input.callerPrincipal,
+      caller:
+        input.caller === undefined ? undefined : simAwsCallerFor(input.caller),
     });
 
     if (

--- a/src/service/sts/auth-z/assume-role-target-auth-z.ts
+++ b/src/service/sts/auth-z/assume-role-target-auth-z.ts
@@ -1,4 +1,4 @@
-import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimIamAccountResolver } from "../../iam/registry/sim-iam-account-resolver.js";
@@ -25,7 +25,7 @@ type AssumeRoleTargetRole = SimGetRoleCommandOutput["Role"];
 interface AssumeRoleTargetAuthorizationInput {
   readonly roleArn: string;
   readonly target: IamRoleArnParts | SimAwsAccountId;
-  readonly caller: SimAwsPrincipal;
+  readonly caller: SimAwsResolvedCaller;
   readonly conditionContext?:
     | Readonly<Record<string, SimIamConditionValue>>
     | undefined;

--- a/src/service/sts/auth-z/assume-role-trust-policy-authorizer.ts
+++ b/src/service/sts/auth-z/assume-role-trust-policy-authorizer.ts
@@ -1,6 +1,7 @@
 import type { JSONString } from "../../../util/type-guard/json.js";
 import { jsonParse } from "../../../util/type-guard/json.js";
-import type { SimAwsPrincipal } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
+import { simAwsCallerFor } from "../../aws/caller/sim-aws-resolved-caller.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
 import type { SimGetRoleCommandOutput } from "../../iam/command/role/get-role/get-role.command.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
@@ -25,7 +26,7 @@ interface AssumeRoleTrustPolicyAuthorizationInput {
    */
   readonly region?: AwsRegionName | undefined;
 
-  readonly caller: SimAwsPrincipal;
+  readonly caller: SimAwsResolvedCaller;
   readonly conditionContext?:
     | Readonly<Record<string, SimIamConditionValue>>
     | undefined;
@@ -65,11 +66,7 @@ export class AssumeRoleTrustPolicyAuthorizer {
     input: AssumeRoleTrustPolicyAuthorizationInput,
   ): AssumeRoleTrustPolicyAuthorization {
     if (input.role.AssumeRolePolicyDocument === undefined) {
-      throw new SimIamAccessDenied({
-        principal: input.caller,
-        action: "sts:AssumeRole",
-        resource: input.roleArn,
-      });
+      this.refuse(input);
     }
 
     const trustPolicy = jsonParse(
@@ -80,7 +77,7 @@ export class AssumeRoleTrustPolicyAuthorizer {
       action: "sts:AssumeRole",
       resource: input.roleArn,
       region: input.region,
-      caller: input.caller,
+      caller: simAwsCallerFor(input.caller),
       conditionContext: input.conditionContext,
       resourcePolicies: [
         {
@@ -93,11 +90,7 @@ export class AssumeRoleTrustPolicyAuthorizer {
     });
 
     if (decision.isDenied || !decision.isAllowedByTrustPolicy) {
-      throw new SimIamAccessDenied({
-        principal: input.caller,
-        action: "sts:AssumeRole",
-        resource: input.roleArn,
-      });
+      this.refuse(input);
     }
 
     return {
@@ -106,5 +99,16 @@ export class AssumeRoleTrustPolicyAuthorizer {
         decision.trustAllowStatements,
       ),
     };
+  }
+
+  /**
+   * Refuse the request as the caller that made it.
+   */
+  private refuse(input: AssumeRoleTrustPolicyAuthorizationInput): never {
+    throw new SimIamAccessDenied({
+      principal: input.caller.principal,
+      action: "sts:AssumeRole",
+      resource: input.roleArn,
+    });
   }
 }

--- a/src/service/sts/command/assume-role/assume-role.handler.ts
+++ b/src/service/sts/command/assume-role/assume-role.handler.ts
@@ -114,7 +114,7 @@ export class AssumeRoleCommandHandler implements CommandHandler<
     const role = await this.authorizationCoordinator.authorize({
       roleArn: request.roleArn,
       roleArnParts: request.roleArnParts,
-      caller: caller.principal,
+      caller,
       conditionContext: request.conditionContext,
     });
 

--- a/src/service/sts/serve/sim-sts-api-assume-role.loc.test.ts
+++ b/src/service/sts/serve/sim-sts-api-assume-role.loc.test.ts
@@ -2,6 +2,7 @@ import {
   CreateAccessKeyCommand,
   CreateRoleCommand,
   CreateUserCommand,
+  PutRolePolicyCommand,
 } from "@aws-sdk/client-iam";
 import {
   AssumeRoleCommand,
@@ -153,6 +154,66 @@ describe("Assuming a Role over the STS endpoint", () => {
     // handler catching it in production would see
     assertIdentical(error.name, "AccessDenied");
     assertStringIncludes(error.message, "sts:AssumeRole");
+  });
+
+  it("chains the session it hands back into a second Role", async () => {
+    // Given a Role this caller may assume, allowed to assume a second Role
+    // that trusts it
+    await createRole("Chainer", userArn);
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Chainer",
+        PolicyName: "Chain",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "sts:AssumeRole",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+    await createRole("Chained", `arn:aws:iam::${accountId}:role/Chainer`);
+
+    // When the credentials from assuming the first are used to assume the
+    // second, which is what a process chaining Roles does
+    const first = await client.send(
+      new AssumeRoleCommand({
+        RoleArn: `arn:aws:iam::${accountId}:role/Chainer`,
+        RoleSessionName: "first",
+      }),
+    );
+    const credentials = first.Credentials;
+    assertDefined(credentials, "the first session's credentials");
+    assertDefined(credentials.AccessKeyId, "the session access key id");
+    assertDefined(credentials.SecretAccessKey, "the session secret");
+    assertDefined(credentials.SessionToken, "the session token");
+
+    const sessionClient = new STSClient({
+      region: simAws.defaultRegionName,
+      endpoint,
+      credentials: {
+        accessKeyId: credentials.AccessKeyId,
+        secretAccessKey: credentials.SecretAccessKey,
+        sessionToken: credentials.SessionToken,
+      },
+    });
+    const second = await sessionClient.send(
+      new AssumeRoleCommand({
+        RoleArn: `arn:aws:iam::${accountId}:role/Chained`,
+        RoleSessionName: "second",
+      }),
+    );
+
+    // Then the trust policy naming the first Role admitted its session, and
+    // that Role's own policy allowed the action
+    const chained = second.AssumedRoleUser;
+    assertDefined(chained, "the chained assumed Role user");
+    assertIdentical(
+      chained.Arn,
+      `arn:aws:sts::${accountId}:assumed-role/Chained/second`,
+    );
   });
 
   /**

--- a/src/service/sts/service-role/sim-service-role.ts
+++ b/src/service/sts/service-role/sim-service-role.ts
@@ -1,4 +1,5 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { simAwsResolvedCallerOf } from "../../aws/caller/sim-aws-resolved-caller.js";
 import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import type { SimIam } from "../../iam/sim-iam.js";
@@ -91,7 +92,10 @@ export async function assumeSimServiceRole(
       role,
       targetIam: iam,
       region: scope.accountRegionScope.regionName,
-      caller: { kind: "service", service: servicePrincipal },
+      caller: simAwsResolvedCallerOf({
+        kind: "service",
+        service: servicePrincipal,
+      }),
       conditionContext: simServiceRoleConditionContext(source),
     });
   } catch (error) {


### PR DESCRIPTION
A session carries two ARNs, its own and the Role whose policies it holds, and only the session ARN reached authorization. A trust policy naming the Role matched nothing, and the Role's identity policies were never consulted. Assuming a second Role from a session was therefore denied. Principal matching now compares a policy against both ARNs, as AWS does, and the AssumeRole handler passes the resolved caller whole where it passed the session principal alone.

The fix reaches further than the issue describes. Its implementation notes named the handler dropping `identityPolicyPrincipal`, and that was half of it. `SimIamPolicyPrincipalMatcher` compared a `Principal` against the effective ARN alone, so a resource policy naming a Role never matched a session of that Role anywhere in the simulator. A Bucket policy naming a Role now covers its sessions, which is what [the IAM docs on role principals](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html) describe and what AWS recommends writing.

Resolves #1109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for STS role chaining, allowing one assumed role session to assume another role when permissions and trust policies permit.
  - Improved assumed-role identity handling across authorization checks, including support for both session and underlying role ARNs.
  - Service-role authorization now preserves service principal identity during policy evaluation.

- **Bug Fixes**
  - Corrected principal matching for assumed-role sessions in resource policies.

- **Documentation**
  - Expanded IAM and STS documentation covering session ARNs, role ARNs, and role chaining behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->