### PR TITLE
feat: read CloudFront Functions back

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1260,6 +1260,84 @@ service does. A test that deploys the Stack reports the overrun where the rest o
 ahead of `cdk deploy`. A handler passed as a function reference carries no source to count, and the
 limit leaves it alone.
 
+### Reading a Function back
+
+`ListFunctions` reports the Functions the Account holds. Each carries the `FunctionConfig` it was
+created with and the `FunctionMetadata` CloudFront gave it. `DescribeFunction` reports one by name,
+and `GetFunction` reports its code. A test that wants to know which Function a stack deployed, and
+on which runtime, asks one of these.
+
+```typescript sim-cloudfront-function-read
+/**
+ * Reading a deployed CloudFront Function back.
+ */
+
+import {
+  CreateFunctionCommand,
+  DescribeFunctionCommand,
+  GetFunctionCommand,
+  ListFunctionsCommand,
+} from "@aws-sdk/client-cloudfront";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCloudFront = simAws.cloudFront();
+
+await simCloudFront.createFunction(
+  new CreateFunctionCommand({
+    Name: "beacon",
+    FunctionConfig: {
+      Comment: "Answers the analytics beacon",
+      Runtime: "cloudfront-js-2.0",
+    },
+    FunctionCode: Buffer.from(`
+      function handler(event) {
+        return { statusCode: 204, statusDescription: "No Content" };
+      }
+    `),
+  }),
+);
+
+// CloudFront publishes a new Function in the background.
+await simAws.backgroundTasksComplete();
+
+const listed = await simCloudFront.listFunctions(new ListFunctionsCommand({}));
+
+// cloudfront-js-2.0
+console.log(listed.FunctionList.Items[0]?.FunctionConfig.Runtime);
+
+const described = await simCloudFront.describeFunction(
+  new DescribeFunctionCommand({ Name: "beacon", Stage: "LIVE" }),
+);
+
+// Answers the analytics beacon
+console.log(described.FunctionSummary.FunctionConfig.Comment);
+
+const got = await simCloudFront.getFunction(
+  new GetFunctionCommand({ Name: "beacon" }),
+);
+
+// The source the Function was created with.
+console.log(Buffer.from(got.FunctionCode).toString());
+```
+
+`Stage` picks the copy to read. A Function is created into `DEVELOPMENT` and reaches `LIVE` once
+CloudFront has published it, and an omitted `Stage` means `DEVELOPMENT`, as it does on AWS. Asking
+for the `LIVE` copy of a Function still waiting to publish fails with `NoSuchFunctionExists`, and so
+does a name the Account holds no Function under.
+
+`CreatedTime` and `LastModifiedTime` come off the simulated clock. Freezing time before the deploy
+pins both to an instant the test picked (see
+[Controlling simulated time](https://yulinsim.dev/time/ "Simulated time usage docs")).
+
+A Function backed by a handler function reference was given no source to keep. `GetFunction` answers
+with that handler's own source text. That is the code the Function runs.
+
+The whole list comes back. `Marker` and `MaxItems` paging is left out, matching the paging left out
+of the other simulated listings. `UpdateFunction`, `PublishFunction` and `TestFunction` are not
+simulated.
+
 ### Calling a Function handler without a Distribution
 
 A test of the handler on its own, with no Distribution in front of it, still has to pass it a whole
@@ -2851,7 +2929,8 @@ Sim CloudFront currently supports:
 
 - `CreateDistributionCommand`, `GetDistributionCommand`, `UpdateDistributionCommand` and
   `DeleteDistributionCommand`
-- `CreateFunctionCommand` and `DeleteFunctionCommand`
+- `CreateFunctionCommand`, `ListFunctionsCommand`, `DescribeFunctionCommand`, `GetFunctionCommand`
+  and `DeleteFunctionCommand`
 - Refusing Function code over CloudFront's 10 KB size limit, with `FunctionSizeLimitExceeded`
 - Key value stores, through both the CloudFront client and the key value store data client
 - S3 Origins backed by sim S3 Buckets, reading them as the Bucket policy allows

--- a/docs/services/cloudfront/sim-cloudfront-function-read.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-function-read.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Reading a deployed CloudFront Function back.
+ */
+
+import {
+  CreateFunctionCommand,
+  DescribeFunctionCommand,
+  GetFunctionCommand,
+  ListFunctionsCommand,
+} from "@aws-sdk/client-cloudfront";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCloudFront = simAws.cloudFront();
+
+await simCloudFront.createFunction(
+  new CreateFunctionCommand({
+    Name: "beacon",
+    FunctionConfig: {
+      Comment: "Answers the analytics beacon",
+      Runtime: "cloudfront-js-2.0",
+    },
+    FunctionCode: Buffer.from(`
+      function handler(event) {
+        return { statusCode: 204, statusDescription: "No Content" };
+      }
+    `),
+  }),
+);
+
+// CloudFront publishes a new Function in the background.
+await simAws.backgroundTasksComplete();
+
+const listed = await simCloudFront.listFunctions(new ListFunctionsCommand({}));
+
+// cloudfront-js-2.0
+console.log(listed.FunctionList.Items[0]?.FunctionConfig.Runtime);
+
+const described = await simCloudFront.describeFunction(
+  new DescribeFunctionCommand({ Name: "beacon", Stage: "LIVE" }),
+);
+
+// Answers the analytics beacon
+console.log(described.FunctionSummary.FunctionConfig.Comment);
+
+const got = await simCloudFront.getFunction(
+  new GetFunctionCommand({ Name: "beacon" }),
+);
+
+// The source the Function was created with.
+console.log(Buffer.from(got.FunctionCode).toString());

--- a/src/service/cloudfront/cff/function-code-input/cff-function-code-input.ts
+++ b/src/service/cloudfront/cff/function-code-input/cff-function-code-input.ts
@@ -19,6 +19,23 @@ export function makeCffFunctionCodeInput(
 }
 
 /**
+ * The source a Function reports as the code it was created with.
+ *
+ * A Function created from source keeps the bytes it was given. One created
+ * from a handler function reference was never given any source, so what it
+ * keeps is that handler's own source text, which is the code it runs.
+ */
+export function cffFunctionCodeSource(
+  functionCodeInput: FunctionCodeInput,
+): Uint8Array {
+  if (functionCodeInput instanceof CffUint8ArrayStowaway) {
+    return Buffer.from(functionCodeInput.handlerFunction.toString());
+  }
+
+  return functionCodeInput ?? new Uint8Array();
+}
+
+/**
  * A little trick to allow passing a handler function into CreateFunctionCommand
  * input as if it were a Uint8Array without TypeScript complaining.
  */

--- a/src/service/cloudfront/cff/sim-cf-function-commands.ts
+++ b/src/service/cloudfront/cff/sim-cf-function-commands.ts
@@ -1,0 +1,118 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimCreateFunctionCommand,
+  SimCreateFunctionCommandOutput,
+} from "../command/create-function/create-function.command.js";
+import {
+  CreateFunctionCommandHandler,
+  type SimCloudFrontFunctionMap,
+} from "../command/create-function/create-function.handler.js";
+import type {
+  SimDeleteFunctionCommand,
+  SimDeleteFunctionCommandOutput,
+} from "../command/delete-function/delete-function.command.js";
+import { DeleteFunctionCommandHandler } from "../command/delete-function/delete-function.handler.js";
+import { SimCfDescribeFunction } from "../command/function/sim-cf-describe-function.js";
+import { SimCfFunctionAccess } from "../command/function/sim-cf-function-access.js";
+import type {
+  SimDescribeFunctionCommand,
+  SimDescribeFunctionCommandOutput,
+  SimGetFunctionCommand,
+  SimGetFunctionCommandOutput,
+  SimListFunctionsCommand,
+  SimListFunctionsCommandOutput,
+} from "../command/function/sim-cf-function-command.types.js";
+import { SimCfGetFunction } from "../command/function/sim-cf-get-function.js";
+import { SimCfListFunctions } from "../command/function/sim-cf-list-functions.js";
+import type { SimCloudFrontKeyValueStoreRegistry } from "../key-value-store/sim-cf-key-value-store-registry.js";
+
+interface SimCfFunctionCommandsProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+  readonly keyValueStores: SimCloudFrontKeyValueStoreRegistry;
+}
+
+interface FunctionRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The CloudFront Function commands on the CloudFront client.
+ *
+ * They are grouped here rather than beside the Distribution commands on
+ * SimCloudFrontCommands because they work on their own state, the Account's
+ * Functions, and because there are enough of them to be their own thing.
+ */
+export class SimCfFunctionCommands {
+  private readonly writeState: SimCfFunctionCommandsProperties;
+  private readonly access: SimCfFunctionAccess;
+
+  constructor(properties: SimCfFunctionCommandsProperties) {
+    this.writeState = properties;
+    this.access = new SimCfFunctionAccess(properties);
+  }
+
+  /**
+   * Handle a Create Function Command from the SDK.
+   */
+  async createFunction(
+    command: SimCreateFunctionCommand,
+    options?: FunctionRequestOptions,
+  ): Promise<SimCreateFunctionCommandOutput> {
+    return await new CreateFunctionCommandHandler(this.writeState).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Delete Function Command from the SDK.
+   */
+  async deleteFunction(
+    command: SimDeleteFunctionCommand,
+    options?: FunctionRequestOptions,
+  ): Promise<SimDeleteFunctionCommandOutput> {
+    return await new DeleteFunctionCommandHandler(this.writeState).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a List Functions Command from the SDK.
+   */
+  async listFunctions(
+    command: SimListFunctionsCommand,
+    options?: FunctionRequestOptions,
+  ): Promise<SimListFunctionsCommandOutput> {
+    return await new SimCfListFunctions(this.access).handle(command, options);
+  }
+
+  /**
+   * Handle a Describe Function Command from the SDK.
+   */
+  async describeFunction(
+    command: SimDescribeFunctionCommand,
+    options?: FunctionRequestOptions,
+  ): Promise<SimDescribeFunctionCommandOutput> {
+    return await new SimCfDescribeFunction(this.access).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Get Function Command from the SDK.
+   */
+  async getFunction(
+    command: SimGetFunctionCommand,
+    options?: FunctionRequestOptions,
+  ): Promise<SimGetFunctionCommandOutput> {
+    return await new SimCfGetFunction(this.access).handle(command, options);
+  }
+}

--- a/src/service/cloudfront/cff/sim-cff-configuration.ts
+++ b/src/service/cloudfront/cff/sim-cff-configuration.ts
@@ -1,0 +1,56 @@
+import { makeSimCloudFrontETag } from "../sim-cf-etag.js";
+
+/**
+ * The JavaScript runtime a CloudFront Function is written against.
+ */
+export type SimCloudFrontFunctionRuntime =
+  | "cloudfront-js-1.0"
+  | "cloudfront-js-2.0";
+
+export interface SimCffConfigurationProperties {
+  /** The `FunctionConfig` comment, which CloudFront requires and reports. */
+  readonly comment?: string | undefined;
+  /** The `FunctionConfig` runtime this Function is written against. */
+  readonly runtime?: SimCloudFrontFunctionRuntime | undefined;
+  /** The source this Function was created with, which GetFunction reports. */
+  readonly functionCode?: Uint8Array | undefined;
+  /** When this Function was created, off the simulation's clock. */
+  readonly createdTime?: Date | undefined;
+}
+
+/**
+ * What a CloudFront Function was created with, which every read of it reports.
+ *
+ * This is the `FunctionConfig` and `FunctionMetadata` pair the API answers
+ * with, held together because they are written once at creation and read
+ * together afterwards. The Function itself is what runs; this is what it says
+ * about itself.
+ */
+export class SimCffConfiguration {
+  public readonly comment: string;
+  public readonly runtime: SimCloudFrontFunctionRuntime;
+  public readonly functionCode: Uint8Array;
+
+  /**
+   * When this Function was created, and when it was last changed.
+   *
+   * They are the same instant here. What moves the modified time apart from
+   * the created time in CloudFront is UpdateFunction and PublishFunction, and
+   * neither is simulated yet.
+   */
+  public readonly createdTime: Date;
+  public readonly lastModifiedTime: Date;
+
+  /**
+   * The version of this Function a write has to carry to be accepted.
+   */
+  public readonly etag: string = makeSimCloudFrontETag();
+
+  constructor(properties: SimCffConfigurationProperties = {}) {
+    this.comment = properties.comment ?? "";
+    this.runtime = properties.runtime ?? "cloudfront-js-2.0";
+    this.functionCode = properties.functionCode ?? new Uint8Array();
+    this.createdTime = properties.createdTime ?? new Date();
+    this.lastModifiedTime = this.createdTime;
+  }
+}

--- a/src/service/cloudfront/cff/sim-cff-stage.ts
+++ b/src/service/cloudfront/cff/sim-cff-stage.ts
@@ -1,0 +1,51 @@
+import { SimCloudFrontInvalidArgument } from "../error/sim-cloudfront.error.js";
+import type { SimCloudFrontFunction } from "./sim-cloudfront-function.js";
+
+/**
+ * The two stages a CloudFront Function can be read from.
+ *
+ * A Function is created into DEVELOPMENT and reaches LIVE once it is
+ * published. LIVE is the copy a Distribution runs.
+ */
+export type SimCloudFrontFunctionStage = "DEVELOPMENT" | "LIVE";
+
+const simCffStages = new Set<SimCloudFrontFunctionStage>([
+  "DEVELOPMENT",
+  "LIVE",
+]);
+
+/**
+ * Read the stage a request asked for.
+ *
+ * CloudFront defaults an omitted `Stage` to DEVELOPMENT, the copy a Function
+ * is created into, and refuses a value that names neither stage.
+ */
+export function simCffRequestedStage(
+  stage: string | undefined,
+): SimCloudFrontFunctionStage {
+  if (stage === undefined) {
+    return "DEVELOPMENT";
+  }
+
+  if (!simCffStages.has(stage as SimCloudFrontFunctionStage)) {
+    throw new SimCloudFrontInvalidArgument(
+      `CloudFront Function stage ${stage} is neither DEVELOPMENT nor LIVE`,
+    );
+  }
+
+  return stage as SimCloudFrontFunctionStage;
+}
+
+/**
+ * Whether a Function can be read from a stage.
+ *
+ * Every Function is in DEVELOPMENT from the moment it is created. It reaches
+ * LIVE once it is published, so a Function still waiting to publish answers to
+ * DEVELOPMENT alone.
+ */
+export function simCffInStage(
+  cloudFrontFunction: SimCloudFrontFunction,
+  stage: SimCloudFrontFunctionStage,
+): boolean {
+  return stage === "DEVELOPMENT" || cloudFrontFunction.status !== "UNPUBLISHED";
+}

--- a/src/service/cloudfront/cff/sim-cloudfront-function.ts
+++ b/src/service/cloudfront/cff/sim-cloudfront-function.ts
@@ -7,6 +7,10 @@ import {
   type SimAwsAccountId,
 } from "../../aws/sim-aws-account.js";
 import type { SimCloudFrontKeyValueStore } from "../key-value-store/sim-cf-key-value-store.js";
+import {
+  SimCffConfiguration,
+  type SimCffConfigurationProperties,
+} from "./sim-cff-configuration.js";
 import { cffCloudFrontModule } from "./kvs/cff-cloudfront-module.js";
 import { simCffCloudFrontGlobal } from "./kvs/sim-cff-cloudfront-global.js";
 
@@ -20,7 +24,7 @@ export type CloudFrontFunctionStatus =
   | "UNASSOCIATED"
   | "ASSOCIATED";
 
-interface SimCloudFrontFunctionProperties {
+interface SimCloudFrontFunctionProperties extends SimCffConfigurationProperties {
   name: SimCloudFrontFunctionName | string;
   status?: CloudFrontFunctionStatus;
   readonly accountId?: SimAwsAccountId;
@@ -45,6 +49,11 @@ export class SimCloudFrontFunction {
   public readonly name: SimCloudFrontFunctionName;
   public readonly accountId: SimAwsAccountId;
 
+  /**
+   * What this Function was created with, which every read of it reports.
+   */
+  public readonly config: SimCffConfiguration;
+
   #status: CloudFrontFunctionStatus;
   private readonly handlerFunction: CloudFrontFunction.Handler;
   private readonly eventAdapter: SimCffEventAdapter;
@@ -63,6 +72,7 @@ export class SimCloudFrontFunction {
     this.name = name as SimCloudFrontFunctionName;
     this.#status = status;
     this.accountId = accountId;
+    this.config = new SimCffConfiguration(properties);
     this.handlerFunction = handlerFunction;
     this.eventAdapter = eventAdapter;
     this.associatedKeyValueStore = properties.keyValueStore;

--- a/src/service/cloudfront/command/create-function/create-function.handler.ts
+++ b/src/service/cloudfront/command/create-function/create-function.handler.ts
@@ -8,7 +8,10 @@ import {
   SimCloudFrontFunction,
   type SimCloudFrontFunctionName,
 } from "../../cff/sim-cloudfront-function.js";
-import { CffUint8ArrayFunctionCodeExtractor } from "../../cff/function-code-input/cff-function-code-input.js";
+import {
+  cffFunctionCodeSource,
+  CffUint8ArrayFunctionCodeExtractor,
+} from "../../cff/function-code-input/cff-function-code-input.js";
 import { cffCloudFrontModule } from "../../cff/kvs/cff-cloudfront-module.js";
 import {
   type BackgroundScheduler,
@@ -117,6 +120,12 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       accountId: this.accountId,
       handlerFunction,
       keyValueStore,
+      // The config a Function was created with is what every read of it
+      // reports, so it is kept rather than only acted on here.
+      comment: command.input.FunctionConfig?.Comment,
+      runtime: command.input.FunctionConfig?.Runtime,
+      functionCode: cffFunctionCodeSource(command.input.FunctionCode),
+      createdTime: this.background.now(),
     });
 
     this.cloudFrontFunctions.set(simCff.name, simCff);

--- a/src/service/cloudfront/command/function/sim-cf-describe-function.ts
+++ b/src/service/cloudfront/command/function/sim-cf-describe-function.ts
@@ -1,0 +1,49 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfFunctionAccess } from "./sim-cf-function-access.js";
+import { simCffRequestedStage } from "../../cff/sim-cff-stage.js";
+import { simCfFunctionSummary } from "./sim-cf-function-summary.js";
+import type {
+  SimDescribeFunctionCommand,
+  SimDescribeFunctionCommandOutput,
+} from "./sim-cf-function-command.types.js";
+
+/**
+ * Simulated CloudFront DescribeFunction command.
+ *
+ * This is the Function's configuration without its code. GetFunction is the
+ * one that answers with the code.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/DescribeFunctionCommand/
+ */
+export class SimCfDescribeFunction {
+  private static readonly action = "cloudfront:DescribeFunction";
+
+  constructor(private readonly access: SimCfFunctionAccess) {}
+
+  /**
+   * Describe one sim CloudFront Function.
+   */
+  async handle(
+    command: SimDescribeFunctionCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimDescribeFunctionCommandOutput> {
+    assertDefined(command.input.Name, "DescribeFunctionCommand.input.Name");
+    const stage = simCffRequestedStage(command.input.Stage);
+
+    await this.access.background.sequence();
+
+    const cloudFrontFunction = this.access.authorizedByName(
+      SimCfDescribeFunction.action,
+      command.input.Name,
+      stage,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      FunctionSummary: simCfFunctionSummary(cloudFrontFunction, stage),
+      ETag: cloudFrontFunction.config.etag,
+    };
+  }
+}

--- a/src/service/cloudfront/command/function/sim-cf-function-access.ts
+++ b/src/service/cloudfront/command/function/sim-cf-function-access.ts
@@ -1,0 +1,82 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type { SimCloudFrontFunctionStage } from "../../cff/sim-cff-stage.js";
+import type { SimCloudFrontFunction } from "../../cff/sim-cloudfront-function.js";
+import { simCfAuthorize } from "../../sim-cf-authorize.js";
+import type { SimCloudFrontFunctionMap } from "../create-function/create-function.handler.js";
+import { simCfFunctionInStage } from "./sim-cf-function-lookup.js";
+
+interface SimCfFunctionAccessProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * What every command reading a Function back needs: the Functions, IAM, and
+ * the clock.
+ *
+ * ListFunctions, DescribeFunction and GetFunction authorize the same way and
+ * resolve a Function the same way, so the wiring is here once rather than in
+ * each of them. Each command class is then only its own AWS behaviour.
+ */
+export class SimCfFunctionAccess {
+  public readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
+  public readonly background: BackgroundScheduler;
+
+  private readonly accountId: SimAwsAccountId;
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimCfFunctionAccessProperties) {
+    this.accountId = properties.accountId;
+    this.cloudFrontFunctions = properties.cloudFrontFunctions;
+    this.iam = properties.iam;
+    this.background = properties.background;
+  }
+
+  /**
+   * Ensure the caller may take an action on a Function ARN.
+   */
+  authorize(action: string, resource: string, caller?: SimAwsCaller): void {
+    simCfAuthorize({ iam: this.iam, action, resource, caller });
+  }
+
+  /**
+   * Ensure the caller may take an action on any Function in the Account.
+   *
+   * ListFunctions names no Function, so a policy granting it has to use the
+   * wildcard, and this is what it is authorized against.
+   */
+  authorizeAnyFunction(action: string, caller?: SimAwsCaller): void {
+    this.authorize(
+      action,
+      `arn:aws:cloudfront::${this.accountId}:function/*`,
+      caller,
+    );
+  }
+
+  /**
+   * Resolve a Function in a stage, having authorized the action against it.
+   *
+   * The ARN is built from the name the caller gave, so authorization happens
+   * before the Function map is read and an unauthorized caller is refused
+   * whether or not the name resolves.
+   */
+  authorizedByName(
+    action: string,
+    functionName: string,
+    stage: SimCloudFrontFunctionStage,
+    caller?: SimAwsCaller,
+  ): SimCloudFrontFunction {
+    this.authorize(
+      action,
+      `arn:aws:cloudfront::${this.accountId}:function/${functionName}`,
+      caller,
+    );
+
+    return simCfFunctionInStage(this.cloudFrontFunctions, functionName, stage);
+  }
+}

--- a/src/service/cloudfront/command/function/sim-cf-function-command.types.ts
+++ b/src/service/cloudfront/command/function/sim-cf-function-command.types.ts
@@ -1,0 +1,105 @@
+/**
+ * Structural types for the commands that read a CloudFront Function back.
+ *
+ * ListFunctions, DescribeFunction and GetFunction all address a Function by
+ * name and a stage, and answer with the same summary shape, so their types are
+ * together here rather than one file each.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/
+ */
+
+import type { SimArn } from "../../../aws/arn.js";
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCloudFrontFunctionRuntime } from "../../cff/sim-cff-configuration.js";
+import type { SimCloudFrontFunctionStage } from "../../cff/sim-cff-stage.js";
+
+/**
+ * Minimal structural sim CloudFront Function config.
+ */
+export interface SimCfFunctionConfig {
+  Comment: string;
+  Runtime: SimCloudFrontFunctionRuntime;
+  KeyValueStoreAssociations?: {
+    Quantity: number;
+    Items: { KeyValueStoreARN: SimArn }[];
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront Function metadata.
+ */
+export interface SimCfFunctionMetadata {
+  FunctionARN: SimArn;
+  Stage: SimCloudFrontFunctionStage;
+  CreatedTime: Date;
+  LastModifiedTime: Date;
+}
+
+/**
+ * Minimal structural sim CloudFront Function summary.
+ */
+export interface SimCfFunctionSummary {
+  Name: string;
+  Status: string;
+  FunctionConfig: SimCfFunctionConfig;
+  FunctionMetadata: SimCfFunctionMetadata;
+}
+
+/**
+ * Minimal structural sim CloudFront ListFunctions command.
+ */
+export interface SimListFunctionsCommand {
+  readonly input: {
+    readonly Stage?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront ListFunctions output.
+ */
+export interface SimListFunctionsCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  FunctionList: {
+    Quantity: number;
+    Items: SimCfFunctionSummary[];
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront DescribeFunction command.
+ */
+export interface SimDescribeFunctionCommand {
+  readonly input: {
+    readonly Name?: string | undefined;
+    readonly Stage?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront DescribeFunction output.
+ */
+export interface SimDescribeFunctionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  FunctionSummary: SimCfFunctionSummary;
+  ETag: string;
+}
+
+/**
+ * Minimal structural sim CloudFront GetFunction command.
+ */
+export interface SimGetFunctionCommand {
+  readonly input: {
+    readonly Name?: string | undefined;
+    readonly Stage?: string | undefined;
+  };
+}
+
+/**
+ * Minimal structural sim CloudFront GetFunction output.
+ */
+export interface SimGetFunctionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+  FunctionCode: Uint8Array;
+  ETag: string;
+  ContentType: string;
+}

--- a/src/service/cloudfront/command/function/sim-cf-function-lookup.ts
+++ b/src/service/cloudfront/command/function/sim-cf-function-lookup.ts
@@ -1,0 +1,43 @@
+import {
+  simCffInStage,
+  type SimCloudFrontFunctionStage,
+} from "../../cff/sim-cff-stage.js";
+import type {
+  SimCloudFrontFunction,
+  SimCloudFrontFunctionName,
+} from "../../cff/sim-cloudfront-function.js";
+import { SimCloudFrontNoSuchFunctionExists } from "../../error/sim-cloudfront.error.js";
+import type { SimCloudFrontFunctionMap } from "../create-function/create-function.handler.js";
+
+/**
+ * Resolve a Function a stage can be read from.
+ *
+ * A name the Account holds no Function under is refused, and so is one whose
+ * Function has not reached the stage asked for. Both answer with
+ * NoSuchFunctionExists. That is what CloudFront answers when a stage holds
+ * nothing under the name asked for.
+ */
+export function simCfFunctionInStage(
+  cloudFrontFunctions: SimCloudFrontFunctionMap,
+  functionName: string,
+  stage: SimCloudFrontFunctionStage,
+): SimCloudFrontFunction {
+  const cloudFrontFunction = cloudFrontFunctions.get(
+    functionName as SimCloudFrontFunctionName,
+  );
+
+  if (cloudFrontFunction === undefined) {
+    throw new SimCloudFrontNoSuchFunctionExists(
+      `No sim CloudFront Function named ${functionName}`,
+    );
+  }
+
+  if (!simCffInStage(cloudFrontFunction, stage)) {
+    throw new SimCloudFrontNoSuchFunctionExists(
+      `Sim CloudFront Function ${functionName} has not been published, so it ` +
+        `is in DEVELOPMENT and not in ${stage}`,
+    );
+  }
+
+  return cloudFrontFunction;
+}

--- a/src/service/cloudfront/command/function/sim-cf-function-summary.ts
+++ b/src/service/cloudfront/command/function/sim-cf-function-summary.ts
@@ -1,0 +1,38 @@
+import type { SimCloudFrontFunctionStage } from "../../cff/sim-cff-stage.js";
+import type { SimCloudFrontFunction } from "../../cff/sim-cloudfront-function.js";
+import type { SimCfFunctionSummary } from "./sim-cf-function-command.types.js";
+
+/**
+ * Describe a Function the way ListFunctions and DescribeFunction both do.
+ *
+ * The stage comes from the request rather than the Function, because a
+ * published Function is in both stages and answers under whichever one was
+ * asked for.
+ */
+export function simCfFunctionSummary(
+  cloudFrontFunction: SimCloudFrontFunction,
+  stage: SimCloudFrontFunctionStage,
+): SimCfFunctionSummary {
+  const keyValueStore = cloudFrontFunction.keyValueStore;
+
+  return {
+    Name: cloudFrontFunction.name,
+    Status: cloudFrontFunction.status,
+    FunctionConfig: {
+      Comment: cloudFrontFunction.config.comment,
+      Runtime: cloudFrontFunction.config.runtime,
+      ...(keyValueStore !== undefined && {
+        KeyValueStoreAssociations: {
+          Quantity: 1,
+          Items: [{ KeyValueStoreARN: keyValueStore.arn }],
+        },
+      }),
+    },
+    FunctionMetadata: {
+      FunctionARN: cloudFrontFunction.arn,
+      Stage: stage,
+      CreatedTime: cloudFrontFunction.config.createdTime,
+      LastModifiedTime: cloudFrontFunction.config.lastModifiedTime,
+    },
+  };
+}

--- a/src/service/cloudfront/command/function/sim-cf-get-function.ts
+++ b/src/service/cloudfront/command/function/sim-cf-get-function.ts
@@ -1,0 +1,50 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfFunctionAccess } from "./sim-cf-function-access.js";
+import { simCffRequestedStage } from "../../cff/sim-cff-stage.js";
+import type {
+  SimGetFunctionCommand,
+  SimGetFunctionCommandOutput,
+} from "./sim-cf-function-command.types.js";
+
+/**
+ * Simulated CloudFront GetFunction command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/GetFunctionCommand/
+ */
+export class SimCfGetFunction {
+  private static readonly action = "cloudfront:GetFunction";
+
+  constructor(private readonly access: SimCfFunctionAccess) {}
+
+  /**
+   * Get one sim CloudFront Function's code.
+   *
+   * A Function created from source answers with the source it was given. One
+   * created from a handler function reference has no uploaded source, and
+   * answers with that handler's own source text. That is the code it runs.
+   */
+  async handle(
+    command: SimGetFunctionCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimGetFunctionCommandOutput> {
+    assertDefined(command.input.Name, "GetFunctionCommand.input.Name");
+    const stage = simCffRequestedStage(command.input.Stage);
+
+    await this.access.background.sequence();
+
+    const cloudFrontFunction = this.access.authorizedByName(
+      SimCfGetFunction.action,
+      command.input.Name,
+      stage,
+      options?.caller,
+    );
+
+    return {
+      $metadata: {},
+      FunctionCode: cloudFrontFunction.config.functionCode,
+      ETag: cloudFrontFunction.config.etag,
+      ContentType: "application/octet-stream",
+    };
+  }
+}

--- a/src/service/cloudfront/command/function/sim-cf-list-functions.ts
+++ b/src/service/cloudfront/command/function/sim-cf-list-functions.ts
@@ -1,0 +1,59 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfFunctionAccess } from "./sim-cf-function-access.js";
+import {
+  simCffInStage,
+  simCffRequestedStage,
+} from "../../cff/sim-cff-stage.js";
+import { simCfFunctionSummary } from "./sim-cf-function-summary.js";
+import type {
+  SimListFunctionsCommand,
+  SimListFunctionsCommandOutput,
+} from "./sim-cf-function-command.types.js";
+
+/**
+ * Simulated CloudFront ListFunctions command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/ListFunctionsCommand/
+ */
+export class SimCfListFunctions {
+  private static readonly action = "cloudfront:ListFunctions";
+
+  constructor(private readonly access: SimCfFunctionAccess) {}
+
+  /**
+   * List this Account's sim CloudFront Functions in one stage.
+   *
+   * The whole list comes back. `Marker` and `MaxItems` are the paging every
+   * other simulated listing leaves out, so there is no `NextMarker` either.
+   */
+  async handle(
+    command: SimListFunctionsCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimListFunctionsCommandOutput> {
+    const stage = simCffRequestedStage(command.input.Stage);
+
+    await this.access.background.sequence();
+
+    // Listing is authorized across the Account rather than per Function, which
+    // is what a policy for this action grants.
+    this.access.authorizeAnyFunction(
+      SimCfListFunctions.action,
+      options?.caller,
+    );
+
+    const cloudFrontFunctions = this.access.cloudFrontFunctions
+      .values()
+      .filter((cloudFrontFunction) => simCffInStage(cloudFrontFunction, stage))
+      .toArray();
+
+    return {
+      $metadata: {},
+      FunctionList: {
+        Quantity: cloudFrontFunctions.length,
+        Items: cloudFrontFunctions.map((cloudFrontFunction) =>
+          simCfFunctionSummary(cloudFrontFunction, stage),
+        ),
+      },
+    };
+  }
+}

--- a/src/service/cloudfront/command/function/sim-cf-read-functions-iam.iso.test.ts
+++ b/src/service/cloudfront/command/function/sim-cf-read-functions-iam.iso.test.ts
@@ -1,0 +1,181 @@
+import {
+  CreateFunctionCommand,
+  DescribeFunctionCommand,
+  GetFunctionCommand,
+  ListFunctionsCommand,
+} from "@aws-sdk/client-cloudfront";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+
+const functionCode = Buffer.from(`
+  function handler(event) {
+    return event.request;
+  }
+`);
+
+/**
+ * A Role in the given Account, granted one policy statement.
+ */
+async function roleGranted(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  roleName: string,
+  statement: object,
+): Promise<string> {
+  const simIam = simAws.account(accountId).iam();
+  const roleCreation = await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: "FunctionAccess",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+
+  return roleCreation.Role.Arn;
+}
+
+/**
+ * A published Function in the given Account, created by its root caller.
+ */
+async function givenFunction(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+  name: string,
+): Promise<void> {
+  await simAws
+    .account(accountId)
+    .cloudFront()
+    .createFunction(
+      new CreateFunctionCommand({
+        Name: name,
+        FunctionConfig: { Comment: name, Runtime: "cloudfront-js-2.0" },
+        FunctionCode: functionCode,
+      }),
+    );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("CloudFront Function read IAM authorization", () => {
+  it("allows a Role granted the read actions on the Function", async () => {
+    // Given a Function, and a Role allowed to read it.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    await givenFunction(simAws, accountId, "readable-cff");
+    const roleArn = await roleGranted(simAws, accountId, "FunctionReader", {
+      Effect: "Allow",
+      Action: ["cloudfront:DescribeFunction", "cloudfront:GetFunction"],
+      Resource: `arn:aws:cloudfront::${accountId}:function/readable-cff`,
+    });
+    const simCloudFront = simAws.account(accountId).cloudFront();
+    const caller = { kind: "arn", arn: roleArn } as const;
+
+    // When the Role describes the Function and reads its code.
+    const described = await simCloudFront.describeFunction(
+      new DescribeFunctionCommand({ Name: "readable-cff" }),
+      { caller },
+    );
+    const got = await simCloudFront.getFunction(
+      new GetFunctionCommand({ Name: "readable-cff" }),
+      { caller },
+    );
+
+    // Then IAM permits both.
+    assertIdentical(described.FunctionSummary.Name, "readable-cff");
+    assertIdentical(got.ETag, described.ETag);
+  });
+
+  it("denies a listing to a Role granted only one Function", async () => {
+    // Given a Role allowed to read one Function by name, which is not what a
+    // policy for the Account-wide listing has to say.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    await givenFunction(simAws, accountId, "readable-cff");
+    const roleArn = await roleGranted(simAws, accountId, "OneFunctionReader", {
+      Effect: "Allow",
+      Action: "cloudfront:ListFunctions",
+      Resource: `arn:aws:cloudfront::${accountId}:function/readable-cff`,
+    });
+
+    // When the Role lists the Account's Functions.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .account(accountId)
+        .cloudFront()
+        .listFunctions(new ListFunctionsCommand({}), {
+          caller: { kind: "arn", arn: roleArn },
+        }),
+    );
+
+    // Then IAM refuses it.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "cloudfront:ListFunctions");
+  });
+
+  it("allows a listing to a Role granted the Function wildcard", async () => {
+    // Given a Function, and a Role allowed to list any of them.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    await givenFunction(simAws, accountId, "readable-cff");
+    const roleArn = await roleGranted(simAws, accountId, "FunctionLister", {
+      Effect: "Allow",
+      Action: "cloudfront:ListFunctions",
+      Resource: `arn:aws:cloudfront::${accountId}:function/*`,
+    });
+
+    // When the Role lists the Account's Functions.
+    const listed = await simAws
+      .account(accountId)
+      .cloudFront()
+      .listFunctions(new ListFunctionsCommand({}), {
+        caller: { kind: "arn", arn: roleArn },
+      });
+
+    // Then IAM permits it.
+    assertIdentical(listed.FunctionList.Quantity, 1);
+  });
+
+  it("denies a caller before it learns whether a Function exists", async () => {
+    // Given a simulation holding no Function of that name.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When an anonymous caller describes it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.describeFunction(
+        new DescribeFunctionCommand({ Name: "no-such-cff" }),
+        { caller: { kind: "anonymous" } },
+      ),
+    );
+
+    // Then IAM refuses it rather than answering NoSuchFunctionExists, so a
+    // caller without permission learns nothing about what the Account holds.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "cloudfront:DescribeFunction");
+  });
+});

--- a/src/service/cloudfront/command/function/sim-cf-read-functions.iso.test.ts
+++ b/src/service/cloudfront/command/function/sim-cf-read-functions.iso.test.ts
@@ -1,0 +1,384 @@
+import {
+  CreateFunctionCommand,
+  DescribeFunctionCommand,
+  GetFunctionCommand,
+  ListFunctionsCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CloudFrontFunction } from "../../typings/cloudfront-functions.namespace.js";
+import { SimCloudFrontInvalidArgument } from "../../error/sim-cloudfront.error.js";
+import { SimCloudFrontNoSuchFunctionExists } from "../../error/sim-cloudfront.error.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+
+const beaconCode = `
+  function handler(event) {
+    return { statusCode: 204, statusDescription: "No Content" };
+  }
+`;
+
+/**
+ * A simulation holding one published Function, the way a deploy leaves one.
+ */
+async function givenPublishedFunction(name: string): Promise<{
+  readonly simAws: SimAws;
+  readonly simCloudFront: SimCloudFront;
+}> {
+  const simAws = new SimAws();
+  const simCloudFront = simAws.cloudFront();
+
+  await simCloudFront.createFunction(
+    new CreateFunctionCommand({
+      Name: name,
+      FunctionConfig: {
+        Comment: "Answers the analytics beacon",
+        Runtime: "cloudfront-js-2.0",
+      },
+      FunctionCode: Buffer.from(beaconCode),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return { simAws, simCloudFront };
+}
+
+describe("CloudFront ListFunctionsCommand", () => {
+  it("lists a Function with the config it was created with", async () => {
+    // Given a published CloudFront Function.
+    const { simCloudFront } = await givenPublishedFunction("beacon-cff");
+
+    // When the Account's Functions are listed.
+    const listed = await simCloudFront.listFunctions(
+      new ListFunctionsCommand({}),
+    );
+
+    // Then the Function comes back carrying its comment and its runtime.
+    assertIdentical(listed.FunctionList.Quantity, 1);
+    assertArrayLength(listed.FunctionList.Items, 1);
+    const summary = listed.FunctionList.Items[0];
+    assertNonNullable(summary);
+    assertIdentical(summary.Name, "beacon-cff");
+    assertIdentical(summary.Status, "UNASSOCIATED");
+    assertIdentical(summary.FunctionConfig.Runtime, "cloudfront-js-2.0");
+    assertIdentical(
+      summary.FunctionConfig.Comment,
+      "Answers the analytics beacon",
+    );
+    assertIdentical(summary.FunctionMetadata.Stage, "DEVELOPMENT");
+    assertStringIncludes(
+      summary.FunctionMetadata.FunctionARN,
+      ":function/beacon-cff",
+    );
+  });
+
+  it("lists a Function a template deployed", async () => {
+    // Given a stack that declares a CloudFront Function.
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplate({
+      template: {
+        Resources: {
+          BeaconFunction: {
+            Type: "AWS::CloudFront::Function",
+            Properties: {
+              Name: "template-beacon-cff",
+              FunctionConfig: {
+                Comment: "Deployed from a template",
+                Runtime: "cloudfront-js-2.0",
+              },
+              FunctionCode: beaconCode,
+            },
+          },
+        },
+      },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // When the Account's Functions are listed.
+    const listed = await simAws
+      .cloudFront()
+      .listFunctions(new ListFunctionsCommand({}));
+
+    // Then the template's Function reports the config the template gave it.
+    const summary = listed.FunctionList.Items[0];
+    assertNonNullable(summary);
+    assertIdentical(summary.Name, "template-beacon-cff");
+    assertIdentical(summary.FunctionConfig.Comment, "Deployed from a template");
+    assertIdentical(summary.FunctionConfig.Runtime, "cloudfront-js-2.0");
+  });
+
+  it("reports the key value store a Function is associated with", async () => {
+    // Given a Function reading a key value store.
+    const simAws = new SimAws();
+    const simCloudFront = simAws.cloudFront();
+    const storeCreation = await simCloudFront
+      .keyValueStores()
+      .createKeyValueStore({ input: { Name: "redirects" } });
+    await simCloudFront.createFunction(
+      new CreateFunctionCommand({
+        Name: "redirecting-cff",
+        FunctionConfig: {
+          Comment: "Reads the redirect table",
+          Runtime: "cloudfront-js-2.0",
+          KeyValueStoreAssociations: {
+            Quantity: 1,
+            Items: [{ KeyValueStoreARN: storeCreation.KeyValueStore.ARN }],
+          },
+        },
+        FunctionCode: Buffer.from(beaconCode),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the Functions are listed.
+    const listed = await simCloudFront.listFunctions(
+      new ListFunctionsCommand({}),
+    );
+
+    // Then the association comes back with the store's ARN.
+    const associations =
+      listed.FunctionList.Items[0]?.FunctionConfig.KeyValueStoreAssociations;
+    assertNonNullable(associations);
+    assertIdentical(associations.Quantity, 1);
+    assertIdentical(
+      associations.Items[0]?.KeyValueStoreARN,
+      storeCreation.KeyValueStore.ARN,
+    );
+  });
+
+  it("leaves an unpublished Function out of the LIVE stage", async () => {
+    // Given a Function that has been created and not yet published.
+    const simAws = new SimAws();
+    const simCloudFront = simAws.cloudFront();
+    await simCloudFront.createFunction(
+      new CreateFunctionCommand({
+        Name: "unpublished-cff",
+        FunctionConfig: { Comment: "", Runtime: "cloudfront-js-2.0" },
+        FunctionCode: Buffer.from(beaconCode),
+      }),
+    );
+
+    // When each stage is listed.
+    const development = await simCloudFront.listFunctions(
+      new ListFunctionsCommand({ Stage: "DEVELOPMENT" }),
+    );
+    const live = await simCloudFront.listFunctions(
+      new ListFunctionsCommand({ Stage: "LIVE" }),
+    );
+
+    // Then it is in DEVELOPMENT alone until CloudFront publishes it.
+    assertIdentical(development.FunctionList.Quantity, 1);
+    assertIdentical(live.FunctionList.Quantity, 0);
+
+    await simAws.backgroundTasksComplete();
+    const published = await simCloudFront.listFunctions(
+      new ListFunctionsCommand({ Stage: "LIVE" }),
+    );
+    assertIdentical(published.FunctionList.Quantity, 1);
+    assertIdentical(
+      published.FunctionList.Items[0]?.FunctionMetadata.Stage,
+      "LIVE",
+    );
+  });
+
+  it("lists nothing for an Account holding no Function", async () => {
+    // Given a simulated CloudFront with no Functions.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When the Functions are listed.
+    const listed = await simCloudFront.listFunctions(
+      new ListFunctionsCommand({}),
+    );
+
+    // Then the list is empty rather than missing.
+    assertIdentical(listed.FunctionList.Quantity, 0);
+    assertArrayLength(listed.FunctionList.Items, 0);
+  });
+
+  it("refuses a stage that names neither DEVELOPMENT nor LIVE", async () => {
+    // Given a published CloudFront Function.
+    const { simCloudFront } = await givenPublishedFunction("beacon-cff");
+
+    // When a listing asks for a stage CloudFront does not have.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.listFunctions(
+        new ListFunctionsCommand({ Stage: "STAGING" as "LIVE" }),
+      ),
+    );
+
+    // Then it is refused rather than answered with everything.
+    assertInstanceOf(error, SimCloudFrontInvalidArgument);
+    assertStringIncludes(error.message, "STAGING");
+  });
+});
+
+describe("CloudFront DescribeFunctionCommand", () => {
+  it("describes one Function by name", async () => {
+    // Given a published CloudFront Function.
+    const { simCloudFront } = await givenPublishedFunction("beacon-cff");
+
+    // When it is described by name.
+    const described = await simCloudFront.describeFunction(
+      new DescribeFunctionCommand({ Name: "beacon-cff" }),
+    );
+
+    // Then its config and its metadata come back, with the Function's ETag.
+    assertIdentical(described.FunctionSummary.Name, "beacon-cff");
+    assertIdentical(
+      described.FunctionSummary.FunctionConfig.Runtime,
+      "cloudfront-js-2.0",
+    );
+    assertUndefined(
+      described.FunctionSummary.FunctionConfig.KeyValueStoreAssociations,
+    );
+    assertStringIncludes(described.ETag, "E");
+    assertIdentical(
+      described.FunctionSummary.FunctionMetadata.CreatedTime.getTime(),
+      described.FunctionSummary.FunctionMetadata.LastModifiedTime.getTime(),
+    );
+  });
+
+  it("answers a name no Function holds with NoSuchFunctionExists", async () => {
+    // Given a simulated CloudFront without the requested Function.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When a missing Function is described.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.describeFunction(
+        new DescribeFunctionCommand({ Name: "no-such-cff" }),
+      ),
+    );
+
+    // Then CloudFront answers with its missing-Function error.
+    assertInstanceOf(error, SimCloudFrontNoSuchFunctionExists);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+  });
+
+  it("answers an unpublished Function in LIVE with NoSuchFunctionExists", async () => {
+    // Given a Function that has been created and not yet published.
+    const simCloudFront = new SimAws().cloudFront();
+    await simCloudFront.createFunction(
+      new CreateFunctionCommand({
+        Name: "unpublished-cff",
+        FunctionConfig: { Comment: "", Runtime: "cloudfront-js-2.0" },
+        FunctionCode: Buffer.from(beaconCode),
+      }),
+    );
+
+    // When the LIVE copy is described.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.describeFunction(
+        new DescribeFunctionCommand({
+          Name: "unpublished-cff",
+          Stage: "LIVE",
+        }),
+      ),
+    );
+
+    // Then there is no LIVE copy to describe yet.
+    assertInstanceOf(error, SimCloudFrontNoSuchFunctionExists);
+  });
+
+  it("requires a Function name", async () => {
+    // Given a simulated CloudFront.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When a description arrives without a name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.describeFunction(
+        new DescribeFunctionCommand({ Name: undefined }),
+      ),
+    );
+
+    // Then it is refused before anything is read.
+    assertInstanceOf(error, Error);
+  });
+});
+
+describe("CloudFront GetFunctionCommand", () => {
+  it("gets the code a Function was created with", async () => {
+    // Given a published CloudFront Function.
+    const { simCloudFront } = await givenPublishedFunction("beacon-cff");
+
+    // When its code is read back.
+    const got = await simCloudFront.getFunction(
+      new GetFunctionCommand({ Name: "beacon-cff" }),
+    );
+
+    // Then the source it was created with comes back.
+    assertIdentical(Buffer.from(got.FunctionCode).toString(), beaconCode);
+    assertIdentical(got.ContentType, "application/octet-stream");
+  });
+
+  it("gets the source of a Function bound to a handler", async () => {
+    // Given a Function a template bound to a handler function.
+    const simAws = new SimAws();
+    await simAws.cloudFormation().deployTemplate({
+      template: {
+        Resources: {
+          BoundFunction: {
+            Type: "AWS::CloudFront::Function",
+            Properties: {
+              Name: "bound-cff",
+              FunctionCode: "function handler(event) { return event.request; }",
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          logicalId: "BoundFunction",
+          handler: (event: CloudFrontFunction.ViewerRequestEvent) =>
+            event.request,
+        },
+      ],
+    });
+    await simAws.backgroundTasksComplete();
+
+    // When its code is read back.
+    const got = await simAws
+      .cloudFront()
+      .getFunction(new GetFunctionCommand({ Name: "bound-cff" }));
+
+    // Then the handler's own source stands in for code never uploaded.
+    assertStringIncludes(
+      Buffer.from(got.FunctionCode).toString(),
+      "event.request",
+    );
+  });
+
+  it("answers a name no Function holds with NoSuchFunctionExists", async () => {
+    // Given a simulated CloudFront without the requested Function.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When a missing Function's code is read.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.getFunction(new GetFunctionCommand({ Name: "no-such" })),
+    );
+
+    // Then CloudFront answers with its missing-Function error.
+    assertInstanceOf(error, SimCloudFrontNoSuchFunctionExists);
+  });
+
+  it("requires a Function name", async () => {
+    // Given a simulated CloudFront.
+    const simCloudFront = new SimAws().cloudFront();
+
+    // When a read arrives without a name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simCloudFront.getFunction(new GetFunctionCommand({ Name: undefined })),
+    );
+
+    // Then it is refused before anything is read.
+    assertInstanceOf(error, Error);
+  });
+});

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store-access.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store-access.ts
@@ -2,7 +2,7 @@ import type { BackgroundScheduler } from "../../../util/background/background.js
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { simCfAuthorize } from "../sim-cf-authorize.js";
 import type { SimCloudFrontKeyValueStore } from "./sim-cf-key-value-store.js";
 import type { SimCloudFrontKeyValueStoreRegistry } from "./sim-cf-key-value-store-registry.js";
 
@@ -38,16 +38,7 @@ export class SimCfKeyValueStoreAccess {
    * Ensure the caller may take an action on a key value store ARN.
    */
   authorize(action: string, resource: string, caller?: SimAwsCaller): void {
-    const decision = this.iam.authorize({ action, resource, caller });
-
-    if (decision.isDenied) {
-      throw new SimIamAccessDenied({
-        principal: decision.caller.principal,
-        reason: decision.denialReason,
-        action,
-        resource,
-      });
-    }
+    simCfAuthorize({ iam: this.iam, action, resource, caller });
   }
 
   /**

--- a/src/service/cloudfront/key-value-store/sim-cf-key-value-store.ts
+++ b/src/service/cloudfront/key-value-store/sim-cf-key-value-store.ts
@@ -7,6 +7,7 @@ import {
   type SimAwsAccountId,
 } from "../../aws/sim-aws-account.js";
 import { SimCloudFrontPreconditionFailed } from "../error/sim-cf-key-value-store.error.js";
+import { makeSimCloudFrontETag } from "../sim-cf-etag.js";
 import {
   type SimCloudFrontKeyValuePair,
   SimCloudFrontKeyValueStoreKeys,
@@ -234,5 +235,5 @@ export function makeKeyValueStoreId(): SimCloudFrontKeyValueStoreId {
  * Generate a fake ETag, in the shape CloudFront gives one.
  */
 export function makeKeyValueStoreETag(): string {
-  return faker.helpers.fromRegExp(/E[0-9A-Z]{13}/);
+  return makeSimCloudFrontETag();
 }

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.iso.test.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.iso.test.ts
@@ -6,7 +6,10 @@ import {
   CreateInvalidationCommand,
   DeleteDistributionCommand,
   DeleteFunctionCommand,
+  DescribeFunctionCommand,
   GetDistributionCommand,
+  GetFunctionCommand,
+  ListFunctionsCommand,
   UpdateDistributionCommand,
 } from "@aws-sdk/client-cloudfront";
 import { CreateBucketCommand } from "@aws-sdk/client-s3";
@@ -134,6 +137,50 @@ describe("simulated CloudFront SDK Command routing", () => {
     assertUndefined(
       simSdk.simAws.cloudFront().getCloudFrontFunctionByName("intercepted-cff"),
     );
+  });
+
+  it("reads a Function back through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    const client = new CloudFrontClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const functionCode = `
+          function handler(event) {
+            return event.request;
+          }
+        `;
+    await client.send(
+      new CreateFunctionCommand({
+        Name: "readable-cff",
+        FunctionConfig: {
+          Comment: "SDK intercepted CloudFront Function",
+          Runtime: "cloudfront-js-2.0",
+        },
+        FunctionCode: Buffer.from(functionCode),
+      }),
+    );
+    await simSdk.simAws.backgroundTasksComplete();
+
+    // Listing, describing and getting all go through the router.
+    const listed = await client.send(new ListFunctionsCommand({}));
+    assertIdentical(
+      listed.FunctionList?.Items?.[0]?.FunctionConfig?.Runtime,
+      "cloudfront-js-2.0",
+    );
+
+    const described = await client.send(
+      new DescribeFunctionCommand({ Name: "readable-cff" }),
+    );
+    assertIdentical(
+      described.FunctionSummary?.FunctionConfig?.Comment,
+      "SDK intercepted CloudFront Function",
+    );
+
+    const got = await client.send(
+      new GetFunctionCommand({ Name: "readable-cff", Stage: "LIVE" }),
+    );
+    assertNonNullable(got.FunctionCode);
+    assertIdentical(Buffer.from(got.FunctionCode).toString(), functionCode);
   });
 
   it("rejects a Command simulated CloudFront does not support", async () => {

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
@@ -7,6 +7,11 @@ import type { SimCreateDistributionCommand } from "../command/create-distributio
 import type { SimCreateFunctionCommand } from "../command/create-function/create-function.command.js";
 import type { SimDeleteDistributionCommand } from "../command/delete-distribution/delete-distribution.command.js";
 import type { SimDeleteFunctionCommand } from "../command/delete-function/delete-function.command.js";
+import type {
+  SimDescribeFunctionCommand,
+  SimGetFunctionCommand,
+  SimListFunctionsCommand,
+} from "../command/function/sim-cf-function-command.types.js";
 import type { SimGetDistributionCommand } from "../command/get-distribution/get-distribution.command.js";
 import type {
   SimCreateKeyValueStoreCommand,
@@ -56,6 +61,30 @@ export class SimCloudFrontSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simCloudFront.deleteFunction(
             command as SimDeleteFunctionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListFunctionsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.listFunctions(
+            command as SimListFunctionsCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeFunctionCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.describeFunction(
+            command as SimDescribeFunctionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetFunctionCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.getFunction(
+            command as SimGetFunctionCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/cloudfront/sim-cf-authorize.ts
+++ b/src/service/cloudfront/sim-cf-authorize.ts
@@ -1,0 +1,30 @@
+import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../iam/error/sim-iam.error.js";
+
+interface SimCfAuthorizeProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly action: string;
+  readonly resource: string;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * Ensure a caller may take a CloudFront action on a resource.
+ *
+ * Every CloudFront command asks IAM the same question and refuses a denial the
+ * same way, so the question is asked here rather than once per command group.
+ */
+export function simCfAuthorize(properties: SimCfAuthorizeProperties): void {
+  const { iam, action, resource, caller } = properties;
+  const decision = iam.authorize({ action, resource, caller });
+
+  if (decision.isDenied) {
+    throw new SimIamAccessDenied({
+      principal: decision.caller.principal,
+      reason: decision.denialReason,
+      action,
+      resource,
+    });
+  }
+}

--- a/src/service/cloudfront/sim-cf-etag.ts
+++ b/src/service/cloudfront/sim-cf-etag.ts
@@ -1,0 +1,11 @@
+import { faker } from "@faker-js/faker";
+
+/**
+ * Generate a fake ETag, in the shape CloudFront gives one.
+ *
+ * Every versioned CloudFront resource carries one of these, and a write says
+ * which version it is writing over by sending it back as `IfMatch`.
+ */
+export function makeSimCloudFrontETag(): string {
+  return faker.helpers.fromRegExp(/E[0-9A-Z]{13}/);
+}

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -16,24 +16,12 @@ import type {
   SimCreateDistributionCommandOutput,
 } from "./command/create-distribution/create-distribution.command.js";
 import { CreateDistributionCommandHandler } from "./command/create-distribution/create-distribution.handler.js";
-import type {
-  SimCreateFunctionCommand,
-  SimCreateFunctionCommandOutput,
-} from "./command/create-function/create-function.command.js";
-import {
-  CreateFunctionCommandHandler,
-  type SimCloudFrontFunctionMap,
-} from "./command/create-function/create-function.handler.js";
+import type { SimCloudFrontFunctionMap } from "./command/create-function/create-function.handler.js";
 import type {
   SimDeleteDistributionCommand,
   SimDeleteDistributionCommandOutput,
 } from "./command/delete-distribution/delete-distribution.command.js";
 import { DeleteDistributionCommandHandler } from "./command/delete-distribution/delete-distribution.handler.js";
-import type {
-  SimDeleteFunctionCommand,
-  SimDeleteFunctionCommandOutput,
-} from "./command/delete-function/delete-function.command.js";
-import { DeleteFunctionCommandHandler } from "./command/delete-function/delete-function.handler.js";
 import type {
   SimGetDistributionCommand,
   SimGetDistributionCommandOutput,
@@ -65,6 +53,7 @@ import { SimCfKeyValueStoreCommands } from "./key-value-store/sim-cf-key-value-s
 import { SimCloudFrontKeyValueStoreRegistry } from "./key-value-store/sim-cf-key-value-store-registry.js";
 import { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.js";
 import { SimCffKeyValueStoreUsers } from "./cff/kvs/sim-cff-key-value-store-users.js";
+import { SimCfFunctionCommands } from "./cff/sim-cf-function-commands.js";
 
 /**
  * How one simulated CloudFront is put together.
@@ -116,17 +105,6 @@ interface SimCloudFrontDistributionState {
 }
 
 /**
- * The state every CloudFront Function command works on.
- */
-interface SimCloudFrontFunctionState {
-  readonly accountId: SimAwsAccountId;
-  readonly cloudFrontFunctions: SimCloudFrontFunctionMap;
-  readonly iam: SimIamInterServiceAuthZ;
-  readonly background: BackgroundScheduler;
-  readonly keyValueStores: SimCloudFrontKeyValueStoreRegistry;
-}
-
-/**
  * The commands of one simulated CloudFront, and the state they share.
  *
  * Every command authorizes against the same IAM and works on the same
@@ -153,8 +131,12 @@ export class SimCloudFrontCommands {
    */
   public readonly edgeFunctions: SimCfEdgeFunctions | undefined;
 
+  /**
+   * The CloudFront Function commands, and the Functions they work on.
+   */
+  public readonly functions: SimCfFunctionCommands;
+
   private readonly distributionState: SimCloudFrontDistributionState;
-  private readonly functionState: SimCloudFrontFunctionState;
   private readonly configurationState: SimCfDistributionConfigurationState;
 
   constructor(properties: SimCloudFrontCommandsProperties) {
@@ -184,13 +166,13 @@ export class SimCloudFrontCommands {
       iam,
       background,
     };
-    this.functionState = {
+    this.functions = new SimCfFunctionCommands({
       accountId,
       cloudFrontFunctions,
       iam,
       background,
       keyValueStores,
-    };
+    });
     this.configurationState = {
       s3OriginResolver,
       customOriginDispatcher,
@@ -267,31 +249,5 @@ export class SimCloudFrontCommands {
     return await new DeleteDistributionCommandHandler(
       this.distributionState,
     ).handle(command, options);
-  }
-
-  /**
-   * Handle a Create Function Command from the SDK.
-   */
-  async createFunction(
-    command: SimCreateFunctionCommand,
-    options?: SimCloudFrontRequestOptions,
-  ): Promise<SimCreateFunctionCommandOutput> {
-    return await new CreateFunctionCommandHandler(this.functionState).handle(
-      command,
-      options,
-    );
-  }
-
-  /**
-   * Handle a Delete Function Command from the SDK.
-   */
-  async deleteFunction(
-    command: SimDeleteFunctionCommand,
-    options?: SimCloudFrontRequestOptions,
-  ): Promise<SimDeleteFunctionCommandOutput> {
-    return await new DeleteFunctionCommandHandler(this.functionState).handle(
-      command,
-      options,
-    );
   }
 }

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -26,6 +26,14 @@ import type {
   SimDeleteFunctionCommandOutput,
 } from "./command/delete-function/delete-function.command.js";
 import type {
+  SimDescribeFunctionCommand,
+  SimDescribeFunctionCommandOutput,
+  SimGetFunctionCommand,
+  SimGetFunctionCommandOutput,
+  SimListFunctionsCommand,
+  SimListFunctionsCommandOutput,
+} from "./command/function/sim-cf-function-command.types.js";
+import type {
   SimGetDistributionCommand,
   SimGetDistributionCommandOutput,
 } from "./command/get-distribution/get-distribution.command.js";
@@ -175,7 +183,7 @@ export class SimCloudFront extends SimCloudFrontPolicies {
     command: SimCreateFunctionCommand,
     options?: SimCloudFrontRequestOptions,
   ): Promise<SimCreateFunctionCommandOutput> {
-    return await this.commands.createFunction(command, options);
+    return await this.commands.functions.createFunction(command, options);
   }
 
   /**
@@ -185,7 +193,37 @@ export class SimCloudFront extends SimCloudFrontPolicies {
     command: SimDeleteFunctionCommand,
     options?: SimCloudFrontRequestOptions,
   ): Promise<SimDeleteFunctionCommandOutput> {
-    return await this.commands.deleteFunction(command, options);
+    return await this.commands.functions.deleteFunction(command, options);
+  }
+
+  /**
+   * Handle a List Functions Command from the SDK.
+   */
+  async listFunctions(
+    command: SimListFunctionsCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimListFunctionsCommandOutput> {
+    return await this.commands.functions.listFunctions(command, options);
+  }
+
+  /**
+   * Handle a Describe Function Command from the SDK.
+   */
+  async describeFunction(
+    command: SimDescribeFunctionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimDescribeFunctionCommandOutput> {
+    return await this.commands.functions.describeFunction(command, options);
+  }
+
+  /**
+   * Handle a Get Function Command from the SDK.
+   */
+  async getFunction(
+    command: SimGetFunctionCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimGetFunctionCommandOutput> {
+    return await this.commands.functions.getFunction(command, options);
   }
 
   /**


### PR DESCRIPTION
ListFunctions, DescribeFunction and GetFunction now answer for the Functions an Account holds. A Function keeps the comment, the runtime and the source it was created with, along with the created and modified times off the simulated clock, and `Stage` picks the DEVELOPMENT or LIVE copy. A name no Function answers to fails with `NoSuchFunctionExists`. The five Function commands move onto `SimCfFunctionCommands`, and `SimCloudFront` exposes its response headers policy and origin access control registries where it used to wrap each of their methods.

Resolves https://github.com/KensioSoftware/yulin/issues/1131

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`