### PR TITLE
fix: authorize iam:PassRole on a passed Role

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1646,6 +1646,10 @@ task definition revision it would run, `DescribeTasks` and `StopTask`, which tak
 and the service operations, which take the service's ARN. `CreateService` authorizes against the ARN
 the service is about to have, and a policy can therefore name one service by name before it exists.
 
+A registration carrying a `taskRoleArn` or an `executionRoleArn` hands ECS a Role it runs the task
+as, and `RegisterTaskDefinition` authorizes `iam:PassRole` against each of them. Either Role left out
+passes nothing. See [passing a Role to a service](https://yulinsim.dev/services/iam/#passing-a-role-to-a-service) in the IAM docs.
+
 ```typescript sim-ecs-iam-policy
 /**
  * A simulated IAM policy allowing a Role to register task definitions.
@@ -1783,7 +1787,8 @@ console.log(described.taskDefinition?.revision); // 1
 
 ## Available functionality
 
-- `RegisterTaskDefinitionCommand`, with revisions numbered per family from one
+- `RegisterTaskDefinitionCommand`, with revisions numbered per family from one, authorizing
+  `iam:PassRole` on the `taskRoleArn` and the `executionRoleArn` it names
 - `DeregisterTaskDefinitionCommand`, marking one revision `INACTIVE`
 - `DescribeTaskDefinitionCommand`, taking a family, a `family:revision` or a full ARN
 - `ListTaskDefinitionsCommand` and `ListTaskDefinitionFamiliesCommand`, with prefix, status and

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -1005,6 +1005,10 @@ console.log(JSON.stringify(policy).length > 0); // true
 A caller refused by IAM gets `AccessDeniedException`. Permission is checked before the bus is looked
 up, and a caller who may not reach a bus is refused whether or not that bus exists.
 
+An ECS target carries a `RoleArn`, which the rule runs the task as. Adding one hands EventBridge that
+Role, and `PutTargets` authorizes `iam:PassRole` against it. See
+[passing a Role to a service](https://yulinsim.dev/services/iam/#passing-a-role-to-a-service) in the IAM docs.
+
 ## Scoping
 
 Buses belong to one account and region, as they do on real AWS:
@@ -1057,6 +1061,7 @@ no permission for.
   listings.
 - The event envelope EventBridge builds from an entry, reached through `eventsOn(...)`.
 - IAM authorization against the bus ARN.
+- `iam:PassRole` authorization of the `RoleArn` an ECS target carries.
 - SDK interception of `EventBridgeClient`.
 
 ## Limitations

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -378,6 +378,10 @@ Deleting the delivery stream stops it reading. Records put afterwards stay on th
 Every Firehose operation authorizes against the `firehose:` action of the same name, on the ARN of
 the delivery stream it names. `ListDeliveryStreams` names none, and authorizes against `*`.
 
+Creating a delivery stream hands Firehose the destination `RoleARN`, and the source `RoleARN` too
+where it reads a Kinesis stream. `CreateDeliveryStream` authorizes `iam:PassRole` against each of
+them. See [passing a Role to a service](https://yulinsim.dev/services/iam/#passing-a-role-to-a-service) in the IAM docs.
+
 The delivery itself is a separate request, made as the delivery stream's `RoleARN`. The caller who
 put the record needs no S3 permission at all, and a Role that cannot write to the Bucket fails the
 delivery. Real
@@ -737,7 +741,7 @@ console.log(Contents?.length);
 
 | Command                  | Notes                                                                                                   |
 | ------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `CreateDeliveryStream`   | A name already in use raises `ResourceInUseException`.                                                  |
+| `CreateDeliveryStream`   | A name already in use raises `ResourceInUseException`. Authorizes `iam:PassRole` on each Role it names. |
 | `DeleteDeliveryStream`   | The name is free again at once. Whatever was buffered goes with it.                                     |
 | `ListDeliveryStreams`    | Sorted by name, paged with `Limit` and `ExclusiveStartDeliveryStreamName`.                              |
 | `DescribeDeliveryStream` | Reports the one destination, and a Kinesis source under `Source`.                                       |

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -921,6 +921,115 @@ action, resource, and caller for diagnostics, before the service mutates any sta
 caller defaults to the Account root. The Account root is allowed within its own Account, and a test
 that never mentions IAM keeps working.
 
+## Passing a Role to a service
+
+A simulated service handed a Role keeps it and uses it later, under its own identity. AWS asks two
+questions about that. The first is whether the caller may create the thing. The second is whether the
+caller may hand that Role over, and its resource is the Role.
+
+Six simulated services ask the second question. A caller allowed the create action and refused
+`iam:PassRole` fails the request with an access-denied error naming the Role and the caller. A scoped
+deployment role refused `iam:PassRole` is one of the commoner ways a real deployment stops, and a
+deployment through
+[simulated CloudFormation](https://yulinsim.dev/services/cloudformation/ "Simulated CloudFormation usage docs")
+carries the same decision to every Resource it creates.
+
+| Request                                                | The Role it hands over                   | `iam:PassedToService`     |
+| ------------------------------------------------------ | ---------------------------------------- | ------------------------- |
+| Lambda `CreateFunction`, `UpdateFunctionConfiguration` | `Role`                                   | `lambda.amazonaws.com`    |
+| Scheduler `CreateSchedule`, `UpdateSchedule`           | `Target.RoleArn`                         | `scheduler.amazonaws.com` |
+| EventBridge `PutTargets`                               | a target's `RoleArn`                     | `events.amazonaws.com`    |
+| Step Functions `CreateStateMachine`                    | `roleArn`                                | `states.amazonaws.com`    |
+| ECS `RegisterTaskDefinition`                           | `taskRoleArn` and `executionRoleArn`     | `ecs-tasks.amazonaws.com` |
+| Firehose `CreateDeliveryStream`                        | the destination Role and the source Role | `firehose.amazonaws.com`  |
+
+Each Role is a separate decision, so a caller allowed one of an ECS task definition's two Roles is
+refused on the other. A request leaving an optional Role out passes nothing and is asked nothing.
+
+The condition key `iam:PassedToService` carries the service principal the Role goes to. A
+CDK-generated deployment policy commonly conditions its `iam:PassRole` statement on that key, and a
+policy written that way matches here.
+
+```typescript sim-iam-pass-role
+/**
+ * Authorizing the execution role a Lambda function is created with.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const simIam = simAws.iam();
+
+const deployerCreation = await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "Deployer",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "cloudformation.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Deployer",
+    PolicyName: "DeployFunctions",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        { Effect: "Allow", Action: "lambda:CreateFunction", Resource: "*" },
+        {
+          Effect: "Allow",
+          Action: "iam:PassRole",
+          Resource: "arn:aws:iam::123456789012:role/ReportsExecutionRole",
+          Condition: {
+            StringEquals: { "iam:PassedToService": "lambda.amazonaws.com" },
+          },
+        },
+      ],
+    }),
+  }),
+);
+
+const asDeployer = {
+  caller: { kind: "arn", arn: deployerCreation.Role.Arn },
+} as const;
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "reports",
+    Role: "arn:aws:iam::123456789012:role/ReportsExecutionRole",
+    Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+  }),
+  asDeployer,
+);
+
+try {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "invoices",
+      Role: "arn:aws:iam::123456789012:role/AdminRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+    }),
+    asDeployer,
+  );
+} catch (error) {
+  console.error("Passing AdminRole to Lambda was refused", error);
+}
+
+await simAws.backgroundTasksComplete();
+```
+
+A request naming no caller is decided as the Account root, which may pass any Role. A test that never
+mentions IAM keeps working.
+
 ## CloudFormation IAM resources
 
 Sim CloudFormation can create IAM resources from `AWS::IAM::Role`, `AWS::IAM::User`,
@@ -1323,6 +1432,8 @@ Sim IAM currently supports:
 - Allow/deny authorization decisions with `authorize(...)`, evaluating identity policies,
   service-supplied resource policies, and policy conditions with explicit-deny precedence
 - IAM authorization at simulated service boundaries, such as Route53 actions
+- `iam:PassRole` authorization of a Role handed to simulated Lambda, Scheduler, EventBridge, Step
+  Functions, ECS or Firehose, with `iam:PassedToService` supplied
 - Resolving the caller of an HTTP request, from an `x-sim-aws-caller` header or a verified SigV4
   signature, defaulting to anonymous, and the resource it is made on behalf of from
   `x-sim-aws-source-arn` and `x-sim-aws-source-account`

--- a/docs/services/iam/sim-iam-pass-role.example.ts
+++ b/docs/services/iam/sim-iam-pass-role.example.ts
@@ -1,0 +1,74 @@
+/**
+ * Authorizing the execution role a Lambda function is created with.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const simIam = simAws.iam();
+
+const deployerCreation = await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "Deployer",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "cloudformation.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "Deployer",
+    PolicyName: "DeployFunctions",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        { Effect: "Allow", Action: "lambda:CreateFunction", Resource: "*" },
+        {
+          Effect: "Allow",
+          Action: "iam:PassRole",
+          Resource: "arn:aws:iam::123456789012:role/ReportsExecutionRole",
+          Condition: {
+            StringEquals: { "iam:PassedToService": "lambda.amazonaws.com" },
+          },
+        },
+      ],
+    }),
+  }),
+);
+
+const asDeployer = {
+  caller: { kind: "arn", arn: deployerCreation.Role.Arn },
+} as const;
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "reports",
+    Role: "arn:aws:iam::123456789012:role/ReportsExecutionRole",
+    Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+  }),
+  asDeployer,
+);
+
+try {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "invoices",
+      Role: "arn:aws:iam::123456789012:role/AdminRole",
+      Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+    }),
+    asDeployer,
+  );
+} catch (error) {
+  console.error("Passing AdminRole to Lambda was refused", error);
+}
+
+await simAws.backgroundTasksComplete();

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -4,7 +4,10 @@ Yulin includes a simulated AWS Lambda service for tests and local development. F
 and invoked in-process and in memory, with no containers and no real AWS infrastructure.
 
 Handlers run with their execution role as the simulated caller, so AWS calls made inside a handler
-are authorized by simulated IAM, as on real Lambda.
+are authorized by simulated IAM, as on real Lambda. Creating a function and changing its role are
+authorized as well, both against `lambda:` actions and against `iam:PassRole` on the execution role
+the request names. See [passing a Role to a service](https://yulinsim.dev/services/iam/#passing-a-role-to-a-service)
+in the IAM docs.
 
 Lambda-specific helpers are imported from the `@kensio/yulin/lambda` subpath. Real `LambdaClient`
 instances can be routed into sim Lambda with
@@ -3495,6 +3498,8 @@ Sim Lambda currently supports:
   event to a simulated SQS queue or SNS topic
 - Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
   with `serveSimAws`
+- `iam:PassRole` authorization of the execution role named by `CreateFunctionCommand` and
+  `UpdateFunctionConfigurationCommand`, with `iam:PassedToService` supplied
 - `AuthType: "AWS_IAM"` Function URLs, authorizing `lambda:InvokeFunctionUrl` against the caller
   resolved from the request, and `lambda:InvokeFunction` as well for a CloudFront origin access
   control

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -510,7 +510,12 @@ no group with nowhere to go.
 
 ## Permissions
 
-Every operation is authorized against the schedule ARN, which carries the group:
+Every operation is authorized against the schedule ARN, which carries the group. A Create or an
+Update also hands Scheduler the `Target.RoleArn` the schedule fires as, and authorizes `iam:PassRole`
+against that Role. See [passing a Role to a service](https://yulinsim.dev/services/iam/#passing-a-role-to-a-service)
+in the IAM docs.
+
+The schedule ARN is what an operation authorizes against:
 
 ```typescript sim-scheduler-iam-policy
 /**
@@ -763,6 +768,7 @@ Resources of the same stack.
 - Creation and modification timestamps from the simulation's clock, and prefix-narrowed,
   state-narrowed, paged listings.
 - IAM authorization against the schedule ARN.
+- `iam:PassRole` authorization of the `Target.RoleArn` a Create or an Update hands over.
 - SDK interception of `SchedulerClient`.
 
 ## Limitations

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -1250,6 +1250,13 @@ rooted at `$`, since the context object is read rather than written.
 `States.UUID` and `States.MathRandom` are left out on purpose. Both answer differently on every call.
 A test asserting on the output of a state machine that used one could only assert on its shape.
 
+## Passing the execution role
+
+A state machine keeps the `roleArn` it is created with and runs every execution as it, so
+`CreateStateMachine` authorizes `iam:PassRole` against that Role as well as `states:CreateStateMachine`
+against the state machine. A caller allowed to create state machines and refused `iam:PassRole` fails
+the creation. See [passing a Role to a service](https://yulinsim.dev/services/iam/#passing-a-role-to-a-service) in the IAM docs.
+
 ## Where this differs from real Step Functions
 
 - **`StartExecution` runs the execution as far as it goes before it answers.** Real Step Functions

--- a/src/service/cloudformation/deploy/sim-cfn-deployment-pass-role.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-deployment-pass-role.iso.test.ts
@@ -1,0 +1,219 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamPolicyDocumentStatement } from "../../iam/policy/sim-iam-policy.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+/**
+ * A Stack declaring a Role and a function that runs as it, which is the shape
+ * a deployment hands a Role over in.
+ */
+const jobStackTemplate = {
+  Resources: {
+    JobRole: {
+      Type: "AWS::IAM::Role",
+      Properties: {
+        RoleName: "JobRole",
+        AssumeRolePolicyDocument: {
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "sts:AssumeRole",
+            Principal: { Service: "lambda.amazonaws.com" },
+          },
+        },
+      },
+    },
+    JobFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        FunctionName: "job-function",
+        Runtime: "nodejs22.x",
+        Handler: "index.handler",
+        Code: { ZipFile: "exports.handler = async () => {};" },
+        Role: { "Fn::GetAtt": ["JobRole", "Arn"] },
+      },
+    },
+  },
+};
+
+describe("a deployment handing a Role to the Resources it creates", () => {
+  it("fails the function a deploy Role may not pass its Role to", async () => {
+    // Given a deploy Role allowed everything except passing a Role, which is
+    // one of the commoner ways a real deployment stops.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await deployRole(simAws, accountId, "deployer", [
+      { Effect: "Allow", Action: "*", Resource: "*" },
+      { Effect: "Deny", Action: "iam:PassRole", Resource: "*" },
+    ]);
+
+    // When it deploys a Stack whose function names a Role.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "analytics-stack",
+        template: jobStackTemplate,
+        caller: deployer,
+      });
+    });
+
+    // Then the function failed on the Role it was handed, naming the deploy
+    // Role that was refused.
+    assertStringIncludes(
+      error.message,
+      `arn:aws:iam::${accountId}:role/deployer is not authorized to ` +
+        `perform: iam:PassRole on resource: ` +
+        `arn:aws:iam::${accountId}:role/JobRole`,
+    );
+
+    const stack = simAws.cloudFormation().getStackByName("analytics-stack");
+    assertNonNullable(stack);
+
+    assertIdentical(stack.getResource("JobRole")?.status, "CREATE_COMPLETE");
+    assertIdentical(stack.getResource("JobFunction")?.status, "CREATE_FAILED");
+    assertUndefined(simAws.lambda().getSimFunctionByName("job-function"));
+  });
+
+  it("deploys as a Role allowed to pass a Role to Lambda", async () => {
+    // Given a deploy Role whose PassRole statement is conditioned on the
+    // service the Role goes to, as a CDK-generated one commonly is.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await deployRole(simAws, accountId, "deployer", [
+      { Effect: "Allow", Action: ["iam:*", "lambda:*"], Resource: "*" },
+      {
+        Effect: "Allow",
+        Action: "iam:PassRole",
+        Resource: "*",
+        Condition: {
+          StringEquals: { "iam:PassedToService": "lambda.amazonaws.com" },
+        },
+      },
+    ]);
+
+    // When it deploys the same Stack.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: jobStackTemplate,
+      caller: deployer,
+    });
+
+    // Then the condition matched and the function was created.
+    assertIdentical(
+      stack.getResource("JobFunction")?.status,
+      "CREATE_COMPLETE",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("fails a state machine on the Role its Stack hands Step Functions", async () => {
+    // Given a deploy Role allowed everything except passing a Role, and a
+    // Stack declaring a Resource of another service that keeps one.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await deployRole(simAws, accountId, "deployer", [
+      { Effect: "Allow", Action: "*", Resource: "*" },
+      { Effect: "Deny", Action: "iam:PassRole", Resource: "*" },
+    ]);
+
+    // When it deploys the Stack.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "enrolment-stack",
+        template: {
+          Resources: {
+            Workflow: {
+              Type: "AWS::StepFunctions::StateMachine",
+              Properties: {
+                StateMachineName: "Enrolment",
+                RoleArn: `arn:aws:iam::${accountId}:role/WorkflowRole`,
+                DefinitionString: JSON.stringify({
+                  StartAt: "Done",
+                  States: { Done: { Type: "Succeed" } },
+                }),
+              },
+            },
+          },
+        },
+        caller: deployer,
+      });
+    });
+
+    // Then the same decision reached it, so the deployment stops wherever a
+    // Role is handed over rather than at Lambda alone.
+    assertStringIncludes(
+      error.message,
+      `iam:PassRole on resource: arn:aws:iam::${accountId}:role/WorkflowRole`,
+    );
+    assertUndefined(simAws.stepFunctions().findStateMachine("Enrolment"));
+  });
+
+  it("leaves a deployment naming no caller as it was", async () => {
+    // Given a simulation with no deploy Role in it.
+    const simAws = new SimAws({ defaultAccountId: makeSimAwsAccountId() });
+
+    // When the same Stack is deployed without naming a principal.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: jobStackTemplate,
+    });
+
+    // Then the root passed the Role, as it did before there was anything to
+    // ask.
+    assertIdentical(
+      stack.getResource("JobFunction")?.status,
+      "CREATE_COMPLETE",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});
+
+/**
+ * A Role a deployment can run as, carrying the statements it is given.
+ */
+async function deployRole(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  roleName: string,
+  statements: readonly SimIamPolicyDocumentStatement[],
+): Promise<SimAwsCaller> {
+  const iam = simAws.account(accountId).iam();
+
+  await iam.createRole({
+    input: {
+      RoleName: roleName,
+      AssumeRolePolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "sts:AssumeRole",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+        },
+      }),
+    },
+  });
+
+  await iam.putRolePolicy({
+    input: {
+      RoleName: roleName,
+      PolicyName: `${roleName}-policy`,
+      PolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: statements,
+      }),
+    },
+  });
+
+  return { kind: "arn", arn: `arn:aws:iam::${accountId}:role/${roleName}` };
+}

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -361,6 +361,11 @@ command instances.
   resource type at all, and gives `CreateCluster`, `ListClusters` and `ListTasks` none either. A
   policy naming a task definition ARN grants none of those, here as on AWS.
 
+`RegisterTaskDefinition` asks a second question through the shared `SimIamPassRoleAuthorizer`,
+whether the caller may hand ECS the `taskRoleArn` and the `executionRoleArn` the registration names.
+Each is its own decision, and one left out passes nothing. The refusal is ECS's own
+`AccessDeniedException`, keeping the rule above.
+
 ## CloudFormation
 
 `cfn/` holds what deploys `AWS::ECS::Cluster`, `AWS::ECS::TaskDefinition` and `AWS::ECS::Service`,

--- a/src/service/ecs/command/authorize/sim-ecs-authorizer.ts
+++ b/src/service/ecs/command/authorize/sim-ecs-authorizer.ts
@@ -1,7 +1,12 @@
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import {
+  SimIamPassRoleAuthorizer,
+  simIamPassRoleDenialMessage,
+} from "../../../iam/authorize/pass-role/sim-iam-pass-role-authorizer.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
 import { SimEcsAccessDeniedException } from "../../error/sim-ecs.error.js";
+import { simEcsTasksServicePrincipal } from "../../sim-ecs-service-principal.js";
 import type { SimEcsRequestOptions } from "../sim-ecs-request-options.js";
 
 /**
@@ -33,13 +38,37 @@ interface SimEcsAuthorizerProperties {
  * A denial is reported as ECS's own AccessDeniedException rather than the
  * shared IAM error, because that is the error a real ECS caller would have to
  * handle.
+ *
+ * A registration carrying a `taskRoleArn` or an `executionRoleArn` hands ECS
+ * Roles it runs the task as later, and each one is authorized as
+ * `iam:PassRole` against the Role itself.
  */
 export class SimEcsAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly callerIdentifier = new SimIamCallerIdentifier();
+  private readonly passRole: SimIamPassRoleAuthorizer;
 
   constructor(properties: SimEcsAuthorizerProperties) {
     this.iam = properties.iam;
+    this.passRole = new SimIamPassRoleAuthorizer({
+      iam: properties.iam,
+      passedToService: simEcsTasksServicePrincipal,
+      denied: (denial): Error =>
+        new SimEcsAccessDeniedException(simIamPassRoleDenialMessage(denial)),
+    });
+  }
+
+  /**
+   * Ensure the caller may hand ECS every Role a task definition names.
+   *
+   * Both Roles are optional on a registration, and one left out passes
+   * nothing.
+   */
+  authorizePassRole(
+    roleArns: readonly (string | undefined)[],
+    options?: SimEcsRequestOptions,
+  ): void {
+    this.passRole.authorizeAll(roleArns, options?.caller);
   }
 
   /**

--- a/src/service/ecs/command/register-task-definition/register-task-definition-pass-role.iso.test.ts
+++ b/src/service/ecs/command/register-task-definition/register-task-definition-pass-role.iso.test.ts
@@ -1,0 +1,155 @@
+import {
+  ListTaskDefinitionsCommand,
+  RegisterTaskDefinitionCommand,
+} from "@aws-sdk/client-ecs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { SimEcsAccessDeniedException } from "../../error/sim-ecs.error.js";
+
+const taskRoleArn = "arn:aws:iam::888888888888:role/CheckoutTaskRole";
+
+const executionRoleArn = "arn:aws:iam::888888888888:role/CheckoutExecutionRole";
+
+/**
+ * A registration naming both of the Roles a task definition can carry.
+ */
+function registration(): ConstructorParameters<
+  typeof RegisterTaskDefinitionCommand
+>[0] {
+  return {
+    family: "checkout",
+    containerDefinitions: [{ name: "app", image: "checkout:1" }],
+    taskRoleArn,
+    executionRoleArn,
+  };
+}
+
+/**
+ * A Role allowed to register task definitions and nothing else.
+ */
+async function registrarIn(simAws: SimAws): Promise<string> {
+  const role = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "Registrar",
+      policyName: "RegisterTaskDefinitions",
+      actions: ["ecs:RegisterTaskDefinition"],
+    },
+    simAws,
+  );
+
+  return role.Arn;
+}
+
+describe("passing Roles to ECS RegisterTaskDefinition", () => {
+  it("refuses a caller that may register and may not pass the task role", async () => {
+    // Given a Role allowed to register task definitions and nothing else.
+    const simAws = new SimAws();
+    const registrar = await registrarIn(simAws);
+
+    // When it registers a task definition naming both Roles.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .registerTaskDefinition(
+          new RegisterTaskDefinitionCommand(registration()),
+          {
+            caller: { kind: "arn", arn: registrar },
+          },
+        ),
+    );
+
+    // Then ECS reports its own AccessDeniedException about the task role,
+    // which is the first of the two the request hands over.
+    assertInstanceOf(error, SimEcsAccessDeniedException);
+    assertStringIncludes(error.message, "iam:PassRole");
+    assertStringIncludes(error.message, taskRoleArn);
+    assertStringIncludes(error.message, registrar);
+    const listed = await simAws
+      .ecs()
+      .listTaskDefinitions(new ListTaskDefinitionsCommand({}));
+
+    assertArrayLength(listed.taskDefinitionArns, 0);
+  });
+
+  it("refuses a caller allowed only one of the two Roles", async () => {
+    // Given a Role allowed the task role and not the execution role.
+    const simAws = new SimAws();
+    const registrar = await registrarIn(simAws);
+
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: "Registrar",
+        PolicyName: "PassTaskRole",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "iam:PassRole", Resource: taskRoleArn },
+        }),
+      },
+    });
+
+    // When it registers the same task definition.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .ecs()
+        .registerTaskDefinition(
+          new RegisterTaskDefinitionCommand(registration()),
+          {
+            caller: { kind: "arn", arn: registrar },
+          },
+        ),
+    );
+
+    // Then the execution role is what stopped it. Each Role is its own
+    // decision.
+    assertStringIncludes(error.message, executionRoleArn);
+  });
+
+  it("registers for a caller allowed to pass both Roles to ECS", async () => {
+    // Given a Role allowed to pass a Role to an ECS task.
+    const simAws = new SimAws();
+    const registrar = await registrarIn(simAws);
+
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: "Registrar",
+        PolicyName: "PassTaskRoles",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "iam:PassRole",
+            Resource: "*",
+            Condition: {
+              StringEquals: {
+                "iam:PassedToService": "ecs-tasks.amazonaws.com",
+              },
+            },
+          },
+        }),
+      },
+    });
+
+    // When it registers the task definition.
+    const registered = await simAws
+      .ecs()
+      .registerTaskDefinition(
+        new RegisterTaskDefinitionCommand(registration()),
+        {
+          caller: { kind: "arn", arn: registrar },
+        },
+      );
+
+    // Then the condition matched and the revision carries both Roles.
+    assertIdentical(registered.taskDefinition?.taskRoleArn, taskRoleArn);
+    assertIdentical(
+      registered.taskDefinition.executionRoleArn,
+      executionRoleArn,
+    );
+  });
+});

--- a/src/service/ecs/command/register-task-definition/register-task-definition.handler.ts
+++ b/src/service/ecs/command/register-task-definition/register-task-definition.handler.ts
@@ -84,6 +84,10 @@ export class RegisterTaskDefinitionCommandHandler
       "ecs:RegisterTaskDefinition",
       options,
     );
+    this.authorizer.authorizePassRole(
+      [settings.taskRoleArn, settings.executionRoleArn],
+      options,
+    );
 
     const familyRevisions = this.taskDefinitions.family(family);
     const revision = familyRevisions.nextRevisionNumber();

--- a/src/service/ecs/sim-ecs-service-principal.ts
+++ b/src/service/ecs/sim-ecs-service-principal.ts
@@ -1,0 +1,8 @@
+/**
+ * The service principal ECS holds a task's Roles as.
+ *
+ * A task role and a task execution role are both trusted by this principal,
+ * and it is what `iam:PassedToService` carries when a task definition is
+ * registered.
+ */
+export const simEcsTasksServicePrincipal = "ecs-tasks.amazonaws.com";

--- a/src/service/eventbridge/README.md
+++ b/src/service/eventbridge/README.md
@@ -94,6 +94,11 @@ types, and a handler class beside it.
 ListEventBuses goes through it, and it authorizes before looking the bus up, so a caller with no
 permission is refused for a bus that does not exist rather than told the bus is missing.
 
+`PutTargets` asks a second question through the shared `SimIamPassRoleAuthorizer`, whether the
+caller may hand EventBridge the `RoleArn` a target carries. An ECS target is the only one a `RoleArn`
+is read from, since a `RoleArn` on any other target is refused as unsimulated. The refusal is
+EventBridge's own `AccessDeniedException`.
+
 `SimEventBridgePutEvents` is the one with real behaviour in it, and most of that behaviour is about
 what fails and how:
 

--- a/src/service/eventbridge/command/authorize/sim-event-bridge-authorizer.ts
+++ b/src/service/eventbridge/command/authorize/sim-event-bridge-authorizer.ts
@@ -1,6 +1,11 @@
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import {
+  SimIamPassRoleAuthorizer,
+  simIamPassRoleDenialMessage,
+} from "../../../iam/authorize/pass-role/sim-iam-pass-role-authorizer.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
+import { simEventBridgeServicePrincipal } from "../../delivery/sim-event-bridge-delivery.js";
 import { SimEventBridgeAccessDeniedException } from "../../error/sim-event-bridge.error.js";
 import type { SimEventBridgeRequestOptions } from "../sim-event-bridge-request-options.js";
 
@@ -29,6 +34,11 @@ interface SimEventBridgeAuthorizerProperties {
  * answers a refused request with. It has no error of its own for the case, so
  * there is nothing service-specific to translate to.
  *
+ * A target carrying a `RoleArn` hands EventBridge a Role it runs the target
+ * as later, and that is authorized as `iam:PassRole` against the Role. An ECS
+ * target is the only one this simulation reads a `RoleArn` from, since a
+ * `RoleArn` on any other target is refused.
+ *
  * Event bus resource policies are not part of the decision yet, because
  * nothing sets one: PutPermission and the bus `Policy` attribute are not
  * simulated. A caller from another Account therefore has no way to be admitted
@@ -37,9 +47,30 @@ interface SimEventBridgeAuthorizerProperties {
 export class SimEventBridgeAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly callerIdentifier = new SimIamCallerIdentifier();
+  private readonly passRole: SimIamPassRoleAuthorizer;
 
   constructor(properties: SimEventBridgeAuthorizerProperties) {
     this.iam = properties.iam;
+    this.passRole = new SimIamPassRoleAuthorizer({
+      iam: properties.iam,
+      passedToService: simEventBridgeServicePrincipal,
+      denied: (denial): Error =>
+        new SimEventBridgeAccessDeniedException(
+          simIamPassRoleDenialMessage(denial),
+        ),
+    });
+  }
+
+  /**
+   * Ensure the caller may hand EventBridge every Role a request names.
+   *
+   * A target with no Role of its own passes nothing.
+   */
+  authorizePassRole(
+    roleArns: readonly (string | undefined)[],
+    options?: SimEventBridgeRequestOptions,
+  ): void {
+    this.passRole.authorizeAll(roleArns, options?.caller);
   }
 
   /**

--- a/src/service/eventbridge/command/rule/sim-event-bridge-rule-access.ts
+++ b/src/service/eventbridge/command/rule/sim-event-bridge-rule-access.ts
@@ -23,6 +23,13 @@ interface SimEventBridgeRuleAccessProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
 }
 
+/**
+ * The part of a target that names a Role.
+ */
+interface SimEventBridgeTargetRole {
+  readonly RoleArn?: string | undefined;
+}
+
 interface SimEventBridgeRuleRequest {
   readonly Name?: string | undefined;
   readonly EventBusName?: string | undefined;
@@ -71,6 +78,22 @@ export class SimEventBridgeRuleAccess {
     options?: SimEventBridgeRequestOptions,
   ): void {
     this.authorizer.authorizeBus(action, this.arnFor(requested), options);
+  }
+
+  /**
+   * Ensure the caller may hand EventBridge every Role a request names.
+   *
+   * A rule runs its targets as the Role each one carries, long after the
+   * request that put them there, so adding one is a hand-over of that Role.
+   */
+  authorizePassRole(
+    targets: readonly SimEventBridgeTargetRole[],
+    options?: SimEventBridgeRequestOptions,
+  ): void {
+    this.authorizer.authorizePassRole(
+      targets.map((target) => target.RoleArn),
+      options,
+    );
   }
 
   /**

--- a/src/service/eventbridge/command/target/sim-event-bridge-pass-role.iso.test.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-pass-role.iso.test.ts
@@ -1,0 +1,128 @@
+import {
+  ListTargetsByRuleCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+  type Target,
+} from "@aws-sdk/client-eventbridge";
+import {
+  assertArrayLength,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { SimEventBridgeAccessDeniedException } from "../../error/sim-event-bridge.error.js";
+
+const clusterArn = "arn:aws:ecs:us-east-1:888888888888:cluster/orders";
+
+const eventsRoleArn = "arn:aws:iam::888888888888:role/EventsRole";
+
+const orderPattern = JSON.stringify({ source: ["orders.service"] });
+
+/**
+ * The ECS target these tests add, which is the one kind of target this
+ * simulation reads a `RoleArn` from.
+ */
+const importTarget: Target = {
+  Id: "import",
+  Arn: clusterArn,
+  RoleArn: eventsRoleArn,
+  EcsParameters: { TaskDefinitionArn: "nightly", TaskCount: 1 },
+};
+
+/**
+ * A simulation holding a rule, and a Role allowed to put targets on it.
+ */
+async function simulationWithRule(): Promise<{
+  simAws: SimAws;
+  wirerArn: string;
+}> {
+  const simAws = new SimAws();
+
+  await simAws
+    .eventBridge()
+    .putRule(
+      new PutRuleCommand({ Name: "orders", EventPattern: orderPattern }),
+    );
+
+  const wirer = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "Wirer",
+      policyName: "WireTargets",
+      actions: ["events:PutTargets"],
+    },
+    simAws,
+  );
+
+  return { simAws, wirerArn: wirer.Arn };
+}
+
+describe("passing a target role to EventBridge PutTargets", () => {
+  it("refuses a caller that may add targets and may not pass the role", async () => {
+    // Given a Role allowed to add targets and nothing else.
+    const { simAws, wirerArn } = await simulationWithRule();
+
+    // When it adds a target carrying a role.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .eventBridge()
+        .putTargets(
+          new PutTargetsCommand({ Rule: "orders", Targets: [importTarget] }),
+          { caller: { kind: "arn", arn: wirerArn } },
+        ),
+    );
+
+    // Then EventBridge reports its own AccessDeniedException about the role
+    // the rule would have run the target as.
+    assertInstanceOf(error, SimEventBridgeAccessDeniedException);
+    assertStringIncludes(error.message, "iam:PassRole");
+    assertStringIncludes(error.message, eventsRoleArn);
+    assertStringIncludes(error.message, wirerArn);
+
+    // And no target was added.
+    const listed = await simAws
+      .eventBridge()
+      .listTargetsByRule(new ListTargetsByRuleCommand({ Rule: "orders" }));
+
+    assertArrayLength(listed.Targets, 0);
+  });
+
+  it("adds the target for a caller allowed to pass a role to EventBridge", async () => {
+    // Given the same Role, also allowed to pass a role to events.
+    const { simAws, wirerArn } = await simulationWithRule();
+
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: "Wirer",
+        PolicyName: "PassEventsRole",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "iam:PassRole",
+            Resource: eventsRoleArn,
+            Condition: {
+              StringEquals: { "iam:PassedToService": "events.amazonaws.com" },
+            },
+          },
+        }),
+      },
+    });
+
+    // When it adds the target.
+    await simAws
+      .eventBridge()
+      .putTargets(
+        new PutTargetsCommand({ Rule: "orders", Targets: [importTarget] }),
+        { caller: { kind: "arn", arn: wirerArn } },
+      );
+
+    // Then the condition matched and the rule holds the target.
+    const listed = await simAws
+      .eventBridge()
+      .listTargetsByRule(new ListTargetsByRuleCommand({ Rule: "orders" }));
+
+    assertArrayLength(listed.Targets, 1);
+  });
+});

--- a/src/service/eventbridge/command/target/sim-event-bridge-put-targets.ts
+++ b/src/service/eventbridge/command/target/sim-event-bridge-put-targets.ts
@@ -63,6 +63,8 @@ export class SimEventBridgePutTargets {
       refuseUnsimulatedTargetInput(target);
     }
 
+    this.access.authorizePassRole(requested, options);
+
     const added = requested.map((target) => SimEventTarget.of(target));
 
     refuseRepeatedTargetIds(added);

--- a/src/service/firehose/README.md
+++ b/src/service/firehose/README.md
@@ -135,6 +135,11 @@ stream's ARN and then looks the delivery stream up, in that order, because that 
 IAM works in. A caller with no permission is refused for a delivery stream that was never created,
 and hears the same refusal either way.
 
+`CreateDeliveryStream` asks a second question through the shared `SimIamPassRoleAuthorizer`, whether
+the caller may hand Firehose the destination `RoleARN` and, for a Kinesis-sourced delivery stream,
+the source `RoleARN`. Both are read before the question is asked, so a configuration this simulation
+cannot deliver to is refused on its own terms rather than on a Role.
+
 Every Firehose operation names its delivery stream by name, and nothing here reads an ARN back.
 Compare `simKinesisRefLookupName`. It exists because a Kinesis request can name its stream either
 way.

--- a/src/service/firehose/command/authorize/sim-firehose-authorizer.ts
+++ b/src/service/firehose/command/authorize/sim-firehose-authorizer.ts
@@ -1,7 +1,9 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import { SimIamPassRoleAuthorizer } from "../../../iam/authorize/pass-role/sim-iam-pass-role-authorizer.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simFirehoseServicePrincipal } from "../../sim-firehose-service-principal.js";
 
 interface SimFirehoseAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -14,12 +16,34 @@ interface SimFirehoseAuthorizerProperties {
  * name, and the resource is the ARN of the delivery stream the operation names.
  * ListDeliveryStreams is the exception. It names no delivery stream, so it
  * authorizes against `*`.
+ *
+ * A delivery stream carries a Role for its destination, and a second one for
+ * its source where it reads a Kinesis stream. Firehose keeps both and delivers
+ * as them later, so creating one authorizes `iam:PassRole` against each.
  */
 export class SimFirehoseAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
+  private readonly passRole: SimIamPassRoleAuthorizer;
 
   constructor(properties: SimFirehoseAuthorizerProperties) {
     this.iam = properties.iam;
+    this.passRole = new SimIamPassRoleAuthorizer({
+      iam: properties.iam,
+      passedToService: simFirehoseServicePrincipal,
+    });
+  }
+
+  /**
+   * Ensure the caller may hand Firehose every Role a delivery stream names.
+   *
+   * A delivery stream taking records through PutRecord has no source Role, and
+   * one left out passes nothing.
+   */
+  authorizePassRole(
+    roleArns: readonly (string | undefined)[],
+    caller?: SimAwsCaller,
+  ): void {
+    this.passRole.authorizeAll(roleArns, caller);
   }
 
   /**

--- a/src/service/firehose/command/authorize/sim-firehose-iam.iso.test.ts
+++ b/src/service/firehose/command/authorize/sim-firehose-iam.iso.test.ts
@@ -19,6 +19,7 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
 import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
 import { simFirehoseDeliveryStreamFactory } from "../../stream/sim-firehose-delivery-stream.factory.js";
 
@@ -222,6 +223,21 @@ describe("Simulated Firehose IAM authorization", () => {
       BucketARN: "arn:aws:s3:::order-archive",
       RoleARN: "arn:aws:iam::888888888888:role/OrderArchiveRole",
     };
+
+    // And allowed to hand Firehose the Role the destination names, which is a
+    // separate decision from creating the delivery stream.
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: "OrderAdminRole",
+        PolicyName: "PassArchiveRole",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "iam:PassRole",
+            Resource: destination.RoleARN,
+          },
+        }),
+      },
+    });
 
     // When it creates that one, and then another.
     await simAws.firehose().createDeliveryStream(

--- a/src/service/firehose/command/sim-firehose-delivery-stream-access.ts
+++ b/src/service/firehose/command/sim-firehose-delivery-stream-access.ts
@@ -66,6 +66,16 @@ export class SimFirehoseDeliveryStreamAccess {
   }
 
   /**
+   * Ensure the caller may hand Firehose every Role a request names.
+   */
+  authorizePassRole(
+    roleArns: readonly (string | undefined)[],
+    options?: SimFirehoseRequestOptions,
+  ): void {
+    this.authorizer.authorizePassRole(roleArns, options?.caller);
+  }
+
+  /**
    * Resolve the delivery stream a request names, authorizing the action first.
    */
   require(

--- a/src/service/firehose/command/stream/sim-firehose-create-delivery-stream.ts
+++ b/src/service/firehose/command/stream/sim-firehose-create-delivery-stream.ts
@@ -70,11 +70,18 @@ export class SimFirehoseCreateDeliveryStream {
 
     const createdAt = this.background.now();
     const source = simFirehoseSourceOf(input, this.scope, createdAt);
+    const destination = simFirehoseDestinationOf(input);
+
+    this.access.authorizePassRole(
+      [destination.roleArn, source.roleArn],
+      options,
+    );
+
     const arn = simFirehoseDeliveryStreamArn(this.scope, name);
     const deliveryStream = new SimFirehoseDeliveryStream({
       name,
       arn,
-      destination: simFirehoseDestinationOf(input),
+      destination,
       source,
       createdAt,
     });

--- a/src/service/firehose/command/stream/sim-firehose-pass-role.iso.test.ts
+++ b/src/service/firehose/command/stream/sim-firehose-pass-role.iso.test.ts
@@ -1,0 +1,105 @@
+import { CreateDeliveryStreamCommand } from "@aws-sdk/client-firehose";
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+
+const deliveryRoleArn = "arn:aws:iam::888888888888:role/OrderArchiveRole";
+
+const destination = {
+  BucketARN: "arn:aws:s3:::order-archive",
+  RoleARN: deliveryRoleArn,
+};
+
+/**
+ * A simulation holding the destination Bucket, and a Role allowed to create
+ * delivery streams and nothing else.
+ */
+async function simulationWithCreator(): Promise<{
+  simAws: SimAws;
+  creatorArn: string;
+}> {
+  const simAws = new SimAws();
+
+  await simAws
+    .s3()
+    .createBucket(new CreateBucketCommand({ Bucket: "order-archive" }));
+
+  const creator = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "Creator",
+      policyName: "CreateDeliveryStreams",
+      actions: ["firehose:CreateDeliveryStream"],
+    },
+    simAws,
+  );
+
+  return { simAws, creatorArn: creator.Arn };
+}
+
+describe("passing a delivery role to Firehose CreateDeliveryStream", () => {
+  it("refuses a caller that may create and may not pass the role", async () => {
+    // Given a Role allowed to create delivery streams and nothing else.
+    const { simAws, creatorArn } = await simulationWithCreator();
+
+    // When it creates one naming the Role Firehose delivers as.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.firehose().createDeliveryStream(
+        new CreateDeliveryStreamCommand({
+          DeliveryStreamName: "order-events",
+          ExtendedS3DestinationConfiguration: destination,
+        }),
+        { caller: { kind: "arn", arn: creatorArn } },
+      ),
+    );
+
+    // Then the refusal is about the Role rather than the delivery stream.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "iam:PassRole");
+    assertIdentical(error.resource, deliveryRoleArn);
+    assertStringIncludes(error.message, creatorArn);
+    assertUndefined(simAws.firehose().findDeliveryStream("order-events"));
+  });
+
+  it("creates for a caller allowed to pass a role to Firehose", async () => {
+    // Given the same Role, also allowed to pass a role to firehose.
+    const { simAws, creatorArn } = await simulationWithCreator();
+
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: "Creator",
+        PolicyName: "PassDeliveryRole",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "iam:PassRole",
+            Resource: deliveryRoleArn,
+            Condition: {
+              StringEquals: { "iam:PassedToService": "firehose.amazonaws.com" },
+            },
+          },
+        }),
+      },
+    });
+
+    // When it creates the delivery stream.
+    const created = await simAws.firehose().createDeliveryStream(
+      new CreateDeliveryStreamCommand({
+        DeliveryStreamName: "order-events",
+        ExtendedS3DestinationConfiguration: destination,
+      }),
+      { caller: { kind: "arn", arn: creatorArn } },
+    );
+
+    // Then the condition matched and the delivery stream is there.
+    assertStringIncludes(created.DeliveryStreamARN, "order-events");
+  });
+});

--- a/src/service/firehose/sim-firehose-service-principal.ts
+++ b/src/service/firehose/sim-firehose-service-principal.ts
@@ -1,0 +1,8 @@
+/**
+ * The service principal Firehose reads and delivers as.
+ *
+ * A delivery stream's destination Role and its source Role are both trusted by
+ * this principal, and it is what `iam:PassedToService` carries when a delivery
+ * stream is created.
+ */
+export const simFirehoseServicePrincipal = "firehose.amazonaws.com";

--- a/src/service/firehose/source/sim-firehose-source.ts
+++ b/src/service/firehose/source/sim-firehose-source.ts
@@ -21,6 +21,12 @@ export class SimFirehoseDirectPutSource {
   public readonly deliveryStreamType = "DirectPut" as const;
 
   /**
+   * The Role reading is done as, which a delivery stream taking puts has none
+   * of. It reads nothing, so there is nothing for a Role to read it as.
+   */
+  public readonly roleArn = undefined;
+
+  /**
    * Take a put, which is where this delivery stream's records come from.
    */
   requirePut(): void {

--- a/src/service/iam/authorize/pass-role/sim-iam-pass-role-authorizer.ts
+++ b/src/service/iam/authorize/pass-role/sim-iam-pass-role-authorizer.ts
@@ -1,0 +1,149 @@
+import type {
+  SimAwsCaller,
+  SimAwsPrincipal,
+} from "../../../aws/caller/sim-aws-caller.js";
+import { SimIamCallerIdentifier } from "../../error/sim-iam-caller-identifier.js";
+import { SimIamAccessDenied } from "../../error/sim-iam.error.js";
+import type { SimIamInterServiceAuthZ } from "../sim-iam-inter-service-auth-z.js";
+
+/**
+ * The IAM action a caller handing a Role to a service is authorized for.
+ */
+const passRoleAction = "iam:PassRole";
+
+/**
+ * The condition key naming the service the Role is being handed to.
+ */
+const passedToServiceKey = "iam:PassedToService";
+
+/**
+ * What a service needs to report a Role the caller may not pass.
+ */
+export interface SimIamPassRoleDenial {
+  readonly principal: SimAwsPrincipal;
+  readonly roleArn: string;
+
+  /**
+   * What else the message should say about why the request was denied, in the
+   * sense SimIamAccessDenied uses it.
+   */
+  readonly reason?: string | undefined;
+}
+
+interface SimIamPassRoleAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+
+  /**
+   * The service principal the Role is being handed to, such as
+   * `lambda.amazonaws.com`. This is what `iam:PassedToService` carries.
+   */
+  readonly passedToService: string;
+
+  /**
+   * The error a refusal is reported as.
+   *
+   * Defaults to the shared IAM AccessDenied. A service reporting its own
+   * denials as its own error type supplies one, so a caller catching that type
+   * catches a refused Role along with everything else the service refused
+   * them.
+   */
+  readonly denied?: (denial: SimIamPassRoleDenial) => Error;
+}
+
+/**
+ * Authorizes handing a Role to a simulated service.
+ *
+ * A service given a Role to keep uses it under its own identity later, so
+ * being allowed to create the thing settles only half of the request. AWS asks
+ * separately whether the caller may hand that Role over, and the resource of
+ * that question is the Role. A scoped deployment role refused `iam:PassRole` is
+ * one of the commoner ways a real deployment stops.
+ *
+ * The Role need not exist. Real IAM decides a request before the service
+ * handles it, so a caller with no permission to pass a Role is refused whether
+ * or not the ARN names one.
+ */
+export class SimIamPassRoleAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+  private readonly passedToService: string;
+  private readonly denied: (denial: SimIamPassRoleDenial) => Error;
+
+  constructor(properties: SimIamPassRoleAuthorizerProperties) {
+    this.iam = properties.iam;
+    this.passedToService = properties.passedToService;
+    this.denied = properties.denied ?? accessDenied;
+  }
+
+  /**
+   * Ensure the caller may hand this Role to the service.
+   *
+   * A request naming no Role passes nothing and is left alone. That covers an
+   * optional Role, such as the one an update request omits to keep the Role
+   * already in place, and saves each call site repeating the check.
+   */
+  authorize(roleArn: string | undefined, caller?: SimAwsCaller): void {
+    if (roleArn === undefined) {
+      return;
+    }
+
+    const decision = this.iam.authorize({
+      action: passRoleAction,
+      resource: roleArn,
+      conditionContext: { [passedToServiceKey]: this.passedToService },
+      caller,
+    });
+
+    if (decision.isDenied) {
+      throw this.denied({
+        principal: decision.caller.principal,
+        roleArn,
+        reason: decision.denialReason,
+      });
+    }
+  }
+
+  /**
+   * Ensure the caller may hand every one of these Roles to the service.
+   *
+   * A Firehose delivery stream carrying a Role for its destination beside one
+   * for its source is what this is for. Each Role is its own question, and the
+   * first refusal is the one reported.
+   */
+  authorizeAll(
+    roleArns: readonly (string | undefined)[],
+    caller?: SimAwsCaller,
+  ): void {
+    for (const roleArn of roleArns) {
+      this.authorize(roleArn, caller);
+    }
+  }
+}
+
+/**
+ * Report a refused Role as the shared IAM AccessDenied.
+ */
+function accessDenied(denial: SimIamPassRoleDenial): Error {
+  return new SimIamAccessDenied({
+    principal: denial.principal,
+    reason: denial.reason,
+    action: passRoleAction,
+    resource: denial.roleArn,
+  });
+}
+
+/**
+ * The message a service reports a refused Role with, in AWS's wording.
+ *
+ * A service reporting denials as its own error type builds its message from
+ * this, so a refused Role reads the same however it is reported.
+ */
+export function simIamPassRoleDenialMessage(
+  denial: SimIamPassRoleDenial,
+): string {
+  const identifier = new SimIamCallerIdentifier().format(denial.principal);
+
+  return (
+    `User: ${identifier} is not authorized to perform: ${passRoleAction} on ` +
+    `resource: ${denial.roleArn}`
+  );
+}

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -663,6 +663,12 @@ account-scoped simulated IAM implementation when constructed through `SimAws`
 direct standalone construction. The Function URL commands share one `FunctionUrlAuthorizer` taking
 the action as a constructor value, since only the action name varies between them.
 
+`CreateFunction` and `UpdateFunctionConfiguration` ask a second question through the shared
+`SimIamPassRoleAuthorizer`, whether the caller may hand Lambda the execution role the request names.
+The resource there is the Role, and `iam:PassedToService` carries `lambda.amazonaws.com`. The
+`lambda:` action is decided first, so a caller refused both is told about the one real Lambda tells
+them about first. An update leaving `Role` out passes nothing and asks nothing.
+
 `command/authorize/sim-lambda-service-invoke-authorizer.ts` answers the other question: whether
 another simulated service may invoke a function. The caller is a service principal, which owns no
 identity policies, so the function's resource policy is the whole decision. The calling service

--- a/src/service/lambda/command/create-function/create-function-authorizer.ts
+++ b/src/service/lambda/command/create-function/create-function-authorizer.ts
@@ -1,6 +1,8 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimIamPassRoleAuthorizer } from "../../../iam/authorize/pass-role/sim-iam-pass-role-authorizer.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simLambdaServicePrincipal } from "../../sim-lambda-service-principal.js";
 
 interface CreateFunctionAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -11,24 +13,35 @@ interface CreateFunctionAuthorizerProperties {
  *
  * AWS maps the CreateFunction API operation to the lambda:CreateFunction IAM
  * action. The resource is the function ARN being created.
+ *
+ * The execution role is a second question. Lambda keeps that Role and runs the
+ * function as it later, so the caller is asked whether they may hand it over,
+ * against the Role rather than the function. The create action is decided
+ * first, which is the order the two answers come in on real AWS.
  */
 export class CreateFunctionAuthorizer {
   private static readonly action = "lambda:CreateFunction";
 
   private readonly iam: SimIamInterServiceAuthZ;
+  private readonly passRole: SimIamPassRoleAuthorizer;
 
   constructor(properties: CreateFunctionAuthorizerProperties) {
     this.iam = properties.iam;
+    this.passRole = new SimIamPassRoleAuthorizer({
+      iam: properties.iam,
+      passedToService: simLambdaServicePrincipal,
+    });
   }
 
   /**
-   * Ensure the caller may create a Lambda function with the given ARN.
+   * Ensure the caller may create a Lambda function with the given ARN, and may
+   * hand Lambda the execution role it names.
    *
    * The caller is passed through unchanged so sim IAM can distinguish an
    * omitted caller, which defaults to Account root, from an explicit anonymous
    * caller.
    */
-  authorize(functionArn: string, caller?: SimAwsCaller): void {
+  authorize(functionArn: string, roleArn: string, caller?: SimAwsCaller): void {
     const decision = this.iam.authorize({
       action: CreateFunctionAuthorizer.action,
       resource: functionArn,
@@ -43,5 +56,7 @@ export class CreateFunctionAuthorizer {
         resource: functionArn,
       });
     }
+
+    this.passRole.authorize(roleArn, caller);
   }
 }

--- a/src/service/lambda/command/create-function/create-function-iam.iso.test.ts
+++ b/src/service/lambda/command/create-function/create-function-iam.iso.test.ts
@@ -35,7 +35,8 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
   });
 
   it("allows a Role when its policy permits lambda:CreateFunction", async () => {
-    // Given a Role allowed to create a specific Lambda function.
+    // Given a Role allowed to create a specific Lambda function, and to pass
+    // the execution role that function will run as.
     const accountId = makeSimAwsAccountId();
     const simAws = new SimAws({ defaultAccountId: accountId });
     const simIam = simAws.iam();
@@ -57,12 +58,20 @@ describe("Lambda CreateFunctionCommand IAM authorization", () => {
         RoleName: "FunctionCreator",
         PolicyName: "CreateFunctionPolicy",
         PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Action: "lambda:CreateFunction",
-            Resource:
-              `arn:aws:lambda:${simAws.defaultRegionName}:` +
-              `${accountId}:function:allowed-function`,
-          },
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: "lambda:CreateFunction",
+              Resource:
+                `arn:aws:lambda:${simAws.defaultRegionName}:` +
+                `${accountId}:function:allowed-function`,
+            },
+            {
+              Effect: "Allow",
+              Action: "iam:PassRole",
+              Resource: `arn:aws:iam::${accountId}:role/ExecutionRole`,
+            },
+          ],
         }),
       }),
     );

--- a/src/service/lambda/command/create-function/create-function-pass-role.iso.test.ts
+++ b/src/service/lambda/command/create-function/create-function-pass-role.iso.test.ts
@@ -1,0 +1,205 @@
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import type { SimIamPolicyDocumentStatement } from "../../../iam/policy/sim-iam-policy.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+
+describe("passing an execution role to Lambda CreateFunction", () => {
+  it("refuses a caller denied iam:PassRole on the role it names", async () => {
+    // Given a Role allowed everything except passing a Role, which is the
+    // shape a scoped deploy Role commonly has.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const creator = await roleAllowed(simAws, accountId, "creator", [
+      { Effect: "Allow", Action: "*", Resource: "*" },
+      { Effect: "Deny", Action: "iam:PassRole", Resource: "*" },
+    ]);
+
+    // When it creates a function naming an execution role.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "reports",
+          Role: `arn:aws:iam::${accountId}:role/JobRole`,
+          Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+        }),
+        { caller: creator },
+      ),
+    );
+
+    // Then the refusal is about the Role rather than the function, and names
+    // the caller that was refused.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "iam:PassRole");
+    assertIdentical(error.resource, `arn:aws:iam::${accountId}:role/JobRole`);
+    assertStringIncludes(
+      error.message,
+      `User: arn:aws:iam::${accountId}:role/creator`,
+    );
+
+    // And no function was created.
+    assertUndefined(simAws.lambda().getSimFunctionByName("reports"));
+  });
+
+  it("still refuses a caller allowed only iam:PassRole", async () => {
+    // Given a Role that may pass the execution role and nothing else.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const passer = await roleAllowed(simAws, accountId, "passer", [
+      { Effect: "Allow", Action: "iam:PassRole", Resource: "*" },
+    ]);
+
+    // When it creates a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "reports",
+          Role: `arn:aws:iam::${accountId}:role/JobRole`,
+          Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+        }),
+        { caller: passer },
+      ),
+    );
+
+    // Then the create action is what refused it, so being allowed to pass a
+    // Role grants nothing on its own.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "lambda:CreateFunction");
+  });
+
+  it("supplies iam:PassedToService for a policy conditioned on it", async () => {
+    // Given a Role that may pass a Role only to Lambda, which is how a
+    // CDK-generated deploy policy is commonly written.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await roleAllowed(simAws, accountId, "deployer", [
+      { Effect: "Allow", Action: "lambda:CreateFunction", Resource: "*" },
+      {
+        Effect: "Allow",
+        Action: "iam:PassRole",
+        Resource: "*",
+        Condition: {
+          StringEquals: { "iam:PassedToService": "lambda.amazonaws.com" },
+        },
+      },
+    ]);
+
+    // When it creates a function.
+    const output = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reports",
+        Role: `arn:aws:iam::${accountId}:role/JobRole`,
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+      { caller: deployer },
+    );
+
+    // Then the condition matched and the function was created.
+    assertIdentical(output.FunctionName, "reports");
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a policy conditioned on passing to another service", async () => {
+    // Given the same Role, allowed to pass a Role to ECS instead.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await roleAllowed(simAws, accountId, "deployer", [
+      { Effect: "Allow", Action: "lambda:CreateFunction", Resource: "*" },
+      {
+        Effect: "Allow",
+        Action: "iam:PassRole",
+        Resource: "*",
+        Condition: {
+          StringEquals: { "iam:PassedToService": "ecs-tasks.amazonaws.com" },
+        },
+      },
+    ]);
+
+    // When it creates a function.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().createFunction(
+        new CreateFunctionCommand({
+          FunctionName: "reports",
+          Role: `arn:aws:iam::${accountId}:role/JobRole`,
+          Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+        }),
+        { caller: deployer },
+      ),
+    );
+
+    // Then the statement matched nothing, because the service the Role went
+    // to was Lambda.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "iam:PassRole");
+  });
+
+  it("leaves a request naming no caller decided as the Account root", async () => {
+    // Given a simulation with no policies in it at all.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+
+    // When a function is created without naming a caller.
+    const output = await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "reports",
+        Role: `arn:aws:iam::${accountId}:role/JobRole`,
+        Code: { ZipFile: makeLambdaZipFileInput(() => null) },
+      }),
+    );
+
+    // Then the root passed the Role as it passes everything else.
+    assertIdentical(output.FunctionName, "reports");
+
+    await simAws.backgroundTasksComplete();
+  });
+});
+
+/**
+ * A Role a request can be made as, carrying the statements it is given.
+ */
+async function roleAllowed(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  roleName: string,
+  statements: readonly SimIamPolicyDocumentStatement[],
+): Promise<SimAwsCaller> {
+  const simIam = simAws.iam();
+
+  await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: `${roleName}-policy`,
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: statements,
+      }),
+    }),
+  );
+
+  return { kind: "arn", arn: `arn:aws:iam::${accountId}:role/${roleName}` };
+}

--- a/src/service/lambda/command/create-function/create-function-s3-code.iso.test.ts
+++ b/src/service/lambda/command/create-function/create-function-s3-code.iso.test.ts
@@ -117,8 +117,8 @@ describe("Lambda CreateFunctionCommand S3 code location", () => {
   });
 
   it("authorizes the code object fetch as the creating caller", async () => {
-    // Given a caller Role allowed to create functions but not to read the
-    // code object from sim S3.
+    // Given a caller Role allowed to create functions and to pass the
+    // execution role, but not to read the code object from sim S3.
     const simAws = new SimAws();
     const accountId = simAws.defaultAccountId;
     await putCodeZip(
@@ -150,7 +150,7 @@ describe("Lambda CreateFunctionCommand S3 code location", () => {
           Version: "2012-10-17",
           Statement: {
             Effect: "Allow",
-            Action: "lambda:CreateFunction",
+            Action: ["lambda:CreateFunction", "iam:PassRole"],
             Resource: "*",
           },
         }),

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -125,7 +125,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       this.accountRegionScope,
       input.name,
     );
-    this.authorizer.authorize(functionArn, options?.caller);
+    this.authorizer.authorize(functionArn, input.roleArn, options?.caller);
 
     this.requireAvailableFunctionName(input.name, functionArn);
 

--- a/src/service/lambda/command/update-function-configuration/update-function-configuration-authorizer.ts
+++ b/src/service/lambda/command/update-function-configuration/update-function-configuration-authorizer.ts
@@ -1,6 +1,8 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimIamPassRoleAuthorizer } from "../../../iam/authorize/pass-role/sim-iam-pass-role-authorizer.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simLambdaServicePrincipal } from "../../sim-lambda-service-principal.js";
 
 interface UpdateFunctionConfigurationAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -12,25 +14,38 @@ interface UpdateFunctionConfigurationAuthorizerProperties {
  * AWS maps the UpdateFunctionConfiguration API operation to the
  * lambda:UpdateFunctionConfiguration IAM action. The resource is the ARN of
  * the function whose settings are changing.
+ *
+ * A request changing the execution role hands Lambda a Role, and is asked
+ * separately whether it may pass that one. A request leaving the role alone
+ * passes nothing and is asked nothing.
  */
 export class UpdateFunctionConfigurationAuthorizer {
   private static readonly action = "lambda:UpdateFunctionConfiguration";
 
   private readonly iam: SimIamInterServiceAuthZ;
+  private readonly passRole: SimIamPassRoleAuthorizer;
 
   constructor(properties: UpdateFunctionConfigurationAuthorizerProperties) {
     this.iam = properties.iam;
+    this.passRole = new SimIamPassRoleAuthorizer({
+      iam: properties.iam,
+      passedToService: simLambdaServicePrincipal,
+    });
   }
 
   /**
    * Ensure the caller may change the settings of the function with the given
-   * ARN.
+   * ARN, and may hand Lambda an execution role the request replaces it with.
    *
    * The caller is passed through unchanged so sim IAM can distinguish an
    * omitted caller, which defaults to Account root, from an explicit anonymous
    * caller.
    */
-  authorize(functionArn: string, caller?: SimAwsCaller): void {
+  authorize(
+    functionArn: string,
+    roleArn: string | undefined,
+    caller?: SimAwsCaller,
+  ): void {
     const decision = this.iam.authorize({
       action: UpdateFunctionConfigurationAuthorizer.action,
       resource: functionArn,
@@ -45,5 +60,7 @@ export class UpdateFunctionConfigurationAuthorizer {
         resource: functionArn,
       });
     }
+
+    this.passRole.authorize(roleArn, caller);
   }
 }

--- a/src/service/lambda/command/update-function-configuration/update-function-configuration-iam.iso.test.ts
+++ b/src/service/lambda/command/update-function-configuration/update-function-configuration-iam.iso.test.ts
@@ -111,4 +111,81 @@ describe("Lambda UpdateFunctionConfigurationCommand IAM authorization", () => {
 
     await simAws.backgroundTasksComplete();
   });
+  it("refuses an update handing Lambda a role the caller may not pass", async () => {
+    // Given a Role allowed to change any function's settings and not to pass
+    // a Role.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    await createOrdersFunction(simAws, accountId);
+    const roleArn = await createRole(simAws, accountId, "SettingsDeployer");
+
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "SettingsDeployer",
+        PolicyName: "UpdateSettings",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "lambda:UpdateFunctionConfiguration",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    // When it replaces the function's execution role.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.lambda().updateFunctionConfiguration(
+        new UpdateFunctionConfigurationCommand({
+          FunctionName: "orders",
+          Role: `arn:aws:iam::${accountId}:role/ReplacementRole`,
+        }),
+        { caller: { kind: "arn", arn: roleArn } },
+      ),
+    );
+
+    // Then the refusal is about the Role it tried to hand over.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "iam:PassRole");
+    assertIdentical(
+      error.resource,
+      `arn:aws:iam::${accountId}:role/ReplacementRole`,
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("asks nothing about a role an update leaves alone", async () => {
+    // Given the same Role, which may change settings and not pass a Role.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    await createOrdersFunction(simAws, accountId);
+    const roleArn = await createRole(simAws, accountId, "SettingsDeployer");
+
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "SettingsDeployer",
+        PolicyName: "UpdateSettings",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "lambda:UpdateFunctionConfiguration",
+            Resource: "*",
+          },
+        }),
+      }),
+    );
+
+    // When it changes a setting without naming a role.
+    const updated = await simAws.lambda().updateFunctionConfiguration(
+      new UpdateFunctionConfigurationCommand({
+        FunctionName: "orders",
+        Timeout: 5,
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then the request passed nothing, so nothing was asked about passing.
+    assertIdentical(updated.Timeout, 5);
+
+    await simAws.backgroundTasksComplete();
+  });
 });

--- a/src/service/lambda/command/update-function-configuration/update-function-configuration.handler.ts
+++ b/src/service/lambda/command/update-function-configuration/update-function-configuration.handler.ts
@@ -85,6 +85,7 @@ export class UpdateFunctionConfigurationCommandHandler implements CommandHandler
     const functionName = simLambdaUnqualifiedFunctionOf(name);
     this.authorizer.authorize(
       this.functions.functionArn(functionName),
+      update.roleArn,
       options?.caller,
     );
 

--- a/src/service/lambda/sim-lambda-service-principal.ts
+++ b/src/service/lambda/sim-lambda-service-principal.ts
@@ -1,0 +1,7 @@
+/**
+ * The service principal Lambda holds an execution role as.
+ *
+ * An execution role's trust policy names it, and so does the
+ * `iam:PassedToService` condition a deploy policy is commonly written with.
+ */
+export const simLambdaServicePrincipal = "lambda.amazonaws.com";

--- a/src/service/scheduler/README.md
+++ b/src/service/scheduler/README.md
@@ -173,6 +173,12 @@ involved in whether a schedule's execution role may invoke its target: that is a
 asked about a different principal, at a different time, and it belongs with firing rather than with
 the command that created the schedule.
 
+It is involved in a third question about that same execution role. Writing a schedule hands Scheduler
+the `Target.RoleArn` it will fire as, so Create and Update both authorize `iam:PassRole` against it
+through the shared `SimIamPassRoleAuthorizer`. The refusal is Scheduler's own
+`AccessDeniedException`, built from `simIamPassRoleDenialMessage`, so a caller catching this
+service's error type catches this refusal with the rest.
+
 ## Divergences
 
 Five, all deliberate.

--- a/src/service/scheduler/command/authorize/sim-scheduler-auth-z.iso.test.ts
+++ b/src/service/scheduler/command/authorize/sim-scheduler-auth-z.iso.test.ts
@@ -28,7 +28,7 @@ const scheduleArn =
  * A simulated AWS and a Role allowed only what one policy statement says.
  */
 async function simAwsWithRole(
-  statement: object,
+  statement: object | readonly object[],
 ): Promise<{ simAws: SimAws; caller: SimAwsCaller }> {
   const simAws = new SimAws();
 
@@ -74,12 +74,16 @@ function creation(): ConstructorParameters<typeof CreateScheduleCommand>[0] {
 
 describe("Scheduler IAM authorization", () => {
   it("admits a caller whose policy names the schedule ARN", async () => {
-    // Given a Role allowed to create one schedule, named with its group.
-    const { simAws, caller } = await simAwsWithRole({
-      Effect: "Allow",
-      Action: "scheduler:CreateSchedule",
-      Resource: scheduleArn,
-    });
+    // Given a Role allowed to create one schedule, named with its group, and
+    // to pass the execution role that schedule fires as.
+    const { simAws, caller } = await simAwsWithRole([
+      {
+        Effect: "Allow",
+        Action: "scheduler:CreateSchedule",
+        Resource: scheduleArn,
+      },
+      { Effect: "Allow", Action: "iam:PassRole", Resource: executionRoleArn },
+    ]);
 
     // When it creates that schedule.
     const created = await simAws

--- a/src/service/scheduler/command/authorize/sim-scheduler-authorizer.ts
+++ b/src/service/scheduler/command/authorize/sim-scheduler-authorizer.ts
@@ -1,6 +1,11 @@
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import {
+  SimIamPassRoleAuthorizer,
+  simIamPassRoleDenialMessage,
+} from "../../../iam/authorize/pass-role/sim-iam-pass-role-authorizer.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamCallerIdentifier } from "../../../iam/error/sim-iam-caller-identifier.js";
+import { simSchedulerServicePrincipal } from "../../delivery/sim-scheduler-delivery.js";
 import { SimSchedulerAccessDeniedException } from "../../error/sim-scheduler.error.js";
 import type { SimSchedulerRequestOptions } from "../sim-scheduler-request-options.js";
 
@@ -28,14 +33,37 @@ interface SimSchedulerAuthorizerProperties {
  * This is the caller's own authorization to manage schedules, and is a separate
  * question from whether a schedule's execution role may invoke its target. The
  * second is asked when the schedule fires, against the role rather than the
- * caller, which is why nothing about the target is consulted here.
+ * caller.
+ *
+ * A third question is asked here, about the same execution role. A schedule
+ * keeps the `Target.RoleArn` it is given and fires as it later, so the caller
+ * writing it needs `iam:PassRole` on that Role.
  */
 export class SimSchedulerAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly callerIdentifier = new SimIamCallerIdentifier();
+  private readonly passRole: SimIamPassRoleAuthorizer;
 
   constructor(properties: SimSchedulerAuthorizerProperties) {
     this.iam = properties.iam;
+    this.passRole = new SimIamPassRoleAuthorizer({
+      iam: properties.iam,
+      passedToService: simSchedulerServicePrincipal,
+      denied: (denial): Error =>
+        new SimSchedulerAccessDeniedException(
+          simIamPassRoleDenialMessage(denial),
+        ),
+    });
+  }
+
+  /**
+   * Ensure the caller may hand Scheduler a schedule's execution role.
+   */
+  authorizePassRole(
+    roleArn: string | undefined,
+    options?: SimSchedulerRequestOptions,
+  ): void {
+    this.passRole.authorize(roleArn, options?.caller);
   }
 
   /**

--- a/src/service/scheduler/command/schedule/sim-scheduler-create-schedule.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-create-schedule.ts
@@ -49,6 +49,7 @@ export class SimSchedulerCreateSchedule {
     const requested = this.access.requested(input);
 
     this.access.authorize("scheduler:CreateSchedule", requested, options);
+    this.access.authorizePassRole(input, options);
     this.access.requireGroup(requested.groupName);
 
     if (

--- a/src/service/scheduler/command/schedule/sim-scheduler-pass-role.iso.test.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-pass-role.iso.test.ts
@@ -1,0 +1,102 @@
+import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { SimSchedulerAccessDeniedException } from "../../error/sim-scheduler.error.js";
+
+const executionRoleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:reconcile";
+
+/**
+ * The request every test here makes, so each names only what it is about.
+ */
+function creation(): ConstructorParameters<typeof CreateScheduleCommand>[0] {
+  return {
+    Name: "nightly-report",
+    ScheduleExpression: "rate(1 hour)",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: { Arn: functionArn, RoleArn: executionRoleArn },
+  };
+}
+
+describe("passing an execution role to Scheduler CreateSchedule", () => {
+  it("refuses a caller that may write a schedule and may not pass its role", async () => {
+    // Given a Role allowed to write schedules and nothing else.
+    const simAws = new SimAws();
+    const writer = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Writer",
+        policyName: "WriteSchedules",
+        actions: ["scheduler:CreateSchedule"],
+      },
+      simAws,
+    );
+
+    // When it creates a schedule that fires as an execution role.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.scheduler().createSchedule(new CreateScheduleCommand(creation()), {
+        caller: { kind: "arn", arn: writer.Arn },
+      }),
+    );
+
+    // Then Scheduler reports its own AccessDeniedException, naming the Role
+    // the schedule would have fired as.
+    assertInstanceOf(error, SimSchedulerAccessDeniedException);
+    assertStringIncludes(error.message, "iam:PassRole");
+    assertStringIncludes(error.message, executionRoleArn);
+    assertStringIncludes(error.message, writer.Arn);
+    assertUndefined(simAws.scheduler().findSchedule("nightly-report"));
+  });
+
+  it("creates for a caller allowed to pass a role to Scheduler", async () => {
+    // Given the same Role, also allowed to pass a role to scheduler.
+    const simAws = new SimAws();
+    const writer = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Writer",
+        policyName: "WriteSchedules",
+        actions: ["scheduler:CreateSchedule"],
+      },
+      simAws,
+    );
+
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: "Writer",
+        PolicyName: "PassExecutionRole",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "iam:PassRole",
+            Resource: executionRoleArn,
+            Condition: {
+              StringEquals: {
+                "iam:PassedToService": "scheduler.amazonaws.com",
+              },
+            },
+          },
+        }),
+      },
+    });
+
+    // When it creates the schedule.
+    const created = await simAws
+      .scheduler()
+      .createSchedule(new CreateScheduleCommand(creation()), {
+        caller: { kind: "arn", arn: writer.Arn },
+      });
+
+    // Then the condition matched and the schedule is there.
+    assertStringIncludes(
+      created.ScheduleArn,
+      "schedule/default/nightly-report",
+    );
+  });
+});

--- a/src/service/scheduler/command/schedule/sim-scheduler-schedule-access.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-schedule-access.ts
@@ -9,6 +9,7 @@ import type { SimSchedulerSchedule } from "../../schedule/sim-scheduler-schedule
 import type { SimSchedulerScheduleStore } from "../../schedule/sim-scheduler-schedule-store.js";
 import type { SimSchedulerAuthorizer } from "../authorize/sim-scheduler-authorizer.js";
 import type { SimSchedulerRequestOptions } from "../sim-scheduler-request-options.js";
+import type { SimSchedulerScheduleInput } from "./schedule.command.js";
 
 /**
  * Which schedule a request names, in which group.
@@ -72,6 +73,19 @@ export class SimSchedulerScheduleAccess {
     options?: SimSchedulerRequestOptions,
   ): void {
     this.authorizer.authorizeResource(action, this.arnFor(requested), options);
+  }
+
+  /**
+   * Ensure the caller may hand Scheduler the execution role a request names.
+   *
+   * A schedule fires as its `Target.RoleArn` long after the request that wrote
+   * it, so writing one is a hand-over of that Role.
+   */
+  authorizePassRole(
+    input: SimSchedulerScheduleInput,
+    options?: SimSchedulerRequestOptions,
+  ): void {
+    this.authorizer.authorizePassRole(input.Target?.RoleArn, options);
   }
 
   /**

--- a/src/service/scheduler/command/schedule/sim-scheduler-update-schedule.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-update-schedule.ts
@@ -54,6 +54,8 @@ export class SimSchedulerUpdateSchedule {
     );
     const requested = this.access.requested(input);
 
+    this.access.authorizePassRole(input, options);
+
     // The creation date survives a replacement, because AWS does not consider
     // an updated schedule to be a new one.
     const schedule = this.writer.write(input, requested, existing.creationDate);

--- a/src/service/stepfunctions/cfn/sim-cfn-state-machine-iam.iso.test.ts
+++ b/src/service/stepfunctions/cfn/sim-cfn-state-machine-iam.iso.test.ts
@@ -94,10 +94,12 @@ describe("the principal an AWS::StepFunctions::StateMachine Resource is created 
   });
 
   it("creates the state machine under a caller allowed the creation", async () => {
-    // Given a Role allowed to make state machines.
+    // Given a Role allowed to make state machines, and to pass the Role each
+    // one runs as.
     const simAws = new SimAws();
     const deployer = await roleAllowing(simAws, "Deployer", [
       "states:CreateStateMachine",
+      "iam:PassRole",
     ]);
 
     // When it deploys the Stack.
@@ -114,6 +116,7 @@ describe("the principal an AWS::StepFunctions::StateMachine Resource is created 
     const simAws = new SimAws();
     const maker = await roleAllowing(simAws, "Maker", [
       "states:CreateStateMachine",
+      "iam:PassRole",
     ]);
     const stack = await deployAsCaller(simAws, maker);
 

--- a/src/service/stepfunctions/command/authorize/sim-step-functions-authorizer.ts
+++ b/src/service/stepfunctions/command/authorize/sim-step-functions-authorizer.ts
@@ -1,9 +1,11 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { SimIamPassRoleAuthorizer } from "../../../iam/authorize/pass-role/sim-iam-pass-role-authorizer.js";
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simStateMachineArn } from "../../machine/sim-state-machine-arn.js";
+import { simStatesServicePrincipal } from "../../task/sim-states-execution-role.js";
 
 interface SimStepFunctionsAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -17,14 +19,30 @@ interface SimStepFunctionsAuthorizerProperties {
  * policy is written in. `CreateStateMachine` has no ARN to be given. It
  * authorizes against the one the state machine is about to have, which a
  * policy naming `stateMachine:orders-*` covers.
+ *
+ * A state machine's `roleArn` is a second question. Step Functions keeps that
+ * Role and runs every execution as it, so the caller creating one needs
+ * `iam:PassRole` on it. The resource there is the Role.
  */
 export class SimStepFunctionsAuthorizer {
   readonly #iam: SimIamInterServiceAuthZ;
   readonly #accountRegionScope: SimAwsAccountRegionScope;
+  readonly #passRole: SimIamPassRoleAuthorizer;
 
   constructor(properties: SimStepFunctionsAuthorizerProperties) {
     this.#iam = properties.iam;
     this.#accountRegionScope = properties.accountRegionScope;
+    this.#passRole = new SimIamPassRoleAuthorizer({
+      iam: properties.iam,
+      passedToService: simStatesServicePrincipal,
+    });
+  }
+
+  /**
+   * Ensure the caller may hand Step Functions a state machine's role.
+   */
+  authorizePassRole(roleArn: string, caller?: SimAwsCaller): void {
+    this.#passRole.authorize(roleArn, caller);
   }
 
   /**

--- a/src/service/stepfunctions/command/machine/sim-state-machine-create.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-create.ts
@@ -60,6 +60,7 @@ export class SimStateMachineCreate {
       read.name,
       options?.caller,
     );
+    this.#authorizer.authorizePassRole(read.roleArn, options?.caller);
 
     const existing = this.#stateMachines.findByName(read.name);
 

--- a/src/service/stepfunctions/command/machine/sim-state-machine-pass-role.iso.test.ts
+++ b/src/service/stepfunctions/command/machine/sim-state-machine-pass-role.iso.test.ts
@@ -1,0 +1,99 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+
+const workflowRoleArn = "arn:aws:iam::888888888888:role/WorkflowRole";
+
+const passThrough = JSON.stringify({
+  StartAt: "Only",
+  States: { Only: { Type: "Pass", End: true } },
+});
+
+describe("passing a role to Step Functions CreateStateMachine", () => {
+  it("refuses a caller that may create and may not pass the role", async () => {
+    // Given a Role allowed to make state machines and nothing else.
+    const simAws = new SimAws();
+    const creator = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Creator",
+        policyName: "CreateWorkflows",
+        actions: ["states:CreateStateMachine"],
+      },
+      simAws,
+    );
+
+    // When it creates a state machine naming a role to run as.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.stepFunctions().createStateMachine(
+        {
+          input: {
+            name: "Enrolment",
+            roleArn: workflowRoleArn,
+            definition: passThrough,
+          },
+        },
+        { caller: { kind: "arn", arn: creator.Arn } },
+      ),
+    );
+
+    // Then the refusal is about the role it was handing over.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "iam:PassRole");
+    assertIdentical(error.resource, workflowRoleArn);
+    assertStringIncludes(error.message, creator.Arn);
+    assertUndefined(simAws.stepFunctions().findStateMachine("Enrolment"));
+  });
+
+  it("creates for a caller allowed to pass a role to Step Functions", async () => {
+    // Given the same Role, also allowed to pass a role to states.
+    const simAws = new SimAws();
+    const creator = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "Creator",
+        policyName: "CreateWorkflows",
+        actions: ["states:CreateStateMachine"],
+      },
+      simAws,
+    );
+
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: "Creator",
+        PolicyName: "PassWorkflowRole",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "iam:PassRole",
+            Resource: workflowRoleArn,
+            Condition: {
+              StringEquals: { "iam:PassedToService": "states.amazonaws.com" },
+            },
+          },
+        }),
+      },
+    });
+
+    // When it creates the state machine.
+    const created = await simAws.stepFunctions().createStateMachine(
+      {
+        input: {
+          name: "Enrolment",
+          roleArn: workflowRoleArn,
+          definition: passThrough,
+        },
+      },
+      { caller: { kind: "arn", arn: creator.Arn } },
+    );
+
+    // Then the condition matched and the state machine is there.
+    assertStringIncludes(created.stateMachineArn, "stateMachine:Enrolment");
+  });
+});


### PR DESCRIPTION
A simulated service handed a Role took it without asking whether the caller may pass it. A principal allowed to create a function and refused `iam:PassRole` created it here and failed in an account. Six services now authorize `iam:PassRole` against each Role a request hands them, supplying `iam:PassedToService` for a deployment policy conditioned on it. The resource of that decision is the Role rather than the thing being created, and the service's own create action is decided first, so a caller allowed to pass a Role and nothing else still fails on the create. A request naming no caller is decided as the Account root and passes any Role, as before.

| Request | The Role it hands over | `iam:PassedToService` |
| --- | --- | --- |
| Lambda `CreateFunction`, `UpdateFunctionConfiguration` | `Role` | `lambda.amazonaws.com` |
| Scheduler `CreateSchedule`, `UpdateSchedule` | `Target.RoleArn` | `scheduler.amazonaws.com` |
| EventBridge `PutTargets` | an ECS target's `RoleArn` | `events.amazonaws.com` |
| Step Functions `CreateStateMachine` | `roleArn` | `states.amazonaws.com` |
| ECS `RegisterTaskDefinition` | `taskRoleArn` and `executionRoleArn` | `ecs-tasks.amazonaws.com` |
| Firehose `CreateDeliveryStream` | the destination Role and a Kinesis source Role | `firehose.amazonaws.com` |

Each Role is its own decision, and an omitted one passes nothing. `SimIamPassRoleAuthorizer` holds the action, the condition key and the message, and takes the error a service reports its refusals as, so Scheduler, EventBridge and ECS keep their own `AccessDeniedException` while the rest report the shared IAM one.

Resolves #1116