### PR TITLE
fix: authorize three Resource types on create

### DIFF
--- a/src/service/aws/factory/sim-aws-registered-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-registered-service-builder.ts
@@ -102,8 +102,11 @@ export class SimAwsRegisteredServiceBuilder {
    * nothing but that URI, and the function need not be in this scope.
    */
   createEcr(scope: SimAwsAccountRegionContainer): SimEcr {
+    const { accountRegionScope, iam } = this.scoped(scope);
+
     return new SimEcr({
-      accountRegionScope: scope.accountRegionScope,
+      accountRegionScope,
+      iam,
       registry: this.registries.ecr,
     });
   }

--- a/src/service/ecr/README.md
+++ b/src/service/ecr/README.md
@@ -17,8 +17,7 @@ Docker. So registering a handler as an image is a Yulin-native operation, `simul
 it cannot be mistaken for a simulated `PutImage`. `DescribeImages` and the rest would answer with
 made-up manifest data for the same reason, so they are absent rather than wrong.
 
-What is left is state and lookup, which is why there is no `command/` directory, no authorizer and
-no SDK router.
+What is left is state and lookup. There is no `command/` directory and no SDK router.
 
 ## Entry points
 
@@ -86,6 +85,12 @@ image is pushed by whatever built it, long before the stack that runs it.
 `SimCfnEcrRepositoryPropertyRules` records every other property as ignored. All of them describe
 image content, so a repository created without them is still a repository that does what one does
 here.
+
+`SimEcrAuthorizer` is the one thing here that reaches IAM, and the CloudFormation path is the only
+caller of it. A deployment authorizes `ecr:CreateRepository` before the repository is named and
+`ecr:DeleteRepository` before a teardown removes it, against the ARN `SimEcrRepositoryAddress`
+builds. Registering an image goes through neither. That is a test saying what an image is, and no
+principal makes the request.
 
 A teardown removes a repository holding no simulated image, and records the deletion of one that
 holds an image rather than carrying it out. The handler in it was registered outside any stack, and

--- a/src/service/ecr/authorize/sim-ecr-authorizer.ts
+++ b/src/service/ecr/authorize/sim-ecr-authorizer.ts
@@ -1,0 +1,56 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import type { SimEcrRepositoryAddress } from "../repository/sim-ecr-repository-address.js";
+
+interface SimEcrAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly address: SimEcrRepositoryAddress;
+}
+
+/**
+ * Applies simulated IAM authorization to ECR requests.
+ *
+ * Registering a simulated image is not one of them. That is a Yulin-native
+ * operation on the simulator's own accessor, and it is how a test says what an
+ * image is. A CloudFormation deployment is what authorizes here. It makes and
+ * removes a repository as the caller its Stack named.
+ */
+export class SimEcrAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly address: SimEcrRepositoryAddress;
+
+  constructor(properties: SimEcrAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.address = properties.address;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a repository of this name.
+   *
+   * The repository need not be there. Real IAM evaluates a request before the
+   * service handles it, so a caller with no permission is refused whether or
+   * not the repository is there, and `CreateRepository` authorizes against the
+   * ARN the repository is about to have.
+   */
+  authorizeRepository(
+    action: string,
+    repositoryName: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    const resource = this.address.arn(repositoryName);
+    const decision = this.iam.authorize({ action, resource, caller });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        reason: decision.denialReason,
+        action,
+        resource,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-creator.ts
+++ b/src/service/ecr/cfn/repository/sim-cfn-ecr-repository-creator.ts
@@ -1,11 +1,14 @@
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimEcrAuthorizer } from "../../authorize/sim-ecr-authorizer.js";
 import type { SimEcrRepository } from "../../repository/sim-ecr-repository.js";
 import type { SimEcr } from "../../sim-ecr.js";
 import { SimCfnEcrRepositoryProperties } from "./sim-cfn-ecr-repository-properties.js";
 
 interface SimCfnEcrRepositoryCreatorProperties {
   readonly ecr: SimEcr;
+  readonly authorizer: SimEcrAuthorizer;
 }
 
 /**
@@ -19,17 +22,25 @@ interface SimCfnEcrRepositoryCreatorProperties {
  */
 export class SimCfnEcrRepositoryCreator {
   private readonly ecr: SimEcr;
+  private readonly authorizer: SimEcrAuthorizer;
 
   constructor(properties: SimCfnEcrRepositoryCreatorProperties) {
     this.ecr = properties.ecr;
+    this.authorizer = properties.authorizer;
   }
 
   /**
    * Create a repository from an AWS::ECR::Repository Resource.
+   *
+   * Naming the repository is what makes it. That is where the deployment's
+   * caller is authorized, as it is on a real deploy before ECR answers. A
+   * repository a test has already registered a handler in is adopted, and the
+   * caller is authorized for it either way.
    */
   create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): SimEcrRepository {
     const repositoryProperties = new SimCfnEcrRepositoryProperties({
       resource,
@@ -38,6 +49,12 @@ export class SimCfnEcrRepositoryCreator {
     const repositoryName = repositoryProperties.repositoryName();
 
     repositoryProperties.recordIgnoredProperties();
+
+    this.authorizer.authorizeRepository(
+      "ecr:CreateRepository",
+      repositoryName,
+      options?.caller,
+    );
 
     return this.ecr.repository(repositoryName);
   }
@@ -58,7 +75,17 @@ export class SimCfnEcrRepositoryCreator {
    * being protected here is a test's own registration rather than anything
    * CloudFormation put there.
    */
-  delete(resource: SimCfnResource, repository: SimEcrRepository): void {
+  delete(
+    resource: SimCfnResource,
+    repository: SimEcrRepository,
+    options?: SimCfnResourceCallerOptions,
+  ): void {
+    this.authorizer.authorizeRepository(
+      "ecr:DeleteRepository",
+      repository.repositoryName,
+      options?.caller,
+    );
+
     if (repository.hasImage) {
       throw new Error(
         `Unsupported sim ECR CloudFormation Resource ${resource.logicalId} ` +

--- a/src/service/ecr/cfn/sim-cfn-ecr-repository-iam.iso.test.ts
+++ b/src/service/ecr/cfn/sim-cfn-ecr-repository-iam.iso.test.ts
@@ -1,0 +1,111 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+
+const repositoryTemplate = {
+  Resources: {
+    OrdersRepository: {
+      Type: "AWS::ECR::Repository",
+      Properties: { RepositoryName: "orders" },
+    },
+  },
+};
+
+/**
+ * Deploy a Stack holding one repository, as the caller it is given.
+ */
+async function deployAsCaller(
+  simAws: SimAws,
+  caller: SimAwsCaller,
+): Promise<SimCfnDeployedStack> {
+  return await simAws.cloudFormation().deployTemplate({
+    stackName: "platform-stack",
+    template: repositoryTemplate,
+    caller,
+  });
+}
+
+/**
+ * A Role allowed the actions it is given, as a caller a deployment can name.
+ */
+async function roleAllowing(
+  simAws: SimAws,
+  roleName: string,
+  actions: readonly string[],
+): Promise<SimAwsCaller> {
+  const role = await simIamRoleWithPolicyFactory.make(
+    { roleName, actions },
+    simAws,
+  );
+
+  return { kind: "arn", arn: role.Arn };
+}
+
+describe("the principal an AWS::ECR::Repository Resource is created as", () => {
+  it("fails the Resource under a caller that may not create repositories", async () => {
+    // Given a Role that may read images and not make a repository to hold
+    // them.
+    const simAws = new SimAws();
+    const puller = await roleAllowing(simAws, "Puller", ["ecr:BatchGetImage"]);
+
+    // When a Stack declaring a repository is deployed as it.
+    const error = await assertThrowsErrorAsync(
+      async () => await deployAsCaller(simAws, puller),
+    );
+
+    // Then the deploy is refused by name, and no repository was made behind
+    // the refusal.
+    assertStringIncludes(error.message, "ecr:CreateRepository");
+    assertStringIncludes(error.message, "role/Puller");
+    assertFalse(simAws.ecr().hasRepository("orders"));
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName("platform-stack")
+        ?.getResource("OrdersRepository")?.status,
+      "CREATE_FAILED",
+    );
+  });
+
+  it("creates the repository under a caller allowed the creation", async () => {
+    // Given a Role allowed to make repositories.
+    const simAws = new SimAws();
+    const deployer = await roleAllowing(simAws, "Deployer", [
+      "ecr:CreateRepository",
+    ]);
+
+    // When it deploys the Stack.
+    await deployAsCaller(simAws, deployer);
+
+    // Then simulated ECR holds the repository the template declared.
+    assertTrue(simAws.ecr().hasRepository("orders"));
+  });
+
+  it("tears the repository down as the principal the Stack was deployed as", async () => {
+    // Given a Stack deployed by a Role that may make a repository and not
+    // remove one.
+    const simAws = new SimAws();
+    const maker = await roleAllowing(simAws, "Maker", ["ecr:CreateRepository"]);
+    const stack = await deployAsCaller(simAws, maker);
+
+    // When the Stack is torn down.
+    const error = await assertThrowsErrorAsync(async () => {
+      await stack.teardown();
+    });
+
+    // Then the deletion was refused by name, and the repository is where it
+    // was.
+    assertStringIncludes(error.message, "ecr:DeleteRepository");
+    assertTrue(simAws.ecr().hasRepository("orders"));
+  });
+});

--- a/src/service/ecr/cfn/sim-ecr-cfn-resource-factory.ts
+++ b/src/service/ecr/cfn/sim-ecr-cfn-resource-factory.ts
@@ -3,13 +3,18 @@ import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource
 import type {
   SimCfnResource,
   SimCloudFormationResourceCreateContext,
+  SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimEcrAuthorizer } from "../authorize/sim-ecr-authorizer.js";
 import type { SimEcrRepository } from "../repository/sim-ecr-repository.js";
 import type { SimEcr } from "../sim-ecr.js";
 import { SimCfnEcrRepositoryCreator } from "./repository/sim-cfn-ecr-repository-creator.js";
+import { unsupportedSimEcrResourceType } from "./sim-ecr-cfn-unsupported-resource.js";
 
 interface SimEcrCfnResourceFactoryProperties {
   readonly ecr: SimEcr;
+  readonly authorizer: SimEcrAuthorizer;
 }
 
 /**
@@ -23,9 +28,7 @@ export class SimEcrCfnResourceFactory implements SimCfnServiceResourceFactory {
   private readonly repositoryCreator: SimCfnEcrRepositoryCreator;
 
   constructor(properties: SimEcrCfnResourceFactoryProperties) {
-    this.repositoryCreator = new SimCfnEcrRepositoryCreator({
-      ecr: properties.ecr,
-    });
+    this.repositoryCreator = new SimCfnEcrRepositoryCreator(properties);
   }
 
   /**
@@ -37,15 +40,14 @@ export class SimEcrCfnResourceFactory implements SimCfnServiceResourceFactory {
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     if (resourceTypeName !== "Repository") {
-      throw new Error(
-        `Unsupported sim ECR CloudFormation Resource ${resourceTypeName}`,
-      );
+      throw unsupportedSimEcrResourceType(resourceTypeName, "");
     }
 
     return Promise.resolve(
       this.repositoryCreator.create(
         resource,
         context.resolvedProperties ?? resource.properties,
+        simCfnResourceCallerOptions(context.caller),
       ),
     );
   }
@@ -53,12 +55,13 @@ export class SimEcrCfnResourceFactory implements SimCfnServiceResourceFactory {
   /**
    * Delete a simulated ECR resource created from a CloudFormation Resource.
    */
-  delete(resourceTypeName: string, resource: SimCfnResource): Promise<void> {
+  delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
     if (resourceTypeName !== "Repository") {
-      throw new Error(
-        `Unsupported sim ECR CloudFormation Resource ${resourceTypeName} ` +
-          `deletion`,
-      );
+      throw unsupportedSimEcrResourceType(resourceTypeName, " deletion");
     }
 
     const repository = resource.simResource as SimEcrRepository | undefined;
@@ -67,7 +70,11 @@ export class SimEcrCfnResourceFactory implements SimCfnServiceResourceFactory {
       `sim ECR repository for CloudFormation Resource ${resource.logicalId}`,
     );
 
-    this.repositoryCreator.delete(resource, repository);
+    this.repositoryCreator.delete(
+      resource,
+      repository,
+      simCfnResourceCallerOptions(context.caller),
+    );
 
     return Promise.resolve();
   }

--- a/src/service/ecr/cfn/sim-ecr-cfn-unsupported-resource.ts
+++ b/src/service/ecr/cfn/sim-ecr-cfn-unsupported-resource.ts
@@ -1,0 +1,14 @@
+/**
+ * A refusal naming an ECR Resource type this simulation has no creator for.
+ *
+ * The wording is what a Stack reads to record the Resource as a skip rather
+ * than failing the whole deployment over it.
+ */
+export function unsupportedSimEcrResourceType(
+  resourceTypeName: string,
+  suffix: string,
+): Error {
+  return new Error(
+    `Unsupported sim ECR CloudFormation Resource ${resourceTypeName}${suffix}`,
+  );
+}

--- a/src/service/ecr/sim-ecr.ts
+++ b/src/service/ecr/sim-ecr.ts
@@ -1,6 +1,9 @@
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
+import { SimEcrAuthorizer } from "./authorize/sim-ecr-authorizer.js";
 import { SimEcrCfnResourceFactory } from "./cfn/sim-ecr-cfn-resource-factory.js";
 import { SimEcrRegistry } from "./registry/sim-ecr-registry.js";
 import { SimEcrRepositoryAddress } from "./repository/sim-ecr-repository-address.js";
@@ -9,6 +12,7 @@ import { SimEcrRepositoryStore } from "./repository/sim-ecr-repository-store.js"
 
 interface SimEcrProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
   readonly registry?: SimEcrRegistry;
 }
 
@@ -25,10 +29,15 @@ interface SimEcrProperties {
  * Repositories are scoped to an account and region, as they are on real AWS:
  * a repository ARN names the region, and the registry host in an image URI
  * carries both the account and the region.
+ *
+ * Nothing a test does here is authorized, for the same reason. Naming a
+ * repository is the simulator's own accessor, and no principal makes that
+ * request. A CloudFormation deployment does make one, and a Stack making or
+ * removing a repository is decided by simulated IAM as the caller it named.
  */
 export class SimEcr {
   private readonly repositories: SimEcrRepositoryStore;
-  private readonly cfnFactory = new SimEcrCfnResourceFactory({ ecr: this });
+  private readonly cfnFactory: SimEcrCfnResourceFactory;
 
   constructor(properties: SimEcrProperties = {}) {
     const {
@@ -36,9 +45,15 @@ export class SimEcr {
       registry = new SimEcrRegistry(),
     } = properties;
 
-    this.repositories = new SimEcrRepositoryStore({
-      address: new SimEcrRepositoryAddress(accountRegionScope),
-      registry,
+    const address = new SimEcrRepositoryAddress(accountRegionScope);
+
+    this.repositories = new SimEcrRepositoryStore({ address, registry });
+    this.cfnFactory = new SimEcrCfnResourceFactory({
+      ecr: this,
+      authorizer: new SimEcrAuthorizer({
+        iam: simIamInRegion(properties.iam, accountRegionScope.regionName),
+        address,
+      }),
     });
   }
 

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -106,10 +106,17 @@ following the shape every other service's resource factory has. `SimCfnLogGroupP
 and `SimCfnLogGroupPropertyRules` records the rest, so a reader can tell a real property this
 simulation chose not to act on from one CloudWatch Logs has never had.
 
-Creation goes through the service writer rather than the command layer, which is what makes a
-declared group and one a Lambda function made for itself the same thing. Real CloudFormation fails a
-deploy that declares a group already in the account; here that is the ordinary case, because a
-function that logged during test setup has already created `/aws/lambda/orders`.
+Creation goes through `CreateLogGroup`, and the refusal it answers a name already in use with is
+caught. The group under that name is adopted. A declared group and one a Lambda function made for
+itself are the same thing here, where real CloudFormation fails a deploy that declares a group
+already in the account. A function that logged during test setup has already created
+`/aws/lambda/orders`, and failing over it would be noise.
+
+Going through the command is what authorizes the deployment's caller for `logs:CreateLogGroup`. The
+refusal for a taken name is raised after that decision. A deployment denied the action fails
+whether or not the group is there. `RetentionInDays` goes through `PutRetentionPolicy` for the same
+reason, and a Resource setting no retention asks for nothing (a real deploy of that template asks
+for nothing either).
 
 Registering the service had one consequence worth recording. `SimCdkProviderScaffolding` used to
 recognise a CDK provider function's log group and report it as deliberately left out, because
@@ -177,11 +184,10 @@ added to CloudWatch Logs long after the log group operations and carry the error
 newer APIs. The two halves of one service therefore report a bad input under different names, and a
 caller catching by name has to know which half it is talking to.
 
-The CloudFormation creators go through the ordinary commands, unlike the log group creator, which
-writes to its store directly. There is no equivalent here of a log group a function already made for
-itself. A
-template therefore hits the same refusals an SDK caller would, down to the region rule and the one
-source per distribution.
+The CloudFormation creators go through the ordinary commands, as the log group creator does. None of
+them adopts what is already there, because there is no equivalent of a log group a function made for
+itself. A template therefore hits the same refusals an SDK caller would, down to the region rule and
+the one source per distribution.
 
 `SimLogsDeliveryOperations` and `SimLogsDeliveryInspection` hold the facade's nine delivery methods
 and its delivery accessors. `SimLogs` grows by one delegating method per simulated operation and was

--- a/src/service/logs/cfn/group/sim-cfn-log-group-creator.ts
+++ b/src/service/logs/cfn/group/sim-cfn-log-group-creator.ts
@@ -1,5 +1,8 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimLogsResourceAlreadyExistsException } from "../../error/sim-logs.error.js";
 import type { SimLogsLogGroup } from "../../group/sim-logs-log-group.js";
 import type { SimLogs } from "../../sim-logs.js";
 import { SimCfnLogGroupProperties } from "./sim-cfn-log-group-properties.js";
@@ -18,6 +21,12 @@ interface SimCfnLogGroupCreatorProperties {
  * ordinary for the function to have logged first: real CloudFormation fails
  * that deploy, which is a genuine misconfiguration in an account and pure
  * noise in a test whose function ran during setup.
+ *
+ * The commands are still the ones an SDK caller would have used. The
+ * deployment's caller is authorized for `logs:CreateLogGroup` and
+ * `logs:PutRetentionPolicy`, as it is on a real deploy. A group that is
+ * already there changes what happens after that decision (the refusal is
+ * caught) and never whether one is made.
  */
 export class SimCfnLogGroupCreator {
   readonly #logs: SimLogs;
@@ -29,10 +38,11 @@ export class SimCfnLogGroupCreator {
   /**
    * Create a log group from an AWS::Logs::LogGroup Resource.
    */
-  create(
+  async create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
-  ): SimLogsLogGroup {
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<SimLogsLogGroup> {
     const logGroupProperties = new SimCfnLogGroupProperties({
       resource,
       properties,
@@ -42,9 +52,20 @@ export class SimCfnLogGroupCreator {
 
     logGroupProperties.recordIgnoredProperties();
 
-    const group = this.#logs.serviceWriter().logGroup(logGroupName);
+    await this.#createOrAdopt(logGroupName, options);
 
-    group.setRetention(retentionInDays);
+    if (retentionInDays !== undefined) {
+      await this.#logs.putRetentionPolicy(
+        { input: { logGroupName, retentionInDays } },
+        options,
+      );
+    }
+
+    const group = this.#logs.findLogGroup(logGroupName);
+    assertDefined(
+      group,
+      `sim log group ${logGroupName} after CloudFormation creation`,
+    );
 
     return group;
   }
@@ -54,7 +75,33 @@ export class SimCfnLogGroupCreator {
    *
    * The events go with it, as they do in an account.
    */
-  delete(group: SimLogsLogGroup): void {
-    this.#logs.serviceWriter().deleteLogGroup(group.logGroupName);
+  async delete(
+    group: SimLogsLogGroup,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#logs.deleteLogGroup(
+      { input: { logGroupName: group.logGroupName } },
+      options,
+    );
+  }
+
+  /**
+   * Make the log group, or leave the one already under that name where it is.
+   *
+   * The refusal is the one `CreateLogGroup` answers a taken name with. It is
+   * raised after the caller has been authorized. A deployment denied
+   * `logs:CreateLogGroup` therefore fails whether or not the group is there.
+   */
+  async #createOrAdopt(
+    logGroupName: string,
+    options: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    try {
+      await this.#logs.createLogGroup({ input: { logGroupName } }, options);
+    } catch (error) {
+      if (!(error instanceof SimLogsResourceAlreadyExistsException)) {
+        throw error;
+      }
+    }
   }
 }

--- a/src/service/logs/cfn/sim-cfn-log-group-iam.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-log-group-iam.iso.test.ts
@@ -1,0 +1,160 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+
+const logGroupName = "/aws/lambda/orders";
+
+/** What the Resource says unless a test is about setting something else. */
+const retainedForAFortnight: SimCfnTemplateValueRecord = {
+  LogGroupName: logGroupName,
+  RetentionInDays: 14,
+};
+
+/**
+ * Deploy a Stack holding one log group, as the caller it is given.
+ */
+async function deployAsCaller(
+  simAws: SimAws,
+  caller: SimAwsCaller,
+  properties: SimCfnTemplateValueRecord = retainedForAFortnight,
+): Promise<SimCfnDeployedStack> {
+  return await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        OrdersLogs: { Type: "AWS::Logs::LogGroup", Properties: properties },
+      },
+    },
+    caller,
+  });
+}
+
+/**
+ * A Role allowed the actions it is given, as a caller a deployment can name.
+ */
+async function roleAllowing(
+  simAws: SimAws,
+  roleName: string,
+  actions: readonly string[],
+): Promise<SimAwsCaller> {
+  const role = await simIamRoleWithPolicyFactory.make(
+    { roleName, actions },
+    simAws,
+  );
+
+  return { kind: "arn", arn: role.Arn };
+}
+
+describe("the principal an AWS::Logs::LogGroup Resource is created as", () => {
+  it("fails the Resource under a caller that may not create log groups", async () => {
+    // Given a Role that may read log groups and not make them.
+    const simAws = new SimAws();
+    const reader = await roleAllowing(simAws, "Reader", [
+      "logs:DescribeLogGroups",
+    ]);
+
+    // When a Stack declaring a log group is deployed as it.
+    const error = await assertThrowsErrorAsync(
+      async () => await deployAsCaller(simAws, reader),
+    );
+
+    // Then the deploy is refused by name, and no group was made behind the
+    // refusal.
+    assertStringIncludes(error.message, "logs:CreateLogGroup");
+    assertStringIncludes(error.message, "role/Reader");
+    assertUndefined(simAws.logs().findLogGroup(logGroupName));
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName("orders")
+        ?.getResource("OrdersLogs")?.status,
+      "CREATE_FAILED",
+    );
+  });
+
+  it("takes over a group a function already made, under a caller allowed the creation", async () => {
+    // Given a log group a Lambda function created by logging during setup, and
+    // a Role allowed to make one and set its retention.
+    const simAws = new SimAws();
+    const deployer = await roleAllowing(simAws, "Deployer", [
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy",
+    ]);
+
+    simAws.logs().serviceWriter().write(logGroupName, "stream-a", ["ran"]);
+
+    // When a Stack declaring that same group is deployed as the Role.
+    await deployAsCaller(simAws, deployer);
+
+    // Then the group is adopted rather than refused, with the retention the
+    // template asked for and the events it already held.
+    const group = simAws.logs().findLogGroup(logGroupName);
+
+    assertNonNullable(group);
+    assertIdentical(group.retentionInDays, 14);
+    assertArrayEquals(
+      group.findStream("stream-a")?.events.map((event) => event.message),
+      ["ran"],
+    );
+  });
+
+  it("fails a Resource setting retention the caller may not put", async () => {
+    // Given a Role allowed to make log groups and nothing else.
+    const simAws = new SimAws();
+    const maker = await roleAllowing(simAws, "Maker", ["logs:CreateLogGroup"]);
+
+    // When it deploys a group the template asks to keep events for a fortnight.
+    const error = await assertThrowsErrorAsync(
+      async () => await deployAsCaller(simAws, maker),
+    );
+
+    // Then setting the retention was refused, rather than done as nobody in
+    // particular.
+    assertStringIncludes(error.message, "logs:PutRetentionPolicy");
+  });
+
+  it("deploys a Resource setting no retention without a caller allowed to put one", async () => {
+    // Given the same Role, allowed to make log groups and nothing else.
+    const simAws = new SimAws();
+    const maker = await roleAllowing(simAws, "Maker", ["logs:CreateLogGroup"]);
+
+    // When it deploys a group the template sets no retention on.
+    await deployAsCaller(simAws, maker, { LogGroupName: logGroupName });
+
+    // Then nothing asked for a retention policy it does not have, which is
+    // what a real deploy of that template needs too.
+    assertNonNullable(simAws.logs().findLogGroup(logGroupName));
+  });
+
+  it("tears the log group down as the principal the Stack was deployed as", async () => {
+    // Given a Stack deployed by a Role that may make a log group and not
+    // remove one.
+    const simAws = new SimAws();
+    const maker = await roleAllowing(simAws, "Maker", [
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy",
+    ]);
+    const stack = await deployAsCaller(simAws, maker);
+
+    // When the Stack is torn down.
+    const error = await assertThrowsErrorAsync(async () => {
+      await stack.teardown();
+    });
+
+    // Then the deletion was refused by name, and the group is where it was.
+    assertStringIncludes(error.message, "logs:DeleteLogGroup");
+    assertNonNullable(simAws.logs().findLogGroup(logGroupName));
+  });
+});

--- a/src/service/logs/cfn/sim-logs-cfn-resource-deleter.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-deleter.ts
@@ -41,7 +41,10 @@ export class SimLogsCfnResourceDeleter {
   ): Promise<void> {
     switch (resourceTypeName) {
       case "LogGroup": {
-        this.#creators.logGroups.delete(created<SimLogsLogGroup>(resource));
+        await this.#creators.logGroups.delete(
+          created<SimLogsLogGroup>(resource),
+          options,
+        );
 
         return;
       }

--- a/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
@@ -65,7 +65,7 @@ export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
 
     switch (resourceTypeName) {
       case "LogGroup": {
-        return this.#logGroups.create(resource, values);
+        return await this.#logGroups.create(resource, values, options);
       }
       case "DeliverySource": {
         return await this.#deliverySources.create(resource, values, options);

--- a/src/service/stepfunctions/cfn/sim-cfn-state-machine-iam.iso.test.ts
+++ b/src/service/stepfunctions/cfn/sim-cfn-state-machine-iam.iso.test.ts
@@ -1,0 +1,130 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+
+const executionRoleArn = "arn:aws:iam::123456789012:role/EnrolmentWorkflowRole";
+
+const passChain = {
+  StartAt: "Record",
+  States: {
+    Record: { Type: "Pass", Result: { enrolled: true }, Next: "Done" },
+    Done: { Type: "Succeed" },
+  },
+};
+
+const workflowTemplate = {
+  Resources: {
+    Workflow: {
+      Type: "AWS::StepFunctions::StateMachine",
+      Properties: {
+        StateMachineName: "Enrolment",
+        RoleArn: executionRoleArn,
+        DefinitionString: JSON.stringify(passChain),
+      },
+    },
+  },
+};
+
+/**
+ * Deploy a Stack holding one state machine, as the caller it is given.
+ */
+async function deployAsCaller(
+  simAws: SimAws,
+  caller: SimAwsCaller,
+): Promise<SimCfnDeployedStack> {
+  return await simAws.cloudFormation().deployTemplate({
+    stackName: "enrolment",
+    template: workflowTemplate,
+    caller,
+  });
+}
+
+/**
+ * A Role allowed the actions it is given, as a caller a deployment can name.
+ */
+async function roleAllowing(
+  simAws: SimAws,
+  roleName: string,
+  actions: readonly string[],
+): Promise<SimAwsCaller> {
+  const role = await simIamRoleWithPolicyFactory.make(
+    { roleName, actions },
+    simAws,
+  );
+
+  return { kind: "arn", arn: role.Arn };
+}
+
+describe("the principal an AWS::StepFunctions::StateMachine Resource is created as", () => {
+  it("fails the Resource under a caller that may not create state machines", async () => {
+    // Given a Role that may start executions and not make the machine that
+    // runs them.
+    const simAws = new SimAws();
+    const starter = await roleAllowing(simAws, "Starter", [
+      "states:StartExecution",
+    ]);
+
+    // When a Stack declaring a state machine is deployed as it.
+    const error = await assertThrowsErrorAsync(
+      async () => await deployAsCaller(simAws, starter),
+    );
+
+    // Then the deploy is refused by name, and no state machine was made
+    // behind the refusal.
+    assertStringIncludes(error.message, "states:CreateStateMachine");
+    assertStringIncludes(error.message, "role/Starter");
+    assertUndefined(simAws.stepFunctions().findStateMachine("Enrolment"));
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName("enrolment")
+        ?.getResource("Workflow")?.status,
+      "CREATE_FAILED",
+    );
+  });
+
+  it("creates the state machine under a caller allowed the creation", async () => {
+    // Given a Role allowed to make state machines.
+    const simAws = new SimAws();
+    const deployer = await roleAllowing(simAws, "Deployer", [
+      "states:CreateStateMachine",
+    ]);
+
+    // When it deploys the Stack.
+    await deployAsCaller(simAws, deployer);
+
+    // Then simulated Step Functions holds the state machine the template
+    // declared.
+    assertNonNullable(simAws.stepFunctions().findStateMachine("Enrolment"));
+  });
+
+  it("tears the state machine down as the principal the Stack was deployed as", async () => {
+    // Given a Stack deployed by a Role that may make a state machine and not
+    // remove one.
+    const simAws = new SimAws();
+    const maker = await roleAllowing(simAws, "Maker", [
+      "states:CreateStateMachine",
+    ]);
+    const stack = await deployAsCaller(simAws, maker);
+
+    // When the Stack is torn down.
+    const error = await assertThrowsErrorAsync(async () => {
+      await stack.teardown();
+    });
+
+    // Then the deletion was refused by name, and the state machine is where
+    // it was.
+    assertStringIncludes(error.message, "states:DeleteStateMachine");
+    assertNonNullable(simAws.stepFunctions().findStateMachine("Enrolment"));
+  });
+});

--- a/src/service/stepfunctions/command/authorize/sim-step-functions-authorizer.ts
+++ b/src/service/stepfunctions/command/authorize/sim-step-functions-authorizer.ts
@@ -1,0 +1,74 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simStateMachineArn } from "../../machine/sim-state-machine-arn.js";
+
+interface SimStepFunctionsAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * Applies simulated IAM authorization to Step Functions requests.
+ *
+ * A state machine is named by its ARN, and that is the form a Step Functions
+ * policy is written in. `CreateStateMachine` has no ARN to be given. It
+ * authorizes against the one the state machine is about to have, which a
+ * policy naming `stateMachine:orders-*` covers.
+ */
+export class SimStepFunctionsAuthorizer {
+  readonly #iam: SimIamInterServiceAuthZ;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimStepFunctionsAuthorizerProperties) {
+    this.#iam = properties.iam;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Ensure the caller may perform an action on a state machine of this name.
+   */
+  authorizeStateMachineName(
+    action: string,
+    name: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeStateMachineArn(
+      action,
+      simStateMachineArn(this.#accountRegionScope, name),
+      caller,
+    );
+  }
+
+  /**
+   * Ensure the caller may perform an action on a state machine ARN.
+   *
+   * The state machine need not be there. Real IAM evaluates a request before
+   * the service handles it, so a caller with no permission is refused whether
+   * or not the ARN names anything.
+   */
+  authorizeStateMachineArn(
+    action: string,
+    stateMachineArn: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    const decision = this.#iam.authorize({
+      action,
+      resource: stateMachineArn,
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        reason: decision.denialReason,
+        action,
+        resource: stateMachineArn,
+      });
+    }
+
+    return decision.caller;
+  }
+}

--- a/src/service/stepfunctions/command/machine/sim-state-machine-create.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-create.ts
@@ -4,6 +4,8 @@ import { SimStateMachineAlreadyExists } from "../../error/sim-step-functions.err
 import { SimStateMachine } from "../../machine/sim-state-machine.js";
 import { simStateMachineArn } from "../../machine/sim-state-machine-arn.js";
 import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
+import type { SimStepFunctionsAuthorizer } from "../authorize/sim-step-functions-authorizer.js";
+import type { SimStepFunctionsRequestOptions } from "../sim-step-functions-request-options.js";
 import type {
   SimCreateStateMachineCommand,
   SimCreateStateMachineCommandOutput,
@@ -15,6 +17,7 @@ import {
 
 interface SimStateMachineCreateProperties {
   readonly stateMachines: SimStateMachineStore;
+  readonly authorizer: SimStepFunctionsAuthorizer;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly background: BackgroundScheduler;
 }
@@ -24,11 +27,13 @@ interface SimStateMachineCreateProperties {
  */
 export class SimStateMachineCreate {
   readonly #stateMachines: SimStateMachineStore;
+  readonly #authorizer: SimStepFunctionsAuthorizer;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
   readonly #background: BackgroundScheduler;
 
   constructor(properties: SimStateMachineCreateProperties) {
     this.#stateMachines = properties.stateMachines;
+    this.#authorizer = properties.authorizer;
     this.#accountRegionScope = properties.accountRegionScope;
     this.#background = properties.background;
   }
@@ -42,12 +47,20 @@ export class SimStateMachineCreate {
    *
    * `CreateStateMachine` is idempotent. A second request carrying the same
    * name, definition and type answers with the state machine that is already
-   * there.
+   * there, and is authorized the same way as the first.
    */
   handle(
     command: SimCreateStateMachineCommand,
+    options?: SimStepFunctionsRequestOptions,
   ): SimCreateStateMachineCommandOutput {
     const read = readSimStateMachineCreateInput(command.input);
+
+    this.#authorizer.authorizeStateMachineName(
+      "states:CreateStateMachine",
+      read.name,
+      options?.caller,
+    );
+
     const existing = this.#stateMachines.findByName(read.name);
 
     if (existing !== undefined) {

--- a/src/service/stepfunctions/command/machine/sim-state-machine-delete.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-delete.ts
@@ -1,0 +1,64 @@
+import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
+import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
+import type { SimStepFunctionsAuthorizer } from "../authorize/sim-step-functions-authorizer.js";
+import type { SimStepFunctionsRequestOptions } from "../sim-step-functions-request-options.js";
+import type {
+  SimDeleteStateMachineCommand,
+  SimDeleteStateMachineCommandOutput,
+} from "./machine.command.js";
+import {
+  requireSimStateMachine,
+  requiredSimStateMachineArn,
+} from "./sim-state-machine-lookup.js";
+
+interface SimStateMachineDeleteProperties {
+  readonly stateMachines: SimStateMachineStore;
+  readonly authorizer: SimStepFunctionsAuthorizer;
+  readonly executions: SimStatesExecutionStore;
+}
+
+/**
+ * The command that deletes a state machine.
+ */
+export class SimStateMachineDelete {
+  readonly #stateMachines: SimStateMachineStore;
+  readonly #authorizer: SimStepFunctionsAuthorizer;
+  readonly #executions: SimStatesExecutionStore;
+
+  constructor(properties: SimStateMachineDeleteProperties) {
+    this.#stateMachines = properties.stateMachines;
+    this.#authorizer = properties.authorizer;
+    this.#executions = properties.executions;
+  }
+
+  /**
+   * Delete a state machine and forget its executions.
+   *
+   * The caller is authorized against the ARN the request carries, before
+   * anything is looked up. A caller with no permission is refused whether or
+   * not the ARN names a state machine.
+   */
+  handle(
+    command: SimDeleteStateMachineCommand,
+    options?: SimStepFunctionsRequestOptions,
+  ): SimDeleteStateMachineCommandOutput {
+    const { stateMachineArn } = command.input;
+
+    this.#authorizer.authorizeStateMachineArn(
+      "states:DeleteStateMachine",
+      requiredSimStateMachineArn(stateMachineArn, "DeleteStateMachine"),
+      options?.caller,
+    );
+
+    const { arn } = requireSimStateMachine(
+      this.#stateMachines,
+      stateMachineArn,
+      "DeleteStateMachine",
+    );
+
+    this.#stateMachines.remove(arn);
+    this.#executions.removeForStateMachine(arn);
+
+    return {};
+  }
+}

--- a/src/service/stepfunctions/command/machine/sim-state-machine-lookup.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-lookup.ts
@@ -6,6 +6,25 @@ import type { SimStateMachine } from "../../machine/sim-state-machine.js";
 import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
 
 /**
+ * The state machine ARN a request names, or a refusal saying it needs one.
+ *
+ * A command authorizes against this before looking anything up, the way real
+ * IAM decides a request before the service handles it.
+ */
+export function requiredSimStateMachineArn(
+  arn: string | undefined,
+  commandName: string,
+): string {
+  if (arn === undefined) {
+    throw new SimStatesInvalidRequest(
+      `${commandName} needs a stateMachineArn.`,
+    );
+  }
+
+  return arn;
+}
+
+/**
  * Find the state machine a request's ARN names, or say why it could not be.
  */
 export function requireSimStateMachine(
@@ -13,13 +32,9 @@ export function requireSimStateMachine(
   arn: string | undefined,
   commandName: string,
 ): SimStateMachine {
-  if (arn === undefined) {
-    throw new SimStatesInvalidRequest(
-      `${commandName} needs a stateMachineArn.`,
-    );
-  }
-
-  const stateMachine = stateMachines.find(arn);
+  const stateMachine = stateMachines.find(
+    requiredSimStateMachineArn(arn, commandName),
+  );
 
   if (stateMachine === undefined) {
     throw new SimStatesResourceNotFound(

--- a/src/service/stepfunctions/command/machine/sim-state-machine-update.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-update.ts
@@ -1,40 +1,34 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import { parseSimStatesDefinition } from "../../definition/sim-states-definition-parse.js";
 import { SimStatesInvalidRequest } from "../../error/sim-step-functions.error.js";
-import type { SimStatesExecutionStore } from "../../execution/sim-states-execution-store.js";
 import type { SimStateMachineStore } from "../../machine/sim-state-machine-store.js";
 import type {
-  SimDeleteStateMachineCommand,
-  SimDeleteStateMachineCommandOutput,
   SimUpdateStateMachineCommand,
   SimUpdateStateMachineCommandOutput,
 } from "./machine.command.js";
 import { requireSimStateMachine } from "./sim-state-machine-lookup.js";
 
-interface SimStateMachineWritesProperties {
+interface SimStateMachineUpdateProperties {
   readonly stateMachines: SimStateMachineStore;
-  readonly executions: SimStatesExecutionStore;
   readonly background: BackgroundScheduler;
 }
 
 /**
- * The commands that change and delete state machines.
+ * The command that changes a state machine's definition or role.
  */
-export class SimStateMachineWrites {
+export class SimStateMachineUpdate {
   readonly #stateMachines: SimStateMachineStore;
-  readonly #executions: SimStatesExecutionStore;
   readonly #background: BackgroundScheduler;
 
-  constructor(properties: SimStateMachineWritesProperties) {
+  constructor(properties: SimStateMachineUpdateProperties) {
     this.#stateMachines = properties.stateMachines;
-    this.#executions = properties.executions;
     this.#background = properties.background;
   }
 
   /**
    * Change a state machine's definition or role.
    */
-  update(
+  handle(
     command: SimUpdateStateMachineCommand,
   ): SimUpdateStateMachineCommandOutput {
     const { stateMachineArn, definition, roleArn } = command.input;
@@ -61,23 +55,5 @@ export class SimStateMachineWrites {
     });
 
     return { updateDate: this.#background.now() };
-  }
-
-  /**
-   * Delete a state machine and forget its executions.
-   */
-  delete(
-    command: SimDeleteStateMachineCommand,
-  ): SimDeleteStateMachineCommandOutput {
-    const found = requireSimStateMachine(
-      this.#stateMachines,
-      command.input.stateMachineArn,
-      "DeleteStateMachine",
-    );
-
-    this.#stateMachines.remove(found.arn);
-    this.#executions.removeForStateMachine(found.arn);
-
-    return {};
   }
 }

--- a/src/service/stepfunctions/sim-step-functions.ts
+++ b/src/service/stepfunctions/sim-step-functions.ts
@@ -5,12 +5,16 @@ import {
 } from "../../util/background/background.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type * as simStatesCommands from "./command/sim-step-functions-command.types.js";
+import { SimStepFunctionsAuthorizer } from "./command/authorize/sim-step-functions-authorizer.js";
 import { SimStatesExecutionDescribe } from "./command/execution/sim-states-execution-describe.js";
 import { SimStatesExecutionStart } from "./command/execution/sim-states-execution-start.js";
 import { SimStateMachineCreate } from "./command/machine/sim-state-machine-create.js";
 import { SimStateMachineReads } from "./command/machine/sim-state-machine-reads.js";
-import { SimStateMachineWrites } from "./command/machine/sim-state-machine-writes.js";
+import { SimStateMachineDelete } from "./command/machine/sim-state-machine-delete.js";
+import { SimStateMachineUpdate } from "./command/machine/sim-state-machine-update.js";
 import { SimStateMachineTagCommands } from "./command/tag/sim-state-machine-tag-commands.js";
 import type { SimStepFunctionsRequestOptions } from "./command/sim-step-functions-request-options.js";
 import {
@@ -28,6 +32,7 @@ import { SimStepFunctionsInspection } from "./sim-step-functions-inspection.js";
 
 interface SimStepFunctionsProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
 
   /**
@@ -52,6 +57,10 @@ interface SimStepFunctionsProperties {
  * `Task`, `Choice`, `Wait`, `Succeed` and `Fail`, and a definition using any
  * other is refused by name.
  *
+ * Creating and deleting a state machine are decided by simulated IAM. The
+ * other operations here are not. A caller an account would refuse still
+ * reaches those.
+ *
  * An execution runs on the simulation's background scheduler rather than in
  * the `StartExecution` call. An execution with nothing to wait for settles
  * before the caller sees it. A failing execution records the failure and never
@@ -62,7 +71,8 @@ export class SimStepFunctions {
   readonly #stateMachines = new SimStateMachineStore();
   readonly #executions = new SimStatesExecutionStore();
   readonly #machineReads: SimStateMachineReads;
-  readonly #machineWrites: SimStateMachineWrites;
+  readonly #machineUpdate: SimStateMachineUpdate;
+  readonly #machineDelete: SimStateMachineDelete;
   readonly #machineCreate: SimStateMachineCreate;
   readonly #executionStart: SimStatesExecutionStart;
   readonly #executionDescribe: SimStatesExecutionDescribe;
@@ -80,19 +90,29 @@ export class SimStepFunctions {
       definitions = new SimStatesNoDefinitionStore(),
     } = properties;
 
+    const authorizer = new SimStepFunctionsAuthorizer({
+      iam: simIamInRegion(properties.iam, accountRegionScope.regionName),
+      accountRegionScope,
+    });
+
     this.#background = background;
     this.#cfnFactory = new SimStepFunctionsCfnResourceFactory({
       stepFunctions: this,
       definitions,
     });
     this.#machineReads = new SimStateMachineReads(this.#stateMachines);
-    this.#machineWrites = new SimStateMachineWrites({
+    this.#machineUpdate = new SimStateMachineUpdate({
       stateMachines: this.#stateMachines,
-      executions: this.#executions,
       background,
+    });
+    this.#machineDelete = new SimStateMachineDelete({
+      stateMachines: this.#stateMachines,
+      authorizer,
+      executions: this.#executions,
     });
     this.#machineCreate = new SimStateMachineCreate({
       stateMachines: this.#stateMachines,
+      authorizer,
       accountRegionScope,
       background,
     });
@@ -126,10 +146,10 @@ export class SimStepFunctions {
   /** Handle a CreateStateMachine Command from the SDK. */
   async createStateMachine(
     command: simStatesCommands.SimCreateStateMachineCommand,
-    _options?: SimStepFunctionsRequestOptions,
+    options?: SimStepFunctionsRequestOptions,
   ): Promise<simStatesCommands.SimCreateStateMachineCommandOutput> {
     await this.#background.sequence();
-    return this.#machineCreate.handle(command);
+    return this.#machineCreate.handle(command, options);
   }
 
   /** Handle a DescribeStateMachine Command from the SDK. */
@@ -147,16 +167,16 @@ export class SimStepFunctions {
     _options?: SimStepFunctionsRequestOptions,
   ): Promise<simStatesCommands.SimUpdateStateMachineCommandOutput> {
     await this.#background.sequence();
-    return this.#machineWrites.update(command);
+    return this.#machineUpdate.handle(command);
   }
 
   /** Handle a DeleteStateMachine Command from the SDK. */
   async deleteStateMachine(
     command: simStatesCommands.SimDeleteStateMachineCommand,
-    _options?: SimStepFunctionsRequestOptions,
+    options?: SimStepFunctionsRequestOptions,
   ): Promise<simStatesCommands.SimDeleteStateMachineCommandOutput> {
     await this.#background.sequence();
-    return this.#machineWrites.delete(command);
+    return this.#machineDelete.handle(command, options);
   }
 
   /** Handle a ListStateMachines Command from the SDK. */


### PR DESCRIPTION
`AWS::Logs::LogGroup`, `AWS::ECR::Repository` and `AWS::StepFunctions::StateMachine` were created through the simulator's own accessors, which ask IAM nothing, and a deployment under a Role that denied the service still reached `CREATE_COMPLETE`. A log group now goes through `CreateLogGroup` and `PutRetentionPolicy`, catching the refusal for a name already in use so a group a Lambda function made for itself is still adopted and its retention still authorizes `logs:PutRetentionPolicy`. Simulated ECR and Step Functions each gained an authorizer of their own, covering the create and the delete a teardown makes, and `SimStateMachineWrites` is split into an update command and a delete command to keep both files under the FTA threshold. `AWS::Glue::Database` and `AWS::Glue::Table` reach `catalogWriter()` the same way and are left for an issue of their own. `iam:PassRole` is out of scope here and belongs to #1116.

Resolves #1115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IAM authorization for CloudFormation-managed ECR repositories, log groups, and Step Functions state machines.
  * Added support for authorized creation, deletion, and updates of Step Functions state machines.
* **Bug Fixes**
  * Log group creation now correctly adopts existing groups when name conflicts occur.
  * Log retention policies are applied through the supported service operation.
  * Improved validation and error handling for unsupported resources and unauthorized actions.
* **Tests**
  * Added coverage for authorized and denied deployment and teardown scenarios across ECR, Logs, and Step Functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->