### PR TITLE
feat: answer least and greatest in Athena

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -383,9 +383,14 @@ its declared result.
 | Binary        | `md5`, `sha1`, `sha256`, `sha512`, `xxhash64`, `murmur3`, `crc32`, `to_hex`, `from_hex`, `to_base64`, `from_base64`, `to_utf8`, `from_utf8`                                                           |
 | URL           | `url_extract_host`, `url_extract_path`, `url_extract_protocol`, `url_extract_port`, `url_extract_query`, `url_extract_fragment`, `url_extract_parameter`, `url_decode`, `url_encode`                  |
 | Approximate   | `approx_distinct`, `approx_percentile`                                                                                                                                                                |
+| Comparison    | `least`, `greatest`                                                                                                                                                                                   |
 
 `substr` and `format` are SQLite's own. Both count from one and take the same `%s` and `%d` a
 statement writes, so shadowing either would replace something that works.
+
+`least` and `greatest` take two arguments or more. Numbers order numerically and text orders by its
+code units, matching SQLite's own `min` and `max` in their wider forms. Trino refuses a call mixing
+the two types and this answers one, ordering everything as text. A `varbinary` argument raises.
 
 The hashing functions answer with bytes and `to_hex` writes those bytes in the upper case Trino
 writes them in. Node carries every digest here apart from xxHash64 and MurmurHash3, and both of
@@ -404,7 +409,8 @@ instant the query started, which is what the execution records.
 
 A function that cannot answer faithfully raises rather than guessing, and the query falls back.
 `date_add` with a unit Trino does not name, `slice` starting at zero, `array_join` over an array of
-objects, and `regexp_extract` naming a capture group the pattern has not got all land there. A null
+objects, `least` over a `varbinary`, and `regexp_extract` naming a capture group the pattern has not
+got all land there. A null
 answer would be a wrong answer wearing the shape of a right one.
 
 A function answers null where any argument is null, the way Trino's do. An argument left out takes

--- a/src/service/athena/engine/sim-athena-comparison-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-comparison-shims.iso.test.ts
@@ -1,0 +1,77 @@
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  anAggregatedExpression,
+  anAnsweredExpression,
+} from "./sim-athena-shim.fixture.js";
+
+describe("Trino's least and greatest on SQLite", () => {
+  it("answers with the smallest and the largest of two numbers", async () => {
+    // Given two numbers written either way round.
+    // When each function reads them.
+    // Then the ordering is numeric rather than by the text of the number, so
+    // ten is above nine.
+    assertIdentical(await anAnsweredExpression("least(60, 12)"), 12);
+    assertIdentical(await anAnsweredExpression("greatest(60, 12)"), 60);
+    assertIdentical(await anAnsweredExpression("least(9, 10)"), 9);
+    assertIdentical(await anAnsweredExpression("greatest(1.5, 2)"), 2);
+    assertIdentical(await anAnsweredExpression("least(-3, 0)"), -3);
+  });
+
+  it("takes more than two arguments", async () => {
+    // Given four numbers, with the answer in the middle of them.
+    // When each function reads them.
+    // Then every argument is weighed rather than the first pair alone.
+    assertIdentical(await anAnsweredExpression("least(4, 2, 7, 3)"), 2);
+    assertIdentical(await anAnsweredExpression("greatest(4, 2, 7, 3)"), 7);
+  });
+
+  it("orders text by its code units", async () => {
+    // Given words rather than numbers.
+    // When each function reads them.
+    // Then they order the way a varchar orders.
+    assertIdentical(await anAnsweredExpression("least('b', 'a', 'c')"), "a");
+    assertIdentical(await anAnsweredExpression("greatest('b', 'a')"), "b");
+  });
+
+  it("answers null where any argument is null", async () => {
+    // Given a null beside a value, in each position.
+    // When each function reads them.
+    // Then null answers, the way Trino has it, rather than the null being
+    // passed over for the value beside it.
+    assertIdentical(await anAnsweredExpression("least(NULL, 2)"), null);
+    assertIdentical(await anAnsweredExpression("least(2, NULL)"), null);
+    assertIdentical(await anAnsweredExpression("greatest(1, NULL, 3)"), null);
+  });
+
+  it("caps an aggregate", async () => {
+    // Given more rows than the cap allows for.
+    // When the count is capped, and when it is under the cap.
+    // Then the cap is what answers, which is the arithmetic a rule written as
+    // a CASE was standing in for.
+    assertIdentical(
+      await anAggregatedExpression("least(count(*), 2)", [1, 2, 3, 4]),
+      2,
+    );
+    assertIdentical(
+      await anAggregatedExpression("least(count(*), 60)", [1, 2]),
+      2,
+    );
+    assertIdentical(
+      await anAggregatedExpression("greatest(count(*), 60)", [1, 2]),
+      60,
+    );
+  });
+
+  it("turns the query down over a varbinary", async () => {
+    // Given two digests, which are bytes rather than text.
+    // When they are ordered.
+    // Then the shim raises. Trino orders a varbinary by its bytes and nothing
+    // written out here orders the same way, so the query falls back rather
+    // than answering from a rendering of them.
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("least(to_utf8('a'), to_utf8('b'))"),
+    );
+  });
+});

--- a/src/service/athena/engine/sim-athena-comparison-shims.ts
+++ b/src/service/athena/engine/sim-athena-comparison-shims.ts
@@ -1,0 +1,90 @@
+import type { DatabaseSync, SQLInputValue, SQLOutputValue } from "node:sqlite";
+
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+import { simAthenaScalarShim } from "./sim-athena-shim-registry.js";
+
+/**
+ * Trino's `least` and `greatest`.
+ *
+ * SQLite carries both already, as the two argument and wider forms of `min`
+ * and `max`. A rewrite renaming the call would reach the same words written
+ * inside a string literal. SQLite resolves a shim by the name the statement
+ * wrote, and the ordering is done here.
+ *
+ * Trino answers null where any argument is null, and SQLite's own `min` and
+ * `max` answer the same way.
+ */
+export function simAthenaInstallComparisonShims(database: DatabaseSync): void {
+  simAthenaScalarShim(database, "least", (...values) => extremeOf(values, -1));
+  simAthenaScalarShim(database, "greatest", (...values) =>
+    extremeOf(values, 1),
+  );
+}
+
+/**
+ * The argument at one end of the ordering, taking -1 for the low end.
+ *
+ * Trino takes two arguments at least. SQLite hands over whatever the call
+ * wrote, and a call carrying none of them answers null.
+ */
+function extremeOf(
+  values: readonly SQLOutputValue[],
+  wanted: -1 | 1,
+): SQLInputValue {
+  if (values.length === 0 || values.includes(null)) {
+    return null;
+  }
+
+  return values.reduce((held, value) =>
+    ordering(value, held) === wanted ? value : held,
+  );
+}
+
+/**
+ * How two arguments order, as -1, 0 or 1.
+ *
+ * Numbers order numerically and everything else orders by its text. SQLite's
+ * own `min` and `max` order the same pair the same way. Trino refuses a call
+ * mixing types. None of the shims here check types, and a mixed call is
+ * ordered as text.
+ */
+function ordering(one: SQLOutputValue, other: SQLOutputValue): number {
+  if (isNumeric(one) && isNumeric(other)) {
+    return signOf(one < other, one > other);
+  }
+
+  const left = comparableText(one);
+  const right = comparableText(other);
+
+  return signOf(left < right, left > right);
+}
+
+/** One comparison read back as -1, 0 or 1. */
+function signOf(below: boolean, above: boolean): number {
+  if (below) {
+    return -1;
+  }
+
+  return above ? 1 : 0;
+}
+
+function isNumeric(value: SQLOutputValue): value is bigint | number {
+  return typeof value === "number" || typeof value === "bigint";
+}
+
+/**
+ * One argument as the text it orders by.
+ *
+ * A `varbinary` orders by its bytes in Trino, and nothing written out here
+ * orders the same way. A call over one raises and the query falls back to its
+ * declared result.
+ */
+function comparableText(value: SQLOutputValue): string {
+  if (value instanceof Uint8Array) {
+    throw new SimAthenaSetUpError(
+      "least and greatest take numbers or text rather than a varbinary",
+    );
+  }
+
+  return String(value);
+}

--- a/src/service/athena/engine/sim-athena-shims.ts
+++ b/src/service/athena/engine/sim-athena-shims.ts
@@ -4,6 +4,7 @@ import { simAthenaInstallAggregateShims } from "./sim-athena-aggregate-shims.js"
 import { simAthenaInstallArrayShims } from "./sim-athena-array-shims.js";
 import { simAthenaInstallBinaryShims } from "./sim-athena-binary-shims.js";
 import { simAthenaInstallClockShims } from "./sim-athena-clock-shims.js";
+import { simAthenaInstallComparisonShims } from "./sim-athena-comparison-shims.js";
 import { simAthenaInstallDateArithmeticShims } from "./sim-athena-date-arithmetic-shims.js";
 import { simAthenaInstallDateShims } from "./sim-athena-date-shims.js";
 import { simAthenaInstallJsonDocumentShims } from "./sim-athena-json-document-shims.js";
@@ -35,4 +36,5 @@ export function simAthenaInstallShims(
   simAthenaInstallRegexpShims(database);
   simAthenaInstallUrlShims(database);
   simAthenaInstallAggregateShims(database);
+  simAthenaInstallComparisonShims(database);
 }

--- a/src/service/athena/sim-athena-engine-functions.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-functions.iso.test.ts
@@ -252,3 +252,40 @@ describe("counting unique visitors from a salted digest", () => {
     assertObjectEquals(answered.rows, [["2"]]);
   });
 });
+
+describe("capping a count the way a rule caps one", () => {
+  it("caps a count per group and leaves a smaller one alone", async () => {
+    // Given four rows, three of them from the one address.
+    const simulation = await aVisitSimulation();
+
+    // When each address is counted under a cap of two.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT c_ip, least(count(*), 2) AS counted FROM rainlytics.visits " +
+        "GROUP BY c_ip ORDER BY c_ip",
+    );
+
+    // Then the engine runs the cap rather than reading back a declaration,
+    // which is what a rule written as a CASE was standing in for.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["198.51.100.7", "2"],
+      ["203.0.113.4", "1"],
+    ]);
+  });
+
+  it("takes a floor under a count as well", async () => {
+    // Given the same rows.
+    const simulation = await aVisitSimulation();
+
+    // When the count is held up to sixty.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT greatest(count(*), 60) AS counted FROM rainlytics.visits",
+    );
+
+    // Then the larger of the two answers.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["60"]]);
+  });
+});


### PR DESCRIPTION
A query calling `least` or `greatest` fell back to its declared result, because neither name was
registered on the SQLite database the engine builds. Both are registered now as scalar shims taking
any number of arguments. Numbers order numerically and everything else orders by its text. A null
argument answers null, the way Trino and SQLite's own `min` and `max` both do. A `varbinary`
argument raises and the query falls back, since nothing written out here orders by the bytes Trino
orders by.

Resolves #1141