### PR TITLE
perf: memoize compiled IAM wildcard patterns

### DIFF
--- a/src/service/iam/authorize/sim-iam-wildcard.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-wildcard.iso.test.ts
@@ -1,0 +1,91 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { simIamWildcardMatch } from "./sim-iam-wildcard.js";
+
+const caseSensitive = { caseSensitive: true };
+const caseInsensitive = { caseSensitive: false };
+
+describe("Sim IAM wildcard matching", () => {
+  it("matches any run of characters with an asterisk", () => {
+    // Given a pattern standing for a whole service.
+    const pattern = "s3:*";
+
+    // When actions of that service are matched against it.
+    // Then the asterisk covers all of them, and nothing outside the service.
+    assertTrue(simIamWildcardMatch(pattern, "s3:GetObject", caseSensitive));
+    assertTrue(simIamWildcardMatch(pattern, "s3:", caseSensitive));
+    assertFalse(
+      simIamWildcardMatch(pattern, "s3control:GetObject", caseSensitive),
+    );
+  });
+
+  it("matches exactly one character with a question mark", () => {
+    // Given a pattern with a question mark where a digit belongs.
+    const pattern = "eu-west-?";
+
+    // When Region names are matched against it.
+    // Then one character fits and two do not.
+    assertTrue(simIamWildcardMatch(pattern, "eu-west-1", caseSensitive));
+    assertFalse(simIamWildcardMatch(pattern, "eu-west-", caseSensitive));
+    assertFalse(simIamWildcardMatch(pattern, "eu-west-12", caseSensitive));
+  });
+
+  it("treats every other regular expression character as itself", () => {
+    // Given a pattern made of characters a regular expression would read as
+    // syntax.
+    const pattern = "a.b+c(d)[e]{f}|g^h$i";
+
+    // When the pattern's own text is matched against it.
+    // Then it matches itself and not what those characters would have meant.
+    assertTrue(simIamWildcardMatch(pattern, pattern, caseSensitive));
+    assertFalse(
+      simIamWildcardMatch(pattern, "axb+c(d)[e]{f}|g^h$i", caseSensitive),
+    );
+    assertFalse(simIamWildcardMatch("a.c", "abc", caseSensitive));
+  });
+
+  it("anchors a pattern to the whole value", () => {
+    // Given a pattern with no wildcard in it.
+    const pattern = "s3:GetObject";
+
+    // When a longer value containing it is matched.
+    // Then the surrounding characters keep it out.
+    assertTrue(simIamWildcardMatch(pattern, "s3:GetObject", caseSensitive));
+    assertFalse(
+      simIamWildcardMatch(pattern, "s3:GetObjectVersion", caseSensitive),
+    );
+    assertFalse(simIamWildcardMatch(pattern, "xs3:GetObject", caseSensitive));
+  });
+
+  it("answers each call site by the case sensitivity it asked for", () => {
+    // Given one pattern differing from a value only by case.
+    const pattern = "s3:getobject";
+
+    // When the same pattern is matched both ways, in both orders.
+    // Then each call site gets its own answer, whichever ran first.
+    assertFalse(simIamWildcardMatch(pattern, "s3:GetObject", caseSensitive));
+    assertTrue(simIamWildcardMatch(pattern, "s3:GetObject", caseInsensitive));
+    assertFalse(simIamWildcardMatch(pattern, "s3:GetObject", caseSensitive));
+  });
+
+  it("gives a repeated match the same answer as the first one", () => {
+    // Given a pattern matched once already.
+    const pattern = "arn:aws:s3:::example-*";
+    assertTrue(
+      simIamWildcardMatch(
+        pattern,
+        "arn:aws:s3:::example-reports",
+        caseSensitive,
+      ),
+    );
+
+    // When it is used again, for a value it matches and one it does not.
+    // Then it answers both as it would have on a first compilation.
+    assertTrue(
+      simIamWildcardMatch(pattern, "arn:aws:s3:::example-logs", caseSensitive),
+    );
+    assertFalse(
+      simIamWildcardMatch(pattern, "arn:aws:s3:::other-logs", caseSensitive),
+    );
+  });
+});

--- a/src/service/iam/authorize/sim-iam-wildcard.ts
+++ b/src/service/iam/authorize/sim-iam-wildcard.ts
@@ -1,6 +1,33 @@
+import { BoundedMemo } from "../../../util/memo/bounded-memo.js";
+
 interface SimIamWildcardMatchOptions {
   readonly caseSensitive: boolean;
 }
+
+/**
+ * How many compiled patterns to keep, for each of the two case sensitivities.
+ *
+ * One realistic organization policy set produces fewer than a hundred distinct
+ * patterns, and every request evaluates the same ones again. A few thousand
+ * leaves room for many documents attached at once, and holds a few thousand
+ * small regular expressions at worst.
+ */
+const compiledPatternLimit = 2000;
+
+/*
+ * Wildcard patterns already turned into regular expressions, held in a store
+ * per case sensitivity so that a lookup needs no key built for it.
+ *
+ * A pattern's text and its case sensitivity decide the whole of what is
+ * compiled. An entry made while evaluating one simulation's policies is the
+ * entry another simulation would have made for itself. A compiled expression
+ * also carries nothing from one use to the next, because the flags below leave
+ * out "g" and "y", and `test` keeps a position only under those. These stores
+ * therefore last as long as the process does, and a `SimAws` that goes out of
+ * scope leaves them behind for the next one.
+ */
+const caseSensitivePatterns = new BoundedMemo<RegExp>(compiledPatternLimit);
+const caseInsensitivePatterns = new BoundedMemo<RegExp>(compiledPatternLimit);
 
 /**
  * Match an IAM-style wildcard pattern.
@@ -12,14 +39,27 @@ export function simIamWildcardMatch(
   value: string,
   options: SimIamWildcardMatchOptions,
 ): boolean {
-  return wildcardMatch(pattern, value, options);
+  return patternRegExp(pattern, options.caseSensitive).test(value);
 }
 
-function wildcardMatch(
-  pattern: string,
-  value: string,
-  options: SimIamWildcardMatchOptions,
-): boolean {
+/**
+ * The regular expression a pattern compiles to, compiling it the first time it
+ * is asked for and reusing it afterwards.
+ */
+function patternRegExp(pattern: string, caseSensitive: boolean): RegExp {
+  return caseSensitive
+    ? caseSensitivePatterns.getOrCreate(pattern, () =>
+        compilePattern(pattern, "u"),
+      )
+    : caseInsensitivePatterns.getOrCreate(pattern, () =>
+        compilePattern(pattern, "iu"),
+      );
+}
+
+/**
+ * Turn a wildcard pattern into the regular expression that matches it.
+ */
+function compilePattern(pattern: string, flags: string): RegExp {
   const regexPattern = pattern
     .replaceAll(/[\\^$.*+?()[\]{}|]/gu, String.raw`\$&`)
     .replaceAll(String.raw`\*`, ".*")
@@ -31,9 +71,5 @@ function wildcardMatch(
    * other regex characters are escaped above.
    */
   // oxlint-disable-next-line security/detect-non-literal-regexp
-  const regExp = new RegExp(
-    `^${regexPattern}$`,
-    options.caseSensitive ? "u" : "iu",
-  );
-  return regExp.test(value);
+  return new RegExp(`^${regexPattern}$`, flags);
 }

--- a/src/util/memo/bounded-memo.iso.test.ts
+++ b/src/util/memo/bounded-memo.iso.test.ts
@@ -1,0 +1,82 @@
+import { assertFalse, assertIdentical, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { BoundedMemo } from "./bounded-memo.js";
+
+describe("Bounded memo", () => {
+  it("creates a value once and hands the same one back", () => {
+    // Given a memo with room to spare.
+    const memo = new BoundedMemo<string>(10);
+    let callCount = 0;
+
+    // When the same key is asked for twice.
+    const first = memo.getOrCreate("key", () => {
+      callCount++;
+      return "created";
+    });
+    const second = memo.getOrCreate("key", () => {
+      callCount++;
+      return "created again";
+    });
+
+    // Then the second answer is the first one, made once.
+    assertIdentical(first, "created");
+    assertIdentical(second, "created");
+    assertIdentical(callCount, 1);
+  });
+
+  it("keeps its keys apart", () => {
+    // Given a memo holding two keys.
+    const memo = new BoundedMemo<number>(10);
+    memo.getOrCreate("a", () => 10);
+    memo.getOrCreate("b", () => 20);
+
+    // When each is read back.
+    // Then each answers with its own value.
+    assertIdentical(
+      memo.getOrCreate("a", () => 99),
+      10,
+    );
+    assertIdentical(
+      memo.getOrCreate("b", () => 99),
+      20,
+    );
+    assertTrue(memo.has("a"));
+    assertFalse(memo.has("c"));
+  });
+
+  it("drops what was cached first once it is full", () => {
+    // Given a memo holding two values, filled to its limit.
+    const memo = new BoundedMemo<string>(2);
+    memo.getOrCreate("first", () => "one");
+    memo.getOrCreate("second", () => "two");
+
+    // When a third value arrives.
+    memo.getOrCreate("third", () => "three");
+
+    // Then the oldest of them has gone and the rest are still there.
+    assertFalse(memo.has("first"));
+    assertTrue(memo.has("second"));
+    assertTrue(memo.has("third"));
+  });
+
+  it("makes an evicted value again when it is next asked for", () => {
+    // Given a memo that has dropped a value to stay within its limit.
+    const memo = new BoundedMemo<string>(1);
+    let callCount = 0;
+    memo.getOrCreate("key", () => {
+      callCount++;
+      return "value";
+    });
+    memo.getOrCreate("other", () => "other value");
+
+    // When the dropped key is asked for again.
+    const value = memo.getOrCreate("key", () => {
+      callCount++;
+      return "value";
+    });
+
+    // Then it is made a second time, and the caller cannot tell.
+    assertIdentical(value, "value");
+    assertIdentical(callCount, 2);
+  });
+});

--- a/src/util/memo/bounded-memo.ts
+++ b/src/util/memo/bounded-memo.ts
@@ -1,0 +1,63 @@
+/**
+ * Memoization cache holding a bounded number of values.
+ *
+ * The bound stops a long-running process accumulating entries without limit.
+ * Which values survive it matters little. A caller gets the same value back
+ * either way, and an evicted one costs another call to the factory that made
+ * it.
+ *
+ * Eviction is by insertion order, and a value read again stays where it is. A
+ * memo worth bounding is one whose reads are hot, and reordering the cache on
+ * every read costs more than the occasional recomputation it saves.
+ *
+ * A cached value has to be something (undefined stands for a key the cache is
+ * missing). A hit then costs one map lookup.
+ */
+export class BoundedMemo<T extends NonNullable<unknown>> {
+  private readonly cache = new Map<PropertyKey, T>();
+
+  /**
+   * Hold up to `limit` values, dropping the oldest to make room past that.
+   */
+  constructor(private readonly limit: number) {}
+
+  /**
+   * Returns the cached value for the given key, or creates and caches it using
+   * `factory`.
+   */
+  getOrCreate<V extends T>(key: PropertyKey, factory: () => V): V {
+    const cached = this.cache.get(key);
+
+    if (cached !== undefined) {
+      return cached as V;
+    }
+
+    const value = factory();
+    this.cache.set(key, value);
+    this.evictOverflow();
+    return value;
+  }
+
+  /**
+   * Returns whether the cache is currently holding `key`.
+   */
+  has(key: PropertyKey): boolean {
+    return this.cache.has(key);
+  }
+
+  /**
+   * Drop what was cached first, until the cache is back within its limit.
+   */
+  private evictOverflow(): void {
+    while (this.cache.size > this.limit) {
+      const oldest = this.cache.keys().next();
+
+      /* v8 ignore next 3 -- a cache over its limit has a first key */
+      if (oldest.done === true) {
+        return;
+      }
+
+      this.cache.delete(oldest.value);
+    }
+  }
+}


### PR DESCRIPTION
@coderabbitai ignore

An `authorize` call under a realistic eight-statement service control policy runs `simIamWildcardMatch` 128 times, and 84 of those patterns are the same on every request. Each call escaped its pattern through three `replaceAll` passes and built a `RegExp` of its own before throwing it away. The compiled expressions now come from a bounded store keyed by pattern text, with one store per case sensitivity so a lookup builds no key of its own. A pattern's text and its case sensitivity decide the whole of what is compiled, and a compiled expression carries nothing from one use to the next (the flags leave out `g` and `y`), so the stores are held for the life of the process and shared between simulations.

`BoundedMemo` is new, next to the existing unbounded `Memo`. It evicts by insertion order and leaves a value read again where it is, because reordering the cache on every read costs more than the recompilation it saves. The limit is 2000 per store, against fewer than a hundred distinct patterns for one realistic organization policy set.

Measured with the reproduction from the issue, 20,000 identical `s3:GetObject` calls with a named Role caller and a Region supplied, three runs each:

| Attached | Before | After |
| --- | --- | --- |
| no policy | 40 to 55 ms | 20 to 37 ms |
| 8-statement SCP | 1,470 to 1,500 ms | 88 to 166 ms |

The attached case now costs about five times the unattached one, down from about 37 times.

Resolves #1118