### PR TITLE
feat: simulate AWS::CloudFront::CachePolicy

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -3390,8 +3390,8 @@ The resource types it creates are:
   `AWS::ApiGatewayV2::Stage`
 - `AWS::CertificateManager::Certificate`
 - `AWS::CloudFormation::WaitConditionHandle`
-- `AWS::CloudFront::Distribution`, `AWS::CloudFront::Function` and
-  `AWS::CloudFront::ResponseHeadersPolicy`
+- `AWS::CloudFront::Distribution`, `AWS::CloudFront::Function`,
+  `AWS::CloudFront::ResponseHeadersPolicy` and `AWS::CloudFront::CachePolicy`
 - `AWS::CloudWatch::Alarm`
 - `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
   `AWS::Cognito::UserPoolGroup`

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2113,6 +2113,139 @@ Behavior is recorded under its `PathPattern`, the way a skipped Lambda@Edge asso
 `CreateDistribution` and `UpdateDistribution` still refuse the same ID, as real CloudFront refuses
 it.
 
+## Cache policies
+
+A cache policy decides what a cache Behavior keys its cache on and how long an object stays there.
+Declare one as `AWS::CloudFront::CachePolicy` and point a Behavior's `CachePolicyId` at it with a
+`Ref`, which is what CDK's `CachePolicy` construct synthesizes.
+
+```typescript sim-cloudfront-cache-policy
+/**
+ * Reading back the cache policy a Behavior was given.
+ */
+
+import { GetDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "site-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      BeaconPolicy: {
+        Type: "AWS::CloudFront::CachePolicy",
+        Properties: {
+          CachePolicyConfig: {
+            Name: "BeaconPolicy",
+            MinTTL: 0,
+            DefaultTTL: 0,
+            MaxTTL: 0,
+            ParametersInCacheKeyAndForwardedToOrigin: {
+              EnableAcceptEncodingGzip: false,
+              CookiesConfig: { CookieBehavior: "none" },
+              HeadersConfig: { HeaderBehavior: "none" },
+              QueryStringsConfig: { QueryStringBehavior: "none" },
+            },
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "BeaconPolicy"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              // CachingOptimized, one of CloudFront's managed policies.
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            },
+            CacheBehaviors: [
+              {
+                PathPattern: "/beacon",
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
+                CachePolicyId: { Ref: "BeaconPolicy" },
+              },
+            ],
+          },
+        },
+      },
+    },
+    Outputs: {
+      DistributionId: { Value: { Ref: "SiteDistribution" } },
+      BeaconPolicyId: { Value: { Ref: "BeaconPolicy" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const read = await simAws
+  .cloudFront()
+  .getDistribution(
+    new GetDistributionCommand({ Id: stack.output("DistributionId") }),
+  );
+const config = read.Distribution?.DistributionConfig;
+
+// The managed ID the default Behavior was given.
+console.log(config?.DefaultCacheBehavior?.CachePolicyId);
+
+// The ID of the policy the template created, which the path Behavior Refs.
+console.log(
+  config?.CacheBehaviors?.Items?.[0]?.CachePolicyId ===
+    stack.output("BeaconPolicyId"),
+);
+```
+
+A Behavior records the ID it was given, and `GetDistribution` reports it back for both the default
+Behavior and a named one. An update changing the policy is reported the same way.
+
+Nothing here reads the policy itself. The TTLs, the cache key and the compression settings need a
+cache, and sim CloudFront holds none. Every request reaches the Origin whatever the policy would
+have cached on real CloudFront.
+
+A policy name is unique within an account, as it is in CloudFront. A second
+`AWS::CloudFront::CachePolicy` claiming a name is refused with `CachePolicyAlreadyExists`.
+`Name` and `Comment` are the parts of `CachePolicyConfig` the policy carries.
+
+### Managed cache policies
+
+CloudFront's seven managed policies are here from the start, under the IDs AWS publishes, and a
+Behavior names one without a template creating anything. `CachingOptimized`
+(`658327ea-f89d-4fab-a63d-7e88639e58f6`), `CachingDisabled` (`4135ea2d-6df8-44a3-9df3-4b5a84be39ad`),
+`CachingOptimizedForUncompressedObjects` (`b2884449-e4de-46a7-ac36-70bc7f1ddd6d`), `Amplify`
+(`2e54312d-136d-493c-8eb9-b001f22f67d2`), `Elemental-MediaPackage`
+(`08627262-05a9-4f76-9ded-b50ca2e3a84f`), `UseOriginCacheControlHeaders`
+(`83da9c7e-98b4-4e11-a168-04f0df8e2c65`) and `UseOriginCacheControlHeaders-QueryStrings`
+(`4cc15a8a-d715-48a4-82b8-cc0b614638fe`) are each held under the name
+[AWS publishes](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html)
+for it. CDK's `CachePolicy.CACHING_OPTIMIZED` and its six siblings synthesize those IDs. A stack
+reaching for one deploys.
+
+The managed policies sit in CloudFront's own namespace. A template may create a policy called
+`CachingDisabled` of its own, and deleting that stack leaves the managed one where it was.
+
+A CloudFormation Distribution whose Behavior names a policy that is neither managed nor created here
+deploys without one. The `CachePolicyId` lands on `stack.ignoredProperties` under that Behavior, the
+way an absent response headers policy does, and the Behavior reports no policy.
+
+`CreateDistribution` and `UpdateDistribution` still refuse the same ID with `NoSuchCachePolicy`, as
+real CloudFront refuses it.
+
 ## Origin access controls
 
 An origin access control is how a Distribution authenticates to a private Origin. The Origin then
@@ -2732,6 +2865,7 @@ Sim CloudFront currently supports:
 - `LambdaFunctionAssociations` on a template's Distribution, and CDK's `edgeLambdas`
 - CloudFront Functions reading an associated key value store through `cf.kvs()`
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
+- `AWS::CloudFront::CachePolicy`, and a Behavior's `CachePolicyId` read back through `GetDistribution`
 - `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
 - `AWS::CloudFront::OriginAccessControl`, letting an Origin read a private Bucket as CloudFront
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
@@ -2874,7 +3008,12 @@ Where sim CloudFront knowingly behaves differently from AWS:
   share of real responses carry `Server-Timing`. This simulation adds it to every response once
   `Enabled` is true. A test asserting on it never depends on chance. The header's value is a
   fixed placeholder, since nothing here measures an Origin fetch the way CloudFront's edge does.
-- **`CachePolicyId` and `OriginRequestPolicyId` are accepted and ignored.** Sim CloudFront models no
-  edge caching. A Behavior's cache policy, including an AWS managed policy such as
-  `CachingOptimized`, is left unvalidated and unapplied to TTLs and the cache key. Every request
-  reaches the Origin, whatever the policy would have cached on real CloudFront.
+- **A cache policy is recorded and never applied.** Sim CloudFront models no edge caching. A
+  Behavior's `CachePolicyId` is checked against the policies this simulation holds and reported
+  back, and the TTLs, the cache key and the compression settings behind it decide nothing. Every
+  request reaches the Origin, whatever the policy would have cached on real CloudFront.
+- **A cache policy carries its name and its comment, and nothing else.** The TTLs and
+  `ParametersInCacheKeyAndForwardedToOrigin` of an `AWS::CloudFront::CachePolicy` are read past,
+  since nothing here would act on them.
+- **`OriginRequestPolicyId` is accepted and ignored.** A Behavior's origin request policy is left
+  unvalidated, and `AWS::CloudFront::OriginRequestPolicy` is skipped.

--- a/docs/services/cloudfront/sim-cloudfront-cache-policy.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-cache-policy.example.ts
@@ -1,0 +1,89 @@
+/**
+ * Reading back the cache policy a Behavior was given.
+ */
+
+import { GetDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "site-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      BeaconPolicy: {
+        Type: "AWS::CloudFront::CachePolicy",
+        Properties: {
+          CachePolicyConfig: {
+            Name: "BeaconPolicy",
+            MinTTL: 0,
+            DefaultTTL: 0,
+            MaxTTL: 0,
+            ParametersInCacheKeyAndForwardedToOrigin: {
+              EnableAcceptEncodingGzip: false,
+              CookiesConfig: { CookieBehavior: "none" },
+              HeadersConfig: { HeaderBehavior: "none" },
+              QueryStringsConfig: { QueryStringBehavior: "none" },
+            },
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "BeaconPolicy"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              // CachingOptimized, one of CloudFront's managed policies.
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            },
+            CacheBehaviors: [
+              {
+                PathPattern: "/beacon",
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
+                CachePolicyId: { Ref: "BeaconPolicy" },
+              },
+            ],
+          },
+        },
+      },
+    },
+    Outputs: {
+      DistributionId: { Value: { Ref: "SiteDistribution" } },
+      BeaconPolicyId: { Value: { Ref: "BeaconPolicy" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const read = await simAws
+  .cloudFront()
+  .getDistribution(
+    new GetDistributionCommand({ Id: stack.output("DistributionId") }),
+  );
+const config = read.Distribution?.DistributionConfig;
+
+// The managed ID the default Behavior was given.
+console.log(config?.DefaultCacheBehavior?.CachePolicyId);
+
+// The ID of the policy the template created, which the path Behavior Refs.
+console.log(
+  config?.CacheBehaviors?.Items?.[0]?.CachePolicyId ===
+    stack.output("BeaconPolicyId"),
+);

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cache-policy-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cache-policy-cfn.iso.test.ts
@@ -1,0 +1,36 @@
+import { assertIdentical, assertInstanceOf } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontCachePolicy } from "../../../../cloudfront/cache-policy/sim-cf-cache-policy.js";
+import { SimCloudFrontCachePolicyCfn } from "./sim-cloudfront-cache-policy-cfn.js";
+import { cloudFrontValueAdapter } from "./sim-cloudfront-cfn-value-adapter.js";
+
+describe("SimCloudFrontCachePolicyCfn", () => {
+  const policy = new SimCloudFrontCachePolicy({ name: "BeaconPolicy" });
+  const adapter = new SimCloudFrontCachePolicyCfn({ policy });
+
+  it("answers a Ref with the policy ID", () => {
+    // Given a created policy.
+    // When a template Refs it, then it gets the ID a Cache Behavior's
+    // CachePolicyId wants.
+    assertIdentical(adapter.refValue(), policy.id);
+  });
+
+  it("answers the Id attribute with the policy ID", () => {
+    // Given a created policy.
+    // When a template reads its Id attribute, then it gets the same ID.
+    assertIdentical(adapter.attributeValue("Id"), policy.id);
+  });
+
+  it("is the adapter the CloudFront registry picks for the Resource type", () => {
+    // Given a created policy stored against its Resource type.
+    // When the CloudFront value adapter registry is asked for one.
+    const resolved = cloudFrontValueAdapter({
+      logicalId: "BeaconPolicy",
+      type: "AWS::CloudFront::CachePolicy",
+      simResource: policy,
+    });
+
+    // Then the policy's own adapter answers.
+    assertInstanceOf(resolved, SimCloudFrontCachePolicyCfn);
+  });
+});

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cache-policy-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cache-policy-cfn.ts
@@ -1,0 +1,41 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontCachePolicy } from "../../../../cloudfront/cache-policy/sim-cf-cache-policy.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCloudFrontCachePolicyCfnProperties {
+  readonly policy: SimCloudFrontCachePolicy;
+}
+
+/**
+ * CloudFormation-facing behavior for an AWS::CloudFront::CachePolicy Resource.
+ */
+export class SimCloudFrontCachePolicyCfn implements SimCfnResourceValueAdapter {
+  private readonly policy: SimCloudFrontCachePolicy;
+
+  constructor(properties: SimCloudFrontCachePolicyCfnProperties) {
+    this.policy = properties.policy;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::CloudFront::CachePolicy returns the policy ID,
+   * which is what a Cache Behavior's CachePolicyId wants.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.policy.id;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::CloudFront::CachePolicy.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Id": {
+        return this.policy.id;
+      }
+      default: {
+        /* v8 ignore next */
+        return `${this.policy.id}.${attributeName}`;
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
@@ -4,6 +4,8 @@ import { SimCloudFrontFunction } from "../../../../cloudfront/cff/sim-cloudfront
 import { SimCloudFrontFunctionCfn } from "./sim-cloudfront-function-cfn.js";
 import { SimCloudFrontResponseHeadersPolicy } from "../../../../cloudfront/response-headers-policy/sim-cf-response-headers-policy.js";
 import { SimCloudFrontResponseHeadersPolicyCfn } from "./sim-cloudfront-rh-policy-cfn.js";
+import { SimCloudFrontCachePolicy } from "../../../../cloudfront/cache-policy/sim-cf-cache-policy.js";
+import { SimCloudFrontCachePolicyCfn } from "./sim-cloudfront-cache-policy-cfn.js";
 import { SimCloudFrontOriginAccessControl } from "../../../../cloudfront/origin-access-control/sim-cf-origin-access-control.js";
 import { SimCloudFrontOriginAccessControlCfn } from "./sim-cloudfront-oac-cfn.js";
 import { SimCloudFrontKeyValueStore } from "../../../../cloudfront/key-value-store/sim-cf-key-value-store.js";
@@ -40,6 +42,15 @@ export function cloudFrontValueAdapter(
     properties.simResource instanceof SimCloudFrontResponseHeadersPolicy
   ) {
     return new SimCloudFrontResponseHeadersPolicyCfn({
+      policy: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::CloudFront::CachePolicy" &&
+    properties.simResource instanceof SimCloudFrontCachePolicy
+  ) {
+    return new SimCloudFrontCachePolicyCfn({
       policy: properties.simResource,
     });
   }

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -254,12 +254,31 @@ header per sub-section, `ServerTimingHeadersConfig` as a fixed header once `Enab
 a test does not depend on chance), and `CorsConfig` into the CORS model above.
 
 A lookup miss at request time is `SimCloudFrontNoSuchResponseHeadersPolicy` rather than a
-pass-through. In practice this is defence in depth rather than the common path: `ResponseHeadersPolicyId` is checked eagerly too, by `SimCloudFrontBehaviorConfigurator` when the Distribution is
+pass-through. In practice this is defence in depth rather than the common path: `ResponseHeadersPolicyId` is checked eagerly too, by `SimCfBehaviorPolicies` when the Distribution is
 created or updated, so a Behavior naming an ID nothing created — commonly a managed policy ID, which
 names a policy AWS owns rather than one a template creates — fails there as
 `SimCloudFrontInvalidResponseHeadersPolicyId`, the same as real CloudFront refuses the whole
 CreateDistribution/UpdateDistribution rather than deploying and failing the first request that needs
 it.
+
+## Cache policies
+
+`cache-policy/` holds the model and its registry, laid out the same way as the response headers
+policies above. A `SimCloudFrontCachePolicy` is a name, an ID and an optional comment.
+`sim-cf-managed-cache-policies.ts` builds CloudFront's seven managed policies under the IDs AWS
+publishes, and the registry keeps them in their own namespace, so a template may create a policy of
+its own under a managed name. There is no CreateCachePolicy command, so `cfn/cache-policy/` is the
+only thing that makes one.
+
+The policy carries nothing of `CachePolicyConfig` beyond `Name` and `Comment`. The TTLs and
+`ParametersInCacheKeyAndForwardedToOrigin` decide what a cache holds and how long it holds it, and
+sim CloudFront has no cache for them to decide anything about. Recording the ID is what lets a test
+assert which policy a Behavior was given.
+
+`SimCfBehaviorPolicies` asks both `SimCfBehaviorResponseHeadersPolicy` and
+`SimCfBehaviorCachePolicy` about one Behavior. A `CachePolicyId` naming nothing is
+`SimCloudFrontNoSuchCachePolicy`, which is what real CloudFront answers, and it comes at creation
+and update time as the response headers policy refusal does.
 
 ## Origin access controls
 
@@ -277,8 +296,9 @@ when the Distribution is created, and stores the result on the `SimCloudFrontS3O
 CloudFront refuses the whole CreateDistribution, and so is an origin type that does not match the
 Origin it was named on: `assertSimCfOacOriginType` checks that in both directions, since an origin
 access control for a Bucket signs nothing a Function URL will admit.
-`SimCloudFrontBehaviorConfigurator` resolves a Behavior's `ResponseHeadersPolicyId` the same eager
-way, for the same reason: CloudFront checks both at creation rather than when a request arrives.
+`SimCfBehaviorPolicies` resolves a Behavior's `ResponseHeadersPolicyId` and its `CachePolicyId` the
+same eager way, for the same reason: CloudFront checks them all at creation rather than when a
+request arrives.
 
 `SimCfS3OriginSigner` reads the stored origin access control on every Origin fetch. One whose
 `signs` getter is true makes the read a request from the `cloudfront.amazonaws.com` service

--- a/src/service/cloudfront/behaviour/sim-cloud-front-behavior.ts
+++ b/src/service/cloudfront/behaviour/sim-cloud-front-behavior.ts
@@ -13,6 +13,11 @@ export interface SimCloudFrontBehavior {
    * The response headers policy applied to every response this Behavior serves.
    */
   responseHeadersPolicyId?: string | undefined;
+  /**
+   * The cache policy this Behavior was given, whether a template created it or
+   * AWS manages it. The simulated cache does not read it yet.
+   */
+  cachePolicyId?: string | undefined;
   functionAssociations?:
     | undefined
     | {

--- a/src/service/cloudfront/cache-policy/sim-cf-cache-policy-registry.iso.test.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-cache-policy-registry.iso.test.ts
@@ -1,0 +1,116 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+  assertUndefined,
+  assertUuidV4,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontCachePolicyAlreadyExists } from "../error/sim-cloudfront.error.js";
+import { SimCloudFrontCachePolicyRegistry } from "./sim-cf-cache-policy-registry.js";
+import { SimCloudFrontCachePolicy } from "./sim-cf-cache-policy.js";
+import { simCfManagedCachePolicyIds } from "./sim-cf-managed-cache-policies.js";
+
+describe("SimCloudFrontCachePolicyRegistry", () => {
+  it("holds a policy a template created, by ID and by name", () => {
+    // Given a registry holding one policy.
+    const registry = new SimCloudFrontCachePolicyRegistry();
+    const policy = new SimCloudFrontCachePolicy({ name: "BeaconPolicy" });
+
+    registry.add(policy);
+
+    // Then it answers to both the ID a Behavior names and the name that
+    // decides whether another policy may be stored.
+    assertIdentical(registry.byId(policy.id), policy);
+    assertIdentical(registry.byName("BeaconPolicy"), policy);
+  });
+
+  it("gives a policy an ID of its own where none was supplied", () => {
+    // Given a policy built without an ID, which is how a template creates one.
+    const policy = new SimCloudFrontCachePolicy({ name: "BeaconPolicy" });
+
+    // Then it has an ID of the shape CloudFront hands back.
+    assertUuidV4(policy.id);
+    assertUndefined(policy.comment);
+  });
+
+  it("keeps the comment a template gave a policy", () => {
+    // Given a policy carrying a comment.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      comment: "Leaves the query string out of the key",
+    });
+
+    // Then the comment is what the template wrote.
+    assertIdentical(policy.comment, "Leaves the query string out of the key");
+  });
+
+  it("refuses a second policy claiming a name", () => {
+    // Given a registry already holding a policy under a name.
+    const registry = new SimCloudFrontCachePolicyRegistry();
+
+    registry.add(new SimCloudFrontCachePolicy({ name: "BeaconPolicy" }));
+
+    // When another policy claims the same name.
+    const error = assertThrowsError(() => {
+      registry.add(new SimCloudFrontCachePolicy({ name: "BeaconPolicy" }));
+    });
+
+    // Then it is refused the way CloudFront refuses one.
+    assertInstanceOf(error, SimCloudFrontCachePolicyAlreadyExists);
+  });
+
+  it("forgets a policy it was told to remove", () => {
+    // Given a registry holding a policy.
+    const registry = new SimCloudFrontCachePolicyRegistry();
+    const policy = new SimCloudFrontCachePolicy({ name: "BeaconPolicy" });
+
+    registry.add(policy);
+
+    // When the policy is removed.
+    registry.remove(policy.id);
+
+    // Then nothing answers to its ID or its name.
+    assertUndefined(registry.byId(policy.id));
+    assertUndefined(registry.byName("BeaconPolicy"));
+  });
+
+  it("answers every managed policy ID AWS publishes", () => {
+    // Given a fresh registry, which no template has reached yet.
+    const registry = new SimCloudFrontCachePolicyRegistry();
+
+    // Then each of CloudFront's managed policies is already there.
+    for (const managedId of Object.values(simCfManagedCachePolicyIds)) {
+      assertInstanceOf(registry.byId(managedId), SimCloudFrontCachePolicy);
+    }
+
+    assertIdentical(
+      registry.byId(simCfManagedCachePolicyIds.cachingOptimized)?.name,
+      "CachingOptimized",
+    );
+  });
+
+  it("leaves a managed policy's name free for a template's own", () => {
+    // Given a registry and a template creating a policy under a managed name.
+    const registry = new SimCloudFrontCachePolicyRegistry();
+    const policy = new SimCloudFrontCachePolicy({ name: "CachingDisabled" });
+
+    registry.add(policy);
+
+    // Then the template's policy is stored, and the managed one is where it
+    // was.
+    assertIdentical(registry.byName("CachingDisabled"), policy);
+    assertIdentical(
+      registry.byId(simCfManagedCachePolicyIds.cachingDisabled)?.name,
+      "CachingDisabled",
+    );
+  });
+
+  it("answers nothing for an ID from a real account", () => {
+    // Given a fresh registry.
+    const registry = new SimCloudFrontCachePolicyRegistry();
+
+    // Then a policy ID that is neither managed nor created here is unknown.
+    assertUndefined(registry.byId("11111111-2222-3333-4444-555555555555"));
+  });
+});

--- a/src/service/cloudfront/cache-policy/sim-cf-cache-policy-registry.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-cache-policy-registry.ts
@@ -1,0 +1,67 @@
+import { SimCloudFrontCachePolicyAlreadyExists } from "../error/sim-cloudfront.error.js";
+import { simCfManagedCachePolicies } from "./sim-cf-managed-cache-policies.js";
+import type {
+  SimCloudFrontCachePolicy,
+  SimCloudFrontCachePolicyId,
+  SimCloudFrontCachePolicyMap,
+} from "./sim-cf-cache-policy.js";
+
+/**
+ * The cache policies one simulated CloudFront holds.
+ *
+ * Policies are found by ID, which is what a cache Behavior's `cachePolicyId`
+ * names, and by name, which is what decides whether a new one may be stored.
+ *
+ * AWS's seven managed policies are held apart from the ones a template
+ * creates. CloudFront keeps them in its own namespace, so a template may
+ * create a policy called `CachingDisabled` of its own, and deleting the stack
+ * that created it leaves the managed one where it was.
+ */
+export class SimCloudFrontCachePolicyRegistry {
+  private readonly policies: SimCloudFrontCachePolicyMap = new Map();
+  private readonly managedPolicies: SimCloudFrontCachePolicyMap =
+    simCfManagedCachePolicies();
+
+  /**
+   * Store a policy a template created, refusing a name another such policy
+   * already holds as CloudFront does.
+   */
+  add(policy: SimCloudFrontCachePolicy): void {
+    if (this.byName(policy.name) !== undefined) {
+      throw new SimCloudFrontCachePolicyAlreadyExists(
+        `Sim CloudFront cache policy ${policy.name} already exists`,
+      );
+    }
+
+    this.policies.set(policy.id, policy);
+  }
+
+  /**
+   * Forget a policy.
+   */
+  remove(policyId: SimCloudFrontCachePolicyId): void {
+    this.policies.delete(policyId);
+  }
+
+  /**
+   * Get a policy by ID, whether a template created it or AWS manages it.
+   */
+  byId(
+    policyId: SimCloudFrontCachePolicyId | string,
+  ): SimCloudFrontCachePolicy | undefined {
+    const id = policyId as SimCloudFrontCachePolicyId;
+
+    return this.policies.get(id) ?? this.managedPolicies.get(id);
+  }
+
+  /**
+   * Get a policy a template created, by name.
+   *
+   * A managed policy is left out. Its name belongs to CloudFront's own
+   * namespace, and this is what decides whether a template may store a policy
+   * under a name.
+   */
+  byName(policyName: string): SimCloudFrontCachePolicy | undefined {
+    return this.policies.values().find((policy) => policy.name === policyName);
+  }
+}

--- a/src/service/cloudfront/cache-policy/sim-cf-cache-policy.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-cache-policy.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from "node:crypto";
+
+import type { Brand } from "../../../util/brand.type.js";
+
+export type SimCloudFrontCachePolicyId = Brand<
+  string,
+  "SimCloudFrontCachePolicyId"
+>;
+
+interface SimCloudFrontCachePolicyProperties {
+  readonly id?: SimCloudFrontCachePolicyId;
+  readonly name: string;
+  readonly comment?: string | undefined;
+}
+
+/**
+ * Simulated CloudFront cache policy.
+ *
+ * A cache policy decides what a cache Behavior keys its cache on and how long
+ * an object stays there. This simulation holds the policy under its ID and
+ * hands it back. The cache key, the TTLs and the compression settings belong
+ * to a simulated cache, which CloudFront here has yet to grow.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html
+ */
+export class SimCloudFrontCachePolicy {
+  public readonly id: SimCloudFrontCachePolicyId;
+  public readonly name: string;
+  public readonly comment: string | undefined;
+
+  constructor(properties: SimCloudFrontCachePolicyProperties) {
+    this.id = properties.id ?? (randomUUID() as SimCloudFrontCachePolicyId);
+    this.name = properties.name;
+    this.comment = properties.comment;
+  }
+}
+
+export type SimCloudFrontCachePolicyMap = Map<
+  SimCloudFrontCachePolicyId,
+  SimCloudFrontCachePolicy
+>;

--- a/src/service/cloudfront/cache-policy/sim-cf-managed-cache-policies.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-managed-cache-policies.ts
@@ -1,0 +1,79 @@
+import {
+  SimCloudFrontCachePolicy,
+  type SimCloudFrontCachePolicyId,
+  type SimCloudFrontCachePolicyMap,
+} from "./sim-cf-cache-policy.js";
+
+/**
+ * The IDs AWS publishes for its managed cache policies.
+ *
+ * A template names one of these directly. CDK's `CachePolicy` statics carry
+ * the same seven, and synthesize the ID into a Behavior's `CachePolicyId` with
+ * no Resource behind it.
+ */
+export const simCfManagedCachePolicyIds = {
+  amplify: "2e54312d-136d-493c-8eb9-b001f22f67d2",
+  cachingOptimized: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+  cachingOptimizedForUncompressedObjects:
+    "b2884449-e4de-46a7-ac36-70bc7f1ddd6d",
+  cachingDisabled: "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+  elementalMediaPackage: "08627262-05a9-4f76-9ded-b50ca2e3a84f",
+  useOriginCacheControlHeaders: "83da9c7e-98b4-4e11-a168-04f0df8e2c65",
+  useOriginCacheControlHeadersQueryStrings:
+    "4cc15a8a-d715-48a4-82b8-cc0b614638fe",
+} as const;
+
+/**
+ * The seven managed cache policies, built fresh for one simulated CloudFront.
+ *
+ * CloudFront owns these and every account has them, so a Behavior can name one
+ * without a template creating anything. Each carries the ID and the name AWS
+ * publishes for it. The cache key and the TTLs behind each one are left out,
+ * along with those of a policy a template creates.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
+ */
+export function simCfManagedCachePolicies(): SimCloudFrontCachePolicyMap {
+  const policies = [
+    managedCachePolicy(simCfManagedCachePolicyIds.amplify, "Amplify"),
+    managedCachePolicy(
+      simCfManagedCachePolicyIds.cachingOptimized,
+      "CachingOptimized",
+    ),
+    managedCachePolicy(
+      simCfManagedCachePolicyIds.cachingOptimizedForUncompressedObjects,
+      "CachingOptimizedForUncompressedObjects",
+    ),
+    managedCachePolicy(
+      simCfManagedCachePolicyIds.cachingDisabled,
+      "CachingDisabled",
+    ),
+    managedCachePolicy(
+      simCfManagedCachePolicyIds.elementalMediaPackage,
+      "Elemental-MediaPackage",
+    ),
+    managedCachePolicy(
+      simCfManagedCachePolicyIds.useOriginCacheControlHeaders,
+      "UseOriginCacheControlHeaders",
+    ),
+    managedCachePolicy(
+      simCfManagedCachePolicyIds.useOriginCacheControlHeadersQueryStrings,
+      "UseOriginCacheControlHeaders-QueryStrings",
+    ),
+  ];
+
+  return new Map(policies.map((policy) => [policy.id, policy]));
+}
+
+/**
+ * One managed policy, under the ID and the name AWS gives it.
+ */
+function managedCachePolicy(
+  id: string,
+  name: string,
+): SimCloudFrontCachePolicy {
+  return new SimCloudFrontCachePolicy({
+    id: id as SimCloudFrontCachePolicyId,
+    name,
+  });
+}

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-config.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-config.ts
@@ -1,0 +1,58 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCloudFrontCachePolicy } from "../../cache-policy/sim-cf-cache-policy.js";
+
+/**
+ * Reads an AWS::CloudFront::CachePolicy Resource into a simulated policy.
+ *
+ * `Name` and `Comment` are what the policy carries. The cache key sections and
+ * the TTLs are read past: what they configure is a cache this simulation has
+ * yet to grow. A Resource missing its `Name` is refused, as CloudFormation
+ * refuses one.
+ */
+export class SimCfnCfCachePolicyConfig {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: {
+    readonly resource: SimCfnResource;
+    readonly properties: SimCfnTemplateValueRecord;
+  }) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * Build the simulated policy this Resource describes.
+   */
+  build(): SimCloudFrontCachePolicy {
+    const config = this.properties["CachePolicyConfig"];
+
+    if (!isRecord(config)) {
+      return this.refuse("CachePolicyConfig must be an object");
+    }
+
+    const name = config["Name"];
+
+    if (typeof name !== "string") {
+      return this.refuse("CachePolicyConfig needs a string Name");
+    }
+
+    const comment = config["Comment"];
+
+    return new SimCloudFrontCachePolicy({
+      name,
+      ...(typeof comment === "string" && { comment }),
+    });
+  }
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  private refuse(detail: string): never {
+    throw new Error(
+      `Invalid AWS::CloudFront::CachePolicy ${this.resource.logicalId}: ${detail}`,
+    );
+  }
+}

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-creator.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-creator.ts
@@ -1,0 +1,51 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import type { SimCloudFrontCachePolicy } from "../../cache-policy/sim-cf-cache-policy.js";
+import { SimCfnCfCachePolicyConfig } from "./sim-cfn-cf-cache-policy-config.js";
+
+interface SimCfnCfCachePolicyCreatorProperties {
+  readonly cloudFront: SimCloudFront;
+}
+
+/**
+ * Creates simulated cache policies from AWS::CloudFront::CachePolicy
+ * Resources.
+ */
+export class SimCfnCfCachePolicyCreator {
+  private readonly cloudFront: SimCloudFront;
+
+  constructor(properties: SimCfnCfCachePolicyCreatorProperties) {
+    this.cloudFront = properties.cloudFront;
+  }
+
+  /**
+   * Create and store the policy one Resource describes.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCloudFrontCachePolicy {
+    const policy = new SimCfnCfCachePolicyConfig({
+      resource,
+      properties,
+    }).build();
+
+    this.cloudFront.addCachePolicy(policy);
+
+    return policy;
+  }
+
+  /**
+   * Remove a policy created from a Resource.
+   */
+  delete(resource: SimCfnResource): void {
+    const policy = resource.simResource as SimCloudFrontCachePolicy | undefined;
+
+    if (policy === undefined) {
+      return;
+    }
+
+    this.cloudFront.removeCachePolicy(policy.id);
+  }
+}

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy.iso.test.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy.iso.test.ts
@@ -1,0 +1,221 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCloudFrontCachePolicy } from "../../cache-policy/sim-cf-cache-policy.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCfnCfCachePolicyConfig } from "./sim-cfn-cf-cache-policy-config.js";
+import { SimCfnCfCachePolicyCreator } from "./sim-cfn-cf-cache-policy-creator.js";
+
+const bucketName = "cache-policy-cfn-bucket";
+
+/**
+ * A template with a cache policy of its own, and a Distribution whose default
+ * Behavior points at it with a Ref.
+ */
+function siteTemplate(
+  cachePolicyConfig: SimCfnTemplateValueRecord = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: bucketName },
+      },
+      BeaconPolicy: {
+        Type: "AWS::CloudFront::CachePolicy",
+        Properties: {
+          CachePolicyConfig: {
+            Name: "BeaconPolicy",
+            MinTTL: 0,
+            DefaultTTL: 0,
+            MaxTTL: 0,
+            ParametersInCacheKeyAndForwardedToOrigin: {
+              EnableAcceptEncodingGzip: false,
+              CookiesConfig: { CookieBehavior: "none" },
+              HeadersConfig: { HeaderBehavior: "none" },
+              QueryStringsConfig: { QueryStringBehavior: "none" },
+            },
+            ...cachePolicyConfig,
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "BeaconPolicy"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Enabled: true,
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: `${bucketName}.s3.amazonaws.com`,
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              CachePolicyId: { Ref: "BeaconPolicy" },
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      PolicyRef: { Value: { Ref: "BeaconPolicy" } },
+      PolicyId: { Value: { "Fn::GetAtt": ["BeaconPolicy", "Id"] } },
+    },
+  };
+}
+
+describe("AWS::CloudFront::CachePolicy", () => {
+  it("creates a policy a Behavior can name", async () => {
+    // Given a template declaring its own cache policy.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "cache-policy-stack",
+      template: siteTemplate(),
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the created policy is read back.
+    const resource = stack.getResource("BeaconPolicy");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontCachePolicy);
+
+    const policy = resource.simResource;
+
+    // Then the policy is held under its name, rather than the Resource being
+    // skipped.
+    assertIdentical(policy.name, "BeaconPolicy");
+    assertIdentical(simAws.cloudFront().getCachePolicyById(policy.id), policy);
+
+    // And the Behavior that Refs it reports its ID.
+    const distributionResource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(distributionResource);
+    assertInstanceOf(
+      distributionResource.simResource,
+      SimCloudFrontDistribution,
+    );
+    assertIdentical(
+      distributionResource.simResource.behaviors[0]?.cachePolicyId,
+      policy.id,
+    );
+
+    // And Ref and the Id attribute both answer with the policy ID.
+    assertIdentical(stack.outputs.get("PolicyRef")?.value, policy.id);
+    assertIdentical(stack.outputs.get("PolicyId")?.value, policy.id);
+  });
+
+  it("keeps the comment the template gave the policy", async () => {
+    // Given a template whose policy carries a comment.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "cache-policy-comment-stack",
+      template: siteTemplate({ Comment: "No query string in the key" }),
+    });
+
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("BeaconPolicy");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontCachePolicy);
+
+    // Then the comment is what the template wrote.
+    assertIdentical(resource.simResource.comment, "No query string in the key");
+  });
+
+  it("forgets the policy when the Stack is torn down", async () => {
+    // Given a deployed Stack holding a policy.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "cache-policy-teardown-stack",
+      template: siteTemplate(),
+    });
+
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("BeaconPolicy");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontCachePolicy);
+
+    const policyId = resource.simResource.id;
+
+    // When the Stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack({ input: { StackName: "cache-policy-teardown-stack" } });
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing answers to the policy's ID.
+    assertUndefined(simAws.cloudFront().getCachePolicyById(policyId));
+  });
+
+  it("refuses a Resource whose CachePolicyConfig is not an object", async () => {
+    // Given a template whose policy config is a string.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "cache-policy-invalid-stack",
+        template: {
+          Resources: {
+            BeaconPolicy: {
+              Type: "AWS::CloudFront::CachePolicy",
+              Properties: { CachePolicyConfig: "BeaconPolicy" },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the refusal names the Resource and the part that could not be read.
+    assertStringIncludes(error.message, "BeaconPolicy");
+    assertStringIncludes(error.message, "CachePolicyConfig must be an object");
+  });
+
+  it("refuses a Resource with no Name", () => {
+    // Given a policy config that left its Name out.
+    const config = new SimCfnCfCachePolicyConfig({
+      resource: new SimCfnResource({ logicalId: "BeaconPolicy" }),
+      properties: { CachePolicyConfig: { MinTTL: 0 } },
+    });
+
+    // When it is read.
+    const error = assertThrowsError(() => config.build());
+
+    // Then the refusal says which field is missing.
+    assertStringIncludes(error.message, "needs a string Name");
+  });
+
+  it("has nothing to forget for a Resource that never created a policy", () => {
+    // Given a Resource whose creation never ran, so it holds no policy.
+    const simAws = new SimAws();
+    const creator = new SimCfnCfCachePolicyCreator({
+      cloudFront: simAws.cloudFront(),
+    });
+
+    // When the teardown reaches it, then it passes over rather than failing.
+    creator.delete(new SimCfnResource({ logicalId: "BeaconPolicy" }));
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-behavior-policies.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-behavior-policies.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../command/create-distribution/create-distribution.command.js";
 import { normalizeSimCfList } from "../../command/create-distribution/sim-cf-normalize-list.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
+import { SimCfnCfDistroPolicyDrops } from "./sim-cfn-cf-distro-policy-drops.js";
 
 /**
  * The path a dropped policy on the default Behavior is recorded under.
@@ -12,48 +13,8 @@ import type { SimCloudFront } from "../../sim-cloudfront.js";
 const defaultBehaviorPath = "DistributionConfig.DefaultCacheBehavior";
 
 /**
- * Takes a `ResponseHeadersPolicyId` naming a policy this simulation does not
- * hold off the Behavior that named it, and records each one.
- */
-class SimCfnCfDistroPolicyDrops {
-  public count = 0;
-
-  constructor(
-    private readonly resource: SimCfnResource,
-    private readonly cloudFront: SimCloudFront,
-  ) {}
-
-  /**
-   * One Behavior, keeping a policy that is here and dropping one that is not.
-   */
-  heldPolicy(
-    behavior: SimCloudFrontCacheBehaviorConfig,
-    behaviorPath: string,
-  ): SimCloudFrontCacheBehaviorConfig {
-    const policyId = behavior.ResponseHeadersPolicyId;
-
-    if (
-      policyId === undefined ||
-      this.cloudFront.getResponseHeadersPolicyById(policyId) !== undefined
-    ) {
-      return behavior;
-    }
-
-    this.count += 1;
-    this.resource.ignoreProperty(
-      `${behaviorPath}.ResponseHeadersPolicyId`,
-      `response headers policy ${policyId} is not held by this simulation, ` +
-        `so the Behavior is deployed without one and serves every response ` +
-        `without the headers that policy would have set`,
-    );
-
-    return { ...behavior, ResponseHeadersPolicyId: undefined };
-  }
-}
-
-/**
- * The DistributionConfig to deploy, without a `ResponseHeadersPolicyId` naming
- * a response headers policy this simulation does not hold.
+ * The DistributionConfig to deploy, without a policy ID naming a response
+ * headers policy or a cache policy this simulation does not hold.
  *
  * `CreateDistribution` refuses such an ID, as real CloudFront refuses one, and
  * a Distribution deployed from a template is the one place that refusal costs
@@ -64,13 +25,14 @@ class SimCfnCfDistroPolicyDrops {
  * make with it. That is the same reason an absent `WebACLId` is left out here.
  *
  * So the property is left off that Behavior and recorded on
- * `stack.ignoredProperties`. The Behavior deploys and serves every response
- * without the policy's headers. A test that cares reads the record.
+ * `stack.ignoredProperties`. The Behavior deploys, and a test that cares reads
+ * the record. CloudFront's managed policies count as held, so a Behavior
+ * naming one keeps it.
  *
- * One Behavior losing its policy leaves the others holding theirs. CloudFront's
- * managed policies count as held, so a Behavior naming one keeps it.
+ * One Behavior losing a policy leaves the others holding theirs, and a
+ * Behavior losing one kind of policy keeps the other.
  */
-export function simCfnCfDistroWithHeldResponseHeadersPolicies(
+export function simCfnCfDistroWithHeldBehaviorPolicies(
   resource: SimCfnResource,
   distributionConfig: SimCloudFrontDistributionConfig,
   cloudFront: SimCloudFront,
@@ -103,7 +65,7 @@ function distroDefaultBehavior(
     return undefined;
   }
 
-  return drops.heldPolicy(behavior, defaultBehaviorPath);
+  return drops.heldPolicies(behavior, defaultBehaviorPath);
 }
 
 /**
@@ -130,7 +92,7 @@ function distroCacheBehaviors(
   return {
     ...behaviors,
     Items: items.map((behavior, index) =>
-      drops.heldPolicy(
+      drops.heldPolicies(
         behavior,
         `DistributionConfig.CacheBehaviors.${behavior.PathPattern ?? String(index)}`,
       ),

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-cache-policy.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-cache-policy.iso.test.ts
@@ -1,0 +1,172 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfManagedCachePolicyIds } from "../../cache-policy/sim-cf-managed-cache-policies.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+const bucketName = "held-cache-policy-bucket";
+
+/**
+ * An ID that is neither a managed policy nor one a template created here,
+ * which is what a policy ID from a real account looks like.
+ */
+const absentPolicyId = "11111111-2222-3333-4444-555555555555";
+
+/**
+ * A template with a Distribution, with the Behaviors the test is about merged
+ * over the default one.
+ */
+function siteTemplate(
+  distributionConfig: SimCfnTemplateValueRecord = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: bucketName },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Enabled: true,
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: `${bucketName}.s3.amazonaws.com`,
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              CachePolicyId: absentPolicyId,
+            },
+            ...distributionConfig,
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("CloudFormation Distribution on an absent cache policy", () => {
+  async function deployedSite(
+    stackName: string,
+    distributionConfig: SimCfnTemplateValueRecord = {},
+  ): Promise<{
+    distribution: SimCloudFrontDistribution;
+    ignoredPaths: readonly string[];
+    ignoredReasons: readonly string[];
+  }> {
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName,
+      template: siteTemplate(distributionConfig),
+    });
+
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+
+    return {
+      distribution: resource.simResource,
+      ignoredPaths: stack.ignoredProperties.map((ignored) => ignored.path),
+      ignoredReasons: stack.ignoredProperties.map((ignored) => ignored.reason),
+    };
+  }
+
+  it("deploys the Distribution and records the policy it dropped", async () => {
+    // Given a template naming a cache policy from some real account.
+    // When the stack is deployed.
+    const { distribution, ignoredPaths, ignoredReasons } = await deployedSite(
+      "dropped-cache-policy-stack",
+    );
+
+    // Then the Distribution is up, with no policy on the Behavior that named
+    // one.
+    assertArrayLength(distribution.behaviors, 1);
+    assertUndefined(distribution.behaviors[0].cachePolicyId);
+
+    // And the property is recorded under the Behavior that named it, so a test
+    // that cares reads why.
+    assertArrayLength(ignoredPaths, 1);
+    assertIdentical(
+      ignoredPaths[0],
+      "DistributionConfig.DefaultCacheBehavior.CachePolicyId",
+    );
+    assertStringIncludes(ignoredReasons[0] ?? "", absentPolicyId);
+  });
+
+  it("keeps a managed policy the template named", async () => {
+    // Given a Distribution whose path Behavior names a managed policy and
+    // whose default Behavior names one from a real account.
+    const { distribution, ignoredPaths } = await deployedSite(
+      "managed-cache-policy-stack",
+      {
+        CacheBehaviors: [
+          {
+            PathPattern: "/beacon",
+            TargetOriginId: "SiteOrigin",
+            ViewerProtocolPolicy: "allow-all",
+            CachePolicyId: simCfManagedCachePolicyIds.cachingDisabled,
+          },
+        ],
+      },
+    );
+
+    // Then only the default Behavior lost its policy.
+    assertArrayLength(ignoredPaths, 1);
+    assertIdentical(
+      ignoredPaths[0],
+      "DistributionConfig.DefaultCacheBehavior.CachePolicyId",
+    );
+
+    // And the path Behavior holds the managed ID it named.
+    assertIdentical(
+      distribution.behaviors[1]?.cachePolicyId,
+      simCfManagedCachePolicyIds.cachingDisabled,
+    );
+  });
+
+  it("records both policies a Behavior loses, under their own paths", async () => {
+    // Given a path Behavior naming a response headers policy and a cache
+    // policy, neither of which is here.
+    const { ignoredPaths } = await deployedSite("both-policies-stack", {
+      CacheBehaviors: [
+        {
+          PathPattern: "/beacon",
+          TargetOriginId: "SiteOrigin",
+          ViewerProtocolPolicy: "allow-all",
+          CachePolicyId: absentPolicyId,
+          ResponseHeadersPolicyId: absentPolicyId,
+        },
+      ],
+    });
+
+    // Then each is recorded on its own, alongside the default Behavior's.
+    assertArrayLength(ignoredPaths, 3);
+    assertIdentical(
+      ignoredPaths[1],
+      "DistributionConfig.CacheBehaviors./beacon.ResponseHeadersPolicyId",
+    );
+    assertIdentical(
+      ignoredPaths[2],
+      "DistributionConfig.CacheBehaviors./beacon.CachePolicyId",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
@@ -12,7 +12,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCloudFrontDistributionConfig } from "../../command/create-distribution/create-distribution.command.js";
 import { SimCfnCfDistroConfigValidator } from "./sim-cfn-cf-distro-config-validator.js";
 import { simCfnCfDistroWithRunnableEdgeAssociations } from "./sim-cfn-cf-distro-edge-associations.js";
-import { simCfnCfDistroWithHeldResponseHeadersPolicies } from "./sim-cfn-cf-distro-response-headers-policy.js";
+import { simCfnCfDistroWithHeldBehaviorPolicies } from "./sim-cfn-cf-distro-behavior-policies.js";
 import { simCfnCfDistroWithoutAbsentWebAcl } from "./sim-cfn-cf-distro-web-acl.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
 import { simCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
@@ -26,11 +26,12 @@ interface SimCfnCfDistroCreatorProperties {
  *
  * A `WebACLId` naming a web ACL this simulation does not hold is left out and
  * recorded, and so are a Lambda@Edge association it cannot run and a
- * `ResponseHeadersPolicyId` naming a policy it does not hold. CloudFront has no
- * Resource of its own for any of the three, so all of them live on the
- * Distribution itself, and refusing one would take the Distribution down over
- * something that was never the point of the template. The site a local dev
- * server and a suite of tests make requests to has to survive that.
+ * `ResponseHeadersPolicyId` or `CachePolicyId` naming a policy it does not
+ * hold. CloudFront has no Resource of its own for any of them, so all of them
+ * live on the Distribution itself, and refusing one would take the
+ * Distribution down over something that was never the point of the template.
+ * The site a local dev server and a suite of tests make requests to has to
+ * survive that.
  */
 export class SimCfnCfDistroCreator {
   private readonly cloudFront: SimCloudFront;
@@ -106,7 +107,7 @@ function deployableConfig(
 ): SimCloudFrontDistributionConfig {
   return simCfnCfDistroWithoutAbsentWebAcl(
     resource,
-    simCfnCfDistroWithHeldResponseHeadersPolicies(
+    simCfnCfDistroWithHeldBehaviorPolicies(
       resource,
       simCfnCfDistroWithRunnableEdgeAssociations(
         resource,

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-policy-drops.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-policy-drops.ts
@@ -1,0 +1,96 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFrontCacheBehaviorConfig } from "../../command/create-distribution/create-distribution.command.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+
+/**
+ * The policy properties a Behavior carries, in the terms a template writes
+ * them in.
+ */
+type BehaviorPolicyProperty = "ResponseHeadersPolicyId" | "CachePolicyId";
+
+/**
+ * Takes a policy ID naming a policy this simulation does not hold off the
+ * Behavior that named it, and records each one on the Resource.
+ */
+export class SimCfnCfDistroPolicyDrops {
+  public count = 0;
+
+  constructor(
+    private readonly resource: SimCfnResource,
+    private readonly cloudFront: SimCloudFront,
+  ) {}
+
+  /**
+   * One Behavior, keeping the policies that are here and dropping those that
+   * are not.
+   */
+  heldPolicies(
+    behavior: SimCloudFrontCacheBehaviorConfig,
+    behaviorPath: string,
+  ): SimCloudFrontCacheBehaviorConfig {
+    const withHeaders = this.heldPolicy(
+      behavior,
+      behaviorPath,
+      "ResponseHeadersPolicyId",
+      (policyId) =>
+        this.cloudFront.getResponseHeadersPolicyById(policyId) !== undefined,
+      headersPolicyDropReason,
+    );
+
+    return this.heldPolicy(
+      withHeaders,
+      behaviorPath,
+      "CachePolicyId",
+      (policyId) => this.cloudFront.getCachePolicyById(policyId) !== undefined,
+      cachePolicyDropReason,
+    );
+  }
+
+  /**
+   * One policy property of one Behavior, dropped where the ID names nothing
+   * this simulation holds.
+   */
+  private heldPolicy(
+    behavior: SimCloudFrontCacheBehaviorConfig,
+    behaviorPath: string,
+    property: BehaviorPolicyProperty,
+    held: (policyId: string) => boolean,
+    reason: (policyId: string) => string,
+  ): SimCloudFrontCacheBehaviorConfig {
+    // oxlint-disable-next-line security/detect-object-injection
+    const policyId = behavior[property];
+
+    if (policyId === undefined || held(policyId)) {
+      return behavior;
+    }
+
+    this.count += 1;
+    this.resource.ignoreProperty(
+      `${behaviorPath}.${property}`,
+      reason(policyId),
+    );
+
+    return { ...behavior, [property]: undefined };
+  }
+}
+
+/**
+ * What a Behavior loses along with a response headers policy.
+ */
+function headersPolicyDropReason(policyId: string): string {
+  return (
+    `response headers policy ${policyId} is not held by this simulation, so ` +
+    `the Behavior is deployed without one and serves every response without ` +
+    `the headers that policy would have set`
+  );
+}
+
+/**
+ * What a Behavior loses along with a cache policy.
+ */
+function cachePolicyDropReason(policyId: string): string {
+  return (
+    `cache policy ${policyId} is not held by this simulation, so the ` +
+    `Behavior is deployed without one and reports no CachePolicyId`
+  );
+}

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
@@ -10,6 +10,7 @@ import { SimCfnCfDistroCreator } from "./distro/sim-cfn-cf-distro-creator.js";
 import { SimCfnCffCreator } from "./cff/sim-cfn-cff-creator.js";
 import { SimCfnCfDistroDeleter } from "./distro/sim-cfn-cf-distro-deleter.js";
 import { SimCfnCfResponseHeadersPolicyCreator } from "./response-headers-policy/sim-cfn-cf-rh-policy-creator.js";
+import { SimCfnCfCachePolicyCreator } from "./cache-policy/sim-cfn-cf-cache-policy-creator.js";
 import { SimCfnCfOriginAccessControlCreator } from "./origin-access-control/sim-cfn-cf-oac-creator.js";
 import { SimCfnCfKeyValueStoreCreator } from "./key-value-store/sim-cfn-cf-kvs-creator.js";
 
@@ -21,6 +22,7 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
   private readonly functionCreator: SimCfnCffCreator;
   private readonly distroDeleter: SimCfnCfDistroDeleter;
   private readonly responseHeadersPolicyCreator: SimCfnCfResponseHeadersPolicyCreator;
+  private readonly cachePolicyCreator: SimCfnCfCachePolicyCreator;
   private readonly originAccessControlCreator: SimCfnCfOriginAccessControlCreator;
   private readonly keyValueStoreCreator: SimCfnCfKeyValueStoreCreator;
 
@@ -30,6 +32,7 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
     this.distroDeleter = new SimCfnCfDistroDeleter({ cloudFront });
     this.responseHeadersPolicyCreator =
       new SimCfnCfResponseHeadersPolicyCreator({ cloudFront });
+    this.cachePolicyCreator = new SimCfnCfCachePolicyCreator({ cloudFront });
     this.originAccessControlCreator = new SimCfnCfOriginAccessControlCreator({
       cloudFront,
     });
@@ -57,6 +60,9 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "ResponseHeadersPolicy": {
         return this.responseHeadersPolicyCreator.create(resource, properties);
+      }
+      case "CachePolicy": {
+        return this.cachePolicyCreator.create(resource, properties);
       }
       case "OriginAccessControl": {
         return this.originAccessControlCreator.create(resource, properties);
@@ -98,6 +104,10 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "ResponseHeadersPolicy": {
         this.responseHeadersPolicyCreator.delete(resource);
+        return;
+      }
+      case "CachePolicy": {
+        this.cachePolicyCreator.delete(resource);
         return;
       }
       case "OriginAccessControl": {

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -171,6 +171,7 @@ export interface SimCloudFrontDefaultCacheBehaviorConfig {
     | SimCloudFrontLambdaFunctionAssociations
     | undefined;
   readonly ResponseHeadersPolicyId?: string | undefined;
+  readonly CachePolicyId?: string | undefined;
 }
 
 /**

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -14,6 +14,7 @@ import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfro
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import type { SimCloudFrontCachePolicyRegistry } from "../../cache-policy/sim-cf-cache-policy-registry.js";
 import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import { makeSimCloudFrontDistributionConfigurator } from "../../distribution/configurator/sim-cf-distribution-configurator.factory.js";
@@ -42,6 +43,7 @@ interface CreateDistributionCommandHandlerProperties {
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
   readonly webAclResolver?: SimCfWebAclResolver | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;

--- a/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
@@ -25,6 +25,7 @@ import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-cus
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import type { SimCloudFrontCachePolicyRegistry } from "../../cache-policy/sim-cf-cache-policy-registry.js";
 import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
 import type { SimCloudFrontRegistry } from "../../registry/sim-cloud-front-registry.js";
 import { SimCloudFrontDistributionConfigNormalizer } from "../create-distribution/sim-cf-distro-config-normalizer.js";
@@ -45,6 +46,7 @@ interface UpdateDistributionCommandHandlerProperties {
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
   readonly webAclResolver?: SimCfWebAclResolver | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-cache-policy.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-cache-policy.ts
@@ -1,0 +1,38 @@
+import type { SimCloudFrontCachePolicyRegistry } from "../../cache-policy/sim-cf-cache-policy-registry.js";
+import { SimCloudFrontNoSuchCachePolicy } from "../../error/sim-cloudfront.error.js";
+
+/**
+ * Refuses a Cache Behavior naming a cache policy this simulation does not
+ * hold.
+ *
+ * Real CloudFront checks this when the Distribution is created or updated, so
+ * a template naming a mistyped policy ID fails the deploy there too, rather
+ * than deploying successfully and only failing the first request that reaches
+ * the Behavior.
+ */
+export class SimCfBehaviorCachePolicy {
+  constructor(private readonly policies: SimCloudFrontCachePolicyRegistry) {}
+
+  /**
+   * Refuse one Behavior naming a policy which is not there.
+   */
+  assertExists(
+    targetOriginId: string | undefined,
+    cachePolicyId: string | undefined,
+  ): void {
+    if (
+      cachePolicyId === undefined ||
+      this.policies.byId(cachePolicyId) !== undefined
+    ) {
+      return;
+    }
+
+    throw new SimCloudFrontNoSuchCachePolicy(
+      `Sim CloudFront Behavior for Origin ${targetOriginId} names cache ` +
+        `policy ${cachePolicyId}, which does not exist. A Behavior names one ` +
+        `of CloudFront's seven managed policies, or a policy an ` +
+        `AWS::CloudFront::CachePolicy Resource created in this simulation. A ` +
+        `policy ID from a real account is neither.`,
+    );
+  }
+}

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-policies.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-policies.ts
@@ -1,0 +1,60 @@
+import type {
+  SimCloudFrontCacheBehaviorConfig,
+  SimCloudFrontDefaultCacheBehaviorConfig,
+  SimCloudFrontDistributionConfig,
+} from "../../command/create-distribution/create-distribution.command.js";
+import type { SimCfBehaviorCachePolicy } from "./sim-cf-behavior-cache-policy.js";
+import type { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
+
+/**
+ * The policies a Cache Behavior names, and whether this simulation holds them.
+ *
+ * A Behavior points at a response headers policy and a cache policy by ID, and
+ * both live outside the Distribution. Each one is checked the same way and at
+ * the same moment, so they are asked together.
+ */
+export class SimCfBehaviorPolicies {
+  constructor(
+    private readonly responseHeadersPolicy: SimCfBehaviorResponseHeadersPolicy,
+    private readonly cachePolicy: SimCfBehaviorCachePolicy,
+  ) {}
+
+  /**
+   * Refuse every Behavior of a DistributionConfig that names a policy which is
+   * not there, without touching the Distribution.
+   *
+   * An update replaces a Distribution's whole configuration, so this runs
+   * before any of it is torn down. A refusal here leaves the Distribution
+   * serving exactly what it served before, rather than half replaced.
+   */
+  assertAllExist(distributionConfig: SimCloudFrontDistributionConfig): void {
+    const behaviors = [
+      distributionConfig.DefaultCacheBehavior,
+      ...(distributionConfig.CacheBehaviors?.Items ?? []),
+    ];
+
+    for (const behavior of behaviors) {
+      if (behavior !== undefined) {
+        this.assertExists(behavior);
+      }
+    }
+  }
+
+  /**
+   * Refuse one Behavior naming a policy of either kind which is not there.
+   */
+  assertExists(
+    behavior:
+      | SimCloudFrontDefaultCacheBehaviorConfig
+      | SimCloudFrontCacheBehaviorConfig,
+  ): void {
+    this.responseHeadersPolicy.assertExists(
+      behavior.TargetOriginId,
+      behavior.ResponseHeadersPolicyId,
+    );
+    this.cachePolicy.assertExists(
+      behavior.TargetOriginId,
+      behavior.CachePolicyId,
+    );
+  }
+}

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-properties.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-properties.ts
@@ -5,7 +5,7 @@ import type {
 } from "../../command/create-distribution/create-distribution.command.js";
 import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
+import type { SimCfBehaviorPolicies } from "./sim-cf-behavior-policies.js";
 import { configureCffAssociations } from "./sim-cff-associations-configure.js";
 import { configureEdgeAssociations } from "../../edge/sim-cf-edge-associations-configure.js";
 import { assertConsistentQuantity } from "../../command/sim-cf-list-quantity.js";
@@ -18,13 +18,14 @@ export function simCfBehaviorProperties(
   cacheBehavior:
     | SimCloudFrontDefaultCacheBehaviorConfig
     | SimCloudFrontCacheBehaviorConfig,
-  responseHeadersPolicy: SimCfBehaviorResponseHeadersPolicy,
+  policies: SimCfBehaviorPolicies,
 ): SimCloudFrontBehavior {
-  const { TargetOriginId, ResponseHeadersPolicyId } = cacheBehavior;
+  const { TargetOriginId, ResponseHeadersPolicyId, CachePolicyId } =
+    cacheBehavior;
 
   assertDefined(TargetOriginId, "CloudFront CacheBehavior TargetOriginId");
 
-  responseHeadersPolicy.assertExists(TargetOriginId, ResponseHeadersPolicyId);
+  policies.assertExists(cacheBehavior);
 
   return {
     targetOriginName: TargetOriginId,
@@ -42,6 +43,9 @@ export function simCfBehaviorProperties(
     }),
     ...(ResponseHeadersPolicyId !== undefined && {
       responseHeadersPolicyId: ResponseHeadersPolicyId,
+    }),
+    ...(CachePolicyId !== undefined && {
+      cachePolicyId: CachePolicyId,
     }),
     functionAssociations: configureCffAssociations(cacheBehavior),
     lambdaFunctionAssociations: configureEdgeAssociations(cacheBehavior),

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-response-headers-policy.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-response-headers-policy.ts
@@ -1,4 +1,3 @@
-import type { SimCloudFrontDistributionConfig } from "../../command/create-distribution/create-distribution.command.js";
 import { SimCloudFrontInvalidResponseHeadersPolicyId } from "../../error/sim-cloudfront.error.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 
@@ -15,30 +14,6 @@ export class SimCfBehaviorResponseHeadersPolicy {
   constructor(
     private readonly policies: SimCloudFrontResponseHeadersPolicyRegistry,
   ) {}
-
-  /**
-   * Refuse every Behavior of a DistributionConfig that names a policy which is
-   * not there, without touching the Distribution.
-   *
-   * An update replaces a Distribution's whole configuration, so this runs
-   * before any of it is torn down: a refusal here leaves the Distribution
-   * serving exactly what it served before, rather than half replaced.
-   */
-  assertAllExist(distributionConfig: SimCloudFrontDistributionConfig): void {
-    const behaviors = [
-      distributionConfig.DefaultCacheBehavior,
-      ...(distributionConfig.CacheBehaviors?.Items ?? []),
-    ];
-
-    for (const behavior of behaviors) {
-      if (behavior !== undefined) {
-        this.assertExists(
-          behavior.TargetOriginId,
-          behavior.ResponseHeadersPolicyId,
-        );
-      }
-    }
-  }
 
   /**
    * Refuse one Behavior naming a policy which is not there.

--- a/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
@@ -1,9 +1,12 @@
+import type { SimCloudFrontCachePolicyRegistry } from "../../cache-policy/sim-cf-cache-policy-registry.js";
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import { SimCfDistributionWebAcl } from "../../web-acl/sim-cf-distribution-web-acl.js";
 import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
+import { SimCfBehaviorCachePolicy } from "./sim-cf-behavior-cache-policy.js";
+import { SimCfBehaviorPolicies } from "./sim-cf-behavior-policies.js";
 import { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
 import { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
 import { SimCloudFrontDistributionConfigurator } from "./sim-cloud-front-distribution-configurator.js";
@@ -14,6 +17,7 @@ interface SimCloudFrontConfiguratorProperties {
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
   readonly webAclResolver?: SimCfWebAclResolver | undefined;
 }
 
@@ -26,8 +30,9 @@ interface SimCloudFrontConfiguratorProperties {
 export function makeSimCloudFrontDistributionConfigurator(
   properties: SimCloudFrontConfiguratorProperties,
 ): SimCloudFrontDistributionConfigurator {
-  const responseHeadersPolicy = new SimCfBehaviorResponseHeadersPolicy(
-    properties.responseHeadersPolicies,
+  const behaviorPolicies = new SimCfBehaviorPolicies(
+    new SimCfBehaviorResponseHeadersPolicy(properties.responseHeadersPolicies),
+    new SimCfBehaviorCachePolicy(properties.cachePolicies),
   );
 
   return new SimCloudFrontDistributionConfigurator(
@@ -36,8 +41,8 @@ export function makeSimCloudFrontDistributionConfigurator(
       properties.originAccessControls,
       properties.customOriginDispatcher,
     ),
-    new SimCloudFrontBehaviorConfigurator(responseHeadersPolicy),
-    responseHeadersPolicy,
+    new SimCloudFrontBehaviorConfigurator(behaviorPolicies),
+    behaviorPolicies,
     new SimCfDistributionWebAcl(properties.webAclResolver),
   );
 }

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-behavior-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-behavior-configurator.ts
@@ -5,15 +5,13 @@ import type {
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCloudFrontDistribution } from "../sim-cloudfront-distribution.js";
 import { simCfBehaviorProperties } from "./sim-cf-behavior-properties.js";
-import type { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
+import type { SimCfBehaviorPolicies } from "./sim-cf-behavior-policies.js";
 
 /**
  * Applies Cache Behavior configuration to a sim CloudFront Distribution.
  */
 export class SimCloudFrontBehaviorConfigurator {
-  constructor(
-    private readonly responseHeadersPolicy: SimCfBehaviorResponseHeadersPolicy,
-  ) {}
+  constructor(private readonly policies: SimCfBehaviorPolicies) {}
 
   /**
    * Configure the default Cache Behavior on a Distribution.
@@ -24,7 +22,7 @@ export class SimCloudFrontBehaviorConfigurator {
   ): void {
     assertDefined(cacheBehavior, "CloudFront DefaultCacheBehavior");
     distribution.addBehavior(
-      simCfBehaviorProperties(cacheBehavior, this.responseHeadersPolicy),
+      simCfBehaviorProperties(cacheBehavior, this.policies),
     );
   }
 
@@ -41,7 +39,7 @@ export class SimCloudFrontBehaviorConfigurator {
     );
     distribution.addBehavior({
       pathPattern: cacheBehavior.PathPattern,
-      ...simCfBehaviorProperties(cacheBehavior, this.responseHeadersPolicy),
+      ...simCfBehaviorProperties(cacheBehavior, this.policies),
     });
   }
 }

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-distribution-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-distribution-configurator.ts
@@ -5,7 +5,7 @@ import type {
 import type { SimCloudFrontDistribution } from "../sim-cloudfront-distribution.js";
 import type { SimCloudFrontOriginConfigurator } from "./sim-cloud-front-origin-configurator.js";
 import type { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
-import type { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
+import type { SimCfBehaviorPolicies } from "./sim-cf-behavior-policies.js";
 import { SimCloudFrontCustomErrorConfigurator } from "./sim-cloud-front-custom-error-configurator.js";
 import { SimCloudFrontInvalidDefaultRootObject } from "../../error/sim-cloudfront.error.js";
 import {
@@ -41,7 +41,7 @@ export class SimCloudFrontDistributionConfigurator {
   constructor(
     private readonly originConfigurator: SimCloudFrontOriginConfigurator,
     private readonly behaviorConfigurator: SimCloudFrontBehaviorConfigurator,
-    private readonly responseHeadersPolicy: SimCfBehaviorResponseHeadersPolicy,
+    private readonly behaviorPolicies: SimCfBehaviorPolicies,
     private readonly webAcl: SimCfDistributionWebAcl,
   ) {}
 
@@ -58,7 +58,7 @@ export class SimCloudFrontDistributionConfigurator {
   assertConfigurable(
     distributionConfig: SimCloudFrontDistributionConfig,
   ): void {
-    this.responseHeadersPolicy.assertAllExist(distributionConfig);
+    this.behaviorPolicies.assertAllExist(distributionConfig);
     this.webAcl.assertUsable(distributionConfig);
   }
 

--- a/src/service/cloudfront/distribution/sim-cf-distribution-cache-policy.iso.test.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-cache-policy.iso.test.ts
@@ -1,0 +1,257 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import {
+  CreateDistributionCommand,
+  GetDistributionCommand,
+  UpdateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimCloudFrontCachePolicy } from "../cache-policy/sim-cf-cache-policy.js";
+import { simCfManagedCachePolicyIds } from "../cache-policy/sim-cf-managed-cache-policies.js";
+import { SimCloudFrontNoSuchCachePolicy } from "../error/sim-cloudfront.error.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+} from "../../../../test/cloudfront/site-fixture.js";
+
+const bucketName = "cache-policy-site-bucket";
+
+/**
+ * An ID that is neither a managed policy nor one created here, which is what a
+ * policy ID from a real account looks like.
+ */
+const absentPolicyId = "11111111-2222-3333-4444-555555555555";
+
+describe("A Cache Behavior's CachePolicyId", () => {
+  async function simAwsWithSite(): Promise<SimAws> {
+    const simAws = new SimAws();
+
+    await simCfSiteBucket(simAws, bucketName, {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    return simAws;
+  }
+
+  it("is reported for a default Behavior given a managed policy", async () => {
+    // Given a Distribution whose default Behavior names a managed policy, the
+    // way CDK's CachePolicy.CACHING_OPTIMIZED synthesizes one.
+    const simAws = await simAwsWithSite();
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+            CachePolicyId: simCfManagedCachePolicyIds.cachingOptimized,
+          },
+        }),
+      }),
+    );
+    const distributionId = creation.Distribution?.Id;
+
+    assertNonNullable(distributionId);
+
+    // When the Distribution is read back.
+    const read = await simAws
+      .cloudFront()
+      .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+
+    // Then GetDistribution reports the managed ID it was given.
+    assertIdentical(
+      read.Distribution?.DistributionConfig?.DefaultCacheBehavior
+        ?.CachePolicyId,
+      simCfManagedCachePolicyIds.cachingOptimized,
+    );
+
+    // And the Behavior itself records it, so two Behaviors keying on different
+    // things no longer read identically.
+    const distribution = simAws
+      .cloudFront()
+      .getSimDistributionById(distributionId);
+
+    assertNonNullable(distribution);
+    assertArrayLength(distribution.behaviors, 1);
+    assertIdentical(
+      distribution.behaviors[0].cachePolicyId,
+      simCfManagedCachePolicyIds.cachingOptimized,
+    );
+  });
+
+  it("is reported for a named Behavior given a policy of its own", async () => {
+    // Given a policy this simulation holds and a Distribution with a path
+    // Behavior naming it.
+    const simAws = await simAwsWithSite();
+    const policy = new SimCloudFrontCachePolicy({ name: "BeaconPolicy" });
+
+    simAws.cloudFront().addCachePolicy(policy);
+
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          CacheBehaviors: {
+            Quantity: 1,
+            Items: [
+              {
+                PathPattern: "/beacon",
+                TargetOriginId: "site-origin",
+                ViewerProtocolPolicy: "allow-all",
+                CachePolicyId: policy.id,
+              },
+            ],
+          },
+        }),
+      }),
+    );
+    const distributionId = creation.Distribution?.Id;
+
+    assertNonNullable(distributionId);
+
+    // When the Distribution is read back.
+    const read = await simAws
+      .cloudFront()
+      .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+
+    // Then the path Behavior reports the policy, and the default Behavior
+    // reports none.
+    const config = read.Distribution?.DistributionConfig;
+
+    assertNonNullable(config);
+    assertIdentical(
+      config.CacheBehaviors?.Items?.[0]?.CachePolicyId,
+      policy.id,
+    );
+    assertUndefined(config.DefaultCacheBehavior?.CachePolicyId);
+  });
+
+  it("is reported after an update changes the policy", async () => {
+    // Given a deployed Distribution keying its cache one way.
+    const simAws = await simAwsWithSite();
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+            CachePolicyId: simCfManagedCachePolicyIds.cachingOptimized,
+          },
+        }),
+      }),
+    );
+    const distributionId = creation.Distribution?.Id;
+
+    assertNonNullable(distributionId);
+
+    // When an update moves it onto another policy.
+    const update = await simAws.cloudFront().updateDistribution(
+      new UpdateDistributionCommand({
+        Id: distributionId,
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+            CachePolicyId: simCfManagedCachePolicyIds.cachingDisabled,
+          },
+        }),
+      }),
+    );
+
+    // Then the update answers with the new policy.
+    assertIdentical(
+      update.Distribution?.DistributionConfig?.DefaultCacheBehavior
+        ?.CachePolicyId,
+      simCfManagedCachePolicyIds.cachingDisabled,
+    );
+
+    const distribution = simAws
+      .cloudFront()
+      .getSimDistributionById(distributionId);
+
+    assertNonNullable(distribution);
+    assertIdentical(
+      distribution.behaviors[0]?.cachePolicyId,
+      simCfManagedCachePolicyIds.cachingDisabled,
+    );
+  });
+
+  it("is refused where no policy and no managed ID answers to it", async () => {
+    // Given a Distribution whose Behavior names a policy from a real account.
+    const simAws = await simAwsWithSite();
+
+    // When it is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+            DefaultCacheBehavior: {
+              TargetOriginId: "site-origin",
+              ViewerProtocolPolicy: "allow-all",
+              CachePolicyId: absentPolicyId,
+            },
+          }),
+        }),
+      );
+    });
+
+    // Then CloudFront refuses it by name, and the message says what a Behavior
+    // may name.
+    assertInstanceOf(error, SimCloudFrontNoSuchCachePolicy);
+    assertStringIncludes(error.message, absentPolicyId);
+  });
+
+  it("leaves an update refused for it serving what it served before", async () => {
+    // Given a deployed Distribution on a policy that is here.
+    const simAws = await simAwsWithSite();
+    const policy = new SimCloudFrontCachePolicy({ name: "BeaconPolicy" });
+
+    simAws.cloudFront().addCachePolicy(policy);
+
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+            CachePolicyId: policy.id,
+          },
+        }),
+      }),
+    );
+    const distributionId = creation.Distribution?.Id;
+
+    assertNonNullable(distributionId);
+
+    // When an update names a policy that is not there.
+    await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().updateDistribution(
+        new UpdateDistributionCommand({
+          Id: distributionId,
+          DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+            DefaultCacheBehavior: {
+              TargetOriginId: "site-origin",
+              ViewerProtocolPolicy: "allow-all",
+              CachePolicyId: absentPolicyId,
+            },
+          }),
+        }),
+      );
+    });
+
+    // Then the Behavior still holds the policy it was created with.
+    const distribution = simAws
+      .cloudFront()
+      .getSimDistributionById(distributionId);
+
+    assertNonNullable(distribution);
+    assertArrayLength(distribution.behaviors, 1);
+    assertIdentical(distribution.behaviors[0].cachePolicyId, policy.id);
+  });
+});

--- a/src/service/cloudfront/distribution/sim-cf-distribution-configuration-state.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-configuration-state.ts
@@ -1,4 +1,5 @@
 import type { SimAcmRegistry } from "../../acm/registry/sim-acm-registry.js";
+import type { SimCloudFrontCachePolicyRegistry } from "../cache-policy/sim-cf-cache-policy-registry.js";
 import type { SimCfCustomOriginDispatcher } from "../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../origin-access-control/sim-cf-origin-access-control-registry.js";
@@ -12,7 +13,7 @@ import type { SimCfEdgeFunctions } from "../edge/sim-cf-edge-functions.js";
  *
  * A DistributionConfig is mostly references: a Bucket or a hostname per
  * Origin, a certificate, an origin access control, a response headers policy,
- * a web ACL, a Lambda@Edge function version. None of them belongs to
+ * a cache policy, a web ACL, a Lambda@Edge function version. None of them belongs to
  * CloudFront, and creation and update resolve every one of them the same way,
  * so they travel together.
  */
@@ -22,6 +23,7 @@ export interface SimCfDistributionConfigurationState {
   readonly acmRegistry: SimAcmRegistry | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
   readonly webAclResolver: SimCfWebAclResolver | undefined;
   readonly edgeFunctions: SimCfEdgeFunctions | undefined;
 }

--- a/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
@@ -1,4 +1,5 @@
 import type { SimCloudFrontDistributionConfig } from "../command/create-distribution/create-distribution.command.js";
+import type { SimCloudFrontCachePolicyRegistry } from "../cache-policy/sim-cf-cache-policy-registry.js";
 import type { SimCfCustomOriginDispatcher } from "../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../origin-access-control/sim-cf-origin-access-control-registry.js";
@@ -15,6 +16,7 @@ interface SimCloudFrontDistributionReconfigurerProperties {
   readonly customOriginDispatcher?: SimCfCustomOriginDispatcher | undefined;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
   readonly webAclResolver?: SimCfWebAclResolver | undefined;
 }
 

--- a/src/service/cloudfront/error/sim-cloudfront.error.ts
+++ b/src/service/cloudfront/error/sim-cloudfront.error.ts
@@ -148,6 +148,35 @@ export class SimCloudFrontResponseHeadersPolicyAlreadyExists extends SimCloudFro
 }
 
 /**
+ * Simulated CloudFront NoSuchCachePolicy error.
+ *
+ * What CloudFront answers when a Behavior's `CachePolicyId` names no cache
+ * policy the account holds, at Distribution create or update time rather than
+ * when a request first needs the policy.
+ */
+export class SimCloudFrontNoSuchCachePolicy extends SimCloudFrontError {
+  public override readonly name = "NoSuchCachePolicy";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated CloudFront CachePolicyAlreadyExists error.
+ *
+ * CloudFront requires a cache policy name to be unique within an account, so a
+ * second policy claiming a name is refused rather than created.
+ */
+export class SimCloudFrontCachePolicyAlreadyExists extends SimCloudFrontError {
+  public override readonly name = "CachePolicyAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
  * Simulated CloudFront InvalidOriginAccessControl error.
  *
  * What CloudFront answers when an Origin's `OriginAccessControlId` names no

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -55,6 +55,7 @@ import {
 } from "./origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import type { SimCloudFrontCachePolicyRegistry } from "./cache-policy/sim-cf-cache-policy-registry.js";
 import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
 import type { SimCfDistributionConfigurationState } from "./distribution/sim-cf-distribution-configuration-state.js";
 import type { SimCfWebAclResolver } from "./web-acl/sim-cf-web-acl.js";
@@ -88,6 +89,7 @@ interface SimCloudFrontCommandsProperties extends SimCloudFrontProperties {
   readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
+  readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
 }
 
 /**
@@ -197,6 +199,7 @@ export class SimCloudFrontCommands {
       edgeFunctions,
       originAccessControls: properties.originAccessControls,
       responseHeadersPolicies: properties.responseHeadersPolicies,
+      cachePolicies: properties.cachePolicies,
     };
     const keyValueStoreAccess = new SimCfKeyValueStoreAccess({
       accountId,

--- a/src/service/cloudfront/sim-cloudfront-policies.ts
+++ b/src/service/cloudfront/sim-cloudfront-policies.ts
@@ -1,0 +1,75 @@
+import type {
+  SimCloudFrontCachePolicy,
+  SimCloudFrontCachePolicyId,
+} from "./cache-policy/sim-cf-cache-policy.js";
+import { SimCloudFrontCachePolicyRegistry } from "./cache-policy/sim-cf-cache-policy-registry.js";
+import type {
+  SimCloudFrontResponseHeadersPolicy,
+  SimCloudFrontResponseHeadersPolicyId,
+} from "./response-headers-policy/sim-cf-response-headers-policy.js";
+import { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
+
+/**
+ * The policies one simulated CloudFront holds.
+ *
+ * A cache Behavior names a response headers policy and a cache policy by ID,
+ * and both are stored here. Neither has a create command in this simulation,
+ * so CloudFormation is the only thing that makes one, and these methods are
+ * how it hands a policy over. `SimCloudFront` extends this, and a caller
+ * reaches the policies on the one service object.
+ */
+export class SimCloudFrontPolicies {
+  protected readonly responseHeadersPolicies =
+    new SimCloudFrontResponseHeadersPolicyRegistry();
+  protected readonly cachePolicies = new SimCloudFrontCachePolicyRegistry();
+
+  /**
+   * Store a simulated response headers policy. A name another policy already
+   * holds is refused, as CloudFront refuses one.
+   */
+  addResponseHeadersPolicy(policy: SimCloudFrontResponseHeadersPolicy): void {
+    this.responseHeadersPolicies.add(policy);
+  }
+
+  /**
+   * Forget a simulated response headers policy.
+   */
+  removeResponseHeadersPolicy(
+    policyId: SimCloudFrontResponseHeadersPolicyId,
+  ): void {
+    this.responseHeadersPolicies.remove(policyId);
+  }
+
+  /**
+   * Get a simulated response headers policy by ID.
+   */
+  getResponseHeadersPolicyById(
+    policyId: SimCloudFrontResponseHeadersPolicyId | string,
+  ): SimCloudFrontResponseHeadersPolicy | undefined {
+    return this.responseHeadersPolicies.byId(policyId);
+  }
+
+  /**
+   * Store a simulated cache policy. A name another policy already holds is
+   * refused, as CloudFront refuses one.
+   */
+  addCachePolicy(policy: SimCloudFrontCachePolicy): void {
+    this.cachePolicies.add(policy);
+  }
+
+  /**
+   * Forget a simulated cache policy.
+   */
+  removeCachePolicy(policyId: SimCloudFrontCachePolicyId): void {
+    this.cachePolicies.remove(policyId);
+  }
+
+  /**
+   * Get a simulated cache policy by ID.
+   */
+  getCachePolicyById(
+    policyId: SimCloudFrontCachePolicyId | string,
+  ): SimCloudFrontCachePolicy | undefined {
+    return this.cachePolicies.byId(policyId);
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -37,11 +37,7 @@ import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
 } from "./distribution/sim-cloudfront-distribution.js";
-import type {
-  SimCloudFrontResponseHeadersPolicy,
-  SimCloudFrontResponseHeadersPolicyId,
-} from "./response-headers-policy/sim-cf-response-headers-policy.js";
-import { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
+import { SimCloudFrontPolicies } from "./sim-cloudfront-policies.js";
 import type {
   SimCloudFrontOriginAccessControl,
   SimCloudFrontOriginAccessControlId,
@@ -66,11 +62,9 @@ export type {
 /**
  * Simulated CloudFront. Handles SDK commands. Emulates AWS behaviour and state.
  */
-export class SimCloudFront {
+export class SimCloudFront extends SimCloudFrontPolicies {
   private readonly distributions: SimCloudFrontDistributionMap = new Map();
   private readonly cloudFrontFunctions: SimCloudFrontFunctionMap = new Map();
-  private readonly responseHeadersPolicies =
-    new SimCloudFrontResponseHeadersPolicyRegistry();
   private readonly originAccessControls =
     new SimCloudFrontOriginAccessControlRegistry();
 
@@ -82,6 +76,7 @@ export class SimCloudFront {
   private readonly sdkRouter = new SimCloudFrontSdkCommandRouter(this);
 
   constructor(properties: SimCloudFrontProperties = {}) {
+    super();
     this.accountRegionScope =
       properties.accountRegionScope ?? simAwsAccountRegionScopeFactory.make();
     this.commands = new SimCloudFrontCommands({
@@ -91,6 +86,7 @@ export class SimCloudFront {
       cloudFrontFunctions: this.cloudFrontFunctions,
       originAccessControls: this.originAccessControls,
       responseHeadersPolicies: this.responseHeadersPolicies,
+      cachePolicies: this.cachePolicies,
     });
   }
 
@@ -215,35 +211,6 @@ export class SimCloudFront {
     return this.cloudFrontFunctions.get(
       cloudFrontFunctionName as SimCloudFrontFunctionName,
     );
-  }
-
-  /**
-   * Store a simulated response headers policy.
-   *
-   * There is no CreateResponseHeadersPolicy command here, so CloudFormation is
-   * the only thing that makes one, and this is how it hands the policy over.
-   * A name another policy already holds is refused, as CloudFront refuses one.
-   */
-  addResponseHeadersPolicy(policy: SimCloudFrontResponseHeadersPolicy): void {
-    this.responseHeadersPolicies.add(policy);
-  }
-
-  /**
-   * Forget a simulated response headers policy.
-   */
-  removeResponseHeadersPolicy(
-    policyId: SimCloudFrontResponseHeadersPolicyId,
-  ): void {
-    this.responseHeadersPolicies.remove(policyId);
-  }
-
-  /**
-   * Get a simulated response headers policy by ID.
-   */
-  getResponseHeadersPolicyById(
-    policyId: SimCloudFrontResponseHeadersPolicyId | string,
-  ): SimCloudFrontResponseHeadersPolicy | undefined {
-    return this.responseHeadersPolicies.byId(policyId);
   }
 
   /**


### PR DESCRIPTION
A cache Behavior records the `CachePolicyId` it was given and reports it back through
`GetDistribution`, for the default Behavior and a named one alike, and an update changing the policy
is reported the same way. An `AWS::CloudFront::CachePolicy` Resource creates a policy a Behavior can
name with a `Ref`, and CloudFront's seven managed policy IDs are held from the start. A Behavior
naming `CachingOptimized` deploys with no Resource behind it. An ID that neither a managed policy
nor a created one answers to is refused with `NoSuchCachePolicy` when the Distribution is created or
updated, and a template naming one deploys without it, recorded on `stack.ignoredProperties` the way
an absent response headers policy is. The policy carries its name and its comment. Applying it to a
cache is another issue, since sim CloudFront holds none.

Resolves #1130