### PR TITLE
docs: recommend a binding before the bundle

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1864,9 +1864,14 @@ CloudFront hostname adapted to the local server.
 
 ## CloudFront Function bindings
 
-When a CDK template contains a CloudFront Function, you can bind the template resource to a real
-local handler function. This lets local integration tests execute the same handler function that
-will run at the CloudFront edge.
+A `bindings` entry backs an executable Resource of the template with a real in-process handler.
+`AWS::CloudFront::Function` and `AWS::Lambda::Function` both take one, and a binding is what to
+reach for first. The bound handler stops on a breakpoint and can close over the test's own state.
+Deploy without one where the test is about the code the template carries. That is the artefact a
+deployment runs.
+
+Binding a CloudFront Function a CDK template declares lets a local integration test run the same
+handler function that will run at the CloudFront edge.
 
 ```typescript sim-cloudformation-cloudfront-function-binding
 /**
@@ -1942,9 +1947,8 @@ to provide an executable local function directly.
 ## Lambda function bindings
 
 `AWS::Lambda::Function` resources support the same bindings. The deployed function is backed by your
-real in-process handler. Tests can close over test state and step through the handler in a debugger,
-while the stack still wires roles, grants and references as the template declares. A bound function
-may omit template `Code` and `Handler` entirely.
+real in-process handler, while the stack still wires roles, grants and references as the template
+declares. A bound function may omit template `Code` and `Handler` entirely.
 
 ```typescript sim-cloudformation-lambda-binding
 /**

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1009,7 +1009,13 @@ A `viewer-response` Function runs for an Origin status below 400. CloudFront ski
 viewer-response event once the Origin has answered 400 or higher (see
 [Limitations](#limitations)), and so does this simulation.
 
-Use `makeCffFunctionCodeInput` to pass a JavaScript handler function to `CreateFunctionCommand`.
+Use `makeCffFunctionCodeInput` to pass a JavaScript handler function to `CreateFunctionCommand`, or
+[CloudFormation bindings](https://yulinsim.dev/services/cloudformation/#cloudfront-function-bindings "CloudFront Function bindings usage docs")
+to back a template Resource with one. A handler reference is what to reach for first. It stops on a
+breakpoint and can close over the test's own state. Publish the source itself where the test is
+about the code the Distribution carries, down to the 10 KB it has to fit in. A
+[Lambda@Edge](#simulated-lambdaedge) function is an ordinary simulated Lambda function, and the same
+choice covers it.
 
 The `host` header a function sees is the hostname the request was made to CloudFront with, being the
 Distribution domain name or one of its alternate domain names. Requests served on localhost arrive

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -81,6 +81,13 @@ The invoke call itself returns normally.
 
 ## Zip-packaged code and the vm runtime
 
+A real in-process handler is the one to reach for first. `makeLambdaZipFileInput(...)` backs a
+function created through the SDK with one, and an [executable binding](#executable-bindings) backs
+one a template declares. The handler stops on a breakpoint and can close over the test's own state.
+Run the packaged code where the test is about the bundle a deployment ships, its imports and its
+bundling included. Both paths invoke through simulated Lambda, and simulated IAM authorizes the
+handler's own AWS calls under the execution role either way.
+
 Real Lambda receives function code as a zip archive. `makeLambdaCodeZip(...)` builds real zip
 bytes from a source string (which becomes a single `index.js` module) or from a files map keyed by
 archive path (like a bundled deployment package). The archive runs in a Node.js `vm` context with


### PR DESCRIPTION
The Lambda, CloudFront and CloudFormation pages each said what a binding does and what running the packaged code does, and left a reader who had not decided to work out which to start with. Each page now says once that a real in-process handler is what to reach for first, and names the case the other path is for. On the Lambda page that is the bundle a deployment ships, and on the CloudFront page it is the Function source a Distribution carries, down to the 10 KB it has to fit in. The trade-offs already stated are kept as they were, and the CloudFormation page loses two sentences that now repeat the new paragraph above them.

@coderabbitai ignore