### PR TITLE
fix: log the error an invocation ended in

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -276,6 +276,62 @@ console.log(logged.events?.map((event) => event.message));
 await simAws.backgroundTasksComplete();
 ```
 
+### When a handler throws
+
+An invocation that ends in an error nothing caught leaves an `ERROR Invoke Error` line in the
+function's log group, as it does in an account. The line carries a JSON document holding the error's
+type, its message and its stack, with one array element per stack frame. Whatever the handler
+printed before it failed is recorded above it. A handler bound in-process and one packaged as zip
+code are both recorded this way.
+
+```typescript sim-lambda-unhandled-error-output
+/**
+ * Reading why an invocation failed out of the function's log group.
+ */
+
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        console.log("INFO handling order-1");
+
+        throw new Error("order has no items");
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+const failure = await simAws.logs().filterLogEvents(
+  new FilterLogEventsCommand({
+    logGroupName: "/aws/lambda/orders",
+    filterPattern: '"Invoke Error"',
+  }),
+);
+
+// ERROR Invoke Error {"errorType":"Error","errorMessage":"order has no items",...}
+console.log(failure.events?.at(0)?.message);
+
+await simAws.backgroundTasksComplete();
+```
+
+The caller still hears about it too. `Invoke` answers with `FunctionError` set to `Unhandled` and
+the same error document in its response payload.
+
+Real Lambda writes `START`, `END` and `REPORT` lines around every invocation. Simulated Lambda
+writes none of those.
+
 ## Function code from S3
 
 Function code can also be fetched from a zip object stored in sim S3, as SAM and CDK deployments

--- a/docs/services/lambda/sim-lambda-unhandled-error-output.example.ts
+++ b/docs/services/lambda/sim-lambda-unhandled-error-output.example.ts
@@ -1,0 +1,39 @@
+/**
+ * Reading why an invocation failed out of the function's log group.
+ */
+
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        console.log("INFO handling order-1");
+
+        throw new Error("order has no items");
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+
+const failure = await simAws.logs().filterLogEvents(
+  new FilterLogEventsCommand({
+    logGroupName: "/aws/lambda/orders",
+    filterPattern: '"Invoke Error"',
+  }),
+);
+
+// ERROR Invoke Error {"errorType":"Error","errorMessage":"order has no items",...}
+console.log(failure.events?.at(0)?.message);
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -260,6 +260,11 @@ The output still reaches the terminal as well. Real Lambda sends it to CloudWatc
 else, but a test tool that swallowed it would make a failing test harder to debug. Recording is a
 tee.
 
+An invocation that ends in an error nothing caught leaves an `ERROR Invoke Error` line in the group
+after whatever it printed, carrying the error's type, its message and its stack. The
+[simulated Lambda docs](https://yulinsim.dev/services/lambda/ "Simulated Lambda usage docs") show
+one.
+
 Each invocation's `context.logGroupName` and `context.logStreamName` name the group and stream that
 were actually written to. Stream names use the real `YYYY/MM/DD/[$LATEST]<hash>` format. The hash
 identifies the execution environment, and one environment serves more than one request. Match the

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -168,6 +168,11 @@ holds back whatever follows the last newline until the write that completes it, 
 two calls is one event rather than two. What is still unterminated when the invocation ends is
 recorded then, whether the handler returned or threw.
 
+An invocation ending in an error nothing caught has the error recorded too, as real Lambda's runtime
+records one. `SimLambdaFunctionLogging.around` catches it, flushes whatever line was open, writes
+the `ERROR Invoke Error` document `simLambdaInvokeErrorLine` builds, and rethrows. The caller still
+gets `FunctionError` and the trace in its Invoke payload.
+
 `SimLambdaExecutableCode.recordOutputTo` is the seam. `SimLambdaVmZipCode` passes the sink to the
 sandbox streams; `SimLambdaHandlerReferenceCode` implements it as a no-op, because a referenced
 handler is an ordinary function closing over the test's own module scope and has no streams of its

--- a/src/service/lambda/function/logging/sim-lambda-function-logging.ts
+++ b/src/service/lambda/function/logging/sim-lambda-function-logging.ts
@@ -2,6 +2,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutputSink } from "./sim-lambda-output-sink.js";
 import type { SimLambdaExecutableCode } from "../code/sim-lambda-executable-code.js";
+import { simLambdaInvokeErrorLine } from "./sim-lambda-invoke-error-log.js";
 import { SimLambdaLogWriter } from "./sim-lambda-log-writer.js";
 import {
   simLambdaLogGroupName,
@@ -89,7 +90,7 @@ export class SimLambdaFunctionLogging {
 
   /**
    * Run an invocation, recording whatever it left unterminated once it is
-   * over.
+   * over, and the error it ended in when it ended in one.
    *
    * The flush happens whether the handler returned or threw, because a handler
    * that logged and then failed is the one a test most wants to read the logs
@@ -98,9 +99,34 @@ export class SimLambdaFunctionLogging {
   async around<T>(run: () => Promise<T>): Promise<T> {
     try {
       return await run();
+    } catch (error) {
+      this.recordInvokeError(error);
+      throw error;
     } finally {
       this.#writer?.flush();
     }
+  }
+
+  /**
+   * Record an invocation that ended in an error nothing caught, as real
+   * Lambda's runtime records one.
+   *
+   * The caller still gets the error: an Invoke answers with `FunctionError`
+   * and the trace in its payload as before, and this only puts the same
+   * failure in the place code goes looking for it.
+   */
+  private recordInvokeError(error: unknown): void {
+    const writer = this.#writer;
+
+    if (writer === undefined) {
+      return;
+    }
+
+    // Whatever the handler wrote without closing the line is a line of its
+    // own. A handler that printed half a line before failing would otherwise
+    // have the error appended to it, where a filter for the error misses it.
+    writer.flush();
+    writer.write(simLambdaInvokeErrorLine(error));
   }
 
   private coldStart(): string {

--- a/src/service/lambda/function/logging/sim-lambda-invoke-error-log.iso.test.ts
+++ b/src/service/lambda/function/logging/sim-lambda-invoke-error-log.iso.test.ts
@@ -1,0 +1,257 @@
+/* oxlint-disable no-console -- printing is what these handlers are here to do. */
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertArrayMinLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambdaFunction } from "../sim-lambda-function.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+
+const ERROR_LINE_PREFIX = "ERROR Invoke Error ";
+
+/**
+ * Resolve after a real pause. A handler can then fail after awaiting work.
+ */
+async function tick(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+/**
+ * A simulated AWS with one stack function backed by an in-process handler,
+ * which is what a `bindings` entry gives a template function.
+ */
+async function simAwsWithBoundFunction(
+  functionName: string,
+  handler: SimLambdaHandler,
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.cloudFormation().deployTemplate({
+    stackName: `${functionName}-stack`,
+    template: {
+      Resources: {
+        HandlerFunction: {
+          Type: "AWS::Lambda::Function",
+          Properties: {
+            FunctionName: functionName,
+            Role: `arn:aws:iam::${simAws.defaultAccountId}:role/${functionName}Role`,
+          },
+        },
+      },
+    },
+    bindings: [{ logicalId: "HandlerFunction", handler }],
+  });
+
+  return simAws;
+}
+
+/**
+ * A simulated AWS with one stack function running the given inline template
+ * source, which is what a `Code.ZipFile` property gives a template function.
+ */
+async function simAwsWithPackagedFunction(
+  functionName: string,
+  source: string,
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.cloudFormation().deployTemplate({
+    stackName: `${functionName}-stack`,
+    template: {
+      Resources: {
+        HandlerFunction: {
+          Type: "AWS::Lambda::Function",
+          Properties: {
+            FunctionName: functionName,
+            Role: `arn:aws:iam::${simAws.defaultAccountId}:role/${functionName}Role`,
+            Handler: "index.handler",
+            Runtime: "nodejs22.x",
+            Code: { ZipFile: source },
+          },
+        },
+      },
+    },
+  });
+
+  return simAws;
+}
+
+async function invokeAndReadLog(
+  simAws: SimAws,
+  functionName: string,
+): Promise<readonly string[]> {
+  await simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: functionName }));
+
+  const found = await simAws.logs().filterLogEvents(
+    new FilterLogEventsCommand({
+      logGroupName: `/aws/lambda/${functionName}`,
+    }),
+  );
+
+  return found.events?.map((event) => event.message) ?? [];
+}
+
+/**
+ * How the recorded line describes the error that ended an invocation.
+ */
+interface RecordedInvokeError {
+  readonly errorType: string;
+  readonly errorMessage: string;
+  readonly stack: readonly string[];
+}
+
+/**
+ * The error document out of the one `Invoke Error` line in what was recorded.
+ */
+function invokeErrorIn(messages: readonly string[]): RecordedInvokeError {
+  const errorLines = messages.filter((message) =>
+    message.startsWith(ERROR_LINE_PREFIX),
+  );
+
+  assertArrayLength(errorLines, 1);
+  const errorLine = errorLines.at(0);
+
+  assertNonNullable(errorLine);
+
+  return JSON.parse(
+    errorLine.slice(ERROR_LINE_PREFIX.length),
+  ) as RecordedInvokeError;
+}
+
+describe("an unhandled Lambda error in CloudWatch Logs", () => {
+  it("records the error a bound handler threw", async () => {
+    // Given a function bound to an in-process handler that logs a line and
+    // then fails.
+    const simAws = await simAwsWithBoundFunction("orders", () => {
+      console.log("INFO handling order-1");
+
+      throw new Error("order has no items");
+    });
+
+    // When it is invoked.
+    const messages = await invokeAndReadLog(simAws, "orders");
+
+    // Then the log group holds what it logged before the throw, and the error
+    // that ended the invocation after it.
+    assertArrayLength(messages, 2);
+    assertIdentical(messages.at(0), "INFO handling order-1");
+    const recorded = invokeErrorIn(messages);
+
+    assertIdentical(recorded.errorType, "Error");
+    assertIdentical(recorded.errorMessage, "order has no items");
+  });
+
+  it("records the error a packaged handler threw", async () => {
+    // Given a function running inline template code that logs a line and then
+    // fails. Template code runs in the vm sandbox, in a realm of its own.
+    const simAws = await simAwsWithPackagedFunction(
+      "invoices",
+      "exports.handler = async () => {\n" +
+        '  console.log("INFO handling invoice-1");\n' +
+        '  throw new Error("invoice has no lines");\n' +
+        "};\n",
+    );
+
+    // When it is invoked.
+    const messages = await invokeAndReadLog(simAws, "invoices");
+
+    // Then the sandboxed throw is recorded the same way. A test reading the
+    // log group is told as much on either path.
+    assertArrayLength(messages, 2);
+    assertIdentical(messages.at(0), "INFO handling invoice-1");
+    assertIdentical(
+      invokeErrorIn(messages).errorMessage,
+      "invoice has no lines",
+    );
+  });
+
+  it("carries the stack the handler failed on", async () => {
+    // Given a handler failing inside a function of its own.
+    const simAws = await simAwsWithBoundFunction("payments", async () => {
+      const takePayment = (): never => {
+        throw new Error("card declined");
+      };
+
+      await tick(1);
+
+      return takePayment();
+    });
+
+    // When it is invoked.
+    const messages = await invokeAndReadLog(simAws, "payments");
+
+    // Then the frames are there to read, one array element each. The line says
+    // where the failure came from as well as what it said.
+    const { stack } = invokeErrorIn(messages);
+
+    assertArrayMinLength(stack, 2);
+    assertStringIncludes(stack.at(0) ?? "", "card declined");
+    assertStringIncludes(stack.at(1) ?? "", "takePayment");
+  });
+
+  it("records nothing extra when a handler returns", async () => {
+    // Given a handler that logs and returns.
+    const simAws = await simAwsWithBoundFunction("refunds", () => {
+      console.log("INFO refund-1 issued");
+
+      return "done";
+    });
+
+    // When it is invoked.
+    const messages = await invokeAndReadLog(simAws, "refunds");
+
+    // Then the log group holds what it printed and no error at all.
+    assertArrayEquals(messages, ["INFO refund-1 issued"]);
+  });
+
+  it("keeps a line the handler never closed out of the error", async () => {
+    // Given a handler that fails part way through writing a line.
+    const simAws = await simAwsWithBoundFunction("shipments", () => {
+      process.stdout.write("INFO shipment-1 ");
+
+      throw new Error("no address");
+    });
+
+    // When it is invoked.
+    const messages = await invokeAndReadLog(simAws, "shipments");
+
+    // Then the half-written line is an event of its own. Appended to the error
+    // line it would hide the error from a filter matching it.
+    assertArrayLength(messages, 2);
+    assertIdentical(messages.at(0), "INFO shipment-1 ");
+    assertIdentical(invokeErrorIn(messages).errorMessage, "no address");
+  });
+
+  it("still reports the error to whoever invoked a function with no logs", async () => {
+    // Given a function built on its own, outside a SimAws instance, so there
+    // is no simulated CloudWatch Logs for it to record to.
+    const simFunction = new SimLambdaFunction({
+      name: "standalone",
+      roleArn: "arn:aws:iam::111111111111:role/StandaloneRole",
+      handlerFunction: () => {
+        throw new Error("nothing to record it");
+      },
+    });
+
+    // When it is invoked, then the error still reaches the caller. Recording
+    // it is the only part that is skipped.
+    const error = await assertThrowsErrorAsync(async () =>
+      simFunction.invoke({}),
+    );
+
+    assertStringIncludes(error.message, "nothing to record it");
+  });
+});

--- a/src/service/lambda/function/logging/sim-lambda-invoke-error-log.ts
+++ b/src/service/lambda/function/logging/sim-lambda-invoke-error-log.ts
@@ -1,0 +1,20 @@
+import { functionErrorDocument } from "../../command/invoke/invoke-payload.js";
+
+/**
+ * What real Lambda writes to a function's log group when an invocation ends in
+ * an error nothing caught.
+ *
+ * The runtime prints `ERROR Invoke Error` and a JSON document holding the
+ * error's type, its message and its stack, one array element per frame. The
+ * whole document is one line. CloudWatch Logs records a line as an event, so a
+ * filter matching the message finds every frame with it.
+ *
+ * The keys are the ones the runtime uses. The log line says `stack` where the
+ * Invoke response payload says `trace`, and the two hold the same frames.
+ */
+export function simLambdaInvokeErrorLine(error: unknown): string {
+  const { errorType, errorMessage, trace } = functionErrorDocument(error);
+  const document = JSON.stringify({ errorType, errorMessage, stack: trace });
+
+  return `ERROR Invoke Error ${document}\n`;
+}


### PR DESCRIPTION
A handler that threw left its log group holding whatever it printed before the throw and nothing about the failure. Reading the group to find out why an invocation failed showed a function that appeared to have run and stopped. The invocation now records an `ERROR Invoke Error` line carrying the error's type, its message and its stack, as real Lambda's runtime does. A bound in-process handler and packaged zip code are both recorded this way, and the caller still gets `FunctionError` and the trace in its Invoke payload.

Resolves #1119

@coderabbitai ignore