### PR TITLE
fix: trim generated names the way CFN does

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2881,8 +2881,8 @@ console.log(queueName); // "orders-stack-OrdersQueue-1dca4dbe253b"
 Each service caps how long a name may be. Where the stack name and the logical ID are too long
 together, thirteen characters of the limit are kept for the tail and its hyphen, and what is left is
 shared between the two parts either side of one more hyphen. The stack name rounds up, and each part
-takes the characters the other leaves. A 64 character limit trims a long stack name to 25 characters
-and a long logical ID to 25.
+takes the characters the other leaves. Where a service allows 64 characters, a long stack name keeps
+25 of them and a long logical ID keeps 25.
 
 The trimmed stack name is what an IAM policy scoped by name prefix matches. A stack called
 `ChineseboostAnalyticsStack` deploying an unnamed `AWS::Events::Rule` puts the rule under

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2839,6 +2839,59 @@ one that reaches an Output in these docs.
 const nameServers = stack.outputs.get("HostedZoneNameServers")?.value;
 ```
 
+## Names CloudFormation generates
+
+A Resource whose template leaves its name out is named `<stack name>-<logical ID>-<tail>`, as real
+CloudFormation names one. The tail is twelve characters derived from the other two parts, standing
+in for the twelve random characters an account produces. The same template deployed under the same
+stack name generates the same name again, and a test reads that name back from a `Ref` or an
+attribute.
+
+```typescript sim-cloudformation-generated-resource-name
+/**
+ * Reading the name CloudFormation generated for a Resource the template does
+ * not name.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersQueue: { Type: "AWS::SQS::Queue" },
+    },
+    Outputs: {
+      QueueName: {
+        Value: { "Fn::GetAtt": ["OrdersQueue", "QueueName"] },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const queueName = stack.output("QueueName");
+
+console.log(queueName); // "orders-stack-OrdersQueue-1dca4dbe253b"
+```
+
+Each service caps how long a name may be. Where the stack name and the logical ID are too long
+together, thirteen characters of the limit are kept for the tail and its hyphen, and what is left is
+shared between the two parts either side of one more hyphen. The stack name rounds up, and each part
+takes the characters the other leaves. A 64 character limit trims a long stack name to 25 characters
+and a long logical ID to 25.
+
+The trimmed stack name is what an IAM policy scoped by name prefix matches. A stack called
+`ChineseboostAnalyticsStack` deploying an unnamed `AWS::Events::Rule` puts the rule under
+`ChineseboostAnalyticsStac-`. A deploy Role allowed `events:PutRule` on
+`ChineseboostAnalyticsStack-*` is refused here, as it is in an account.
+
+AWS documents none of the trimming, and the rule here is inferred from names real CloudFormation
+produced.
+
 ## Inspecting stacks and resources
 
 After deployment, you can inspect the returned stack and its resources.

--- a/docs/services/cloudformation/sim-cloudformation-generated-resource-name.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-generated-resource-name.example.ts
@@ -1,0 +1,28 @@
+/**
+ * Reading the name CloudFormation generated for a Resource the template does
+ * not name.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "orders-stack",
+  template: {
+    Resources: {
+      OrdersQueue: { Type: "AWS::SQS::Queue" },
+    },
+    Outputs: {
+      QueueName: {
+        Value: { "Fn::GetAtt": ["OrdersQueue", "QueueName"] },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const queueName = stack.output("QueueName");
+
+console.log(queueName); // "orders-stack-OrdersQueue-1dca4dbe253b"

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -285,10 +285,12 @@ deploy the stack, publish a breaching datapoint, advance the clock and read the 
 whatever is subscribed. Deleting the stack deletes the alarm and takes its scheduled evaluation back
 off the clock with it.
 
-`AlarmName` may be left out, and the alarm is then named after the stack and the logical ID. A test
-still has a name to pass to `DescribeAlarms`. Real CloudFormation generates a physical ID of the
-same shape with a random tail on the end. The tail is left off here, so the name is one a test can
-predict.
+`AlarmName` may be left out, and the alarm is then named after the stack, the logical ID and a tail
+derived from both. Real CloudFormation ends a physical ID of the same shape in twelve random
+characters, and the tail here comes from the name it follows, giving one alarm the same name at
+every deployment. `simAws.cloudWatch().allAlarms()` hands a test the name to pass to
+`DescribeAlarms`, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how a long name is trimmed.
 
 These are the properties acted on: `AlarmName`, `AlarmDescription`, `ActionsEnabled`,
 `AlarmActions`, `OKActions`, `InsufficientDataActions`, `Namespace`, `MetricName`, `Dimensions`,

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3314,10 +3314,11 @@ same thing about the property and differ in what they do about it. A direct API 
 request to fail, and a template has every other resource in it to think about.
 
 `UserPoolName` and `ClientName` are optional. A template that sets neither gets
-`<stack name>-<logical id>`, as real CloudFormation generates a name, trimmed to the 128 characters
-Cognito allows if the two are longer than that together. Real CloudFormation adds random characters
-on the end and this adds none. The name is the same on every deployment of the same template, and a
-test can assert it.
+`<stack name>-<logical id>-<tail>`, as real CloudFormation generates a name, trimmed to the 128
+characters Cognito allows if the parts are longer than that together. The tail is twelve characters
+derived from the other two, where real CloudFormation ends the name in twelve random ones. The name
+is the same on every deployment of the same template, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how a long name is trimmed.
 
 ## Registering a pool with a chosen pool id
 
@@ -3461,13 +3462,13 @@ await stack.waitForDeployComplete();
 
 const userPoolId = stack.output("PoolId");
 
-// The pool is named after the stack and the logical id, as the template named
-// neither it nor the client.
+// The pool is named after the stack, the logical id and a tail derived from
+// both, as the template named neither it nor the client.
 const described = await simAws
   .cognitoIdentityProvider()
   .describeUserPool(new DescribeUserPoolCommand({ UserPoolId: userPoolId }));
 
-console.log(described.UserPool?.Name); // "app-stack-Pool"
+console.log(described.UserPool?.Name); // "app-stack-Pool-2c3041dc539d"
 
 // What the template declared is reported back. This one is acted on: it is
 // what says only an admin creates users in this pool.

--- a/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
+++ b/docs/services/cognito/sim-cognito-cdk-defaults.example.ts
@@ -55,13 +55,13 @@ await stack.waitForDeployComplete();
 
 const userPoolId = stack.output("PoolId");
 
-// The pool is named after the stack and the logical id, as the template named
-// neither it nor the client.
+// The pool is named after the stack, the logical id and a tail derived from
+// both, as the template named neither it nor the client.
 const described = await simAws
   .cognitoIdentityProvider()
   .describeUserPool(new DescribeUserPoolCommand({ UserPoolId: userPoolId }));
 
-console.log(described.UserPool?.Name); // "app-stack-Pool"
+console.log(described.UserPool?.Name); // "app-stack-Pool-2c3041dc539d"
 
 // What the template declared is reported back. This one is acted on: it is
 // what says only an admin creates users in this pool.

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3107,11 +3107,12 @@ the template gets wrong fails the same way it would for an SDK caller.
 updates it. A specification the template got wrong is refused in the words `UpdateTimeToLive`
 refuses it in.
 
-A table with no `TableName` is named after the stack and its logical ID. The table above with its
-name left out would be `orders-stack-OrdersTable`. Real CloudFormation adds random characters to
-that, which a template cannot predict either way. Two stacks deploying the same template get two
-differently named tables. The generated name is trimmed to the 255 characters a table name allows,
-ending in a hash of the untrimmed name so two long names that start the same stay apart.
+A table with no `TableName` is named after the stack, its logical ID and a tail derived from both.
+The table above with its name left out would be `orders-stack-OrdersTable-` and twelve more
+characters, where real CloudFormation ends the name in twelve random ones. Two stacks deploying the
+same template get two differently named tables. The name is trimmed to the 255 characters a table
+name allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
 
 `Fn::GetAtt … StreamArn` gives the ARN of the stream the table's `StreamSpecification` gave it. On a
 table with no `StreamSpecification` it is refused by name, naming the table, since an invented

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1432,7 +1432,9 @@ console.log(processedOrders); // ["outstanding orders"]
 
 A binding can name the task definition Resource instead, which is what a CDK stack gives a test to
 name. The construct ID is accepted as well as the synthesized logical ID, and the container name can
-be left out where the task definition declares one container. A binding naming an image repository
+be left out where the task definition declares one container. This is the form to use for a task
+definition the template declares no `Family` for, since the family CloudFormation generates for it
+ends in a tail a test would have to deploy the stack to learn. A binding naming an image repository
 matches any container running an image from it, whichever family declares it, which covers a tag
 that changes with every build.
 
@@ -1605,9 +1607,9 @@ const listed = await simAws
 console.log(listed.taskArns?.length); // 2
 ```
 
-An unnamed service is named after the stack and the logical ID, as a cluster and a family are. A
-service declaring no `DesiredCount` keeps one task running, which is what real CloudFormation gives
-a new service.
+An unnamed service is named after the stack, the logical ID and a tail derived from both, as a
+cluster and a family are. `Fn::GetAtt ... Name` answers with the generated name. A service declaring
+no `DesiredCount` keeps one task running, which is what real CloudFormation gives a new service.
 
 Updating the stack moves the service. A changed `DesiredCount` scales it, and a changed task
 definition moves it onto the revision the update registered, replacing the tasks it was keeping.
@@ -1968,9 +1970,12 @@ Current documented limitations:
   `DescribeServices` and `ListTasks` are what report those.
 - Task definition and cluster tags are stored and reported, but `TagResource`, `UntagResource` and
   `ListTagsForResource` are absent.
-- An unnamed cluster, task definition or service gets a name composed from the stack name and the
-  logical ID, without the random part real CloudFormation adds, which makes it predictable in a
-  test. A stack deployed twice under different names therefore gets two different families.
+- An unnamed cluster, task definition or service gets a name composed from the stack name, the
+  logical ID and a tail derived from both, in place of the random characters real CloudFormation
+  ends one with. The same stack redeployed gets the same names, and a stack deployed twice under
+  different names gets two different families.
+  [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+  cover the tail and how a long name is trimmed.
 - A service that declares no `DesiredCount` keeps one task running. That is the default real
   CloudFormation documents for a new service. A `DesiredCount` written as the text of a number is
   taken as that number, since a String Parameter resolves to text, and anything else is refused

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -1421,8 +1421,11 @@ fails the deployment.
 - `TargetGroupArn`, `TargetGroupName` and `TargetGroupFullName` on a target group
 - `ListenerArn` on a listener, and `RuleArn` and `IsDefault` on a rule
 
-An unnamed load balancer or target group is named after the stack and the logical ID, trimmed to the
-32 characters ELB allows. A target group declaring `Targets` has them registered as part of creating
+An unnamed load balancer or target group is named after the stack, the logical ID and a tail derived
+from both, trimmed to the 32 characters ELB allows. The tail takes 13 of those, which leaves nine
+characters for the stack name and nine for the logical ID once a name has to be trimmed.
+[the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover the rule. A target group declaring `Targets` has them registered as part of creating
 it, and the group routes as soon as the stack has deployed.
 
 ```typescript sim-elbv2-cloudformation

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -1422,8 +1422,9 @@ fails the deployment.
 - `ListenerArn` on a listener, and `RuleArn` and `IsDefault` on a rule
 
 An unnamed load balancer or target group is named after the stack, the logical ID and a tail derived
-from both, trimmed to the 32 characters ELB allows. The tail takes 13 of those, which leaves nine
-characters for the stack name and nine for the logical ID once a name has to be trimmed.
+from both, trimmed to the 32 characters ELB allows. The tail takes 13 of those. A name that has to
+be trimmed gives the stack name and the logical ID nine characters each, and either takes what the
+other leaves.
 [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
 cover the rule. A target group declaring `Targets` has them registered as part of creating
 it, and the group routes as soon as the stack has deployed.

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -909,7 +909,10 @@ console.log(handled.length); // 1
 `Ref` returns the **name** of a bus or a rule, and never its ARN. That is what AWS returns, and it
 makes a bus `Ref` usable straight away as another resource's `EventBusName`. The ARN comes from
 `Fn::GetAtt ... Arn`, which an `AWS::Lambda::Permission` `SourceArn` needs. An unnamed rule gets a
-name generated from the stack name and the logical ID, as real CloudFormation generates one.
+name generated from the stack name, the logical ID and a tail derived from both, as
+[the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+describe. A rule name caps at 64 characters, and a stack name and logical ID longer than that
+together are trimmed to 25 characters each.
 
 A target property this simulation leaves out, such as `InputTransformer` or `InputPath`, is refused
 at deploy time naming the property and the Resource. The alternative is a rule that sends the whole

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -911,8 +911,8 @@ makes a bus `Ref` usable straight away as another resource's `EventBusName`. The
 `Fn::GetAtt ... Arn`, which an `AWS::Lambda::Permission` `SourceArn` needs. An unnamed rule gets a
 name generated from the stack name, the logical ID and a tail derived from both, as
 [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
-describe. A rule name caps at 64 characters, and a stack name and logical ID longer than that
-together are trimmed to 25 characters each.
+describe. A rule name caps at 64 characters. A stack name and logical ID longer than that together
+are trimmed to 25 characters each, and either takes what the other leaves.
 
 A target property this simulation leaves out, such as `InputTransformer` or `InputPath`, is refused
 at deploy time naming the property and the Resource. The alternative is a rule that sends the whole

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -607,8 +607,10 @@ writes into the Bucket beside it, as the Role beside it, and a Role without `s3:
 delivery the same way one created through `CreateDeliveryStream` does. Deleting the stack deletes the
 delivery stream.
 
-A delivery stream the template does not name is named after the stack and the logical ID, as real
-CloudFormation names one. The name is trimmed to the 64 characters Firehose allows.
+A delivery stream the template does not name is named after the stack, the logical ID and a tail
+derived from both, as real CloudFormation names one. The name is trimmed to the 64 characters
+Firehose allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the two parts share what is left.
 
 `DeliveryStreamEncryptionConfigurationInput` and `DirectPutSourceConfiguration` are recorded against
 the resource as unsimulated, and the delivery stream deploys anyway. The destination properties this

--- a/docs/services/kinesis/README.md
+++ b/docs/services/kinesis/README.md
@@ -275,8 +275,9 @@ await simAws.kinesis().putRecord(
 ```
 
 `Name`, `ShardCount`, `RetentionPeriodHours`, `StreamModeDetails` and `Tags` are read. A stream the
-template does not name is named after the stack and the logical ID, as real CloudFormation names
-one.
+template does not name is named after the stack, the logical ID and a tail derived from both, as
+[the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+describe.
 
 `RetentionPeriodHours` is applied after the stream is created, because `CreateStream` takes no
 retention on real Kinesis either. It only ever goes up: a new stream keeps records for 24 hours,

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -678,7 +678,9 @@ console.log(simAws.scheduler().deliveryFailures.length); // 0
 
 `Ref` returns the schedule's **name** and `Fn::GetAtt ... Arn` its ARN, which carries the schedule
 group as it always does. A schedule the template leaves unnamed gets one generated from the stack
-name and the logical ID.
+name, the logical ID and a tail derived from both, as
+[the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+describe.
 
 A property this simulation leaves out is refused at deploy time, naming the Resource. Deploying a
 schedule that behaves differently from the one declared would be worse. Tearing the stack down
@@ -735,8 +737,8 @@ console.log(stack.output("GroupArn"));
 ```
 
 `Ref` returns the group's **name** and `Fn::GetAtt` answers `Arn`, `State`, `CreationDate` and
-`LastModificationDate`. A group the template leaves unnamed gets one generated from the stack name
-and the logical ID.
+`LastModificationDate`. A group the template leaves unnamed gets one generated from the stack name,
+the logical ID and a tail derived from both, as a schedule does.
 
 `Tags` on a group are recorded as an ignored property and the group deploys without them. The CDK
 puts a stack's tags on every taggable Resource in it, so a template gains them without asking.

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -515,7 +515,9 @@ CloudFormation is creating an identity that is already there.
 `FromEmailAddress`. `Ref` on a template, and its `Id` attribute, both return the template name.
 `Ref` on a configuration set returns its name. That Resource type has no `Fn::GetAtt` attributes at
 all, so reading one fails the deploy rather than answering something AWS would not. A set with no
-`Name` is named after the stack and the logical ID, as real CloudFormation names one.
+`Name` is named after the stack, the logical ID and a tail derived from both, as
+[the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+describe.
 
 Deleting the stack removes all three.
 

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -1688,11 +1688,11 @@ const { Messages } = await simAws
 console.log(Messages?.[0]?.Body); // "order-1"
 ```
 
-A topic with no `TopicName` is named from the stack name and the logical ID. The topic above with its
-name left out would be `orders-stack-OrdersTopic`. Real CloudFormation adds random characters to
-that, which a template cannot predict either way. The generated name is trimmed to the 256 characters
-a topic name allows, ending in a hash of the untrimmed name so two long names that start the same
-stay apart.
+A topic with no `TopicName` is named from the stack name, the logical ID and a tail derived from
+both. The topic above with its name left out would be `orders-stack-OrdersTopic-` and twelve more
+characters, where real CloudFormation ends the name in twelve random ones. The name is trimmed to
+the 256 characters a topic name allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
 
 A topic can also declare its subscriptions inside itself, with the `Subscription` property. That is
 how a hand-written template usually writes them. Each entry is a `Protocol` and an `Endpoint`, and

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -1052,11 +1052,11 @@ The properties applied to the queue are `VisibilityTimeout`, `DelaySeconds`,
 `MessageRetentionPeriod`, `MaximumMessageSize` and `ReceiveMessageWaitTimeSeconds`. Each is passed to
 `CreateQueue`, and a value outside the range real SQS accepts fails the resource.
 
-A queue with no `QueueName` is named from the stack name and the logical ID. The queue above with its
-name left out would be `orders-stack-OrdersQueue`. Real CloudFormation adds random characters to
-that, which a template cannot predict either way. The generated name is trimmed to the 80 characters
-a queue name allows, ending in a hash of the untrimmed name so two long names that start the same
-stay apart.
+A queue with no `QueueName` is named from the stack name, the logical ID and a tail derived from
+both. The queue above with its name left out would be `orders-stack-OrdersQueue-` and twelve more
+characters, where real CloudFormation ends the name in twelve random ones. The name is trimmed to
+the 80 characters a queue name allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
 
 `FifoQueue: true` fails the resource. Only standard queues are simulated, and a FIFO queue is named
 `<name>.fifo`, a name simulated SQS refuses to an SDK caller as well. There is no queue to create

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -1181,8 +1181,10 @@ created. A location this simulation holds no object for drops that one state mac
 where it looked.
 
 `StateMachineName`, `RoleArn`, `StateMachineType` and `Tags` are carried across. A state machine the
-template does not name is named after the stack and the logical ID (`enrolment-Workflow`), the way
-CloudFormation names one. `Ref` answers with the ARN and `Fn::GetAtt` answers `Arn` and `Name`. Real
+template does not name is named after the stack, the logical ID and a tail derived from both
+(`enrolment-Workflow-8d267c9d4ae1`), the way CloudFormation names one, and
+[the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover the tail. `Ref` answers with the ARN and `Fn::GetAtt` answers `Arn` and `Name`. Real
 CloudFormation publishes this one that way round too. Deleting the stack deletes the state machine.
 
 A definition holding a state type this simulator does not run drops that one state machine. The

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -1060,9 +1060,10 @@ A web ACL nothing coherent could be deployed from still fails the stack. A `Scop
 `REGIONAL` and `CLOUDFRONT`, a `Rules` written as an object, a `Name` written as a number. The
 failure names the logical ID.
 
-`Name` is optional on all three named types. An unnamed resource is named after the stack and the
-logical ID, as real CloudFormation names one, so `orders-acl` above would have deployed as
-`orders-OrdersAcl`.
+`Name` is optional on all three named types. An unnamed resource is named after the stack, the
+logical ID and a tail derived from both, as real CloudFormation names one. The `orders-acl` above
+would have deployed as `orders-OrdersAcl-5615bd3c857f`, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover where the tail comes from.
 
 ### Putting a deployed web ACL in front of something
 

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -1061,8 +1061,9 @@ A web ACL nothing coherent could be deployed from still fails the stack. A `Scop
 failure names the logical ID.
 
 `Name` is optional on all three named types. An unnamed resource is named after the stack, the
-logical ID and a tail derived from both, as real CloudFormation names one. The `orders-acl` above
-would have deployed as `orders-OrdersAcl-5615bd3c857f`, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+logical ID and a tail derived from both, as real CloudFormation names one. The web ACL above sets a
+`Name` and keeps `orders-acl`. With that property left out it would have deployed as
+`orders-OrdersAcl-5615bd3c857f`, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
 cover where the tail comes from.
 
 ### Putting a deployed web ACL in front of something

--- a/src/service/cloudformation/resource/name/sim-cfn-generated-name-authorization.iso.test.ts
+++ b/src/service/cloudformation/resource/name/sim-cfn-generated-name-authorization.iso.test.ts
@@ -1,0 +1,134 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+
+const regionName = "us-east-1";
+
+/**
+ * The stack of the deployment this is all about, whose name is 26 characters,
+ * one more than a rule name leaves the stack half of a generated name.
+ */
+const stackName = "ChineseboostAnalyticsStack";
+
+const scheduledRule = {
+  Resources: {
+    RainlyticsSummariesJobFunction: {
+      Type: "AWS::Events::Rule",
+      Properties: { ScheduleExpression: "rate(1 hour)" },
+    },
+  },
+};
+
+describe("a Resource named under a policy scoped to a name prefix", () => {
+  it("creates a rule the prefix real CloudFormation produces allows", async () => {
+    // Given a deploy Role allowed EventBridge on the prefix a real deployment
+    // of this stack produces, which trims the stack name to 25 characters.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({
+      defaultAccountId: accountId,
+      defaultRegionName: regionName,
+    });
+    const deployer = await deployRole(
+      simAws,
+      accountId,
+      "allowed-deployer",
+      "ChineseboostAnalyticsStac-*",
+    );
+
+    // When the stack is deployed as that Role.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName,
+      template: scheduledRule,
+      caller: deployer,
+    });
+
+    // Then the rule was created, because the name generated for it starts with
+    // the prefix an account would have put the rule under.
+    assertIdentical(
+      stack.getResource("RainlyticsSummariesJobFunction")?.status,
+      "CREATE_COMPLETE",
+    );
+  });
+
+  it("refuses a rule under the untrimmed stack name", async () => {
+    // Given the same deployment under a Role scoped to the whole stack name,
+    // which a real deployment is refused by, since CloudFormation trims the
+    // stack name to fit a rule name.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({
+      defaultAccountId: accountId,
+      defaultRegionName: regionName,
+    });
+    const deployer = await deployRole(
+      simAws,
+      accountId,
+      "refused-deployer",
+      `${stackName}-*`,
+    );
+
+    // When the stack is deployed as that Role, then the rule is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName,
+        template: scheduledRule,
+        caller: deployer,
+      });
+    });
+
+    assertStringIncludes(error.message, "events:PutRule");
+    assertStringIncludes(error.message, "rule/ChineseboostAnalyticsStac-");
+  });
+});
+
+/**
+ * A Role a deployment can run as, allowed EventBridge on the rules of one name
+ * prefix and nothing else.
+ */
+async function deployRole(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  roleName: string,
+  namePrefix: string,
+): Promise<SimAwsCaller> {
+  const iam = simAws.account(accountId).iam();
+
+  await iam.createRole({
+    input: {
+      RoleName: roleName,
+      AssumeRolePolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "sts:AssumeRole",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+        },
+      }),
+    },
+  });
+
+  await iam.putRolePolicy({
+    input: {
+      RoleName: roleName,
+      PolicyName: `${roleName}-policy`,
+      PolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "events:*",
+          Resource: `arn:aws:events:${regionName}:${accountId}:rule/${namePrefix}`,
+        },
+      }),
+    },
+  });
+
+  return { kind: "arn", arn: `arn:aws:iam::${accountId}:role/${roleName}` };
+}

--- a/src/service/cloudformation/resource/name/sim-cfn-generated-resource-name.iso.test.ts
+++ b/src/service/cloudformation/resource/name/sim-cfn-generated-resource-name.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertStringLength,
+  assertStringMatches,
+  assertStringStartsWith,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCfnGeneratedResourceName } from "./sim-cfn-generated-resource-name.js";
+
+describe("SimCfnGeneratedResourceName", () => {
+  it("names a Resource after the stack, the logical ID and a tail", () => {
+    // Given a Resource in a stack, whose name is well inside what the service
+    // allows.
+    const name = new SimCfnGeneratedResourceName({
+      stackName: "orders-stack",
+      logicalId: "OrdersQueue",
+      maximumLength: 80,
+    });
+
+    // When the generated name is read, then it carries both parts whole,
+    // followed by a tail, as a real CloudFormation generated name does.
+    assertStringStartsWith(name.value, "orders-stack-OrdersQueue-");
+    assertStringMatches(name.value, /^orders-stack-OrdersQueue-[\da-f]{12}$/);
+  });
+
+  it("splits a name too long for the service between the two parts", () => {
+    // Given the stack name and logical ID of a role real CloudFormation named
+    // ChineseboostAnalyticsStac-RainlyticsSummariesJobFun-UjecjFhpdr1d, where
+    // 64 characters leave 25 for the stack name and 25 for the logical ID.
+    const name = new SimCfnGeneratedResourceName({
+      stackName: "ChineseboostAnalyticsStack",
+      logicalId: "RainlyticsSummariesJobFunctionServiceRole1C6CB09C",
+      maximumLength: 64,
+    });
+
+    // When the generated name is read, then both parts are trimmed to their
+    // share of it, so the stack name matches the prefix a real deployment
+    // produces and an IAM policy scoped by that prefix allows the same
+    // deployments here as in an account.
+    assertStringStartsWith(
+      name.value,
+      "ChineseboostAnalyticsStac-RainlyticsSummariesJobFun-",
+    );
+    assertStringLength(name.value, 64);
+  });
+
+  it("rounds the split up in the stack name's favour", () => {
+    // Given a name too long for a bucket, where the 63 characters S3 allows
+    // leave an odd number to share between the two parts.
+    const name = new SimCfnGeneratedResourceName({
+      stackName: "ChineseboostAnalyticsStack",
+      logicalId: "RainlyticsLogsBucket8DF4B7A6",
+      maximumLength: 63,
+    });
+
+    // When the generated name is read, then the stack name has 25 characters
+    // and the logical ID 24, which is how real CloudFormation named the bucket
+    // chineseboostanalyticsstac-rainlyticslogsbucket8df4-hdst4ohfvdif.
+    assertStringStartsWith(
+      name.value,
+      "ChineseboostAnalyticsStac-RainlyticsLogsBucket8DF4-",
+    );
+    assertStringLength(name.value, 63);
+  });
+
+  it("gives one part the characters the other does not use", () => {
+    // Given a short stack name and a logical ID too long for the two of them to
+    // fit a load balancer name together.
+    const name = new SimCfnGeneratedResourceName({
+      stackName: "orders",
+      logicalId: "OrdersLoadBalancerC9C60EF3",
+      maximumLength: 32,
+    });
+
+    // When the generated name is read, then the stack name is kept whole and
+    // the logical ID takes the rest, rather than half of it going unused.
+    assertStringStartsWith(name.value, "orders-OrdersLoadBa-");
+    assertStringLength(name.value, 32);
+  });
+
+  it("falls back to the logical ID with no stack name", () => {
+    // Given a Resource created outside a stack, which has no stack name to
+    // derive a name from.
+    const noStackName = new SimCfnGeneratedResourceName({
+      stackName: undefined,
+      logicalId: "OrdersQueue",
+      maximumLength: 80,
+    });
+    const emptyStackName = new SimCfnGeneratedResourceName({
+      stackName: "",
+      logicalId: "OrdersQueue",
+      maximumLength: 80,
+    });
+
+    // When the generated name is read, then it is the logical ID and a tail
+    // rather than a name with an empty part in it.
+    assertStringMatches(noStackName.value, /^OrdersQueue-[\da-f]{12}$/);
+    assertIdentical(emptyStackName.value, noStackName.value);
+  });
+
+  it("trims a logical ID standing in for a whole name", () => {
+    // Given a Resource outside a stack whose logical ID is on its own longer
+    // than the service allows.
+    const name = new SimCfnGeneratedResourceName({
+      stackName: undefined,
+      logicalId: "OrdersQueue".repeat(8),
+      maximumLength: 80,
+    });
+
+    // When the generated name is read, then it is trimmed to leave room for
+    // the tail, as a name with a stack name in it is.
+    assertStringStartsWith(name.value, "OrdersQueue".repeat(6));
+    assertStringLength(name.value, 80);
+  });
+
+  it("generates the same name for the same Resource each deployment", () => {
+    // Given the same stack name and logical ID named twice, as two deployments
+    // of one template do.
+    const properties = {
+      stackName: "orders-stack",
+      logicalId: "OrdersQueueWithARatherLongLogicalIdIndeed",
+      maximumLength: 40,
+    };
+
+    // When both generated names are read, then they are the same name, so a
+    // test can rely on the name a deployment gives a Resource.
+    assertIdentical(
+      new SimCfnGeneratedResourceName(properties).value,
+      new SimCfnGeneratedResourceName(properties).value,
+    );
+  });
+
+  it("keeps two trimmed names apart where only the trimmed-off part differs", () => {
+    // Given two logical IDs that are the same up to the point a generated name
+    // is trimmed at. CDK puts its disambiguating hash at the end of a logical
+    // ID, which is the part trimming takes off.
+    const stackName = "orders-stack";
+    const sharedPrefix = "OrdersQueue".repeat(4);
+    const first = new SimCfnGeneratedResourceName({
+      stackName,
+      logicalId: `${sharedPrefix}E6CA6235`,
+      maximumLength: 64,
+    });
+    const second = new SimCfnGeneratedResourceName({
+      stackName,
+      logicalId: `${sharedPrefix}1B3D8A07`,
+      maximumLength: 64,
+    });
+
+    // When both names are read, then they are different names, so the two
+    // Resources do not collide on one name.
+    assertStringLength(first.value, 64);
+    assertStringLength(second.value, 64);
+    assertFalse(first.value === second.value);
+  });
+
+  it("keeps a name inside a limit with no room for both parts", () => {
+    // Given a limit shorter than a name and its tail together, which no
+    // service this simulates has, but which the trimming should survive.
+    const name = new SimCfnGeneratedResourceName({
+      stackName: "orders-stack",
+      logicalId: "OrdersQueue",
+      maximumLength: 10,
+    });
+
+    // When the generated name is read, then it is the tail cut to the limit,
+    // rather than a name longer than the service would accept.
+    assertStringMatches(name.value, /^[\da-f]{10}$/);
+  });
+});

--- a/src/service/cloudformation/resource/name/sim-cfn-generated-resource-name.ts
+++ b/src/service/cloudformation/resource/name/sim-cfn-generated-resource-name.ts
@@ -26,8 +26,8 @@ interface SimCfnGeneratedResourceNameProperties {
  * reserves the last thirteen characters of it for the tail and its hyphen. What
  * is left over goes to the stack name and the logical ID either side of one
  * more hyphen, half each, the stack name rounding up and either taking what the
- * other does not use. So a 64 character limit trims a long stack name and a
- * long logical ID to 25 characters each. The rule is inferred from names real
+ * other does not use. Where a service allows 64 characters, a long stack name
+ * and a long logical ID keep 25 each. The rule is inferred from names real
  * CloudFormation produced, since AWS documents none of it.
  *
  * The tail is derived from the whole untrimmed name. That is what keeps two

--- a/src/service/cloudformation/resource/name/sim-cfn-generated-resource-name.ts
+++ b/src/service/cloudformation/resource/name/sim-cfn-generated-resource-name.ts
@@ -1,10 +1,10 @@
 import { createHash } from "node:crypto";
 
 /**
- * How many characters of the hash of the untrimmed name a trimmed one ends
- * with, so two long names that start the same do not become one name.
+ * How many characters the tail on the end of a generated name is, which is as
+ * many as the random characters real CloudFormation ends one with.
  */
-const distinguisherLength = 8;
+const tailLength = 12;
 
 interface SimCfnGeneratedResourceNameProperties {
   readonly stackName: string | undefined;
@@ -15,18 +15,25 @@ interface SimCfnGeneratedResourceNameProperties {
 /**
  * The name CloudFormation gives a Resource whose template does not name it.
  *
- * Real CloudFormation generates `<stack name>-<logical ID>-<random>`. The
- * random part is left out here so a test can predict the name, which is the one
- * thing a template cannot rely on for real. Everything else follows AWS: two
+ * CloudFormation generates `<stack name>-<logical ID>-<random>`. The tail here
+ * is a hash of the other two parts rather than random characters. The same
+ * template deployed under the same stack name generates the same name again,
+ * and a test can read it back and compare. Everything else follows AWS. Two
  * stacks deploying the same template get different names, because the stack
  * name is part of it.
  *
- * Each service has its own limit on how long a name can be, so a long stack
- * name and logical ID together are trimmed to fit. The start is kept, since
- * that is where the stack name is, and the trimmed name ends in a hash of the
- * untrimmed one. CDK puts its own disambiguating hash at the end of a logical
- * ID, which is exactly what trimming cuts off, so without that two Resources in
- * one stack could end up asking for the same name.
+ * Each service has its own limit on how long a name can be, and CloudFormation
+ * reserves the last thirteen characters of it for the tail and its hyphen. What
+ * is left over goes to the stack name and the logical ID either side of one
+ * more hyphen, half each, the stack name rounding up and either taking what the
+ * other does not use. So a 64 character limit trims a long stack name and a
+ * long logical ID to 25 characters each. The rule is inferred from names real
+ * CloudFormation produced, since AWS documents none of it.
+ *
+ * The tail is derived from the whole untrimmed name. That is what keeps two
+ * trimmed names apart. CDK puts its own disambiguating hash at the end of a
+ * logical ID, which is exactly what trimming cuts off, so without that two
+ * Resources in one stack could end up asking for the same name.
  */
 export class SimCfnGeneratedResourceName {
   private readonly stackName: string | undefined;
@@ -43,31 +50,59 @@ export class SimCfnGeneratedResourceName {
    * The generated name.
    */
   get value(): string {
-    const composed = this.composed();
+    const tail = this.tail();
 
-    if (composed.length <= this.maximumLength) {
-      return composed;
+    if (this.maximumLength <= tailLength + 1) {
+      return tail.slice(0, this.maximumLength);
     }
 
-    const kept = composed.slice(
-      0,
-      this.maximumLength - distinguisherLength - 1,
-    );
-
-    return `${kept}-${this.distinguisher(composed)}`;
+    return `${this.trimmed()}-${tail}`;
   }
 
   /**
-   * The tail a trimmed name ends with, derived from the whole untrimmed name.
+   * The stack name and logical ID, trimmed to the room the tail leaves them.
+   *
+   * A name that already fits is kept whole. One that does not gives each part
+   * half of what is left. The stack name is trimmed rather than lost, since
+   * that is the part an IAM policy scoped by resource prefix matches on.
+   */
+  private trimmed(): string {
+    const composed = this.composed();
+    const budget = this.maximumLength - tailLength - 1;
+
+    if (composed.length <= budget) {
+      return composed;
+    }
+
+    if (this.stackName === undefined || this.stackName === "") {
+      return composed.slice(0, budget);
+    }
+
+    const shared = budget - 1;
+    const stackNameKept = Math.min(
+      this.stackName.length,
+      shared - Math.min(this.logicalId.length, Math.floor(shared / 2)),
+    );
+
+    return [
+      this.stackName.slice(0, stackNameKept),
+      this.logicalId.slice(0, shared - stackNameKept),
+    ].join("-");
+  }
+
+  /**
+   * The tail the name ends with, derived from the whole untrimmed name.
    *
    * It is a hash rather than the random characters real CloudFormation uses, so
-   * the name stays the same between deployments of the same template.
+   * the name stays the same between deployments of the same template. Hex
+   * suits every service, since one that only allows lowercase takes it as it
+   * is.
    */
-  private distinguisher(composed: string): string {
+  private tail(): string {
     return createHash("sha1")
-      .update(composed)
+      .update(this.composed())
       .digest("hex")
-      .slice(0, distinguisherLength);
+      .slice(0, tailLength);
   }
 
   /**

--- a/src/service/cloudwatch/cfn/sim-cfn-alarm.iso.test.ts
+++ b/src/service/cloudwatch/cfn/sim-cfn-alarm.iso.test.ts
@@ -11,6 +11,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertTypeString,
 } from "@kensio/smartass";
@@ -139,7 +140,7 @@ describe("AWS::CloudWatch::Alarm", () => {
     const alarms = simAws.cloudWatch().allAlarms();
 
     assertArrayLength(alarms, 1);
-    assertIdentical(alarms.at(0)?.name, "orders-OrdersAlarm");
+    assertStringStartsWith(alarms.at(0)?.name, "orders-OrdersAlarm-");
   });
 
   it("resolves Ref to the name and Fn::GetAtt Arn to the alarm ARN", async () => {

--- a/src/service/cognito/cfn/sim-cfn-cognito-cdk-defaults.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-cdk-defaults.iso.test.ts
@@ -9,6 +9,7 @@ import {
   assertNonNullable,
   assertObjectEquals,
   assertStringIncludes,
+  assertStringStartsWith,
   assertTrue,
   assertTypeString,
 } from "@kensio/smartass";
@@ -97,7 +98,7 @@ describe("Cognito CloudFormation defaults a CDK stack emits", () => {
     const described = await cognito.describeUserPool(
       new DescribeUserPoolCommand({ UserPoolId: userPoolId }),
     );
-    assertIdentical(described.UserPool?.Name, "app-stack-PoolD3F588B8");
+    assertStringStartsWith(described.UserPool?.Name, "app-stack-PoolD3F588B8-");
 
     // And the properties the template declared are reported back, so what the
     // stack asked for stays visible even though nothing here reads any of it.
@@ -128,9 +129,9 @@ describe("Cognito CloudFormation defaults a CDK stack emits", () => {
       }),
     );
     assertNonNullable(describedClient.UserPoolClient);
-    assertIdentical(
+    assertStringStartsWith(
       describedClient.UserPoolClient.ClientName,
-      "app-stack-PoolClient8A3E5EB7",
+      "app-stack-PoolClient8A3E5EB7-",
     );
     assertFalse(describedClient.UserPoolClient.AllowedOAuthFlowsUserPoolClient);
     assertArrayEquals(

--- a/src/service/cognito/cfn/sim-cfn-cognito-generated-name.iso.test.ts
+++ b/src/service/cognito/cfn/sim-cfn-cognito-generated-name.iso.test.ts
@@ -2,6 +2,7 @@ import {
   assertFalse,
   assertIdentical,
   assertStringLength,
+  assertStringMatches,
   assertStringStartsWith,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -22,10 +23,10 @@ describe("SimCfnCognitoGeneratedName", () => {
       logicalId: "AppPoolClient",
     });
 
-    // When each generated name is read, then it carries both parts, as a real
-    // CloudFormation generated name does.
-    assertIdentical(pool.value, "app-stack-AppPool");
-    assertIdentical(client.value, "app-stack-AppPoolClient");
+    // When each generated name is read, then it carries both parts and a
+    // tail, as a real CloudFormation generated name does.
+    assertStringMatches(pool.value, /^app-stack-AppPool-[\da-f]{12}$/);
+    assertStringMatches(client.value, /^app-stack-AppPoolClient-[\da-f]{12}$/);
   });
 
   it("falls back to the logical ID with no stack name", () => {
@@ -40,10 +41,10 @@ describe("SimCfnCognitoGeneratedName", () => {
       logicalId: "AppPool",
     });
 
-    // When the generated name is read, then it is the logical ID on its own
+    // When the generated name is read, then it is the logical ID and a tail
     // rather than a name with an empty part in it.
-    assertIdentical(noStack.value, "AppPool");
-    assertIdentical(emptyStackName.value, "AppPool");
+    assertStringMatches(noStack.value, /^AppPool-[\da-f]{12}$/);
+    assertIdentical(emptyStackName.value, noStack.value);
   });
 
   it("trims a generated name to the 128 characters Cognito allows", () => {
@@ -52,10 +53,10 @@ describe("SimCfnCognitoGeneratedName", () => {
     const logicalId = "AppPoolWithARatherLongLogicalIdIndeed";
     const name = new SimCfnCognitoGeneratedName({ stackName, logicalId });
 
-    // When the generated name is read, then it is trimmed to fit, keeping the
-    // start, so the stack name is still in it.
+    // When the generated name is read, then it is trimmed to fit, and the
+    // logical ID keeps the characters the stack name does not need.
     assertStringLength(name.value, 128);
-    assertStringStartsWith(name.value, `${stackName}-AppPoolWithARather`);
+    assertStringStartsWith(name.value, `${"a".repeat(77)}-${logicalId}-`);
 
     // And the same template generates the same name again, rather than a new
     // one each deployment.

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-global-table.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-global-table.iso.test.ts
@@ -9,6 +9,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertObjectEquals,
+  assertStringStartsWith,
   assertTrue,
   assertTypeString,
 } from "@kensio/smartass";
@@ -318,7 +319,7 @@ describe("DynamoDB CloudFormation GlobalTable deployment", () => {
 
     const tableName = stack.outputs.get("OrdersTableName")?.value;
     assertTypeString(tableName);
-    assertIdentical(tableName, "orders-stack-OrdersTable");
+    assertStringStartsWith(tableName, "orders-stack-OrdersTable-");
 
     // When an item is written to the table the Ref named.
     await simAws.dynamoDb().putItem(

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table.iso.test.ts
@@ -259,11 +259,10 @@ describe("DynamoDB CloudFormation Table deployment", () => {
 
     // Then the name carries the stack name and the logical ID, so a Lambda
     // environment variable built from the Ref reaches the deployed table.
-    assertIdentical(
-      stack.outputs.get("OrdersTableName")?.value,
-      "orders-stack-OrdersTable",
-    );
-    assertNonNullable(simAws.dynamoDb().findTable("orders-stack-OrdersTable"));
+    const tableName = stack.outputs.get("OrdersTableName")?.value;
+
+    assertStringStartsWith(tableName, "orders-stack-OrdersTable-");
+    assertNonNullable(simAws.dynamoDb().findTable(tableName));
   });
 
   it("gives two stacks deploying one template two differently named tables", async () => {

--- a/src/service/ecr/cfn/sim-cfn-ecr-repository.iso.test.ts
+++ b/src/service/ecr/cfn/sim-cfn-ecr-repository.iso.test.ts
@@ -4,6 +4,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertTrue,
 } from "@kensio/smartass";
@@ -104,7 +105,10 @@ describe("AWS::ECR::Repository", () => {
     await stack.waitForDeployComplete();
 
     // Then the generated name is lower cased, since ECR names are.
-    assertTrue(simAws.ecr().hasRepository("platform-stack-ordersrepository"));
+    assertStringStartsWith(
+      simAws.ecr().allRepositories().at(0)?.repositoryName,
+      "platform-stack-ordersrepository-",
+    );
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/ecs/README.md
+++ b/src/service/ecs/README.md
@@ -440,8 +440,9 @@ them.
 - `SimEcsContainerDefinitionType` carries no index signature. One would stop a real SDK
   `RegisterTaskDefinitionCommand` input being assignable to it, which is the whole point of the
   structural types. A field it does not name is stored and reported back all the same.
-- A cluster or task definition a template does not name gets a name composed from the stack name and
-  the logical ID, without the random part real CloudFormation adds, so a test can predict it.
+- A cluster or task definition a template does not name gets a name composed from the stack name,
+  the logical ID and a tail derived from both, through the shared `SimCfnGeneratedResourceName`. The
+  tail stands in for the random characters real CloudFormation ends one with.
 - A cluster property or task definition property `CreateCluster` or `RegisterTaskDefinition` would
   refuse is recorded as ignored rather than refused, so the stack deploys. A declaration nothing acts
   on is worth less than a stack that will not come up.

--- a/src/service/ecs/cfn/sim-cfn-ecs-binding-targets.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-binding-targets.iso.test.ts
@@ -86,8 +86,9 @@ describe("ECS CloudFormation binding targets", () => {
   });
 
   it("binds a task definition by the family CloudFormation generated", async () => {
-    // Given a task definition the template names no family for, so the family
-    // is the one CloudFormation would have generated.
+    // Given a deployed task definition the template names no family for, whose
+    // generated family a Ref hands the test, since it ends in a tail derived
+    // from the stack name and the logical ID.
     const simAws = new SimAws();
     let runs = 0;
 
@@ -106,27 +107,37 @@ describe("ECS CloudFormation binding targets", () => {
             },
           },
         },
-      },
-      bindings: [
-        {
-          family: "orders-stack-WorkerTaskDefinition",
-          containerName: "app",
-          run: () => {
-            runs += 1;
-          },
+        Outputs: {
+          TaskDefinitionRef: { Value: { Ref: "WorkerTaskDefinition" } },
         },
-      ],
+      },
     });
 
     await stack.waitForDeployComplete();
 
-    // When a task is run from it.
-    await simAws.ecs().runTask(
-      new RunTaskCommand({
-        cluster: "orders",
-        taskDefinition: "orders-stack-WorkerTaskDefinition",
-      }),
+    const taskDefinitionArn = stack.outputs.get("TaskDefinitionRef")?.value;
+
+    assertStringIncludes(
+      taskDefinitionArn,
+      "task-definition/orders-stack-WorkerTaskDefinition-",
     );
+
+    const { family } = simAws.ecs().taskDefinition(taskDefinitionArn);
+
+    // When a handler is bound to that family and a task is run from it.
+    simAws.ecs().bindContainer({
+      family,
+      containerName: "app",
+      run: () => {
+        runs += 1;
+      },
+    });
+
+    await simAws
+      .ecs()
+      .runTask(
+        new RunTaskCommand({ cluster: "orders", taskDefinition: family }),
+      );
 
     await simAws.backgroundTasksComplete();
 

--- a/src/service/ecs/cfn/sim-cfn-ecs-cluster.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-cluster.iso.test.ts
@@ -1,10 +1,11 @@
 import { DescribeClustersCommand } from "@aws-sdk/client-ecs";
 import {
   assertArrayLength,
-  assertIdentical,
   assertFalse,
+  assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertTrue,
 } from "@kensio/smartass";
@@ -102,13 +103,13 @@ describe("AWS::ECS::Cluster", () => {
 
     await stack.waitForDeployComplete();
 
-    // Then the cluster is named from the stack and the logical ID, without the
-    // random part real CloudFormation adds, so a test can predict it.
-    assertIdentical(
-      stack.outputs.get("ClusterRef")?.value,
-      "orders-stack-OrdersCluster",
-    );
-    assertTrue(simAws.ecs().cluster("orders-stack-OrdersCluster").isActive());
+    // Then the cluster is named from the stack, the logical ID and a tail
+    // derived from both, which a Ref hands a test rather than it writing the
+    // name out.
+    const clusterName = stack.outputs.get("ClusterRef")?.value;
+
+    assertStringStartsWith(clusterName, "orders-stack-OrdersCluster-");
+    assertTrue(simAws.ecs().cluster(clusterName).isActive());
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-service-properties.iso.test.ts
@@ -4,6 +4,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertTrue,
   assertTypeString,
@@ -74,21 +75,29 @@ describe("AWS::ECS::Service properties", () => {
     // which real CloudFormation fills both of in.
     const simAws = new SimAws();
 
-    // When it is deployed.
+    // When it is deployed, with the name it generated for the service read
+    // back through an attribute.
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "orders-stack",
-      template: serviceTemplate({}),
+      template: {
+        ...serviceTemplate({}),
+        Outputs: {
+          Name: { Value: { "Fn::GetAtt": ["WorkerService", "Name"] } },
+        },
+      },
     });
 
     await stack.waitForDeployComplete();
     await simAws.backgroundTasksComplete();
 
-    // Then the service is named from the stack and the logical ID, without the
-    // random part real CloudFormation adds, and it keeps the one task real
-    // CloudFormation gives a new service that declares no count.
-    const service = simAws
-      .ecs()
-      .service("orders-stack-WorkerService", "orders");
+    // Then the service is named from the stack, the logical ID and a tail
+    // derived from both, and it keeps the one task real CloudFormation gives a
+    // new service that declares no count.
+    const serviceName = stack.outputs.get("Name")?.value;
+
+    assertStringStartsWith(serviceName, "orders-stack-WorkerService-");
+
+    const service = simAws.ecs().service(serviceName, "orders");
 
     assertTrue(service.isActive());
     assertIdentical(service.desiredCount, 1);

--- a/src/service/ecs/cfn/sim-cfn-ecs-task-definition.iso.test.ts
+++ b/src/service/ecs/cfn/sim-cfn-ecs-task-definition.iso.test.ts
@@ -231,17 +231,23 @@ describe("AWS::ECS::TaskDefinition", () => {
             Properties: { ContainerDefinitions: [workerContainer] },
           },
         },
+        Outputs: {
+          TaskDefinitionRef: { Value: { Ref: "WorkerTaskDefinition" } },
+        },
       },
     });
 
     await stack.waitForDeployComplete();
 
-    // Then the family comes from the stack and the logical ID, without the
-    // random part real CloudFormation adds, so a test can predict it.
-    assertIdentical(
-      simAws.ecs().taskDefinition("orders-stack-WorkerTaskDefinition").revision,
-      1,
+    // Then the family comes from the stack, the logical ID and a tail derived
+    // from both, which the Ref a test reads carries.
+    const taskDefinitionArn = stack.outputs.get("TaskDefinitionRef")?.value;
+
+    assertStringIncludes(
+      taskDefinitionArn,
+      "task-definition/orders-stack-WorkerTaskDefinition-",
     );
+    assertIdentical(simAws.ecs().taskDefinition(taskDefinitionArn).revision, 1);
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-load-balancer.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-load-balancer.iso.test.ts
@@ -5,6 +5,7 @@ import {
   assertNonNullable,
   assertStringEndsWith,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
@@ -142,12 +143,12 @@ describe("AWS::ElasticLoadBalancingV2::LoadBalancer", () => {
 
     await stack.waitForDeployComplete();
 
-    // Then the name is the stack and the logical ID, without the random part
-    // real CloudFormation adds, so a test can predict it.
-    assertIdentical(stack.outputs.get("Name")?.value, "shop-stack-ShopAlb");
-    assertNonNullable(
-      simAws.elbV2().findLoadBalancerByName("shop-stack-ShopAlb"),
-    );
+    // Then the name is the stack, the logical ID and a tail derived from both,
+    // as real CloudFormation names one.
+    const loadBalancerName = stack.outputs.get("Name")?.value;
+
+    assertStringStartsWith(loadBalancerName, "shop-stack-ShopAlb-");
+    assertNonNullable(simAws.elbV2().findLoadBalancerByName(loadBalancerName));
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/elbv2/cfn/sim-cfn-elbv2-target-group.iso.test.ts
+++ b/src/service/elbv2/cfn/sim-cfn-elbv2-target-group.iso.test.ts
@@ -8,6 +8,7 @@ import {
   assertNonNullable,
   assertStringEndsWith,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
@@ -243,7 +244,10 @@ describe("AWS::ElasticLoadBalancingV2::TargetGroup", () => {
     await stack.waitForDeployComplete();
 
     // Then it is named from the stack and the logical ID.
-    assertIdentical(simCfnElbV2Output(stack, "Name"), "shop-stack-Checkout");
+    assertStringStartsWith(
+      simCfnElbV2Output(stack, "Name"),
+      "shop-stack-Checkout-",
+    );
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream.iso.test.ts
+++ b/src/service/firehose/cfn/sim-cfn-firehose-delivery-stream.iso.test.ts
@@ -4,6 +4,7 @@ import {
   assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertTrue,
 } from "@kensio/smartass";
@@ -136,13 +137,12 @@ describe("deployed AWS::KinesisFirehose::DeliveryStream Resources", () => {
     await stack.waitForDeployComplete();
 
     // Then CloudFormation named it, as real CloudFormation names one.
+    const streamName = stack.outputs.get("StreamRef")?.value;
+
+    assertStringStartsWith(streamName, "orders-stack-OrderEvents-");
     assertIdentical(
-      stack.outputs.get("StreamRef")?.value,
-      "orders-stack-OrderEvents",
-    );
-    assertIdentical(
-      simAws.firehose().findDeliveryStream("orders-stack-OrderEvents")?.name,
-      "orders-stack-OrderEvents",
+      simAws.firehose().findDeliveryStream(streamName)?.name,
+      streamName,
     );
   });
 

--- a/src/service/kinesis/cfn/sim-cfn-kinesis-stream.iso.test.ts
+++ b/src/service/kinesis/cfn/sim-cfn-kinesis-stream.iso.test.ts
@@ -4,6 +4,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -82,9 +83,9 @@ describe("deployed AWS::Kinesis::Stream Resources", () => {
     await stack.waitForDeployComplete();
 
     // Then CloudFormation named it, as real CloudFormation does.
-    assertIdentical(
+    assertStringStartsWith(
       stack.outputs.get("StreamRef")?.value,
-      "orders-stack-OrdersStream",
+      "orders-stack-OrdersStream-",
     );
   });
 

--- a/src/service/ses/cfn/sim-cfn-ses-template.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-template.iso.test.ts
@@ -5,6 +5,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
@@ -111,8 +112,8 @@ describe("AWS::SES::Template", () => {
     // Then CloudFormation named it, the way it names any unnamed Resource.
     const name = stack.outputs.get("Name")?.value;
 
-    assertIdentical(name, "orders-WelcomeEmail");
-    assertNonNullable(simAws.sesV2().findTemplate("orders-WelcomeEmail"));
+    assertStringStartsWith(name, "orders-WelcomeEmail-");
+    assertNonNullable(simAws.sesV2().findTemplate(name));
   });
 
   it("leaves out a part the template does not set", async () => {

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -377,8 +377,9 @@ says the Resource is invalid, and `simCfnSnsResourceCreation` renames SNS's own 
 Resource asked for it, since an SNS error carries no logical ID.
 
 `SimCfnSnsTopicName` is the name a topic whose template does not name it gets, built on the shared
-`SimCfnGeneratedResourceName`. It leaves out the random characters real CloudFormation adds, so a test
-can predict it.
+`SimCfnGeneratedResourceName`. The tail on the end of it is derived from the stack name and the
+logical ID, in place of the random characters real CloudFormation ends one with, and the same
+template deployed again gets the same name.
 
 `AWS::SNS::TopicPolicy` has no existence of its own, in the same way `AWS::SQS::QueuePolicy` has
 none: it is the `Policy` attribute of the topics it names. The Resource is backed by the first of

--- a/src/service/sns/cfn/sim-cfn-sns-topic.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-topic.iso.test.ts
@@ -3,6 +3,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertStringStartsWith,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -130,14 +131,12 @@ describe("SNS CloudFormation Topic deployment", () => {
       },
     });
 
-    // Then the topic is named from the stack name and the logical ID, as real
-    // CloudFormation names one, without the random characters a template could
-    // not predict anyway.
-    assertIdentical(
-      stack.outputs.get("TopicName")?.value,
-      "orders-stack-OrdersTopic",
-    );
-    assertNonNullable(simAws.sns().findTopic("orders-stack-OrdersTopic"));
+    // Then the topic is named from the stack name, the logical ID and a tail
+    // derived from both, as real CloudFormation names one.
+    const topicName = stack.outputs.get("TopicName")?.value;
+
+    assertStringStartsWith(topicName, "orders-stack-OrdersTopic-");
+    assertNonNullable(simAws.sns().findTopic(topicName));
   });
 
   it("backs the CloudFormation Resource with the simulated topic", async () => {

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-name.iso.test.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-name.iso.test.ts
@@ -2,6 +2,7 @@ import {
   assertFalse,
   assertIdentical,
   assertStringLength,
+  assertStringMatches,
   assertStringStartsWith,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -16,9 +17,9 @@ describe("SimCfnSnsTopicName", () => {
       logicalId: "OrdersTopic",
     });
 
-    // When the generated name is read, then it carries both, as a real
-    // CloudFormation generated name does.
-    assertIdentical(name.value, "orders-stack-OrdersTopic");
+    // When the generated name is read, then it carries both and a tail, as a
+    // real CloudFormation generated name does.
+    assertStringMatches(name.value, /^orders-stack-OrdersTopic-[\da-f]{12}$/);
   });
 
   it("falls back to the logical ID with no stack name", () => {
@@ -33,10 +34,10 @@ describe("SimCfnSnsTopicName", () => {
       logicalId: "OrdersTopic",
     });
 
-    // When the generated name is read, then it is the logical ID on its own
+    // When the generated name is read, then it is the logical ID and a tail
     // rather than a name with an empty part in it.
-    assertIdentical(noStack.value, "OrdersTopic");
-    assertIdentical(emptyStackName.value, "OrdersTopic");
+    assertStringMatches(noStack.value, /^OrdersTopic-[\da-f]{12}$/);
+    assertIdentical(emptyStackName.value, noStack.value);
   });
 
   it("trims a generated name to the 256 characters SNS allows", () => {
@@ -47,10 +48,13 @@ describe("SimCfnSnsTopicName", () => {
       logicalId: "OrdersTopicWithARatherLongLogicalIdIndeed".repeat(2),
     });
 
-    // When the generated name is read, then it is trimmed to fit, keeping the
-    // start, so the stack name is still in it.
+    // When the generated name is read, then it is trimmed to fit, and the
+    // logical ID keeps the characters the stack name does not need.
     assertStringLength(name.value, 256);
-    assertStringStartsWith(name.value, `${"a".repeat(200)}-OrdersTopic`);
+    assertStringStartsWith(
+      name.value,
+      `${"a".repeat(160)}-${"OrdersTopicWithARatherLongLogicalIdIndeed".repeat(2)}-`,
+    );
 
     // And the same template generates the same name again, rather than a new
     // one each deployment.

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -203,8 +203,9 @@ rather than an unsupported one, because sim CloudFormation skips a resource whos
 unsupported, and skipping is the wrong answer for a queue that cannot be created as asked.
 
 `SimCfnSqsQueueName` generates the name for a queue the template does not name, from the stack name
-and the logical ID. The random characters real CloudFormation adds are left out so a test can predict
-the name.
+and the logical ID. It applies the 80 character limit through the shared
+`SimCfnGeneratedResourceName`, which ends the name in a tail derived from the other two parts, in
+place of the random characters real CloudFormation ends one with.
 
 `Ref` and `Fn::GetAtt` behaviour lives with the other CloudFormation value adapters, in
 `cloudformation/resource/cfn/sqs/`. `Ref` gives the queue URL, as real CloudFormation does.

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -203,7 +203,7 @@ rather than an unsupported one, because sim CloudFormation skips a resource whos
 unsupported, and skipping is the wrong answer for a queue that cannot be created as asked.
 
 `SimCfnSqsQueueName` generates the name for a queue the template does not name, from the stack name
-and the logical ID. It applies the 80 character limit through the shared
+and the logical ID. It applies the 80 characters a queue name allows through the shared
 `SimCfnGeneratedResourceName`, which ends the name in a tail derived from the other two parts, in
 place of the random characters real CloudFormation ends one with.
 

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.iso.test.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-name.iso.test.ts
@@ -2,6 +2,7 @@ import {
   assertFalse,
   assertIdentical,
   assertStringLength,
+  assertStringMatches,
   assertStringStartsWith,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -16,9 +17,9 @@ describe("SimCfnSqsQueueName", () => {
       logicalId: "OrdersQueue",
     });
 
-    // When the generated name is read, then it carries both, as a real
-    // CloudFormation generated name does.
-    assertIdentical(name.value, "orders-stack-OrdersQueue");
+    // When the generated name is read, then it carries both and a tail, as a
+    // real CloudFormation generated name does.
+    assertStringMatches(name.value, /^orders-stack-OrdersQueue-[\da-f]{12}$/);
   });
 
   it("falls back to the logical ID with no stack name", () => {
@@ -33,10 +34,10 @@ describe("SimCfnSqsQueueName", () => {
       logicalId: "OrdersQueue",
     });
 
-    // When the generated name is read, then it is the logical ID on its own
+    // When the generated name is read, then it is the logical ID and a tail
     // rather than a name with an empty part in it.
-    assertIdentical(noStack.value, "OrdersQueue");
-    assertIdentical(emptyStackName.value, "OrdersQueue");
+    assertStringMatches(noStack.value, /^OrdersQueue-[\da-f]{12}$/);
+    assertIdentical(emptyStackName.value, noStack.value);
   });
 
   it("trims a generated name to the 80 characters SQS allows", () => {
@@ -47,10 +48,13 @@ describe("SimCfnSqsQueueName", () => {
       logicalId: "OrdersQueueWithARatherLongLogicalId",
     });
 
-    // When the generated name is read, then it is trimmed to fit, keeping the
-    // start, so the stack name is still in it.
+    // When the generated name is read, then the stack name and the logical ID
+    // share what the tail leaves, so the stack name is still in it.
     assertStringLength(name.value, 80);
-    assertStringStartsWith(name.value, `${"a".repeat(60)}-OrdersQu`);
+    assertStringStartsWith(
+      name.value,
+      `${"a".repeat(33)}-OrdersQueueWithARatherLongLogical-`,
+    );
 
     // And the same template generates the same name again, rather than a new
     // one each deployment.

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue.iso.test.ts
@@ -7,6 +7,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertStringStartsWith,
   assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
@@ -201,14 +202,12 @@ describe("SQS CloudFormation Queue deployment", () => {
     });
     await stack.waitForDeployComplete();
 
-    // Then the queue is named from the stack name and the logical ID, as real
-    // CloudFormation names one, without the random characters a template could
-    // not predict anyway.
-    assertIdentical(
-      stack.outputs.get("QueueName")?.value,
-      "orders-stack-OrdersQueue",
-    );
-    assertNonNullable(simAws.sqs().findQueue("orders-stack-OrdersQueue"));
+    // Then the queue is named from the stack name, the logical ID and a tail
+    // derived from both, as real CloudFormation names one.
+    const queueName = stack.outputs.get("QueueName")?.value;
+
+    assertStringStartsWith(queueName, "orders-stack-OrdersQueue-");
+    assertNonNullable(simAws.sqs().findQueue(queueName));
   });
 
   it("backs the CloudFormation Resource with the simulated queue", async () => {

--- a/src/service/stepfunctions/cfn/sim-cfn-state-machine.iso.test.ts
+++ b/src/service/stepfunctions/cfn/sim-cfn-state-machine.iso.test.ts
@@ -1,6 +1,7 @@
 import {
   assertIdentical,
   assertInstanceOf,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertTypeString,
   assertUndefined,
@@ -130,9 +131,9 @@ describe("deployed AWS::StepFunctions::StateMachine Resources", () => {
     await stack.waitForDeployComplete();
 
     // Then CloudFormation named it, as real CloudFormation does.
-    assertIdentical(
+    assertStringStartsWith(
       stack.outputs.get("WorkflowName")?.value,
-      "enrolment-Workflow",
+      "enrolment-Workflow-",
     );
   });
 

--- a/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-web-acl.iso.test.ts
@@ -7,6 +7,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertTypeString,
 } from "@kensio/smartass";
@@ -258,9 +259,9 @@ describe("AWS::WAFv2::WebACL", () => {
     await stack.waitForDeployComplete();
 
     // Then the web ACL carries the name CloudFormation generated for it.
-    assertIdentical(
+    assertStringStartsWith(
       simAws.wafV2().allWebAcls("REGIONAL")[0]?.name,
-      "orders-OrdersAcl",
+      "orders-OrdersAcl-",
     );
   });
 


### PR DESCRIPTION
A Resource whose template does not name it now gets `<stack name>-<logical ID>-<tail>`, with a
twelve character tail derived from the other two parts in place of the random characters an account
produces. Where the two parts are too long for the service, thirteen characters of the limit are
kept for the tail and its hyphen and the rest is shared between them either side of one more hyphen,
the stack name rounding up and each part taking what the other leaves. The stack name is the part an
IAM policy scoped by resource prefix matches, and trimming it any other way gave a deployment the
opposite verdict here from the one an account gives. The rule reproduces all three of the real
CloudFormation names in the issue.

Every generated name now carries the tail, including one short enough to fit whole, so a test
asserting on a full generated name has to read it back from a `Ref`, an attribute or a simulator
accessor. The 27 assertions in the suite that wrote such a name out have been changed that way, and
the docs for the seventeen services using this class say where the tail comes from. An ECS container
binding that named a generated task definition family is the one case that cannot be written out up
front at all, and the `logicalId` binding form is what covers it.

Resolves #1113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CloudFormation-created resource names now use consistent, deterministic suffixes based on the stack and logical resource ID across supported services.
  - Name generation respects each service’s length limits, preserving meaningful identifiers when trimming is required.
  - Generated names can be retrieved through CloudFormation references, attributes, or service listings.
- **Documentation**
  - Added naming guidance, examples, deployment behavior, and IAM prefix-matching considerations for generated names across AWS services.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->