### PR TITLE
feat: enforce IAM's policy document limits

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -220,6 +220,21 @@ Creating a duplicate Policy name in the same path throws an error, while the sam
 paths is allowed. Stored Policies can be inspected with `GetPolicyCommand` and
 `ListPoliciesCommand`.
 
+## Policy document character limits
+
+IAM caps a policy document by where it is going. A managed policy takes 6,144 characters, an inline
+policy on a Role or a User takes 10,240, and a Role trust policy takes 2,048. `CreatePolicy`,
+`PutRolePolicy`, `PutUserPolicy` and `CreateRole` refuse a document past the cap with
+`LimitExceeded`, in IAM's own wording. An `AWS::IAM::ManagedPolicy` or an `AWS::IAM::Policy`
+carrying one fails its Resource.
+
+IAM leaves whitespace out of the count, and so does the check here. A document indented for a
+reader measures the same as the one line `JSON.stringify` writes.
+
+A policy that has outgrown its cap cannot be deployed. The account keeps whichever version last
+fit, and the permission the policy was grown to grant goes missing weeks later, against a
+repository that still says it is there.
+
 ## Policy conditions
 
 Policy statements can carry `Condition` blocks. Sim IAM currently supports the `StringEquals`,
@@ -1437,6 +1452,7 @@ Sim IAM currently supports:
 - `GetRoleCommand` and `ListRolesCommand`, with pagination
 - `PutRolePolicyCommand`, for inline Role policies
 - `CreatePolicyCommand`, `GetPolicyCommand` and `ListPoliciesCommand`, for managed Policies
+- Refusing a policy document over IAM's character limit, with `LimitExceeded`
 - `AttachRolePolicyCommand`
 - `CreateUserCommand`, `DeleteUserCommand`, `PutUserPolicyCommand` and `AttachUserPolicyCommand`
 - `CreateLoginProfileCommand`, for a User's console password
@@ -1466,6 +1482,9 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
 - Permissions boundaries and session policies are not evaluated. Service control policies are, and
   are attached through [simulated Organizations](https://yulinsim.dev/services/organizations/ "Simulated Organizations service control policies usage docs")
 - Managed Policies have a single version, and the policy version commands are absent
+- A policy document is measured against IAM's character limit one document at a time. The
+  20,480-character cap on the sum of a User's inline policies is absent, and so is the cap on how
+  many managed policies a Role may carry
 - `DeleteUserPolicy` and `DetachUserPolicy` are absent, along with `DeleteAccessKey` and
   `DeleteLoginProfile`. `DeleteUserCommand` refuses a User that still holds a policy, and
   CloudFormation teardown clears a User's policies before deleting it

--- a/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-validation.iso.test.ts
+++ b/src/service/iam/cfn/managed-policy/sim-cfn-iam-managed-policy-validation.iso.test.ts
@@ -1,5 +1,6 @@
 import {
   assertArrayLength,
+  assertIdentical,
   assertInstanceOf,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
@@ -7,6 +8,8 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamNoSuchEntity } from "../../error/sim-iam.error.js";
+import { SimIamLimitExceeded } from "../../error/sim-iam.error.js";
+import { maxSimIamManagedPolicyCharacters } from "../../validate/size/sim-iam-policy-document-size.js";
 
 const readObjectsDocument = {
   Version: "2012-10-17",
@@ -310,6 +313,51 @@ describe("IAM CloudFormation ManagedPolicy validation", () => {
         (policy) => policy.PolicyName === "OrphanCheckPolicy",
       ),
       0,
+    );
+  });
+
+  it("fails the Resource when the PolicyDocument is over IAM's limit", async () => {
+    // Given a CloudFormation template whose Managed Policy document is past
+    // the 6,144 characters IAM takes.
+    const simAws = new SimAws();
+    const oversizedDocument = {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "s3:GetObject",
+          Resource: `arn:aws:s3:::reports-bucket/${"x".repeat(
+            maxSimIamManagedPolicyCharacters,
+          )}`,
+        },
+      ],
+    };
+
+    // When / then deploying the template throws.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "iam-managed-policy-oversized-stack",
+        template: {
+          Resources: {
+            OversizedPolicy: {
+              Type: "AWS::IAM::ManagedPolicy",
+              Properties: {
+                ManagedPolicyName: "OversizedPolicy",
+                PolicyDocument: oversizedDocument,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the Resource fails on the document, rather than deploying a policy
+    // the account would refuse.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource OversizedPolicy creation failed: " +
+        "Cannot exceed quota for PolicySize: 6144",
     );
   });
 });

--- a/src/service/iam/cfn/policy/sim-cfn-iam-policy-validation.iso.test.ts
+++ b/src/service/iam/cfn/policy/sim-cfn-iam-policy-validation.iso.test.ts
@@ -7,6 +7,8 @@ import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimIamMalformedPolicyDocument } from "../../error/sim-iam.error.js";
+import { SimIamLimitExceeded } from "../../error/sim-iam.error.js";
+import { maxSimIamInlinePolicyCharacters } from "../../validate/size/sim-iam-policy-document-size.js";
 import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
 import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
@@ -263,6 +265,59 @@ describe("IAM CloudFormation Policy validation", () => {
         '"QueryRole" policy "RunQueries" statement 1: Resource must be a ' +
         "string or an array of strings, but holds " +
         '{"Fn::GetAtt":["DoesNotExist","Arn"]}',
+    );
+  });
+
+  it("fails the Resource when the PolicyDocument is over IAM's limit", async () => {
+    // Given a CloudFormation template whose inline policy document is past
+    // the 10,240 characters IAM takes.
+    const simAws = new SimAws();
+    const oversizedDocument = {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "s3:GetObject",
+          Resource: `arn:aws:s3:::reports-bucket/${"x".repeat(
+            maxSimIamInlinePolicyCharacters,
+          )}`,
+        },
+      ],
+    };
+
+    // When / then deploying the template throws.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "oversized-inline-policy-stack",
+        template: {
+          Resources: {
+            QueryRole: {
+              Type: "AWS::IAM::Role",
+              Properties: {
+                RoleName: "QueryRole",
+                AssumeRolePolicyDocument: assumeRolePolicyDocument,
+              },
+            },
+            QueryPolicy: {
+              Type: "AWS::IAM::Policy",
+              Properties: {
+                PolicyName: "RunQueries",
+                Roles: [{ Ref: "QueryRole" }],
+                PolicyDocument: oversizedDocument,
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    // Then the Resource fails on the document, naming the Role it was going
+    // onto.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource QueryPolicy creation failed: " +
+        "Maximum policy size of 10240 bytes exceeded for role QueryRole",
     );
   });
 });

--- a/src/service/iam/command/policy/create-policy/create-policy-input-resolver.ts
+++ b/src/service/iam/command/policy/create-policy/create-policy-input-resolver.ts
@@ -5,6 +5,7 @@ import type { SimIamPolicyName } from "../../../policy/sim-iam-policy.js";
 import { makeSimPolicyArn } from "../../../policy/sim-iam-policy-arn.js";
 import { normalisePolicyPath } from "../../../policy/sim-iam-policy-path.js";
 import { SimIamPolicyDocumentValidator } from "../../../validate/sim-iam-policy-document-validator.js";
+import { assertSimIamManagedPolicyWithinSizeLimit } from "../../../validate/size/sim-iam-policy-document-size.js";
 
 /**
  * The validated identity of a policy about to be created, derived from the
@@ -42,6 +43,8 @@ export class CreatePolicyInputResolver {
     if (policyName === undefined || policyName.length === 0) {
       throw new Error("PolicyName is required");
     }
+
+    assertSimIamManagedPolicyWithinSizeLimit(command.input.PolicyDocument);
 
     this.policyDocValidator.validateOptional(command.input.PolicyDocument, {
       attachedTo: "Policy",

--- a/src/service/iam/command/policy/create-policy/create-policy.iso.test.ts
+++ b/src/service/iam/command/policy/create-policy/create-policy.iso.test.ts
@@ -10,6 +10,10 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../../aws/sim-aws.js";
 import { makeSimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import { SimIamLimitExceeded } from "../../../error/sim-iam.error.js";
+import { simIamPolicyDocumentOfSize } from "../../../policy/sim-iam-policy-document-of-size.js";
+import { maxSimIamManagedPolicyCharacters } from "../../../validate/size/sim-iam-policy-document-size.js";
 
 describe("IAM CreatePolicyCommand", () => {
   it("creates an IAM Policy through the SimIam service", async () => {
@@ -246,5 +250,51 @@ describe("IAM CreatePolicyCommand", () => {
       secondPolicyOutput.Policy.Arn,
       "arn:aws:iam::123456789012:policy/service-role/SharedPolicyName",
     );
+  });
+
+  it("refuses a policy document over IAM's character limit", async () => {
+    // Given a managed policy document one character past the 6,144 IAM takes.
+    const simAws = new SimAws();
+    const simIam = simAws.account(makeSimAwsAccountId()).iam();
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamManagedPolicyCharacters + 1),
+    );
+
+    // When the Policy is created from it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.createPolicy(
+        new CreatePolicyCommand({
+          PolicyName: "ExecutionPolicy",
+          PolicyDocument: policyDocument,
+        }),
+      ),
+    );
+
+    // Then IAM refuses the document rather than keeping a policy no account
+    // would carry.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(error.message, "Cannot exceed quota for PolicySize: 6144");
+  });
+
+  it("accepts a document only under the limit once whitespace is out", async () => {
+    // Given a managed policy document at the limit, indented well past it.
+    const simAws = new SimAws();
+    const simIam = simAws.account(makeSimAwsAccountId()).iam();
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamManagedPolicyCharacters),
+      undefined,
+      4,
+    );
+
+    // When the Policy is created from it.
+    const policyCreation = await simIam.createPolicy(
+      new CreatePolicyCommand({
+        PolicyName: "IndentedPolicy",
+        PolicyDocument: policyDocument,
+      }),
+    );
+
+    // Then the indentation counted for nothing, as it does in IAM.
+    assertIdentical(policyCreation.Policy.PolicyName, "IndentedPolicy");
   });
 });

--- a/src/service/iam/command/policy/put-role-policy/put-role-policy-error.iso.test.ts
+++ b/src/service/iam/command/policy/put-role-policy/put-role-policy-error.iso.test.ts
@@ -8,6 +8,10 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../../../aws/sim-aws.js";
 import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
 import { makeSimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import { SimIamLimitExceeded } from "../../../error/sim-iam.error.js";
+import { simIamPolicyDocumentOfSize } from "../../../policy/sim-iam-policy-document-of-size.js";
+import { maxSimIamInlinePolicyCharacters } from "../../../validate/size/sim-iam-policy-document-size.js";
 
 describe("IAM PutRolePolicyCommand errors", () => {
   it("throws when RoleName is undefined", async () => {
@@ -215,5 +219,47 @@ describe("IAM PutRolePolicyCommand errors", () => {
     // Then IAM reports that the entity does not exist.
     assertInstanceOf(error, SimIamNoSuchEntity);
     assertIdentical(error.message, "No IAM Role with name MissingRole");
+  });
+
+  it("refuses an inline policy document over IAM's character limit", async () => {
+    // Given an IAM Role exists.
+    const simAws = new SimAws();
+    const accountId = makeSimAwsAccountId();
+    const simIam = simAws.account(accountId).iam();
+
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "ReportingRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Statement: {
+            Effect: "Allow",
+            Action: "sts:AssumeRole",
+            Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          },
+        }),
+      }),
+    );
+
+    // When an inline policy one character past the 10,240 IAM takes is put
+    // onto it.
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamInlinePolicyCharacters + 1),
+    );
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.putRolePolicy(
+        new PutRolePolicyCommand({
+          RoleName: "ReportingRole",
+          PolicyName: "ReadObjects",
+          PolicyDocument: policyDocument,
+        }),
+      ),
+    );
+
+    // Then IAM refuses the document, naming the Role it was going onto.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(
+      error.message,
+      "Maximum policy size of 10240 bytes exceeded for role ReportingRole",
+    );
   });
 });

--- a/src/service/iam/command/policy/put-role-policy/put-role-policy.handler.ts
+++ b/src/service/iam/command/policy/put-role-policy/put-role-policy.handler.ts
@@ -10,6 +10,7 @@ import type {
   SimPutRolePolicyCommandOutput,
 } from "./put-role-policy.command.js";
 import { SimIamPolicyDocumentValidator } from "../../../validate/sim-iam-policy-document-validator.js";
+import { assertSimIamInlinePolicyWithinSizeLimit } from "../../../validate/size/sim-iam-policy-document-size.js";
 
 interface PutRolePolicyCommandHandlerProperties {
   readonly roles: Map<SimIamRoleName, SimIamRole>;
@@ -58,6 +59,12 @@ export class PutRolePolicyCommandHandler implements CommandHandler<
     }
 
     const policyDocument = command.input.PolicyDocument;
+
+    assertSimIamInlinePolicyWithinSizeLimit(policyDocument, {
+      kind: "role",
+      name: roleName,
+    });
+
     this.policyDocValidator.validateRequired(policyDocument, {
       attachedTo: "Role",
       name: roleName,

--- a/src/service/iam/command/policy/put-user-policy/put-user-policy.handler.ts
+++ b/src/service/iam/command/policy/put-user-policy/put-user-policy.handler.ts
@@ -6,6 +6,7 @@ import {
 import { SimIamNoSuchEntity } from "../../../error/sim-iam.error.js";
 import type { SimIamUser, SimIamUsername } from "../../../user/sim-iam-user.js";
 import { SimIamPolicyDocumentValidator } from "../../../validate/sim-iam-policy-document-validator.js";
+import { assertSimIamInlinePolicyWithinSizeLimit } from "../../../validate/size/sim-iam-policy-document-size.js";
 import type {
   SimPutUserPolicyCommand,
   SimPutUserPolicyCommandOutput,
@@ -52,6 +53,11 @@ export class PutUserPolicyCommandHandler implements CommandHandler<
     const policyName = command.input.PolicyName;
     assertDefined(policyName, "PutUserPolicyCommand.input.PolicyName");
     const policyDocument = command.input.PolicyDocument;
+
+    assertSimIamInlinePolicyWithinSizeLimit(policyDocument, {
+      kind: "user",
+      name: username,
+    });
 
     this.policyDocValidator.validateRequired(policyDocument, {
       attachedTo: "User",

--- a/src/service/iam/command/policy/put-user-policy/put-user-policy.iso.test.ts
+++ b/src/service/iam/command/policy/put-user-policy/put-user-policy.iso.test.ts
@@ -17,6 +17,10 @@ import {
   SimIamMalformedPolicyDocument,
   SimIamNoSuchEntity,
 } from "../../../error/sim-iam.error.js";
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import { SimIamLimitExceeded } from "../../../error/sim-iam.error.js";
+import { simIamPolicyDocumentOfSize } from "../../../policy/sim-iam-policy-document-of-size.js";
+import { maxSimIamInlinePolicyCharacters } from "../../../validate/size/sim-iam-policy-document-size.js";
 
 describe("IAM PutUserPolicyCommand", () => {
   it("adds an inline identity policy to a User", async () => {
@@ -169,6 +173,37 @@ describe("IAM PutUserPolicyCommand", () => {
     assertIdentical(
       error.message,
       'User "ApplicationUser" policy "InvalidPolicy" statement 1: must define either Action or NotAction',
+    );
+  });
+
+  it("refuses an inline policy document over IAM's character limit", async () => {
+    // Given an IAM User exists.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simIam = simAws.account(accountId).iam();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: "Analyst" }));
+
+    // When an inline policy one character past the 10,240 IAM takes is put
+    // onto them.
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamInlinePolicyCharacters + 1),
+    );
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.putUserPolicy(
+        new PutUserPolicyCommand({
+          UserName: "Analyst",
+          PolicyName: "ReadObjects",
+          PolicyDocument: policyDocument,
+        }),
+      ),
+    );
+
+    // Then IAM refuses the document, naming the User it was going onto.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(
+      error.message,
+      "Maximum policy size of 10240 bytes exceeded for user Analyst",
     );
   });
 });

--- a/src/service/iam/command/role/create-role/create-role.handler.ts
+++ b/src/service/iam/command/role/create-role/create-role.handler.ts
@@ -14,6 +14,7 @@ import type { SimIamRole, SimIamRoleName } from "../../../role/sim-iam-role.js";
 import { normaliseRolePath } from "../../../role/sim-iam-role-path.js";
 import { makeSimRoleArn } from "../../../role/arn/sim-iam-role-arn.js";
 import { SimIamTrustPolicyDocumentValidator } from "../../../validate/trust/sim-iam-trust-policy-document-validator.js";
+import { assertSimIamTrustPolicyWithinSizeLimit } from "../../../validate/size/sim-iam-policy-document-size.js";
 
 interface CreateRoleCommandHandlerProperties {
   readonly accountId: SimAwsAccountId;
@@ -61,9 +62,10 @@ export class CreateRoleCommandHandler implements CommandHandler<
       throw new Error("RoleName is required");
     }
 
-    this.trustPolicyValidator.validateRequired(
-      command.input.AssumeRolePolicyDocument,
-    );
+    const trustPolicyDocument = command.input.AssumeRolePolicyDocument;
+
+    assertSimIamTrustPolicyWithinSizeLimit(trustPolicyDocument, roleName);
+    this.trustPolicyValidator.validateRequired(trustPolicyDocument);
 
     const path = normaliseRolePath(command.input.Path);
     const arn = makeSimRoleArn({

--- a/src/service/iam/command/role/create-role/create-role.iso.test.ts
+++ b/src/service/iam/command/role/create-role/create-role.iso.test.ts
@@ -10,6 +10,10 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../../../aws/sim-aws.js";
 import { makeSimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import { SimIamLimitExceeded } from "../../../error/sim-iam.error.js";
+import { simIamTrustPolicyDocumentOfSize } from "../../../policy/sim-iam-policy-document-of-size.js";
+import { maxSimIamTrustPolicyCharacters } from "../../../validate/size/sim-iam-policy-document-size.js";
 
 describe("IAM CreateRoleCommand", () => {
   it("creates an IAM Role through the top-level SimIam service", async () => {
@@ -272,6 +276,32 @@ describe("IAM CreateRoleCommand", () => {
     assertIdentical(
       error.message,
       "Sim IAM Role already exists: DuplicateRole",
+    );
+  });
+
+  it("refuses a trust policy document over IAM's character limit", async () => {
+    // Given a trust policy one character past the 2,048 IAM takes.
+    const simAws = new SimAws();
+    const simIam = simAws.account(makeSimAwsAccountId()).iam();
+    const trustPolicy = jsonStringify(
+      simIamTrustPolicyDocumentOfSize(maxSimIamTrustPolicyCharacters + 1),
+    );
+
+    // When a Role is created with it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simIam.createRole(
+        new CreateRoleCommand({
+          RoleName: "ReportingRole",
+          AssumeRolePolicyDocument: trustPolicy,
+        }),
+      ),
+    );
+
+    // Then IAM refuses the document, naming the Role it was going onto.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(
+      error.message,
+      "Maximum policy size of 2048 bytes exceeded for role ReportingRole",
     );
   });
 });

--- a/src/service/iam/error/sim-iam.error.ts
+++ b/src/service/iam/error/sim-iam.error.ts
@@ -130,3 +130,18 @@ export class SimIamMalformedPolicyDocument extends SimIamError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated IAM LimitExceeded error.
+ *
+ * IAM answers a request that would take the account past one of its quotas
+ * with this, such as a policy document longer than the limit for where it is
+ * going.
+ */
+export class SimIamLimitExceeded extends SimIamError {
+  public override readonly name = "LimitExceeded";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}

--- a/src/service/iam/policy/sim-iam-policy-document-of-size.ts
+++ b/src/service/iam/policy/sim-iam-policy-document-of-size.ts
@@ -1,0 +1,53 @@
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import type { SimIamPolicyDocument } from "./sim-iam-policy.js";
+
+/**
+ * Build a policy document IAM would measure at exactly this many characters.
+ *
+ * A test about IAM's character limits has a size to state rather than a
+ * statement. Padding an ARN leaves a document IAM would otherwise take, so the
+ * size is the only thing the command is being asked about. The size is the one
+ * IAM counts, of the document written compactly, and a caller is free to
+ * indent what it hands over.
+ */
+export function simIamPolicyDocumentOfSize(
+  characters: number,
+): SimIamPolicyDocument {
+  return padded(characters, (padding) => ({
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Action: "s3:GetObject",
+      Resource: `arn:aws:s3:::reports-bucket/${padding}`,
+    },
+  }));
+}
+
+/**
+ * Build a Role trust policy document of exactly this many characters.
+ *
+ * A trust policy carries a Principal and no Resource, so it is padded through
+ * a Sid instead.
+ */
+export function simIamTrustPolicyDocumentOfSize(
+  characters: number,
+): SimIamPolicyDocument {
+  return padded(characters, (padding) => ({
+    Version: "2012-10-17",
+    Statement: {
+      Sid: padding,
+      Effect: "Allow",
+      Principal: { Service: "lambda.amazonaws.com" },
+      Action: "sts:AssumeRole",
+    },
+  }));
+}
+
+function padded(
+  characters: number,
+  make: (padding: string) => SimIamPolicyDocument,
+): SimIamPolicyDocument {
+  const unpadded = jsonStringify(make("")).length;
+
+  return make("x".repeat(characters - unpadded));
+}

--- a/src/service/iam/validate/size/sim-iam-policy-document-size.iso.test.ts
+++ b/src/service/iam/validate/size/sim-iam-policy-document-size.iso.test.ts
@@ -1,0 +1,209 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import { SimIamLimitExceeded } from "../../error/sim-iam.error.js";
+import {
+  simIamPolicyDocumentOfSize,
+  simIamTrustPolicyDocumentOfSize,
+} from "../../policy/sim-iam-policy-document-of-size.js";
+import {
+  assertSimIamInlinePolicyWithinSizeLimit,
+  assertSimIamManagedPolicyWithinSizeLimit,
+  assertSimIamTrustPolicyWithinSizeLimit,
+  maxSimIamInlinePolicyCharacters,
+  maxSimIamManagedPolicyCharacters,
+  maxSimIamTrustPolicyCharacters,
+  simIamPolicyDocumentSize,
+} from "./sim-iam-policy-document-size.js";
+
+describe("simIamPolicyDocumentSize", () => {
+  it("counts the characters of a document written without whitespace", () => {
+    // Given a policy document of a stated size.
+    const policyDocument = jsonStringify(simIamPolicyDocumentOfSize(512));
+
+    // When the document is measured.
+    const size = simIamPolicyDocumentSize(policyDocument);
+
+    // Then the count is the size it was built at.
+    assertIdentical(size, 512);
+  });
+
+  it("leaves whitespace out of the count", () => {
+    // Given the same document indented for a reader.
+    const indented = jsonStringify(
+      simIamPolicyDocumentOfSize(512),
+      undefined,
+      2,
+    );
+
+    // When the indented document is measured.
+    const size = simIamPolicyDocumentSize(indented);
+
+    // Then indenting it counted for nothing.
+    assertIdentical(size, 512);
+  });
+});
+
+describe("assertSimIamManagedPolicyWithinSizeLimit", () => {
+  it("accepts a document of exactly the limit", () => {
+    // Given a managed policy document at the limit itself.
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamManagedPolicyCharacters),
+    );
+
+    // When the document is measured against the limit.
+    assertSimIamManagedPolicyWithinSizeLimit(policyDocument);
+
+    // Then it is accepted.
+  });
+
+  it("accepts a document only under the limit once whitespace is out", () => {
+    // Given a managed policy document at the limit, indented past it.
+    const indented = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamManagedPolicyCharacters),
+      undefined,
+      4,
+    );
+
+    // When the indented document is measured against the limit.
+    assertSimIamManagedPolicyWithinSizeLimit(indented);
+
+    // Then the indentation it carries is not what decides it.
+  });
+
+  it("refuses a document one character over the limit", () => {
+    // Given a managed policy document one character past the limit.
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamManagedPolicyCharacters + 1),
+    );
+
+    // When the document is measured against the limit.
+    const error = assertThrowsError(() => {
+      assertSimIamManagedPolicyWithinSizeLimit(policyDocument);
+    });
+
+    // Then it is refused in IAM's own wording.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(error.name, "LimitExceeded");
+    assertIdentical(error.message, "Cannot exceed quota for PolicySize: 6144");
+  });
+
+  it("has nothing to measure when the document is absent", () => {
+    // Given no managed policy document at all.
+
+    // When the absent document is measured against the limit.
+    assertSimIamManagedPolicyWithinSizeLimit(undefined);
+
+    // Then requiredness is left to the check that owns it.
+  });
+});
+
+describe("assertSimIamInlinePolicyWithinSizeLimit", () => {
+  it("accepts a document of exactly the limit", () => {
+    // Given an inline policy document at the limit itself.
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamInlinePolicyCharacters),
+    );
+
+    // When the document is measured against the limit.
+    assertSimIamInlinePolicyWithinSizeLimit(policyDocument, {
+      kind: "role",
+      name: "ReportingRole",
+    });
+
+    // Then it is accepted.
+  });
+
+  it("names the Role a refused document was going onto", () => {
+    // Given an inline policy document one character past the limit.
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamInlinePolicyCharacters + 1),
+    );
+
+    // When the document is measured against the limit for a Role.
+    const error = assertThrowsError(() => {
+      assertSimIamInlinePolicyWithinSizeLimit(policyDocument, {
+        kind: "role",
+        name: "ReportingRole",
+      });
+    });
+
+    // Then the refusal names the Role, as IAM's message does.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(
+      error.message,
+      "Maximum policy size of 10240 bytes exceeded for role ReportingRole",
+    );
+  });
+
+  it("names the User a refused document was going onto", () => {
+    // Given an inline policy document one character past the limit.
+    const policyDocument = jsonStringify(
+      simIamPolicyDocumentOfSize(maxSimIamInlinePolicyCharacters + 1),
+    );
+
+    // When the document is measured against the limit for a User.
+    const error = assertThrowsError(() => {
+      assertSimIamInlinePolicyWithinSizeLimit(policyDocument, {
+        kind: "user",
+        name: "Analyst",
+      });
+    });
+
+    // Then the refusal names the User.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(
+      error.message,
+      "Maximum policy size of 10240 bytes exceeded for user Analyst",
+    );
+  });
+
+  it("has nothing to measure when the document is absent", () => {
+    // Given no inline policy document at all.
+
+    // When the absent document is measured against the limit.
+    assertSimIamInlinePolicyWithinSizeLimit(undefined, {
+      kind: "role",
+      name: "ReportingRole",
+    });
+
+    // Then requiredness is left to the check that owns it.
+  });
+});
+
+describe("assertSimIamTrustPolicyWithinSizeLimit", () => {
+  it("accepts a document of exactly the limit", () => {
+    // Given a trust policy document at the limit itself.
+    const policyDocument = jsonStringify(
+      simIamTrustPolicyDocumentOfSize(maxSimIamTrustPolicyCharacters),
+    );
+
+    // When the document is measured against the limit.
+    assertSimIamTrustPolicyWithinSizeLimit(policyDocument, "ReportingRole");
+
+    // Then it is accepted.
+  });
+
+  it("refuses a document one character over the limit", () => {
+    // Given a trust policy document one character past the limit.
+    const policyDocument = jsonStringify(
+      simIamTrustPolicyDocumentOfSize(maxSimIamTrustPolicyCharacters + 1),
+    );
+
+    // When the document is measured against the limit.
+    const error = assertThrowsError(() => {
+      assertSimIamTrustPolicyWithinSizeLimit(policyDocument, "ReportingRole");
+    });
+
+    // Then it is refused naming the Role it was going onto.
+    assertInstanceOf(error, SimIamLimitExceeded);
+    assertIdentical(
+      error.message,
+      "Maximum policy size of 2048 bytes exceeded for role ReportingRole",
+    );
+  });
+});

--- a/src/service/iam/validate/size/sim-iam-policy-document-size.ts
+++ b/src/service/iam/validate/size/sim-iam-policy-document-size.ts
@@ -1,0 +1,124 @@
+import { SimIamLimitExceeded } from "../../error/sim-iam.error.js";
+
+/**
+ * The longest managed policy document IAM will take.
+ *
+ * https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html
+ */
+export const maxSimIamManagedPolicyCharacters = 6144;
+
+/**
+ * The longest inline policy document IAM will take on a Role or a User.
+ */
+export const maxSimIamInlinePolicyCharacters = 10_240;
+
+/**
+ * The longest trust policy document IAM will take on a Role.
+ *
+ * This one is adjustable, up to 8,192 characters. A simulation holds the
+ * default an account carries until it asks for more.
+ */
+export const maxSimIamTrustPolicyCharacters = 2048;
+
+/**
+ * The Role or the User an inline policy is being put onto.
+ */
+export interface SimIamPolicyDocumentHolder {
+  /**
+   * What IAM calls the holder in the message, `role` or `user`.
+   */
+  readonly kind: "role" | "user";
+
+  /**
+   * The holder's name.
+   */
+  readonly name: string;
+}
+
+/**
+ * Measure a policy document the way IAM does, which leaves whitespace out.
+ *
+ * A document indented for a reader therefore counts the same as the one line
+ * `JSON.stringify` produces, and a template can be written either way.
+ */
+export function simIamPolicyDocumentSize(policyDocument: string): number {
+  return policyDocument.replaceAll(/\s/gu, "").length;
+}
+
+/**
+ * Refuse a managed policy document over the character limit.
+ *
+ * A policy past the limit cannot be deployed, and the account keeps whichever
+ * version last fit. The permission the document was grown to grant then goes
+ * missing weeks later, at a distance from the change that lost it. Refusing
+ * the document here puts the fault beside the policy that carries it.
+ *
+ * The requiredness check refuses an absent document. This one has nothing to
+ * measure.
+ */
+export function assertSimIamManagedPolicyWithinSizeLimit(
+  policyDocument: string | undefined,
+): void {
+  if (
+    policyDocument === undefined ||
+    simIamPolicyDocumentSize(policyDocument) <= maxSimIamManagedPolicyCharacters
+  ) {
+    return;
+  }
+
+  throw new SimIamLimitExceeded(
+    `Cannot exceed quota for PolicySize: ${String(maxSimIamManagedPolicyCharacters)}`,
+  );
+}
+
+/**
+ * Refuse an inline policy document over the character limit.
+ */
+export function assertSimIamInlinePolicyWithinSizeLimit(
+  policyDocument: string | undefined,
+  holder: SimIamPolicyDocumentHolder,
+): void {
+  assertWithinMaximumPolicySize(
+    policyDocument,
+    maxSimIamInlinePolicyCharacters,
+    holder,
+  );
+}
+
+/**
+ * Refuse a Role trust policy document over the character limit.
+ */
+export function assertSimIamTrustPolicyWithinSizeLimit(
+  policyDocument: string | undefined,
+  roleName: string,
+): void {
+  assertWithinMaximumPolicySize(
+    policyDocument,
+    maxSimIamTrustPolicyCharacters,
+    { kind: "role", name: roleName },
+  );
+}
+
+/**
+ * IAM reports both of these in bytes, over a count that is really characters
+ * with the whitespace taken out. The wording is kept as IAM writes it. A
+ * reader searching for the message finds what a real deploy would have told
+ * them.
+ */
+function assertWithinMaximumPolicySize(
+  policyDocument: string | undefined,
+  maxCharacters: number,
+  holder: SimIamPolicyDocumentHolder,
+): void {
+  if (
+    policyDocument === undefined ||
+    simIamPolicyDocumentSize(policyDocument) <= maxCharacters
+  ) {
+    return;
+  }
+
+  throw new SimIamLimitExceeded(
+    `Maximum policy size of ${String(maxCharacters)} bytes exceeded for ` +
+      `${holder.kind} ${holder.name}`,
+  );
+}


### PR DESCRIPTION
IAM caps a policy document at 6,144 characters for a managed policy, 10,240 for an inline policy on a Role or a User, and 2,048 for a Role trust policy, counted with the whitespace taken out. Yulin took documents four times the size of any of them. `CreatePolicy`, `PutRolePolicy`, `PutUserPolicy` and `CreateRole` now refuse one past the cap with `LimitExceeded`, in IAM's own wording, and `AWS::IAM::ManagedPolicy` and `AWS::IAM::Policy` fail their Resource. A policy that has outgrown its cap cannot be deployed, and the account keeps whichever version last fit. The permission it was grown to grant then goes missing weeks later, against a repository that still says it is there.

Resolves #1134