### PR TITLE
fix: authorize CloudFront on a delivery source

### DIFF
--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -749,6 +749,12 @@ the three listing operations an SDK caller reaches, and a deployment goes near n
 CloudFormation execution Role therefore carries the same policy here that a real deploy of the
 template needs.
 
+A delivery source over a CloudFront distribution takes one CloudFront permission on top of those.
+CloudWatch Logs checks the caller for `cloudfront:AllowVendedLogDeliveryForResource` against the
+distribution's ARN as the source is put, and a caller holding every `logs:` action and no CloudFront
+permission is refused. A policy naming another distribution is refused the same way. A delivery
+source over a resource of any other service asks for nothing outside `logs:`.
+
 ```typescript sim-logs-permissions
 /**
  * A simulated IAM policy allowing a Role to write one function's logs.

--- a/src/service/logs/cfn/sim-cfn-delivery-iam.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery-iam.iso.test.ts
@@ -25,6 +25,10 @@ const sourceName = "site-access-logs";
  * destination policy actions those handlers also list are left out, because
  * this simulation refuses tags and records a destination policy without acting
  * on it.
+ *
+ * The CloudFront action is the odd one. CloudWatch Logs checks it as the
+ * source over a distribution is put, and a policy assembled from the `logs:`
+ * side alone leaves it out.
  */
 const deliveryDeployActions = [
   "logs:GetDeliverySource",
@@ -33,13 +37,15 @@ const deliveryDeployActions = [
   "logs:PutDeliveryDestination",
   "logs:GetDelivery",
   "logs:CreateDelivery",
+  "cloudfront:AllowVendedLogDeliveryForResource",
 ];
 
 /**
  * The three Resources CloudFront standard logging v2 is made of.
  *
- * The Distribution is created outside the Stack and named here by its ARN. A
- * Role that may deploy this template therefore needs no CloudFront permission.
+ * The Distribution is created outside the Stack and named here by its ARN, so
+ * the Stack creates nothing of CloudFront. The Role deploying it still needs
+ * the one CloudFront permission that delivering a distribution's logs takes.
  */
 function loggingTemplate(resourceArn: string): CfnTemplateBodyRecord {
   return {
@@ -146,6 +152,28 @@ describe("the principal an AWS::Logs delivery Resource is created as", () => {
     // source was never put behind the refusal.
     assertStringIncludes(error.message, "logs:GetDeliverySource");
     assertStringIncludes(error.message, "role/Putter");
+    assertUndefined(simAws.logs().findDeliverySource(sourceName));
+  });
+
+  it("fails a delivery source under a caller denied the CloudFront action", async () => {
+    // Given a Role allowed every action the delivery handlers name, and
+    // nothing of CloudFront. That is the policy someone writes by asking which
+    // service owns the Resource type.
+    const simAws = new SimAws();
+    const error = await assertThrowsErrorAsync(async () => {
+      await deployAllowing(
+        simAws,
+        "Logger",
+        allBut("cloudfront:AllowVendedLogDeliveryForResource"),
+      );
+    });
+
+    // Then the deploy stops where the real one stopped, on an action of the
+    // service that owns the distribution being logged.
+    assertStringIncludes(
+      error.message,
+      "cloudfront:AllowVendedLogDeliveryForResource",
+    );
     assertUndefined(simAws.logs().findDeliverySource(sourceName));
   });
 

--- a/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
+++ b/src/service/logs/command/authorize/sim-logs-iam.iso.test.ts
@@ -242,12 +242,20 @@ describe("CloudWatch Logs delivery IAM authorization", () => {
   });
 
   it("allows a delivery source a policy names", async () => {
-    // Given a Role allowed to put delivery sources, and a distribution for
-    // the source to be over.
-    const simAws = await simAwsWithRole({
-      Action: "logs:PutDeliverySource",
-      Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:delivery-source:*`,
-    });
+    // Given a Role allowed to put delivery sources over the distributions of
+    // its own account, and a distribution for the source to be over.
+    const simAws = await simAwsWithRole([
+      {
+        Effect: "Allow",
+        Action: "logs:PutDeliverySource",
+        Resource: `arn:aws:logs:us-east-1:${accountIdOneOnes}:delivery-source:*`,
+      },
+      {
+        Effect: "Allow",
+        Action: "cloudfront:AllowVendedLogDeliveryForResource",
+        Resource: `arn:aws:cloudfront::${accountIdOneOnes}:distribution/*`,
+      },
+    ]);
     const resourceArn = await simLogsDeliveryDistributionArn(simAws);
 
     // When it puts a delivery source.

--- a/src/service/logs/command/delivery/sim-logs-delivery-source-commands.ts
+++ b/src/service/logs/command/delivery/sim-logs-delivery-source-commands.ts
@@ -1,4 +1,5 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import { authorizeSimLogsVendedLogDelivery } from "../../delivery/cloudfront/sim-logs-vended-log-delivery.js";
 import {
   simLogsAnyDeliverySourceArn,
   simLogsDeliverySourceArn,
@@ -63,10 +64,12 @@ export class SimLogsDeliverySourceCommands {
    * Put a delivery source over a resource whose logs are to be delivered.
    *
    * The service is read from the resource ARN, as real CloudWatch Logs reads
-   * it, and the region the request was made in has to be one that service's
-   * delivery can be set up from. The ARN is then resolved to a resource the
-   * account holds. A source over a distribution the account never created
-   * fails here, ahead of the delivery that would have carried nothing.
+   * it. The caller is then checked against that service as well, because
+   * delivering a resource's logs is a permission the service owning it holds.
+   * The region the request was made in has to be one that service's delivery
+   * can be set up from, and the ARN is then resolved to a resource the account
+   * holds. A source over a distribution the account never created fails here,
+   * ahead of the delivery that would have carried nothing.
    */
   putDeliverySource(
     command: SimPutDeliverySourceCommand,
@@ -88,6 +91,13 @@ export class SimLogsDeliverySourceCommands {
     );
 
     const service = requiredSimLogsDeliveredService(resourceArn);
+
+    authorizeSimLogsVendedLogDelivery({
+      authorizer: this.#authorizer,
+      service,
+      resourceArn,
+      caller: options?.caller,
+    });
 
     requireSimLogsDeliverySource({
       service,

--- a/src/service/logs/delivery/cloudfront/sim-logs-vended-log-delivery-iam.iso.test.ts
+++ b/src/service/logs/delivery/cloudfront/sim-logs-vended-log-delivery-iam.iso.test.ts
@@ -1,0 +1,168 @@
+import { PutDeliverySourceCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simLogsDeliveryDistributionArn } from "../../../../../test/logs/delivery-distribution-fixture.js";
+
+const sourceName = "site-access-logs";
+const vendedLogDeliveryAction = "cloudfront:AllowVendedLogDeliveryForResource";
+
+/**
+ * A Role holding one policy statement, as a caller a request can be made as.
+ *
+ * Every statement here allows every `logs:` action, because the permission
+ * under test is the one a policy written from the `logs:` side leaves out.
+ */
+async function roleAllowedLogsAnd(
+  simAws: SimAws,
+  statement?: object,
+): Promise<SimAwsCaller> {
+  const roleName = "SiteLoggingDeployer";
+  const created = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: roleName,
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { Service: "cloudformation.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: roleName,
+      PolicyName: "SetUpLogging",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: [
+          { Effect: "Allow", Action: "logs:*", Resource: "*" },
+          ...(statement === undefined ? [] : [statement]),
+        ],
+      }),
+    }),
+  );
+
+  assertNonNullable(created.Role.Arn);
+
+  return { kind: "arn", arn: created.Role.Arn };
+}
+
+/**
+ * Put a delivery source over a resource as the caller given.
+ */
+async function putSourceAs(
+  simAws: SimAws,
+  resourceArn: string,
+  caller: SimAwsCaller,
+): Promise<void> {
+  await simAws.logs().putDeliverySource(
+    new PutDeliverySourceCommand({
+      name: sourceName,
+      resourceArn,
+      logType: "ACCESS_LOGS",
+    }),
+    { caller },
+  );
+}
+
+describe("the CloudFront permission a delivery source over a distribution needs", () => {
+  it("refuses a source over a distribution under a caller denied CloudFront", async () => {
+    // Given a Role allowed every CloudWatch Logs action and nothing of
+    // CloudFront, which is the policy a delivery source looks like it needs.
+    const simAws = new SimAws();
+    const resourceArn = await simLogsDeliveryDistributionArn(simAws);
+    const caller = await roleAllowedLogsAnd(simAws);
+
+    // When it puts a delivery source over the distribution.
+    const error = await assertThrowsErrorAsync(async () => {
+      await putSourceAs(simAws, resourceArn, caller);
+    });
+
+    // Then CloudWatch Logs refuses it on an action of CloudFront, the way a
+    // real account refuses it, and no source was put behind the refusal.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, vendedLogDeliveryAction);
+    assertStringIncludes(error.message, "role/SiteLoggingDeployer");
+    assertUndefined(simAws.logs().findDeliverySource(sourceName));
+  });
+
+  it("allows a source over the distribution a policy names", async () => {
+    // Given a Role allowed to deliver the logs of one distribution by ARN.
+    const simAws = new SimAws();
+    const resourceArn = await simLogsDeliveryDistributionArn(simAws);
+    const caller = await roleAllowedLogsAnd(simAws, {
+      Effect: "Allow",
+      Action: vendedLogDeliveryAction,
+      Resource: resourceArn,
+    });
+
+    // When it puts a delivery source over that distribution.
+    await putSourceAs(simAws, resourceArn, caller);
+
+    // Then the source is there, so the distribution ARN is what the request
+    // authorized against.
+    assertIdentical(
+      simAws.logs().findDeliverySource(sourceName)?.name,
+      sourceName,
+    );
+  });
+
+  it("refuses a source over a distribution the policy does not name", async () => {
+    // Given a Role allowed to deliver the logs of one distribution, and a
+    // second distribution beside it.
+    const simAws = new SimAws();
+    const allowedArn = await simLogsDeliveryDistributionArn(
+      simAws,
+      "allowed-site",
+    );
+    const otherArn = await simLogsDeliveryDistributionArn(simAws, "other-site");
+    const caller = await roleAllowedLogsAnd(simAws, {
+      Effect: "Allow",
+      Action: vendedLogDeliveryAction,
+      Resource: allowedArn,
+    });
+
+    // When it puts a delivery source over the second one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await putSourceAs(simAws, otherArn, caller);
+    });
+
+    // Then it is refused, so the permission is held per distribution rather
+    // than over CloudFront as a whole.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertStringIncludes(error.message, otherArn);
+    assertUndefined(simAws.logs().findDeliverySource(sourceName));
+  });
+
+  it("leaves a source over a resource of another service alone", async () => {
+    // Given the same Role denied CloudFront, and an API Gateway stage to
+    // deliver access logs from.
+    const simAws = new SimAws();
+    const caller = await roleAllowedLogsAnd(simAws);
+    const stageArn =
+      "arn:aws:apigateway:us-east-1::/restapis/abc123/stages/prod";
+
+    // When it puts a delivery source over the stage.
+    await putSourceAs(simAws, stageArn, caller);
+
+    // Then nothing of CloudFront was asked for, because the ARN names another
+    // service, and the source is there.
+    assertIdentical(
+      simAws.logs().findDeliverySource(sourceName)?.resourceArn,
+      stageArn,
+    );
+  });
+});

--- a/src/service/logs/delivery/cloudfront/sim-logs-vended-log-delivery.ts
+++ b/src/service/logs/delivery/cloudfront/sim-logs-vended-log-delivery.ts
@@ -1,0 +1,47 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimLogsAuthorizer } from "../../command/authorize/sim-logs-authorizer.js";
+import { simLogsCloudFrontDeliveryService } from "../sim-logs-delivery-source-service.js";
+
+/**
+ * The CloudFront action a delivery source over a distribution is checked for.
+ *
+ * CloudFront names it and nobody calls it. It exists so that setting up
+ * delivery from a distribution is a permission of its own, held apart from
+ * everything else a caller may do to that distribution.
+ */
+const simLogsVendedLogDeliveryAction =
+  "cloudfront:AllowVendedLogDeliveryForResource";
+
+interface SimLogsVendedLogDeliveryAuthorization {
+  readonly authorizer: SimLogsAuthorizer;
+  readonly service: string;
+  readonly resourceArn: string;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * Authorize delivering the logs of the resource a delivery source names.
+ *
+ * Creating a delivery source calls CloudWatch Logs, and CloudWatch Logs then
+ * checks the caller against the service that owns the resource being logged.
+ * A policy is usually written by asking which service owns the resource type,
+ * and that question gives the wrong answer here. A caller allowed every
+ * `logs:` action and denied CloudFront outright is refused.
+ *
+ * CloudFront is the one delivered service checked, because it is the one the
+ * simulation can name a resource of. A source over an ARN of any other service
+ * carries on as it always did.
+ */
+export function authorizeSimLogsVendedLogDelivery(
+  properties: SimLogsVendedLogDeliveryAuthorization,
+): void {
+  if (properties.service !== simLogsCloudFrontDeliveryService) {
+    return;
+  }
+
+  properties.authorizer.authorizeResource(
+    simLogsVendedLogDeliveryAction,
+    properties.resourceArn,
+    properties.caller,
+  );
+}


### PR DESCRIPTION
Creating an `AWS::Logs::DeliverySource` over a CloudFront distribution calls CloudWatch Logs, and CloudWatch Logs then checks the caller against CloudFront for the distribution being logged. No `cloudfront:` action appeared anywhere in the delivery path here. A source over a distribution deployed under a caller allowed every `logs:` action and denied CloudFront outright, which is the policy someone writes by asking which service owns the Resource type, and a downstream project hit the real refusal after granting every `logs:` permission it thought it needed. Putting a delivery source now authorizes `cloudfront:AllowVendedLogDeliveryForResource` against the distribution's ARN, and a policy naming another distribution refuses it. A source over a resource of any other service is unchanged, and the CloudFormation delivery Role now carries the CloudFront action alongside the `logs:` ones a real deploy needs.

Resolves #1137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authorization checks for CloudFront log delivery sources.
  * CloudFront delivery sources now require explicit permission for the specified distribution.
  * Delivery sources for other services continue using existing CloudWatch Logs permissions.

* **Bug Fixes**
  * Prevented deployment when CloudFront authorization is missing or targets an unauthorized distribution.

* **Documentation**
  * Documented the required CloudFront permission and authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->