### PR TITLE
fix: name an unnamed Resource after its stack

### DIFF
--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -131,6 +131,12 @@ Column names keep the case they were given, including partition keys. Real Glue 
 and simulated [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") folds a
 column name only when it runs a query.
 
+A database or a table the template leaves unnamed is named from the stack name, the logical ID and a
+tail derived from both, folded the same way. A `LogTable` in `analytics-stack` becomes
+`analytics-stack-logtable-` and twelve more characters, where real CloudFormation ends the name in
+twelve random ones. The name is trimmed to the 255 bytes the catalog allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
+
 ## Reading the catalog back
 
 `GetDatabase`, `GetDatabases`, `GetTable` and `GetTables` answer through the SDK. A `SimGlue` also

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -1050,6 +1050,18 @@ is created (the attachment `AttachRolePolicy` records). A name no simulated Role
 answers to fails the resource. Deleting the stack takes the policy back off the Roles still
 carrying it, and then deletes the policy.
 
+A Role with no `RoleName`, a User with no `UserName` and a Managed Policy with no
+`ManagedPolicyName` are each named from the stack name, the logical ID and a tail derived from both.
+A `ServiceRole` in `iam-stack` becomes `iam-stack-ServiceRole-` and twelve more characters, where
+real CloudFormation ends the name in twelve random ones. The case is kept as it was written, the way
+IAM keeps it. A Role name and a User name are trimmed to 64 characters and a policy name to 128, and
+[the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
+
+That name is what an IAM policy scoped by name prefix matches. A deploy Role allowed `iam:CreateRole`
+on `arn:aws:iam::123456789012:role/iam-stack-*` covers the Roles its own stack creates, here and in
+an account.
+
 ```typescript sim-iam-cloudformation
 /**
  * Creating IAM resources through simulated CloudFormation.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2838,7 +2838,7 @@ For `AWS::Lambda::Function`, `Ref` returns the function name and `Fn::GetAtt` su
 
 Supported function properties:
 
-- `FunctionName` (defaults to the logical ID)
+- `FunctionName` (a function with none is named after the stack and the logical ID)
 - `Role` (typically a `Ref`/`Fn::GetAtt` to a same-stack `AWS::IAM::Role`, both resolving to the
   role's ARN)
 - `Code` (inline `ZipFile` source string, or `S3Bucket`/`S3Key` fetched from same-scope sim S3)
@@ -2850,6 +2850,12 @@ Supported function properties:
 - `Environment`
 - `DeadLetterConfig`, whose `TargetArn` names a queue or a topic. See
   [retries and destinations in templates](#retries-and-destinations-in-templates)
+
+A function with no `FunctionName` is named from the stack name, the logical ID and a tail derived
+from both. A `RatesFunction` in `orders-stack` becomes `orders-stack-RatesFunction-` and twelve more
+characters, where real CloudFormation ends the name in twelve random ones. The name is trimmed to
+the 64 characters a function name allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
 
 Code in a missing bucket fails the deploy AWS-style with a `NoSuchBucket` diagnostic.
 

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1697,8 +1697,13 @@ writes fall outside it. Without that, the simulation stops after a thousand deli
 An `AWS::S3::Bucket` resource carries five properties simulated S3 acts on. Those are `BucketName`,
 `LifecycleConfiguration`, `NotificationConfiguration`, `PublicAccessBlockConfiguration` and
 `WebsiteConfiguration`. See [Lifecycle configuration](#lifecycle-configuration) for the parts of a
-rule that are read. Without `BucketName` the Bucket is named after the resource's logical id,
-lowercased, where real CloudFormation invents a generated name.
+rule that are read.
+
+A Bucket with no `BucketName` is named from the stack name, the logical ID and a tail derived from
+both, lower cased as a bucket name has to be. A `SiteBucket` in `orders-stack` becomes
+`orders-stack-sitebucket-` and twelve more characters, where real CloudFormation ends the name in
+twelve random ones. The name is trimmed to the 63 characters a bucket name allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
 
 Any other property is left out and recorded in
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without),

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -577,9 +577,12 @@ The other generation options behave as they do on real AWS, being `PasswordLengt
 `IncludeSpace`, and `RequireEachIncludedType`. The last is on unless turned off, and a generated
 password carries one of every character type it was not told to exclude.
 
-A secret with no `Name` is named after its logical ID. Real CloudFormation names it after the stack
-and appends its own random characters. A template cannot rely on the exact generated name either
-way.
+A secret with no `Name` is named from the stack name, the logical ID and a tail derived from both.
+An `ApiSecret` in `db-stack` becomes `db-stack-ApiSecret-` and twelve more characters, where real
+CloudFormation ends the name in twelve random ones. Simulated Secrets Manager then appends its own
+six characters to the ARN, as it does for a secret named by hand. The name is trimmed to the 512
+characters a secret name allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
 
 ## Inside a simulated Lambda handler
 

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -361,9 +361,13 @@ console.log(read.Parameter?.Value); // "db.internal"
 console.log(read.Parameter?.Version); // 1
 ```
 
-A parameter with no `Name` is named after its logical ID. Real CloudFormation generates a name from
-the stack name and its own random characters. A template cannot rely on the exact generated name
-either way.
+A parameter with no `Name` is named from the stack name, the logical ID and a tail derived from
+both. A `FeatureFlags` in `config-stack` becomes `config-stack-FeatureFlags-` and twelve more
+characters, where real CloudFormation ends the name in twelve random ones. The name carries no
+leading slash, putting the parameter at the top of the hierarchy where real CloudFormation puts one
+it names itself. Parameter Store counts the ARN prefix towards the 1011 characters a name may use,
+and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
+cover how the stack name and the logical ID share what is left.
 
 An IAM policy granting access to a template-created parameter needs the ARN rather than the `Ref`.
 Build it with `Fn::Sub`, remembering that the ARN drops the name's leading slash:

--- a/src/service/cloudformation/cdk/demo-proj/sim-cdk-website-cff.loc.test.ts
+++ b/src/service/cloudformation/cdk/demo-proj/sim-cdk-website-cff.loc.test.ts
@@ -193,7 +193,7 @@ app.synth();
     // Then the Outputs should be available.
     assertStringStartsWith(
       stack.outputs.get("SiteBucketName")?.value,
-      "sitebucket",
+      "teststack-sitebucket",
     );
     const distroId = stack.outputs.get("CloudFrontDistributionId")?.value;
     assertStringLength(distroId, 14);

--- a/src/service/cloudformation/deploy/sim-cfn-deployment-generated-name.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-deployment-generated-name.iso.test.ts
@@ -1,0 +1,120 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamPolicyDocumentStatement } from "../../iam/policy/sim-iam-policy.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+/** A Stack whose Bucket leaves CloudFormation to name it. */
+const assetsStackTemplate = {
+  Resources: { AssetsBucket: { Type: "AWS::S3::Bucket" } },
+};
+
+describe("a deployment authorized against the names it generates", () => {
+  it("creates a Bucket a Role scoped to the Stack's own prefix allows", async () => {
+    // Given a deploy Role allowed to create buckets only under the prefix its
+    // own Stack generates names with, which is how an account scopes one.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await deployRole(simAws, accountId, [
+      {
+        Effect: "Allow",
+        Action: "s3:CreateBucket",
+        Resource: "arn:aws:s3:::analytics-stack-*",
+      },
+    ]);
+
+    // When it deploys the Stack the prefix names.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "analytics-stack",
+      template: assetsStackTemplate,
+      caller: deployer,
+    });
+
+    // Then the Bucket was created, because the name carries the Stack.
+    const bucketName = stack.getResource("AssetsBucket")?.refValue;
+
+    assertTypeString(bucketName);
+    assertStringStartsWith(bucketName, "analytics-stack-assetsbucket-");
+    assertIdentical(
+      stack.getResource("AssetsBucket")?.status,
+      "CREATE_COMPLETE",
+    );
+    assertNonNullable(simAws.s3().getSimBucketByName(bucketName));
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a Bucket whose Stack is outside the prefix the Role allows", async () => {
+    // Given the same Role, and a Stack named something else, which is the
+    // decision the prefix exists to make.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await deployRole(simAws, accountId, [
+      {
+        Effect: "Allow",
+        Action: "s3:CreateBucket",
+        Resource: "arn:aws:s3:::analytics-stack-*",
+      },
+    ]);
+
+    // When that Role deploys the same template under another Stack name.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "reporting-stack",
+        template: assetsStackTemplate,
+        caller: deployer,
+      });
+    });
+
+    // Then the Bucket was refused, naming the Bucket the Stack asked for.
+    assertStringIncludes(error.message, "s3:CreateBucket");
+    assertStringIncludes(error.message, "reporting-stack-assetsbucket-");
+  });
+});
+
+/** A Role a deployment can run as, carrying the statements it is given. */
+async function deployRole(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  statements: readonly SimIamPolicyDocumentStatement[],
+): Promise<SimAwsCaller> {
+  const roleName = "deployer";
+  const iam = simAws.account(accountId).iam();
+
+  await iam.createRole({
+    input: {
+      RoleName: roleName,
+      AssumeRolePolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "sts:AssumeRole",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+        },
+      }),
+    },
+  });
+
+  await iam.putRolePolicy({
+    input: {
+      RoleName: roleName,
+      PolicyName: `${roleName}-policy`,
+      PolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: statements,
+      }),
+    },
+  });
+
+  return { kind: "arn", arn: `arn:aws:iam::${accountId}:role/${roleName}` };
+}

--- a/src/service/cloudformation/sam/sim-cfn-sam-function.iso.test.ts
+++ b/src/service/cloudformation/sam/sim-cfn-sam-function.iso.test.ts
@@ -4,7 +4,9 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
+  assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -106,12 +108,12 @@ describe("SAM Serverless Function expansion", () => {
     );
   });
 
-  it("names the function from the SAM logical ID where the template does not", async () => {
+  it("names an unnamed SAM function after the stack and the SAM logical ID", async () => {
     // Given a SAM function that names itself nothing
     const simAws = new SimAws();
 
     // When it is deployed
-    await simAws.cloudFormation().deployTemplate({
+    const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "unnamed-rates-stack",
       template: {
         Transform: "AWS::Serverless-2016-10-31",
@@ -128,9 +130,13 @@ describe("SAM Serverless Function expansion", () => {
       },
     });
 
-    // Then the function is named after the logical ID, as CloudFormation names
-    // an unnamed function from one
-    assertNonNullable(simAws.lambda().getSimFunctionByName("Rates"));
+    // Then the function is named after the stack and the SAM logical ID, as
+    // CloudFormation names an unnamed function
+    const functionName = stack.getResource("Rates")?.refValue;
+
+    assertTypeString(functionName);
+    assertStringStartsWith(functionName, "unnamed-rates-stack-Rates-");
+    assertNonNullable(simAws.lambda().getSimFunctionByName(functionName));
   });
 
   it("answers Ref and Fn::GetAtt against the SAM logical ID", async () => {
@@ -336,7 +342,7 @@ describe("SAM Serverless Function expansion", () => {
     const simAws = new SimAws();
 
     // When it is deployed with a handler bound to it
-    await simAws.cloudFormation().deployTemplate({
+    const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "defaulted-rates-stack",
       template: {
         Transform: "AWS::Serverless-2016-10-31",
@@ -349,7 +355,11 @@ describe("SAM Serverless Function expansion", () => {
     });
 
     // Then the function was created from the defaults alone
-    const simFunction = simAws.lambda().getSimFunctionByName("Rates");
+    const functionName = stack.getResource("Rates")?.refValue;
+
+    assertTypeString(functionName);
+
+    const simFunction = simAws.lambda().getSimFunctionByName(functionName);
     assertNonNullable(simFunction);
     assertIdentical(simFunction.runtimeName, "nodejs22.x");
   });

--- a/src/service/glue/README.md
+++ b/src/service/glue/README.md
@@ -34,7 +34,9 @@ partition keys.
   condition parser in `src/service/dynamodb/expression/key-condition/`.
 - `cfn/` reads `AWS::Glue::Database` and `AWS::Glue::Table` properties and creates from them.
   `AWS::Glue::Crawler` and `AWS::Glue::Partition` are real resource types with no creator here. A
-  template declaring either records that Resource as skipped.
+  template declaring either records that Resource as skipped. An unnamed database or table is named
+  by `sim-cfn-glue-generated-name.ts`, which puts the shared `SimCfnGeneratedResourceName` through
+  the same lowercase fold every catalog name gets.
 - `write/sim-glue-catalog-writer.ts` is how CloudFormation writes to the catalog. A deploy happens
   as CloudFormation, and never as the caller a later request carries, so a Resource creator goes
   through here and skips the IAM authorization an SDK Command applies. The store refusals still

--- a/src/service/glue/cfn/database/sim-cfn-glue-database-properties.ts
+++ b/src/service/glue/cfn/database/sim-cfn-glue-database-properties.ts
@@ -4,6 +4,7 @@ import type { SimGlueDatabaseInput } from "../../database/sim-glue-database-stor
 import { glueCfnPropertyError } from "../sim-cfn-glue-property-error.js";
 import { SimCfnGlueValues } from "../sim-cfn-glue-values.js";
 import { SimCfnGlueDatabaseRules } from "./sim-cfn-glue-database-rules.js";
+import { simCfnGlueGeneratedName } from "../sim-cfn-glue-generated-name.js";
 
 const resourceType = "AWS::Glue::Database";
 
@@ -46,12 +47,11 @@ export class SimCfnGlueDatabaseProperties {
    */
   databaseName(): string {
     const values = this.#values;
-    const stackName = this.#resource.stackName ?? "stack";
 
     return (
       values.optionalString(this.#input()["Name"], "DatabaseInput.Name") ??
       values.optionalString(this.#properties["DatabaseName"], "DatabaseName") ??
-      `${stackName}-${this.#resource.logicalId}`.toLowerCase()
+      simCfnGlueGeneratedName(this.#resource)
     );
   }
 

--- a/src/service/glue/cfn/sim-cfn-glue-generated-name.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-generated-name.ts
@@ -1,0 +1,30 @@
+import { SimCfnGeneratedResourceName } from "../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import { simGlueFolded } from "../database/sim-glue-catalog-name.js";
+
+/**
+ * The longest name the Data Catalog accepts for a database or a table.
+ *
+ * Glue states the limit in UTF-8 bytes and `SimCfnGeneratedResourceName` trims
+ * by character, which come to the same thing here: a logical ID is
+ * alphanumeric, a stack name adds only hyphens, and the tail is hex.
+ */
+const maximumNameLength = 255;
+
+/**
+ * The name CloudFormation gives a database or a table whose template does not
+ * name it.
+ *
+ * One function covers both because the Data Catalog gives a database and a
+ * table the same name rules. The name is folded to lowercase the way the
+ * catalog folds any name it stores, for compatibility with Apache Hive.
+ */
+export function simCfnGlueGeneratedName(resource: SimCfnResource): string {
+  return simGlueFolded(
+    new SimCfnGeneratedResourceName({
+      stackName: resource.stackName,
+      logicalId: resource.logicalId,
+      maximumLength: maximumNameLength,
+    }).value,
+  );
+}

--- a/src/service/glue/cfn/sim-cfn-glue-generated-name.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-generated-name.ts
@@ -6,7 +6,7 @@ import { simGlueFolded } from "../database/sim-glue-catalog-name.js";
  * The longest name the Data Catalog accepts for a database or a table.
  *
  * Glue states the limit in UTF-8 bytes and `SimCfnGeneratedResourceName` trims
- * by character, which come to the same thing here: a logical ID is
+ * by character. The two come to the same thing here. A logical ID is
  * alphanumeric, a stack name adds only hyphens, and the tail is hex.
  */
 const maximumNameLength = 255;

--- a/src/service/glue/cfn/sim-cfn-glue-properties.iso.test.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-properties.iso.test.ts
@@ -3,6 +3,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -42,10 +43,13 @@ describe("AWS::Glue::Database properties", () => {
     });
 
     // Then the name is built from the stack and the logical ID, lowercased,
-    // since Glue names are lowercase for Hive compatibility.
-    assertNonNullable(
-      simAws.glue().findDatabase("analytics-stack-logdatabase"),
-    );
+    // since Glue names are lowercase for Hive compatibility, and ends in the
+    // tail CloudFormation puts on a name it generates.
+    const [created] = simAws.glue().allDatabases();
+
+    assertNonNullable(created);
+    assertStringStartsWith(created.name, "analytics-stack-logdatabase-");
+    assertIdentical(created.name, created.name.toLowerCase());
 
     await simAws.backgroundTasksComplete();
   });

--- a/src/service/glue/cfn/sim-cfn-glue-table-properties.iso.test.ts
+++ b/src/service/glue/cfn/sim-cfn-glue-table-properties.iso.test.ts
@@ -2,6 +2,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
   assertTrue,
   assertUndefined,
@@ -285,10 +286,12 @@ describe("AWS::Glue::Table storage descriptor", () => {
       },
     });
 
-    // Then the name is built from the stack and the logical ID.
-    assertNonNullable(
-      simAws.glue().findTable("site_logs", "analytics-stack-logtable"),
-    );
+    // Then the name is built from the stack and the logical ID, and ends in
+    // the tail CloudFormation puts on a name it generates.
+    const [created] = simAws.glue().tablesInDatabase("site_logs");
+
+    assertNonNullable(created);
+    assertStringStartsWith(created.name, "analytics-stack-logtable-");
     assertUndefined(simAws.glue().findTable("site_logs", "LogTable"));
 
     await simAws.backgroundTasksComplete();

--- a/src/service/glue/cfn/table/sim-cfn-glue-table-properties.ts
+++ b/src/service/glue/cfn/table/sim-cfn-glue-table-properties.ts
@@ -6,6 +6,7 @@ import { SimCfnGlueRecord } from "../sim-cfn-glue-record.js";
 import { SimCfnGlueValues } from "../sim-cfn-glue-values.js";
 import { SimCfnGlueTableInputReader } from "./sim-cfn-glue-table-input.js";
 import { simCfnGlueTableIgnored } from "./sim-cfn-glue-table-rules.js";
+import { simCfnGlueGeneratedName } from "../sim-cfn-glue-generated-name.js";
 
 const resourceType = "AWS::Glue::Table";
 
@@ -56,11 +57,8 @@ export class SimCfnGlueTableProperties {
    * since Glue names are lowercase for Hive compatibility.
    */
   tableName(): string {
-    const stackName = this.#resource.stackName ?? "stack";
-
     return (
-      this.#input().string("Name") ??
-      `${stackName}-${this.#resource.logicalId}`.toLowerCase()
+      this.#input().string("Name") ?? simCfnGlueGeneratedName(this.#resource)
     );
   }
 

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-creator.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-creator.ts
@@ -3,6 +3,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimIam } from "../../sim-iam.js";
 import type { SimIamManagedPolicy } from "../../policy/sim-iam-policy.js";
 import { SimCfnIamManagedPolicyAttacher } from "./sim-cfn-iam-managed-policy-attacher.js";
+import { simCfnIamPolicyGeneratedName } from "../name/sim-cfn-iam-generated-name.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
@@ -66,7 +67,7 @@ export class SimCfnIamManagedPolicyCreator {
     const managedPolicyName = properties["ManagedPolicyName"];
 
     if (managedPolicyName === undefined) {
-      return resource.logicalId;
+      return simCfnIamPolicyGeneratedName(resource);
     }
 
     if (typeof managedPolicyName !== "string") {

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy.iso.test.ts
@@ -2,6 +2,7 @@ import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertStringStartsWith,
   assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
@@ -61,7 +62,7 @@ describe("IAM CloudFormation ManagedPolicy", () => {
     assertIdentical(simAws.iam().policies.get(policy.arn), policy);
   });
 
-  it("defaults ManagedPolicyName to the logical ID and Path to the root", async () => {
+  it("names an unnamed Managed Policy after the stack and the logical ID", async () => {
     // Given a CloudFormation template with a Managed Policy that omits its name
     // and path.
     const simAws = new SimAws();
@@ -90,7 +91,8 @@ describe("IAM CloudFormation ManagedPolicy", () => {
       },
     });
 
-    // Then the Managed Policy uses the logical ID as its name and the root path.
+    // Then the Managed Policy is named after the stack and the logical ID,
+    // as CloudFormation names one, and takes the root path.
     const resource = stack.getResource("DefaultNamedPolicy");
 
     assertNonNullable(resource);
@@ -98,7 +100,10 @@ describe("IAM CloudFormation ManagedPolicy", () => {
     const policy = simAws.iam().policies.get(resource.refValue as SimArn);
 
     assertNonNullable(policy);
-    assertIdentical(policy.policyName, "DefaultNamedPolicy");
+    assertStringStartsWith(
+      policy.policyName,
+      "iam-managed-policy-default-stack-DefaultNamedPolicy-",
+    );
     assertIdentical(policy.path, "/");
     assertUndefined(policy.description);
   });

--- a/src/service/iam/cfn/name/sim-cfn-iam-generated-name.ts
+++ b/src/service/iam/cfn/name/sim-cfn-iam-generated-name.ts
@@ -1,0 +1,48 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+
+/**
+ * The longest name IAM accepts for a Role or a User, which is the same length
+ * for both.
+ *
+ * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
+ */
+const maximumPrincipalNameLength = 64;
+
+/** The longest name IAM accepts for a Policy, which is twice a Role's. */
+const maximumPolicyNameLength = 128;
+
+/**
+ * The name CloudFormation gives a Role or a User whose template does not name
+ * it.
+ *
+ * Sixty-four characters is short for a name made of a stack name and a logical
+ * ID, so the trimming `SimCfnGeneratedResourceName` does is the usual case here
+ * rather than the exception. The case is left alone, since IAM keeps a name as
+ * it was given, and every character a stack name or a logical ID is made of is
+ * one an IAM name allows.
+ */
+export function simCfnIamPrincipalGeneratedName(
+  resource: SimCfnResource,
+): string {
+  return generatedName(resource, maximumPrincipalNameLength);
+}
+
+/**
+ * The name CloudFormation gives a Managed Policy whose template does not name
+ * it, under the same rules as a Role's but with twice the room.
+ */
+export function simCfnIamPolicyGeneratedName(resource: SimCfnResource): string {
+  return generatedName(resource, maximumPolicyNameLength);
+}
+
+function generatedName(
+  resource: SimCfnResource,
+  maximumLength: number,
+): string {
+  return new SimCfnGeneratedResourceName({
+    stackName: resource.stackName,
+    logicalId: resource.logicalId,
+    maximumLength,
+  }).value;
+}

--- a/src/service/iam/cfn/name/sim-cfn-iam-generated-name.ts
+++ b/src/service/iam/cfn/name/sim-cfn-iam-generated-name.ts
@@ -2,14 +2,14 @@ import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/na
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 
 /**
- * The longest name IAM accepts for a Role or a User, which is the same length
- * for both.
+ * The longest name IAM accepts for a Role or a User. Both take the same
+ * length.
  *
  * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
  */
 const maximumPrincipalNameLength = 64;
 
-/** The longest name IAM accepts for a Policy, which is twice a Role's. */
+/** The longest name IAM accepts for a Policy, twice what a Role takes. */
 const maximumPolicyNameLength = 128;
 
 /**
@@ -17,10 +17,9 @@ const maximumPolicyNameLength = 128;
  * it.
  *
  * Sixty-four characters is short for a name made of a stack name and a logical
- * ID, so the trimming `SimCfnGeneratedResourceName` does is the usual case here
- * rather than the exception. The case is left alone, since IAM keeps a name as
- * it was given, and every character a stack name or a logical ID is made of is
- * one an IAM name allows.
+ * ID, so `SimCfnGeneratedResourceName` usually has to trim one. The case is
+ * left alone, since IAM keeps a name as it was given, and every character a
+ * stack name or a logical ID is made of is one an IAM name allows.
  */
 export function simCfnIamPrincipalGeneratedName(
   resource: SimCfnResource,

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy.iso.test.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy.iso.test.ts
@@ -4,6 +4,7 @@ import {
   assertNonNullable,
   assertThrowsErrorAsync,
   assertTrue,
+  assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -90,7 +91,7 @@ describe("IAM CloudFormation Policy", () => {
     const simAws = new SimAws();
 
     // When the template is deployed through sim CloudFormation.
-    await simAws.cloudFormation().deployTemplate({
+    const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "iam-shared-policy-stack",
       template: {
         Resources: {
@@ -125,8 +126,12 @@ describe("IAM CloudFormation Policy", () => {
       },
     });
 
-    // Then both Roles carry the inline policy.
-    for (const roleName of ["FirstRole", "SecondRole"]) {
+    // Then both Roles carry the inline policy, under the names the stack
+    // generated for them. Neither is named after its logical ID alone.
+    for (const logicalId of ["FirstRole", "SecondRole"]) {
+      const roleName = stack.getResource(logicalId)?.refValue;
+      assertTypeString(roleName);
+
       const role = simAws.iam().roles.get(roleName as SimIamRoleName);
       assertNonNullable(role);
       assertNonNullable(role.inlinePolicies.get("SharedPolicy"));
@@ -194,7 +199,7 @@ describe("IAM CloudFormation Policy", () => {
     const simAws = new SimAws();
 
     // When the template is deployed through sim CloudFormation.
-    await simAws.cloudFormation().deployTemplate({
+    const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "iam-mixed-principal-policy-stack",
       template: {
         Resources: {
@@ -220,10 +225,17 @@ describe("IAM CloudFormation Policy", () => {
       },
     });
 
-    // Then both principals carry the inline policy.
+    // Then both principals carry the inline policy, under the names the
+    // stack generated for them. Neither is named after its logical ID alone.
+    const roleName = stack.getResource("SharedRole")?.refValue;
+    const username = stack.getResource("SharedUser")?.refValue;
+
+    assertTypeString(roleName);
+    assertTypeString(username);
+
     const simIam = simAws.iam();
-    const role = simIam.roles.get("SharedRole" as SimIamRoleName);
-    const user = simIam.users.get("SharedUser" as SimIamUsername);
+    const role = simIam.roles.get(roleName as SimIamRoleName);
+    const user = simIam.users.get(username as SimIamUsername);
 
     assertNonNullable(role);
     assertNonNullable(user);

--- a/src/service/iam/cfn/role/sim-cfn-iam-role-properties-parser.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role-properties-parser.ts
@@ -1,5 +1,7 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnIamPrincipalGeneratedName } from "../name/sim-cfn-iam-generated-name.js";
+import { simCfnIamOptionalString } from "../sim-cfn-iam-optional-string.js";
 import {
   SimCfnIamPoliciesParser,
   type SimCfnIamInlinePolicy,
@@ -36,7 +38,7 @@ export class SimCfnIamRolePropertiesParser {
     return {
       roleName:
         this.optionalString(resource, properties["RoleName"], "RoleName") ??
-        resource.logicalId,
+        simCfnIamPrincipalGeneratedName(resource),
       path: this.optionalString(resource, properties["Path"], "Path"),
       description: this.optionalString(
         resource,
@@ -61,17 +63,12 @@ export class SimCfnIamRolePropertiesParser {
     value: SimCfnTemplateValueRecord[string] | undefined,
     label: string,
   ): string | undefined {
-    if (value === undefined) {
-      return undefined;
-    }
-
-    if (typeof value !== "string") {
-      throw new TypeError(
-        `Invalid AWS::IAM::Role ${resource.logicalId}: ${label} must be a string`,
-      );
-    }
-
-    return value;
+    return simCfnIamOptionalString({
+      resourceType: "AWS::IAM::Role",
+      resource,
+      value,
+      label,
+    });
   }
 
   private jsonObject(

--- a/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role.iso.test.ts
@@ -1,6 +1,7 @@
 import {
   assertIdentical,
   assertNonNullable,
+  assertStringStartsWith,
   assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
@@ -71,7 +72,7 @@ describe("IAM CloudFormation Role", () => {
     assertIdentical(roleOut.Role.Arn, role.arn);
   });
 
-  it("defaults RoleName to the logical ID and Path to the root", async () => {
+  it("names an unnamed Role after the stack and the logical ID", async () => {
     // Given a CloudFormation template with a Role that omits its name and path.
     const simAws = new SimAws();
 
@@ -90,7 +91,8 @@ describe("IAM CloudFormation Role", () => {
       },
     });
 
-    // Then the Role uses the logical ID as its name and the root path.
+    // Then the Role is named after the stack and the logical ID, as
+    // CloudFormation names one, and takes the root path.
     const resource = stack.getResource("DefaultNamedRole");
 
     assertNonNullable(resource);
@@ -98,7 +100,10 @@ describe("IAM CloudFormation Role", () => {
     const role = simAws.iam().roles.get(resource.refValue as never);
 
     assertNonNullable(role);
-    assertIdentical(role.roleName, "DefaultNamedRole");
+    assertStringStartsWith(
+      role.roleName,
+      "iam-role-default-stack-DefaultNamedRole-",
+    );
     assertIdentical(role.path, "/");
     assertUndefined(role.description);
   });

--- a/src/service/iam/cfn/sim-cfn-iam-optional-string.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-optional-string.ts
@@ -1,0 +1,34 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+interface SimCfnIamOptionalStringProperties {
+  readonly resourceType: string;
+  readonly resource: SimCfnResource;
+  readonly value: SimCfnTemplateValueRecord[string] | undefined;
+  readonly label: string;
+}
+
+/**
+ * Read a string property an IAM Resource may leave out.
+ *
+ * A Role and a User read most of their own properties this way, and both
+ * refuse a non-string the same way, naming the Resource type the template
+ * declared.
+ */
+export function simCfnIamOptionalString(
+  properties: SimCfnIamOptionalStringProperties,
+): string | undefined {
+  const { resourceType, resource, value, label } = properties;
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `Invalid ${resourceType} ${resource.logicalId}: ${label} must be a string`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-properties-parser.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-properties-parser.ts
@@ -1,5 +1,7 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnIamPrincipalGeneratedName } from "../name/sim-cfn-iam-generated-name.js";
+import { simCfnIamOptionalString } from "../sim-cfn-iam-optional-string.js";
 import {
   SimCfnIamPoliciesParser,
   type SimCfnIamInlinePolicy,
@@ -44,7 +46,7 @@ export class SimCfnIamUserPropertiesParser {
     return {
       userName:
         this.optionalString(resource, properties["UserName"], "UserName") ??
-        resource.logicalId,
+        simCfnIamPrincipalGeneratedName(resource),
       path: this.optionalString(resource, properties["Path"], "Path"),
       inlinePolicies: this.policiesParser.inlinePolicies(resource, properties),
       managedPolicyArns: this.policiesParser.managedPolicyArns(
@@ -134,16 +136,6 @@ export class SimCfnIamUserPropertiesParser {
     value: SimCfnTemplateValueRecord[string] | undefined,
     label: string,
   ): string | undefined {
-    if (value === undefined) {
-      return undefined;
-    }
-
-    if (typeof value !== "string") {
-      throw new TypeError(
-        `Invalid ${resourceType} ${resource.logicalId}: ${label} must be a string`,
-      );
-    }
-
-    return value;
+    return simCfnIamOptionalString({ resourceType, resource, value, label });
   }
 }

--- a/src/service/iam/cfn/user/sim-cfn-iam-user.iso.test.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user.iso.test.ts
@@ -2,6 +2,7 @@ import {
   assertFalse,
   assertIdentical,
   assertNonNullable,
+  assertStringStartsWith,
   assertTypeString,
   assertTrue,
 } from "@kensio/smartass";
@@ -53,7 +54,7 @@ describe("IAM CloudFormation User", () => {
     assertIdentical(simAws.iam().users.get(user.userName), user);
   });
 
-  it("defaults UserName to the logical ID and Path to the root", async () => {
+  it("names an unnamed User after the stack and the logical ID", async () => {
     // Given a CloudFormation template with a User that omits its name and path.
     const simAws = new SimAws();
 
@@ -70,7 +71,8 @@ describe("IAM CloudFormation User", () => {
       },
     });
 
-    // Then the User uses the logical ID as its name and the root path.
+    // Then the User is named after the stack and the logical ID, as
+    // CloudFormation names one, and takes the root path.
     const resource = stack.getResource("DefaultNamedUser");
 
     assertNonNullable(resource);
@@ -78,7 +80,10 @@ describe("IAM CloudFormation User", () => {
     const user = simAws.iam().users.get(resource.refValue as never);
 
     assertNonNullable(user);
-    assertIdentical(user.userName, "DefaultNamedUser");
+    assertStringStartsWith(
+      user.userName,
+      "iam-user-default-stack-DefaultNamedUser-",
+    );
     assertIdentical(user.path, "/");
   });
 

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -687,7 +687,8 @@ via `SimLambda.cfnResourceFactory()` and resolved by the generic CloudFormation 
 deploying a template containing `AWS::Lambda::Function` creates a real `SimLambdaFunction`,
 reachable afterwards through `simAws.lambda()` and invokable via the SDK `InvokeCommand`.
 
-Supported `AWS::Lambda::Function` properties: `FunctionName` (defaults to the logical ID), `Role`
+Supported `AWS::Lambda::Function` properties: `FunctionName` (a function with none is named after
+the stack and the logical ID, through the shared `SimCfnGeneratedResourceName`), `Role`
 (typically a `Ref`/`Fn::GetAtt` to a same-stack `AWS::IAM::Role`), `Code`, `Handler`, `Runtime`,
 `Description`, `Timeout`, `MemorySize`, `Environment`, and `DeadLetterConfig`. Malformed property
 values fail AWS-style with a `TypeError` naming the property and logical ID, down to the individual

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-function-properties-parser.ts
@@ -12,6 +12,7 @@ import { SimCfnLambdaDeadLetterParser } from "./sim-cfn-lambda-dead-letter-parse
 import { SimCfnLambdaEnvironmentParser } from "./sim-cfn-lambda-environment-parser.js";
 import { SimCfnLambdaFunctionCodeParser } from "./sim-cfn-lambda-function-code-parser.js";
 import { SimCfnLambdaPropertyParser } from "./sim-cfn-lambda-property-parser.js";
+import { simCfnLambdaGeneratedFunctionName } from "./sim-cfn-lambda-generated-function-name.js";
 
 export interface SimCfnLambdaFunctionProperties {
   readonly functionName: string;
@@ -149,8 +150,8 @@ export class SimCfnLambdaFunctionPropertiesParser {
   }
 
   /**
-   * The function name defaults to the logical ID, as CloudFormation
-   * effectively names unnamed functions from it.
+   * An unnamed function gets the name CloudFormation generates for it, from
+   * the stack name and the logical ID.
    */
   private functionName(
     resource: SimCfnResource,
@@ -161,7 +162,7 @@ export class SimCfnLambdaFunctionPropertiesParser {
         resource,
         properties["FunctionName"],
         "FunctionName",
-      ) ?? resource.logicalId
+      ) ?? simCfnLambdaGeneratedFunctionName(resource)
     );
   }
 }

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-generated-function-name.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-generated-function-name.ts
@@ -1,0 +1,31 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+
+/**
+ * The longest name Lambda accepts for a function.
+ *
+ * The 140 characters `CreateFunction` documents are for a full ARN. A bare
+ * function name, which is what a template generates, gets 64.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html
+ */
+const maximumNameLength = 64;
+
+/**
+ * The name CloudFormation gives a function whose template does not name it.
+ *
+ * Sixty-four characters is short for a name made of a stack name and a logical
+ * ID, so the trimming `SimCfnGeneratedResourceName` does is the usual case here
+ * rather than the exception. The case is left alone, since Lambda keeps a name
+ * as it was given, and every character a stack name or a logical ID is made of
+ * is one a function name allows.
+ */
+export function simCfnLambdaGeneratedFunctionName(
+  resource: SimCfnResource,
+): string {
+  return new SimCfnGeneratedResourceName({
+    stackName: resource.stackName,
+    logicalId: resource.logicalId,
+    maximumLength: maximumNameLength,
+  }).value;
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-generated-function-name.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-generated-function-name.ts
@@ -5,7 +5,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
  * The longest name Lambda accepts for a function.
  *
  * The 140 characters `CreateFunction` documents are for a full ARN. A bare
- * function name, which is what a template generates, gets 64.
+ * function name gets 64, and that is what a template generates.
  *
  * https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html
  */
@@ -15,10 +15,9 @@ const maximumNameLength = 64;
  * The name CloudFormation gives a function whose template does not name it.
  *
  * Sixty-four characters is short for a name made of a stack name and a logical
- * ID, so the trimming `SimCfnGeneratedResourceName` does is the usual case here
- * rather than the exception. The case is left alone, since Lambda keeps a name
- * as it was given, and every character a stack name or a logical ID is made of
- * is one a function name allows.
+ * ID, so `SimCfnGeneratedResourceName` usually has to trim one. The case is
+ * left alone, since Lambda keeps a name as it was given, and every character a
+ * stack name or a logical ID is made of is one a function name allows.
  */
 export function simCfnLambdaGeneratedFunctionName(
   resource: SimCfnResource,

--- a/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.iso.test.ts
+++ b/src/service/lambda/cfn/sim-cfn-lambda-resource-factory.iso.test.ts
@@ -3,6 +3,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -120,11 +121,12 @@ describe("SimLambdaCloudFormationResourceFactory", () => {
     // When the Function resource type is created.
     const created = await factory.create("Function", resource, context);
 
-    // Then a function named from the logical ID is created with AWS-like
-    // default configuration.
-    const storedFunction = simLambda.getSimFunctionByName(
-      "DefaultNamedFunction",
-    );
+    // Then the name falls back to the logical ID, since there is no stack
+    // name to put in front of it, and the rest takes AWS-like defaults.
+    assertInstanceOf(created, SimLambdaFunction);
+    assertStringStartsWith(created.name, "DefaultNamedFunction-");
+
+    const storedFunction = simLambda.getSimFunctionByName(created.name);
 
     assertNonNullable(storedFunction);
     assertIdentical(created, storedFunction);

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -799,7 +799,9 @@ Bucket resource creation flow:
 1. determine the Bucket name
 
 - use resolved `BucketName` when it is a string
-- otherwise default to the lowercased logical ID
+- otherwise generate one from the stack name and the logical ID, through the shared
+  `SimCfnGeneratedResourceName` in `sim-cfn-s3-bucket-generated-name.ts`, lower cased afterwards
+  because a bucket name is lowercase and a logical ID usually is not
 
 1. validate the Bucket name
 1. create the Bucket through the normal simulated `createBucket` command path

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-creator.ts
@@ -3,6 +3,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimS3 } from "../../sim-s3.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { validateS3BucketName } from "../../bucket/validate/validate-s3-bucket-name.js";
+import { simCfnS3BucketGeneratedName } from "./sim-cfn-s3-bucket-generated-name.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimCfnS3BucketConfigurator } from "./sim-cfn-s3-bucket-configurator.js";
 import { SimCfnS3BucketPropertyRules } from "./sim-cfn-s3-bucket-property-rules.js";
@@ -64,8 +65,8 @@ export class SimCfnS3BucketCreator {
   }
 
   /**
-   * A Resource without a BucketName is named after its logical id, rather than
-   * the generated name real CloudFormation invents.
+   * A Resource without a BucketName gets the name CloudFormation generates for
+   * it, from the stack name and the logical ID.
    */
   private bucketNameForResource(
     resource: SimCfnResource,
@@ -77,6 +78,6 @@ export class SimCfnS3BucketCreator {
       return bucketName;
     }
 
-    return resource.logicalId.toLowerCase();
+    return simCfnS3BucketGeneratedName(resource);
   }
 }

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-generated-name.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-generated-name.ts
@@ -10,11 +10,11 @@ const maximumNameLength = 63;
  * The name CloudFormation gives a Bucket whose template does not name it.
  *
  * Sixty-three characters is short for a name made of a stack name and a logical
- * ID, so the trimming `SimCfnGeneratedResourceName` does is the usual case here
- * rather than the exception. It is lower cased afterwards because a bucket name
- * is lowercase and a stack name and a logical ID are usually not. The
- * characters left are ones a bucket name allows: a logical ID is alphanumeric,
- * a stack name adds only hyphens, and the tail is hex.
+ * ID, so `SimCfnGeneratedResourceName` usually has to trim one. It is lower
+ * cased afterwards because a bucket name is lowercase and a stack name and a
+ * logical ID are usually not. Every character left is one a bucket name allows.
+ * A logical ID is alphanumeric, a stack name adds only hyphens, and the tail is
+ * hex.
  */
 export function simCfnS3BucketGeneratedName(resource: SimCfnResource): string {
   return new SimCfnGeneratedResourceName({

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-generated-name.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-generated-name.ts
@@ -1,0 +1,25 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+
+/**
+ * The longest name S3 accepts, which `validateS3BucketName` applies in full.
+ */
+const maximumNameLength = 63;
+
+/**
+ * The name CloudFormation gives a Bucket whose template does not name it.
+ *
+ * Sixty-three characters is short for a name made of a stack name and a logical
+ * ID, so the trimming `SimCfnGeneratedResourceName` does is the usual case here
+ * rather than the exception. It is lower cased afterwards because a bucket name
+ * is lowercase and a stack name and a logical ID are usually not. The
+ * characters left are ones a bucket name allows: a logical ID is alphanumeric,
+ * a stack name adds only hyphens, and the tail is hex.
+ */
+export function simCfnS3BucketGeneratedName(resource: SimCfnResource): string {
+  return new SimCfnGeneratedResourceName({
+    stackName: resource.stackName,
+    logicalId: resource.logicalId,
+    maximumLength: maximumNameLength,
+  }).value.toLowerCase();
+}

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket.iso.test.ts
@@ -7,12 +7,15 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
+  assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { validateS3BucketName } from "../../bucket/validate/validate-s3-bucket-name.js";
 import { SimS3BucketAlreadyExists } from "../../error/sim-s3.error.js";
 import { makeAwsRegionName } from "../../../aws/sim-aws-region.js";
 
@@ -58,7 +61,7 @@ describe("S3 CloudFormation Bucket Resource", () => {
     assertIdentical(resource.simResource, bucket);
   });
 
-  it("uses the logical ID as the Bucket name when BucketName is not specified", async () => {
+  it("names an unnamed Bucket after the stack and the logical ID", async () => {
     // Given a CloudFormation template declaring an S3 Bucket without BucketName.
     const unnamedBucketTemplate = {
       Resources: {
@@ -76,18 +79,55 @@ describe("S3 CloudFormation Bucket Resource", () => {
       template: unnamedBucketTemplate,
     });
 
-    // Then the simulated S3 Bucket is created using the logical ID fallback.
-    const bucket = simAws.s3().getSimBucketByName("testbucket");
-
-    assertNonNullable(bucket);
-    assertInstanceOf(bucket, SimS3Bucket);
-    assertIdentical(bucket.bucketName, "testbucket");
-
+    // Then the Bucket carries the name CloudFormation generates, lower cased
+    // as a bucket name has to be.
     const resource = stack.getResource("TestBucket");
 
     assertNonNullable(resource);
+    assertTypeString(resource.refValue);
+    assertStringStartsWith(resource.refValue, "test-stack-testbucket-");
+
+    const bucket = simAws.s3().getSimBucketByName(resource.refValue);
+
+    assertNonNullable(bucket);
+    assertInstanceOf(bucket, SimS3Bucket);
+    assertIdentical(bucket.bucketName, resource.refValue);
     assertIdentical(resource.status, "CREATE_COMPLETE");
     assertIdentical(resource.simResource, bucket);
+
+    // And the generated name is one S3 itself accepts.
+    validateS3BucketName(bucket.bucketName);
+  });
+
+  it("gives two stacks deploying one template distinct Bucket names", async () => {
+    // Given one template with an unnamed Bucket, which two stacks deploy. On
+    // real AWS each stack gets its own bucket, because the stack name is part
+    // of the generated name.
+    const template = { Resources: { Assets: { Type: "AWS::S3::Bucket" } } };
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    // When both are deployed.
+    const staging = await cloudFormation.deployTemplate({
+      stackName: "staging-stack",
+      template,
+    });
+    const production = await cloudFormation.deployTemplate({
+      stackName: "production-stack",
+      template,
+    });
+
+    // Then neither collided with the other, and each name carries its own
+    // stack.
+    const stagingName = staging.getResource("Assets")?.refValue;
+    const productionName = production.getResource("Assets")?.refValue;
+
+    assertTypeString(stagingName);
+    assertTypeString(productionName);
+    assertStringStartsWith(stagingName, "staging-stack-assets-");
+    assertStringStartsWith(productionName, "production-stack-assets-");
+    assertNonNullable(simAws.s3().getSimBucketByName(stagingName));
+    assertNonNullable(simAws.s3().getSimBucketByName(productionName));
   });
 
   it("creates Buckets in the CloudFormation Account Region scope and rejects duplicate names from another scope", async () => {

--- a/src/service/s3/cfn/sim-cfn-s3-resource-factory.iso.test.ts
+++ b/src/service/s3/cfn/sim-cfn-s3-resource-factory.iso.test.ts
@@ -1,11 +1,14 @@
 import {
   assertIdentical,
+  assertInstanceOf,
   assertNonNullable,
+  assertStringStartsWith,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
+import { SimS3Bucket } from "../bucket/sim-s3-bucket.js";
 import type { SimCloudFormationResourceCreateContext } from "../../cloudformation/resource/sim-cfn-resource.js";
 import { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
 import { SimS3CloudFormationResourceFactory } from "./sim-cfn-s3-resource-factory.js";
@@ -48,7 +51,7 @@ describe("SimS3CloudFormationResourceFactory", () => {
     assertIdentical(bucket, storedBucket);
   });
 
-  it("creates an S3 Bucket using the lower-case logical ID by default", async () => {
+  it("names a Bucket created outside a stack after the logical ID alone", async () => {
     // Given an S3 CloudFormation Resource factory and a Bucket resource without a
     // BucketName.
     const simAws = new SimAws();
@@ -72,8 +75,12 @@ describe("SimS3CloudFormationResourceFactory", () => {
     // When the Bucket resource type is created.
     const bucket = await factory.create("Bucket", resource, context);
 
-    // Then a Bucket named from the lower-case logical ID is created and returned.
-    const storedBucket = simS3.getSimBucketByName("examplebucket");
+    // Then the name falls back to the logical ID, since there is no stack
+    // name to put in front of it, lower cased as a bucket name has to be.
+    assertInstanceOf(bucket, SimS3Bucket);
+    assertStringStartsWith(bucket.bucketName, "examplebucket-");
+
+    const storedBucket = simS3.getSimBucketByName(bucket.bucketName);
 
     assertNonNullable(storedBucket);
     assertIdentical(bucket, storedBucket);

--- a/src/service/secretsmanager/README.md
+++ b/src/service/secretsmanager/README.md
@@ -128,7 +128,10 @@ unsupported, which is what makes the engine skip them rather than fail the stack
 building a secret directly, so a secret a template deployed is the same thing an SDK caller would
 have got, name validation and ARN suffix included. Property reading lives in
 `SimCfnSecretsManagerSecretProperties`, which owns the one rule worth stating in a single place: a
-template supplies a value or asks for one to be generated, never both and never neither.
+template supplies a value or asks for one to be generated, never both and never neither. A secret
+with no `Name` gets one from the stack name and the logical ID, through the shared
+`SimCfnGeneratedResourceName`, trimmed to the same 512 characters `SimSecretsManagerSecretName`
+enforces.
 
 Password generation lives in `secret/generate/` rather than in `cfn/`, because it is Secrets Manager
 behaviour rather than CloudFormation behaviour — `GetRandomPassword` would use the same rules under

--- a/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-generated-name.ts
+++ b/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-generated-name.ts
@@ -1,0 +1,27 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { maximumSimSecretsManagerNameLength } from "../../secret/sim-secrets-manager-secret-name.js";
+
+/**
+ * The name CloudFormation gives a secret whose template does not name it.
+ *
+ * Five hundred and twelve characters is long enough that a stack name and a
+ * logical ID rarely reach it, so the trimming `SimCfnGeneratedResourceName`
+ * does is the exception here rather than the usual case. The case is left
+ * alone, since Secrets Manager keeps a name as it was given, and every
+ * character a stack name or a logical ID is made of is one a secret name
+ * allows.
+ *
+ * Real Secrets Manager appends six random characters of its own to a secret's
+ * ARN whatever the name is, which is why a template reading the ARN back has to
+ * read it off the Resource either way.
+ */
+export function simCfnSecretsManagerGeneratedName(
+  resource: SimCfnResource,
+): string {
+  return new SimCfnGeneratedResourceName({
+    stackName: resource.stackName,
+    logicalId: resource.logicalId,
+    maximumLength: maximumSimSecretsManagerNameLength,
+  }).value;
+}

--- a/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-generated-name.ts
+++ b/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-generated-name.ts
@@ -6,15 +6,14 @@ import { maximumSimSecretsManagerNameLength } from "../../secret/sim-secrets-man
  * The name CloudFormation gives a secret whose template does not name it.
  *
  * Five hundred and twelve characters is long enough that a stack name and a
- * logical ID rarely reach it, so the trimming `SimCfnGeneratedResourceName`
- * does is the exception here rather than the usual case. The case is left
- * alone, since Secrets Manager keeps a name as it was given, and every
- * character a stack name or a logical ID is made of is one a secret name
- * allows.
+ * logical ID rarely reach it, so `SimCfnGeneratedResourceName` seldom has to
+ * trim one. The case is left alone, since Secrets Manager keeps a name as it
+ * was given, and every character a stack name or a logical ID is made of is one
+ * a secret name allows.
  *
  * Real Secrets Manager appends six random characters of its own to a secret's
- * ARN whatever the name is, which is why a template reading the ARN back has to
- * read it off the Resource either way.
+ * ARN whatever the name is. A template reading the ARN back reads it off the
+ * Resource either way.
  */
 export function simCfnSecretsManagerGeneratedName(
   resource: SimCfnResource,

--- a/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-properties.ts
+++ b/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-properties.ts
@@ -6,6 +6,8 @@ import type {
 import type { SimSecretsManagerTag } from "../../secret/sim-secrets-manager-secret.js";
 import { SimCfnSecretsManagerPropertyParser } from "../sim-cfn-secrets-manager-property-parser.js";
 import { SimCfnSecretsManagerGenerateSecretStringParser } from "./sim-cfn-secrets-manager-generate-secret-string-parser.js";
+import { simCfnSecretsManagerGeneratedName } from "./sim-cfn-secrets-manager-generated-name.js";
+import { simCfnSecretsManagerSecretValue } from "./sim-cfn-secrets-manager-secret-value.js";
 
 interface SimCfnSecretsManagerSecretPropertiesProperties {
   readonly resource: SimCfnResource;
@@ -17,8 +19,8 @@ interface SimCfnSecretsManagerSecretPropertiesProperties {
  * the secret creator needs.
  *
  * Keeping the property-shape rules here leaves the creator to do nothing but
- * call CreateSecret, and puts the one rule worth stating in a single place:
- * a template supplies a value or asks for one to be generated, never both.
+ * call CreateSecret. Which of the two value properties wins is its own
+ * decision, and lives in `simCfnSecretsManagerSecretValue`.
  */
 export class SimCfnSecretsManagerSecretProperties {
   private readonly resource: SimCfnResource;
@@ -35,15 +37,13 @@ export class SimCfnSecretsManagerSecretProperties {
   /**
    * The secret name.
    *
-   * An unnamed secret is named after its logical ID, as sim CloudFormation
-   * names other unnamed resources. Real CloudFormation prefixes the stack
-   * name and appends its own random characters, so a template relying on the
-   * exact generated name would be relying on something it cannot predict
-   * anyway.
+   * An unnamed secret is named after the stack and the logical ID, as
+   * CloudFormation names one.
    */
   name(): string {
     return (
-      this.string(this.properties["Name"], "Name") ?? this.resource.logicalId
+      this.string(this.properties["Name"], "Name") ??
+      simCfnSecretsManagerGeneratedName(this.resource)
     );
   }
 
@@ -74,41 +74,16 @@ export class SimCfnSecretsManagerSecretProperties {
 
   /**
    * The value the secret's first version holds.
-   *
-   * Either the template supplies one or it asks for one to be generated.
    */
   secretString(): string {
-    const supplied = this.string(
-      this.properties["SecretString"],
-      "SecretString",
-    );
-    const generated = this.generateParser.parse(
-      this.resource,
-      this.properties["GenerateSecretString"],
-    );
-
-    if (supplied !== undefined && generated !== undefined) {
-      throw this.propertyError(
-        "SecretString and GenerateSecretString cannot both be declared: " +
-          "a secret either holds the value the template supplies or one " +
-          "Secrets Manager generates",
-      );
-    }
-
-    if (supplied !== undefined) {
-      return supplied;
-    }
-
-    if (generated !== undefined) {
-      return generated.generate();
-    }
-
-    throw this.propertyError(
-      "either SecretString or GenerateSecretString is required. Real " +
-        "CloudFormation creates an empty secret when both are omitted, " +
-        "which simulated Secrets Manager does not model, so it refuses the " +
-        "Resource rather than creating a secret that has no value to read",
-    );
+    return simCfnSecretsManagerSecretValue({
+      resource: this.resource,
+      supplied: this.string(this.properties["SecretString"], "SecretString"),
+      generated: this.generateParser.parse(
+        this.resource,
+        this.properties["GenerateSecretString"],
+      ),
+    });
   }
 
   private string(
@@ -116,12 +91,5 @@ export class SimCfnSecretsManagerSecretProperties {
     name: string,
   ): string | undefined {
     return this.propertyParser.optionalString(this.resource, value, name);
-  }
-
-  private propertyError(reason: string): Error {
-    return new Error(
-      `Invalid AWS::SecretsManager::Secret Resource ` +
-        `${this.resource.logicalId}: ${reason}`,
-    );
   }
 }

--- a/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-value.ts
+++ b/src/service/secretsmanager/cfn/secret/sim-cfn-secrets-manager-secret-value.ts
@@ -1,0 +1,54 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimSecretsManagerGeneratedSecretString } from "../../secret/generate/sim-secrets-manager-generated-secret-string.js";
+
+interface SimCfnSecretsManagerSecretValueProperties {
+  readonly resource: SimCfnResource;
+  readonly supplied: string | undefined;
+  readonly generated: SimSecretsManagerGeneratedSecretString | undefined;
+}
+
+/**
+ * The value a secret's first version holds.
+ *
+ * A template supplies a value or asks for one to be generated, never both and
+ * never neither. Real CloudFormation creates an empty secret where both are
+ * omitted, which simulated Secrets Manager has no model for, and a secret with
+ * no value to read is worse to be handed than a refusal.
+ */
+export function simCfnSecretsManagerSecretValue(
+  properties: SimCfnSecretsManagerSecretValueProperties,
+): string {
+  const { resource, supplied, generated } = properties;
+
+  if (supplied !== undefined && generated !== undefined) {
+    throw refusal(
+      resource,
+      "SecretString and GenerateSecretString cannot both be declared: " +
+        "a secret either holds the value the template supplies or one " +
+        "Secrets Manager generates",
+    );
+  }
+
+  if (supplied !== undefined) {
+    return supplied;
+  }
+
+  if (generated !== undefined) {
+    return generated.generate();
+  }
+
+  throw refusal(
+    resource,
+    "either SecretString or GenerateSecretString is required. Real " +
+      "CloudFormation creates an empty secret when both are omitted, " +
+      "which simulated Secrets Manager does not model, so it refuses the " +
+      "Resource rather than creating a secret that has no value to read",
+  );
+}
+
+function refusal(resource: SimCfnResource, reason: string): Error {
+  return new Error(
+    `Invalid AWS::SecretsManager::Secret Resource ` +
+      `${resource.logicalId}: ${reason}`,
+  );
+}

--- a/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret.iso.test.ts
+++ b/src/service/secretsmanager/cfn/sim-cfn-secrets-manager-secret.iso.test.ts
@@ -200,11 +200,19 @@ describe("Secrets Manager CloudFormation Secret deployment", () => {
     });
     await stack.waitForDeployComplete();
 
-    // Then the secret is named after its logical ID, as sim CloudFormation
-    // names other unnamed resources.
+    // Then the secret is named after the stack and the logical ID, as
+    // CloudFormation names one, which its ARN carries.
+    const secretArn = stack.getResource("ApiSecret")?.refValue;
+
+    assertTypeString(secretArn);
+    assertStringStartsWith(
+      secretArn,
+      "arn:aws:secretsmanager:eu-west-2:111111111111:secret:db-stack-ApiSecret-",
+    );
+
     const read = await simAws
       .secretsManager()
-      .getSecretValue(new GetSecretValueCommand({ SecretId: "ApiSecret" }));
+      .getSecretValue(new GetSecretValueCommand({ SecretId: secretArn }));
 
     // And it holds the 32-character password real Secrets Manager defaults to.
     assertTypeString(read.SecretString);

--- a/src/service/secretsmanager/secret/sim-secrets-manager-secret-name.ts
+++ b/src/service/secretsmanager/secret/sim-secrets-manager-secret-name.ts
@@ -1,7 +1,12 @@
 import { SimSecretsManagerInvalidParameterException } from "../error/sim-secrets-manager.error.js";
 import { secretArnSuffixPattern } from "./sim-secrets-manager-secret-arn.js";
 
-const maxNameLength = 512;
+/**
+ * The longest name Secrets Manager accepts for a secret.
+ *
+ * https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_CreateSecret.html
+ */
+export const maximumSimSecretsManagerNameLength = 512;
 const allowedCharacters = /^[\w+=./@-]+$/;
 
 /**
@@ -25,9 +30,9 @@ export class SimSecretsManagerSecretName {
       );
     }
 
-    if (name.length > maxNameLength) {
+    if (name.length > maximumSimSecretsManagerNameLength) {
       throw new SimSecretsManagerInvalidParameterException(
-        `Secret name '${name}' is longer than the ${String(maxNameLength)} characters Secrets Manager allows`,
+        `Secret name '${name}' is longer than the ${String(maximumSimSecretsManagerNameLength)} characters Secrets Manager allows`,
       );
     }
 

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -102,6 +102,11 @@ the template properties and `SimCfnSsmParameterCreator` hands them to PutParamet
 template-created parameter is the same thing an SDK caller would get and the options this simulation
 refuses are refused in one place.
 
+A parameter the template does not name gets one from the stack name and the logical ID, through the
+shared `SimCfnGeneratedResourceName`. How much room the name has depends on the Account and Region,
+since Parameter Store counts the ARN prefix towards the same allowance, and
+`maximumSimSsmParameterNameLength` is where the two agree on the figure.
+
 The one rule that lives in the CloudFormation layer is the type. Real CloudFormation refuses
 `SecureString` for this Resource type whatever Parameter Store itself supports, because the plaintext
 value would sit in the template, so the refusal belongs to the Resource rather than to the

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-generated-parameter-name.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-generated-parameter-name.ts
@@ -1,0 +1,30 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import { maximumSimSsmParameterNameLength } from "../../parameter/sim-ssm-parameter-arn.js";
+
+/**
+ * The name CloudFormation gives a parameter whose template does not name it.
+ *
+ * How much room a name has is a question about the Account and Region rather
+ * than about Parameter Store alone, since the ARN prefix comes out of the same
+ * allowance. There is enough of it that a stack name and a logical ID rarely
+ * reach the limit, so the trimming `SimCfnGeneratedResourceName` does is the
+ * exception here rather than the usual case.
+ *
+ * The name carries no leading slash and so sits at the top of the hierarchy,
+ * which is where real CloudFormation puts a parameter it names itself. The
+ * case is left alone, since Parameter Store keeps a name as it was given, and
+ * every character a stack name or a logical ID is made of is one a parameter
+ * name allows.
+ */
+export function simCfnSsmGeneratedParameterName(
+  resource: SimCfnResource,
+): string {
+  return new SimCfnGeneratedResourceName({
+    stackName: resource.stackName,
+    logicalId: resource.logicalId,
+    maximumLength: maximumSimSsmParameterNameLength(
+      resource.accountRegionScope,
+    ),
+  }).value;
+}

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-generated-parameter-name.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-generated-parameter-name.ts
@@ -5,17 +5,16 @@ import { maximumSimSsmParameterNameLength } from "../../parameter/sim-ssm-parame
 /**
  * The name CloudFormation gives a parameter whose template does not name it.
  *
- * How much room a name has is a question about the Account and Region rather
- * than about Parameter Store alone, since the ARN prefix comes out of the same
- * allowance. There is enough of it that a stack name and a logical ID rarely
- * reach the limit, so the trimming `SimCfnGeneratedResourceName` does is the
- * exception here rather than the usual case.
+ * How much room a name has depends on the Account and Region, since the ARN
+ * prefix comes out of the same allowance. There is enough of it that a stack
+ * name and a logical ID rarely reach the limit, so
+ * `SimCfnGeneratedResourceName` seldom has to trim one.
  *
  * The name carries no leading slash and so sits at the top of the hierarchy,
- * which is where real CloudFormation puts a parameter it names itself. The
- * case is left alone, since Parameter Store keeps a name as it was given, and
- * every character a stack name or a logical ID is made of is one a parameter
- * name allows.
+ * where real CloudFormation puts a parameter it names itself. The case is left
+ * alone, since Parameter Store keeps a name as it was given, and every
+ * character a stack name or a logical ID is made of is one a parameter name
+ * allows.
  */
 export function simCfnSsmGeneratedParameterName(
   resource: SimCfnResource,

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-properties.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-properties.ts
@@ -4,6 +4,7 @@ import type {
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimSsmTag } from "../../command/parameter/parameter.command.js";
+import { simCfnSsmGeneratedParameterName } from "./sim-cfn-ssm-generated-parameter-name.js";
 
 interface SimCfnSsmParameterPropertiesProperties {
   readonly resource: SimCfnResource;
@@ -33,14 +34,13 @@ export class SimCfnSsmParameterProperties {
   /**
    * The parameter name.
    *
-   * An unnamed parameter is named after its logical ID, as sim CloudFormation
-   * names other unnamed resources. Real CloudFormation generates a name from
-   * the stack name and its own random characters, which a template could not
-   * predict anyway.
+   * An unnamed parameter is named after the stack and the logical ID, as
+   * CloudFormation names one.
    */
   name(): string {
     return (
-      this.string(this.properties["Name"], "Name") ?? this.resource.logicalId
+      this.string(this.properties["Name"], "Name") ??
+      simCfnSsmGeneratedParameterName(this.resource)
     );
   }
 

--- a/src/service/ssm/cfn/sim-cfn-ssm-parameter.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-parameter.iso.test.ts
@@ -3,6 +3,8 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertStringStartsWith,
+  assertTypeString,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -104,7 +106,7 @@ describe("SSM CloudFormation Parameter deployment", () => {
     assertIdentical(stack.outputs.get("ParameterValue")?.value, "db.internal");
   });
 
-  it("names an unnamed parameter after its logical ID", async () => {
+  it("names an unnamed parameter after the stack and the logical ID", async () => {
     // Given a template leaving Name out, as CDK does for a parameter with no
     // explicit name.
     const simAws = simAwsInEuWest2();
@@ -123,11 +125,16 @@ describe("SSM CloudFormation Parameter deployment", () => {
     });
     await stack.waitForDeployComplete();
 
-    // Then the parameter is named after its logical ID, as sim CloudFormation
-    // names other unnamed resources.
+    // Then the parameter is named after the stack and the logical ID, as
+    // CloudFormation names one.
+    const parameterName = stack.getResource("FeatureFlags")?.refValue;
+
+    assertTypeString(parameterName);
+    assertStringStartsWith(parameterName, "config-stack-FeatureFlags-");
+
     const read = await simAws
       .ssm()
-      .getParameter(new GetParameterCommand({ Name: "FeatureFlags" }));
+      .getParameter(new GetParameterCommand({ Name: parameterName }));
 
     assertNonNullable(read.Parameter);
     assertIdentical(read.Parameter.Value, "beta,canary");

--- a/src/service/ssm/parameter/sim-ssm-parameter-arn.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-arn.ts
@@ -15,6 +15,32 @@ export function ssmParameterArnPrefix(
   return `arn:aws:ssm:${regionName}:${accountId}:parameter/`;
 }
 
+/**
+ * The longest a parameter name may be, counting the ARN that precedes it.
+ *
+ * Real Parameter Store reserves the rest of the 2048 character ARN for its own
+ * use, and counts the ARN prefix towards the 1011 characters left. That is why
+ * this limit needs the Account and Region: the same name is legal in one
+ * Region and too long in another.
+ */
+export const maximumSsmParameterArnLength = 1011;
+
+/**
+ * The longest name a parameter may be given in this Account and Region.
+ *
+ * The ARN prefix comes out of the same allowance the name does, so the room
+ * left for a name depends on how long the Region's name is. A generated name
+ * is trimmed to this so that it is never one PutParameter would then refuse.
+ */
+export function maximumSimSsmParameterNameLength(
+  accountRegionScope: SimAwsAccountRegionScope,
+): number {
+  return (
+    maximumSsmParameterArnLength -
+    ssmParameterArnPrefix(accountRegionScope).length
+  );
+}
+
 interface SimSsmParameterArnProperties {
   readonly resource: string;
   readonly accountRegionScope: SimAwsAccountRegionScope;

--- a/src/service/ssm/parameter/sim-ssm-parameter-name.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-name.ts
@@ -4,21 +4,14 @@ import {
   SimSsmParameterPatternMismatchException,
   SimSsmValidationException,
 } from "../error/sim-ssm.error.js";
-import { ssmParameterArnPrefix } from "./sim-ssm-parameter-arn.js";
+import {
+  maximumSsmParameterArnLength,
+  ssmParameterArnPrefix,
+} from "./sim-ssm-parameter-arn.js";
 
 const allowedCharacters = /^[\w./-]+$/;
 const maxHierarchyLevels = 15;
 const reservedPrefixes = ["aws", "ssm"];
-
-/**
- * The longest a parameter name may be, counting the ARN that precedes it.
- *
- * Real Parameter Store reserves the rest of the 2048 character ARN for its own
- * use, and counts the ARN prefix towards the 1011 characters left. That is why
- * this limit needs the Account and Region: the same name is legal in one
- * Region and too long in another.
- */
-const maxArnLength = 1011;
 
 interface SimSsmParameterNameProperties {
   readonly name: string | undefined;
@@ -159,13 +152,13 @@ export class SimSsmParameterName {
     const arnLength =
       ssmParameterArnPrefix(accountRegionScope).length + this.resource.length;
 
-    if (arnLength <= maxArnLength) {
+    if (arnLength <= maximumSsmParameterArnLength) {
       return;
     }
 
     throw new SimSsmValidationException(
       `Parameter name '${this.value}' makes an ARN of ${String(arnLength)} ` +
-        `characters; Parameter Store allows ${String(maxArnLength)} ` +
+        `characters; Parameter Store allows ${String(maximumSsmParameterArnLength)} ` +
         `including the ARN prefix for this Account and Region`,
     );
   }


### PR DESCRIPTION
An `AWS::S3::Bucket`, `AWS::IAM::Role`, `AWS::IAM::User`, `AWS::IAM::ManagedPolicy`,
`AWS::Lambda::Function`, `AWS::SecretsManager::Secret` or `AWS::SSM::Parameter` whose template
leaves its name out now gets `<stack name>-<logical ID>-<tail>` from the shared
`SimCfnGeneratedResourceName`, as the seventeen other services already did. Each carries its own
service's length limit and case rules. A bucket name is still lower cased and still passes
`validateS3BucketName`, and an IAM name keeps the case it was written in. Glue databases and tables
compose their name through the same class and gain the trimming they were skipping, losing the
literal `stack` they fell back on outside a stack. The generated name is what an IAM policy scoped
by resource prefix matches, and a deployment running as a Role scoped to its own stack's prefix was
refused here where an account allows it.

The issue's own reproduction now returns what the account returned for that template, tail aside:

```
chineseboostanalyticsstac-rainlyticslogsbucket8df4-447f4012d159
```

Limits are per service, looked up rather than shared. S3 takes 63 characters, an IAM Role and User
64, an IAM Managed Policy 128, a Lambda function 64, a Secrets Manager secret 512, and a Glue
database or table 255. SSM is the odd one, since Parameter Store counts the ARN prefix towards the
same 1011 characters a name draws on, and `maximumSimSsmParameterNameLength` derives the figure from
the Account and Region the stack deploys into.

## The no-stack fallback

A Resource created outside a stack has no stack name to draw on. The issue asked for that case to
keep the name it had, which was written before #1113 landed and made the tail unconditional. The
seventeen services already on the shared class changed under that PR, so the criterion was already
untrue for them.

These eight follow the shared class there too, and a Resource outside a stack is now
`examplebucket-<12 hex>`. Real CloudFormation has no no-stack case to copy, since every stack has a
name, and the two things it does unconditionally settle which simulator rule is the closer analogue.
A generated name always ends in random characters, and nothing about that depends on the stack name.
AWS never invents the literal word `stack` from nowhere the way Glue's fallback did.

## Tests

`sim-cfn-deployment-generated-name.iso.test.ts` covers the payoff the issue names. A deploy Role
allowed `s3:CreateBucket` on `arn:aws:s3:::analytics-stack-*` now deploys that stack, and is refused
under another stack name. Before this the bucket was `assetsbucket` and the first case failed.

The S3 page gains a two-stack test, and the factory tests for S3 and Lambda now document the
no-stack path, since both build a Resource without one.

Resolves #1114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CloudFormation-created Glue, IAM, Lambda, S3, Secrets Manager, and SSM resources now receive names derived from their stack and logical resource names when explicit names are omitted.
  - Generated names follow each service’s casing, formatting, and length requirements.
  - IAM policy matching and resource lookups now work with generated names and stack-based prefixes.
  - Secret and IAM property validation provides clearer handling of omitted or invalid values.

- **Documentation**
  - Updated service documentation to explain generated naming behavior and limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->