### PR TITLE
fix: authorize kms:Decrypt on a SecureString read

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -706,7 +706,8 @@ real ECS accepts for a parameter in the task's own region. A Secrets Manager ARN
 key, a version stage and a version id after the secret id, in the form
 `...:secret:orders/db-AbCdEf:password::` that a CDK construct given a field writes. The key selects
 one field of a secret holding a JSON object. A `SecureString` parameter is decrypted, as it is for a
-real task.
+real task. The decryption is made with the execution role's own permissions, and that role needs
+`kms:Decrypt` on top of `ssm:GetParameter`.
 
 A secret that cannot be resolved stops the task before any container runs, with a
 `ResourceInitializationError` reason naming the variable:

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -351,12 +351,17 @@ customer default:
 - The account root is allowed to read the key's metadata. That is the whole of what this policy
   delegates to IAM.
 
-That is why a role holding only `ssm:GetParameter` reads a decrypted `SecureString` under `aws/ssm`,
-and why a role holding `kms:Decrypt` on that key still cannot use it by calling KMS itself.
+That is why a role holding `kms:Decrypt` on such a key cannot use it by calling KMS itself.
 
 `kms:ViaService` is set by the service making the call on the caller's behalf. Sim SSM does this for
 `SecureString` parameters. Code calling simulated KMS directly sets it with the `viaService` request
 option, naming the service on its own (`ssm`), since the region is the key's.
+
+A service passing on the caller's own KMS permissions sets `withCallerPermissions` alongside it.
+What the policy above admits is the service a request came through. A request carrying this option
+is allowed only where IAM allows the caller the KMS action too, and a key policy naming the caller
+allows it on its own. Sim SSM sets the option when it decrypts a `SecureString`. A role holding
+`ssm:GetParameter` and no `kms:Decrypt` is refused the decrypted value.
 
 ```typescript sim-kms-aws-managed-key
 /**

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -911,15 +911,24 @@ try {
 }
 ```
 
-### The aws/ssm managed key needs no permission
+### The aws/ssm managed key needs kms:Decrypt too
 
-A parameter naming no key is encrypted under the `aws/ssm` AWS managed key, and that key asks the
-caller for nothing. Parameter Store supplies `kms:ViaService`, and the managed key's policy allows
-the account's principals to use it through Systems Manager. A role holding only `ssm:GetParameter`
-therefore reads the decrypted value, as it does on real AWS.
+A parameter naming no key is encrypted under the `aws/ssm` AWS managed key. Parameter Store supplies
+`kms:ViaService`, and that key's policy allows the account's principals to use it through Systems
+Manager. What the policy admits is whoever the request came from. Parameter Store decrypts with the
+caller's own permissions, and a decrypting read needs `kms:Decrypt` on top of `ssm:GetParameter`. A
+role holding the parameter permission alone reads the ciphertext and is refused when it asks for
+decryption, as it is in a real account.
 
-The same role cannot take the ciphertext to KMS itself, because that policy allows nothing to a
-request arriving directly.
+The managed key's id is unknown when a template is synthesized. A policy scopes the grant with a
+`kms:ViaService` condition naming `ssm.<region>.amazonaws.com`, and simulated IAM evaluates that
+condition against the region the parameter belongs to.
+
+`GetParameters` and `GetParametersByPath` decrypt through the same path, and refuse the same way for
+a caller without the key permission.
+
+The same role cannot take the ciphertext to KMS itself, because the managed key's policy applies
+only to a request that reached KMS through Systems Manager.
 
 ```typescript sim-ssm-secure-string-managed-key
 /**
@@ -956,18 +965,26 @@ const role = await simAws.iam().createRole(
   }),
 );
 
-// The parameter, and no KMS permission at all.
+// The parameter, and the key through Systems Manager.
 await simAws.iam().putRolePolicy(
   new PutRolePolicyCommand({
     RoleName: "ConfigReader",
     PolicyName: "ReadDbPassword",
     PolicyDocument: JSON.stringify({
       Version: "2012-10-17",
-      Statement: {
-        Effect: "Allow",
-        Action: "ssm:GetParameter",
-        Resource: "*",
-      },
+      Statement: [
+        { Effect: "Allow", Action: "ssm:GetParameter", Resource: "*" },
+        {
+          Effect: "Allow",
+          Action: "kms:Decrypt",
+          Resource: "*",
+          Condition: {
+            StringEquals: {
+              "kms:ViaService": `ssm.${simAws.defaultRegionName}.amazonaws.com`,
+            },
+          },
+        },
+      ],
     }),
   }),
 );
@@ -1031,6 +1048,9 @@ Current documented limitations:
   without complaint.
 - `KeyId` on a `String` or `StringList` parameter is refused, since nothing would encrypt a value
   stored in the clear.
+- Writing a `SecureString` under the `aws/ssm` managed key asks the caller for no KMS permission,
+  where AWS documents `kms:Encrypt` for a standard tier write. A write under a customer managed key
+  does need it.
 - `DataType` other than `text` is refused. Real Parameter Store validates an `aws:ec2:image` value
   against EC2, which this simulation cannot do.
 - Filters are refused outright. `GetParametersByPath` refuses `ParameterFilters`, and

--- a/docs/services/ssm/sim-ssm-secure-string-managed-key.example.ts
+++ b/docs/services/ssm/sim-ssm-secure-string-managed-key.example.ts
@@ -32,18 +32,26 @@ const role = await simAws.iam().createRole(
   }),
 );
 
-// The parameter, and no KMS permission at all.
+// The parameter, and the key through Systems Manager.
 await simAws.iam().putRolePolicy(
   new PutRolePolicyCommand({
     RoleName: "ConfigReader",
     PolicyName: "ReadDbPassword",
     PolicyDocument: JSON.stringify({
       Version: "2012-10-17",
-      Statement: {
-        Effect: "Allow",
-        Action: "ssm:GetParameter",
-        Resource: "*",
-      },
+      Statement: [
+        { Effect: "Allow", Action: "ssm:GetParameter", Resource: "*" },
+        {
+          Effect: "Allow",
+          Action: "kms:Decrypt",
+          Resource: "*",
+          Condition: {
+            StringEquals: {
+              "kms:ViaService": `ssm.${simAws.defaultRegionName}.amazonaws.com`,
+            },
+          },
+        },
+      ],
     }),
   }),
 );

--- a/src/service/ecs/command/run-task/run-task-secrets.iso.test.ts
+++ b/src/service/ecs/command/run-task/run-task-secrets.iso.test.ts
@@ -73,8 +73,13 @@ describe("Resolving a simulated ECS container's secrets", () => {
         Value: "k-1234",
       }),
     );
+    // The decryption is the execution Role's own, so it holds kms:Decrypt as
+    // well as the parameter permission.
     const executionRole = await simIamRoleWithPolicyFactory.make(
-      { roleName: "OrdersExecutionRole", actions: ["ssm:GetParameter"] },
+      {
+        roleName: "OrdersExecutionRole",
+        actions: ["ssm:GetParameter", "kms:Decrypt"],
+      },
       simAws,
     );
 

--- a/src/service/iam/authorize/allow/sim-iam-allow-requirement.ts
+++ b/src/service/iam/authorize/allow/sim-iam-allow-requirement.ts
@@ -7,6 +7,13 @@ interface SimIamAllowSidesProperties {
    * Defaults to the resource side, for callers with no reason to distinguish.
    */
   readonly resourceDirect?: boolean | undefined;
+
+  /**
+   * Whether a resource-policy Allow named the caller, rather than admitting it
+   * as one of a wider set through a wildcard principal. Defaults to the
+   * resource side in the same way.
+   */
+  readonly resourceNamesCaller?: boolean | undefined;
 }
 
 /**
@@ -21,12 +28,15 @@ export class SimIamAllowSides {
   private readonly identityAllowed: boolean;
   private readonly resourceAllowed: boolean;
   private readonly resourceDirectAllowed: boolean;
+  private readonly resourceNamesCallerAllowed: boolean;
 
   constructor(properties: SimIamAllowSidesProperties) {
     this.identityAllowed = properties.identity;
     this.resourceAllowed = properties.resource;
     this.resourceDirectAllowed =
       properties.resourceDirect ?? properties.resource;
+    this.resourceNamesCallerAllowed =
+      properties.resourceNamesCaller ?? properties.resource;
   }
 
   /**
@@ -44,8 +54,8 @@ export class SimIamAllowSides {
   }
 
   /**
-   * Whether a resource-based policy allowed the request by naming the caller,
-   * rather than by delegating to the caller's Account.
+   * Whether a resource-based policy allowed the request without delegating to
+   * the caller's Account.
    */
   get resourceDirect(): boolean {
     return this.resourceDirectAllowed;
@@ -57,6 +67,14 @@ export class SimIamAllowSides {
    */
   get resourceDelegated(): boolean {
     return this.resourceAllowed && !this.resourceDirectAllowed;
+  }
+
+  /**
+   * Whether a resource-based policy allowed the request by naming the caller,
+   * rather than by admitting whoever the request came from.
+   */
+  get resourceNamesCaller(): boolean {
+    return this.resourceNamesCallerAllowed;
   }
 }
 
@@ -129,6 +147,28 @@ export class SimIamMandatoryResourcePolicyRequirement implements SimIamAllowRequ
     }
 
     return allows.resourceDelegated && allows.identity;
+  }
+}
+
+/**
+ * The rule for a request one service makes to another with the caller's own
+ * permissions. The caller needs the permission itself.
+ *
+ * A resource policy naming the caller still allows the request on its own, as
+ * a KMS key policy naming a Role does. A policy admitting whoever the request
+ * came from does not, because what it admits is the service. That is the
+ * difference between a key policy naming a Role and the aws/ssm key policy,
+ * which admits the Account's principals reaching KMS through Parameter Store
+ * and still leaves a Role holding only ssm:GetParameter unable to decrypt a
+ * SecureString.
+ */
+export class SimIamCallerPermissionRequirement implements SimIamAllowRequirement {
+  /**
+   * Whether the caller holds the permission itself, or was named outright by
+   * the resource.
+   */
+  isSatisfiedBy(allows: SimIamAllowSides): boolean {
+    return allows.resourceNamesCaller || allows.identity;
   }
 }
 

--- a/src/service/iam/authorize/allow/sim-iam-allow-statements.ts
+++ b/src/service/iam/authorize/allow/sim-iam-allow-statements.ts
@@ -17,13 +17,14 @@ export class SimIamAllowStatements {
   private readonly resourceStatements: SimIamPolicyDocumentStatement[] = [];
   private readonly trustStatements: SimIamPolicyDocumentStatement[] = [];
   private readonly delegatedStatements: SimIamPolicyDocumentStatement[] = [];
+  private readonly namingStatements: SimIamPolicyDocumentStatement[] = [];
 
   /**
    * Record a matching Allow against the policy side it came from.
    *
-   * A resource-policy Allow that matched by way of the caller's Account rather
-   * than the caller itself is kept apart as well, so a rule that cares about
-   * the difference can ask for it.
+   * How a resource-policy Allow came to match is kept alongside it, for the
+   * rules that care. A statement can match by way of the caller's Account, by
+   * naming the caller, or by admitting whoever the request came from.
    */
   record(
     policy: SimIamAuthZPolicySource,
@@ -36,6 +37,10 @@ export class SimIamAllowStatements {
 
     if (principal.isAccountDelegation) {
       this.delegatedStatements.push(statement);
+    }
+
+    if (principal.namesCaller) {
+      this.namingStatements.push(statement);
     }
 
     this.sideStatements(policy).push(statement);
@@ -74,12 +79,16 @@ export class SimIamAllowStatements {
    */
   get sides(): SimIamAllowSides {
     const delegated = new Set(this.delegatedStatements);
+    const naming = new Set(this.namingStatements);
 
     return new SimIamAllowSides({
       identity: this.identityStatements.length > 0,
       resource: this.resourceStatements.length > 0,
       resourceDirect: this.resourceStatements.some(
         (statement) => !delegated.has(statement),
+      ),
+      resourceNamesCaller: this.resourceStatements.some((statement) =>
+        naming.has(statement),
       ),
     });
   }

--- a/src/service/iam/authorize/context/sim-iam-auth-z-allow-requirement.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-allow-requirement.ts
@@ -1,17 +1,28 @@
 import {
   type SimIamAllowRequirement,
+  SimIamCallerPermissionRequirement,
   SimIamEveryAllowRequirement,
   SimIamMandatoryResourcePolicyRequirement,
 } from "../allow/sim-iam-allow-requirement.js";
 import type { SimIamCallerAccount } from "../caller-account/sim-iam-caller-account.js";
 
 /**
+ * What an authorization request says about the rules it is subject to, beyond
+ * the caller and the policies themselves.
+ */
+export interface SimIamAllowRequirementInput {
+  readonly requiresResourcePolicyAllow?: boolean | undefined;
+  readonly withCallerPermissions?: boolean | undefined;
+}
+
+/**
  * Works out which allow rules apply to one authorization request.
  *
- * Two things decide it, and both have to hold. The caller's Account says whose
- * Allow counts: either side within one Account, both sides across Accounts.
- * The resource-owning service says whether its resource insists on allowing,
- * which is true of a KMS key and of nothing else so far.
+ * Three things decide it, and all of them have to hold. The caller's Account
+ * says whose Allow counts: either side within one Account, both sides across
+ * Accounts. The resource-owning service says whether its resource insists on
+ * allowing, which is true of a KMS key and of nothing else so far, and whether
+ * it is passing on the caller's own permissions rather than its own.
  */
 export class SimIamAuthZAllowRequirement {
   /**
@@ -19,15 +30,20 @@ export class SimIamAuthZAllowRequirement {
    */
   resolve(
     callerAccount: SimIamCallerAccount,
-    requiresResourcePolicyAllow: boolean | undefined,
+    input: SimIamAllowRequirementInput,
   ): SimIamAllowRequirement {
-    if (requiresResourcePolicyAllow !== true) {
-      return callerAccount.allowRequirement;
+    const requirements: SimIamAllowRequirement[] = [
+      callerAccount.allowRequirement,
+    ];
+
+    if (input.requiresResourcePolicyAllow === true) {
+      requirements.push(new SimIamMandatoryResourcePolicyRequirement());
     }
 
-    return new SimIamEveryAllowRequirement([
-      callerAccount.allowRequirement,
-      new SimIamMandatoryResourcePolicyRequirement(),
-    ]);
+    if (input.withCallerPermissions === true) {
+      requirements.push(new SimIamCallerPermissionRequirement());
+    }
+
+    return new SimIamEveryAllowRequirement(requirements);
   }
 }

--- a/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-context-builder.ts
@@ -1,8 +1,6 @@
 import type { SimArn } from "../../../aws/arn.js";
-import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import { makeSimAwsAccountRootPrincipal } from "../../../aws/caller/sim-aws-account-root-principal.js";
 import type {
-  SimAwsCaller,
   SimAwsDefaultCaller,
   SimAwsPrincipal,
 } from "../../../aws/caller/sim-aws-caller.js";
@@ -13,15 +11,13 @@ import type { SimIamAccountResolver } from "../../registry/sim-iam-account-resol
 import type {
   SimIamConditionValue,
   SimIamPolicy,
-  SimIamPolicyDocument,
 } from "../../policy/sim-iam-policy.js";
 import type { SimIamRole, SimIamRoleName } from "../../role/sim-iam-role.js";
-import type { SimIamCallerConditionSource } from "./sim-iam-caller-condition-source.js";
 import type {
   SimIamAuthZContext,
   SimIamAuthZPolicySource,
-  SimIamAuthZPolicySourceType,
 } from "./sim-iam-auth-z-context.js";
+import type { SimIamAuthorizationInput } from "./sim-iam-auth-z-input.js";
 import { SimIamAuthZIdentityPolicyCoordinator } from "./identity-policy-source/sim-iam-auth-z-id-pol-coordinator.js";
 import {
   SimIamAuthZCallerContextBuilder,
@@ -35,85 +31,6 @@ import type { SimIamUser, SimIamUsername } from "../../user/sim-iam-user.js";
 import { SimIamAuthZScpSourceBuilder } from "./sim-iam-auth-z-scp-source-builder.js";
 import { SimIamDerivedConditions } from "./sim-iam-derived-conditions.js";
 import type { SimIamServiceControlPolicyResolver } from "../scp/sim-iam-scp-resolver.js";
-
-export interface SimIamResourcePolicyInput {
-  readonly document: SimIamPolicyDocument;
-  readonly sourceType?: Extract<
-    SimIamAuthZPolicySourceType,
-    "resource" | "trust"
-  >;
-  readonly policyName?: string | undefined;
-  readonly resourceArn?: string | undefined;
-}
-
-/**
- * Entry-point input for sim IAM allow/deny authorization.
- */
-export interface SimIamAuthorizationInput {
-  readonly action: string;
-  readonly resource: string;
-
-  /**
-   * The Region the request was made in, which sim IAM derives
-   * `aws:RequestedRegion` from.
-   *
-   * A simulated service supplies its own Region. A request reaching one
-   * through its command handlers therefore carries it, with the caller saying
-   * nothing. IAM itself belongs to an Account and has no Region to fall back
-   * on. A request arriving without one leaves the key out of the condition
-   * context, and a statement conditioned on it matches nothing.
-   */
-  readonly region?: AwsRegionName | undefined;
-
-  /**
-   * Condition values known by the service handling the simulated request, such
-   * as S3 object tags. Sim IAM automatically supplies global condition values
-   * that it can derive itself, such as AWS:PrincipalArn.
-   *
-   * Context-key names are matched case-insensitively by the condition matcher,
-   * while string values remain case-sensitive. IAM-derived values take
-   * precedence over supplied values for equivalent keys.
-   */
-  readonly conditionContext?:
-    | Readonly<Record<string, SimIamConditionValue>>
-    | undefined;
-
-  /**
-   * Condition values the service can only supply once IAM has resolved the
-   * caller, such as the Account a KMS request came from.
-   *
-   * These are combined with the values supplied directly, and IAM-derived
-   * values still take precedence over both.
-   */
-  readonly callerConditions?: SimIamCallerConditionSource | undefined;
-
-  /**
-   * Simulated request caller.
-   *
-   * If credentials are supplied, they are authenticated before policy
-   * evaluation. If omitted, authorization defaults to the Account root.
-   */
-  readonly caller?: SimAwsCaller | undefined;
-
-  /**
-   * Resource policies supplied by the service that owns the target resource.
-   *
-   * Resource policies are not loaded from IAM's managed-policy store. They are
-   * supplied by the target service, such as an S3 Bucket policy or other
-   * service-level resource policy.
-   */
-  readonly resourcePolicies?: readonly SimIamResourcePolicyInput[] | undefined;
-
-  /**
-   * Whether the resource's own policy must allow the request.
-   *
-   * Off by default, which is the ordinary AWS rule: a resource with no policy
-   * leaves the decision to the caller's identity policies. A service sets it
-   * for a resource whose policy is mandatory and is the root of trust for
-   * reaching it, which in AWS means a KMS key policy.
-   */
-  readonly requiresResourcePolicyAllow?: boolean | undefined;
-}
 
 interface SimIamAuthZContextBuilderProperties {
   /**
@@ -218,10 +135,7 @@ export class SimIamAuthZContextBuilder {
       ],
       resourcePolicies: this.resourcePolicySources(input),
       serviceControlPolicies: this.scpSourceBuilder.build(callerContext.caller),
-      allowRequirement: this.allowRequirement.resolve(
-        callerAccount,
-        input.requiresResourcePolicyAllow,
-      ),
+      allowRequirement: this.allowRequirement.resolve(callerAccount, input),
       action: input.action,
       resource: input.resource,
       conditionContext: this.conditionContext(input, callerContext.caller),

--- a/src/service/iam/authorize/context/sim-iam-auth-z-input.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-input.ts
@@ -1,0 +1,102 @@
+import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type {
+  SimIamConditionValue,
+  SimIamPolicyDocument,
+} from "../../policy/sim-iam-policy.js";
+import type { SimIamCallerConditionSource } from "./sim-iam-caller-condition-source.js";
+import type { SimIamAuthZPolicySourceType } from "./sim-iam-auth-z-context.js";
+
+export interface SimIamResourcePolicyInput {
+  readonly document: SimIamPolicyDocument;
+  readonly sourceType?: Extract<
+    SimIamAuthZPolicySourceType,
+    "resource" | "trust"
+  >;
+  readonly policyName?: string | undefined;
+  readonly resourceArn?: string | undefined;
+}
+
+/**
+ * Entry-point input for sim IAM allow/deny authorization.
+ */
+export interface SimIamAuthorizationInput {
+  readonly action: string;
+  readonly resource: string;
+
+  /**
+   * The Region the request was made in, which sim IAM derives
+   * `aws:RequestedRegion` from.
+   *
+   * A simulated service supplies its own Region. A request reaching one
+   * through its command handlers therefore carries it, with the caller saying
+   * nothing. IAM itself belongs to an Account and has no Region to fall back
+   * on. A request arriving without one leaves the key out of the condition
+   * context, and a statement conditioned on it matches nothing.
+   */
+  readonly region?: AwsRegionName | undefined;
+
+  /**
+   * Condition values known by the service handling the simulated request, such
+   * as S3 object tags. Sim IAM automatically supplies global condition values
+   * that it can derive itself, such as AWS:PrincipalArn.
+   *
+   * Context-key names are matched case-insensitively by the condition matcher,
+   * while string values remain case-sensitive. IAM-derived values take
+   * precedence over supplied values for equivalent keys.
+   */
+  readonly conditionContext?:
+    | Readonly<Record<string, SimIamConditionValue>>
+    | undefined;
+
+  /**
+   * Condition values the service can only supply once IAM has resolved the
+   * caller, such as the Account a KMS request came from.
+   *
+   * These are combined with the values supplied directly, and IAM-derived
+   * values still take precedence over both.
+   */
+  readonly callerConditions?: SimIamCallerConditionSource | undefined;
+
+  /**
+   * Simulated request caller.
+   *
+   * If credentials are supplied, they are authenticated before policy
+   * evaluation. If omitted, authorization defaults to the Account root.
+   */
+  readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * Resource policies supplied by the service that owns the target resource.
+   *
+   * Resource policies are not loaded from IAM's managed-policy store. They are
+   * supplied by the target service, such as an S3 Bucket policy or other
+   * service-level resource policy.
+   */
+  readonly resourcePolicies?: readonly SimIamResourcePolicyInput[] | undefined;
+
+  /**
+   * Whether the resource's own policy must allow the request.
+   *
+   * Off by default, which is the ordinary AWS rule: a resource with no policy
+   * leaves the decision to the caller's identity policies. A service sets it
+   * for a resource whose policy is mandatory and is the root of trust for
+   * reaching it, which in AWS means a KMS key policy.
+   */
+  readonly requiresResourcePolicyAllow?: boolean | undefined;
+
+  /**
+   * Whether the service is making this request with the caller's own
+   * permissions rather than with its own.
+   *
+   * Off by default, which is the ordinary AWS rule. Within one Account a
+   * resource policy admitting the caller is enough on its own. A service sets
+   * this where it reaches another service as the caller. A resource policy
+   * that admits whoever the request came from then grants nothing by itself,
+   * because what it admits is the service. Reading a SecureString needs
+   * kms:Decrypt for that reason, even under the aws/ssm key, whose policy
+   * admits the Account's principals reaching KMS through Parameter Store. A
+   * resource policy naming the caller still allows the request on its own.
+   */
+  readonly withCallerPermissions?: boolean | undefined;
+}

--- a/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
@@ -50,9 +50,9 @@ export class SimIamPolicyPrincipalMatcher {
     }
 
     if (statement.notPrincipal !== undefined) {
-      // Excluding the caller says nothing about the Account delegating, so a
-      // NotPrincipal that leaves the caller in is a direct grant.
-      return SimIamPrincipalMatch.direct().when(
+      // Leaving the caller out of the exclusion admits it without naming it,
+      // in the way a wildcard principal does.
+      return SimIamPrincipalMatch.everyone().when(
         !this.valueMatches(statement.notPrincipal).matched,
       );
     }
@@ -112,9 +112,9 @@ export class SimIamPolicyPrincipalMatcher {
   /**
    * Compare an AWS principal pattern with the resolved caller.
    *
-   * The wildcard matches both authenticated and anonymous requests. Other AWS
-   * forms require an ARN-based caller. Account delegation forms compare against
-   * the account ID derived by the caller resolver.
+   * The wildcard matches both authenticated and anonymous requests, and names
+   * neither. Other AWS forms require an ARN-based caller. Account delegation
+   * forms compare against the account ID derived by the caller resolver.
    *
    * A pattern is compared against two ARNs, because an assumed-role session
    * has two. The session ARN is the caller, and the Role behind it is the
@@ -124,7 +124,7 @@ export class SimIamPolicyPrincipalMatcher {
    */
   private awsPatternMatches(pattern: string): SimIamPrincipalMatch {
     if (pattern === "*") {
-      return SimIamPrincipalMatch.direct();
+      return SimIamPrincipalMatch.everyone();
     }
 
     const caller = this.context.caller;

--- a/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
+++ b/src/service/iam/authorize/match/sim-iam-policy-principal-matcher.ts
@@ -114,7 +114,10 @@ export class SimIamPolicyPrincipalMatcher {
    *
    * The wildcard matches both authenticated and anonymous requests, and names
    * neither. Other AWS forms require an ARN-based caller. Account delegation
-   * forms compare against the account ID derived by the caller resolver.
+   * forms compare against the account ID derived by the caller resolver. An
+   * ARN carrying a wildcard of its own admits a set of principals without
+   * naming one, so it counts as a match on the same terms as `*`. Real IAM
+   * accepts no wildcard inside a Principal ARN at all.
    *
    * A pattern is compared against two ARNs, because an assumed-role session
    * has two. The session ARN is the caller, and the Role behind it is the
@@ -140,10 +143,20 @@ export class SimIamPolicyPrincipalMatcher {
       );
     }
 
-    return SimIamPrincipalMatch.direct().when(
+    return this.arnPatternMatch(pattern).when(
       this.arnMatches(pattern, caller.arn) ||
         this.arnMatches(pattern, caller.identityPolicyArn),
     );
+  }
+
+  /**
+   * The kind of match an ARN principal pattern makes, by whether it names one
+   * principal or admits a set of them.
+   */
+  private arnPatternMatch(pattern: string): SimIamPrincipalMatch {
+    return pattern.includes("*") || pattern.includes("?")
+      ? SimIamPrincipalMatch.everyone()
+      : SimIamPrincipalMatch.direct();
   }
 
   /**

--- a/src/service/iam/authorize/match/sim-iam-principal-match.iso.test.ts
+++ b/src/service/iam/authorize/match/sim-iam-principal-match.iso.test.ts
@@ -36,6 +36,38 @@ describe("SimIamPrincipalMatch.first", () => {
     assertTrue(first.isAccountDelegation);
   });
 
+  it("prefers a match naming the caller over a wildcard", () => {
+    // Given a Principal list holding a wildcard and the caller's own ARN.
+    const matches = [
+      SimIamPrincipalMatch.everyone(),
+      SimIamPrincipalMatch.direct(),
+    ];
+
+    // When the winning match is chosen.
+    const first = SimIamPrincipalMatch.first(matches);
+
+    // Then the statement counts as naming the caller. That is what lets a
+    // resource policy allow a request the caller has no permission for.
+    assertTrue(first.namesCaller);
+  });
+
+  it("keeps a wildcard match apart from one naming the caller", () => {
+    // Given only a wildcard, as the aws/ssm key policy has.
+    const matches = [
+      SimIamPrincipalMatch.none(),
+      SimIamPrincipalMatch.everyone(),
+    ];
+
+    // When the winning match is chosen.
+    const first = SimIamPrincipalMatch.first(matches);
+
+    // Then it matches without naming the caller, so a service passing on the
+    // caller's own permissions still needs IAM to allow them.
+    assertTrue(first.matched);
+    assertFalse(first.namesCaller);
+    assertFalse(first.isAccountDelegation);
+  });
+
   it("reports no match when nothing applies", () => {
     // Given nothing matching.
     const matches = [SimIamPrincipalMatch.none(), SimIamPrincipalMatch.none()];

--- a/src/service/iam/authorize/match/sim-iam-principal-match.ts
+++ b/src/service/iam/authorize/match/sim-iam-principal-match.ts
@@ -1,53 +1,85 @@
 /**
  * How a resource-policy statement came to apply to the caller.
  *
- * AWS treats these two differently. A statement naming the caller's own ARN is
- * a grant to that principal. A statement naming the Account, as a bare account
- * ID or a root ARN, delegates the decision to that Account's IAM rather than
- * granting anything by itself. Most of this simulator does not yet act on the
- * difference; a KMS key policy does, because it is the whole reason the
- * default key policy does not make a key usable by everyone in the Account.
+ * AWS treats these apart. A statement naming the caller's own ARN is a grant
+ * to that principal. A statement naming the Account, as a bare account ID or a
+ * root ARN, delegates the decision to that Account's IAM and grants nothing by
+ * itself. A statement whose principal is a wildcard names nobody. It admits
+ * whoever the request came from, and a service calling with the caller's own
+ * permissions still needs IAM to allow that caller.
+ *
+ * A KMS key policy is where the difference shows. It is the whole reason the
+ * default key policy leaves a key unusable by the Account's principals until
+ * IAM allows them, and the reason the aws/ssm key leaves a SecureString
+ * unreadable to a caller holding no kms:Decrypt.
  */
 export class SimIamPrincipalMatch {
+  /**
+   * Whether the statement applies to the caller at all.
+   */
   public readonly matched: boolean;
+
+  /**
+   * Whether the statement applies by way of the caller's Account.
+   */
   public readonly isAccountDelegation: boolean;
 
-  private constructor(matched: boolean, isAccountDelegation: boolean) {
+  /**
+   * Whether the statement named the caller, rather than admitting it as one
+   * of a wider set.
+   */
+  public readonly namesCaller: boolean;
+
+  private constructor(
+    matched: boolean,
+    isAccountDelegation: boolean,
+    namesCaller: boolean,
+  ) {
     this.matched = matched;
     this.isAccountDelegation = isAccountDelegation;
+    this.namesCaller = namesCaller;
   }
 
   /**
    * The statement does not apply to this caller.
    */
   static none(): SimIamPrincipalMatch {
-    return new SimIamPrincipalMatch(false, false);
+    return new SimIamPrincipalMatch(false, false, false);
   }
 
   /**
    * The statement names this caller, or applies without naming an Account.
    */
   static direct(): SimIamPrincipalMatch {
-    return new SimIamPrincipalMatch(true, false);
+    return new SimIamPrincipalMatch(true, false, true);
   }
 
   /**
    * The statement applies by way of the caller's Account.
    */
   static accountDelegation(): SimIamPrincipalMatch {
-    return new SimIamPrincipalMatch(true, true);
+    return new SimIamPrincipalMatch(true, true, false);
+  }
+
+  /**
+   * The statement applies to whoever made the request, naming nobody.
+   */
+  static everyone(): SimIamPrincipalMatch {
+    return new SimIamPrincipalMatch(true, false, false);
   }
 
   /**
    * The first match among alternatives, since Principal lists are an OR.
    *
-   * A direct match wins over a delegated one where both apply, because a
-   * statement naming the caller grants to the caller whatever else it says.
+   * A statement naming the caller wins over one that admits it some other
+   * way, because naming the caller grants to the caller whatever else the
+   * statement says.
    */
   static first(matches: readonly SimIamPrincipalMatch[]): SimIamPrincipalMatch {
     const matched = matches.filter((result) => result.matched);
 
     return (
+      matched.find((result) => result.namesCaller) ??
       matched.find((result) => !result.isAccountDelegation) ??
       matched[0] ??
       this.none()

--- a/src/service/iam/authorize/sim-iam-account-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-account-auth-z.ts
@@ -10,7 +10,7 @@ import type { SimIamRole, SimIamRoleName } from "../role/sim-iam-role.js";
 import type { SimIamUser, SimIamUsername } from "../user/sim-iam-user.js";
 import type { SimIamAccountResolver } from "../registry/sim-iam-account-resolver.js";
 import { SimIamAuthorizer } from "./sim-iam-authorizer.js";
-import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-context-builder.js";
+import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-input.js";
 import type { SimIamAuthZPolicySource } from "./context/sim-iam-auth-z-context.js";
 import type { SimIamAccountIdentityPolicies } from "./identity/sim-iam-account-identity-policies.js";
 import type { SimIamPolicyDecision } from "./sim-iam-decision.js";

--- a/src/service/iam/authorize/sim-iam-auth-z-principal.iso.test.ts
+++ b/src/service/iam/authorize/sim-iam-auth-z-principal.iso.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@kensio/smartass";
 import { SimIamPolicyDecisionValue } from "./sim-iam-decision.js";
 import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
-import type { SimIamResourcePolicyInput } from "./context/sim-iam-auth-z-context-builder.js";
+import type { SimIamResourcePolicyInput } from "./context/sim-iam-auth-z-input.js";
 
 const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:orders";
 

--- a/src/service/iam/authorize/sim-iam-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-authorizer.ts
@@ -1,10 +1,8 @@
 import type { SimArn } from "../../aws/arn.js";
 import type { SimIamPolicy } from "../policy/sim-iam-policy.js";
 import type { SimIamRole, SimIamRoleName } from "../role/sim-iam-role.js";
-import {
-  SimIamAuthZContextBuilder,
-  type SimIamAuthorizationInput,
-} from "./context/sim-iam-auth-z-context-builder.js";
+import { SimIamAuthZContextBuilder } from "./context/sim-iam-auth-z-context-builder.js";
+import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-input.js";
 import { SimIamPolicyDecision } from "./sim-iam-decision.js";
 import type {
   SimAwsDefaultCaller,

--- a/src/service/iam/authorize/sim-iam-inter-service-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-inter-service-auth-z.ts
@@ -1,4 +1,4 @@
-import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-context-builder.js";
+import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-input.js";
 import type { SimAwsResolvedCaller } from "../../aws/caller/sim-aws-caller-resolver.js";
 import { SimAwsCallerResolver } from "../../aws/caller/sim-aws-caller-resolver.js";
 

--- a/src/service/iam/authorize/sim-iam-region-auth-z.ts
+++ b/src/service/iam/authorize/sim-iam-region-auth-z.ts
@@ -1,6 +1,6 @@
 import type { SimAwsAccountRegionContainer } from "../../aws/sim-aws-account-region-scope.js";
 import type { AwsRegionName } from "../../aws/sim-aws-region.js";
-import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-context-builder.js";
+import type { SimIamAuthorizationInput } from "./context/sim-iam-auth-z-input.js";
 import {
   SimIamAllowAllAuth,
   type SimIamAuthorizationDecision,

--- a/src/service/iam/sim-iam.ts
+++ b/src/service/iam/sim-iam.ts
@@ -3,7 +3,7 @@ import type { SimAwsAccountId } from "../aws/sim-aws-account.js";
 import type { SimIamManagedPolicy } from "./policy/sim-iam-policy.js";
 import type { SimIamRole, SimIamRoleName } from "./role/sim-iam-role.js";
 import type { SimIamUser, SimIamUsername } from "./user/sim-iam-user.js";
-import type { SimIamAuthorizationInput } from "./authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamAuthorizationInput } from "./authorize/context/sim-iam-auth-z-input.js";
 import type { SimIamPolicyDecision } from "./authorize/sim-iam-decision.js";
 import type * as simIamCommands from "./command/sim-iam-command.types.js";
 import type { SimIamRequestOptions } from "./command/sim-iam-request-options.js";

--- a/src/service/kms/README.md
+++ b/src/service/kms/README.md
@@ -153,8 +153,10 @@ usable in its own region.
 `SimKmsKeyPolicy.awsManaged` is the policy those two exist for. It is the policy real AWS gives an
 AWS managed key: use of the key allowed to `*` conditioned on both keys, and a second statement
 delegating only the key's metadata to the account. Nothing about using the key is delegated, so an
-identity policy granting `kms:Decrypt` on such a key reaches nothing, and a caller with no KMS
-permission at all reaches it through the owning service. The key factory builds it whenever a key is
+identity policy granting `kms:Decrypt` on such a key reaches nothing by itself, and a caller reaches
+the key through the owning service. What the first statement admits is whoever the request came
+from, so a service passing the caller's own permissions on with `withCallerPermissions` needs IAM to
+allow that caller too. The key factory builds it whenever a key is
 made for a service, which the key store does on first reference to a reserved `alias/aws/` name.
 
 Operations with no key to speak of, `CreateKey`, `ListKeys` and `ListAliases`, authorize against the

--- a/src/service/kms/command/authorize/sim-kms-authorizer.ts
+++ b/src/service/kms/command/authorize/sim-kms-authorizer.ts
@@ -25,7 +25,9 @@ interface SimKmsAuthorizerProperties {
  * Both carry the KMS condition values a key policy can be written against:
  * `kms:CallerAccount` for the Account the request came from, and
  * `kms:ViaService` where another service made the request on the caller's
- * behalf.
+ * behalf. A service passing on the caller's own KMS permissions says so, and
+ * a key policy admitting whoever the request came from is then not enough by
+ * itself.
  */
 export class SimKmsAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
@@ -57,6 +59,7 @@ export class SimKmsAuthorizer {
       callerConditions: this.callerAccount,
       resourcePolicies: [key.policy.asResourcePolicy()],
       requiresResourcePolicyAllow: true,
+      withCallerPermissions: options.withCallerPermissions,
     });
 
     if (decision.isDenied) {

--- a/src/service/kms/command/authorize/sim-kms-aws-managed-key-authz.iso.test.ts
+++ b/src/service/kms/command/authorize/sim-kms-aws-managed-key-authz.iso.test.ts
@@ -17,6 +17,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
 
 const managedKeyAlias = "alias/aws/ssm";
 const plaintext = Uint8Array.from(Buffer.from("hunter2", "utf8"));
@@ -61,6 +62,57 @@ describe("KMS AWS managed key authorization", () => {
 
     // Then the key policy admits it on its own, which is why a Role holding
     // only ssm:GetParameter reads a SecureString on real AWS.
+    assertNonNullable(encrypted.KeyId);
+  });
+
+  it("refuses a caller with no permission where the service passes its own on", async () => {
+    // Given a Role holding no KMS permission.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Role-no-kms", actions: ["ssm:GetParameter"] },
+      simAws,
+    );
+
+    // When a service reaches the key with that Role's own permissions.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .kms()
+        .encrypt(
+          new EncryptCommand({ KeyId: managedKeyAlias, Plaintext: plaintext }),
+          {
+            caller: { kind: "arn", arn: role.Arn },
+            viaService: "ssm",
+            withCallerPermissions: true,
+          },
+        ),
+    );
+
+    // Then the key policy is not enough on its own: it admits whoever the
+    // request came from, which is the service rather than the Role behind it.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("admits a caller holding the permission where the service passes its own on", async () => {
+    // Given a Role holding the KMS permission itself.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "Role-kms-Encrypt", actions: ["kms:Encrypt"] },
+      simAws,
+    );
+
+    // When a service reaches the key with that Role's own permissions.
+    const encrypted = await simAws
+      .kms()
+      .encrypt(
+        new EncryptCommand({ KeyId: managedKeyAlias, Plaintext: plaintext }),
+        {
+          caller: { kind: "arn", arn: role.Arn },
+          viaService: "ssm",
+          withCallerPermissions: true,
+        },
+      );
+
+    // Then both sides allow it and the key is used.
     assertNonNullable(encrypted.KeyId);
   });
 

--- a/src/service/kms/command/authorize/sim-kms-key-policy-authz.iso.test.ts
+++ b/src/service/kms/command/authorize/sim-kms-key-policy-authz.iso.test.ts
@@ -200,6 +200,52 @@ describe("KMS key policy authorization", () => {
     assertIdentical(roundTripped.toString("utf8"), "hunter2");
   });
 
+  it("refuses a wildcard ARN principal to a caller passing its own permissions", async () => {
+    // Given a key whose policy names a set of Roles with a wildcard, and a
+    // Role in that set holding no permissions of its own.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    const roleArn = await makeRole(simAws, accountId, "MatchedByWildcard");
+
+    const created = await simAws.kms().createKey(
+      new CreateKeyCommand({
+        Policy: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: { AWS: `arn:aws:iam::${accountId}:role/*` },
+              Action: "kms:Encrypt",
+              Resource: "*",
+            },
+          ],
+        }),
+      }),
+    );
+    assertNonNullable(created.KeyMetadata);
+
+    // When a service reaches the key with that Role's own permissions.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.kms().encrypt(
+        new EncryptCommand({
+          KeyId: created.KeyMetadata?.Arn,
+          Plaintext: plaintext,
+        }),
+        {
+          caller: { kind: "arn", arn: roleArn },
+          viaService: "ssm",
+          withCallerPermissions: true,
+        },
+      ),
+    );
+
+    // Then the statement admits a set of principals without naming one, and
+    // the caller still needs the permission itself. Real IAM accepts no
+    // wildcard inside a Principal ARN in the first place.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
   it("authorizes Decrypt against the key the ciphertext names", async () => {
     // Given two keys, and a Role the second key's policy admits but not the
     // first's.

--- a/src/service/kms/command/sim-kms-request-options.ts
+++ b/src/service/kms/command/sim-kms-request-options.ts
@@ -22,4 +22,16 @@ export interface SimKmsRequestOptions {
    * and a policy conditioned on `kms:ViaService` then does not match.
    */
   readonly viaService?: string | undefined;
+
+  /**
+   * Whether the service named by `viaService` is making the request with the
+   * caller's own KMS permissions rather than with its own.
+   *
+   * Parameter Store decrypts a SecureString this way. A caller holding
+   * ssm:GetParameter and no kms:Decrypt is refused even under the aws/ssm key,
+   * whose policy admits the Account's principals reaching KMS through Systems
+   * Manager. A key policy naming the caller still allows the request on its
+   * own, as it does for any other KMS request.
+   */
+  readonly withCallerPermissions?: boolean | undefined;
 }

--- a/src/service/kms/key/sim-kms-key-policy.ts
+++ b/src/service/kms/key/sim-kms-key-policy.ts
@@ -1,5 +1,5 @@
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
-import type { SimIamResourcePolicyInput } from "../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamResourcePolicyInput } from "../../iam/authorize/context/sim-iam-auth-z-input.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
 import { simKmsCallerAccountConditionKey } from "./sim-kms-caller-account.js";
 import {

--- a/src/service/kms/key/sim-kms-key-policy.ts
+++ b/src/service/kms/key/sim-kms-key-policy.ts
@@ -64,9 +64,10 @@ export class SimKmsKeyPolicy {
    * through the service that owns the key, and it delegates nothing else to
    * IAM: the second statement covers reading the key's metadata and no more.
    *
-   * That is what makes an AWS managed key usable by a caller holding no KMS
-   * permission at all, and unusable by a caller holding kms:Decrypt on it who
-   * calls KMS directly.
+   * That is what makes an AWS managed key unusable by a caller holding
+   * kms:Decrypt on it who calls KMS directly. What the first statement admits
+   * is whoever reached KMS through the owning service, which allows the
+   * request on its own only where that service used its own permissions.
    */
   static awsManaged(
     keyArn: string,

--- a/src/service/lambda/command/authorize/sim-lambda-resource-policies.ts
+++ b/src/service/lambda/command/authorize/sim-lambda-resource-policies.ts
@@ -1,4 +1,4 @@
-import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-input.js";
 import type { SimLambdaPolicyResource } from "../../function/policy/sim-lambda-policy-resource.js";
 
 /**

--- a/src/service/s3/command/authorize/sim-s3-bucket-resource-policies.ts
+++ b/src/service/s3/command/authorize/sim-s3-bucket-resource-policies.ts
@@ -1,4 +1,4 @@
-import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-input.js";
 import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 

--- a/src/service/sns/command/authorize/sim-sns-authorizer.ts
+++ b/src/service/sns/command/authorize/sim-sns-authorizer.ts
@@ -1,5 +1,5 @@
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
-import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-input.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
 import { SimSnsAuthorizationErrorException } from "../../error/sim-sns.error.js";

--- a/src/service/sns/command/authorize/sim-sns-topic-resource-policies.ts
+++ b/src/service/sns/command/authorize/sim-sns-topic-resource-policies.ts
@@ -1,4 +1,4 @@
-import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-input.js";
 import type { SimSnsTopic } from "../../topic/sim-sns-topic.js";
 
 /**

--- a/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-authorizer.ts
@@ -1,5 +1,5 @@
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
-import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-input.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";

--- a/src/service/sqs/command/authorize/sim-sqs-queue-resource-policies.ts
+++ b/src/service/sqs/command/authorize/sim-sqs-queue-resource-policies.ts
@@ -1,4 +1,4 @@
-import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-context-builder.js";
+import type { SimIamResourcePolicyInput } from "../../../iam/authorize/context/sim-iam-auth-z-input.js";
 import type { SimSqsQueue } from "../../queue/sim-sqs-queue.js";
 
 /**

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -59,9 +59,10 @@ call and nothing more. Two details matter:
 - the calls are made as the caller rather than as the service, so under a customer managed key a
   write needs the caller's own `kms:Encrypt` and a decrypting read needs `kms:Decrypt`, each on top
   of the SSM permission for the parameter;
-- they are made through the service as well, carrying `kms:ViaService`, which is what lets the
-  `aws/ssm` managed key be used by a caller with no KMS permission at all and by nothing calling KMS
-  directly;
+- they are made through the service as well, carrying `kms:ViaService`, which is what reaches the
+  `aws/ssm` managed key at all and keeps it out of reach of anything calling KMS directly. A
+  decrypting read carries `withCallerPermissions` with it, leaving that key's account-wide statement
+  short of allowing the read on its own;
 - the parameter's ARN is bound in as the `PARAMETER_ARN` encryption context, as real Parameter Store
   binds it, so a ciphertext moved into another parameter cannot be decrypted there.
 

--- a/src/service/ssm/parameter/sim-ssm-kms-crypto.ts
+++ b/src/service/ssm/parameter/sim-ssm-kms-crypto.ts
@@ -14,10 +14,10 @@ export const ssmDefaultKeyAlias = "alias/aws/ssm";
  * The service Parameter Store's KMS calls are made through, as
  * `kms:ViaService` names it.
  *
- * Supplying it is what lets a caller read a `SecureString` under the
- * `aws/ssm` managed key with no KMS permission of its own: that key's policy
- * admits the Account's principals only when the request reached KMS through
- * Systems Manager.
+ * The `aws/ssm` managed key's policy admits the Account's principals only when
+ * the request reached KMS through Systems Manager, so a request that does not
+ * supply this reaches the key at all only where the key policy names the
+ * caller.
  */
 export const ssmKmsViaService = "ssm";
 
@@ -40,6 +40,7 @@ export interface SimSsmKmsCrypto {
     options?: {
       caller?: SimAwsCaller | undefined;
       viaService?: string | undefined;
+      withCallerPermissions?: boolean | undefined;
     },
   ): Promise<{
     CiphertextBlob?: Uint8Array | undefined;
@@ -56,6 +57,7 @@ export interface SimSsmKmsCrypto {
     options?: {
       caller?: SimAwsCaller | undefined;
       viaService?: string | undefined;
+      withCallerPermissions?: boolean | undefined;
     },
   ): Promise<{
     Plaintext?: Uint8Array | undefined;

--- a/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
@@ -32,18 +32,20 @@ interface SimSsmParameterKmsProperties {
 /**
  * The KMS calls a SecureString parameter makes.
  *
- * The calls are made as the caller rather than as the service, which is the
- * point: a standard tier write needs `kms:Encrypt` on the key and a decrypting
- * read needs `kms:Decrypt`, each on top of the SSM permission for the
- * parameter itself.
+ * The calls are made as the caller rather than as the service. Under a
+ * customer managed key a standard tier write needs `kms:Encrypt` on the key
+ * and a decrypting read needs `kms:Decrypt`, each on top of the SSM permission
+ * for the parameter itself.
  *
  * They are also made through the service, which is what reaches the `aws/ssm`
- * managed key at all: its policy admits the Account's principals when
+ * managed key at all. That key's policy admits the Account's principals when
  * `kms:ViaService` names Systems Manager, and Parameter Store is what supplies
- * that. Reaching the key is not the same as being allowed to use it, and a
- * decrypting read says so, because that policy admits whoever the request came
- * from rather than the caller behind it. A Role holding `ssm:GetParameter` and
- * no `kms:Decrypt` reads the ciphertext and not the value.
+ * it. Reaching the key is not the same as being allowed to use it, and a
+ * decrypting read says so with `withCallerPermissions`, because that policy
+ * admits whoever the request came from rather than the caller behind it. A
+ * Role holding `ssm:GetParameter` and no `kms:Decrypt` reads the ciphertext
+ * and not the value. A write under that key asks the caller for no KMS
+ * permission here, where AWS documents `kms:Encrypt` for one.
  *
  * Standard tier Parameter Store encrypts under the key directly rather than
  * through a data key, so this is one Encrypt and one Decrypt and nothing more.

--- a/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
@@ -33,14 +33,17 @@ interface SimSsmParameterKmsProperties {
  * The KMS calls a SecureString parameter makes.
  *
  * The calls are made as the caller rather than as the service, which is the
- * point: under a customer managed key a standard tier write needs
- * `kms:Encrypt` on the key and a decrypting read needs `kms:Decrypt`, each on
- * top of the SSM permission for the parameter itself.
+ * point: a standard tier write needs `kms:Encrypt` on the key and a decrypting
+ * read needs `kms:Decrypt`, each on top of the SSM permission for the
+ * parameter itself.
  *
- * They are also made through the service, which is why the `aws/ssm` managed
- * key needs no KMS permission at all: its policy admits the Account's
- * principals when `kms:ViaService` names Systems Manager, and Parameter Store
- * is what supplies that.
+ * They are also made through the service, which is what reaches the `aws/ssm`
+ * managed key at all: its policy admits the Account's principals when
+ * `kms:ViaService` names Systems Manager, and Parameter Store is what supplies
+ * that. Reaching the key is not the same as being allowed to use it, and a
+ * decrypting read says so, because that policy admits whoever the request came
+ * from rather than the caller behind it. A Role holding `ssm:GetParameter` and
+ * no `kms:Decrypt` reads the ciphertext and not the value.
  *
  * Standard tier Parameter Store encrypts under the key directly rather than
  * through a data key, so this is one Encrypt and one Decrypt and nothing more.
@@ -87,7 +90,8 @@ export class SimSsmParameterKms {
   }
 
   /**
-   * Decrypt a parameter value, which needs the same binding it was made with.
+   * Decrypt a parameter value, which needs the same binding it was made with,
+   * and the caller's own permission to use the key.
    */
   async decrypt(
     parameterArn: string,
@@ -103,7 +107,11 @@ export class SimSsmParameterKms {
               EncryptionContext: this.contextFor(parameterArn),
             },
           },
-          { caller, viaService: ssmKmsViaService },
+          {
+            caller,
+            viaService: ssmKmsViaService,
+            withCallerPermissions: true,
+          },
         ),
     );
 

--- a/src/service/ssm/parameter/sim-ssm-secure-string-iam.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string-iam.iso.test.ts
@@ -13,6 +13,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
 
 describe("SSM SecureString IAM authorization", () => {
   it("decrypts for a caller allowed both the parameter and the key", async () => {
@@ -70,6 +71,55 @@ describe("SSM SecureString IAM authorization", () => {
     );
 
     // Then it gets the plaintext.
+    assertIdentical(read.Parameter?.Value, "hunter2");
+  });
+
+  it("decrypts for a caller the key policy names and IAM allows nothing", async () => {
+    // Given a Role allowed to read and write parameters and no KMS action.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ConfigReader",
+        actions: ["ssm:GetParameter", "ssm:PutParameter"],
+      },
+      simAws,
+    );
+
+    // And a customer managed key whose own policy names that Role.
+    const key = await simAws.kms().createKey(
+      new CreateKeyCommand({
+        Policy: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: role.Arn },
+            Action: ["kms:Encrypt", "kms:Decrypt"],
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+    assertNonNullable(key.KeyMetadata?.Arn);
+
+    // When the Role stores a SecureString under it and reads it back.
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-password",
+        Type: "SecureString",
+        Value: "hunter2",
+        KeyId: key.KeyMetadata.Arn,
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+    const read = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-password",
+        WithDecryption: true,
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // Then the key policy is enough on its own, as it is on real AWS: a policy
+    // naming the caller grants to that caller, and only a policy admitting the
+    // Account at large leaves the permission to IAM.
     assertIdentical(read.Parameter?.Value, "hunter2");
   });
 

--- a/src/service/ssm/parameter/sim-ssm-secure-string-managed-key-iam.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string-managed-key-iam.iso.test.ts
@@ -1,88 +1,275 @@
-import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { DecryptCommand } from "@aws-sdk/client-kms";
-import { GetParameterCommand, PutParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  GetParameterCommand,
+  GetParametersByPathCommand,
+  GetParametersCommand,
+  PutParameterCommand,
+} from "@aws-sdk/client-ssm";
 import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertStringNotIncludes,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+
+/**
+ * The parameter these tests read, and the value it holds.
+ */
+const parameterName = "/myapp/prod/db-password";
+const parameterValue = "hunter2";
 
 describe("SSM SecureString under the aws/ssm managed key", () => {
-  it("decrypts for a caller holding no KMS permission", async () => {
-    // Given a parameter under the managed key.
+  it("refuses a decrypting read to a caller holding no kms:Decrypt", async () => {
+    // Given a parameter under the managed key, and a Role allowed to read
+    // parameters and nothing else.
     const simAws = new SimAws();
     await simAws.ssm().putParameter(
       new PutParameterCommand({
-        Name: "/myapp/prod/db-password",
+        Name: parameterName,
         Type: "SecureString",
-        Value: "hunter2",
+        Value: parameterValue,
       }),
     );
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigReader", actions: ["ssm:GetParameter"] },
+      simAws,
+    );
 
-    // And a Role allowed only ssm:GetParameter.
-    const role = await simAws.iam().createRole(
-      new CreateRoleCommand({
-        RoleName: "ConfigReader",
-        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
-            Action: "sts:AssumeRole",
-          },
+    // When it reads the parameter with decryption.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParameter(
+        new GetParameterCommand({
+          Name: parameterName,
+          WithDecryption: true,
         }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    // Then it is refused. Reaching the key through Systems Manager is what the
+    // managed key's policy admits, and using it is still the caller's own
+    // permission, which is the AccessDenied such a Role gets in an account.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:Decrypt");
+  });
+
+  it("decrypts for a caller holding kms:Decrypt as well", async () => {
+    // Given a parameter under the managed key, and a Role allowed both the
+    // parameter and the key.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: parameterName,
+        Type: "SecureString",
+        Value: parameterValue,
       }),
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ConfigReader",
+        actions: ["ssm:GetParameter", "kms:Decrypt"],
+      },
+      simAws,
+    );
+
+    // When it reads the parameter with decryption.
+    const read = await simAws
+      .ssm()
+      .getParameter(
+        new GetParameterCommand({ Name: parameterName, WithDecryption: true }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      );
+
+    // Then it gets the plaintext.
+    assertIdentical(read.Parameter?.Value, parameterValue);
+  });
+
+  it("decrypts for a caller whose kms:Decrypt is scoped to Systems Manager", async () => {
+    // Given a parameter under the managed key, and a Role whose key permission
+    // is conditioned on the request reaching KMS through Parameter Store. The
+    // managed key's id is not knowable when a template is synthesized, so this
+    // is how consumers scope the grant.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: parameterName,
+        Type: "SecureString",
+        Value: parameterValue,
+      }),
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigReader", actions: ["ssm:GetParameter"] },
+      simAws,
     );
     await simAws.iam().putRolePolicy(
       new PutRolePolicyCommand({
         RoleName: "ConfigReader",
-        PolicyName: "SsmOnly",
+        PolicyName: "KeyPolicy",
         PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: "ssm:GetParameter", Resource: "*" },
+          Statement: {
+            Action: "kms:Decrypt",
+            Resource: "*",
+            Condition: {
+              StringEquals: {
+                "kms:ViaService": `ssm.${simAws.defaultRegionName}.amazonaws.com`,
+              },
+            },
+          },
         }),
       }),
     );
 
     // When it reads the parameter with decryption.
-    const read = await simAws.ssm().getParameter(
-      new GetParameterCommand({
-        Name: "/myapp/prod/db-password",
-        WithDecryption: true,
+    const read = await simAws
+      .ssm()
+      .getParameter(
+        new GetParameterCommand({ Name: parameterName, WithDecryption: true }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      );
+
+    // Then the condition matches and the read succeeds, as it does in an
+    // account. A check ignoring the condition would refuse a policy real IAM
+    // allows.
+    assertIdentical(read.Parameter?.Value, parameterValue);
+  });
+
+  it("reads a String parameter for a caller holding no kms:Decrypt", async () => {
+    // Given a parameter stored in the clear, and a Role allowed to read
+    // parameters and nothing else.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-host",
+        Type: "String",
+        Value: "db.example.com",
       }),
-      { caller: { kind: "arn", arn: role.Role.Arn } },
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigReader", actions: ["ssm:GetParameter"] },
+      simAws,
     );
 
-    // Then it gets the plaintext with no kms:Decrypt of its own, because the
-    // managed key's policy admits the Account's principals reaching it through
-    // Systems Manager. Asking for that grant is what real AWS does not.
-    assertIdentical(read.Parameter?.Value, "hunter2");
+    // When it reads that parameter, asking for decryption.
+    const read = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-host",
+        WithDecryption: true,
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // Then it reads the value: no key protects it, so there is nothing to be
+    // allowed to use, and Parameter Store ignores WithDecryption for it.
+    assertIdentical(read.Parameter?.Value, "db.example.com");
+  });
+
+  it("reads the ciphertext for a caller holding no kms:Decrypt", async () => {
+    // Given a parameter under the managed key, and a Role allowed to read
+    // parameters and nothing else.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: parameterName,
+        Type: "SecureString",
+        Value: parameterValue,
+      }),
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigReader", actions: ["ssm:GetParameter"] },
+      simAws,
+    );
+
+    // When it reads the parameter without asking for decryption.
+    const read = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: parameterName }), {
+        caller: { kind: "arn", arn: role.Arn },
+      });
+
+    // Then the read succeeds, because nothing decrypted, and what comes back
+    // is the ciphertext rather than the secret.
+    assertStringNotIncludes(String(read.Parameter?.Value), parameterValue);
+  });
+
+  it("refuses a decrypting batch read to a caller holding no kms:Decrypt", async () => {
+    // Given a parameter under the managed key, and a Role allowed to read
+    // parameters in batches and nothing else.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: parameterName,
+        Type: "SecureString",
+        Value: parameterValue,
+      }),
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigReader", actions: ["ssm:GetParameters"] },
+      simAws,
+    );
+
+    // When it reads the parameter through GetParameters with decryption.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParameters(
+        new GetParametersCommand({
+          Names: [parameterName],
+          WithDecryption: true,
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    // Then the batch is refused rather than reporting the name as invalid: a
+    // denial is not a name that resolves to nothing.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:Decrypt");
+  });
+
+  it("refuses a decrypting path listing to a caller holding no kms:Decrypt", async () => {
+    // Given a parameter under the managed key, and a Role allowed to list a
+    // path and nothing else.
+    const simAws = new SimAws();
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: parameterName,
+        Type: "SecureString",
+        Value: parameterValue,
+      }),
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigReader", actions: ["ssm:GetParametersByPath"] },
+      simAws,
+    );
+
+    // When it lists the path the parameter is under, with decryption.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().getParametersByPath(
+        new GetParametersByPathCommand({
+          Path: "/myapp/prod",
+          WithDecryption: true,
+        }),
+        { caller: { kind: "arn", arn: role.Arn } },
+      ),
+    );
+
+    // Then the listing is refused as well: access to a path is not access to
+    // the key protecting what is under it.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "kms:Decrypt");
   });
 
   it("writes for a caller holding no KMS permission", async () => {
     // Given a Role allowed only ssm:PutParameter.
     const simAws = new SimAws();
-    const role = await simAws.iam().createRole(
-      new CreateRoleCommand({
-        RoleName: "ConfigReader",
-        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
-      }),
-    );
-    await simAws.iam().putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "ConfigReader",
-        PolicyName: "SsmOnly",
-        PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: "ssm:PutParameter", Resource: "*" },
-        }),
-      }),
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigWriter", actions: ["ssm:PutParameter"] },
+      simAws,
     );
 
     // When it writes a SecureString naming no key of its own.
@@ -92,10 +279,10 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
         Type: "SecureString",
         Value: "secret",
       }),
-      { caller: { kind: "arn", arn: role.Role.Arn } },
+      { caller: { kind: "arn", arn: role.Arn } },
     );
 
-    // Then the write succeeds: the same rule covers the encrypting side.
+    // Then the write succeeds.
     assertIdentical(written.Version, 1);
   });
 
@@ -105,39 +292,22 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
     const simAws = new SimAws();
     await simAws.ssm().putParameter(
       new PutParameterCommand({
-        Name: "/myapp/prod/db-password",
+        Name: parameterName,
         Type: "SecureString",
-        Value: "hunter2",
+        Value: parameterValue,
       }),
     );
-    const role = await simAws.iam().createRole(
-      new CreateRoleCommand({
-        RoleName: "ConfigReader",
-        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
-      }),
-    );
-    await simAws.iam().putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "ConfigReader",
-        PolicyName: "SsmOnly",
-        PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: "ssm:GetParameter", Resource: "*" },
-        }),
-      }),
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigReader", actions: ["ssm:GetParameter"] },
+      simAws,
     );
 
     // And that Role reading it as its stored ciphertext.
     const stored = await simAws
       .ssm()
-      .getParameter(
-        new GetParameterCommand({ Name: "/myapp/prod/db-password" }),
-        { caller: { kind: "arn", arn: role.Role.Arn } },
-      );
+      .getParameter(new GetParameterCommand({ Name: parameterName }), {
+        caller: { kind: "arn", arn: role.Arn },
+      });
     const ciphertext = stored.Parameter?.Value;
     assertNonNullable(ciphertext);
 
@@ -147,7 +317,7 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
         new DecryptCommand({
           CiphertextBlob: Buffer.from(ciphertext, "base64"),
         }),
-        { caller: { kind: "arn", arn: role.Role.Arn } },
+        { caller: { kind: "arn", arn: role.Arn } },
       ),
     );
 


### PR DESCRIPTION
Reading a `SecureString` with `WithDecryption: true` decrypted through simulated KMS as the caller, and the `aws/ssm` managed key policy admitted the request on its own. What that policy admits is whoever the request came from, and Parameter Store decrypts with the caller's own permissions. A role holding `ssm:GetParameter` and no `kms:Decrypt` read the plaintext here and collected `AccessDenied` in an account. A simulated KMS request now carries `withCallerPermissions` to say that the calling service is passing the caller's own permissions on, and a key policy statement with a wildcard principal stops being enough by itself for such a request. Sim SSM sets it when it decrypts a parameter value.

## What this covers

`GetParameter`, `GetParameters` and `GetParametersByPath` decrypt through the same encryption collaborator, and all three now refuse a caller without `kms:Decrypt`. There is a test for each.

Still working, with a test each: a `String` parameter read by the same caller, a `SecureString` read without `WithDecryption`, a caller holding both permissions, and a `kms:Decrypt` grant scoped with a `kms:ViaService` condition naming `ssm.<region>.amazonaws.com`. A customer managed key policy naming the caller also still allows a decrypting read with no identity policy behind it, which is the KMS rule the wildcard case is being separated from.

## What this leaves

Writing a `SecureString` under the managed key still asks the caller for no `kms:Encrypt`, where the [AWS docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/secure-string-parameter-kms-encryption.html) say a standard tier write needs it. #1120 is about the read path and measures reads, so the write side is untouched and recorded as a limitation in the SSM docs instead. Happy to move it in a follow-up.

## Two side effects worth flagging

One ECS test grants `kms:Decrypt` to the execution role that reads a `SecureString` secret, because a container's secret resolution goes through the same read. The ECS docs say so now.

`SimIamAuthorizationInput` and `SimIamResourcePolicyInput` moved into `sim-iam-auth-z-input.ts`. The new field pushed the context builder past the 300-line limit, and the input types were the part of it that belonged elsewhere.

Resolves #1120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for evaluating caller KMS permissions during service-mediated encryption and decryption.
  - Improved IAM authorization for explicitly named callers and wildcard principals.

- **Bug Fixes**
  - SecureString decryption now correctly requires `kms:Decrypt` alongside SSM access when applicable.
  - Corrected authorization behavior for managed and customer-managed KMS keys.

- **Documentation**
  - Clarified required permissions, service-mediated KMS requests, batch and path reads, and SecureString limitations.
  - Updated examples to show appropriate conditional KMS permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->