### PR TITLE
fix: authorize logs:GetDeliverySource on a deploy

### DIFF
--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -741,6 +741,14 @@ exactly as on real AWS.
 `DescribeLogGroups` names no particular group. It authorizes against every log group in the account
 and region, and a policy scoped to one group cannot describe them all.
 
+A Stack deploying the three delivery Resource types authorizes the actions CloudFormation names.
+Each handler reads its own resource back before it writes. `AWS::Logs::DeliverySource` therefore
+needs `logs:GetDeliverySource` alongside `logs:PutDeliverySource`, and the destination and the
+delivery need `logs:GetDeliveryDestination` and `logs:GetDelivery` the same way. The `Describe` actions cover
+the three listing operations an SDK caller reaches, and a deployment goes near none of them. A
+CloudFormation execution Role therefore carries the same policy here that a real deploy of the
+template needs.
+
 ```typescript sim-logs-permissions
 /**
  * A simulated IAM policy allowing a Role to write one function's logs.
@@ -852,8 +860,9 @@ console.log(described.logGroups?.[0]?.logGroupArn);
   log group and the three delivery resource types are what simulated CloudFormation deploys here.
 - **Nothing is actually delivered.** A delivery records that a source was joined to a destination
   and how the records would be written. No access log file ever reaches the bucket.
-- **`GetDeliverySource`, `GetDeliveryDestination` and `GetDelivery`.** Absent. The three `Describe`
-  operations report the same resources.
+- **`GetDeliverySource`, `GetDeliveryDestination` and `GetDelivery`.** Absent as SDK operations. The
+  three `Describe` operations report the same resources. The three action names are authorized where
+  CloudFormation reads a delivery Resource back.
 - **Delivery resource tags and cross-account delivery.** `PutDeliverySource`,
   `PutDeliveryDestination` and `CreateDelivery` refuse tags outright. `DeliveryDestinationPolicy` in
   a template is recorded and acted on by nothing.

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-authorization.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-authorization.ts
@@ -1,0 +1,81 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimLogsAuthorizer } from "../../command/authorize/sim-logs-authorizer.js";
+import {
+  simLogsAnyDeliveryArn,
+  simLogsDeliveryDestinationArn,
+  simLogsDeliverySourceArn,
+} from "../../delivery/sim-logs-delivery-arn.js";
+
+interface SimCfnDeliveryAuthorizationProperties {
+  readonly authorizer: SimLogsAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The permissions a CloudFormation delivery Resource handler checks on top of
+ * the API call it makes.
+ *
+ * Each of the three handlers reads its own resource back by name, with
+ * `GetDeliverySource`, `GetDeliveryDestination` or `GetDelivery`. The read
+ * comes before the write, and an execution Role denied it is refused before the
+ * resource exists. The three `Describe` listings belong to the SDK operations
+ * of those names, and no handler goes near one. A policy written from a real
+ * CloudFormation refusal therefore grants the `Get` action, and that policy has
+ * to deploy here.
+ *
+ * The checks sit together because they are the whole of what a deployment's
+ * caller meets before the delivery commands take over.
+ */
+export class SimCfnDeliveryAuthorization {
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #scope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimCfnDeliveryAuthorizationProperties) {
+    this.#authorizer = properties.authorizer;
+    this.#scope = properties.accountRegionScope;
+  }
+
+  /**
+   * Authorize creating an AWS::Logs::DeliverySource.
+   *
+   * The source need not be there. CloudFormation reads the name it is about to
+   * take, and IAM decides the request before CloudWatch Logs answers it.
+   */
+  authorizeDeliverySourceCreate(name: string, caller?: SimAwsCaller): void {
+    this.#authorizer.authorizeResource(
+      "logs:GetDeliverySource",
+      simLogsDeliverySourceArn(this.#scope, name),
+      caller,
+    );
+  }
+
+  /**
+   * Authorize creating an AWS::Logs::DeliveryDestination.
+   */
+  authorizeDeliveryDestinationCreate(
+    name: string,
+    caller?: SimAwsCaller,
+  ): void {
+    this.#authorizer.authorizeResource(
+      "logs:GetDeliveryDestination",
+      simLogsDeliveryDestinationArn(this.#scope, name),
+      caller,
+    );
+  }
+
+  /**
+   * Authorize creating an AWS::Logs::Delivery.
+   *
+   * A delivery carries an identifier CloudWatch Logs has yet to issue. The read
+   * is authorized against every delivery in the scope, the way `CreateDelivery`
+   * itself is.
+   */
+  authorizeDeliveryCreate(caller?: SimAwsCaller): void {
+    this.#authorizer.authorizeResource(
+      "logs:GetDelivery",
+      simLogsAnyDeliveryArn(this.#scope),
+      caller,
+    );
+  }
+}

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimLogsDelivery } from "../../delivery/sim-logs-delivery.js";
 import type { SimLogs } from "../../sim-logs.js";
 import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimCfnDeliveryAuthorization } from "./sim-cfn-delivery-authorization.js";
 import { simCfnDeliveryInput } from "./sim-cfn-delivery-input.js";
 import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
 import { deliveryUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
@@ -20,6 +21,7 @@ const actedOnProperties = new Set([
 
 interface SimCfnDeliveryCreatorProperties {
   readonly logs: SimLogs;
+  readonly authorization: SimCfnDeliveryAuthorization;
 }
 
 /**
@@ -28,12 +30,17 @@ interface SimCfnDeliveryCreatorProperties {
  * A delivery is the join between a source and a destination, and both have to
  * be deployed before it. A template gets that ordering from naming them
  * through `Ref` and `Fn::GetAtt`.
+ *
+ * The handler reads deliveries back before it creates one, and that read is
+ * what a CloudFormation execution Role needs `logs:GetDelivery` for.
  */
 export class SimCfnDeliveryCreator {
   readonly #logs: SimLogs;
+  readonly #authorization: SimCfnDeliveryAuthorization;
 
   constructor(properties: SimCfnDeliveryCreatorProperties) {
     this.#logs = properties.logs;
+    this.#authorization = properties.authorization;
   }
 
   /**
@@ -53,6 +60,8 @@ export class SimCfnDeliveryCreator {
     });
 
     reader.recordIgnoredProperties();
+
+    this.#authorization.authorizeDeliveryCreate(options?.caller);
 
     const created = await this.#logs.createDelivery(
       { input: simCfnDeliveryInput(reader) },

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-destination-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-destination-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimLogsDeliveryDestination } from "../../delivery/sim-logs-delivery-destination.js";
 import type { SimLogs } from "../../sim-logs.js";
 import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimCfnDeliveryAuthorization } from "./sim-cfn-delivery-authorization.js";
 import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
 import { deliveryDestinationUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
 
@@ -16,6 +17,7 @@ const actedOnProperties = new Set([
 
 interface SimCfnDeliveryDestinationCreatorProperties {
   readonly logs: SimLogs;
+  readonly authorization: SimCfnDeliveryAuthorization;
 }
 
 /**
@@ -26,12 +28,17 @@ interface SimCfnDeliveryDestinationCreatorProperties {
  * changes it replaces the Resource. Sim CloudFormation replaces a Resource
  * whose template entry changed at all, which lands on the same behaviour
  * without the destination having to say so.
+ *
+ * The handler reads the destination back before it puts one, and that read is
+ * what a CloudFormation execution Role needs `logs:GetDeliveryDestination` for.
  */
 export class SimCfnDeliveryDestinationCreator {
   readonly #logs: SimLogs;
+  readonly #authorization: SimCfnDeliveryAuthorization;
 
   constructor(properties: SimCfnDeliveryDestinationCreatorProperties) {
     this.#logs = properties.logs;
+    this.#authorization = properties.authorization;
   }
 
   /**
@@ -52,6 +59,11 @@ export class SimCfnDeliveryDestinationCreator {
     const name = reader.requiredString("Name");
 
     reader.recordIgnoredProperties();
+
+    this.#authorization.authorizeDeliveryDestinationCreate(
+      name,
+      options?.caller,
+    );
 
     await this.#logs.putDeliveryDestination(
       {

--- a/src/service/logs/cfn/delivery/sim-cfn-delivery-source-creator.ts
+++ b/src/service/logs/cfn/delivery/sim-cfn-delivery-source-creator.ts
@@ -4,6 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimLogsDeliverySource } from "../../delivery/sim-logs-delivery-source.js";
 import type { SimLogs } from "../../sim-logs.js";
 import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimCfnDeliveryAuthorization } from "./sim-cfn-delivery-authorization.js";
 import { SimCfnDeliveryProperties } from "./sim-cfn-delivery-properties.js";
 import { deliverySourceUnsimulatedReasons } from "./sim-cfn-delivery-unsimulated-properties.js";
 
@@ -12,6 +13,7 @@ const actedOnProperties = new Set(["Name", "ResourceArn", "LogType"]);
 
 interface SimCfnDeliverySourceCreatorProperties {
   readonly logs: SimLogs;
+  readonly authorization: SimCfnDeliveryAuthorization;
 }
 
 /**
@@ -21,12 +23,17 @@ interface SimCfnDeliverySourceCreatorProperties {
  * store, so a template hits the same refusals an SDK caller would: a
  * distribution that already has a delivery source, and a CloudFront source
  * declared in a stack outside us-east-1.
+ *
+ * The handler reads the source back before it puts one, and that read is what
+ * a CloudFormation execution Role needs `logs:GetDeliverySource` for.
  */
 export class SimCfnDeliverySourceCreator {
   readonly #logs: SimLogs;
+  readonly #authorization: SimCfnDeliveryAuthorization;
 
   constructor(properties: SimCfnDeliverySourceCreatorProperties) {
     this.#logs = properties.logs;
+    this.#authorization = properties.authorization;
   }
 
   /**
@@ -47,6 +54,8 @@ export class SimCfnDeliverySourceCreator {
     const name = reader.requiredString("Name");
 
     reader.recordIgnoredProperties();
+
+    this.#authorization.authorizeDeliverySourceCreate(name, options?.caller);
 
     await this.#logs.putDeliverySource(
       {

--- a/src/service/logs/cfn/sim-cfn-delivery-iam.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery-iam.iso.test.ts
@@ -1,0 +1,206 @@
+import {
+  assertArrayLength,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simLogsDeliveryDistributionArn } from "../../../../test/logs/delivery-distribution-fixture.js";
+
+const bucketArn = "arn:aws:s3:::example-access-logs";
+const sourceName = "site-access-logs";
+
+/**
+ * Every action the three CloudFormation delivery handlers name on refusal.
+ *
+ * Taken from the `create` handler permissions of AWS::Logs::DeliverySource,
+ * AWS::Logs::DeliveryDestination and AWS::Logs::Delivery. The tagging and
+ * destination policy actions those handlers also list are left out, because
+ * this simulation refuses tags and records a destination policy without acting
+ * on it.
+ */
+const deliveryDeployActions = [
+  "logs:GetDeliverySource",
+  "logs:PutDeliverySource",
+  "logs:GetDeliveryDestination",
+  "logs:PutDeliveryDestination",
+  "logs:GetDelivery",
+  "logs:CreateDelivery",
+];
+
+/**
+ * The three Resources CloudFront standard logging v2 is made of.
+ *
+ * The Distribution is created outside the Stack and named here by its ARN. A
+ * Role that may deploy this template therefore needs no CloudFront permission.
+ */
+function loggingTemplate(resourceArn: string): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      AccessLogsSource: {
+        Type: "AWS::Logs::DeliverySource",
+        Properties: {
+          Name: sourceName,
+          ResourceArn: resourceArn,
+          LogType: "ACCESS_LOGS",
+        },
+      },
+      AccessLogsDestination: {
+        Type: "AWS::Logs::DeliveryDestination",
+        Properties: {
+          Name: sourceName,
+          DestinationResourceArn: bucketArn,
+          OutputFormat: "json",
+        },
+      },
+      AccessLogsDelivery: {
+        Type: "AWS::Logs::Delivery",
+        Properties: {
+          DeliverySourceName: { Ref: "AccessLogsSource" },
+          DeliveryDestinationArn: {
+            "Fn::GetAtt": ["AccessLogsDestination", "Arn"],
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * A Role allowed the actions it is given, as a caller a deployment can name.
+ */
+async function roleAllowing(
+  simAws: SimAws,
+  roleName: string,
+  actions: readonly string[],
+): Promise<SimAwsCaller> {
+  const role = await simIamRoleWithPolicyFactory.make(
+    { roleName, actions },
+    simAws,
+  );
+
+  return { kind: "arn", arn: role.Arn };
+}
+
+/**
+ * Deploy the logging Stack as a Role allowed the actions it is given.
+ */
+async function deployAllowing(
+  simAws: SimAws,
+  roleName: string,
+  actions: readonly string[],
+): Promise<SimCfnDeployedStack> {
+  const resourceArn = await simLogsDeliveryDistributionArn(simAws);
+  const caller = await roleAllowing(simAws, roleName, actions);
+
+  return await simAws.cloudFormation().deployTemplate({
+    stackName: "site-logging",
+    template: loggingTemplate(resourceArn),
+    caller,
+  });
+}
+
+/**
+ * The deploy actions with one of them taken out.
+ */
+function allBut(action: string): readonly string[] {
+  return deliveryDeployActions.filter((allowed) => allowed !== action);
+}
+
+describe("the principal an AWS::Logs delivery Resource is created as", () => {
+  it("deploys the whole logging Stack as a Role allowed the actions AWS names", async () => {
+    // Given a Role holding the create handler permissions of the three
+    // delivery Resource types and no listing permission at all.
+    const simAws = new SimAws();
+    const stack = await deployAllowing(
+      simAws,
+      "Deployer",
+      deliveryDeployActions,
+    );
+
+    // Then all three Resources deployed. This is the policy a real
+    // CloudFormation refusal sends someone to write, and it has to be enough
+    // here.
+    assertArrayLength(stack.skippedResources, 0);
+    assertNonNullable(simAws.logs().findDeliverySource(sourceName));
+    assertNonNullable(simAws.logs().findDeliveryDestination(sourceName));
+    assertArrayLength(simAws.logs().allDeliveries(), 1);
+  });
+
+  it("fails a delivery source under a caller denied logs:GetDeliverySource", async () => {
+    // Given a Role allowed to put a delivery source and not to read one. That
+    // is the policy Yulin used to send someone away with.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployAllowing(simAws, "Putter", allBut("logs:GetDeliverySource"));
+    });
+
+    // Then the deploy stops on the action a real account stops on, and the
+    // source was never put behind the refusal.
+    assertStringIncludes(error.message, "logs:GetDeliverySource");
+    assertStringIncludes(error.message, "role/Putter");
+    assertUndefined(simAws.logs().findDeliverySource(sourceName));
+  });
+
+  it("fails a delivery destination under a caller denied logs:GetDeliveryDestination", async () => {
+    // Given a Role allowed everything the three handlers name except the read
+    // of a delivery destination.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployAllowing(
+        simAws,
+        "Putter",
+        allBut("logs:GetDeliveryDestination"),
+      );
+    });
+
+    // Then the destination Resource fails by that name, with the delivery
+    // source it follows already deployed.
+    assertStringIncludes(error.message, "logs:GetDeliveryDestination");
+    assertNonNullable(simAws.logs().findDeliverySource(sourceName));
+    assertUndefined(simAws.logs().findDeliveryDestination(sourceName));
+  });
+
+  it("fails a delivery under a caller denied logs:GetDelivery", async () => {
+    // Given a Role allowed to join a source to a destination and not to read
+    // the delivery back.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployAllowing(simAws, "Joiner", allBut("logs:GetDelivery"));
+    });
+
+    // Then the delivery Resource fails by that name, with the two Resources it
+    // joins already deployed.
+    assertStringIncludes(error.message, "logs:GetDelivery");
+    assertNonNullable(simAws.logs().findDeliveryDestination(sourceName));
+    assertArrayLength(simAws.logs().allDeliveries(), 0);
+  });
+
+  it("tears the delivery source down under the delete action AWS names", async () => {
+    // Given the logging Stack deployed by a Role that may create the three
+    // Resources and remove only two of them.
+    const simAws = new SimAws();
+    const stack = await deployAllowing(simAws, "Deployer", [
+      ...deliveryDeployActions,
+      "logs:DeleteDelivery",
+      "logs:DeleteDeliveryDestination",
+    ]);
+
+    // When the Stack is torn down.
+    const error = await assertThrowsErrorAsync(async () => {
+      await stack.teardown();
+    });
+
+    // Then the rollback stops on `logs:DeleteDeliverySource`, the way the real
+    // one did, and the source is where it was.
+    assertStringIncludes(error.message, "logs:DeleteDeliverySource");
+    assertNonNullable(simAws.logs().findDeliverySource(sourceName));
+  });
+});

--- a/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
@@ -5,7 +5,10 @@ import type {
   SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
 import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimLogsAuthorizer } from "../command/authorize/sim-logs-authorizer.js";
 import type { SimLogs } from "../sim-logs.js";
+import { SimCfnDeliveryAuthorization } from "./delivery/sim-cfn-delivery-authorization.js";
 import { SimCfnDeliveryCreator } from "./delivery/sim-cfn-delivery-creator.js";
 import { SimCfnDeliveryDestinationCreator } from "./delivery/sim-cfn-delivery-destination-creator.js";
 import { SimCfnDeliverySourceCreator } from "./delivery/sim-cfn-delivery-source-creator.js";
@@ -15,6 +18,8 @@ import { unsupportedSimLogsResourceType } from "./sim-logs-cfn-unsupported-resou
 
 interface SimLogsCfnResourceFactoryProperties {
   readonly logs: SimLogs;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
 }
 
 /**
@@ -37,12 +42,15 @@ export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
   readonly #deleter: SimLogsCfnResourceDeleter;
 
   constructor(properties: SimLogsCfnResourceFactoryProperties) {
+    const delivery = {
+      logs: properties.logs,
+      authorization: new SimCfnDeliveryAuthorization(properties),
+    };
+
     this.#logGroups = new SimCfnLogGroupCreator(properties);
-    this.#deliverySources = new SimCfnDeliverySourceCreator(properties);
-    this.#deliveryDestinations = new SimCfnDeliveryDestinationCreator(
-      properties,
-    );
-    this.#deliveries = new SimCfnDeliveryCreator(properties);
+    this.#deliverySources = new SimCfnDeliverySourceCreator(delivery);
+    this.#deliveryDestinations = new SimCfnDeliveryDestinationCreator(delivery);
+    this.#deliveries = new SimCfnDeliveryCreator(delivery);
     this.#deleter = new SimLogsCfnResourceDeleter({
       logGroups: this.#logGroups,
       deliverySources: this.#deliverySources,

--- a/src/service/logs/sim-logs-commands.ts
+++ b/src/service/logs/sim-logs-commands.ts
@@ -62,6 +62,8 @@ export interface SimLogsProperties {
  * somewhere it is not competing for room with them.
  */
 export class SimLogsCommands {
+  readonly authorizer: SimLogsAuthorizer;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly groups: SimLogsLogGroupStore;
   readonly logGroups: SimLogsLogGroupCommands;
   readonly retention: SimLogsRetentionCommands;
@@ -99,6 +101,8 @@ export class SimLogsCommands {
       background,
     });
 
+    this.authorizer = authorizer;
+    this.accountRegionScope = accountRegionScope;
     this.background = background;
     this.groups = groups;
     this.fanOut = fanOut;

--- a/src/service/logs/sim-logs.ts
+++ b/src/service/logs/sim-logs.ts
@@ -33,11 +33,16 @@ export class SimLogs extends SimLogsDeliveryOperations {
   protected readonly commands: SimLogsCommands;
 
   readonly #sdkRouter = new SimLogsSdkCommandRouter(this);
-  readonly #cfnFactory = new SimLogsCfnResourceFactory({ logs: this });
+  readonly #cfnFactory: SimLogsCfnResourceFactory;
 
   constructor(properties: SimLogsProperties = {}) {
     super();
     this.commands = new SimLogsCommands(properties);
+    this.#cfnFactory = new SimLogsCfnResourceFactory({
+      logs: this,
+      authorizer: this.commands.authorizer,
+      accountRegionScope: this.commands.accountRegionScope,
+    });
   }
 
   /**


### PR DESCRIPTION
CloudFormation reads a delivery Resource back before it writes anything, and it reads it by name. `AWS::Logs::DeliverySource` uses `GetDeliverySource`, and the destination and the delivery use `GetDeliveryDestination` and `GetDelivery`. A downstream project deployed a delivery source into an account whose execution Role named none of the three and stopped on `logs:GetDeliverySource` before anything was created. Yulin authorized `logs:DescribeDeliverySources` for the same Resource, so a policy written from the real failure was refused here and a policy written from Yulin's message was refused by AWS.

The three CloudFormation delivery creators now authorize the read their handler makes, ahead of the put or create behind it. The checks sit together in one `SimCfnDeliveryAuthorization`, built by the CloudWatch Logs Resource factory the way simulated ECR already builds its own. The action names come from the `create` handler permissions of the three Resource types in the CloudFormation registry, read back from `describe-type`. Deletion is unchanged: the delete handlers name only `DeleteDeliverySource`, `DeleteDeliveryDestination` and `DeleteDelivery`, which is what a rollback already stopped on here.

## The open question

The issue asked whether the SDK commands keep the `Describe*` names while the CloudFormation path uses the `Get*` names. They keep them. `logs:DescribeDeliverySources` is the IAM action for the API operation of that name, and the three `Describe` commands are the only ones an SDK caller can reach in this simulation. Moving them would break the SDK path to fix the CloudFormation one. The split also matches how the two paths are authorized on real AWS, where the `Describe` actions appear in the `list` handler permissions and the `Get` actions in `create` and `read`. An SDK caller sees no change from this PR.

The CloudFormation `create` handlers name tagging and destination policy actions as well. Those are left out, because this simulation refuses delivery tags outright and records `DeliveryDestinationPolicy` without acting on it. The delivery `create` handler also lists `GetDeliverySource` and `GetDeliveryDestination`, and requiring those on an `AWS::Logs::Delivery` would refuse a policy a real deploy takes, so each Resource type is checked for its own read only.

## Tests

`src/service/logs/cfn/sim-cfn-delivery-iam.iso.test.ts` deploys the three Resources as a Role holding the actions AWS names and nothing else, then drops one `Get` action at a time and asserts the deploy stops on that name with the Resources behind it unmade. A fifth test tears the Stack down under a Role missing `logs:DeleteDeliverySource`, which is the rollback the original report ended in. Three of the five fail without the change.

Resolves #1136

Issue #1137 adds a `cloudfront:AllowVendedLogDeliveryForResource` check to the delivery source create path. It goes in `authorizeDeliverySourceCreate`, which will need the source's `ResourceArn` passed alongside its name.