### PR TITLE
ci: skip jobs a change cannot affect

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -5,6 +5,21 @@ on:
   push:
     branches:
       - main
+    # This job installs SAM and Terraform and runs the whole suite to move one
+    # number on a badge. A merge touching only the paths below cannot change
+    # that number, and skips the run. A plain filter is safe here because
+    # nothing in this workflow is a required check on main. The pull request
+    # workflow skips its jobs with `if` for that reason.
+    paths-ignore:
+      - README.md
+      - LICENSE
+      - .gitignore
+      - .coderabbit.yaml
+      - .github/pull_request_template.md
+      - .github/dependabot.yml
+      - .idea/**
+      - docs/*.md
+      - docs/**/*.md
 
 defaults:
   run:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,8 +17,75 @@ env:
 # and 16 GB, and on a public repository it costs nothing. The suite ran on a
 # larger third-party machine until August 2026.
 jobs:
+  # Lint, Test, Build and Pack are required checks on main. A workflow-level
+  # paths-ignore would leave a documentation-only pull request waiting forever
+  # on four checks that never report, because a filtered-out workflow reports
+  # nothing at all. Skipping each job with `if` does report, and a skipped
+  # required check counts as a passing one.
+  changes:
+    name: Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.classify.outputs.code }}
+      pack: ${{ steps.classify.outputs.pack }}
+    steps:
+      # There is no checkout here. The API already knows what the pull request
+      # touches, and asking it takes a few seconds against the minute a
+      # checkout and a pnpm install cost.
+      - id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          files=$(
+            gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" \
+              --jq '.[].filename'
+          )
+
+          code=false
+          pack=false
+          count=0
+
+          while IFS= read -r file; do
+            count=$((count + 1))
+
+            case "$file" in
+              # `*` matches `/` in a case pattern. One entry covers a tree.
+              README.md | LICENSE | .gitignore | .coderabbit.yaml) ;;
+              .github/pull_request_template.md | .github/dependabot.yml) ;;
+              .idea/*) ;;
+              # The Pack job runs `pnpm build`. That writes llms.txt from the
+              # links in docs/README.md, and fails on a page nothing links to.
+              # Lint and the type check only ever read the .example.ts files
+              # extracted from these pages, and those are committed.
+              docs/*.md) pack=true ;;
+              *)
+                code=true
+                pack=true
+                ;;
+            esac
+          done <<< "$files"
+
+          # The endpoint stops at 3000 files. Past that the list is truncated,
+          # and a job the pull request needs could be skipped on a partial
+          # view of it.
+          if [ "$count" -ge 3000 ]; then
+            code=true
+            pack=true
+          fi
+
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "pack=$pack" >> "$GITHUB_OUTPUT"
+          echo "$count changed files: code=$code pack=$pack" >> "$GITHUB_STEP_SUMMARY"
+
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -35,6 +102,8 @@ jobs:
 
   test:
     name: Test
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -71,6 +140,8 @@ jobs:
 
   build:
     name: Build
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -86,6 +157,8 @@ jobs:
 
   pack:
     name: Pack
+    needs: changes
+    if: needs.changes.outputs.pack == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
@coderabbitai ignore

A pull request touching only markdown, the licence or an editor config ran the whole suite, including the SAM and Terraform installs the test job needs. Lint, Test, Build and Pack are required checks on main, and a workflow-level paths-ignore would leave a documentation-only pull request blocked on four checks that never report. The four jobs now skip themselves with `if` on the output of a new Changes job, which reads the pull request's file list from the API. GitHub counts a skipped required check as a passing one. Pack still runs on a documentation markdown change, because `pnpm build` writes llms.txt from the links in docs/README.md and fails on a page nothing links to. The coverage badge workflow on main ignores the same paths through a plain filter, and it can do that because nothing requires it.

The paths treated as inert are `README.md`, `LICENSE`, `.gitignore`, `.coderabbit.yaml`, `.github/pull_request_template.md`, `.github/dependabot.yml`, `.idea/**`, and (for Lint, Test and Build only) `docs/**/*.md`. Anything else, including a truncated file list from a pull request over 3000 files, runs everything.