### PR TITLE
feat: deploy independent Resources in reverse

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1086,6 +1086,72 @@ await stack.waitForDeployComplete();
 Resources that reference another resource with `Ref` are also created after the referenced resource
 is ready.
 
+### The order independent Resources are created in
+
+Resources with no dependency between them are created together, and the template's own order
+decides which one starts first. CloudFormation is free to pick either. A Stack that deploys only
+because of the order its template happens to be written in passes here and then fails in the
+account.
+
+The pair that costs a real deployment is an `AWS::IAM::Policy` widening the deploy Role and a
+Resource in the service that widening allows. Declare the policy first and the deployment succeeds.
+Declare the Topic first and it fails on `sns:CreateTopic`. Both templates are the same template.
+
+`resourceOrder: "reversed"` starts each dependency batch from its last Resource.
+
+```typescript sim-cloudformation-resource-order
+/**
+ * Deploying a template in the order CloudFormation could have picked instead.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "alerts-stack",
+  template: {
+    Resources: {
+      DeployerSns: {
+        Type: "AWS::IAM::Policy",
+        Properties: {
+          PolicyName: "DeployerSns",
+          Roles: ["cdk-deploy-role"],
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: { Effect: "Allow", Action: "sns:*", Resource: "*" },
+          },
+        },
+      },
+      Alerts: {
+        Type: "AWS::SNS::Topic",
+        DependsOn: "DeployerSns",
+        Properties: { TopicName: "alerts" },
+      },
+    },
+  },
+  caller: {
+    kind: "arn",
+    arn: "arn:aws:iam::123456789012:role/cdk-deploy-role",
+  },
+  resourceOrder: "reversed",
+});
+
+console.log(stack.getResource("Alerts")?.status); // "CREATE_COMPLETE"
+```
+
+Declared dependencies hold under either order. A Resource waits for everything its `Ref` and
+`Fn::GetAtt` expressions reach, and for everything its `DependsOn` names. Reversing a batch moves
+only the Resources CloudFormation was free to create either way round (the `DependsOn` above is what
+keeps the Topic behind the policy).
+
+Reversing one order gives the other one. Run a deployment both ways to cover the pair, since the
+template's own order is one of the two and `"reversed"` is the other. The default is `"template"`,
+which every deployment that asks for nothing gets.
+
+`deployTemplateFile(...)` takes the option too. `deployCdkOut(...)` takes one order for every Stack
+in the assembly, and a Stack named in `stackOptions` carries its own.
+
 ## Deploying synthesized CDK templates
 
 Use `deployTemplateFile(...)` to deploy a template file, including the JSON templates CDK synthesis

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1086,7 +1086,7 @@ await stack.waitForDeployComplete();
 Resources that reference another resource with `Ref` are also created after the referenced resource
 is ready.
 
-### The order independent Resources are created in
+### Deploying independent Resources in either order
 
 Resources with no dependency between them are created together, and the template's own order
 decides which one starts first. CloudFormation is free to pick either. A Stack that deploys only
@@ -1107,6 +1107,33 @@ Declare the Topic first and it fails on `sns:CreateTopic`. Both templates are th
 import { SimAws } from "@kensio/yulin";
 
 const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+// The Role a real deployment already runs as, allowed to attach policies and
+// nothing else.
+await simAws.iam().createRole({
+  input: {
+    RoleName: "cdk-deploy-role",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "sts:AssumeRole",
+        Principal: { Service: "cloudformation.amazonaws.com" },
+      },
+    }),
+  },
+});
+
+await simAws.iam().putRolePolicy({
+  input: {
+    RoleName: "cdk-deploy-role",
+    PolicyName: "deploy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "iam:*", Resource: "*" },
+    }),
+  },
+});
 
 const stack = await simAws.cloudFormation().deployTemplate({
   stackName: "alerts-stack",

--- a/docs/services/cloudformation/sim-cloudformation-resource-order.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-resource-order.example.ts
@@ -6,6 +6,33 @@ import { SimAws } from "@kensio/yulin";
 
 const simAws = new SimAws({ defaultAccountId: "123456789012" });
 
+// The Role a real deployment already runs as, allowed to attach policies and
+// nothing else.
+await simAws.iam().createRole({
+  input: {
+    RoleName: "cdk-deploy-role",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "sts:AssumeRole",
+        Principal: { Service: "cloudformation.amazonaws.com" },
+      },
+    }),
+  },
+});
+
+await simAws.iam().putRolePolicy({
+  input: {
+    RoleName: "cdk-deploy-role",
+    PolicyName: "deploy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "iam:*", Resource: "*" },
+    }),
+  },
+});
+
 const stack = await simAws.cloudFormation().deployTemplate({
   stackName: "alerts-stack",
   template: {

--- a/docs/services/cloudformation/sim-cloudformation-resource-order.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-resource-order.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Deploying a template in the order CloudFormation could have picked instead.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "alerts-stack",
+  template: {
+    Resources: {
+      DeployerSns: {
+        Type: "AWS::IAM::Policy",
+        Properties: {
+          PolicyName: "DeployerSns",
+          Roles: ["cdk-deploy-role"],
+          PolicyDocument: {
+            Version: "2012-10-17",
+            Statement: { Effect: "Allow", Action: "sns:*", Resource: "*" },
+          },
+        },
+      },
+      Alerts: {
+        Type: "AWS::SNS::Topic",
+        DependsOn: "DeployerSns",
+        Properties: { TopicName: "alerts" },
+      },
+    },
+  },
+  caller: {
+    kind: "arn",
+    arn: "arn:aws:iam::123456789012:role/cdk-deploy-role",
+  },
+  resourceOrder: "reversed",
+});
+
+console.log(stack.getResource("Alerts")?.status); // "CREATE_COMPLETE"

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -22,6 +22,7 @@ import { makeSimCfnParameterStore } from "../../parameters/store/sim-cfn-paramet
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
 import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
+import type { SimCfnResourceOrder } from "../../stack/deploy/sim-cfn-resource-order.js";
 
 interface CreateStackCommandHandlerProperties {
   readonly simAws: SimAws;
@@ -33,6 +34,9 @@ interface CreateStackCommandHandlerProperties {
 
   /** The principal the Stack's Resources are created as. */
   readonly caller?: SimAwsCaller | undefined;
+
+  /** The order Resources with no dependency between them are started in. */
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
 
   readonly exports?: SimCfnExports | undefined;
 }
@@ -53,6 +57,7 @@ export class CreateStackCommandHandler implements CommandHandler<
   private readonly cdkOutContext: SimCdkOutContext | undefined;
   private readonly bindings: readonly SimCfnBinding[] | undefined;
   private readonly caller: SimAwsCaller | undefined;
+  private readonly resourceOrder: SimCfnResourceOrder | undefined;
   private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: CreateStackCommandHandlerProperties) {
@@ -64,6 +69,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       cdkOutContext,
       bindings,
       caller,
+      resourceOrder,
       exports,
     } = properties;
 
@@ -74,6 +80,7 @@ export class CreateStackCommandHandler implements CommandHandler<
     this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
     this.caller = caller;
+    this.resourceOrder = resourceOrder;
     this.exports = exports;
   }
 
@@ -129,6 +136,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       cdkOutContext: this.cdkOutContext,
       bindings: this.bindings,
       caller: this.caller,
+      resourceOrder: this.resourceOrder,
       exports: this.exports,
     });
 

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
@@ -59,7 +59,7 @@ export class SimCfnCdkOutDeployer {
     deployed: ReadonlyMap<string, SimCfnDeployedStack>,
   ): Promise<SimCfnDeployedStack> {
     const { simAws, accountRegionScope } = this.scope;
-    const { transform, caller, ...options } = cdkOutOptionsFor(
+    const { transform, caller, resourceOrder, ...options } = cdkOutOptionsFor(
       stack,
       plan.stackOptions,
     );
@@ -72,6 +72,7 @@ export class SimCfnCdkOutDeployer {
         stackName: stack.stackName,
         ...options,
         caller: caller ?? plan.caller,
+        resourceOrder: resourceOrder ?? plan.resourceOrder,
         transform: cdkOutBoundTransform(transform, deployed),
       });
   }

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
@@ -11,6 +11,7 @@ import {
   assertCdkOutOptionsAreDeployed,
   type SimCfnCdkOutStackOptionsByName,
 } from "./sim-cfn-cdk-out-stack-options.js";
+import type { SimCfnResourceOrder } from "../stack/deploy/sim-cfn-resource-order.js";
 
 export interface SimCloudFormationDeployCdkOutProperties {
   /** The `cdk.out` directory to deploy, holding a `manifest.json`. */
@@ -36,8 +37,16 @@ export interface SimCloudFormationDeployCdkOutProperties {
   readonly caller?: SimAwsCaller | undefined;
 
   /**
-   * Bindings, parameters, a caller and a transform for individual Stacks,
-   * keyed the same way `stackNames` names them.
+   * The order every Stack in the assembly creates Resources with no dependency
+   * between them in, which one named in `stackOptions` overrides for its own
+   * Stack. `reversed` deploys each Stack the other way round from the one its
+   * template is written in.
+   */
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
+
+  /**
+   * Bindings, parameters, a caller, a Resource order and a transform for
+   * individual Stacks, keyed the same way `stackNames` names them.
    */
   readonly stackOptions?: SimCfnCdkOutStackOptionsByName | undefined;
 }
@@ -50,6 +59,7 @@ export interface SimCfnCdkOutPlannedStack extends SimCdkAssemblyStack {
 export interface SimCfnCdkOutPlan {
   readonly stacks: readonly SimCfnCdkOutPlannedStack[];
   readonly caller?: SimAwsCaller | undefined;
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
   readonly stackOptions?: SimCfnCdkOutStackOptionsByName | undefined;
 }
 
@@ -63,9 +73,8 @@ export async function planCdkOutDeployment(properties: {
   readonly request: SimCloudFormationDeployCdkOutProperties | string;
   readonly defaultRegionName: AwsRegionName;
 }): Promise<SimCfnCdkOutPlan> {
-  const { directoryPath, stackNames, caller, stackOptions } = cdkOutDeployment(
-    properties.request,
-  );
+  const { directoryPath, stackNames, caller, resourceOrder, stackOptions } =
+    cdkOutDeployment(properties.request);
 
   const selected = selectCdkAssemblyStacks({
     stacks: await loadCdkAssemblyStacks(directoryPath),
@@ -81,6 +90,7 @@ export async function planCdkOutDeployment(properties: {
       regionName: stack.regionName ?? properties.defaultRegionName,
     })),
     caller,
+    resourceOrder,
     stackOptions,
   };
 }

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
@@ -4,6 +4,7 @@ import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimCfnDeployedStack } from "../stack/sim-cfn-deployed-stack.type.js";
 import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
 import type { SimCfnTemplateFileTransform } from "./sim-cfn-template-file-transform.js";
+import type { SimCfnResourceOrder } from "../stack/deploy/sim-cfn-resource-order.js";
 
 /**
  * Adapts one Stack's parsed template, with the Stacks the same call has already
@@ -39,6 +40,12 @@ export interface SimCfnCdkOutStackOptions {
    * application Stack deployed by another is what this is for.
    */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The order this Stack creates Resources with no dependency between them in,
+   * where the assembly's own order is not the right one for it.
+   */
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
 
   readonly transform?: SimCfnCdkOutTemplateTransform | undefined;
 }

--- a/src/service/cloudformation/deploy/sim-cfn-deployment-resource-order.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-deployment-resource-order.iso.test.ts
@@ -1,0 +1,239 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { simCdkCloudAssemblyFactory } from "../cdk/sim-cdk-cloud-assembly.factory.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+/**
+ * An inline policy widening the deploy Role to the service the Topic below
+ * needs. Nothing in the template says it has to be created first.
+ */
+const widening = {
+  Type: "AWS::IAM::Policy",
+  Properties: {
+    PolicyName: "DeployerSns",
+    Roles: ["deployer"],
+    PolicyDocument: {
+      Version: "2012-10-17",
+      Statement: { Effect: "Allow", Action: "sns:*", Resource: "*" },
+    },
+  },
+};
+
+const topic = {
+  Type: "AWS::SNS::Topic",
+  Properties: { TopicName: "alerts" },
+};
+
+const wideningFirst = { Widening: widening, Alerts: topic };
+const topicFirst = { Alerts: topic, Widening: widening };
+
+describe("the order a simulated CloudFormation deployment creates Resources in", () => {
+  it("keeps the template's order when the deployment asks for nothing else", async () => {
+    // Given a deploy Role a Stack widens to SNS before declaring a Topic.
+    const { simAws, deployer } = await deployment();
+
+    // When the Stack is deployed as it comes.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "alerts-stack",
+      template: { Resources: wideningFirst },
+      caller: deployer,
+    });
+
+    // Then the widening went first, as the template wrote it.
+    assertIdentical(stack.getResource("Alerts")?.status, "CREATE_COMPLETE");
+    assertNonNullable(simAws.sns().findTopic("alerts"));
+  });
+
+  it("fails the Stack the template's order was carrying when reversed", async () => {
+    // Given the same Stack, whose only reason to deploy is the order it is
+    // written in.
+    const { simAws, deployer } = await deployment();
+
+    // When it is deployed in the other order CloudFormation could pick.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "alerts-stack",
+        template: { Resources: wideningFirst },
+        caller: deployer,
+        resourceOrder: "reversed",
+      });
+    });
+
+    // Then the Topic was refused, because the widening had not landed yet.
+    assertStringIncludes(error.message, "sns:CreateTopic");
+  });
+
+  it("fails the Stack in the template's order when the Topic is written first", async () => {
+    // Given the same pair, declared the other way round.
+    const { simAws, deployer } = await deployment();
+
+    // When it is deployed as it comes.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "alerts-stack",
+        template: { Resources: topicFirst },
+        caller: deployer,
+      });
+    });
+
+    // Then the Topic was refused, so the pair is caught in one of the two
+    // orders whichever way the template declares it.
+    assertStringIncludes(error.message, "sns:CreateTopic");
+  });
+
+  it("deploys the pair the option puts the widening in front of", async () => {
+    // Given the same pair with the Topic written first.
+    const { simAws, deployer } = await deployment();
+
+    // When the reversed order puts the widening first.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "alerts-stack",
+      template: { Resources: topicFirst },
+      caller: deployer,
+      resourceOrder: "reversed",
+    });
+
+    // Then it deploys, since reversing one order is the other one. The option
+    // is the second order to run, not a second chance at the same one.
+    assertIdentical(stack.getResource("Alerts")?.status, "CREATE_COMPLETE");
+  });
+
+  it("deploys a Stack whose ordering requirement DependsOn declares", async () => {
+    // Given the pair with the requirement written down, in the order the
+    // reversal would otherwise break.
+    const { simAws, deployer } = await deployment();
+
+    // When it is deployed reversed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "alerts-stack",
+      template: {
+        Resources: {
+          Widening: widening,
+          Alerts: { ...topic, DependsOn: "Widening" },
+        },
+      },
+      caller: deployer,
+      resourceOrder: "reversed",
+    });
+
+    // Then the edge held, so only Resources with nothing between them moved.
+    assertIdentical(stack.getResource("Alerts")?.status, "CREATE_COMPLETE");
+    assertNonNullable(simAws.sns().findTopic("alerts"));
+  });
+
+  it("reverses every Stack in a cloud assembly asked for the reversed order", async () => {
+    // Given an assembly whose one Stack holds the pair, widening first.
+    const { simAws, deployer } = await deployment();
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "AlertsStack",
+          regionName: "eu-west-2",
+          resources: wideningFirst,
+        },
+      ],
+    });
+
+    // When the assembly is deployed reversed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployCdkOut({
+        directoryPath: directory.join("cdk.out"),
+        caller: deployer,
+        resourceOrder: "reversed",
+      });
+    });
+
+    // Then the Stack was deployed in the other order, and said so.
+    assertStringIncludes(error.message, "sns:CreateTopic");
+  });
+
+  it("lets a Stack's own order override the assembly's", async () => {
+    // Given the same assembly, deployed reversed.
+    const { simAws, deployer } = await deployment();
+    const directory = await simCdkCloudAssemblyFactory.make({
+      stacks: [
+        {
+          artifactId: "AlertsStack",
+          regionName: "eu-west-2",
+          resources: wideningFirst,
+        },
+      ],
+    });
+
+    // When the Stack names the template's own order for itself.
+    await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      caller: deployer,
+      resourceOrder: "reversed",
+      stackOptions: { AlertsStack: { resourceOrder: "template" } },
+    });
+
+    // Then it deployed the way its template is written.
+    assertNonNullable(
+      simAws
+        .accountRegionScope(simAws.defaultAccountId, "eu-west-2")
+        .sns()
+        .findTopic("alerts"),
+    );
+  });
+});
+
+/**
+ * A simulated AWS holding a deploy Role that may attach policies and may not
+ * reach SNS, which is what the widening in the template above is for.
+ */
+async function deployment(): Promise<{
+  readonly simAws: SimAws;
+  readonly deployer: SimAwsCaller;
+}> {
+  const accountId = makeSimAwsAccountId();
+  const simAws = new SimAws({
+    defaultAccountId: accountId,
+    defaultRegionName: "eu-west-2",
+  });
+
+  return { simAws, deployer: await deployRole(simAws, accountId) };
+}
+
+async function deployRole(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+): Promise<SimAwsCaller> {
+  const iam = simAws.account(accountId).iam();
+
+  await iam.createRole({
+    input: {
+      RoleName: "deployer",
+      AssumeRolePolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "sts:AssumeRole",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+        },
+      }),
+    },
+  });
+
+  await iam.putRolePolicy({
+    input: {
+      RoleName: "deployer",
+      PolicyName: "deployer-policy",
+      PolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: { Effect: "Allow", Action: "iam:*", Resource: "*" },
+      }),
+    },
+  });
+
+  return { kind: "arn", arn: `arn:aws:iam::${accountId}:role/deployer` };
+}

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -33,6 +33,7 @@ import type { SimCreateStackCommandOutput } from "../command/create-stack/create
 import { CreateStackCommandHandler } from "../command/create-stack/create-stack.handler.js";
 import { faker } from "@faker-js/faker";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
+import type { SimCfnResourceOrder } from "../stack/deploy/sim-cfn-resource-order.js";
 
 export interface SimCloudFormationCreateStackProperties {
   readonly stackName?: SimCloudFormationStackName | string;
@@ -49,6 +50,17 @@ export interface SimCloudFormationCreateStackProperties {
    * policy denying an Account's root principal then denies.
    */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The order Resources with no dependency between them are created in.
+   *
+   * CloudFormation is free to create them either way round, and the template's
+   * own order is what a deployment does by default. `reversed` starts each
+   * dependency batch from its last Resource, so a Stack that only deploys in
+   * the order its template happens to be written fails here rather than in the
+   * account. Declared dependencies and `DependsOn` are honoured either way.
+   */
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
 
   /**
    * The synthesized CDK template file this in-memory template stands in for.
@@ -126,6 +138,7 @@ export class SimCloudFormationTemplateDeployer {
       parameters: properties.parameters,
       bindings: properties.bindings,
       caller: properties.caller,
+      resourceOrder: properties.resourceOrder,
       cdkOutContext: await cdkOutContextForTemplatePath(
         properties.templatePath,
       ),
@@ -188,31 +201,10 @@ export class SimCloudFormationTemplateDeployer {
     this.watches.stopAll();
   }
 
-  private async deployTemplateWithContext(properties: {
-    readonly stackName: SimCloudFormationStackName | string;
-    readonly template: CfnTemplateBodyRecord;
-    readonly parameters?: Record<string, string> | undefined;
-    readonly bindings?: readonly SimCfnBinding[] | undefined;
-    readonly caller?: SimAwsCaller | undefined;
-    readonly cdkOutContext?: SimCdkOutContext | undefined;
-  }): Promise<SimCfnDeployedStack> {
-    await this.createStackWithContext(
-      {
-        input: {
-          StackName: properties.stackName,
-          TemplateBody: jsonStringify(properties.template),
-          Parameters: Object.entries(properties.parameters ?? {}).map(
-            ([parameterKey, parameterValue]) => ({
-              ParameterKey: parameterKey,
-              ParameterValue: parameterValue,
-            }),
-          ),
-        },
-      },
-      properties.cdkOutContext,
-      properties.bindings,
-      properties.caller,
-    );
+  private async deployTemplateWithContext(
+    properties: SimCfnTemplateDeployment,
+  ): Promise<SimCfnDeployedStack> {
+    await this.createStackWithContext(properties);
 
     const stack = this.stacks.get(
       properties.stackName as SimCloudFormationStackName,
@@ -228,33 +220,44 @@ export class SimCloudFormationTemplateDeployer {
   }
 
   private async createStackWithContext(
-    command: {
-      readonly input: {
-        readonly StackName: SimCloudFormationStackName | string;
-        readonly TemplateBody: string;
-        readonly Parameters: readonly {
-          readonly ParameterKey: string;
-          readonly ParameterValue: string;
-        }[];
-      };
-    },
-    cdkOutContext?: SimCdkOutContext,
-    bindings?: readonly SimCfnBinding[],
-    caller?: SimAwsCaller,
+    deployment: SimCfnTemplateDeployment,
   ): Promise<SimCreateStackCommandOutput> {
     const handler = new CreateStackCommandHandler({
       simAws: this.simAws,
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,
-      cdkOutContext,
-      bindings,
-      caller,
+      cdkOutContext: deployment.cdkOutContext,
+      bindings: deployment.bindings,
+      caller: deployment.caller,
+      resourceOrder: deployment.resourceOrder,
       exports: this.exports,
     });
 
-    return await handler.handle(command);
+    return await handler.handle({
+      input: {
+        StackName: deployment.stackName,
+        TemplateBody: jsonStringify(deployment.template),
+        Parameters: Object.entries(deployment.parameters ?? {}).map(
+          ([parameterKey, parameterValue]) => ({
+            ParameterKey: parameterKey,
+            ParameterValue: parameterValue,
+          }),
+        ),
+      },
+    });
   }
+}
+
+/** One template on its way into a Stack, with everything it deploys with. */
+interface SimCfnTemplateDeployment {
+  readonly stackName: SimCloudFormationStackName | string;
+  readonly template: CfnTemplateBodyRecord;
+  readonly parameters?: Record<string, string> | undefined;
+  readonly bindings?: readonly SimCfnBinding[] | undefined;
+  readonly caller?: SimAwsCaller | undefined;
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
+  readonly cdkOutContext?: SimCdkOutContext | undefined;
 }
 
 /**

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -16,6 +16,7 @@ import {
 } from "./sim-cfn-template-file-transform.js";
 import { readTemplateFile } from "./sim-cfn-template-file-read.js";
 import { parseTemplateFileBody } from "./sim-cfn-template-file-parse.js";
+import type { SimCfnResourceOrder } from "../stack/deploy/sim-cfn-resource-order.js";
 
 export interface SimCloudFormationDeployTemplateFileProperties {
   readonly templatePath: string;
@@ -32,6 +33,17 @@ export interface SimCloudFormationDeployTemplateFileProperties {
    * policy denying an Account's root principal then denies.
    */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The order Resources with no dependency between them are created in.
+   *
+   * CloudFormation is free to create them either way round, and the template's
+   * own order is what a deployment does by default. `reversed` starts each
+   * dependency batch from its last Resource, so a Stack that only deploys in
+   * the order its template happens to be written fails here rather than in the
+   * account. Declared dependencies and `DependsOn` are honoured either way.
+   */
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
 
   /**
    * Adapt the parsed template before it is deployed, and again every time a
@@ -69,6 +81,7 @@ export interface SimCfnLoadedTemplateFile {
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly caller?: SimAwsCaller | undefined;
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
 }
 
@@ -85,7 +98,8 @@ export class SimCfnTemplateFileLoader {
     properties: SimCloudFormationDeployTemplateFileProperties | string,
   ): Promise<SimCfnLoadedTemplateFile> {
     const deployment = simCfnTemplateFileDeployment(properties);
-    const { templatePath, parameters, bindings, caller } = deployment;
+    const { templatePath, parameters, bindings, caller, resourceOrder } =
+      deployment;
     const stackName =
       deployment.stackName ?? stackNameFromTemplatePath(templatePath);
 
@@ -108,6 +122,7 @@ export class SimCfnTemplateFileLoader {
       parameters,
       bindings,
       caller,
+      resourceOrder,
       cdkOutContext,
     };
   }

--- a/src/service/cloudformation/stack/deploy/sim-cfn-resource-order.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-resource-order.ts
@@ -1,0 +1,26 @@
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+
+/**
+ * The order the Resources in one dependency batch are started in.
+ *
+ * CloudFormation creates Resources with no dependency between them in whatever
+ * order it likes, so a template whose Resources only work in the order it wrote
+ * them deploys some of the time. `template` is the order the template declared,
+ * which is what a deployment does unless it is asked for something else.
+ * `reversed` starts each batch from its last Resource, which is the other order
+ * a pair with nothing between them could be created in.
+ *
+ * Dependencies are unaffected either way: a Resource still waits for everything
+ * it refers to and everything its `DependsOn` names.
+ */
+export type SimCfnResourceOrder = "template" | "reversed";
+
+/**
+ * The Resources of one batch, in the order the deployment asked for.
+ */
+export function simCfnOrderedResources(
+  resources: readonly SimCfnResource[],
+  order: SimCfnResourceOrder | undefined,
+): readonly SimCfnResource[] {
+  return order === "reversed" ? resources.toReversed() : resources;
+}

--- a/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-batch-creator.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-batch-creator.ts
@@ -3,6 +3,10 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import {
+  simCfnOrderedResources,
+  type SimCfnResourceOrder,
+} from "./sim-cfn-resource-order.js";
 
 interface SimCfnStackResourceBatchCreatorProperties {
   readonly simAws: SimAws;
@@ -10,6 +14,7 @@ interface SimCfnStackResourceBatchCreatorProperties {
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly caller?: SimAwsCaller | undefined;
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
 }
 
 /**
@@ -19,6 +24,7 @@ interface SimCfnStackResourceBatchCreatorProperties {
  * class owns only the batch execution details:
  *
  * - create all Resources in the batch in parallel
+ * - start them in the order the deployment asked for
  * - pass the shared Stack creation context to each Resource
  *
  * It does not choose which Resources are ready, retry incomplete Resources, or
@@ -32,15 +38,24 @@ export class SimCfnStackResourceBatchCreator {
   private readonly cdkOutContext: SimCdkOutContext | undefined;
   private readonly bindings: readonly SimCfnBinding[] | undefined;
   private readonly caller: SimAwsCaller | undefined;
+  private readonly resourceOrder: SimCfnResourceOrder | undefined;
 
   constructor(properties: SimCfnStackResourceBatchCreatorProperties) {
-    const { simAws, resources, cdkOutContext, bindings, caller } = properties;
+    const {
+      simAws,
+      resources,
+      cdkOutContext,
+      bindings,
+      caller,
+      resourceOrder,
+    } = properties;
 
     this.simAws = simAws;
     this.resources = resources;
     this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
     this.caller = caller;
+    this.resourceOrder = resourceOrder;
   }
 
   /**
@@ -48,18 +63,23 @@ export class SimCfnStackResourceBatchCreator {
    *
    * Each Resource still owns its own create lifecycle and status transitions.
    * This method only waits for the batch to settle.
+   *
+   * Nothing in the batch depends on anything else in it, so the order they
+   * start in is the deployment's to choose.
    */
   async create(resources: readonly SimCfnResource[]): Promise<void> {
     await Promise.all(
-      resources.map(async (resource) => {
-        await resource.create({
-          simAws: this.simAws,
-          resources: this.resources,
-          cdkOutContext: this.cdkOutContext,
-          bindings: this.bindings,
-          caller: this.caller,
-        });
-      }),
+      simCfnOrderedResources(resources, this.resourceOrder).map(
+        async (resource) => {
+          await resource.create({
+            simAws: this.simAws,
+            resources: this.resources,
+            cdkOutContext: this.cdkOutContext,
+            bindings: this.bindings,
+            caller: this.caller,
+          });
+        },
+      ),
     );
   }
 }

--- a/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-creator.ts
+++ b/src/service/cloudformation/stack/deploy/sim-cfn-stack-resource-creator.ts
@@ -5,6 +5,7 @@ import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
 import { SimCfnStackResourceBatchCreator } from "./sim-cfn-stack-resource-batch-creator.js";
 import { SimCfnStackPendingResources } from "./sim-cfn-stack-pending-resources.js";
+import type { SimCfnResourceOrder } from "./sim-cfn-resource-order.js";
 
 interface SimCfnStackResourceCreatorProperties {
   readonly simAws: SimAws;
@@ -13,6 +14,7 @@ interface SimCfnStackResourceCreatorProperties {
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly caller?: SimAwsCaller | undefined;
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
 }
 
 /**
@@ -37,8 +39,15 @@ export class SimCfnStackResourceCreator {
   private readonly batchCreator: SimCfnStackResourceBatchCreator;
 
   constructor(properties: SimCfnStackResourceCreatorProperties) {
-    const { simAws, resources, stackName, cdkOutContext, bindings, caller } =
-      properties;
+    const {
+      simAws,
+      resources,
+      stackName,
+      cdkOutContext,
+      bindings,
+      caller,
+      resourceOrder,
+    } = properties;
 
     this.resources = resources;
     this.stackName = stackName;
@@ -48,6 +57,7 @@ export class SimCfnStackResourceCreator {
       cdkOutContext,
       bindings,
       caller,
+      resourceOrder,
     });
   }
 

--- a/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
@@ -8,6 +8,7 @@ import { SimCdkAssetsPublisher } from "../cdk/assets/sim-cdk-assets-publisher.js
 import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
 import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
 import { SimCfnStackResourceCreator } from "./deploy/sim-cfn-stack-resource-creator.js";
+import type { SimCfnResourceOrder } from "./deploy/sim-cfn-resource-order.js";
 import { SimCfnStackResourceDeleter } from "./teardown/sim-cfn-stack-resource-deleter.js";
 import { SimCfnStackUpdater } from "./update/sim-cfn-stack-updater.js";
 import type { SimCloudFormationStackName } from "./sim-cfn-stack.js";
@@ -31,6 +32,11 @@ interface SimCfnStackResourceOperationsProperties {
    * caller leaves each service to decide the request as the Account root.
    */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The order Resources with no dependency between them are started in.
+   */
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
 }
 
 /**
@@ -51,6 +57,7 @@ export class SimCfnStackResourceOperations {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly stackName: SimCloudFormationStackName;
   private readonly bindings: readonly SimCfnBinding[] | undefined;
+  private readonly resourceOrder: SimCfnResourceOrder | undefined;
   private cdkOutContext: SimCdkOutContext | undefined;
   private caller: SimAwsCaller | undefined;
 
@@ -62,6 +69,7 @@ export class SimCfnStackResourceOperations {
       cdkOutContext,
       bindings,
       caller,
+      resourceOrder,
     } = properties;
 
     this.simAws = simAws;
@@ -70,6 +78,7 @@ export class SimCfnStackResourceOperations {
     this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
     this.caller = caller;
+    this.resourceOrder = resourceOrder;
   }
 
   /**
@@ -170,6 +179,7 @@ export class SimCfnStackResourceOperations {
       cdkOutContext: this.cdkOutContext,
       bindings: this.bindings,
       caller: this.caller,
+      resourceOrder: this.resourceOrder,
     });
   }
 

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -68,6 +68,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
       cdkOutContext,
       bindings,
       caller,
+      resourceOrder,
       exports,
     } = properties;
 
@@ -93,6 +94,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
       cdkOutContext,
       bindings,
       caller,
+      resourceOrder,
     });
     this.lifecycle = new SimCfnStackDeploymentLifecycle({
       background,

--- a/src/service/cloudformation/stack/sim-cfn-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.type.ts
@@ -7,6 +7,7 @@ import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
+import type { SimCfnResourceOrder } from "./deploy/sim-cfn-resource-order.js";
 
 export type SimCloudFormationStackName = Brand<
   string,
@@ -56,6 +57,12 @@ export interface SimCloudFormationStackProperties {
    * simulation.
    */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The order this Stack starts Resources with no dependency between them in.
+   * The template's own order unless the deployment asked for another one.
+   */
+  readonly resourceOrder?: SimCfnResourceOrder | undefined;
 
   /**
    * The export names published in the Account and Region this Stack deploys


### PR DESCRIPTION
`SimCfnStackResourceBatchCreator` started each dependency batch in template order. A Stack that deploys only because of the order its template happens to declare therefore passed here and failed in the account. A `resourceOrder` deployment option now chooses that order. `"reversed"` starts each batch from its last Resource, and `deployTemplate`, `deployTemplateFile` and `deployCdkOut` all take it (an assembly names one order for every Stack in it, and `stackOptions` carries a Stack's own). Declared dependencies hold under either order, since only Resources CloudFormation was free to create either way round move. The default order is the template's.

On the issue's open question I took the smaller option. Yulin offers the order and leaves the second run to the caller. That has one consequence worth naming against the acceptance criteria. Reversing one order gives the other one, so no single run catches the pair whichever way the template declares it. Running a deployment both ways is what catches it. Declared policy first, the default order deploys and `"reversed"` fails. Declared topic first, the default order fails already. Running both orders and reporting the difference is the option that would catch it in one call, and the issue says that one is bigger.

`sim-cfn-deployment-resource-order.iso.test.ts` covers both declaration orders under both orders, an explicit `DependsOn` edge deploying under the option, the unchanged default, and the assembly-wide and per-Stack options for `deployCdkOut`. The CloudFormation docs gain a section under Resource dependencies.

Resolves #1135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CloudFormation resource creation order.
  * Resources can deploy in template order by default or in reversed order within dependency batches.
  * Supported across direct template deployments, template files, CDK assemblies, and stack-level settings.
  * Explicit and intrinsic dependencies continue to be respected.

* **Documentation**
  * Added usage guidance and examples for reversed resource deployment ordering.

* **Tests**
  * Added coverage for ordering modes, dependency handling, deployment methods, and overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->