### PR TITLE
feat: simulate CloudFront origin request policies

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -3518,7 +3518,8 @@ The resource types it creates are:
 - `AWS::CertificateManager::Certificate`
 - `AWS::CloudFormation::WaitConditionHandle`
 - `AWS::CloudFront::Distribution`, `AWS::CloudFront::Function`,
-  `AWS::CloudFront::ResponseHeadersPolicy` and `AWS::CloudFront::CachePolicy`
+  `AWS::CloudFront::ResponseHeadersPolicy`, `AWS::CloudFront::CachePolicy` and
+  `AWS::CloudFront::OriginRequestPolicy`
 - `AWS::CloudWatch::Alarm`
 - `AWS::Cognito::UserPool`, `AWS::Cognito::UserPoolClient` and
   `AWS::Cognito::UserPoolGroup`

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2324,6 +2324,136 @@ way an absent response headers policy does, and the Behavior reports no policy.
 `CreateDistribution` and `UpdateDistribution` still refuse the same ID with `NoSuchCachePolicy`, as
 real CloudFront refuses it.
 
+## Origin request policies
+
+An origin request policy decides which of the viewer's headers, cookies and query strings a cache
+Behavior carries to its Origin. Declare one as `AWS::CloudFront::OriginRequestPolicy` and point a
+Behavior's `OriginRequestPolicyId` at it with a `Ref`, which is what CDK's `OriginRequestPolicy`
+construct synthesizes.
+
+```typescript sim-cloudfront-origin-request-policy
+/**
+ * Reading back the origin request policy a Behavior was given.
+ */
+
+import { GetDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "site-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      BeaconPolicy: {
+        Type: "AWS::CloudFront::OriginRequestPolicy",
+        Properties: {
+          OriginRequestPolicyConfig: {
+            Name: "BeaconPolicy",
+            CookiesConfig: { CookieBehavior: "none" },
+            HeadersConfig: { HeaderBehavior: "none" },
+            QueryStringsConfig: { QueryStringBehavior: "all" },
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "BeaconPolicy"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              // CORS-S3Origin, one of CloudFront's managed policies.
+              OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf",
+            },
+            CacheBehaviors: [
+              {
+                PathPattern: "/beacon",
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
+                OriginRequestPolicyId: { Ref: "BeaconPolicy" },
+              },
+            ],
+          },
+        },
+      },
+    },
+    Outputs: {
+      DistributionId: { Value: { Ref: "SiteDistribution" } },
+      BeaconPolicyId: { Value: { Ref: "BeaconPolicy" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const read = await simAws
+  .cloudFront()
+  .getDistribution(
+    new GetDistributionCommand({ Id: stack.output("DistributionId") }),
+  );
+const config = read.Distribution?.DistributionConfig;
+
+// The managed ID the default Behavior was given.
+console.log(config?.DefaultCacheBehavior?.OriginRequestPolicyId);
+
+// The ID of the policy the template created, which the path Behavior Refs.
+console.log(
+  config?.CacheBehaviors?.Items?.[0]?.OriginRequestPolicyId ===
+    stack.output("BeaconPolicyId"),
+);
+```
+
+A Behavior records the ID it was given, and `GetDistribution` reports it back for both the default
+Behavior and a named one. An update changing the policy is reported the same way.
+
+Nothing here reads the policy itself. Sim CloudFront forwards the viewer's headers, cookies and
+query string to the Origin whole, whatever the policy would have narrowed them to on real
+CloudFront.
+
+A policy name is unique within an account, as it is in CloudFront. A second
+`AWS::CloudFront::OriginRequestPolicy` claiming a name is refused with
+`OriginRequestPolicyAlreadyExists`. `Name` and `Comment` are the parts of
+`OriginRequestPolicyConfig` the policy carries.
+
+### Managed origin request policies
+
+CloudFront's eight managed policies are here from the start, under the IDs AWS publishes, and a
+Behavior names one without a template creating anything. `AllViewer`
+(`216adef6-5c7f-47e4-b989-5492eafa07d3`), `AllViewerAndCloudFrontHeaders-2022-06`
+(`33f36d7e-f396-46d9-90e0-52428a34d9dc`), `AllViewerExceptHostHeader`
+(`b689b0a8-53d0-40ab-baf2-68738e2966ac`), `CORS-CustomOrigin`
+(`59781a5b-3903-41f3-afcb-af62929ccde1`), `CORS-S3Origin` (`88a5eaf4-2fd4-4709-b370-b4c650ea3fcf`),
+`Elemental-MediaTailor-PersonalizedManifests` (`775133bc-15f2-49f9-abea-afb2e0bf67d2`),
+`HostHeaderOnly` (`bf0718e1-ba1e-49d1-88b1-f726733018ae`) and `UserAgentRefererHeaders`
+(`acba4595-bd28-49b8-b9fe-13317c0390fa`) are each held under the name
+[AWS publishes](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html)
+for it. CDK's `OriginRequestPolicy.ALL_VIEWER` and its seven siblings synthesize those IDs. A stack
+reaching for one deploys.
+
+The managed policies sit in CloudFront's own namespace. A template may create a policy called
+`AllViewer` of its own, and deleting that stack leaves the managed one where it was.
+
+A CloudFormation Distribution whose Behavior names a policy that is neither managed nor created here
+deploys without one. The `OriginRequestPolicyId` lands on `stack.ignoredProperties` under that
+Behavior, the way an absent cache policy does, and the Behavior reports no policy.
+
+`CreateDistribution` and `UpdateDistribution` still refuse the same ID with
+`NoSuchOriginRequestPolicy`, as real CloudFront refuses it.
+
 ## Origin access controls
 
 An origin access control is how a Distribution authenticates to a private Origin. The Origin then
@@ -2945,6 +3075,8 @@ Sim CloudFront currently supports:
 - CloudFront Functions reading an associated key value store through `cf.kvs()`
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
 - `AWS::CloudFront::CachePolicy`, and a Behavior's `CachePolicyId` read back through `GetDistribution`
+- `AWS::CloudFront::OriginRequestPolicy`, and a Behavior's `OriginRequestPolicyId` read back the
+  same way
 - `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
 - `AWS::CloudFront::OriginAccessControl`, letting an Origin read a private Bucket as CloudFront
 - Viewer certificates from sim ACM, including CloudFront's `us-east-1` requirement
@@ -3094,5 +3226,10 @@ Where sim CloudFront knowingly behaves differently from AWS:
 - **A cache policy carries its name and its comment, and nothing else.** The TTLs and
   `ParametersInCacheKeyAndForwardedToOrigin` of an `AWS::CloudFront::CachePolicy` are read past,
   since nothing here would act on them.
-- **`OriginRequestPolicyId` is accepted and ignored.** A Behavior's origin request policy is left
-  unvalidated, and `AWS::CloudFront::OriginRequestPolicy` is skipped.
+- **An origin request policy is recorded and never applied.** A Behavior's `OriginRequestPolicyId`
+  is checked against the policies this simulation holds and reported back. Sim CloudFront forwards
+  the viewer's headers, cookies and query string to the Origin whole, whatever the policy would
+  have narrowed them to on real CloudFront.
+- **An origin request policy carries its name and its comment, and nothing else.** The
+  `HeadersConfig`, `CookiesConfig` and `QueryStringsConfig` of an
+  `AWS::CloudFront::OriginRequestPolicy` are read past, since nothing here would act on them.

--- a/docs/services/cloudfront/sim-cloudfront-origin-request-policy.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-origin-request-policy.example.ts
@@ -1,0 +1,83 @@
+/**
+ * Reading back the origin request policy a Behavior was given.
+ */
+
+import { GetDistributionCommand } from "@aws-sdk/client-cloudfront";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "site-stack",
+  template: {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      BeaconPolicy: {
+        Type: "AWS::CloudFront::OriginRequestPolicy",
+        Properties: {
+          OriginRequestPolicyConfig: {
+            Name: "BeaconPolicy",
+            CookiesConfig: { CookieBehavior: "none" },
+            HeadersConfig: { HeaderBehavior: "none" },
+            QueryStringsConfig: { QueryStringBehavior: "all" },
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "BeaconPolicy"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: "site-bucket.s3.amazonaws.com",
+                S3OriginConfig: {},
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              // CORS-S3Origin, one of CloudFront's managed policies.
+              OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf",
+            },
+            CacheBehaviors: [
+              {
+                PathPattern: "/beacon",
+                TargetOriginId: "SiteOrigin",
+                ViewerProtocolPolicy: "allow-all",
+                OriginRequestPolicyId: { Ref: "BeaconPolicy" },
+              },
+            ],
+          },
+        },
+      },
+    },
+    Outputs: {
+      DistributionId: { Value: { Ref: "SiteDistribution" } },
+      BeaconPolicyId: { Value: { Ref: "BeaconPolicy" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const read = await simAws
+  .cloudFront()
+  .getDistribution(
+    new GetDistributionCommand({ Id: stack.output("DistributionId") }),
+  );
+const config = read.Distribution?.DistributionConfig;
+
+// The managed ID the default Behavior was given.
+console.log(config?.DefaultCacheBehavior?.OriginRequestPolicyId);
+
+// The ID of the policy the template created, which the path Behavior Refs.
+console.log(
+  config?.CacheBehaviors?.Items?.[0]?.OriginRequestPolicyId ===
+    stack.output("BeaconPolicyId"),
+);

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-cfn-value-adapter.ts
@@ -6,6 +6,8 @@ import { SimCloudFrontResponseHeadersPolicy } from "../../../../cloudfront/respo
 import { SimCloudFrontResponseHeadersPolicyCfn } from "./sim-cloudfront-rh-policy-cfn.js";
 import { SimCloudFrontCachePolicy } from "../../../../cloudfront/cache-policy/sim-cf-cache-policy.js";
 import { SimCloudFrontCachePolicyCfn } from "./sim-cloudfront-cache-policy-cfn.js";
+import { SimCloudFrontOriginRequestPolicy } from "../../../../cloudfront/origin-request-policy/sim-cf-origin-request-policy.js";
+import { SimCloudFrontOriginRequestPolicyCfn } from "./sim-cloudfront-orp-cfn.js";
 import { SimCloudFrontOriginAccessControl } from "../../../../cloudfront/origin-access-control/sim-cf-origin-access-control.js";
 import { SimCloudFrontOriginAccessControlCfn } from "./sim-cloudfront-oac-cfn.js";
 import { SimCloudFrontKeyValueStore } from "../../../../cloudfront/key-value-store/sim-cf-key-value-store.js";
@@ -51,6 +53,15 @@ export function cloudFrontValueAdapter(
     properties.simResource instanceof SimCloudFrontCachePolicy
   ) {
     return new SimCloudFrontCachePolicyCfn({
+      policy: properties.simResource,
+    });
+  }
+
+  if (
+    properties.type === "AWS::CloudFront::OriginRequestPolicy" &&
+    properties.simResource instanceof SimCloudFrontOriginRequestPolicy
+  ) {
+    return new SimCloudFrontOriginRequestPolicyCfn({
       policy: properties.simResource,
     });
   }

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-orp-cfn.iso.test.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-orp-cfn.iso.test.ts
@@ -1,0 +1,36 @@
+import { assertIdentical, assertInstanceOf } from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontOriginRequestPolicy } from "../../../../cloudfront/origin-request-policy/sim-cf-origin-request-policy.js";
+import { SimCloudFrontOriginRequestPolicyCfn } from "./sim-cloudfront-orp-cfn.js";
+import { cloudFrontValueAdapter } from "./sim-cloudfront-cfn-value-adapter.js";
+
+describe("SimCloudFrontOriginRequestPolicyCfn", () => {
+  const policy = new SimCloudFrontOriginRequestPolicy({ name: "BeaconPolicy" });
+  const adapter = new SimCloudFrontOriginRequestPolicyCfn({ policy });
+
+  it("answers a Ref with the policy ID", () => {
+    // Given a created policy.
+    // When a template Refs it, then it gets the ID a Cache Behavior's
+    // OriginRequestPolicyId wants.
+    assertIdentical(adapter.refValue(), policy.id);
+  });
+
+  it("answers the Id attribute with the policy ID", () => {
+    // Given a created policy.
+    // When a template reads its Id attribute, then it gets the same ID.
+    assertIdentical(adapter.attributeValue("Id"), policy.id);
+  });
+
+  it("is the adapter the CloudFront registry picks for the Resource type", () => {
+    // Given a created policy stored against its Resource type.
+    // When the CloudFront value adapter registry is asked for one.
+    const resolved = cloudFrontValueAdapter({
+      logicalId: "BeaconPolicy",
+      type: "AWS::CloudFront::OriginRequestPolicy",
+      simResource: policy,
+    });
+
+    // Then the policy's own adapter answers.
+    assertInstanceOf(resolved, SimCloudFrontOriginRequestPolicyCfn);
+  });
+});

--- a/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-orp-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/cloudfront/sim-cloudfront-orp-cfn.ts
@@ -1,0 +1,42 @@
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontOriginRequestPolicy } from "../../../../cloudfront/origin-request-policy/sim-cf-origin-request-policy.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimCloudFrontOriginRequestPolicyCfnProperties {
+  readonly policy: SimCloudFrontOriginRequestPolicy;
+}
+
+/**
+ * CloudFormation-facing behavior for an AWS::CloudFront::OriginRequestPolicy
+ * Resource.
+ */
+export class SimCloudFrontOriginRequestPolicyCfn implements SimCfnResourceValueAdapter {
+  private readonly policy: SimCloudFrontOriginRequestPolicy;
+
+  constructor(properties: SimCloudFrontOriginRequestPolicyCfnProperties) {
+    this.policy = properties.policy;
+  }
+
+  /**
+   * CloudFormation Ref for AWS::CloudFront::OriginRequestPolicy returns the
+   * policy ID, which is what a Cache Behavior's OriginRequestPolicyId wants.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.policy.id;
+  }
+
+  /**
+   * CloudFormation attributes for AWS::CloudFront::OriginRequestPolicy.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    switch (attributeName) {
+      case "Id": {
+        return this.policy.id;
+      }
+      default: {
+        /* v8 ignore next */
+        return `${this.policy.id}.${attributeName}`;
+      }
+    }
+  }
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -275,10 +275,27 @@ The policy carries nothing of `CachePolicyConfig` beyond `Name` and `Comment`. T
 sim CloudFront has no cache for them to decide anything about. Recording the ID is what lets a test
 assert which policy a Behavior was given.
 
-`SimCfBehaviorPolicies` asks both `SimCfBehaviorResponseHeadersPolicy` and
-`SimCfBehaviorCachePolicy` about one Behavior. A `CachePolicyId` naming nothing is
+`SimCfBehaviorPolicies` asks `SimCfBehaviorResponseHeadersPolicy`, `SimCfBehaviorCachePolicy` and
+`SimCfBehaviorOriginRequestPolicy` about one Behavior. A `CachePolicyId` naming nothing is
 `SimCloudFrontNoSuchCachePolicy`, which is what real CloudFront answers, and it comes at creation
 and update time as the response headers policy refusal does.
+
+## Origin request policies
+
+`origin-request-policy/` holds the model and its registry, laid out the same way as the cache
+policies above. A `SimCloudFrontOriginRequestPolicy` is a name, an ID and an optional comment.
+`sim-cf-managed-origin-request-policies.ts` builds CloudFront's eight managed policies under the IDs
+AWS publishes, and the registry keeps them in their own namespace. There is no
+CreateOriginRequestPolicy command, so `cfn/origin-request-policy/` is the only thing that makes one.
+
+The policy carries nothing of `OriginRequestPolicyConfig` beyond `Name` and `Comment`.
+`HeadersConfig`, `CookiesConfig` and `QueryStringsConfig` decide what an Origin fetch carries, and
+sim CloudFront forwards the viewer's request whole. Recording the ID is what lets a test assert
+which policy a Behavior was given.
+
+`SimCfBehaviorOriginRequestPolicy` refuses an `OriginRequestPolicyId` naming nothing with
+`SimCloudFrontNoSuchOriginRequestPolicy`, at creation and update time as the cache policy refusal
+comes.
 
 ## Origin access controls
 
@@ -296,9 +313,9 @@ when the Distribution is created, and stores the result on the `SimCloudFrontS3O
 CloudFront refuses the whole CreateDistribution, and so is an origin type that does not match the
 Origin it was named on: `assertSimCfOacOriginType` checks that in both directions, since an origin
 access control for a Bucket signs nothing a Function URL will admit.
-`SimCfBehaviorPolicies` resolves a Behavior's `ResponseHeadersPolicyId` and its `CachePolicyId` the
-same eager way, for the same reason: CloudFront checks them all at creation rather than when a
-request arrives.
+`SimCfBehaviorPolicies` resolves a Behavior's `ResponseHeadersPolicyId`, `CachePolicyId` and
+`OriginRequestPolicyId` the same eager way, for the same reason: CloudFront checks them all at
+creation rather than when a request arrives.
 
 `SimCfS3OriginSigner` reads the stored origin access control on every Origin fetch. One whose
 `signs` getter is true makes the read a request from the `cloudfront.amazonaws.com` service

--- a/src/service/cloudfront/behaviour/sim-cloud-front-behavior.ts
+++ b/src/service/cloudfront/behaviour/sim-cloud-front-behavior.ts
@@ -18,6 +18,12 @@ export interface SimCloudFrontBehavior {
    * AWS manages it. The simulated cache does not read it yet.
    */
   cachePolicyId?: string | undefined;
+  /**
+   * The origin request policy this Behavior was given, whether a template
+   * created it or AWS manages it. What reaches the Origin does not read it
+   * yet.
+   */
+  originRequestPolicyId?: string | undefined;
   functionAssociations?:
     | undefined
     | {

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-behavior-policy-kinds.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-behavior-policy-kinds.ts
@@ -1,0 +1,44 @@
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+
+/**
+ * One kind of policy a Behavior names, in the terms a template writes it in,
+ * with the way this simulation is asked whether it holds one and what the
+ * Behavior loses along with it.
+ */
+export interface BehaviorPolicyKind {
+  readonly property:
+    | "ResponseHeadersPolicyId"
+    | "CachePolicyId"
+    | "OriginRequestPolicyId";
+  readonly name: string;
+  readonly loses: string;
+  readonly held: (cloudFront: SimCloudFront, policyId: string) => boolean;
+}
+
+/**
+ * The three policies a Behavior names outside itself.
+ */
+export const behaviorPolicyKinds: readonly BehaviorPolicyKind[] = [
+  {
+    property: "ResponseHeadersPolicyId",
+    name: "response headers policy",
+    loses:
+      "serves every response without the headers that policy would have set",
+    held: (cloudFront, policyId) =>
+      cloudFront.getResponseHeadersPolicyById(policyId) !== undefined,
+  },
+  {
+    property: "CachePolicyId",
+    name: "cache policy",
+    loses: "reports no CachePolicyId",
+    held: (cloudFront, policyId) =>
+      cloudFront.getCachePolicyById(policyId) !== undefined,
+  },
+  {
+    property: "OriginRequestPolicyId",
+    name: "origin request policy",
+    loses: "reports no OriginRequestPolicyId",
+    held: (cloudFront, policyId) =>
+      cloudFront.getOriginRequestPolicyById(policyId) !== undefined,
+  },
+];

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-behavior-policies.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-behavior-policies.ts
@@ -14,7 +14,8 @@ const defaultBehaviorPath = "DistributionConfig.DefaultCacheBehavior";
 
 /**
  * The DistributionConfig to deploy, without a policy ID naming a response
- * headers policy or a cache policy this simulation does not hold.
+ * headers policy, a cache policy or an origin request policy this simulation
+ * does not hold.
  *
  * `CreateDistribution` refuses such an ID, as real CloudFront refuses one, and
  * a Distribution deployed from a template is the one place that refusal costs
@@ -30,7 +31,7 @@ const defaultBehaviorPath = "DistributionConfig.DefaultCacheBehavior";
  * naming one keeps it.
  *
  * One Behavior losing a policy leaves the others holding theirs, and a
- * Behavior losing one kind of policy keeps the other.
+ * Behavior losing one kind of policy keeps the others.
  */
 export function simCfnCfDistroWithHeldBehaviorPolicies(
   resource: SimCfnResource,

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-creator.ts
@@ -26,12 +26,12 @@ interface SimCfnCfDistroCreatorProperties {
  *
  * A `WebACLId` naming a web ACL this simulation does not hold is left out and
  * recorded, and so are a Lambda@Edge association it cannot run and a
- * `ResponseHeadersPolicyId` or `CachePolicyId` naming a policy it does not
- * hold. CloudFront has no Resource of its own for any of them, so all of them
- * live on the Distribution itself, and refusing one would take the
- * Distribution down over something that was never the point of the template.
- * The site a local dev server and a suite of tests make requests to has to
- * survive that.
+ * `ResponseHeadersPolicyId`, `CachePolicyId` or `OriginRequestPolicyId`
+ * naming a policy it does not hold. CloudFront has no Resource of its own for
+ * any of them, so all of them live on the Distribution itself, and refusing
+ * one would take the Distribution down over something that was never the point
+ * of the template. The site a local dev server and a suite of tests make
+ * requests to has to survive that.
  */
 export class SimCfnCfDistroCreator {
   private readonly cloudFront: SimCloudFront;

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-origin-request-policy.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-origin-request-policy.iso.test.ts
@@ -1,0 +1,178 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfManagedOriginRequestPolicyIds } from "../../origin-request-policy/sim-cf-managed-origin-request-policies.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+
+const bucketName = "held-origin-request-policy-bucket";
+
+/**
+ * An ID that is neither a managed policy nor one a template created here,
+ * which is what a policy ID from a real account looks like.
+ */
+const absentPolicyId = "11111111-2222-3333-4444-555555555555";
+
+/**
+ * A template with a Distribution, with the Behaviors the test is about merged
+ * over the default one.
+ */
+function siteTemplate(
+  distributionConfig: SimCfnTemplateValueRecord = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: bucketName },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Enabled: true,
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: `${bucketName}.s3.amazonaws.com`,
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              OriginRequestPolicyId: absentPolicyId,
+            },
+            ...distributionConfig,
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("CloudFormation Distribution on an absent origin request policy", () => {
+  async function deployedSite(
+    stackName: string,
+    distributionConfig: SimCfnTemplateValueRecord = {},
+  ): Promise<{
+    distribution: SimCloudFrontDistribution;
+    ignoredPaths: readonly string[];
+    ignoredReasons: readonly string[];
+  }> {
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName,
+      template: siteTemplate(distributionConfig),
+    });
+
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+
+    return {
+      distribution: resource.simResource,
+      ignoredPaths: stack.ignoredProperties.map((ignored) => ignored.path),
+      ignoredReasons: stack.ignoredProperties.map((ignored) => ignored.reason),
+    };
+  }
+
+  it("deploys the Distribution and records the policy it dropped", async () => {
+    // Given a template naming an origin request policy from some real account.
+    // When the stack is deployed.
+    const { distribution, ignoredPaths, ignoredReasons } = await deployedSite(
+      "dropped-origin-request-policy-stack",
+    );
+
+    // Then the Distribution is up, with no policy on the Behavior that named
+    // one.
+    assertArrayLength(distribution.behaviors, 1);
+    assertUndefined(distribution.behaviors[0].originRequestPolicyId);
+
+    // And the property is recorded under the Behavior that named it, so a test
+    // that cares reads why.
+    assertArrayLength(ignoredPaths, 1);
+    assertIdentical(
+      ignoredPaths[0],
+      "DistributionConfig.DefaultCacheBehavior.OriginRequestPolicyId",
+    );
+    assertStringIncludes(ignoredReasons[0] ?? "", absentPolicyId);
+  });
+
+  it("keeps a managed policy the template named", async () => {
+    // Given a Distribution whose path Behavior names a managed policy and
+    // whose default Behavior names one from a real account.
+    const { distribution, ignoredPaths } = await deployedSite(
+      "managed-origin-request-policy-stack",
+      {
+        CacheBehaviors: [
+          {
+            PathPattern: "/beacon",
+            TargetOriginId: "SiteOrigin",
+            ViewerProtocolPolicy: "allow-all",
+            OriginRequestPolicyId:
+              simCfManagedOriginRequestPolicyIds.corsS3Origin,
+          },
+        ],
+      },
+    );
+
+    // Then only the default Behavior lost its policy.
+    assertArrayLength(ignoredPaths, 1);
+    assertIdentical(
+      ignoredPaths[0],
+      "DistributionConfig.DefaultCacheBehavior.OriginRequestPolicyId",
+    );
+
+    // And the path Behavior holds the managed ID it named.
+    assertIdentical(
+      distribution.behaviors[1]?.originRequestPolicyId,
+      simCfManagedOriginRequestPolicyIds.corsS3Origin,
+    );
+  });
+
+  it("records all three policies a Behavior loses, under their own paths", async () => {
+    // Given a path Behavior naming a response headers policy, a cache policy
+    // and an origin request policy, none of which is here.
+    const { ignoredPaths } = await deployedSite("all-policies-stack", {
+      CacheBehaviors: [
+        {
+          PathPattern: "/beacon",
+          TargetOriginId: "SiteOrigin",
+          ViewerProtocolPolicy: "allow-all",
+          CachePolicyId: absentPolicyId,
+          ResponseHeadersPolicyId: absentPolicyId,
+          OriginRequestPolicyId: absentPolicyId,
+        },
+      ],
+    });
+
+    // Then each is recorded on its own, alongside the default Behavior's.
+    assertArrayLength(ignoredPaths, 4);
+    assertIdentical(
+      ignoredPaths[1],
+      "DistributionConfig.CacheBehaviors./beacon.ResponseHeadersPolicyId",
+    );
+    assertIdentical(
+      ignoredPaths[2],
+      "DistributionConfig.CacheBehaviors./beacon.CachePolicyId",
+    );
+    assertIdentical(
+      ignoredPaths[3],
+      "DistributionConfig.CacheBehaviors./beacon.OriginRequestPolicyId",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-policy-drops.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-policy-drops.ts
@@ -1,12 +1,10 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCloudFrontCacheBehaviorConfig } from "../../command/create-distribution/create-distribution.command.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
-
-/**
- * The policy properties a Behavior carries, in the terms a template writes
- * them in.
- */
-type BehaviorPolicyProperty = "ResponseHeadersPolicyId" | "CachePolicyId";
+import {
+  type BehaviorPolicyKind,
+  behaviorPolicyKinds,
+} from "./sim-cfn-cf-behavior-policy-kinds.js";
 
 /**
  * Takes a policy ID naming a policy this simulation does not hold off the
@@ -28,21 +26,9 @@ export class SimCfnCfDistroPolicyDrops {
     behavior: SimCloudFrontCacheBehaviorConfig,
     behaviorPath: string,
   ): SimCloudFrontCacheBehaviorConfig {
-    const withHeaders = this.heldPolicy(
+    return behaviorPolicyKinds.reduce(
+      (held, kind) => this.heldPolicy(held, behaviorPath, kind),
       behavior,
-      behaviorPath,
-      "ResponseHeadersPolicyId",
-      (policyId) =>
-        this.cloudFront.getResponseHeadersPolicyById(policyId) !== undefined,
-      headersPolicyDropReason,
-    );
-
-    return this.heldPolicy(
-      withHeaders,
-      behaviorPath,
-      "CachePolicyId",
-      (policyId) => this.cloudFront.getCachePolicyById(policyId) !== undefined,
-      cachePolicyDropReason,
     );
   }
 
@@ -53,44 +39,21 @@ export class SimCfnCfDistroPolicyDrops {
   private heldPolicy(
     behavior: SimCloudFrontCacheBehaviorConfig,
     behaviorPath: string,
-    property: BehaviorPolicyProperty,
-    held: (policyId: string) => boolean,
-    reason: (policyId: string) => string,
+    kind: BehaviorPolicyKind,
   ): SimCloudFrontCacheBehaviorConfig {
-    // oxlint-disable-next-line security/detect-object-injection
-    const policyId = behavior[property];
+    const policyId = behavior[kind.property];
 
-    if (policyId === undefined || held(policyId)) {
+    if (policyId === undefined || kind.held(this.cloudFront, policyId)) {
       return behavior;
     }
 
     this.count += 1;
     this.resource.ignoreProperty(
-      `${behaviorPath}.${property}`,
-      reason(policyId),
+      `${behaviorPath}.${kind.property}`,
+      `${kind.name} ${policyId} is not held by this simulation, so the ` +
+        `Behavior is deployed without one and ${kind.loses}`,
     );
 
-    return { ...behavior, [property]: undefined };
+    return { ...behavior, [kind.property]: undefined };
   }
-}
-
-/**
- * What a Behavior loses along with a response headers policy.
- */
-function headersPolicyDropReason(policyId: string): string {
-  return (
-    `response headers policy ${policyId} is not held by this simulation, so ` +
-    `the Behavior is deployed without one and serves every response without ` +
-    `the headers that policy would have set`
-  );
-}
-
-/**
- * What a Behavior loses along with a cache policy.
- */
-function cachePolicyDropReason(policyId: string): string {
-  return (
-    `cache policy ${policyId} is not held by this simulation, so the ` +
-    `Behavior is deployed without one and reports no CachePolicyId`
-  );
 }

--- a/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-config.ts
+++ b/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-config.ts
@@ -1,0 +1,59 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCloudFrontOriginRequestPolicy } from "../../origin-request-policy/sim-cf-origin-request-policy.js";
+
+/**
+ * Reads an AWS::CloudFront::OriginRequestPolicy Resource into a simulated
+ * policy.
+ *
+ * `Name` and `Comment` are what the policy carries. The header, cookie and
+ * query string sections are read past: what they configure is a narrowing of
+ * the origin request this simulation has yet to grow. A Resource missing its
+ * `Name` is refused, as CloudFormation refuses one.
+ */
+export class SimCfnCfOriginRequestPolicyConfig {
+  private readonly resource: SimCfnResource;
+  private readonly properties: SimCfnTemplateValueRecord;
+
+  constructor(properties: {
+    readonly resource: SimCfnResource;
+    readonly properties: SimCfnTemplateValueRecord;
+  }) {
+    this.resource = properties.resource;
+    this.properties = properties.properties;
+  }
+
+  /**
+   * Build the simulated policy this Resource describes.
+   */
+  build(): SimCloudFrontOriginRequestPolicy {
+    const config = this.properties["OriginRequestPolicyConfig"];
+
+    if (!isRecord(config)) {
+      return this.refuse("OriginRequestPolicyConfig must be an object");
+    }
+
+    const name = config["Name"];
+
+    if (typeof name !== "string") {
+      return this.refuse("OriginRequestPolicyConfig needs a string Name");
+    }
+
+    const comment = config["Comment"];
+
+    return new SimCloudFrontOriginRequestPolicy({
+      name,
+      ...(typeof comment === "string" && { comment }),
+    });
+  }
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  private refuse(detail: string): never {
+    throw new Error(
+      `Invalid AWS::CloudFront::OriginRequestPolicy ${this.resource.logicalId}: ${detail}`,
+    );
+  }
+}

--- a/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-creator.ts
+++ b/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-creator.ts
@@ -1,0 +1,53 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import type { SimCloudFrontOriginRequestPolicy } from "../../origin-request-policy/sim-cf-origin-request-policy.js";
+import { SimCfnCfOriginRequestPolicyConfig } from "./sim-cfn-cf-orp-config.js";
+
+interface SimCfnCfOriginRequestPolicyCreatorProperties {
+  readonly cloudFront: SimCloudFront;
+}
+
+/**
+ * Creates simulated origin request policies from
+ * AWS::CloudFront::OriginRequestPolicy Resources.
+ */
+export class SimCfnCfOriginRequestPolicyCreator {
+  private readonly cloudFront: SimCloudFront;
+
+  constructor(properties: SimCfnCfOriginRequestPolicyCreatorProperties) {
+    this.cloudFront = properties.cloudFront;
+  }
+
+  /**
+   * Create and store the policy one Resource describes.
+   */
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCloudFrontOriginRequestPolicy {
+    const policy = new SimCfnCfOriginRequestPolicyConfig({
+      resource,
+      properties,
+    }).build();
+
+    this.cloudFront.addOriginRequestPolicy(policy);
+
+    return policy;
+  }
+
+  /**
+   * Remove a policy created from a Resource.
+   */
+  delete(resource: SimCfnResource): void {
+    const policy = resource.simResource as
+      | SimCloudFrontOriginRequestPolicy
+      | undefined;
+
+    if (policy === undefined) {
+      return;
+    }
+
+    this.cloudFront.removeOriginRequestPolicy(policy.id);
+  }
+}

--- a/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp.iso.test.ts
@@ -1,0 +1,225 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../../cloudformation/template/sim-cfn-template.js";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCloudFrontOriginRequestPolicy } from "../../origin-request-policy/sim-cf-origin-request-policy.js";
+import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCfnCfOriginRequestPolicyConfig } from "./sim-cfn-cf-orp-config.js";
+import { SimCfnCfOriginRequestPolicyCreator } from "./sim-cfn-cf-orp-creator.js";
+
+const bucketName = "origin-request-policy-cfn-bucket";
+
+/**
+ * A template with an origin request policy of its own, and a Distribution
+ * whose default Behavior points at it with a Ref.
+ */
+function siteTemplate(
+  originRequestPolicyConfig: SimCfnTemplateValueRecord = {},
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: bucketName },
+      },
+      BeaconPolicy: {
+        Type: "AWS::CloudFront::OriginRequestPolicy",
+        Properties: {
+          OriginRequestPolicyConfig: {
+            Name: "BeaconPolicy",
+            CookiesConfig: { CookieBehavior: "none" },
+            HeadersConfig: { HeaderBehavior: "none" },
+            QueryStringsConfig: { QueryStringBehavior: "none" },
+            ...originRequestPolicyConfig,
+          },
+        },
+      },
+      SiteDistribution: {
+        Type: "AWS::CloudFront::Distribution",
+        DependsOn: ["SiteBucket", "BeaconPolicy"],
+        Properties: {
+          DistributionConfig: {
+            DefaultRootObject: "index.html",
+            Enabled: true,
+            Origins: [
+              {
+                Id: "SiteOrigin",
+                DomainName: `${bucketName}.s3.amazonaws.com`,
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            DefaultCacheBehavior: {
+              TargetOriginId: "SiteOrigin",
+              ViewerProtocolPolicy: "allow-all",
+              OriginRequestPolicyId: { Ref: "BeaconPolicy" },
+            },
+          },
+        },
+      },
+    },
+    Outputs: {
+      PolicyRef: { Value: { Ref: "BeaconPolicy" } },
+      PolicyId: { Value: { "Fn::GetAtt": ["BeaconPolicy", "Id"] } },
+    },
+  };
+}
+
+describe("AWS::CloudFront::OriginRequestPolicy", () => {
+  it("creates a policy a Behavior can name", async () => {
+    // Given a template declaring its own origin request policy.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "origin-request-policy-stack",
+      template: siteTemplate(),
+    });
+
+    await stack.waitForDeployComplete();
+
+    // When the created policy is read back.
+    const resource = stack.getResource("BeaconPolicy");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontOriginRequestPolicy);
+
+    const policy = resource.simResource;
+
+    // Then the policy is held under its name, rather than the Resource being
+    // skipped.
+    assertIdentical(policy.name, "BeaconPolicy");
+    assertIdentical(
+      simAws.cloudFront().getOriginRequestPolicyById(policy.id),
+      policy,
+    );
+
+    // And the Behavior that Refs it reports its ID.
+    const distributionResource = stack.getResource("SiteDistribution");
+
+    assertNonNullable(distributionResource);
+    assertInstanceOf(
+      distributionResource.simResource,
+      SimCloudFrontDistribution,
+    );
+    assertIdentical(
+      distributionResource.simResource.behaviors[0]?.originRequestPolicyId,
+      policy.id,
+    );
+
+    // And Ref and the Id attribute both answer with the policy ID.
+    assertIdentical(stack.outputs.get("PolicyRef")?.value, policy.id);
+    assertIdentical(stack.outputs.get("PolicyId")?.value, policy.id);
+  });
+
+  it("keeps the comment the template gave the policy", async () => {
+    // Given a template whose policy carries a comment.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "origin-request-policy-comment-stack",
+      template: siteTemplate({ Comment: "Only the Origin header" }),
+    });
+
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("BeaconPolicy");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontOriginRequestPolicy);
+
+    // Then the comment is what the template wrote.
+    assertIdentical(resource.simResource.comment, "Only the Origin header");
+  });
+
+  it("forgets the policy when the Stack is torn down", async () => {
+    // Given a deployed Stack holding a policy.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "origin-request-policy-teardown-stack",
+      template: siteTemplate(),
+    });
+
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("BeaconPolicy");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontOriginRequestPolicy);
+
+    const policyId = resource.simResource.id;
+
+    // When the Stack is deleted.
+    await simAws.cloudFormation().deleteStack({
+      input: { StackName: "origin-request-policy-teardown-stack" },
+    });
+    await simAws.backgroundTasksComplete();
+
+    // Then nothing answers to the policy's ID.
+    assertUndefined(simAws.cloudFront().getOriginRequestPolicyById(policyId));
+  });
+
+  it("refuses a Resource whose OriginRequestPolicyConfig is not an object", async () => {
+    // Given a template whose policy config is a string.
+    const simAws = new SimAws();
+
+    // When it is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "origin-request-policy-invalid-stack",
+        template: {
+          Resources: {
+            BeaconPolicy: {
+              Type: "AWS::CloudFront::OriginRequestPolicy",
+              Properties: { OriginRequestPolicyConfig: "BeaconPolicy" },
+            },
+          },
+        },
+      });
+
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the refusal names the Resource and the part that could not be read.
+    assertStringIncludes(error.message, "BeaconPolicy");
+    assertStringIncludes(
+      error.message,
+      "OriginRequestPolicyConfig must be an object",
+    );
+  });
+
+  it("refuses a Resource with no Name", () => {
+    // Given a policy config that left its Name out.
+    const config = new SimCfnCfOriginRequestPolicyConfig({
+      resource: new SimCfnResource({ logicalId: "BeaconPolicy" }),
+      properties: {
+        OriginRequestPolicyConfig: {
+          CookiesConfig: { CookieBehavior: "none" },
+        },
+      },
+    });
+
+    // When it is read.
+    const error = assertThrowsError(() => config.build());
+
+    // Then the refusal says which field is missing.
+    assertStringIncludes(error.message, "needs a string Name");
+  });
+
+  it("has nothing to forget for a Resource that never created a policy", () => {
+    // Given a Resource whose creation never ran, so it holds no policy.
+    const simAws = new SimAws();
+    const creator = new SimCfnCfOriginRequestPolicyCreator({
+      cloudFront: simAws.cloudFront(),
+    });
+
+    // When the teardown reaches it, then it passes over rather than failing.
+    creator.delete(new SimCfnResource({ logicalId: "BeaconPolicy" }));
+  });
+});

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
@@ -11,6 +11,7 @@ import { SimCfnCffCreator } from "./cff/sim-cfn-cff-creator.js";
 import { SimCfnCfDistroDeleter } from "./distro/sim-cfn-cf-distro-deleter.js";
 import { SimCfnCfResponseHeadersPolicyCreator } from "./response-headers-policy/sim-cfn-cf-rh-policy-creator.js";
 import { SimCfnCfCachePolicyCreator } from "./cache-policy/sim-cfn-cf-cache-policy-creator.js";
+import { SimCfnCfOriginRequestPolicyCreator } from "./origin-request-policy/sim-cfn-cf-orp-creator.js";
 import { SimCfnCfOriginAccessControlCreator } from "./origin-access-control/sim-cfn-cf-oac-creator.js";
 import { SimCfnCfKeyValueStoreCreator } from "./key-value-store/sim-cfn-cf-kvs-creator.js";
 
@@ -23,6 +24,7 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
   private readonly distroDeleter: SimCfnCfDistroDeleter;
   private readonly responseHeadersPolicyCreator: SimCfnCfResponseHeadersPolicyCreator;
   private readonly cachePolicyCreator: SimCfnCfCachePolicyCreator;
+  private readonly originRequestPolicyCreator: SimCfnCfOriginRequestPolicyCreator;
   private readonly originAccessControlCreator: SimCfnCfOriginAccessControlCreator;
   private readonly keyValueStoreCreator: SimCfnCfKeyValueStoreCreator;
 
@@ -33,6 +35,9 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
     this.responseHeadersPolicyCreator =
       new SimCfnCfResponseHeadersPolicyCreator({ cloudFront });
     this.cachePolicyCreator = new SimCfnCfCachePolicyCreator({ cloudFront });
+    this.originRequestPolicyCreator = new SimCfnCfOriginRequestPolicyCreator({
+      cloudFront,
+    });
     this.originAccessControlCreator = new SimCfnCfOriginAccessControlCreator({
       cloudFront,
     });
@@ -63,6 +68,9 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "CachePolicy": {
         return this.cachePolicyCreator.create(resource, properties);
+      }
+      case "OriginRequestPolicy": {
+        return this.originRequestPolicyCreator.create(resource, properties);
       }
       case "OriginAccessControl": {
         return this.originAccessControlCreator.create(resource, properties);
@@ -108,6 +116,10 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "CachePolicy": {
         this.cachePolicyCreator.delete(resource);
+        return;
+      }
+      case "OriginRequestPolicy": {
+        this.originRequestPolicyCreator.delete(resource);
         return;
       }
       case "OriginAccessControl": {

--- a/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.command.ts
@@ -172,6 +172,7 @@ export interface SimCloudFrontDefaultCacheBehaviorConfig {
     | undefined;
   readonly ResponseHeadersPolicyId?: string | undefined;
   readonly CachePolicyId?: string | undefined;
+  readonly OriginRequestPolicyId?: string | undefined;
 }
 
 /**

--- a/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
+++ b/src/service/cloudfront/command/create-distribution/create-distribution.handler.ts
@@ -13,6 +13,7 @@ import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontOriginRequestPolicyRegistry } from "../../origin-request-policy/sim-cf-origin-request-policy-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { SimCloudFrontCachePolicyRegistry } from "../../cache-policy/sim-cf-cache-policy-registry.js";
 import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
@@ -44,6 +45,7 @@ interface CreateDistributionCommandHandlerProperties {
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
+  readonly originRequestPolicies: SimCloudFrontOriginRequestPolicyRegistry;
   readonly webAclResolver?: SimCfWebAclResolver | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;

--- a/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
+++ b/src/service/cloudfront/command/update-distribution/update-distribution.handler.ts
@@ -24,6 +24,7 @@ import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.erro
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontOriginRequestPolicyRegistry } from "../../origin-request-policy/sim-cf-origin-request-policy-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { SimCloudFrontCachePolicyRegistry } from "../../cache-policy/sim-cf-cache-policy-registry.js";
 import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
@@ -47,6 +48,7 @@ interface UpdateDistributionCommandHandlerProperties {
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
+  readonly originRequestPolicies: SimCloudFrontOriginRequestPolicyRegistry;
   readonly webAclResolver?: SimCfWebAclResolver | undefined;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly acmRegistry?: SimAcmRegistry | undefined;

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-origin-request-policy.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-origin-request-policy.ts
@@ -1,0 +1,40 @@
+import { SimCloudFrontNoSuchOriginRequestPolicy } from "../../error/sim-cf-origin-request-policy.error.js";
+import type { SimCloudFrontOriginRequestPolicyRegistry } from "../../origin-request-policy/sim-cf-origin-request-policy-registry.js";
+
+/**
+ * Refuses a Cache Behavior naming an origin request policy this simulation
+ * does not hold.
+ *
+ * Real CloudFront checks this when the Distribution is created or updated, so
+ * a template naming a mistyped policy ID fails the deploy there too, rather
+ * than deploying successfully and only failing the first request that reaches
+ * the Behavior.
+ */
+export class SimCfBehaviorOriginRequestPolicy {
+  constructor(
+    private readonly policies: SimCloudFrontOriginRequestPolicyRegistry,
+  ) {}
+
+  /**
+   * Refuse one Behavior naming a policy which is not there.
+   */
+  assertExists(
+    targetOriginId: string | undefined,
+    originRequestPolicyId: string | undefined,
+  ): void {
+    if (
+      originRequestPolicyId === undefined ||
+      this.policies.byId(originRequestPolicyId) !== undefined
+    ) {
+      return;
+    }
+
+    throw new SimCloudFrontNoSuchOriginRequestPolicy(
+      `Sim CloudFront Behavior for Origin ${targetOriginId} names origin ` +
+        `request policy ${originRequestPolicyId}, which does not exist. A ` +
+        `Behavior names one of CloudFront's eight managed policies, or a ` +
+        `policy an AWS::CloudFront::OriginRequestPolicy Resource created in ` +
+        `this simulation. A policy ID from a real account is neither.`,
+    );
+  }
+}

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-policies.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-policies.ts
@@ -4,19 +4,21 @@ import type {
   SimCloudFrontDistributionConfig,
 } from "../../command/create-distribution/create-distribution.command.js";
 import type { SimCfBehaviorCachePolicy } from "./sim-cf-behavior-cache-policy.js";
+import type { SimCfBehaviorOriginRequestPolicy } from "./sim-cf-behavior-origin-request-policy.js";
 import type { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
 
 /**
  * The policies a Cache Behavior names, and whether this simulation holds them.
  *
- * A Behavior points at a response headers policy and a cache policy by ID, and
- * both live outside the Distribution. Each one is checked the same way and at
- * the same moment, so they are asked together.
+ * A Behavior points at a response headers policy, a cache policy and an origin
+ * request policy by ID, and all three live outside the Distribution. Each one
+ * is checked the same way and at the same moment, so they are asked together.
  */
 export class SimCfBehaviorPolicies {
   constructor(
     private readonly responseHeadersPolicy: SimCfBehaviorResponseHeadersPolicy,
     private readonly cachePolicy: SimCfBehaviorCachePolicy,
+    private readonly originRequestPolicy: SimCfBehaviorOriginRequestPolicy,
   ) {}
 
   /**
@@ -41,7 +43,7 @@ export class SimCfBehaviorPolicies {
   }
 
   /**
-   * Refuse one Behavior naming a policy of either kind which is not there.
+   * Refuse one Behavior naming a policy of any kind which is not there.
    */
   assertExists(
     behavior:
@@ -55,6 +57,10 @@ export class SimCfBehaviorPolicies {
     this.cachePolicy.assertExists(
       behavior.TargetOriginId,
       behavior.CachePolicyId,
+    );
+    this.originRequestPolicy.assertExists(
+      behavior.TargetOriginId,
+      behavior.OriginRequestPolicyId,
     );
   }
 }

--- a/src/service/cloudfront/distribution/configurator/sim-cf-behavior-properties.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-behavior-properties.ts
@@ -20,8 +20,12 @@ export function simCfBehaviorProperties(
     | SimCloudFrontCacheBehaviorConfig,
   policies: SimCfBehaviorPolicies,
 ): SimCloudFrontBehavior {
-  const { TargetOriginId, ResponseHeadersPolicyId, CachePolicyId } =
-    cacheBehavior;
+  const {
+    TargetOriginId,
+    ResponseHeadersPolicyId,
+    CachePolicyId,
+    OriginRequestPolicyId,
+  } = cacheBehavior;
 
   assertDefined(TargetOriginId, "CloudFront CacheBehavior TargetOriginId");
 
@@ -46,6 +50,9 @@ export function simCfBehaviorProperties(
     }),
     ...(CachePolicyId !== undefined && {
       cachePolicyId: CachePolicyId,
+    }),
+    ...(OriginRequestPolicyId !== undefined && {
+      originRequestPolicyId: OriginRequestPolicyId,
     }),
     functionAssociations: configureCffAssociations(cacheBehavior),
     lambdaFunctionAssociations: configureEdgeAssociations(cacheBehavior),

--- a/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
@@ -2,10 +2,12 @@ import type { SimCloudFrontCachePolicyRegistry } from "../../cache-policy/sim-cf
 import type { SimCfCustomOriginDispatcher } from "../../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontOriginRequestPolicyRegistry } from "../../origin-request-policy/sim-cf-origin-request-policy-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import { SimCfDistributionWebAcl } from "../../web-acl/sim-cf-distribution-web-acl.js";
 import type { SimCfWebAclResolver } from "../../web-acl/sim-cf-web-acl.js";
 import { SimCfBehaviorCachePolicy } from "./sim-cf-behavior-cache-policy.js";
+import { SimCfBehaviorOriginRequestPolicy } from "./sim-cf-behavior-origin-request-policy.js";
 import { SimCfBehaviorPolicies } from "./sim-cf-behavior-policies.js";
 import { SimCfBehaviorResponseHeadersPolicy } from "./sim-cf-behavior-response-headers-policy.js";
 import { SimCloudFrontBehaviorConfigurator } from "./sim-cloud-front-behavior-configurator.js";
@@ -18,6 +20,7 @@ interface SimCloudFrontConfiguratorProperties {
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
+  readonly originRequestPolicies: SimCloudFrontOriginRequestPolicyRegistry;
   readonly webAclResolver?: SimCfWebAclResolver | undefined;
 }
 
@@ -33,6 +36,7 @@ export function makeSimCloudFrontDistributionConfigurator(
   const behaviorPolicies = new SimCfBehaviorPolicies(
     new SimCfBehaviorResponseHeadersPolicy(properties.responseHeadersPolicies),
     new SimCfBehaviorCachePolicy(properties.cachePolicies),
+    new SimCfBehaviorOriginRequestPolicy(properties.originRequestPolicies),
   );
 
   return new SimCloudFrontDistributionConfigurator(

--- a/src/service/cloudfront/distribution/sim-cf-distribution-configuration-state.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-configuration-state.ts
@@ -3,6 +3,7 @@ import type { SimCloudFrontCachePolicyRegistry } from "../cache-policy/sim-cf-ca
 import type { SimCfCustomOriginDispatcher } from "../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontOriginRequestPolicyRegistry } from "../origin-request-policy/sim-cf-origin-request-policy-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { SimCfWebAclResolver } from "../web-acl/sim-cf-web-acl.js";
 import type { SimCfEdgeFunctions } from "../edge/sim-cf-edge-functions.js";
@@ -13,9 +14,9 @@ import type { SimCfEdgeFunctions } from "../edge/sim-cf-edge-functions.js";
  *
  * A DistributionConfig is mostly references: a Bucket or a hostname per
  * Origin, a certificate, an origin access control, a response headers policy,
- * a cache policy, a web ACL, a Lambda@Edge function version. None of them belongs to
- * CloudFront, and creation and update resolve every one of them the same way,
- * so they travel together.
+ * a cache policy, an origin request policy, a web ACL, a Lambda@Edge function
+ * version. None of them belongs to CloudFront, and creation and update resolve
+ * every one of them the same way, so they travel together.
  */
 export interface SimCfDistributionConfigurationState {
   readonly s3OriginResolver: SimCloudFrontS3OriginResolver;
@@ -24,6 +25,7 @@ export interface SimCfDistributionConfigurationState {
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
+  readonly originRequestPolicies: SimCloudFrontOriginRequestPolicyRegistry;
   readonly webAclResolver: SimCfWebAclResolver | undefined;
   readonly edgeFunctions: SimCfEdgeFunctions | undefined;
 }

--- a/src/service/cloudfront/distribution/sim-cf-distribution-origin-request-policy.iso.test.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-origin-request-policy.iso.test.ts
@@ -1,0 +1,262 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import {
+  CreateDistributionCommand,
+  GetDistributionCommand,
+  UpdateDistributionCommand,
+} from "@aws-sdk/client-cloudfront";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimCloudFrontOriginRequestPolicy } from "../origin-request-policy/sim-cf-origin-request-policy.js";
+import { simCfManagedOriginRequestPolicyIds } from "../origin-request-policy/sim-cf-managed-origin-request-policies.js";
+import { SimCloudFrontNoSuchOriginRequestPolicy } from "../error/sim-cf-origin-request-policy.error.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+} from "../../../../test/cloudfront/site-fixture.js";
+
+const bucketName = "origin-request-policy-site-bucket";
+
+/**
+ * An ID that is neither a managed policy nor one created here, which is what a
+ * policy ID from a real account looks like.
+ */
+const absentPolicyId = "11111111-2222-3333-4444-555555555555";
+
+describe("A Cache Behavior's OriginRequestPolicyId", () => {
+  async function simAwsWithSite(): Promise<SimAws> {
+    const simAws = new SimAws();
+
+    await simCfSiteBucket(simAws, bucketName, {
+      "index.html": "<h1>Home</h1>",
+    });
+
+    return simAws;
+  }
+
+  it("is reported for a default Behavior given a managed policy", async () => {
+    // Given a Distribution whose default Behavior names a managed policy, the
+    // way CDK's OriginRequestPolicy.ALL_VIEWER synthesizes one.
+    const simAws = await simAwsWithSite();
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+            OriginRequestPolicyId: simCfManagedOriginRequestPolicyIds.allViewer,
+          },
+        }),
+      }),
+    );
+    const distributionId = creation.Distribution?.Id;
+
+    assertNonNullable(distributionId);
+
+    // When the Distribution is read back.
+    const read = await simAws
+      .cloudFront()
+      .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+
+    // Then GetDistribution reports the managed ID it was given.
+    assertIdentical(
+      read.Distribution?.DistributionConfig?.DefaultCacheBehavior
+        ?.OriginRequestPolicyId,
+      simCfManagedOriginRequestPolicyIds.allViewer,
+    );
+
+    // And the Behavior itself records it, so two Behaviors forwarding
+    // different things to their Origin no longer read identically.
+    const distribution = simAws
+      .cloudFront()
+      .getSimDistributionById(distributionId);
+
+    assertNonNullable(distribution);
+    assertArrayLength(distribution.behaviors, 1);
+    assertIdentical(
+      distribution.behaviors[0].originRequestPolicyId,
+      simCfManagedOriginRequestPolicyIds.allViewer,
+    );
+  });
+
+  it("is reported for a named Behavior given a policy of its own", async () => {
+    // Given a policy this simulation holds and a Distribution with a path
+    // Behavior naming it.
+    const simAws = await simAwsWithSite();
+    const policy = new SimCloudFrontOriginRequestPolicy({
+      name: "BeaconPolicy",
+    });
+
+    simAws.cloudFront().addOriginRequestPolicy(policy);
+
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          CacheBehaviors: {
+            Quantity: 1,
+            Items: [
+              {
+                PathPattern: "/beacon",
+                TargetOriginId: "site-origin",
+                ViewerProtocolPolicy: "allow-all",
+                OriginRequestPolicyId: policy.id,
+              },
+            ],
+          },
+        }),
+      }),
+    );
+    const distributionId = creation.Distribution?.Id;
+
+    assertNonNullable(distributionId);
+
+    // When the Distribution is read back.
+    const read = await simAws
+      .cloudFront()
+      .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+
+    // Then the path Behavior reports the policy, and the default Behavior
+    // reports none.
+    const config = read.Distribution?.DistributionConfig;
+
+    assertNonNullable(config);
+    assertIdentical(
+      config.CacheBehaviors?.Items?.[0]?.OriginRequestPolicyId,
+      policy.id,
+    );
+    assertUndefined(config.DefaultCacheBehavior?.OriginRequestPolicyId);
+  });
+
+  it("is reported after an update changes the policy", async () => {
+    // Given a deployed Distribution carrying one thing to its Origin.
+    const simAws = await simAwsWithSite();
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+            OriginRequestPolicyId: simCfManagedOriginRequestPolicyIds.allViewer,
+          },
+        }),
+      }),
+    );
+    const distributionId = creation.Distribution?.Id;
+
+    assertNonNullable(distributionId);
+
+    // When an update moves it onto another policy.
+    const update = await simAws.cloudFront().updateDistribution(
+      new UpdateDistributionCommand({
+        Id: distributionId,
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+            OriginRequestPolicyId:
+              simCfManagedOriginRequestPolicyIds.corsS3Origin,
+          },
+        }),
+      }),
+    );
+
+    // Then the update answers with the new policy.
+    assertIdentical(
+      update.Distribution?.DistributionConfig?.DefaultCacheBehavior
+        ?.OriginRequestPolicyId,
+      simCfManagedOriginRequestPolicyIds.corsS3Origin,
+    );
+
+    const distribution = simAws
+      .cloudFront()
+      .getSimDistributionById(distributionId);
+
+    assertNonNullable(distribution);
+    assertIdentical(
+      distribution.behaviors[0]?.originRequestPolicyId,
+      simCfManagedOriginRequestPolicyIds.corsS3Origin,
+    );
+  });
+
+  it("is refused where no policy and no managed ID answers to it", async () => {
+    // Given a Distribution whose Behavior names a policy from a real account.
+    const simAws = await simAwsWithSite();
+
+    // When it is created.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().createDistribution(
+        new CreateDistributionCommand({
+          DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+            DefaultCacheBehavior: {
+              TargetOriginId: "site-origin",
+              ViewerProtocolPolicy: "allow-all",
+              OriginRequestPolicyId: absentPolicyId,
+            },
+          }),
+        }),
+      );
+    });
+
+    // Then CloudFront refuses it by name, and the message says what a Behavior
+    // may name.
+    assertInstanceOf(error, SimCloudFrontNoSuchOriginRequestPolicy);
+    assertStringIncludes(error.message, absentPolicyId);
+  });
+
+  it("leaves an update refused for it serving what it served before", async () => {
+    // Given a deployed Distribution on a policy that is here.
+    const simAws = await simAwsWithSite();
+    const policy = new SimCloudFrontOriginRequestPolicy({
+      name: "BeaconPolicy",
+    });
+
+    simAws.cloudFront().addOriginRequestPolicy(policy);
+
+    const creation = await simAws.cloudFront().createDistribution(
+      new CreateDistributionCommand({
+        DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+          DefaultCacheBehavior: {
+            TargetOriginId: "site-origin",
+            ViewerProtocolPolicy: "allow-all",
+            OriginRequestPolicyId: policy.id,
+          },
+        }),
+      }),
+    );
+    const distributionId = creation.Distribution?.Id;
+
+    assertNonNullable(distributionId);
+
+    // When an update names a policy that is not there.
+    await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFront().updateDistribution(
+        new UpdateDistributionCommand({
+          Id: distributionId,
+          DistributionConfig: simCfSiteDistributionConfig(bucketName, {
+            DefaultCacheBehavior: {
+              TargetOriginId: "site-origin",
+              ViewerProtocolPolicy: "allow-all",
+              OriginRequestPolicyId: absentPolicyId,
+            },
+          }),
+        }),
+      );
+    });
+
+    // Then the Behavior still holds the policy it was created with.
+    const distribution = simAws
+      .cloudFront()
+      .getSimDistributionById(distributionId);
+
+    assertNonNullable(distribution);
+    assertArrayLength(distribution.behaviors, 1);
+    assertIdentical(distribution.behaviors[0].originRequestPolicyId, policy.id);
+  });
+});

--- a/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-reconfigurer.ts
@@ -3,6 +3,7 @@ import type { SimCloudFrontCachePolicyRegistry } from "../cache-policy/sim-cf-ca
 import type { SimCfCustomOriginDispatcher } from "../origin/custom/sim-cf-custom-origin-dispatcher.js";
 import type { SimCloudFrontS3OriginResolver } from "../origin/s3/sim-cloudfront-s3-origin.js";
 import type { SimCloudFrontOriginAccessControlRegistry } from "../origin-access-control/sim-cf-origin-access-control-registry.js";
+import type { SimCloudFrontOriginRequestPolicyRegistry } from "../origin-request-policy/sim-cf-origin-request-policy-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "../response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { SimCloudFrontRegistry } from "../registry/sim-cloud-front-registry.js";
 import type { SimCfWebAclResolver } from "../web-acl/sim-cf-web-acl.js";
@@ -17,6 +18,7 @@ interface SimCloudFrontDistributionReconfigurerProperties {
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
+  readonly originRequestPolicies: SimCloudFrontOriginRequestPolicyRegistry;
   readonly webAclResolver?: SimCfWebAclResolver | undefined;
 }
 

--- a/src/service/cloudfront/error/sim-cf-origin-request-policy.error.ts
+++ b/src/service/cloudfront/error/sim-cf-origin-request-policy.error.ts
@@ -1,0 +1,30 @@
+import { SimCloudFrontError } from "./sim-cloudfront.error.js";
+
+/**
+ * Simulated CloudFront NoSuchOriginRequestPolicy error.
+ *
+ * What CloudFront answers when a Behavior's `OriginRequestPolicyId` names no
+ * origin request policy the account holds, at Distribution create or update
+ * time rather than when a request first needs the policy.
+ */
+export class SimCloudFrontNoSuchOriginRequestPolicy extends SimCloudFrontError {
+  public override readonly name = "NoSuchOriginRequestPolicy";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated CloudFront OriginRequestPolicyAlreadyExists error.
+ *
+ * CloudFront requires an origin request policy name to be unique within an
+ * account, so a second policy claiming a name is refused rather than created.
+ */
+export class SimCloudFrontOriginRequestPolicyAlreadyExists extends SimCloudFrontError {
+  public override readonly name = "OriginRequestPolicyAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}

--- a/src/service/cloudfront/origin-request-policy/sim-cf-managed-origin-request-policies.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-managed-origin-request-policies.ts
@@ -1,0 +1,87 @@
+import {
+  SimCloudFrontOriginRequestPolicy,
+  type SimCloudFrontOriginRequestPolicyId,
+  type SimCloudFrontOriginRequestPolicyMap,
+} from "./sim-cf-origin-request-policy.js";
+
+/**
+ * The IDs AWS publishes for its managed origin request policies.
+ *
+ * A template names one of these directly. CDK's `OriginRequestPolicy` statics
+ * carry the same eight, and synthesize the ID into a Behavior's
+ * `OriginRequestPolicyId` with no Resource behind it.
+ */
+export const simCfManagedOriginRequestPolicyIds = {
+  allViewer: "216adef6-5c7f-47e4-b989-5492eafa07d3",
+  allViewerAndCloudFrontHeaders2022: "33f36d7e-f396-46d9-90e0-52428a34d9dc",
+  allViewerExceptHostHeader: "b689b0a8-53d0-40ab-baf2-68738e2966ac",
+  corsCustomOrigin: "59781a5b-3903-41f3-afcb-af62929ccde1",
+  corsS3Origin: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf",
+  elementalMediaTailorPersonalizedManifests:
+    "775133bc-15f2-49f9-abea-afb2e0bf67d2",
+  hostHeaderOnly: "bf0718e1-ba1e-49d1-88b1-f726733018ae",
+  userAgentRefererHeaders: "acba4595-bd28-49b8-b9fe-13317c0390fa",
+} as const;
+
+/**
+ * The eight managed origin request policies, built fresh for one simulated
+ * CloudFront.
+ *
+ * CloudFront owns these and every account has them, so a Behavior can name one
+ * without a template creating anything. Each carries the ID and the name AWS
+ * publishes for it. What each one forwards is left out, along with what a
+ * policy a template creates forwards.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
+ */
+export function simCfManagedOriginRequestPolicies(): SimCloudFrontOriginRequestPolicyMap {
+  const policies = [
+    managedOriginRequestPolicy(
+      simCfManagedOriginRequestPolicyIds.allViewer,
+      "AllViewer",
+    ),
+    managedOriginRequestPolicy(
+      simCfManagedOriginRequestPolicyIds.allViewerAndCloudFrontHeaders2022,
+      "AllViewerAndCloudFrontHeaders-2022-06",
+    ),
+    managedOriginRequestPolicy(
+      simCfManagedOriginRequestPolicyIds.allViewerExceptHostHeader,
+      "AllViewerExceptHostHeader",
+    ),
+    managedOriginRequestPolicy(
+      simCfManagedOriginRequestPolicyIds.corsCustomOrigin,
+      "CORS-CustomOrigin",
+    ),
+    managedOriginRequestPolicy(
+      simCfManagedOriginRequestPolicyIds.corsS3Origin,
+      "CORS-S3Origin",
+    ),
+    managedOriginRequestPolicy(
+      simCfManagedOriginRequestPolicyIds.elementalMediaTailorPersonalizedManifests,
+      "Elemental-MediaTailor-PersonalizedManifests",
+    ),
+    managedOriginRequestPolicy(
+      simCfManagedOriginRequestPolicyIds.hostHeaderOnly,
+      "HostHeaderOnly",
+    ),
+    managedOriginRequestPolicy(
+      simCfManagedOriginRequestPolicyIds.userAgentRefererHeaders,
+      "UserAgentRefererHeaders",
+    ),
+  ];
+
+  return new Map(policies.map((policy) => [policy.id, policy]));
+}
+
+/**
+ * One managed policy, under the ID and the name AWS gives it.
+ */
+function managedOriginRequestPolicy(
+  id: string,
+  name: string,
+): SimCloudFrontOriginRequestPolicy {
+  return new SimCloudFrontOriginRequestPolicy({
+    id: id as SimCloudFrontOriginRequestPolicyId,
+    name,
+  });
+}

--- a/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-policy-registry.iso.test.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-policy-registry.iso.test.ts
@@ -1,0 +1,132 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsError,
+  assertUndefined,
+  assertUuidV4,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontOriginRequestPolicyAlreadyExists } from "../error/sim-cf-origin-request-policy.error.js";
+import { SimCloudFrontOriginRequestPolicyRegistry } from "./sim-cf-origin-request-policy-registry.js";
+import { SimCloudFrontOriginRequestPolicy } from "./sim-cf-origin-request-policy.js";
+import { simCfManagedOriginRequestPolicyIds } from "./sim-cf-managed-origin-request-policies.js";
+
+describe("SimCloudFrontOriginRequestPolicyRegistry", () => {
+  it("holds a policy a template created, by ID and by name", () => {
+    // Given a registry holding one policy.
+    const registry = new SimCloudFrontOriginRequestPolicyRegistry();
+    const policy = new SimCloudFrontOriginRequestPolicy({
+      name: "BeaconPolicy",
+    });
+
+    registry.add(policy);
+
+    // Then it answers to both the ID a Behavior names and the name that
+    // decides whether another policy may be stored.
+    assertIdentical(registry.byId(policy.id), policy);
+    assertIdentical(registry.byName("BeaconPolicy"), policy);
+  });
+
+  it("gives a policy an ID of its own where none was supplied", () => {
+    // Given a policy built without an ID, which is how a template creates one.
+    const policy = new SimCloudFrontOriginRequestPolicy({
+      name: "BeaconPolicy",
+    });
+
+    // Then it has an ID of the shape CloudFront hands back.
+    assertUuidV4(policy.id);
+    assertUndefined(policy.comment);
+  });
+
+  it("keeps the comment a template gave a policy", () => {
+    // Given a policy carrying a comment.
+    const policy = new SimCloudFrontOriginRequestPolicy({
+      name: "BeaconPolicy",
+      comment: "Carries the Origin header and nothing else",
+    });
+
+    // Then the comment is what the template wrote.
+    assertIdentical(
+      policy.comment,
+      "Carries the Origin header and nothing else",
+    );
+  });
+
+  it("refuses a second policy claiming a name", () => {
+    // Given a registry already holding a policy under a name.
+    const registry = new SimCloudFrontOriginRequestPolicyRegistry();
+
+    registry.add(
+      new SimCloudFrontOriginRequestPolicy({ name: "BeaconPolicy" }),
+    );
+
+    // When another policy claims the same name.
+    const error = assertThrowsError(() => {
+      registry.add(
+        new SimCloudFrontOriginRequestPolicy({ name: "BeaconPolicy" }),
+      );
+    });
+
+    // Then it is refused the way CloudFront refuses one.
+    assertInstanceOf(error, SimCloudFrontOriginRequestPolicyAlreadyExists);
+  });
+
+  it("forgets a policy it was told to remove", () => {
+    // Given a registry holding a policy.
+    const registry = new SimCloudFrontOriginRequestPolicyRegistry();
+    const policy = new SimCloudFrontOriginRequestPolicy({
+      name: "BeaconPolicy",
+    });
+
+    registry.add(policy);
+
+    // When the policy is removed.
+    registry.remove(policy.id);
+
+    // Then nothing answers to its ID or its name.
+    assertUndefined(registry.byId(policy.id));
+    assertUndefined(registry.byName("BeaconPolicy"));
+  });
+
+  it("answers every managed policy ID AWS publishes", () => {
+    // Given a fresh registry, which no template has reached yet.
+    const registry = new SimCloudFrontOriginRequestPolicyRegistry();
+
+    // Then each of CloudFront's managed policies is already there.
+    for (const managedId of Object.values(simCfManagedOriginRequestPolicyIds)) {
+      assertInstanceOf(
+        registry.byId(managedId),
+        SimCloudFrontOriginRequestPolicy,
+      );
+    }
+
+    assertIdentical(
+      registry.byId(simCfManagedOriginRequestPolicyIds.allViewer)?.name,
+      "AllViewer",
+    );
+  });
+
+  it("leaves a managed policy's name free for a template's own", () => {
+    // Given a registry and a template creating a policy under a managed name.
+    const registry = new SimCloudFrontOriginRequestPolicyRegistry();
+    const policy = new SimCloudFrontOriginRequestPolicy({ name: "AllViewer" });
+
+    registry.add(policy);
+
+    // Then the template's policy is stored, and the managed one is where it
+    // was.
+    assertIdentical(registry.byName("AllViewer"), policy);
+    assertIdentical(
+      registry.byId(simCfManagedOriginRequestPolicyIds.allViewer)?.name,
+      "AllViewer",
+    );
+  });
+
+  it("answers nothing for an ID from a real account", () => {
+    // Given a fresh registry.
+    const registry = new SimCloudFrontOriginRequestPolicyRegistry();
+
+    // Then a policy ID that is neither managed nor created here is unknown.
+    assertUndefined(registry.byId("11111111-2222-3333-4444-555555555555"));
+  });
+});

--- a/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-policy-registry.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-policy-registry.ts
@@ -1,0 +1,68 @@
+import { SimCloudFrontOriginRequestPolicyAlreadyExists } from "../error/sim-cf-origin-request-policy.error.js";
+import { simCfManagedOriginRequestPolicies } from "./sim-cf-managed-origin-request-policies.js";
+import type {
+  SimCloudFrontOriginRequestPolicy,
+  SimCloudFrontOriginRequestPolicyId,
+  SimCloudFrontOriginRequestPolicyMap,
+} from "./sim-cf-origin-request-policy.js";
+
+/**
+ * The origin request policies one simulated CloudFront holds.
+ *
+ * Policies are found by ID, which is what a cache Behavior's
+ * `originRequestPolicyId` names, and by name, which is what decides whether a
+ * new one may be stored.
+ *
+ * AWS's eight managed policies are held apart from the ones a template
+ * creates. CloudFront keeps them in its own namespace, so a template may
+ * create a policy called `AllViewer` of its own, and deleting the stack that
+ * created it leaves the managed one where it was.
+ */
+export class SimCloudFrontOriginRequestPolicyRegistry {
+  private readonly policies: SimCloudFrontOriginRequestPolicyMap = new Map();
+  private readonly managedPolicies: SimCloudFrontOriginRequestPolicyMap =
+    simCfManagedOriginRequestPolicies();
+
+  /**
+   * Store a policy a template created, refusing a name another such policy
+   * already holds as CloudFront does.
+   */
+  add(policy: SimCloudFrontOriginRequestPolicy): void {
+    if (this.byName(policy.name) !== undefined) {
+      throw new SimCloudFrontOriginRequestPolicyAlreadyExists(
+        `Sim CloudFront origin request policy ${policy.name} already exists`,
+      );
+    }
+
+    this.policies.set(policy.id, policy);
+  }
+
+  /**
+   * Forget a policy.
+   */
+  remove(policyId: SimCloudFrontOriginRequestPolicyId): void {
+    this.policies.delete(policyId);
+  }
+
+  /**
+   * Get a policy by ID, whether a template created it or AWS manages it.
+   */
+  byId(
+    policyId: SimCloudFrontOriginRequestPolicyId | string,
+  ): SimCloudFrontOriginRequestPolicy | undefined {
+    const id = policyId as SimCloudFrontOriginRequestPolicyId;
+
+    return this.policies.get(id) ?? this.managedPolicies.get(id);
+  }
+
+  /**
+   * Get a policy a template created, by name.
+   *
+   * A managed policy is left out. Its name belongs to CloudFront's own
+   * namespace, and this is what decides whether a template may store a policy
+   * under a name.
+   */
+  byName(policyName: string): SimCloudFrontOriginRequestPolicy | undefined {
+    return this.policies.values().find((policy) => policy.name === policyName);
+  }
+}

--- a/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-policy.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-policy.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from "node:crypto";
+
+import type { Brand } from "../../../util/brand.type.js";
+
+export type SimCloudFrontOriginRequestPolicyId = Brand<
+  string,
+  "SimCloudFrontOriginRequestPolicyId"
+>;
+
+interface SimCloudFrontOriginRequestPolicyProperties {
+  readonly id?: SimCloudFrontOriginRequestPolicyId;
+  readonly name: string;
+  readonly comment?: string | undefined;
+}
+
+/**
+ * Simulated CloudFront origin request policy.
+ *
+ * An origin request policy decides which of the viewer's headers, cookies and
+ * query strings a cache Behavior carries to its Origin. This simulation holds
+ * the policy under its ID and hands it back. Sim CloudFront forwards the
+ * viewer's request whole, so the header, cookie and query string sections
+ * belong to a narrowing it has yet to grow.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html
+ */
+export class SimCloudFrontOriginRequestPolicy {
+  public readonly id: SimCloudFrontOriginRequestPolicyId;
+  public readonly name: string;
+  public readonly comment: string | undefined;
+
+  constructor(properties: SimCloudFrontOriginRequestPolicyProperties) {
+    this.id =
+      properties.id ?? (randomUUID() as SimCloudFrontOriginRequestPolicyId);
+    this.name = properties.name;
+    this.comment = properties.comment;
+  }
+}
+
+export type SimCloudFrontOriginRequestPolicyMap = Map<
+  SimCloudFrontOriginRequestPolicyId,
+  SimCloudFrontOriginRequestPolicy
+>;

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -44,6 +44,7 @@ import {
 import type { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
 import type { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-policy/sim-cf-response-headers-policy-registry.js";
 import type { SimCloudFrontCachePolicyRegistry } from "./cache-policy/sim-cf-cache-policy-registry.js";
+import type { SimCloudFrontOriginRequestPolicyRegistry } from "./origin-request-policy/sim-cf-origin-request-policy-registry.js";
 import { SimCloudFrontRegistry } from "./registry/sim-cloud-front-registry.js";
 import type { SimCfDistributionConfigurationState } from "./distribution/sim-cf-distribution-configuration-state.js";
 import type { SimCfWebAclResolver } from "./web-acl/sim-cf-web-acl.js";
@@ -79,6 +80,7 @@ interface SimCloudFrontCommandsProperties extends SimCloudFrontProperties {
   readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry;
   readonly responseHeadersPolicies: SimCloudFrontResponseHeadersPolicyRegistry;
   readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
+  readonly originRequestPolicies: SimCloudFrontOriginRequestPolicyRegistry;
 }
 
 /**
@@ -182,6 +184,7 @@ export class SimCloudFrontCommands {
       originAccessControls: properties.originAccessControls,
       responseHeadersPolicies: properties.responseHeadersPolicies,
       cachePolicies: properties.cachePolicies,
+      originRequestPolicies: properties.originRequestPolicies,
     };
     const keyValueStoreAccess = new SimCfKeyValueStoreAccess({
       accountId,

--- a/src/service/cloudfront/sim-cloudfront-policies.ts
+++ b/src/service/cloudfront/sim-cloudfront-policies.ts
@@ -4,6 +4,11 @@ import type {
 } from "./cache-policy/sim-cf-cache-policy.js";
 import { SimCloudFrontCachePolicyRegistry } from "./cache-policy/sim-cf-cache-policy-registry.js";
 import type {
+  SimCloudFrontOriginRequestPolicy,
+  SimCloudFrontOriginRequestPolicyId,
+} from "./origin-request-policy/sim-cf-origin-request-policy.js";
+import { SimCloudFrontOriginRequestPolicyRegistry } from "./origin-request-policy/sim-cf-origin-request-policy-registry.js";
+import type {
   SimCloudFrontResponseHeadersPolicy,
   SimCloudFrontResponseHeadersPolicyId,
 } from "./response-headers-policy/sim-cf-response-headers-policy.js";
@@ -12,16 +17,19 @@ import { SimCloudFrontResponseHeadersPolicyRegistry } from "./response-headers-p
 /**
  * The policies one simulated CloudFront holds.
  *
- * A cache Behavior names a response headers policy and a cache policy by ID,
- * and both are stored here. Neither has a create command in this simulation,
- * so CloudFormation is the only thing that makes one, and these methods are
- * how it hands a policy over. `SimCloudFront` extends this, and a caller
- * reaches the policies on the one service object.
+ * A cache Behavior names a response headers policy, a cache policy and an
+ * origin request policy by ID, and all three are stored here. None of them has
+ * a create command in this simulation, so CloudFormation is the only thing
+ * that makes one, and these methods are how it hands a policy over.
+ * `SimCloudFront` extends this, and a caller reaches the policies on the one
+ * service object.
  */
 export class SimCloudFrontPolicies {
   protected readonly responseHeadersPolicies =
     new SimCloudFrontResponseHeadersPolicyRegistry();
   protected readonly cachePolicies = new SimCloudFrontCachePolicyRegistry();
+  protected readonly originRequestPolicies =
+    new SimCloudFrontOriginRequestPolicyRegistry();
 
   /**
    * Store a simulated response headers policy. A name another policy already
@@ -71,5 +79,31 @@ export class SimCloudFrontPolicies {
     policyId: SimCloudFrontCachePolicyId | string,
   ): SimCloudFrontCachePolicy | undefined {
     return this.cachePolicies.byId(policyId);
+  }
+
+  /**
+   * Store a simulated origin request policy. A name another policy already
+   * holds is refused, as CloudFront refuses one.
+   */
+  addOriginRequestPolicy(policy: SimCloudFrontOriginRequestPolicy): void {
+    this.originRequestPolicies.add(policy);
+  }
+
+  /**
+   * Forget a simulated origin request policy.
+   */
+  removeOriginRequestPolicy(
+    policyId: SimCloudFrontOriginRequestPolicyId,
+  ): void {
+    this.originRequestPolicies.remove(policyId);
+  }
+
+  /**
+   * Get a simulated origin request policy by ID.
+   */
+  getOriginRequestPolicyById(
+    policyId: SimCloudFrontOriginRequestPolicyId | string,
+  ): SimCloudFrontOriginRequestPolicy | undefined {
+    return this.originRequestPolicies.byId(policyId);
   }
 }

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -95,6 +95,7 @@ export class SimCloudFront extends SimCloudFrontPolicies {
       originAccessControls: this.originAccessControls,
       responseHeadersPolicies: this.responseHeadersPolicies,
       cachePolicies: this.cachePolicies,
+      originRequestPolicies: this.originRequestPolicies,
     });
   }
 


### PR DESCRIPTION
A cache Behavior records the OriginRequestPolicyId it was given and reports it back through GetDistribution, for the default Behavior and a named one alike, and an update changing the policy is reported the same way. An AWS::CloudFront::OriginRequestPolicy Resource creates a policy a Behavior can name with a Ref, and CloudFront's eight managed policy IDs are held from the start. An ID that neither a managed policy nor a created one answers to is refused with NoSuchOriginRequestPolicy when the Distribution is created or updated, and a template naming one deploys without it, recorded on stack.ignoredProperties the way an absent cache policy is. The policy carries its name and its comment. Narrowing what a request carries to the Origin is issue #1146.

Resolves #1145