### PR TITLE
fix: read a managed key SecureString without KMS

### DIFF
--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -706,8 +706,11 @@ real ECS accepts for a parameter in the task's own region. A Secrets Manager ARN
 key, a version stage and a version id after the secret id, in the form
 `...:secret:orders/db-AbCdEf:password::` that a CDK construct given a field writes. The key selects
 one field of a secret holding a JSON object. A `SecureString` parameter is decrypted, as it is for a
-real task. The decryption is made with the execution role's own permissions, and that role needs
-`kms:Decrypt` on top of `ssm:GetParameter`.
+real task. The decryption is made with the execution role's own permissions. Under the `aws/ssm`
+managed key that role needs `ssm:GetParameter` and nothing on KMS, since the key's policy allows the
+decryption itself (see
+[Sim SSM](../ssm/README.md#the-awsssm-managed-key-allows-the-read-itself)). Under a customer managed
+key it needs `kms:Decrypt` as well.
 
 A secret that cannot be resolved stops the task before any container runs, with a
 `ResourceInitializationError` reason naming the variable:

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -357,11 +357,15 @@ That is why a role holding `kms:Decrypt` on such a key cannot use it by calling 
 `SecureString` parameters. Code calling simulated KMS directly sets it with the `viaService` request
 option, naming the service on its own (`ssm`), since the region is the key's.
 
-A service passing on the caller's own KMS permissions sets `withCallerPermissions` alongside it.
-What the policy above admits is the service a request came through. A request carrying this option
-is allowed only where IAM allows the caller the KMS action too, and a key policy naming the caller
-allows it on its own. Sim SSM sets the option when it decrypts a `SecureString`. A role holding
-`ssm:GetParameter` and no `kms:Decrypt` is refused the decrypted value.
+The first statement above allows the request outright, so nothing further is asked of the caller. A
+role holding `ssm:GetParameter` and nothing on KMS reads a decrypted `SecureString` under `aws/ssm`,
+because Parameter Store supplies the `kms:ViaService` value the policy wants (see
+[Sim SSM](../ssm/README.md#the-awsssm-managed-key-allows-the-read-itself)).
+
+A service that passes the caller's own KMS permissions on rather than its own sets
+`withCallerPermissions` alongside `viaService`. A request carrying that option is allowed only where
+IAM allows the caller the KMS action too, and a key policy naming the caller still allows it on its
+own. No simulated service sets it.
 
 ```typescript sim-kms-aws-managed-key
 /**

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -472,9 +472,10 @@ recorded the same way.
 references use, so a reference can sit inside a longer value and inside `Fn::Sub`.
 
 Decryption goes to simulated KMS under the key the parameter was written with, as the caller
-deploying the stack. A caller lacking `kms:Decrypt` on that key fails the resource with the
-`AccessDenied` a decrypting `GetParameter` raises (see
+deploying the stack. A caller lacking `kms:Decrypt` on a customer managed key fails the resource with
+the `AccessDenied` a decrypting `GetParameter` raises (see
 [A customer managed key needs its own permission](#a-customer-managed-key-needs-its-own-permission)).
+A parameter under the `aws/ssm` managed key needs no KMS permission of the caller.
 
 CDK writes one of these from `SecretValue.ssmSecure`, from
 `ssm.StringParameter.fromSecureStringParameterAttributes` and from the deprecated
@@ -915,24 +916,27 @@ try {
 }
 ```
 
-### The aws/ssm managed key needs kms:Decrypt too
+### The aws/ssm managed key allows the read itself
 
-A parameter naming no key is encrypted under the `aws/ssm` AWS managed key. Parameter Store supplies
-`kms:ViaService`, and that key's policy allows the account's principals to use it through Systems
-Manager. What the policy admits is whoever the request came from. Parameter Store decrypts with the
-caller's own permissions, and a decrypting read needs `kms:Decrypt` on top of `ssm:GetParameter`. A
-role holding the parameter permission alone reads the ciphertext and is refused when it asks for
-decryption, as it is in a real account.
+A parameter naming no key is encrypted under the `aws/ssm` AWS managed key. That key's policy allows
+the cryptographic actions to a wildcard principal under `kms:ViaService` and `kms:CallerAccount`
+conditions, and Parameter Store satisfies both. A grant of that shape delegates nothing to IAM. A
+role holding `ssm:GetParameter` and nothing on KMS reads the decrypted value, as it does in an
+account, and withholding that access takes an explicit `Deny`.
 
-The managed key's id is unknown when a template is synthesized. A policy scopes the grant with a
-`kms:ViaService` condition naming `ssm.<region>.amazonaws.com`, and simulated IAM evaluates that
-condition against the region the parameter belongs to.
+`GetParameters` and `GetParametersByPath` decrypt through the same path and on the same permission.
+A `SecureString` write under the managed key asks for no KMS permission either.
 
-`GetParameters` and `GetParametersByPath` decrypt through the same path, and refuse the same way for
-a caller without the key permission.
+A `kms:Decrypt` grant scoped with a `kms:ViaService` condition (the shape a stack writes when the
+key is chosen after synthesis) still works, and it is what a customer managed key wants.
 
-The same role cannot take the ciphertext to KMS itself, because the managed key's policy applies
-only to a request that reached KMS through Systems Manager.
+The key stays out of reach of anything calling KMS directly. The same role handed the stored
+ciphertext cannot decrypt it through `Decrypt`, because the policy's `kms:ViaService` condition
+matches only a request that arrived through Systems Manager. A caller in another account is refused
+by the `kms:CallerAccount` condition.
+
+An ECS task resolves a `secrets` entry through this path. An execution role holding
+`ssm:GetParameter` alone reads a managed key `SecureString` into a container's environment.
 
 ```typescript sim-ssm-secure-string-managed-key
 /**
@@ -969,26 +973,14 @@ const role = await simAws.iam().createRole(
   }),
 );
 
-// The parameter, and the key through Systems Manager.
+// The parameter, and nothing on KMS.
 await simAws.iam().putRolePolicy(
   new PutRolePolicyCommand({
     RoleName: "ConfigReader",
     PolicyName: "ReadDbPassword",
     PolicyDocument: JSON.stringify({
       Version: "2012-10-17",
-      Statement: [
-        { Effect: "Allow", Action: "ssm:GetParameter", Resource: "*" },
-        {
-          Effect: "Allow",
-          Action: "kms:Decrypt",
-          Resource: "*",
-          Condition: {
-            StringEquals: {
-              "kms:ViaService": `ssm.${simAws.defaultRegionName}.amazonaws.com`,
-            },
-          },
-        },
-      ],
+      Statement: { Effect: "Allow", Action: "ssm:GetParameter", Resource: "*" },
     }),
   }),
 );
@@ -1052,9 +1044,10 @@ Current documented limitations:
   without complaint.
 - `KeyId` on a `String` or `StringList` parameter is refused, since nothing would encrypt a value
   stored in the clear.
-- Writing a `SecureString` under the `aws/ssm` managed key asks the caller for no KMS permission,
-  where AWS documents `kms:Encrypt` for a standard tier write. A write under a customer managed key
-  does need it.
+- Reading and writing a `SecureString` under the `aws/ssm` managed key ask the caller for no KMS
+  permission, which follows that key's policy and the Parameter Store setup page. AWS's SecureString
+  encryption page documents `kms:Encrypt` and `kms:Decrypt` for either kind of key, and the two
+  disagree. A parameter under a customer managed key does need them.
 - `DataType` other than `text` is refused. Real Parameter Store validates an `aws:ec2:image` value
   against EC2, which this simulation cannot do.
 - Filters are refused outright. `GetParametersByPath` refuses `ParameterFilters`, and

--- a/docs/services/ssm/sim-ssm-secure-string-managed-key.example.ts
+++ b/docs/services/ssm/sim-ssm-secure-string-managed-key.example.ts
@@ -32,26 +32,14 @@ const role = await simAws.iam().createRole(
   }),
 );
 
-// The parameter, and the key through Systems Manager.
+// The parameter, and nothing on KMS.
 await simAws.iam().putRolePolicy(
   new PutRolePolicyCommand({
     RoleName: "ConfigReader",
     PolicyName: "ReadDbPassword",
     PolicyDocument: JSON.stringify({
       Version: "2012-10-17",
-      Statement: [
-        { Effect: "Allow", Action: "ssm:GetParameter", Resource: "*" },
-        {
-          Effect: "Allow",
-          Action: "kms:Decrypt",
-          Resource: "*",
-          Condition: {
-            StringEquals: {
-              "kms:ViaService": `ssm.${simAws.defaultRegionName}.amazonaws.com`,
-            },
-          },
-        },
-      ],
+      Statement: { Effect: "Allow", Action: "ssm:GetParameter", Resource: "*" },
     }),
   }),
 );

--- a/src/service/ecs/command/run-task/run-task-secrets.iso.test.ts
+++ b/src/service/ecs/command/run-task/run-task-secrets.iso.test.ts
@@ -73,13 +73,10 @@ describe("Resolving a simulated ECS container's secrets", () => {
         Value: "k-1234",
       }),
     );
-    // The decryption is the execution Role's own, so it holds kms:Decrypt as
-    // well as the parameter permission.
+    // The parameter is under the aws/ssm managed key, whose policy allows the
+    // decryption on its own, so the execution Role needs no KMS permission.
     const executionRole = await simIamRoleWithPolicyFactory.make(
-      {
-        roleName: "OrdersExecutionRole",
-        actions: ["ssm:GetParameter", "kms:Decrypt"],
-      },
+      { roleName: "OrdersExecutionRole", actions: ["ssm:GetParameter"] },
       simAws,
     );
 

--- a/src/service/iam/authorize/allow/sim-iam-allow-requirement.ts
+++ b/src/service/iam/authorize/allow/sim-iam-allow-requirement.ts
@@ -156,11 +156,12 @@ export class SimIamMandatoryResourcePolicyRequirement implements SimIamAllowRequ
  *
  * A resource policy naming the caller still allows the request on its own, as
  * a KMS key policy naming a Role does. A policy admitting whoever the request
- * came from does not, because what it admits is the service. That is the
- * difference between a key policy naming a Role and the aws/ssm key policy,
- * which admits the Account's principals reaching KMS through Parameter Store
- * and still leaves a Role holding only ssm:GetParameter unable to decrypt a
- * SecureString.
+ * came from does not, because what it admits is the service, and an identity
+ * policy has to allow the action as well.
+ *
+ * Nothing in the simulation asks for this rule. Parameter Store is the case it
+ * was written for, and the aws/ssm key policy grants its cryptographic actions
+ * to a wildcard principal outright.
  */
 export class SimIamCallerPermissionRequirement implements SimIamAllowRequirement {
   /**

--- a/src/service/iam/authorize/context/sim-iam-auth-z-input.ts
+++ b/src/service/iam/authorize/context/sim-iam-auth-z-input.ts
@@ -95,10 +95,12 @@ export interface SimIamAuthorizationInput {
    * resource policy admitting the caller is enough on its own. A service sets
    * this where it reaches another service as the caller. A resource policy
    * that admits whoever the request came from then grants nothing by itself,
-   * because what it admits is the service. Reading a SecureString needs
-   * kms:Decrypt for that reason, even under the aws/ssm key, whose policy
-   * admits the Account's principals reaching KMS through Parameter Store. A
-   * resource policy naming the caller still allows the request on its own.
+   * because what it admits is the service. A resource policy naming the caller
+   * still allows the request on its own.
+   *
+   * No simulated service sets this. Parameter Store is the case it was written
+   * for, and the aws/ssm key policy grants its cryptographic actions to a
+   * wildcard principal outright.
    */
   readonly withCallerPermissions?: boolean | undefined;
 }

--- a/src/service/kms/README.md
+++ b/src/service/kms/README.md
@@ -154,10 +154,12 @@ usable in its own region.
 AWS managed key: use of the key allowed to `*` conditioned on both keys, and a second statement
 delegating only the key's metadata to the account. Nothing about using the key is delegated, so an
 identity policy granting `kms:Decrypt` on such a key reaches nothing by itself, and a caller reaches
-the key through the owning service. What the first statement admits is whoever the request came
-from, so a service passing the caller's own permissions on with `withCallerPermissions` needs IAM to
-allow that caller too. The key factory builds it whenever a key is
-made for a service, which the key store does on first reference to a reserved `alias/aws/` name.
+the key through the owning service. The first statement admits whoever the request came from and
+allows the request outright, which is why a caller holding `ssm:GetParameter` and nothing on KMS
+reads a `SecureString` under `aws/ssm`. `withCallerPermissions` is the option for a service passing
+the caller's own permissions on instead, which then needs IAM to allow that caller too. No simulated
+service sets it. The key factory builds the policy whenever a key is made for a service, which the
+key store does on first reference to a reserved `alias/aws/` name.
 
 Operations with no key to speak of, `CreateKey`, `ListKeys` and `ListAliases`, authorize against the
 region's keys with identity policies alone, because real KMS gives those actions no resource-level

--- a/src/service/kms/command/sim-kms-request-options.ts
+++ b/src/service/kms/command/sim-kms-request-options.ts
@@ -27,11 +27,15 @@ export interface SimKmsRequestOptions {
    * Whether the service named by `viaService` is making the request with the
    * caller's own KMS permissions rather than with its own.
    *
-   * Parameter Store decrypts a SecureString this way. A caller holding
-   * ssm:GetParameter and no kms:Decrypt is refused even under the aws/ssm key,
-   * whose policy admits the Account's principals reaching KMS through Systems
-   * Manager. A key policy naming the caller still allows the request on its
-   * own, as it does for any other KMS request.
+   * A key policy admitting whoever the request came from then grants nothing
+   * by itself, because what it admits is the service, and the caller has to
+   * hold the KMS action in an identity policy as well. A key policy naming the
+   * caller still allows the request on its own, as it does for any other KMS
+   * request.
+   *
+   * No simulated service sets this. Parameter Store is the case it was written
+   * for, and the aws/ssm key policy grants its cryptographic actions to a
+   * wildcard principal outright.
    */
   readonly withCallerPermissions?: boolean | undefined;
 }

--- a/src/service/ssm/README.md
+++ b/src/service/ssm/README.md
@@ -60,9 +60,10 @@ call and nothing more. Two details matter:
   write needs the caller's own `kms:Encrypt` and a decrypting read needs `kms:Decrypt`, each on top
   of the SSM permission for the parameter;
 - they are made through the service as well, carrying `kms:ViaService`, which is what reaches the
-  `aws/ssm` managed key at all and keeps it out of reach of anything calling KMS directly. A
-  decrypting read carries `withCallerPermissions` with it, leaving that key's account-wide statement
-  short of allowing the read on its own;
+  `aws/ssm` managed key at all and keeps it out of reach of anything calling KMS directly. That
+  key's statement allows the cryptographic actions to a wildcard principal under its two conditions,
+  and Parameter Store satisfies both, so a caller holding `ssm:GetParameter` alone reads the
+  decrypted value;
 - the parameter's ARN is bound in as the `PARAMETER_ARN` encryption context, as real Parameter Store
   binds it, so a ciphertext moved into another parameter cannot be decrypted there.
 

--- a/src/service/ssm/parameter/sim-ssm-kms-crypto.ts
+++ b/src/service/ssm/parameter/sim-ssm-kms-crypto.ts
@@ -21,6 +21,11 @@ export const ssmDefaultKeyAlias = "alias/aws/ssm";
  */
 export const ssmKmsViaService = "ssm";
 
+interface SimSsmKmsOptions {
+  readonly caller?: SimAwsCaller | undefined;
+  readonly viaService?: string | undefined;
+}
+
 /**
  * The narrow slice of simulated KMS that SecureString parameters need.
  *
@@ -37,11 +42,7 @@ export interface SimSsmKmsCrypto {
         EncryptionContext?: Readonly<Record<string, string>> | undefined;
       };
     },
-    options?: {
-      caller?: SimAwsCaller | undefined;
-      viaService?: string | undefined;
-      withCallerPermissions?: boolean | undefined;
-    },
+    options?: SimSsmKmsOptions,
   ): Promise<{
     CiphertextBlob?: Uint8Array | undefined;
     KeyId?: string | undefined;
@@ -54,11 +55,7 @@ export interface SimSsmKmsCrypto {
         EncryptionContext?: Readonly<Record<string, string>> | undefined;
       };
     },
-    options?: {
-      caller?: SimAwsCaller | undefined;
-      viaService?: string | undefined;
-      withCallerPermissions?: boolean | undefined;
-    },
+    options?: SimSsmKmsOptions,
   ): Promise<{
     Plaintext?: Uint8Array | undefined;
     KeyId?: string | undefined;

--- a/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
+++ b/src/service/ssm/parameter/sim-ssm-parameter-kms.ts
@@ -37,15 +37,15 @@ interface SimSsmParameterKmsProperties {
  * and a decrypting read needs `kms:Decrypt`, each on top of the SSM permission
  * for the parameter itself.
  *
- * They are also made through the service, which is what reaches the `aws/ssm`
- * managed key at all. That key's policy admits the Account's principals when
- * `kms:ViaService` names Systems Manager, and Parameter Store is what supplies
- * it. Reaching the key is not the same as being allowed to use it, and a
- * decrypting read says so with `withCallerPermissions`, because that policy
- * admits whoever the request came from rather than the caller behind it. A
- * Role holding `ssm:GetParameter` and no `kms:Decrypt` reads the ciphertext
- * and not the value. A write under that key asks the caller for no KMS
- * permission here, where AWS documents `kms:Encrypt` for one.
+ * They are also made through the service, and passing through it is what
+ * reaches the `aws/ssm` managed key at all. That key's policy allows the
+ * cryptographic actions to a wildcard principal under `kms:ViaService` and
+ * `kms:CallerAccount` conditions, and Parameter Store supplies the first of
+ * them. A grant of that shape delegates nothing to IAM, and it admits the
+ * request by itself. A Role holding `ssm:GetParameter` and nothing on KMS
+ * reads the decrypted value, as it does in an account. A caller in another
+ * Account fails the `kms:CallerAccount` condition, and a caller reaching KMS
+ * directly carries no `kms:ViaService` for the policy to match.
  *
  * Standard tier Parameter Store encrypts under the key directly rather than
  * through a data key, so this is one Encrypt and one Decrypt and nothing more.
@@ -92,8 +92,7 @@ export class SimSsmParameterKms {
   }
 
   /**
-   * Decrypt a parameter value, which needs the same binding it was made with,
-   * and the caller's own permission to use the key.
+   * Decrypt a parameter value, which needs the same binding it was made with.
    */
   async decrypt(
     parameterArn: string,
@@ -109,11 +108,7 @@ export class SimSsmParameterKms {
               EncryptionContext: this.contextFor(parameterArn),
             },
           },
-          {
-            caller,
-            viaService: ssmKmsViaService,
-            withCallerPermissions: true,
-          },
+          { caller, viaService: ssmKmsViaService },
         ),
     );
 

--- a/src/service/ssm/parameter/sim-ssm-secure-string-managed-key-iam.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string-managed-key-iam.iso.test.ts
@@ -1,4 +1,3 @@
-import { PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { DecryptCommand } from "@aws-sdk/client-kms";
 import {
   GetParameterCommand,
@@ -16,7 +15,6 @@ import {
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
-import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
 import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
 
 /**
@@ -26,7 +24,7 @@ const parameterName = "/myapp/prod/db-password";
 const parameterValue = "hunter2";
 
 describe("SSM SecureString under the aws/ssm managed key", () => {
-  it("refuses a decrypting read to a caller holding no kms:Decrypt", async () => {
+  it("decrypts for a caller holding no KMS permission at all", async () => {
     // Given a parameter under the managed key, and a Role allowed to read
     // parameters and nothing else.
     const simAws = new SimAws();
@@ -43,43 +41,6 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
     );
 
     // When it reads the parameter with decryption.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.ssm().getParameter(
-        new GetParameterCommand({
-          Name: parameterName,
-          WithDecryption: true,
-        }),
-        { caller: { kind: "arn", arn: role.Arn } },
-      ),
-    );
-
-    // Then it is refused. Reaching the key through Systems Manager is what the
-    // managed key's policy admits, and using it is still the caller's own
-    // permission, which is the AccessDenied such a Role gets in an account.
-    assertInstanceOf(error, SimIamAccessDenied);
-    assertIdentical(error.action, "kms:Decrypt");
-  });
-
-  it("decrypts for a caller holding kms:Decrypt as well", async () => {
-    // Given a parameter under the managed key, and a Role allowed both the
-    // parameter and the key.
-    const simAws = new SimAws();
-    await simAws.ssm().putParameter(
-      new PutParameterCommand({
-        Name: parameterName,
-        Type: "SecureString",
-        Value: parameterValue,
-      }),
-    );
-    const role = await simIamRoleWithPolicyFactory.make(
-      {
-        roleName: "ConfigReader",
-        actions: ["ssm:GetParameter", "kms:Decrypt"],
-      },
-      simAws,
-    );
-
-    // When it reads the parameter with decryption.
     const read = await simAws
       .ssm()
       .getParameter(
@@ -87,56 +48,10 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
         { caller: { kind: "arn", arn: role.Arn } },
       );
 
-    // Then it gets the plaintext.
-    assertIdentical(read.Parameter?.Value, parameterValue);
-  });
-
-  it("decrypts for a caller whose kms:Decrypt is scoped to Systems Manager", async () => {
-    // Given a parameter under the managed key, and a Role whose key permission
-    // is conditioned on the request reaching KMS through Parameter Store. The
-    // managed key's id is not knowable when a template is synthesized, so this
-    // is how consumers scope the grant.
-    const simAws = new SimAws();
-    await simAws.ssm().putParameter(
-      new PutParameterCommand({
-        Name: parameterName,
-        Type: "SecureString",
-        Value: parameterValue,
-      }),
-    );
-    const role = await simIamRoleWithPolicyFactory.make(
-      { roleName: "ConfigReader", actions: ["ssm:GetParameter"] },
-      simAws,
-    );
-    await simAws.iam().putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "ConfigReader",
-        PolicyName: "KeyPolicy",
-        PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Action: "kms:Decrypt",
-            Resource: "*",
-            Condition: {
-              StringEquals: {
-                "kms:ViaService": `ssm.${simAws.defaultRegionName}.amazonaws.com`,
-              },
-            },
-          },
-        }),
-      }),
-    );
-
-    // When it reads the parameter with decryption.
-    const read = await simAws
-      .ssm()
-      .getParameter(
-        new GetParameterCommand({ Name: parameterName, WithDecryption: true }),
-        { caller: { kind: "arn", arn: role.Arn } },
-      );
-
-    // Then the condition matches and the read succeeds, as it does in an
-    // account. A check ignoring the condition would refuse a policy real IAM
-    // allows.
+    // Then it gets the plaintext, as it does in an account. The managed key's
+    // policy grants the cryptographic actions to a wildcard principal under
+    // its via-service and caller-account conditions, and Parameter Store
+    // satisfies both of them.
     assertIdentical(read.Parameter?.Value, parameterValue);
   });
 
@@ -170,7 +85,7 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
     assertIdentical(read.Parameter?.Value, "db.example.com");
   });
 
-  it("reads the ciphertext for a caller holding no kms:Decrypt", async () => {
+  it("reads the ciphertext where the read asks for no decryption", async () => {
     // Given a parameter under the managed key, and a Role allowed to read
     // parameters and nothing else.
     const simAws = new SimAws();
@@ -198,7 +113,7 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
     assertStringNotIncludes(String(read.Parameter?.Value), parameterValue);
   });
 
-  it("refuses a decrypting batch read to a caller holding no kms:Decrypt", async () => {
+  it("decrypts a batch read for a caller holding no KMS permission", async () => {
     // Given a parameter under the managed key, and a Role allowed to read
     // parameters in batches and nothing else.
     const simAws = new SimAws();
@@ -215,23 +130,21 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
     );
 
     // When it reads the parameter through GetParameters with decryption.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.ssm().getParameters(
-        new GetParametersCommand({
-          Names: [parameterName],
-          WithDecryption: true,
-        }),
-        { caller: { kind: "arn", arn: role.Arn } },
-      ),
+    const read = await simAws.ssm().getParameters(
+      new GetParametersCommand({
+        Names: [parameterName],
+        WithDecryption: true,
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
     );
 
-    // Then the batch is refused rather than reporting the name as invalid: a
-    // denial is not a name that resolves to nothing.
-    assertInstanceOf(error, SimIamAccessDenied);
-    assertIdentical(error.action, "kms:Decrypt");
+    // Then the batch comes back decrypted, and the name is not reported as one
+    // that failed to resolve.
+    assertIdentical(read.Parameters?.[0]?.Value, parameterValue);
+    assertIdentical(read.InvalidParameters?.length, 0);
   });
 
-  it("refuses a decrypting path listing to a caller holding no kms:Decrypt", async () => {
+  it("decrypts a path listing for a caller holding no KMS permission", async () => {
     // Given a parameter under the managed key, and a Role allowed to list a
     // path and nothing else.
     const simAws = new SimAws();
@@ -248,20 +161,17 @@ describe("SSM SecureString under the aws/ssm managed key", () => {
     );
 
     // When it lists the path the parameter is under, with decryption.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.ssm().getParametersByPath(
-        new GetParametersByPathCommand({
-          Path: "/myapp/prod",
-          WithDecryption: true,
-        }),
-        { caller: { kind: "arn", arn: role.Arn } },
-      ),
+    const listed = await simAws.ssm().getParametersByPath(
+      new GetParametersByPathCommand({
+        Path: "/myapp/prod",
+        WithDecryption: true,
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
     );
 
-    // Then the listing is refused as well: access to a path is not access to
-    // the key protecting what is under it.
-    assertInstanceOf(error, SimIamAccessDenied);
-    assertIdentical(error.action, "kms:Decrypt");
+    // Then the listing decrypts what is under the path, on the parameter
+    // permission alone.
+    assertIdentical(listed.Parameters?.[0]?.Value, parameterValue);
   });
 
   it("writes for a caller holding no KMS permission", async () => {

--- a/src/service/ssm/parameter/sim-ssm-secure-string-read-iam.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string-read-iam.iso.test.ts
@@ -7,7 +7,6 @@ import {
   assertNonNullable,
   assertStringNotIncludes,
   assertThrowsErrorAsync,
-  assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
@@ -15,7 +14,7 @@ import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
 import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
 import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
 
-describe("SSM SecureString IAM authorization", () => {
+describe("SSM SecureString read IAM authorization", () => {
   it("decrypts for a caller allowed both the parameter and the key", async () => {
     // Given a SecureString parameter under a customer managed key.
     const simAws = new SimAws();
@@ -123,6 +122,62 @@ describe("SSM SecureString IAM authorization", () => {
     assertIdentical(read.Parameter?.Value, "hunter2");
   });
 
+  it("decrypts for a caller whose kms:Decrypt is scoped to Systems Manager", async () => {
+    // Given a SecureString parameter under a customer managed key.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+    assertNonNullable(key.KeyMetadata?.Arn);
+    await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/db-password",
+        Type: "SecureString",
+        Value: "hunter2",
+        KeyId: key.KeyMetadata.Arn,
+      }),
+    );
+
+    // And a Role whose key permission is conditioned on the request reaching
+    // KMS through Parameter Store, which is how a stack scopes the grant when
+    // the key is chosen after synthesis.
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "ConfigReader", actions: ["ssm:GetParameter"] },
+      simAws,
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ConfigReader",
+        PolicyName: "KeyPolicy",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "kms:Decrypt",
+            Resource: "*",
+            Condition: {
+              StringEquals: {
+                "kms:ViaService": `ssm.${simAws.defaultRegionName}.amazonaws.com`,
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    // When it reads the parameter with decryption.
+    const read = await simAws.ssm().getParameter(
+      new GetParameterCommand({
+        Name: "/myapp/prod/db-password",
+        WithDecryption: true,
+      }),
+      { caller: { kind: "arn", arn: role.Arn } },
+    );
+
+    // Then the condition matches and the read succeeds, as it does in an
+    // account. A check ignoring the condition would refuse a policy real IAM
+    // allows.
+    assertIdentical(read.Parameter?.Value, "hunter2");
+  });
+
   it("denies a decrypting read to a caller with no key permission", async () => {
     // Given a SecureString parameter under a customer managed key.
     const simAws = new SimAws();
@@ -226,151 +281,5 @@ describe("SSM SecureString IAM authorization", () => {
     // Then the read succeeds, because nothing decrypted, and what comes back
     // is the ciphertext rather than the secret.
     assertStringNotIncludes(String(read.Parameter?.Value), "hunter2");
-  });
-
-  it("denies a write to a caller with no key permission", async () => {
-    // Given a customer managed key.
-    const simAws = new SimAws();
-    const key = await simAws
-      .kms()
-      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
-    assertNonNullable(key.KeyMetadata?.Arn);
-
-    // And a Role allowed to write parameters but not to use the key.
-    const role = await simAws.iam().createRole(
-      new CreateRoleCommand({
-        RoleName: "ConfigReader",
-        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
-      }),
-    );
-    await simAws.iam().putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "ConfigReader",
-        PolicyName: "SecretPolicy",
-        PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: "ssm:PutParameter", Resource: "*" },
-        }),
-      }),
-    );
-
-    // When it writes a SecureString under that key.
-    const error = await assertThrowsErrorAsync(async () =>
-      simAws.ssm().putParameter(
-        new PutParameterCommand({
-          Name: "/myapp/prod/api-key",
-          Type: "SecureString",
-          Value: "secret",
-          KeyId: key.KeyMetadata?.Arn,
-        }),
-        { caller: { kind: "arn", arn: role.Role.Arn } },
-      ),
-    );
-
-    // Then it is denied: a standard tier write needs kms:Encrypt as well.
-    assertInstanceOf(error, SimIamAccessDenied);
-  });
-
-  it("writes for a caller allowed both the parameter and the key", async () => {
-    // Given a customer managed key.
-    const simAws = new SimAws();
-    const key = await simAws
-      .kms()
-      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
-    assertNonNullable(key.KeyMetadata?.Arn);
-
-    // And a Role allowed to write parameters and to encrypt with the key.
-    const role = await simAws.iam().createRole(
-      new CreateRoleCommand({
-        RoleName: "ConfigReader",
-        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
-      }),
-    );
-    await simAws.iam().putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "ConfigReader",
-        PolicyName: "SecretPolicy",
-        PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: [
-            { Effect: "Allow", Action: "ssm:PutParameter", Resource: "*" },
-            {
-              Effect: "Allow",
-              Action: "kms:Encrypt",
-              Resource: key.KeyMetadata.Arn,
-            },
-          ],
-        }),
-      }),
-    );
-
-    // When it writes a SecureString under that key.
-    const written = await simAws.ssm().putParameter(
-      new PutParameterCommand({
-        Name: "/myapp/prod/api-key",
-        Type: "SecureString",
-        Value: "secret",
-        KeyId: key.KeyMetadata.Arn,
-      }),
-      { caller: { kind: "arn", arn: role.Role.Arn } },
-    );
-
-    // Then the write succeeds.
-    assertIdentical(written.Version, 1);
-  });
-
-  it("leaves no parameter behind when the key permission is missing", async () => {
-    // Given a customer managed key.
-    const simAws = new SimAws();
-    const key = await simAws
-      .kms()
-      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
-    assertNonNullable(key.KeyMetadata?.Arn);
-
-    // And a Role allowed to write parameters but not to use the key.
-    const role = await simAws.iam().createRole(
-      new CreateRoleCommand({
-        RoleName: "ConfigReader",
-        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: {
-            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
-            Action: "sts:AssumeRole",
-          },
-        }),
-      }),
-    );
-    await simAws.iam().putRolePolicy(
-      new PutRolePolicyCommand({
-        RoleName: "ConfigReader",
-        PolicyName: "SecretPolicy",
-        PolicyDocument: simIamPolicyDocumentFactory.make({
-          Statement: { Action: "ssm:PutParameter", Resource: "*" },
-        }),
-      }),
-    );
-
-    // When a create is denied at the encryption step.
-    await assertThrowsErrorAsync(async () =>
-      simAws.ssm().putParameter(
-        new PutParameterCommand({
-          Name: "/myapp/prod/api-key",
-          Type: "SecureString",
-          Value: "secret",
-          KeyId: key.KeyMetadata?.Arn,
-        }),
-        { caller: { kind: "arn", arn: role.Role.Arn } },
-      ),
-    );
-
-    // Then no half-made parameter is left in the store.
-    assertUndefined(simAws.ssm().findParameter("/myapp/prod/api-key"));
   });
 });

--- a/src/service/ssm/parameter/sim-ssm-secure-string-write-iam.iso.test.ts
+++ b/src/service/ssm/parameter/sim-ssm-secure-string-write-iam.iso.test.ts
@@ -1,0 +1,162 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateKeyCommand } from "@aws-sdk/client-kms";
+import { PutParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../iam/policy/sim-iam-policy-document.factory.js";
+
+describe("SSM SecureString write IAM authorization", () => {
+  it("denies a write to a caller with no key permission", async () => {
+    // Given a customer managed key.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+    assertNonNullable(key.KeyMetadata?.Arn);
+
+    // And a Role allowed to write parameters but not to use the key.
+    const role = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "ConfigReader",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ConfigReader",
+        PolicyName: "SecretPolicy",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "ssm:PutParameter", Resource: "*" },
+        }),
+      }),
+    );
+
+    // When it writes a SecureString under that key.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/prod/api-key",
+          Type: "SecureString",
+          Value: "secret",
+          KeyId: key.KeyMetadata?.Arn,
+        }),
+        { caller: { kind: "arn", arn: role.Role.Arn } },
+      ),
+    );
+
+    // Then it is denied: a standard tier write needs kms:Encrypt as well.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("writes for a caller allowed both the parameter and the key", async () => {
+    // Given a customer managed key.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+    assertNonNullable(key.KeyMetadata?.Arn);
+
+    // And a Role allowed to write parameters and to encrypt with the key.
+    const role = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "ConfigReader",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ConfigReader",
+        PolicyName: "SecretPolicy",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: [
+            { Effect: "Allow", Action: "ssm:PutParameter", Resource: "*" },
+            {
+              Effect: "Allow",
+              Action: "kms:Encrypt",
+              Resource: key.KeyMetadata.Arn,
+            },
+          ],
+        }),
+      }),
+    );
+
+    // When it writes a SecureString under that key.
+    const written = await simAws.ssm().putParameter(
+      new PutParameterCommand({
+        Name: "/myapp/prod/api-key",
+        Type: "SecureString",
+        Value: "secret",
+        KeyId: key.KeyMetadata.Arn,
+      }),
+      { caller: { kind: "arn", arn: role.Role.Arn } },
+    );
+
+    // Then the write succeeds.
+    assertIdentical(written.Version, 1);
+  });
+
+  it("leaves no parameter behind when the key permission is missing", async () => {
+    // Given a customer managed key.
+    const simAws = new SimAws();
+    const key = await simAws
+      .kms()
+      .createKey(new CreateKeyCommand({ Description: "Parameter key" }));
+    assertNonNullable(key.KeyMetadata?.Arn);
+
+    // And a Role allowed to write parameters but not to use the key.
+    const role = await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "ConfigReader",
+        AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ConfigReader",
+        PolicyName: "SecretPolicy",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: "ssm:PutParameter", Resource: "*" },
+        }),
+      }),
+    );
+
+    // When a create is denied at the encryption step.
+    await assertThrowsErrorAsync(async () =>
+      simAws.ssm().putParameter(
+        new PutParameterCommand({
+          Name: "/myapp/prod/api-key",
+          Type: "SecureString",
+          Value: "secret",
+          KeyId: key.KeyMetadata?.Arn,
+        }),
+        { caller: { kind: "arn", arn: role.Role.Arn } },
+      ),
+    );
+
+    // Then no half-made parameter is left in the store.
+    assertUndefined(simAws.ssm().findParameter("/myapp/prod/api-key"));
+  });
+});


### PR DESCRIPTION
Simulated SSM asked the caller for `kms:Decrypt` before decrypting a SecureString under the `aws/ssm` managed key. That key's policy allows the cryptographic actions to a wildcard principal under `kms:ViaService` and `kms:CallerAccount` conditions. A grant of that shape delegates nothing to IAM and admits the read by itself, which is why a role holding `ssm:GetParameter` alone reads the value in an account. Parameter Store was the only caller of `withCallerPermissions` in `src/`. Dropping it leaves the customer managed key alone, where `SimIamMandatoryResourcePolicyRequirement` still refuses a read without `kms:Decrypt` and a write without `kms:Encrypt`.

The acceptance criterion for a cross-account caller is met by `sim-kms-aws-managed-key-authz.iso.test.ts`, which already exercises the exact request shape SSM now makes. A cross-account read through `GetParameter` never reaches KMS, because a parameter has no resource policy and the caller is refused on `ssm:GetParameter` first.

Two managed key tests lost their point once the permission stopped mattering. The one granting `kms:Decrypt` outright was dropped, and the one granting it under a `kms:ViaService` condition moved to the customer managed key file, where the condition still decides the outcome. That pushed the file past the 400 line limit, so its write tests moved into `sim-ssm-secure-string-write-iam.iso.test.ts` and the reads file was renamed to match.

Resolves #1156