### PR TITLE
feat: record a cache policy's TTLs and cache key

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2221,13 +2221,16 @@ const stack = await simAws.cloudFormation().deployTemplate({
           CachePolicyConfig: {
             Name: "BeaconPolicy",
             MinTTL: 0,
-            DefaultTTL: 0,
-            MaxTTL: 0,
+            DefaultTTL: 60,
+            MaxTTL: 3600,
             ParametersInCacheKeyAndForwardedToOrigin: {
-              EnableAcceptEncodingGzip: false,
+              EnableAcceptEncodingGzip: true,
               CookiesConfig: { CookieBehavior: "none" },
               HeadersConfig: { HeaderBehavior: "none" },
-              QueryStringsConfig: { QueryStringBehavior: "none" },
+              QueryStringsConfig: {
+                QueryStringBehavior: "whitelist",
+                QueryStrings: ["page"],
+              },
             },
           },
         },
@@ -2287,18 +2290,36 @@ console.log(
   config?.CacheBehaviors?.Items?.[0]?.CachePolicyId ===
     stack.output("BeaconPolicyId"),
 );
+
+// The policy itself, holding the TTLs and the cache key the template gave it.
+const beaconPolicy = simAws
+  .cloudFront()
+  .getCachePolicyById(stack.output("BeaconPolicyId"));
+
+console.log(beaconPolicy?.defaultTtlSec); // 60
+console.log(beaconPolicy?.cacheKey.queryStringBehavior); // "whitelist"
+console.log(beaconPolicy?.cacheKey.queryStrings); // ["page"]
 ```
 
 A Behavior records the ID it was given, and `GetDistribution` reports it back for both the default
 Behavior and a named one. An update changing the policy is reported the same way.
 
-Nothing here reads the policy itself. The TTLs, the cache key and the compression settings need a
-cache, and sim CloudFront holds none. Every request reaches the Origin whatever the policy would
-have cached on real CloudFront.
+The policy itself carries everything `CachePolicyConfig` holds. `getCachePolicyById` hands back the
+three TTLs, the three sections of `ParametersInCacheKeyAndForwardedToOrigin` and the two
+`EnableAcceptEncoding` flags. A test can assert that its Behavior leaves the query string out of the
+cache key before sim CloudFront has a cache to key.
+
+Nothing acts on any of it. Sim CloudFront holds no edge cache, and every request reaches the Origin
+whatever the policy would have cached on real CloudFront.
+
+A TTL the template left out falls back to CloudFront's own default (0 seconds for `MinTTL`, one day
+for `DefaultTTL` and 365 days for `MaxTTL`), and a `MinTTL` above a day raises the `DefaultTTL` with
+it the way CloudFront does. An absent cache key section falls back to `none`. A section naming a
+behaviour CloudFront does not offer fails the Stack, naming the Resource. `HeaderBehavior` takes
+`none` and `whitelist` alone, where CloudFront gives an origin request policy a wider set.
 
 A policy name is unique within an account, as it is in CloudFront. A second
 `AWS::CloudFront::CachePolicy` claiming a name is refused with `CachePolicyAlreadyExists`.
-`Name` and `Comment` are the parts of `CachePolicyConfig` the policy carries.
 
 ### Managed cache policies
 
@@ -2313,6 +2334,10 @@ Behavior names one without a template creating anything. `CachingOptimized`
 [AWS publishes](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html)
 for it. CDK's `CachePolicy.CACHING_OPTIMIZED` and its six siblings synthesize those IDs. A stack
 reaching for one deploys.
+
+Each also carries the TTLs and the cache key AWS publishes for it. A Behavior on `CachingOptimized`
+here holds the same 1 second floor, the same day of default TTL and the same empty cache key as one
+in an account.
 
 The managed policies sit in CloudFront's own namespace. A template may create a policy called
 `CachingDisabled` of its own, and deleting that stack leaves the managed one where it was.
@@ -3219,13 +3244,10 @@ Where sim CloudFront knowingly behaves differently from AWS:
   share of real responses carry `Server-Timing`. This simulation adds it to every response once
   `Enabled` is true. A test asserting on it never depends on chance. The header's value is a
   fixed placeholder, since nothing here measures an Origin fetch the way CloudFront's edge does.
-- **A cache policy is recorded and never applied.** Sim CloudFront models no edge caching. A
-  Behavior's `CachePolicyId` is checked against the policies this simulation holds and reported
-  back, and the TTLs, the cache key and the compression settings behind it decide nothing. Every
+- **A cache policy is recorded and never applied.** Sim CloudFront models no edge caching. A policy
+  holds its three TTLs and the whole of its cache key, and a Behavior's `CachePolicyId` is checked
+  against the policies this simulation holds and reported back. None of it decides anything. Every
   request reaches the Origin, whatever the policy would have cached on real CloudFront.
-- **A cache policy carries its name and its comment, and nothing else.** The TTLs and
-  `ParametersInCacheKeyAndForwardedToOrigin` of an `AWS::CloudFront::CachePolicy` are read past,
-  since nothing here would act on them.
 - **An origin request policy is recorded and never applied.** A Behavior's `OriginRequestPolicyId`
   is checked against the policies this simulation holds and reported back. Sim CloudFront forwards
   the viewer's headers, cookies and query string to the Origin whole, whatever the policy would

--- a/docs/services/cloudfront/sim-cloudfront-cache-policy.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-cache-policy.example.ts
@@ -21,13 +21,16 @@ const stack = await simAws.cloudFormation().deployTemplate({
           CachePolicyConfig: {
             Name: "BeaconPolicy",
             MinTTL: 0,
-            DefaultTTL: 0,
-            MaxTTL: 0,
+            DefaultTTL: 60,
+            MaxTTL: 3600,
             ParametersInCacheKeyAndForwardedToOrigin: {
-              EnableAcceptEncodingGzip: false,
+              EnableAcceptEncodingGzip: true,
               CookiesConfig: { CookieBehavior: "none" },
               HeadersConfig: { HeaderBehavior: "none" },
-              QueryStringsConfig: { QueryStringBehavior: "none" },
+              QueryStringsConfig: {
+                QueryStringBehavior: "whitelist",
+                QueryStrings: ["page"],
+              },
             },
           },
         },
@@ -87,3 +90,12 @@ console.log(
   config?.CacheBehaviors?.Items?.[0]?.CachePolicyId ===
     stack.output("BeaconPolicyId"),
 );
+
+// The policy itself, holding the TTLs and the cache key the template gave it.
+const beaconPolicy = simAws
+  .cloudFront()
+  .getCachePolicyById(stack.output("BeaconPolicyId"));
+
+console.log(beaconPolicy?.defaultTtlSec); // 60
+console.log(beaconPolicy?.cacheKey.queryStringBehavior); // "whitelist"
+console.log(beaconPolicy?.cacheKey.queryStrings); // ["page"]

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -264,16 +264,27 @@ it.
 ## Cache policies
 
 `cache-policy/` holds the model and its registry, laid out the same way as the response headers
-policies above. A `SimCloudFrontCachePolicy` is a name, an ID and an optional comment.
-`sim-cf-managed-cache-policies.ts` builds CloudFront's seven managed policies under the IDs AWS
-publishes, and the registry keeps them in their own namespace, so a template may create a policy of
-its own under a managed name. There is no CreateCachePolicy command, so `cfn/cache-policy/` is the
-only thing that makes one.
+policies above. A `SimCloudFrontCachePolicy` is a name, an ID, an optional comment, three TTLs and a
+`SimCloudFrontCacheKey`. `sim-cf-managed-cache-policies.ts` builds CloudFront's seven managed
+policies under the IDs AWS publishes, each with the TTLs and the cache key AWS publishes beside the
+ID, and the registry keeps them in their own namespace, so a template may create a policy of its own
+under a managed name. There is no CreateCachePolicy command, so `cfn/cache-policy/` is the only
+thing that makes one.
 
-The policy carries nothing of `CachePolicyConfig` beyond `Name` and `Comment`. The TTLs and
-`ParametersInCacheKeyAndForwardedToOrigin` decide what a cache holds and how long it holds it, and
-sim CloudFront has no cache for them to decide anything about. Recording the ID is what lets a test
-assert which policy a Behavior was given.
+`sim-cf-cache-key.ts` holds the three sections of `ParametersInCacheKeyAndForwardedToOrigin` and the
+two `EnableAcceptEncoding` flags, along with the behaviour set each section may name.
+`HeadersConfig` is the narrow one, taking `none` and `whitelist` where the other two also take
+`allExcept` and `all`.
+
+`cfn/cache-policy/` reads that half of the Resource. `sim-cfn-cf-cache-policy-section.ts` holds one
+reader for all three sections, along with the field names and the behaviour set each one takes. An
+absent section comes out as `none`, and a behaviour outside the set for its section fails the Stack,
+naming the Resource. `sim-cfn-cf-cache-policy-config.ts` reads the TTLs, giving one the template
+left out the default CloudFront applies, including the two cases where a long `MinTTL` raises the
+`DefaultTTL` and a long `DefaultTTL` raises the `MaxTTL`.
+
+Sim CloudFront has no cache. None of this decides anything yet, and recording the ID is what lets a
+test assert which policy a Behavior was given.
 
 `SimCfBehaviorPolicies` asks `SimCfBehaviorResponseHeadersPolicy`, `SimCfBehaviorCachePolicy` and
 `SimCfBehaviorOriginRequestPolicy` about one Behavior. A `CachePolicyId` naming nothing is

--- a/src/service/cloudfront/cache-policy/sim-cf-cache-key.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-cache-key.ts
@@ -1,0 +1,94 @@
+/**
+ * The cookie behaviours a cache policy may name.
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudfront-cachepolicy-cookiesconfig.html
+ */
+export const simCfCacheKeyCookieBehaviors = [
+  "none",
+  "whitelist",
+  "allExcept",
+  "all",
+] as const;
+
+export type SimCfCacheKeyCookieBehavior =
+  (typeof simCfCacheKeyCookieBehaviors)[number];
+
+/**
+ * The header behaviours a cache policy may name.
+ *
+ * These are two of the four an origin request policy offers. A cache key can
+ * name headers or leave them all out; there is no `allViewer` to key a cache
+ * on, since keying on every header a viewer sent would cache almost nothing
+ * twice.
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudfront-cachepolicy-headersconfig.html
+ */
+export const simCfCacheKeyHeaderBehaviors = ["none", "whitelist"] as const;
+
+export type SimCfCacheKeyHeaderBehavior =
+  (typeof simCfCacheKeyHeaderBehaviors)[number];
+
+/**
+ * The query string behaviours a cache policy may name.
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudfront-cachepolicy-querystringsconfig.html
+ */
+export const simCfCacheKeyQueryStringBehaviors = [
+  "none",
+  "whitelist",
+  "allExcept",
+  "all",
+] as const;
+
+export type SimCfCacheKeyQueryStringBehavior =
+  (typeof simCfCacheKeyQueryStringBehaviors)[number];
+
+interface SimCloudFrontCacheKeyProperties {
+  readonly cookieBehavior?: SimCfCacheKeyCookieBehavior;
+  readonly cookies?: readonly string[];
+  readonly headerBehavior?: SimCfCacheKeyHeaderBehavior;
+  readonly headers?: readonly string[];
+  readonly queryStringBehavior?: SimCfCacheKeyQueryStringBehavior;
+  readonly queryStrings?: readonly string[];
+  readonly enableAcceptEncodingGzip?: boolean;
+  readonly enableAcceptEncodingBrotli?: boolean;
+}
+
+/**
+ * What a cache policy keys its cache on.
+ *
+ * This is CloudFront's `ParametersInCacheKeyAndForwardedToOrigin`. Each of the
+ * three sections carries a behaviour and the names it applies to: a
+ * `whitelist` keys on the names listed, an `allExcept` keys on everything but
+ * them, and `all` and `none` ignore the list. The names listed are also the
+ * ones CloudFront forwards to the Origin.
+ *
+ * The two `EnableAcceptEncoding` flags decide whether the normalized
+ * `Accept-Encoding` header joins the key, which is what lets one object be
+ * cached once compressed and once not.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html
+ */
+export class SimCloudFrontCacheKey {
+  public readonly cookieBehavior: SimCfCacheKeyCookieBehavior;
+  public readonly cookies: readonly string[];
+  public readonly headerBehavior: SimCfCacheKeyHeaderBehavior;
+  public readonly headers: readonly string[];
+  public readonly queryStringBehavior: SimCfCacheKeyQueryStringBehavior;
+  public readonly queryStrings: readonly string[];
+  public readonly enableAcceptEncodingGzip: boolean;
+  public readonly enableAcceptEncodingBrotli: boolean;
+
+  constructor(properties: SimCloudFrontCacheKeyProperties = {}) {
+    this.cookieBehavior = properties.cookieBehavior ?? "none";
+    this.cookies = properties.cookies ?? [];
+    this.headerBehavior = properties.headerBehavior ?? "none";
+    this.headers = properties.headers ?? [];
+    this.queryStringBehavior = properties.queryStringBehavior ?? "none";
+    this.queryStrings = properties.queryStrings ?? [];
+    this.enableAcceptEncodingGzip =
+      properties.enableAcceptEncodingGzip ?? false;
+    this.enableAcceptEncodingBrotli =
+      properties.enableAcceptEncodingBrotli ?? false;
+  }
+}

--- a/src/service/cloudfront/cache-policy/sim-cf-cache-policy.iso.test.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-cache-policy.iso.test.ts
@@ -1,0 +1,77 @@
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontCacheKey } from "./sim-cf-cache-key.js";
+import { SimCloudFrontCachePolicy } from "./sim-cf-cache-policy.js";
+
+describe("SimCloudFrontCachePolicy", () => {
+  it("falls back on CloudFront's own TTLs and an empty cache key", () => {
+    // Given a policy carrying nothing but a name.
+    const policy = new SimCloudFrontCachePolicy({ name: "BeaconPolicy" });
+
+    // Then the TTLs are the ones CloudFront applies to a policy that named
+    // none: nothing held for less than no time, a day by default, a year at
+    // most.
+    assertIdentical(policy.minTtlSec, 0);
+    assertIdentical(policy.defaultTtlSec, 86_400);
+    assertIdentical(policy.maxTtlSec, 31_536_000);
+
+    // And nothing of the request joins the cache key.
+    assertIdentical(policy.cacheKey.cookieBehavior, "none");
+    assertIdentical(policy.cacheKey.headerBehavior, "none");
+    assertIdentical(policy.cacheKey.queryStringBehavior, "none");
+    assertArrayEquals(policy.cacheKey.cookies, []);
+    assertArrayEquals(policy.cacheKey.headers, []);
+    assertArrayEquals(policy.cacheKey.queryStrings, []);
+    assertFalse(policy.cacheKey.enableAcceptEncodingGzip);
+    assertFalse(policy.cacheKey.enableAcceptEncodingBrotli);
+  });
+
+  it("raises the default TTL to a MinTTL that sits above a day", () => {
+    // Given a policy holding objects for at least a week, naming no other TTL.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 604_800,
+    });
+
+    // Then the default TTL is the floor rather than the day that would sit
+    // below it, and the maximum is still a year.
+    assertIdentical(policy.defaultTtlSec, 604_800);
+    assertIdentical(policy.maxTtlSec, 31_536_000);
+  });
+
+  it("raises the maximum TTL to a default TTL that sits above a year", () => {
+    // Given a policy whose default TTL is longer than a year.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      defaultTtlSec: 63_072_000,
+    });
+
+    // Then the maximum is the default rather than the year that would cap the
+    // policy below its own default.
+    assertIdentical(policy.maxTtlSec, 63_072_000);
+  });
+
+  it("keeps the cache key a policy was given", () => {
+    // Given a policy keying on one cookie and everything but one query string.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      cacheKey: new SimCloudFrontCacheKey({
+        cookieBehavior: "whitelist",
+        cookies: ["session"],
+        queryStringBehavior: "allExcept",
+        queryStrings: ["utm_source"],
+        enableAcceptEncodingBrotli: true,
+      }),
+    });
+
+    // Then the cache key is what it was given.
+    assertIdentical(policy.cacheKey.cookieBehavior, "whitelist");
+    assertArrayEquals(policy.cacheKey.cookies, ["session"]);
+    assertIdentical(policy.cacheKey.queryStringBehavior, "allExcept");
+    assertArrayEquals(policy.cacheKey.queryStrings, ["utm_source"]);
+  });
+});

--- a/src/service/cloudfront/cache-policy/sim-cf-cache-policy.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-cache-policy.ts
@@ -1,25 +1,33 @@
 import { randomUUID } from "node:crypto";
 
 import type { Brand } from "../../../util/brand.type.js";
+import { SimCloudFrontCacheKey } from "./sim-cf-cache-key.js";
 
 export type SimCloudFrontCachePolicyId = Brand<
   string,
   "SimCloudFrontCachePolicyId"
 >;
 
+const daySeconds = 86_400;
+const yearSeconds = 31_536_000;
+
 interface SimCloudFrontCachePolicyProperties {
   readonly id?: SimCloudFrontCachePolicyId;
   readonly name: string;
   readonly comment?: string | undefined;
+  readonly minTtlSec?: number;
+  readonly defaultTtlSec?: number;
+  readonly maxTtlSec?: number;
+  readonly cacheKey?: SimCloudFrontCacheKey;
 }
 
 /**
  * Simulated CloudFront cache policy.
  *
  * A cache policy decides what a cache Behavior keys its cache on and how long
- * an object stays there. This simulation holds the policy under its ID and
- * hands it back. The cache key, the TTLs and the compression settings belong
- * to a simulated cache, which CloudFront here has yet to grow.
+ * an object stays there. This simulation holds the policy under its ID, along
+ * with its three TTLs and its cache key, and hands it back. Nothing caches
+ * anything on them yet.
  *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html
  */
@@ -27,12 +35,37 @@ export class SimCloudFrontCachePolicy {
   public readonly id: SimCloudFrontCachePolicyId;
   public readonly name: string;
   public readonly comment: string | undefined;
+  public readonly minTtlSec: number;
+  public readonly defaultTtlSec: number;
+  public readonly maxTtlSec: number;
+  public readonly cacheKey: SimCloudFrontCacheKey;
 
   constructor(properties: SimCloudFrontCachePolicyProperties) {
     this.id = properties.id ?? (randomUUID() as SimCloudFrontCachePolicyId);
     this.name = properties.name;
     this.comment = properties.comment;
+    this.minTtlSec = properties.minTtlSec ?? 0;
+    this.defaultTtlSec =
+      properties.defaultTtlSec ?? Math.max(daySeconds, this.minTtlSec);
+    this.maxTtlSec =
+      properties.maxTtlSec ?? maxTtlDefault(this.minTtlSec, this.defaultTtlSec);
+    this.cacheKey = properties.cacheKey ?? new SimCloudFrontCacheKey();
   }
+}
+
+/**
+ * The `MaxTTL` CloudFront settles on where a policy left it out.
+ *
+ * It is a year, except where a longer `MinTTL` or `DefaultTTL` would sit above
+ * it, in which case CloudFront takes the `DefaultTTL` rather than capping the
+ * policy below its own floor.
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudfront-cachepolicy-cachepolicyconfig.html
+ */
+function maxTtlDefault(minTtlSec: number, defaultTtlSec: number): number {
+  return minTtlSec > yearSeconds || defaultTtlSec > yearSeconds
+    ? defaultTtlSec
+    : yearSeconds;
 }
 
 export type SimCloudFrontCachePolicyMap = Map<

--- a/src/service/cloudfront/cache-policy/sim-cf-managed-cache-policies.iso.test.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-managed-cache-policies.iso.test.ts
@@ -1,0 +1,148 @@
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCloudFrontCachePolicyRegistry } from "./sim-cf-cache-policy-registry.js";
+import type { SimCloudFrontCachePolicy } from "./sim-cf-cache-policy.js";
+import { simCfManagedCachePolicyIds } from "./sim-cf-managed-cache-policies.js";
+
+describe("Managed CloudFront cache policies", () => {
+  /**
+   * One managed policy, from a registry no template has reached.
+   */
+  function policy(policyId: string): SimCloudFrontCachePolicy {
+    const managed = new SimCloudFrontCachePolicyRegistry().byId(policyId);
+
+    assertNonNullable(managed);
+
+    return managed;
+  }
+
+  it("carries the TTLs AWS publishes for each of the seven", () => {
+    // Given the seven managed policies.
+    // When each one's TTLs are read.
+    const ttls = Object.values(simCfManagedCachePolicyIds).map((policyId) => {
+      const managed = policy(policyId);
+
+      return `${managed.name} ${managed.minTtlSec}/${managed.defaultTtlSec}/${managed.maxTtlSec}`;
+    });
+
+    // Then each holds objects for as long as one in an account would.
+    assertArrayEquals(ttls, [
+      "Amplify 2/2/600",
+      "CachingOptimized 1/86400/31536000",
+      "CachingOptimizedForUncompressedObjects 1/86400/31536000",
+      "CachingDisabled 0/0/0",
+      "Elemental-MediaPackage 0/86400/31536000",
+      "UseOriginCacheControlHeaders 0/0/31536000",
+      "UseOriginCacheControlHeaders-QueryStrings 0/0/31536000",
+    ]);
+  });
+
+  it("keys CachingOptimized on nothing but the compression", () => {
+    // Given the policy CDK reaches for by default.
+    const { cacheKey } = policy(simCfManagedCachePolicyIds.cachingOptimized);
+
+    // Then one object is cached once, whatever the request carried, apart from
+    // the compressed copies the Accept-Encoding flags separate.
+    assertIdentical(cacheKey.cookieBehavior, "none");
+    assertIdentical(cacheKey.headerBehavior, "none");
+    assertIdentical(cacheKey.queryStringBehavior, "none");
+    assertTrue(cacheKey.enableAcceptEncodingGzip);
+    assertTrue(cacheKey.enableAcceptEncodingBrotli);
+  });
+
+  it("leaves the compression out of CachingOptimizedForUncompressedObjects", () => {
+    // Given the policy that differs from CachingOptimized in compression
+    // alone.
+    const { cacheKey } = policy(
+      simCfManagedCachePolicyIds.cachingOptimizedForUncompressedObjects,
+    );
+
+    // Then neither Accept-Encoding flag is set, so the key is the same for a
+    // viewer that would take a compressed copy and one that would not.
+    assertFalse(cacheKey.enableAcceptEncodingGzip);
+    assertFalse(cacheKey.enableAcceptEncodingBrotli);
+  });
+
+  it("keys Amplify on the three headers, every cookie and every query string", () => {
+    // Given the policy an Amplify web app Origin is served through.
+    const { cacheKey } = policy(simCfManagedCachePolicyIds.amplify);
+
+    // Then the cache key is the one AWS publishes for it.
+    assertIdentical(cacheKey.headerBehavior, "whitelist");
+    assertArrayEquals(cacheKey.headers, [
+      "Authorization",
+      "CloudFront-Viewer-Country",
+      "Host",
+    ]);
+    assertIdentical(cacheKey.cookieBehavior, "all");
+    assertIdentical(cacheKey.queryStringBehavior, "all");
+  });
+
+  it("keys Elemental-MediaPackage on the manifest query strings", () => {
+    // Given the policy a MediaPackage endpoint Origin is served through.
+    const { cacheKey } = policy(
+      simCfManagedCachePolicyIds.elementalMediaPackage,
+    );
+
+    // Then the four query strings that select a manifest are in the key, along
+    // with the Origin header, and Gzip alone is enabled.
+    assertIdentical(cacheKey.queryStringBehavior, "whitelist");
+    assertArrayEquals(cacheKey.queryStrings, [
+      "aws.manifestfilter",
+      "start",
+      "end",
+      "m",
+    ]);
+    assertIdentical(cacheKey.headerBehavior, "whitelist");
+    assertArrayEquals(cacheKey.headers, ["Origin"]);
+    assertIdentical(cacheKey.cookieBehavior, "none");
+    assertTrue(cacheKey.enableAcceptEncodingGzip);
+    assertFalse(cacheKey.enableAcceptEncodingBrotli);
+  });
+
+  it("separates the two UseOriginCacheControlHeaders policies by query string", () => {
+    // Given the pair that differ from each other in query strings alone.
+    const withoutQueryStrings = policy(
+      simCfManagedCachePolicyIds.useOriginCacheControlHeaders,
+    ).cacheKey;
+    const withQueryStrings = policy(
+      simCfManagedCachePolicyIds.useOriginCacheControlHeadersQueryStrings,
+    ).cacheKey;
+
+    // Then both key on the same five headers and every cookie.
+    const headers = [
+      "Host",
+      "Origin",
+      "X-HTTP-Method-Override",
+      "X-HTTP-Method",
+      "X-Method-Override",
+    ];
+
+    assertArrayEquals(withoutQueryStrings.headers, headers);
+    assertArrayEquals(withQueryStrings.headers, headers);
+    assertIdentical(withoutQueryStrings.cookieBehavior, "all");
+    assertIdentical(withQueryStrings.cookieBehavior, "all");
+
+    // And only the second one caches a request's query string apart.
+    assertIdentical(withoutQueryStrings.queryStringBehavior, "none");
+    assertIdentical(withQueryStrings.queryStringBehavior, "all");
+  });
+
+  it("disables caching in CachingDisabled without keying on anything", () => {
+    // Given the policy that caches nothing.
+    const disabled = policy(simCfManagedCachePolicyIds.cachingDisabled);
+
+    // Then every TTL is zero and nothing of the request is in the key.
+    assertIdentical(disabled.maxTtlSec, 0);
+    assertIdentical(disabled.cacheKey.cookieBehavior, "none");
+    assertIdentical(disabled.cacheKey.headerBehavior, "none");
+    assertIdentical(disabled.cacheKey.queryStringBehavior, "none");
+    assertFalse(disabled.cacheKey.enableAcceptEncodingGzip);
+  });
+});

--- a/src/service/cloudfront/cache-policy/sim-cf-managed-cache-policies.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-managed-cache-policies.ts
@@ -1,3 +1,4 @@
+import { SimCloudFrontCacheKey } from "./sim-cf-cache-key.js";
 import {
   SimCloudFrontCachePolicy,
   type SimCloudFrontCachePolicyId,
@@ -23,42 +24,132 @@ export const simCfManagedCachePolicyIds = {
     "4cc15a8a-d715-48a4-82b8-cc0b614638fe",
 } as const;
 
+const daySeconds = 86_400;
+const yearSeconds = 31_536_000;
+
+/**
+ * The headers the two UseOriginCacheControlHeaders policies key on. They
+ * differ from each other in their query strings alone.
+ */
+const originCacheControlHeaders = [
+  "Host",
+  "Origin",
+  "X-HTTP-Method-Override",
+  "X-HTTP-Method",
+  "X-Method-Override",
+];
+
 /**
  * The seven managed cache policies, built fresh for one simulated CloudFront.
  *
  * CloudFront owns these and every account has them, so a Behavior can name one
- * without a template creating anything. Each carries the ID and the name AWS
- * publishes for it. The cache key and the TTLs behind each one are left out,
- * along with those of a policy a template creates.
+ * without a template creating anything. Each carries the ID, the name, the
+ * TTLs and the cache key AWS publishes for it, so a Behavior on
+ * `CachingOptimized` here holds what one in an account holds.
+ *
+ * The normalized `Accept-Encoding` header AWS lists in some of these keys is
+ * not a header name in the whitelist. It is what the two `EnableAcceptEncoding`
+ * flags put in the key, which is why a policy carrying no header at all still
+ * caches a compressed object apart from an uncompressed one.
  *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html
  */
 export function simCfManagedCachePolicies(): SimCloudFrontCachePolicyMap {
   const policies = [
-    managedCachePolicy(simCfManagedCachePolicyIds.amplify, "Amplify"),
+    managedCachePolicy(simCfManagedCachePolicyIds.amplify, "Amplify", {
+      minTtlSec: 2,
+      defaultTtlSec: 2,
+      maxTtlSec: 600,
+      cacheKey: new SimCloudFrontCacheKey({
+        cookieBehavior: "all",
+        headerBehavior: "whitelist",
+        headers: ["Authorization", "CloudFront-Viewer-Country", "Host"],
+        queryStringBehavior: "all",
+        enableAcceptEncodingGzip: true,
+        enableAcceptEncodingBrotli: true,
+      }),
+    }),
     managedCachePolicy(
       simCfManagedCachePolicyIds.cachingOptimized,
       "CachingOptimized",
+      {
+        minTtlSec: 1,
+        defaultTtlSec: daySeconds,
+        maxTtlSec: yearSeconds,
+        cacheKey: new SimCloudFrontCacheKey({
+          enableAcceptEncodingGzip: true,
+          enableAcceptEncodingBrotli: true,
+        }),
+      },
     ),
     managedCachePolicy(
       simCfManagedCachePolicyIds.cachingOptimizedForUncompressedObjects,
       "CachingOptimizedForUncompressedObjects",
+      {
+        minTtlSec: 1,
+        defaultTtlSec: daySeconds,
+        maxTtlSec: yearSeconds,
+        cacheKey: new SimCloudFrontCacheKey(),
+      },
     ),
     managedCachePolicy(
       simCfManagedCachePolicyIds.cachingDisabled,
       "CachingDisabled",
+      {
+        minTtlSec: 0,
+        defaultTtlSec: 0,
+        maxTtlSec: 0,
+        cacheKey: new SimCloudFrontCacheKey(),
+      },
     ),
     managedCachePolicy(
       simCfManagedCachePolicyIds.elementalMediaPackage,
       "Elemental-MediaPackage",
+      {
+        minTtlSec: 0,
+        defaultTtlSec: daySeconds,
+        maxTtlSec: yearSeconds,
+        cacheKey: new SimCloudFrontCacheKey({
+          headerBehavior: "whitelist",
+          headers: ["Origin"],
+          queryStringBehavior: "whitelist",
+          queryStrings: ["aws.manifestfilter", "start", "end", "m"],
+          enableAcceptEncodingGzip: true,
+        }),
+      },
     ),
     managedCachePolicy(
       simCfManagedCachePolicyIds.useOriginCacheControlHeaders,
       "UseOriginCacheControlHeaders",
+      {
+        minTtlSec: 0,
+        defaultTtlSec: 0,
+        maxTtlSec: yearSeconds,
+        cacheKey: new SimCloudFrontCacheKey({
+          cookieBehavior: "all",
+          headerBehavior: "whitelist",
+          headers: originCacheControlHeaders,
+          enableAcceptEncodingGzip: true,
+          enableAcceptEncodingBrotli: true,
+        }),
+      },
     ),
     managedCachePolicy(
       simCfManagedCachePolicyIds.useOriginCacheControlHeadersQueryStrings,
       "UseOriginCacheControlHeaders-QueryStrings",
+      {
+        minTtlSec: 0,
+        defaultTtlSec: 0,
+        maxTtlSec: yearSeconds,
+        cacheKey: new SimCloudFrontCacheKey({
+          cookieBehavior: "all",
+          headerBehavior: "whitelist",
+          headers: originCacheControlHeaders,
+          queryStringBehavior: "all",
+          enableAcceptEncodingGzip: true,
+          enableAcceptEncodingBrotli: true,
+        }),
+      },
     ),
   ];
 
@@ -66,14 +157,21 @@ export function simCfManagedCachePolicies(): SimCloudFrontCachePolicyMap {
 }
 
 /**
- * One managed policy, under the ID and the name AWS gives it.
+ * One managed policy, under the ID, the name and the settings AWS gives it.
  */
 function managedCachePolicy(
   id: string,
   name: string,
+  settings: {
+    readonly minTtlSec: number;
+    readonly defaultTtlSec: number;
+    readonly maxTtlSec: number;
+    readonly cacheKey: SimCloudFrontCacheKey;
+  },
 ): SimCloudFrontCachePolicy {
   return new SimCloudFrontCachePolicy({
     id: id as SimCloudFrontCachePolicyId,
     name,
+    ...settings,
   });
 }

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-config.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-config.ts
@@ -2,18 +2,30 @@ import { isRecord } from "../../../../util/type-guard/record.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimCloudFrontCachePolicy } from "../../cache-policy/sim-cf-cache-policy.js";
+import { simCfnCfCachePolicyCacheKey } from "./sim-cfn-cf-cache-policy-key.js";
+import type { SimCfnCfCachePolicyRefuse } from "./sim-cfn-cf-cache-policy-section.js";
 
 /**
  * Reads an AWS::CloudFront::CachePolicy Resource into a simulated policy.
  *
- * `Name` and `Comment` are what the policy carries. The cache key sections and
- * the TTLs are read past: what they configure is a cache this simulation has
- * yet to grow. A Resource missing its `Name` is refused, as CloudFormation
- * refuses one.
+ * The policy carries its `Name`, its `Comment`, its three TTLs and the cache
+ * key of its `ParametersInCacheKeyAndForwardedToOrigin`. A TTL a template left
+ * out falls back to CloudFront's own default rather than to nothing, so a
+ * policy holds what one in an account holds either way. A Resource missing its
+ * `Name` is refused, as CloudFormation refuses one.
  */
 export class SimCfnCfCachePolicyConfig {
   private readonly resource: SimCfnResource;
   private readonly properties: SimCfnTemplateValueRecord;
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  private readonly refuse: SimCfnCfCachePolicyRefuse = (detail) => {
+    throw new Error(
+      `Invalid AWS::CloudFront::CachePolicy ${this.resource.logicalId}: ${detail}`,
+    );
+  };
 
   constructor(properties: {
     readonly resource: SimCfnResource;
@@ -27,32 +39,57 @@ export class SimCfnCfCachePolicyConfig {
    * Build the simulated policy this Resource describes.
    */
   build(): SimCloudFrontCachePolicy {
+    const { refuse } = this;
     const config = this.properties["CachePolicyConfig"];
 
     if (!isRecord(config)) {
-      return this.refuse("CachePolicyConfig must be an object");
+      return refuse("CachePolicyConfig must be an object");
     }
 
     const name = config["Name"];
 
     if (typeof name !== "string") {
-      return this.refuse("CachePolicyConfig needs a string Name");
+      return refuse("CachePolicyConfig needs a string Name");
     }
 
     const comment = config["Comment"];
+    const minTtlSec = ttlSeconds(config, "MinTTL", refuse);
+    const defaultTtlSec = ttlSeconds(config, "DefaultTTL", refuse);
+    const maxTtlSec = ttlSeconds(config, "MaxTTL", refuse);
 
     return new SimCloudFrontCachePolicy({
       name,
       ...(typeof comment === "string" && { comment }),
+      ...(minTtlSec !== undefined && { minTtlSec }),
+      ...(defaultTtlSec !== undefined && { defaultTtlSec }),
+      ...(maxTtlSec !== undefined && { maxTtlSec }),
+      cacheKey: simCfnCfCachePolicyCacheKey(config, refuse),
     });
   }
+}
 
-  /**
-   * Refuse this Resource, saying which part of it could not be read.
-   */
-  private refuse(detail: string): never {
-    throw new Error(
-      `Invalid AWS::CloudFront::CachePolicy ${this.resource.logicalId}: ${detail}`,
-    );
+/**
+ * One TTL, or nothing where the template left it out for CloudFront's default
+ * to stand in.
+ *
+ * A template here is often a JavaScript object rather than parsed JSON, so a
+ * fraction, a negative or a NaN can reach this where a deployed template could
+ * not carry one, and none of them is a length of time an object could sit in a
+ * cache for.
+ */
+function ttlSeconds(
+  config: Record<string, unknown>,
+  field: string,
+  refuse: SimCfnCfCachePolicyRefuse,
+): number | undefined {
+  // oxlint-disable-next-line security/detect-object-injection
+  const value = config[field];
+
+  if (value === undefined) {
+    return undefined;
   }
+
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : refuse(`CachePolicyConfig ${field} must be a whole number of seconds`);
 }

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-key.iso.test.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-key.iso.test.ts
@@ -1,0 +1,227 @@
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontCachePolicy } from "../../cache-policy/sim-cf-cache-policy.js";
+import { SimCfnCfCachePolicyConfig } from "./sim-cfn-cf-cache-policy-config.js";
+
+describe("AWS::CloudFront::CachePolicy cache key", () => {
+  /**
+   * The policy a `CachePolicyConfig` describes, under a Name of its own so
+   * every case here is about the rest of the config.
+   */
+  function build(
+    cachePolicyConfig: SimCfnTemplateValueRecord,
+  ): SimCloudFrontCachePolicy {
+    return new SimCfnCfCachePolicyConfig({
+      resource: new SimCfnResource({ logicalId: "BeaconPolicy" }),
+      properties: {
+        CachePolicyConfig: { Name: "BeaconPolicy", ...cachePolicyConfig },
+      },
+    }).build();
+  }
+
+  /**
+   * The message refusing a `CachePolicyConfig` that could not be read.
+   */
+  function refusal(cachePolicyConfig: SimCfnTemplateValueRecord): string {
+    return assertThrowsError(() => build(cachePolicyConfig)).message;
+  }
+
+  it("records the three TTLs a template wrote", () => {
+    // Given a policy holding an object for a minute at least and an hour at
+    // most.
+    const policy = build({ MinTTL: 60, DefaultTTL: 300, MaxTTL: 3600 });
+
+    // Then all three are what the template wrote.
+    assertIdentical(policy.minTtlSec, 60);
+    assertIdentical(policy.defaultTtlSec, 300);
+    assertIdentical(policy.maxTtlSec, 3600);
+  });
+
+  it("defaults a TTL the template left out", () => {
+    // Given a policy naming its floor alone, which is the one CloudFormation
+    // asks for.
+    const policy = build({ MinTTL: 30 });
+
+    // Then the other two are CloudFront's own defaults.
+    assertIdentical(policy.minTtlSec, 30);
+    assertIdentical(policy.defaultTtlSec, 86_400);
+    assertIdentical(policy.maxTtlSec, 31_536_000);
+  });
+
+  it("records a cache key naming cookies, headers and query strings", () => {
+    // Given a policy keying on one of each.
+    const policy = build({
+      ParametersInCacheKeyAndForwardedToOrigin: {
+        EnableAcceptEncodingGzip: true,
+        EnableAcceptEncodingBrotli: true,
+        CookiesConfig: { CookieBehavior: "whitelist", Cookies: ["session"] },
+        HeadersConfig: { HeaderBehavior: "whitelist", Headers: ["Accept"] },
+        QueryStringsConfig: {
+          QueryStringBehavior: "allExcept",
+          QueryStrings: ["utm_source"],
+        },
+      },
+    });
+
+    // Then each section carries its behaviour and the names it applies to.
+    assertIdentical(policy.cacheKey.cookieBehavior, "whitelist");
+    assertArrayEquals(policy.cacheKey.cookies, ["session"]);
+    assertIdentical(policy.cacheKey.headerBehavior, "whitelist");
+    assertArrayEquals(policy.cacheKey.headers, ["Accept"]);
+    assertIdentical(policy.cacheKey.queryStringBehavior, "allExcept");
+    assertArrayEquals(policy.cacheKey.queryStrings, ["utm_source"]);
+
+    // And both compression flags are set.
+    assertTrue(policy.cacheKey.enableAcceptEncodingGzip);
+    assertTrue(policy.cacheKey.enableAcceptEncodingBrotli);
+  });
+
+  it("keys on nothing where the template named no parameters at all", () => {
+    // Given a policy with no ParametersInCacheKeyAndForwardedToOrigin.
+    const policy = build({ MinTTL: 0 });
+
+    // Then nothing of a request joins the key, which is CloudFront's `none`.
+    assertIdentical(policy.cacheKey.cookieBehavior, "none");
+    assertIdentical(policy.cacheKey.headerBehavior, "none");
+    assertIdentical(policy.cacheKey.queryStringBehavior, "none");
+    assertFalse(policy.cacheKey.enableAcceptEncodingGzip);
+    assertFalse(policy.cacheKey.enableAcceptEncodingBrotli);
+  });
+
+  it("keys on every cookie where the section says all", () => {
+    // Given a policy whose cookies section names `all` and lists nothing.
+    const policy = build({
+      ParametersInCacheKeyAndForwardedToOrigin: {
+        CookiesConfig: { CookieBehavior: "all" },
+      },
+    });
+
+    // Then the behaviour stands on its own, with an empty list beside it.
+    assertIdentical(policy.cacheKey.cookieBehavior, "all");
+    assertArrayEquals(policy.cacheKey.cookies, []);
+  });
+
+  it("refuses a cookie behaviour outside CloudFront's set", () => {
+    // Given a policy naming a behaviour CloudFront does not offer.
+    // When it is read, then the refusal names the Resource and the behaviour.
+    const message = refusal({
+      ParametersInCacheKeyAndForwardedToOrigin: {
+        CookiesConfig: { CookieBehavior: "allViewer" },
+      },
+    });
+
+    assertStringIncludes(message, "BeaconPolicy");
+    assertStringIncludes(
+      message,
+      "CookiesConfig CookieBehavior must be one of",
+    );
+    assertStringIncludes(message, "allExcept");
+  });
+
+  it("refuses a header behaviour a cache key cannot take", () => {
+    // Given a policy naming `allViewer`, which an origin request policy takes
+    // and a cache key does not.
+    // When it is read, then it is refused rather than kept as something else.
+    const message = refusal({
+      ParametersInCacheKeyAndForwardedToOrigin: {
+        HeadersConfig: { HeaderBehavior: "allViewer" },
+      },
+    });
+
+    assertStringIncludes(message, "BeaconPolicy");
+    assertStringIncludes(
+      message,
+      "HeadersConfig HeaderBehavior must be one of none, whitelist",
+    );
+  });
+
+  it("refuses a query string behaviour outside CloudFront's set", () => {
+    // Given a policy naming a behaviour CloudFront does not offer.
+    // When it is read, then the refusal names the section.
+    assertStringIncludes(
+      refusal({
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          QueryStringsConfig: { QueryStringBehavior: "some" },
+        },
+      }),
+      "QueryStringsConfig QueryStringBehavior must be one of",
+    );
+  });
+
+  it("refuses parameters that are not an object", () => {
+    // Given a policy whose parameters are a string.
+    // When it is read, then the refusal says what could not be read.
+    assertStringIncludes(
+      refusal({ ParametersInCacheKeyAndForwardedToOrigin: "none" }),
+      "ParametersInCacheKeyAndForwardedToOrigin must be an object",
+    );
+  });
+
+  it("refuses a section that is not an object", () => {
+    // Given a policy whose cookies section is a string.
+    // When it is read, then the refusal names the section.
+    assertStringIncludes(
+      refusal({
+        ParametersInCacheKeyAndForwardedToOrigin: { CookiesConfig: "none" },
+      }),
+      "CookiesConfig must be an object",
+    );
+  });
+
+  it("refuses a name list holding something other than names", () => {
+    // Given a policy whose header list carries a number.
+    // When it is read, then the refusal names the list.
+    assertStringIncludes(
+      refusal({
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          HeadersConfig: {
+            HeaderBehavior: "whitelist",
+            Headers: ["Accept", 1],
+          },
+        },
+      }),
+      "HeadersConfig Headers must be a list of strings",
+    );
+  });
+
+  it("refuses a compression flag that is not a boolean", () => {
+    // Given a policy whose Gzip flag is the string CloudFormation would have
+    // parsed into one.
+    // When it is read, then the refusal names the flag.
+    assertStringIncludes(
+      refusal({
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          EnableAcceptEncodingGzip: "true",
+        },
+      }),
+      "EnableAcceptEncodingGzip must be a boolean",
+    );
+  });
+
+  it("refuses a TTL that is not a whole number of seconds", () => {
+    // Given a policy whose MaxTTL is a fraction of a second.
+    // When it is read, then the refusal names the TTL.
+    assertStringIncludes(
+      refusal({ MaxTTL: 0.5 }),
+      "CachePolicyConfig MaxTTL must be a whole number of seconds",
+    );
+  });
+
+  it("refuses a TTL below zero", () => {
+    // Given a policy holding an object for less than no time.
+    // When it is read, then it is refused rather than kept.
+    assertStringIncludes(
+      refusal({ MinTTL: -1 }),
+      "CachePolicyConfig MinTTL must be a whole number of seconds",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-key.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-key.ts
@@ -1,0 +1,83 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import { SimCloudFrontCacheKey } from "../../cache-policy/sim-cf-cache-key.js";
+import {
+  simCfnCfCacheKeySection,
+  simCfnCfCookiesSpec,
+  simCfnCfHeadersSpec,
+  simCfnCfQueryStringsSpec,
+  type SimCfnCfCachePolicyRefuse,
+} from "./sim-cfn-cf-cache-policy-section.js";
+
+const parametersField = "ParametersInCacheKeyAndForwardedToOrigin";
+
+/**
+ * Read the `ParametersInCacheKeyAndForwardedToOrigin` of a
+ * `CachePolicyConfig` into the cache key a policy carries.
+ *
+ * A template leaving the whole thing out gets CloudFront's own `none` in all
+ * three sections, with neither compression flag set.
+ */
+export function simCfnCfCachePolicyCacheKey(
+  config: Record<string, unknown>,
+  refuse: SimCfnCfCachePolicyRefuse,
+): SimCloudFrontCacheKey {
+  // oxlint-disable-next-line security/detect-object-injection
+  const parameters = config[parametersField];
+
+  if (parameters === undefined) {
+    return new SimCloudFrontCacheKey();
+  }
+
+  if (!isRecord(parameters)) {
+    return refuse(`${parametersField} must be an object`);
+  }
+
+  const cookies = simCfnCfCacheKeySection(
+    parameters,
+    simCfnCfCookiesSpec,
+    refuse,
+  );
+  const headers = simCfnCfCacheKeySection(
+    parameters,
+    simCfnCfHeadersSpec,
+    refuse,
+  );
+  const queries = simCfnCfCacheKeySection(
+    parameters,
+    simCfnCfQueryStringsSpec,
+    refuse,
+  );
+
+  return new SimCloudFrontCacheKey({
+    cookieBehavior: cookies.behavior,
+    cookies: cookies.items,
+    headerBehavior: headers.behavior,
+    headers: headers.items,
+    queryStringBehavior: queries.behavior,
+    queryStrings: queries.items,
+    enableAcceptEncodingGzip: encodingFlag(parameters, "Gzip", refuse),
+    enableAcceptEncodingBrotli: encodingFlag(parameters, "Brotli", refuse),
+  });
+}
+
+/**
+ * One of the two flags that put the normalized `Accept-Encoding` header in the
+ * cache key. Both are off where a template says nothing.
+ */
+function encodingFlag(
+  parameters: Record<string, unknown>,
+  encoding: string,
+  refuse: SimCfnCfCachePolicyRefuse,
+): boolean {
+  const field = `EnableAcceptEncoding${encoding}`;
+  // oxlint-disable-next-line security/detect-object-injection
+  const value = parameters[field];
+
+  if (value === undefined) {
+    return false;
+  }
+
+  return typeof value === "boolean"
+    ? value
+    : refuse(`${parametersField} ${field} must be a boolean`);
+}

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-section.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-section.ts
@@ -1,0 +1,119 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import {
+  simCfCacheKeyCookieBehaviors,
+  simCfCacheKeyHeaderBehaviors,
+  simCfCacheKeyQueryStringBehaviors,
+} from "../../cache-policy/sim-cf-cache-key.js";
+
+export type SimCfnCfCachePolicyRefuse = (detail: string) => never;
+
+export interface SimCfnCfCacheKeySectionSpec<TBehavior extends string> {
+  readonly section: string;
+  readonly behaviorField: string;
+  readonly itemsField: string;
+  readonly behaviors: readonly TBehavior[];
+  readonly defaultBehavior: TBehavior;
+}
+
+/**
+ * The three sections of a cache key, each with the fields CloudFormation
+ * names it by and the behaviours CloudFront offers for it.
+ */
+export const simCfnCfCookiesSpec = {
+  section: "CookiesConfig",
+  behaviorField: "CookieBehavior",
+  itemsField: "Cookies",
+  behaviors: simCfCacheKeyCookieBehaviors,
+  defaultBehavior: "none",
+} as const;
+
+export const simCfnCfHeadersSpec = {
+  section: "HeadersConfig",
+  behaviorField: "HeaderBehavior",
+  itemsField: "Headers",
+  behaviors: simCfCacheKeyHeaderBehaviors,
+  defaultBehavior: "none",
+} as const;
+
+export const simCfnCfQueryStringsSpec = {
+  section: "QueryStringsConfig",
+  behaviorField: "QueryStringBehavior",
+  itemsField: "QueryStrings",
+  behaviors: simCfCacheKeyQueryStringBehaviors,
+  defaultBehavior: "none",
+} as const;
+
+/**
+ * One `<name>Config` section of a cache key, as the behaviour it names and the
+ * names that behaviour applies to.
+ *
+ * An absent section is CloudFront's `none` with an empty list, and so is a
+ * section that named no behaviour of its own. A behaviour outside the set
+ * CloudFront offers for the section is refused.
+ */
+export function simCfnCfCacheKeySection<TBehavior extends string>(
+  parameters: Record<string, unknown>,
+  spec: SimCfnCfCacheKeySectionSpec<TBehavior>,
+  refuse: SimCfnCfCachePolicyRefuse,
+): { behavior: TBehavior; items: readonly string[] } {
+  // oxlint-disable-next-line security/detect-object-injection
+  const section = parameters[spec.section];
+
+  if (section === undefined) {
+    return { behavior: spec.defaultBehavior, items: [] };
+  }
+
+  if (!isRecord(section)) {
+    return refuse(`${spec.section} must be an object`);
+  }
+
+  return {
+    // oxlint-disable-next-line security/detect-object-injection
+    behavior: behaviorNamed(section[spec.behaviorField], spec, refuse),
+    items: namesListed(section, spec, refuse),
+  };
+}
+
+/**
+ * The behaviour a section named, refused where CloudFront does not offer it
+ * for that section.
+ */
+function behaviorNamed<TBehavior extends string>(
+  named: unknown,
+  spec: SimCfnCfCacheKeySectionSpec<TBehavior>,
+  refuse: SimCfnCfCachePolicyRefuse,
+): TBehavior {
+  if (named === undefined) {
+    return spec.defaultBehavior;
+  }
+
+  const offered: readonly string[] = spec.behaviors;
+
+  return typeof named === "string" && offered.includes(named)
+    ? (named as TBehavior)
+    : refuse(
+        `${spec.section} ${spec.behaviorField} must be one of ${offered.join(", ")}`,
+      );
+}
+
+/**
+ * The names a section lists, which a `whitelist` keys on and an `allExcept`
+ * keys on everything but.
+ */
+function namesListed(
+  section: Record<string, unknown>,
+  spec: SimCfnCfCacheKeySectionSpec<string>,
+  refuse: SimCfnCfCachePolicyRefuse,
+): readonly string[] {
+  // oxlint-disable-next-line security/detect-object-injection
+  const listed = section[spec.itemsField];
+
+  if (listed === undefined) {
+    return [];
+  }
+
+  return Array.isArray(listed) &&
+    listed.every((name) => typeof name === "string")
+    ? listed
+    : refuse(`${spec.section} ${spec.itemsField} must be a list of strings`);
+}

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy.iso.test.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy.iso.test.ts
@@ -1,10 +1,12 @@
 import {
+  assertArrayEquals,
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsError,
   assertThrowsErrorAsync,
+  assertTrue,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -139,6 +141,46 @@ describe("AWS::CloudFront::CachePolicy", () => {
 
     // Then the comment is what the template wrote.
     assertIdentical(resource.simResource.comment, "No query string in the key");
+  });
+
+  it("carries the TTLs and the cache key a deployed template wrote", async () => {
+    // Given a template whose policy holds an object for an hour and keys on
+    // one query string.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "cache-policy-key-stack",
+      template: siteTemplate({
+        MinTTL: 60,
+        DefaultTTL: 3600,
+        MaxTTL: 86_400,
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          EnableAcceptEncodingGzip: true,
+          CookiesConfig: { CookieBehavior: "none" },
+          HeadersConfig: { HeaderBehavior: "none" },
+          QueryStringsConfig: {
+            QueryStringBehavior: "whitelist",
+            QueryStrings: ["page"],
+          },
+        },
+      }),
+    });
+
+    await stack.waitForDeployComplete();
+
+    const resource = stack.getResource("BeaconPolicy");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontCachePolicy);
+
+    // Then the policy the Behavior names holds what the template configured.
+    const policy = resource.simResource;
+
+    assertIdentical(policy.minTtlSec, 60);
+    assertIdentical(policy.defaultTtlSec, 3600);
+    assertIdentical(policy.maxTtlSec, 86_400);
+    assertIdentical(policy.cacheKey.queryStringBehavior, "whitelist");
+    assertArrayEquals(policy.cacheKey.queryStrings, ["page"]);
+    assertTrue(policy.cacheKey.enableAcceptEncodingGzip);
   });
 
   it("forgets the policy when the Stack is torn down", async () => {


### PR DESCRIPTION
A simulated CloudFront cache policy now carries its `MinTTL`, `DefaultTTL` and `MaxTTL` along with the whole of `ParametersInCacheKeyAndForwardedToOrigin`, so a test can assert what a Behavior keys its cache on before there is a cache to key. A TTL the template left out falls back to CloudFront's own default, including the two cases where a long `MinTTL` raises the `DefaultTTL` and a long `DefaultTTL` raises the `MaxTTL`. An absent cache key section comes out as `none`, and a section naming a behaviour outside the set CloudFront offers for it fails the Stack, naming the Resource. `HeaderBehavior` takes `none` and `whitelist` alone, a narrower set than the other two sections take. Each of the seven managed policies carries the TTLs and the cache key AWS publishes for it, taken from the managed cache policies page rather than guessed. Nothing acts on any of it yet, which is what #1149 and the four issues behind it are for.

Resolves #1148