### PR TITLE
feat: cache what a Distribution serves

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -263,7 +263,8 @@ A viewer-response function never sees a custom error page. CloudFront runs no vi
 function once the Origin has answered 400 or higher, and simulated CloudFront does the same, for a
 CloudFront Function and a Lambda@Edge function alike. The status the Origin returned is what decides
 that, whatever `ResponseCode` puts in its place. `ErrorCachingMinTTL` is accepted and ignored, along
-with a rule that sets nothing else, since sim CloudFront has no cache to apply it to.
+with a rule that sets nothing else. An Origin error is never cached here, so there is no TTL for it
+to shorten.
 
 ## Serve simulated CloudFront on localhost
 
@@ -2309,8 +2310,9 @@ three TTLs, the three sections of `ParametersInCacheKeyAndForwardedToOrigin` and
 `EnableAcceptEncoding` flags. A test can assert that its Behavior leaves the query string out of the
 cache key before sim CloudFront has a cache to key.
 
-Nothing acts on any of it. Sim CloudFront holds no edge cache, and every request reaches the Origin
-whatever the policy would have cached on real CloudFront.
+The Distribution reads the policy on every request. The cache key comes from the three sections and
+the two flags, and a `MaxTTL` of zero is what makes a Behavior on `CachingDisabled` reach the Origin
+every time. [Caching](#caching) below covers what is stored and what is keyed on.
 
 A TTL the template left out falls back to CloudFront's own default (0 seconds for `MinTTL`, one day
 for `DefaultTTL` and 365 days for `MaxTTL`), and a `MinTTL` above a day raises the `DefaultTTL` with
@@ -2348,6 +2350,174 @@ way an absent response headers policy does, and the Behavior reports no policy.
 
 `CreateDistribution` and `UpdateDistribution` still refuse the same ID with `NoSuchCachePolicy`, as
 real CloudFront refuses it.
+
+## Caching
+
+A Distribution holds a cache. A request for a key it already holds is answered from that cache,
+leaving the Origin unread. The Behavior's cache policy decides the key, and decides whether the
+Behavior has one at all.
+
+```typescript sim-cloudfront-caching
+/**
+ * Serving a request from a Distribution's cache, and missing it at another
+ * edge.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+  await simS3.putPublicAccessBlock(
+    new PutPublicAccessBlockCommand({
+      Bucket: "site-bucket",
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "site-bucket",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::site-bucket/*",
+        },
+      }),
+    }),
+  );
+
+  const publish = async (body: string): Promise<void> => {
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "site-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: body,
+      }),
+    );
+  };
+
+  await publish("<h1>First</h1>");
+
+  const distributionCreation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "cached-site",
+        Comment: "Cached site",
+        Enabled: true,
+        DefaultRootObject: "index.html",
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "site-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          // CachingOptimized, one of CloudFront's managed policies.
+          CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        },
+      },
+    }),
+  );
+
+  const distroHostname = distributionCreation.Distribution!.DomainName!;
+  const home = srv.localUrl(`http://${distroHostname}/`);
+
+  const first = await fetch(home);
+  console.log(await first.text()); // <h1>First</h1>
+
+  // The Bucket holds a new page, which the Distribution has not been told
+  // about.
+  await publish("<h1>Second</h1>");
+
+  const second = await fetch(home);
+  console.log(await second.text()); // <h1>First</h1>
+
+  // Another point of presence has nothing cached under that key.
+  const coldEdge = await fetch(home, {
+    headers: { "x-sim-aws-cloudfront-edge": "second-edge" },
+  });
+  console.log(await coldEdge.text()); // <h1>Second</h1>
+
+  // With caching off, every request reaches the Origin.
+  simAws.cloudFront().configureCaching({ enabled: false });
+
+  const uncached = await fetch(home);
+  console.log(await uncached.text()); // <h1>Second</h1>
+} finally {
+  await srv.close();
+}
+```
+
+### What the key is made of
+
+The key is the request path, plus whatever the Behavior's cache policy names. A query string, a
+header or a cookie the policy lists joins the key. Two requests differing only in a campaign
+parameter the policy leaves out share one entry. Where the policy enables gzip or brotli, the
+normalized `Accept-Encoding` joins the key, and one object is cached once compressed and once
+plain.
+
+The request method is part of the key as well, since a HEAD response carries no body and a GET
+response does. `CachedMethods` on the Behavior decides which methods are cached at all. It is `GET`
+and `HEAD` unless the Behavior widens it, and a POST reaches the Origin every time.
+
+### The edge a request arrives at
+
+CloudFront caches at each of its points of presence, several hundred of them, and one viewer's
+request fills the cache at one of them. The key carries an edge ID for that. Every request arrives
+at the same edge unless it sends an `x-sim-aws-cloudfront-edge` header naming another. A test that
+sends a different one is proving its app survives arriving somewhere cold.
+
+The header follows the `x-sim-aws-*` convention of the caller and request source headers, and sim
+CloudFront takes it off the request once it has read it. A web ACL rule, a CloudFront Function, a
+Lambda@Edge function and the Origin all see the request the viewer sent without it.
+
+### What a Distribution stores
+
+A Behavior stores what it serves where its cache policy is one this simulation holds and that
+policy's `MaxTTL` is above zero. That leaves out a Behavior naming a `CachePolicyId` from a real
+account, a Behavior naming none at all, and a Behavior on `CachingDisabled`. The alternative in each
+case would be a guessed TTL.
+
+An Origin error stays out of the cache. Real CloudFront holds one for `ErrorCachingMinTTL`, which
+wants an expiry this simulation has yet to keep.
+
+### Applying a response headers policy
+
+A response headers policy is applied to a response on its way out of the cache, as CloudFront
+applies one. The stored entry carries the Origin's own headers. A Behavior given a different policy
+therefore serves what it already holds under the new one, with no invalidation.
+
+### Turning it off
+
+`simAws.cloudFront().configureCaching({ enabled: false })` turns caching off for every Distribution
+in one `SimAws`, across every Account and Region. Caching is on by default, as CloudFront's is. A
+suite that repeats a request and wants each one to reach the Origin can turn it off in setup.
 
 ## Origin request policies
 
@@ -3100,6 +3270,8 @@ Sim CloudFront currently supports:
 - CloudFront Functions reading an associated key value store through `cf.kvs()`
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
 - `AWS::CloudFront::CachePolicy`, and a Behavior's `CachePolicyId` read back through `GetDistribution`
+- A cache on each Distribution, keyed on the Behavior's cache policy and on the edge the request
+  arrived at
 - `AWS::CloudFront::OriginRequestPolicy`, and a Behavior's `OriginRequestPolicyId` read back the
   same way
 - `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
@@ -3116,11 +3288,16 @@ whether the simulator needs them to model the requested behaviour safely.
 
 Where sim CloudFront knowingly behaves differently from AWS:
 
-- **The origin events run on every request that reaches the Origin.** Real CloudFront runs
-  `origin-request` and `origin-response` on a cache miss, and serves a cache hit without reaching
-  either. Simulated CloudFront holds no cache, and every request that gets as far as the Origin is a
-  miss here. A request a web ACL blocked or a viewer-request function answered reaches neither
-  event, and an `origin-request` function that returns a response leaves the Origin unread with no
+- **A cached entry never expires.** A cache policy's three TTLs decide whether the Behavior caches
+  at all, and a `MaxTTL` of zero turns it off. Any other value stores an entry that is served until
+  the `SimAws` holding it is thrown away. There is no invalidation, and no `X-Cache` or `Age` header
+  on the response.
+- **A Behavior with no cache policy caches nothing.** Real CloudFront falls back to the legacy
+  `ForwardedValues` and the TTLs beside it, and sim CloudFront skips both. Give the Behavior a
+  `CachePolicyId`, as CDK and the console both do.
+- **The origin events run on a cache miss, and every request that reaches the Origin is one.** A
+  request a web ACL blocked or a viewer-request function answered reaches neither event, and an
+  `origin-request` function that returns a response leaves the Origin unread with no
   `origin-response` event after it.
 - **An Origin keeps its kind and its Bucket through an origin-request function.** Real CloudFront
   lets a handler hand back `origin.s3` where it was given `origin.custom`, or point an S3 Origin at

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2493,8 +2493,9 @@ request fills the cache at one of them. The key carries an edge ID for that. Eve
 at the same edge unless it sends an `x-sim-aws-cloudfront-edge` header naming another. A test that
 sends a different one is proving its app survives arriving somewhere cold.
 
-The header follows the `x-sim-aws-*` convention of the caller and request source headers, and sim
-CloudFront takes it off the request once it has read it. A web ACL rule, a CloudFront Function, a
+The header follows the `x-sim-aws-*` convention of the caller and request source headers, and
+`@kensio/yulin/cloudfront` exports the name as `simCfEdgeHeaderName`. Sim CloudFront takes it off
+the request once it has read it. A web ACL rule, a CloudFront Function, a
 Lambda@Edge function and the Origin all see the request the viewer sent without it.
 
 ### What a Distribution stores

--- a/docs/services/cloudfront/sim-cloudfront-caching.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-caching.example.ts
@@ -1,0 +1,114 @@
+/**
+ * Serving a request from a Distribution's cache, and missing it at another
+ * edge.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "site-bucket" }));
+  await simS3.putPublicAccessBlock(
+    new PutPublicAccessBlockCommand({
+      Bucket: "site-bucket",
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "site-bucket",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::site-bucket/*",
+        },
+      }),
+    }),
+  );
+
+  const publish = async (body: string): Promise<void> => {
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "site-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: body,
+      }),
+    );
+  };
+
+  await publish("<h1>First</h1>");
+
+  const distributionCreation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "cached-site",
+        Comment: "Cached site",
+        Enabled: true,
+        DefaultRootObject: "index.html",
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "site-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          // CachingOptimized, one of CloudFront's managed policies.
+          CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        },
+      },
+    }),
+  );
+
+  const distroHostname = distributionCreation.Distribution!.DomainName!;
+  const home = srv.localUrl(`http://${distroHostname}/`);
+
+  const first = await fetch(home);
+  console.log(await first.text()); // <h1>First</h1>
+
+  // The Bucket holds a new page, which the Distribution has not been told
+  // about.
+  await publish("<h1>Second</h1>");
+
+  const second = await fetch(home);
+  console.log(await second.text()); // <h1>First</h1>
+
+  // Another point of presence has nothing cached under that key.
+  const coldEdge = await fetch(home, {
+    headers: { "x-sim-aws-cloudfront-edge": "second-edge" },
+  });
+  console.log(await coldEdge.text()); // <h1>Second</h1>
+
+  // With caching off, every request reaches the Origin.
+  simAws.cloudFront().configureCaching({ enabled: false });
+
+  const uncached = await fetch(home);
+  console.log(await uncached.text()); // <h1>Second</h1>
+} finally {
+  await srv.close();
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -222,15 +222,17 @@ right sim Distribution, Origin and Behavior.
 ## Caching
 
 `cache/` holds the cache itself, and `SimCfContentStage` under `controller/content/` is what the
-pipeline asks. The stage reads the key first. A hit is answered there, and the Origin stage with its
-two origin events runs on a miss alone, the way CloudFront runs them.
+pipeline asks. The stage reads the key first. A hit is answered there, and the Origin stage runs on
+a miss alone, the way CloudFront runs it. Which of the two origin events run on that miss is the
+Origin stage's own business, since an `origin-request` function answering with a response of its own
+leaves the Origin unread and nothing for `origin-response` to run on.
 
-`simCfCacheableKey` decides whether a request has a key at all. Three things leave it without one.
+`simCfCacheableKey` decides whether a request has a key at all. Four things leave it without one.
 Caching may be off for the `SimAws`. The Behavior's `cachePolicyId` may resolve to no policy this
-simulation holds, which covers a Behavior naming none. And the method may be outside the Behavior's
-`cachedMethods`. A policy whose `MaxTTL` is zero counts as caching nothing. That is the `MaxTTL`
-`CachingDisabled` carries, and it keeps that Behavior reading the Origin every time. Nothing
-expires yet, and the other two TTLs decide nothing.
+simulation holds, which covers a Behavior naming none. The policy it resolves to may have a `MaxTTL`
+of zero, which counts as caching nothing. That is the `MaxTTL` `CachingDisabled` carries, and it
+keeps that Behavior reading the Origin every time. And the method may be outside the Behavior's
+`cachedMethods`. Nothing expires yet, and the other two TTLs decide nothing.
 
 `simCfCacheEntryKey` builds the key from the request path, the query strings, headers and cookies
 the policy names, the normalized `Accept-Encoding` where the policy enables gzip or brotli, the

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -202,6 +202,8 @@ HTTP request behaviour is split across a few directories:
 - `router/` resolves an incoming `Request` to a simulated Distribution by CloudFront hostname or
   alternate domain name.
 - `resolver/` chooses the matching Cache Behavior for a request path.
+- `controller/content/` answers a request from the Distribution's cache or from the Origin, and is
+  where the custom error responder and the Origin stage now sit.
 - `origin/` adapts CloudFront Origin requests/responses. `origin/s3/` reads a sim S3 Bucket through
   that Bucket's own GetObject command, while `origin/custom/` turns the Origin request back into an
   HTTP request and sends it into the wider simulated environment.
@@ -216,6 +218,41 @@ HTTP request behaviour is split across a few directories:
 
 When a sim AWS is served on localhost, CloudFront requests are routed through this layer to find the
 right sim Distribution, Origin and Behavior.
+
+## Caching
+
+`cache/` holds the cache itself, and `SimCfContentStage` under `controller/content/` is what the
+pipeline asks. The stage reads the key first. A hit is answered there, and the Origin stage with its
+two origin events runs on a miss alone, the way CloudFront runs them.
+
+`simCfCacheableKey` decides whether a request has a key at all. Three things leave it without one.
+Caching may be off for the `SimAws`. The Behavior's `cachePolicyId` may resolve to no policy this
+simulation holds, which covers a Behavior naming none. And the method may be outside the Behavior's
+`cachedMethods`. A policy whose `MaxTTL` is zero counts as caching nothing. That is the `MaxTTL`
+`CachingDisabled` carries, and it keeps that Behavior reading the Origin every time. Nothing
+expires yet, and the other two TTLs decide nothing.
+
+`simCfCacheEntryKey` builds the key from the request path, the query strings, headers and cookies
+the policy names, the normalized `Accept-Encoding` where the policy enables gzip or brotli, the
+request method and the edge. The parts go through `jsonStringify`, so that a value carrying a
+separator cannot collide with another key. The method is in the key because a HEAD response carries
+no body.
+
+`SimCfDistributionCache` on the Distribution holds the bytes of a response. A body can be read once
+and two viewers each need one, so storing hands back a new Response built from what was stored, and
+the pipeline carries on with that. A status HTTP gives no body is rebuilt without one.
+
+`simCfRequestEdge` reads `x-sim-aws-cloudfront-edge` and takes it off the request, at the top of the
+pipeline before the web ACL. The name follows the `x-sim-aws-*` convention. The header is
+deliberately outside `simAwsControlHeaderNames`, whose members the HTTP boundary strips before a
+controller sees them. This one has to survive as far as CloudFront.
+
+The response headers policy is applied after the content stage. A policy change therefore takes
+effect on entries already stored. An Origin error is left unstored. Caching one with no expiry
+would have the Distribution answering with it for the length of the test.
+
+Caching is on. `SimCloudFrontRegistry` holds the flag, one registry per `SimAws` across every
+Account and Region, and `SimCloudFront.configureCaching` is how a test turns it off.
 
 ## CloudFront Functions
 
@@ -283,8 +320,7 @@ naming the Resource. `sim-cfn-cf-cache-policy-config.ts` reads the TTLs, giving 
 left out the default CloudFront applies, including the two cases where a long `MinTTL` raises the
 `DefaultTTL` and a long `DefaultTTL` raises the `MaxTTL`.
 
-Sim CloudFront has no cache. None of this decides anything yet, and recording the ID is what lets a
-test assert which policy a Behavior was given.
+`cache/` reads the policy on every request. See the Caching section below.
 
 `SimCfBehaviorPolicies` asks `SimCfBehaviorResponseHeadersPolicy`, `SimCfBehaviorCachePolicy` and
 `SimCfBehaviorOriginRequestPolicy` about one Behavior. A `CachePolicyId` naming nothing is

--- a/src/service/cloudfront/behaviour/sim-cloud-front-behavior.ts
+++ b/src/service/cloudfront/behaviour/sim-cloud-front-behavior.ts
@@ -6,6 +6,10 @@ export interface SimCloudFrontBehavior {
   pathPattern?: string; // undefined/default = *
   targetOriginName: string;
   allowedMethods: Set<string>;
+  /**
+   * The methods this Behavior caches a response for. A request made with any
+   * other method reaches the Origin every time.
+   */
   cachedMethods: Set<string>;
   viewerProtocolPolicy?: "allow-all" | "redirect-to-https" | "https-only";
   originPath?: string;
@@ -15,7 +19,8 @@ export interface SimCloudFrontBehavior {
   responseHeadersPolicyId?: string | undefined;
   /**
    * The cache policy this Behavior was given, whether a template created it or
-   * AWS manages it. The simulated cache does not read it yet.
+   * AWS manages it. It decides what the Distribution's cache keys on, and a
+   * Behavior naming no policy this simulation holds caches nothing.
    */
   cachePolicyId?: string | undefined;
   /**

--- a/src/service/cloudfront/cache-policy/sim-cf-cache-policy.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-cache-policy.ts
@@ -26,8 +26,9 @@ interface SimCloudFrontCachePolicyProperties {
  *
  * A cache policy decides what a cache Behavior keys its cache on and how long
  * an object stays there. This simulation holds the policy under its ID, along
- * with its three TTLs and its cache key, and hands it back. Nothing caches
- * anything on them yet.
+ * with its three TTLs and its cache key, and keys the Distribution's cache on
+ * it. Nothing expires yet, so a `MaxTTL` of zero is read as a Behavior that
+ * caches nothing and the other two TTLs decide nothing.
  *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html
  */

--- a/src/service/cloudfront/cache/sim-cf-accept-encoding.ts
+++ b/src/service/cloudfront/cache/sim-cf-accept-encoding.ts
@@ -1,0 +1,37 @@
+import type { SimCloudFrontCacheKey } from "../cache-policy/sim-cf-cache-key.js";
+
+/**
+ * The compression the policy keys on, as CloudFront's normalized
+ * `Accept-Encoding`.
+ *
+ * This is what caches one object twice, once compressed and once not, without
+ * the header being in the policy's whitelist. An encoding the viewer accepts
+ * but the policy does not enable is left out, since CloudFront would not have
+ * asked the Origin for it.
+ */
+export function simCfNormalizedAcceptEncoding(
+  headers: Headers,
+  cacheKey: SimCloudFrontCacheKey,
+): string[] {
+  const enabled = [
+    ...(cacheKey.enableAcceptEncodingBrotli ? ["br"] : []),
+    ...(cacheKey.enableAcceptEncodingGzip ? ["gzip"] : []),
+  ];
+  const accepted = acceptedEncodings(headers.get("accept-encoding"));
+
+  return enabled.filter((encoding) => accepted.has(encoding));
+}
+
+/**
+ * The encodings a viewer said it accepts, by name alone. A quality value is
+ * ignored, so a viewer that sent `gzip;q=0` is taken to accept gzip.
+ */
+function acceptedEncodings(headerValue: string | null): Set<string> {
+  return new Set(
+    (headerValue ?? "").split(",").map((encoding) => {
+      const [name = ""] = encoding.split(";", 1);
+
+      return name.trim().toLowerCase();
+    }),
+  );
+}

--- a/src/service/cloudfront/cache/sim-cf-cache-entry-key.iso.test.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-entry-key.iso.test.ts
@@ -1,0 +1,203 @@
+import { assertIdentical, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCloudFrontCacheKey } from "../cache-policy/sim-cf-cache-key.js";
+import { simCfCacheEntryKey } from "./sim-cf-cache-entry-key.js";
+
+const edgeId = "default";
+const site = "https://d111111abcdef8.cloudfront.net";
+
+/**
+ * The key one request is stored under, for a policy keying on nothing unless
+ * the test says otherwise.
+ */
+function keyFor(
+  path: string,
+  cacheKey: SimCloudFrontCacheKey = new SimCloudFrontCacheKey(),
+  requestInit: RequestInit = {},
+  edge = edgeId,
+): string {
+  return simCfCacheEntryKey({
+    request: new Request(`${site}${path}`, requestInit),
+    cacheKey,
+    edgeId: edge,
+  });
+}
+
+describe("A sim CloudFront cache key", () => {
+  it("keys two paths apart", () => {
+    // Given a policy keying on nothing but the path.
+    // When two requests for different paths are keyed.
+    // Then they are held apart.
+    assertTrue(keyFor("/one.html") !== keyFor("/two.html"));
+  });
+
+  it("leaves out a query string the policy does not name", () => {
+    // Given a policy naming one query string.
+    const cacheKey = new SimCloudFrontCacheKey({
+      queryStringBehavior: "whitelist",
+      queryStrings: ["page"],
+    });
+
+    // When two requests differ only in a query string it does not name.
+    // Then they share one key.
+    assertIdentical(
+      keyFor("/list?page=2&utm=email", cacheKey),
+      keyFor("/list?page=2&utm=social", cacheKey),
+    );
+  });
+
+  it("keys on a query string the policy names", () => {
+    // Given the same policy.
+    const cacheKey = new SimCloudFrontCacheKey({
+      queryStringBehavior: "whitelist",
+      queryStrings: ["page"],
+    });
+
+    // When two requests differ in the query string it names.
+    // Then they are held apart.
+    assertTrue(
+      keyFor("/list?page=1", cacheKey) !== keyFor("/list?page=2", cacheKey),
+    );
+  });
+
+  it("keys on the query strings a policy naming all of them sends", () => {
+    // Given a policy keying on every query string.
+    const cacheKey = new SimCloudFrontCacheKey({ queryStringBehavior: "all" });
+
+    // When two requests differ in one the other policy would have ignored.
+    // Then they are held apart.
+    assertTrue(
+      keyFor("/list?utm=email", cacheKey) !==
+        keyFor("/list?utm=social", cacheKey),
+    );
+  });
+
+  it("leaves out the query string an allExcept policy names", () => {
+    // Given a policy keying on every query string but one.
+    const cacheKey = new SimCloudFrontCacheKey({
+      queryStringBehavior: "allExcept",
+      queryStrings: ["utm"],
+    });
+
+    // When two requests differ in the one it excludes.
+    // Then they share one key, and two differing in another do not.
+    assertIdentical(
+      keyFor("/list?utm=email", cacheKey),
+      keyFor("/list?utm=social", cacheKey),
+    );
+    assertTrue(
+      keyFor("/list?page=1", cacheKey) !== keyFor("/list?page=2", cacheKey),
+    );
+  });
+
+  it("keys the same query strings sent in either order together", () => {
+    // Given a policy keying on every query string.
+    const cacheKey = new SimCloudFrontCacheKey({ queryStringBehavior: "all" });
+
+    // When one viewer sends them the other way round.
+    // Then both key the same, as CloudFront sorts them before keying.
+    assertIdentical(
+      keyFor("/list?page=1&sort=asc", cacheKey),
+      keyFor("/list?sort=asc&page=1", cacheKey),
+    );
+  });
+
+  it("keys on a header the policy names", () => {
+    // Given a policy naming one header.
+    const cacheKey = new SimCloudFrontCacheKey({
+      headerBehavior: "whitelist",
+      headers: ["Accept-Language"],
+    });
+
+    // When two requests send different values for it, and a third sends a
+    // header the policy does not name.
+    const english = keyFor("/", cacheKey, {
+      headers: { "accept-language": "en" },
+    });
+    const french = keyFor("/", cacheKey, {
+      headers: { "accept-language": "fr" },
+    });
+    const traced = keyFor("/", cacheKey, {
+      headers: { "accept-language": "en", "x-request-id": "abc" },
+    });
+
+    // Then the named header holds two apart and the other does not.
+    assertTrue(english !== french);
+    assertIdentical(english, traced);
+  });
+
+  it("keys on a cookie the policy names", () => {
+    // Given a policy naming one cookie.
+    const cacheKey = new SimCloudFrontCacheKey({
+      cookieBehavior: "whitelist",
+      cookies: ["theme"],
+    });
+
+    // When two requests send different values for it, alongside one it does
+    // not name.
+    const dark = keyFor("/", cacheKey, {
+      headers: { cookie: "theme=dark; session=1" },
+    });
+    const light = keyFor("/", cacheKey, {
+      headers: { cookie: "theme=light; session=1" },
+    });
+    const otherSession = keyFor("/", cacheKey, {
+      headers: { cookie: "theme=dark; session=2" },
+    });
+
+    // Then the named cookie holds two apart and the other does not.
+    assertTrue(dark !== light);
+    assertIdentical(dark, otherSession);
+  });
+
+  it("keys a compressed response apart where the policy enables gzip", () => {
+    // Given a policy enabling gzip in the cache key.
+    const cacheKey = new SimCloudFrontCacheKey({
+      enableAcceptEncodingGzip: true,
+    });
+
+    // When one viewer accepts gzip and another accepts nothing.
+    // Then the two are held apart, so one object is cached compressed and
+    // once not.
+    assertTrue(
+      keyFor("/", cacheKey, { headers: { "accept-encoding": "gzip" } }) !==
+        keyFor("/", cacheKey),
+    );
+  });
+
+  it("ignores an encoding the policy does not enable", () => {
+    // Given a policy enabling gzip alone.
+    const cacheKey = new SimCloudFrontCacheKey({
+      enableAcceptEncodingGzip: true,
+    });
+
+    // When two viewers accept gzip and differ in brotli alone.
+    // Then they share one key, since CloudFront would not have asked the
+    // Origin for brotli.
+    assertIdentical(
+      keyFor("/", cacheKey, { headers: { "accept-encoding": "gzip, br" } }),
+      keyFor("/", cacheKey, { headers: { "accept-encoding": "gzip" } }),
+    );
+  });
+
+  it("keys a GET and a HEAD apart", () => {
+    // Given a policy keying on nothing but the path.
+    // When the same path is asked for both ways.
+    // Then the two are held apart, since a HEAD response carries no body.
+    assertTrue(
+      keyFor("/one.html", new SimCloudFrontCacheKey(), { method: "HEAD" }) !==
+        keyFor("/one.html"),
+    );
+  });
+
+  it("keys two edges apart", () => {
+    // Given the same request arriving at two points of presence.
+    // When each one is keyed.
+    // Then neither is answered from the other's cache.
+    assertTrue(
+      keyFor("/one.html", new SimCloudFrontCacheKey(), {}, "edge-one") !==
+        keyFor("/one.html", new SimCloudFrontCacheKey(), {}, "edge-two"),
+    );
+  });
+});

--- a/src/service/cloudfront/cache/sim-cf-cache-entry-key.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-entry-key.ts
@@ -1,0 +1,157 @@
+import { jsonStringify } from "../../../util/type-guard/json.js";
+import { simCfNormalizedAcceptEncoding } from "./sim-cf-accept-encoding.js";
+import type {
+  SimCfCacheKeyCookieBehavior,
+  SimCloudFrontCacheKey,
+} from "../cache-policy/sim-cf-cache-key.js";
+
+interface SimCfCacheEntryKeyProperties {
+  readonly request: Request;
+
+  /**
+   * What the Behavior's cache policy keys on.
+   */
+  readonly cacheKey: SimCloudFrontCacheKey;
+
+  /**
+   * The edge the request arrived at, which caches apart from every other edge.
+   */
+  readonly edgeId: string;
+}
+
+/**
+ * The key one request is cached under.
+ *
+ * CloudFront keys on the request path plus whatever the cache policy names:
+ * the query strings, the headers and the cookies it lists, and the normalized
+ * `Accept-Encoding` where it enables gzip or brotli. Two requests differing
+ * only in something the policy leaves out share one entry, which is the whole
+ * point of a cache key.
+ *
+ * The method is part of the key here because a HEAD response carries no body
+ * and a GET response does, so serving one from the other would answer with the
+ * wrong thing.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/understanding-the-cache-key.html
+ */
+export function simCfCacheEntryKey(
+  properties: SimCfCacheEntryKeyProperties,
+): string {
+  const { request, cacheKey, edgeId } = properties;
+  const url = new URL(request.url);
+
+  return jsonStringify([
+    edgeId,
+    request.method.toUpperCase(),
+    url.pathname,
+    keyedQueryStrings(url.searchParams, cacheKey),
+    keyedHeaders(request.headers, cacheKey),
+    keyedCookies(request.headers, cacheKey),
+    simCfNormalizedAcceptEncoding(request.headers, cacheKey),
+  ]);
+}
+
+/**
+ * The query strings the policy keys on, in an order two requests sending them
+ * differently still agree on.
+ */
+function keyedQueryStrings(
+  searchParameters: URLSearchParams,
+  cacheKey: SimCloudFrontCacheKey,
+): string[] {
+  return [...searchParameters]
+    .filter(([name]) =>
+      isKeyedOn(cacheKey.queryStringBehavior, cacheKey.queryStrings, name),
+    )
+    .map(([name, value]) => `${name}=${value}`)
+    .toSorted(byCodePoint);
+}
+
+/**
+ * The headers the policy keys on, by lower-case name since a header name is
+ * case insensitive.
+ *
+ * A header the policy names and the viewer did not send keys as an empty
+ * value, so a request sending it and one leaving it out are kept apart.
+ */
+function keyedHeaders(
+  headers: Headers,
+  cacheKey: SimCloudFrontCacheKey,
+): string[] {
+  if (cacheKey.headerBehavior === "none") {
+    return [];
+  }
+
+  return cacheKey.headers
+    .map((name) => `${name.toLowerCase()}=${headers.get(name) ?? ""}`)
+    .toSorted(byCodePoint);
+}
+
+/**
+ * The cookies the policy keys on, read out of the one `Cookie` header a
+ * request sends them all in.
+ */
+function keyedCookies(
+  headers: Headers,
+  cacheKey: SimCloudFrontCacheKey,
+): string[] {
+  return (headers.get("cookie") ?? "")
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .filter((cookie) => cookie.length > 0)
+    .filter((cookie) =>
+      isKeyedOn(cacheKey.cookieBehavior, cacheKey.cookies, cookieName(cookie)),
+    )
+    .toSorted(byCodePoint);
+}
+
+/**
+ * Order two parts of a key the same way whatever the host's locale is, which a
+ * key two requests have to agree on cannot be left to `localeCompare`.
+ */
+function byCodePoint(one: string, other: string): number {
+  if (one === other) {
+    return 0;
+  }
+
+  return one < other ? -1 : 1;
+}
+
+/**
+ * The name half of one `name=value` cookie.
+ */
+function cookieName(cookie: string): string {
+  const [name = ""] = cookie.split("=", 1);
+
+  return name;
+}
+
+/**
+ * Whether one name is in the cache key, under the behaviour its section names.
+ *
+ * A `whitelist` keys on the names listed and an `allExcept` keys on everything
+ * but them, which is the same list read two ways.
+ *
+ * The cookie behaviours and the query string behaviours are the same four
+ * values, so one function reads both.
+ */
+function isKeyedOn(
+  behavior: SimCfCacheKeyCookieBehavior,
+  names: readonly string[],
+  name: string,
+): boolean {
+  switch (behavior) {
+    case "all": {
+      return true;
+    }
+    case "whitelist": {
+      return names.includes(name);
+    }
+    case "allExcept": {
+      return !names.includes(name);
+    }
+    case "none": {
+      return false;
+    }
+  }
+}

--- a/src/service/cloudfront/cache/sim-cf-cacheable-request.ts
+++ b/src/service/cloudfront/cache/sim-cf-cacheable-request.ts
@@ -1,0 +1,47 @@
+import type { SimCloudFrontBehavior } from "../behaviour/sim-cloud-front-behavior.js";
+import type { SimCloudFront } from "../sim-cloudfront.js";
+import { simCfCacheEntryKey } from "./sim-cf-cache-entry-key.js";
+
+interface SimCfCacheableRequestProperties {
+  readonly cloudFront: SimCloudFront;
+  readonly behaviour: SimCloudFrontBehavior;
+  readonly request: Request;
+  readonly edgeId: string;
+}
+
+/**
+ * The key this request is cached under, or none where the Behavior caches
+ * nothing.
+ *
+ * Three things stop a Behavior caching. Its cache policy may be one this
+ * simulation does not hold, including the Behavior that names no policy at
+ * all, and there is nothing to key on and no TTL that is not a guess. Its
+ * policy may cache nothing, which is what a `MaxTTL` of zero says and is how
+ * `CachingDisabled` reaches the Origin every time. Or the request's method may
+ * be outside the Behavior's `CachedMethods`, which is CloudFront's own rule
+ * that a POST is never served from a cache.
+ */
+export function simCfCacheableKey(
+  properties: SimCfCacheableRequestProperties,
+): string | undefined {
+  const { cloudFront, behaviour, request, edgeId } = properties;
+
+  if (!cloudFront.cachingEnabled) {
+    return undefined;
+  }
+
+  const policy =
+    behaviour.cachePolicyId === undefined
+      ? undefined
+      : cloudFront.getCachePolicyById(behaviour.cachePolicyId);
+
+  if (policy === undefined || policy.maxTtlSec <= 0) {
+    return undefined;
+  }
+
+  if (!behaviour.cachedMethods.has(request.method.toUpperCase())) {
+    return undefined;
+  }
+
+  return simCfCacheEntryKey({ request, cacheKey: policy.cacheKey, edgeId });
+}

--- a/src/service/cloudfront/cache/sim-cf-distribution-cache.ts
+++ b/src/service/cloudfront/cache/sim-cf-distribution-cache.ts
@@ -1,0 +1,75 @@
+/**
+ * A response as a Distribution holds it, rather than as a stream something has
+ * already read.
+ *
+ * A Response body can be read once, so what is stored is the bytes, and every
+ * read builds a Response of its own from them. Two viewers served the same
+ * entry therefore get a body each.
+ */
+interface SimCfCachedResponse {
+  readonly status: number;
+  readonly statusText: string;
+  readonly headers: readonly (readonly [string, string])[];
+  readonly body: Uint8Array;
+}
+
+/**
+ * The statuses HTTP gives no body, which a Response refuses to be built with
+ * one for.
+ */
+const bodylessStatuses = new Set([101, 103, 204, 205, 304]);
+
+/**
+ * What one simulated Distribution has cached.
+ *
+ * Real CloudFront caches at each of its points of presence rather than once
+ * per Distribution, which the edge in the key stands for. One cache holds an
+ * entry per edge, and a request arriving at another edge misses.
+ *
+ * Nothing expires. There is no TTL here yet, so an entry stays until something
+ * removes it, and the cache policy's TTLs decide only whether a Behavior
+ * caches at all.
+ */
+export class SimCfDistributionCache {
+  private readonly entries = new Map<string, SimCfCachedResponse>();
+
+  /**
+   * The response cached under a key, or none where the cache does not hold it.
+   */
+  read(key: string): Response | undefined {
+    const entry = this.entries.get(key);
+
+    return entry === undefined ? undefined : cachedResponse(entry);
+  }
+
+  /**
+   * Cache a response under a key, and hand back one to carry on with.
+   *
+   * Storing reads the response's body, which can only happen once, so the
+   * response the caller continues with is built from the bytes that were
+   * stored rather than being the one passed in.
+   */
+  async store(key: string, response: Response): Promise<Response> {
+    const entry: SimCfCachedResponse = {
+      status: response.status,
+      statusText: response.statusText,
+      headers: [...response.headers],
+      body: new Uint8Array(await response.arrayBuffer()),
+    };
+
+    this.entries.set(key, entry);
+
+    return cachedResponse(entry);
+  }
+}
+
+/**
+ * Build a response from a cached one, which every read needs its own of.
+ */
+function cachedResponse(entry: SimCfCachedResponse): Response {
+  return new Response(bodylessStatuses.has(entry.status) ? null : entry.body, {
+    status: entry.status,
+    statusText: entry.statusText,
+    headers: new Headers(entry.headers.map(([name, value]) => [name, value])),
+  });
+}

--- a/src/service/cloudfront/cache/sim-cf-edge.ts
+++ b/src/service/cloudfront/cache/sim-cf-edge.ts
@@ -17,7 +17,8 @@ export const simCfEdgeHeaderName = "x-sim-aws-cloudfront-edge";
  * The edge a request arrives at when it names none.
  *
  * Every request in a test lands here unless the test says otherwise, and a
- * second request for a key the first one stored is a hit.
+ * second request for a key the first one stored is a hit. A header carrying no
+ * value names no edge, and lands here too.
  */
 export const simCfDefaultEdgeId = "default";
 
@@ -40,7 +41,7 @@ export interface SimCfRequestEdge {
 export function simCfRequestEdge(request: Request): SimCfRequestEdge {
   const named = request.headers.get(simCfEdgeHeaderName)?.trim();
 
-  if (named === undefined) {
+  if (named === undefined || named.length === 0) {
     return { edgeId: simCfDefaultEdgeId, request };
   }
 

--- a/src/service/cloudfront/cache/sim-cf-edge.ts
+++ b/src/service/cloudfront/cache/sim-cf-edge.ts
@@ -1,0 +1,51 @@
+/**
+ * The header naming the CloudFront edge a request arrives at.
+ *
+ * CloudFront caches at each of its several hundred points of presence, so a
+ * viewer is never guaranteed the entry another viewer's request stored. A
+ * request naming an edge of its own is answered from that edge's cache, which
+ * is how a test proves its app survives arriving somewhere cold.
+ *
+ * The name follows the `x-sim-aws-*` convention of `simAwsControlHeaderNames`,
+ * and like those headers it states something to the simulator rather than to
+ * the application. Sim CloudFront reads it, drops it from the request, and
+ * nothing downstream of the edge sees it.
+ */
+export const simCfEdgeHeaderName = "x-sim-aws-cloudfront-edge";
+
+/**
+ * The edge a request arrives at when it names none.
+ *
+ * Every request in a test lands here unless the test says otherwise, and a
+ * second request for a key the first one stored is a hit.
+ */
+export const simCfDefaultEdgeId = "default";
+
+/**
+ * A request and the edge it arrived at.
+ */
+export interface SimCfRequestEdge {
+  readonly edgeId: string;
+
+  /**
+   * The request with the edge header removed, which is the one the rest of the
+   * pipeline works on.
+   */
+  readonly request: Request;
+}
+
+/**
+ * Read the edge a request arrived at, and take the header back off it.
+ */
+export function simCfRequestEdge(request: Request): SimCfRequestEdge {
+  const named = request.headers.get(simCfEdgeHeaderName)?.trim();
+
+  if (named === undefined) {
+    return { edgeId: simCfDefaultEdgeId, request };
+  }
+
+  const headers = new Headers(request.headers);
+  headers.delete(simCfEdgeHeaderName);
+
+  return { edgeId: named, request: new Request(request, { headers }) };
+}

--- a/src/service/cloudfront/controller/content/sim-cf-cache-edge.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-cache-edge.iso.test.ts
@@ -1,0 +1,151 @@
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertStringNotIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simCfEdgeHeaderName } from "../../cache/sim-cf-edge.js";
+import { SimCloudFrontResponseHeader } from "../../response-headers-policy/sim-cf-response-header.js";
+import {
+  SimCloudFrontResponseHeadersPolicy,
+  type SimCloudFrontResponseHeadersPolicyId,
+} from "../../response-headers-policy/sim-cf-response-headers-policy.js";
+import {
+  countingOrigin,
+  distributionServing,
+  type OriginReads,
+  readNumber,
+} from "../../../../../test/cloudfront/cache-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+describe("A sim CloudFront edge cache", () => {
+  it("misses at an edge the answer was not stored at, and tells the Origin nothing about it", async () => {
+    // Given a Distribution that has answered a request at its default edge.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // When the same request arrives at another point of presence.
+    const elsewhere = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/greeting",
+      { headers: { [simCfEdgeHeaderName]: "edge-two" } },
+    );
+
+    // Then that edge had nothing cached and read the Origin.
+    assertIdentical(await readNumber(elsewhere), 2);
+
+    // And the Origin was never told which edge it was answering, since the
+    // header is an instruction to the simulator rather than part of the
+    // request being simulated.
+    const repeated = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/greeting",
+      { headers: { [simCfEdgeHeaderName]: "edge-three" } },
+    );
+
+    assertStringNotIncludes(await repeated.text(), simCfEdgeHeaderName);
+  });
+
+  it("sends the Origin the body of a request that named an edge", async () => {
+    // Given a Distribution in front of an Origin that says what it was sent.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+
+    // When a POST carrying a body names an edge.
+    const posted = await simCfSiteRequest(simAws, distributionId, "/greeting", {
+      method: "POST",
+      body: "a body the Origin should see",
+      headers: { [simCfEdgeHeaderName]: "edge-four" },
+    });
+
+    // Then taking the header off the request left the body where it was.
+    assertStringIncludes(await posted.text(), "a body the Origin should see");
+  });
+
+  it("reaches the Origin every time once caching is turned off", async () => {
+    // Given a simulated AWS whose Distributions hold no cache.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+
+    simAws.cloudFront().configureCaching({ enabled: false });
+
+    // When the same path is asked for twice.
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then both reached the Origin, as they did before a Distribution held a
+    // cache at all.
+    assertIdentical(await readNumber(second), 2);
+    assertIdentical(reads.count, 2);
+  });
+
+  it("applies the response headers policy a Behavior names now, not the one it named when the answer was stored", async () => {
+    // Given a Behavior whose response headers policy sets a header.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const policyId =
+      "22222222-3333-4444-5555-666666666666" as SimCloudFrontResponseHeadersPolicyId;
+
+    simAws.cloudFront().addResponseHeadersPolicy(
+      new SimCloudFrontResponseHeadersPolicy({
+        id: policyId,
+        name: "CacheHeaders",
+        customHeaders: [
+          new SimCloudFrontResponseHeader({
+            name: "x-served-by",
+            value: "first-policy",
+          }),
+        ],
+      }),
+    );
+
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      { TargetOriginId: "api", ResponseHeadersPolicyId: policyId },
+    );
+
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // When the policy is replaced and the cached answer is asked for again.
+    simAws.cloudFront().removeResponseHeadersPolicy(policyId);
+    simAws.cloudFront().addResponseHeadersPolicy(
+      new SimCloudFrontResponseHeadersPolicy({
+        id: policyId,
+        name: "CacheHeaders",
+        customHeaders: [
+          new SimCloudFrontResponseHeader({
+            name: "x-served-by",
+            value: "second-policy",
+          }),
+        ],
+      }),
+    );
+
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the hit carries the new policy's header, because CloudFront applies
+    // a policy on the way out of the cache rather than storing it with the
+    // response. A policy change therefore needs no invalidation.
+    assertIdentical(await readNumber(second), 1);
+    assertIdentical(second.headers.get("x-served-by"), "second-policy");
+  });
+});

--- a/src/service/cloudfront/controller/content/sim-cf-cache-edge.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-cache-edge.iso.test.ts
@@ -56,6 +56,27 @@ describe("A sim CloudFront edge cache", () => {
     assertStringNotIncludes(await repeated.text(), simCfEdgeHeaderName);
   });
 
+  it("arrives at the default edge when the header names none", async () => {
+    // Given a Distribution that has answered a request at its default edge.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // When a request carries the header with nothing in it.
+    const blank = await simCfSiteRequest(simAws, distributionId, "/greeting", {
+      headers: { [simCfEdgeHeaderName]: " " },
+    });
+
+    // Then it lands at the same edge, and the cache answers it.
+    assertIdentical(await readNumber(blank), 1);
+    assertIdentical(reads.count, 1);
+  });
+
   it("sends the Origin the body of a request that named an edge", async () => {
     // Given a Distribution in front of an Origin that says what it was sent.
     const simAws = new SimAws();

--- a/src/service/cloudfront/controller/content/sim-cf-cache-keying.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-cache-keying.iso.test.ts
@@ -1,0 +1,136 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFrontCacheKey } from "../../cache-policy/sim-cf-cache-key.js";
+import { SimCloudFrontCachePolicy } from "../../cache-policy/sim-cf-cache-policy.js";
+import { simCfManagedCachePolicyIds } from "../../cache-policy/sim-cf-managed-cache-policies.js";
+import {
+  countingOrigin,
+  distributionServing,
+  type OriginReads,
+  readNumber,
+} from "../../../../../test/cloudfront/cache-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+describe("What a sim CloudFront Distribution keys its cache on", () => {
+  it("keys two requests apart on a query string its cache policy names", async () => {
+    // Given a Behavior on a policy keying on the `page` query string.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const policy = new SimCloudFrontCachePolicy({
+      name: "PagedPolicy",
+      cacheKey: new SimCloudFrontCacheKey({
+        queryStringBehavior: "whitelist",
+        queryStrings: ["page"],
+      }),
+    });
+
+    simAws.cloudFront().addCachePolicy(policy);
+
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      { TargetOriginId: "api", CachePolicyId: policy.id },
+    );
+
+    // When two requests differ in that query string, and the first is
+    // repeated.
+    const first = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/list?page=1",
+    );
+    const second = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/list?page=2",
+    );
+    const repeated = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/list?page=1",
+    );
+
+    // Then each page was read from the Origin once, and the repeat came from
+    // the cache.
+    assertIdentical(await readNumber(first), 1);
+    assertIdentical(await readNumber(second), 2);
+    assertIdentical(await readNumber(repeated), 1);
+    assertIdentical(reads.count, 2);
+  });
+
+  it("shares one entry for two requests differing only in a query string the policy leaves out", async () => {
+    // Given a Behavior on CachingOptimized, which keys on no query string.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+
+    // When two requests differ only in a campaign parameter.
+    await simCfSiteRequest(simAws, distributionId, "/list?utm=email");
+    const second = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/list?utm=social",
+    );
+
+    // Then the second is answered from the first one's entry.
+    assertIdentical(await readNumber(second), 1);
+    assertIdentical(reads.count, 1);
+  });
+
+  it("reaches the Origin every time on CachingDisabled", async () => {
+    // Given a Behavior on the managed policy that caches nothing.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      {
+        TargetOriginId: "api",
+        CachePolicyId: simCfManagedCachePolicyIds.cachingDisabled,
+      },
+    );
+
+    // When the same path is asked for twice.
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then both reached the Origin.
+    assertIdentical(await readNumber(second), 2);
+    assertIdentical(reads.count, 2);
+  });
+
+  it("reaches the Origin every time for a method outside CachedMethods", async () => {
+    // Given a Behavior allowing every method and caching GET and HEAD.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      {
+        TargetOriginId: "api",
+        AllowedMethods: {
+          Quantity: 7,
+          Items: ["GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"],
+          CachedMethods: { Quantity: 2, Items: ["GET", "HEAD"] },
+        },
+      },
+    );
+
+    // When the same path is posted to twice.
+    await simCfSiteRequest(simAws, distributionId, "/greeting", {
+      method: "POST",
+    });
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting", {
+      method: "POST",
+    });
+
+    // Then both reached the Origin, since CloudFront caches no POST.
+    assertIdentical(await readNumber(second), 2);
+    assertIdentical(reads.count, 2);
+  });
+});

--- a/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
@@ -1,0 +1,80 @@
+import { simCfCacheableKey } from "../../cache/sim-cf-cacheable-request.js";
+import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import type { SimCfCustomErrorResponder } from "../error/sim-cf-custom-error-responder.js";
+import type {
+  SimCfOriginStage,
+  SimCfOriginStageResult,
+} from "../origin/sim-cf-origin-stage.js";
+
+/**
+ * One request, and everything the content stage needs to answer it.
+ */
+export interface SimCfContentRequest {
+  readonly request: Request;
+  readonly cloudFront: SimCloudFront;
+  readonly distribution: SimCloudFrontDistribution;
+  readonly behaviour: SimCloudFrontBehavior;
+
+  /**
+   * The edge the request arrived at, whose cache answers it.
+   */
+  readonly edgeId: string;
+}
+
+/**
+ * Answers a request from the Distribution's cache, or from the Origin.
+ *
+ * This is CloudFront's cache lookup and everything behind it. A key the cache
+ * already holds is answered with the Origin left unread. A miss goes to the
+ * Origin, has an error replaced with the Distribution's custom error page, and
+ * is stored under the key it missed on.
+ *
+ * An Origin error stays out of the cache. Real CloudFront holds one for
+ * `ErrorCachingMinTTL`, which wants a TTL this simulation has yet to keep.
+ * Caching an error with no expiry would leave a Distribution answering with it
+ * for the length of the test.
+ */
+export class SimCfContentStage {
+  constructor(
+    private readonly originStage: SimCfOriginStage,
+    private readonly customErrorResponder: SimCfCustomErrorResponder,
+  ) {}
+
+  /**
+   * Answer one request, reading the Origin only where the cache cannot.
+   */
+  async serve(content: SimCfContentRequest): Promise<SimCfOriginStageResult> {
+    const { request, distribution, behaviour } = content;
+    const key = simCfCacheableKey(content);
+    const cached = key === undefined ? undefined : distribution.cache.read(key);
+
+    // A hit is answered as the Origin answered it when it was stored, so the
+    // status the pipeline reads is the cached one and a viewer-response
+    // function runs on a hit as it ran on the miss that filled the cache.
+    if (cached !== undefined) {
+      return { response: cached, originStatus: cached.status };
+    }
+
+    const originResult = await this.originStage.fetch(
+      request,
+      distribution,
+      behaviour,
+    );
+    const response = await this.customErrorResponder.apply(
+      request,
+      distribution,
+      originResult.response,
+    );
+
+    if (key === undefined || originResult.originStatus >= 400) {
+      return { response, originStatus: originResult.originStatus };
+    }
+
+    return {
+      response: await distribution.cache.store(key, response),
+      originStatus: originResult.originStatus,
+    };
+  }
+}

--- a/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
@@ -31,10 +31,11 @@ export interface SimCfContentRequest {
  * Origin, has an error replaced with the Distribution's custom error page, and
  * is stored under the key it missed on.
  *
- * An Origin error stays out of the cache. Real CloudFront holds one for
- * `ErrorCachingMinTTL`, which wants a TTL this simulation has yet to keep.
- * Caching an error with no expiry would leave a Distribution answering with it
- * for the length of the test.
+ * An error stays out of the cache, whether the Origin answered with it or an
+ * origin-response function made one of an Origin's answer. Real CloudFront
+ * holds one for `ErrorCachingMinTTL`, which wants a TTL this simulation has yet
+ * to keep. Caching an error with no expiry would leave a Distribution answering
+ * with it for the length of the test.
  */
 export class SimCfContentStage {
   constructor(
@@ -68,7 +69,11 @@ export class SimCfContentStage {
       originResult.response,
     );
 
-    if (key === undefined || originResult.originStatus >= 400) {
+    if (
+      key === undefined ||
+      originResult.originStatus >= 400 ||
+      response.status >= 400
+    ) {
       return { response, originStatus: originResult.originStatus };
     }
 

--- a/src/service/cloudfront/controller/content/sim-cf-distribution-cache.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-distribution-cache.iso.test.ts
@@ -6,6 +6,8 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import { makeEdgeFunctionVersionArn } from "../../../../../test/cloudfront/edge-function-fixture.js";
 import {
   countingOrigin,
   distributionServing,
@@ -52,6 +54,47 @@ describe("What a sim CloudFront Distribution caches", () => {
     // Then the empty answer was held on to and served again.
     assertResponseStatus(second, 204, await describeResponse(second));
     assertIdentical(reads.count, 1);
+  });
+
+  it("stores nothing an origin-response function turned into an error", async () => {
+    // Given a Behavior whose origin-response function answers 503 for the
+    // Origin's 200.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "failing-origin-response",
+      handler: (
+        event: LambdaAtEdge.OriginResponseEvent,
+      ): LambdaAtEdge.Response => ({
+        ...event.Records[0].cf.response,
+        status: "503",
+        statusDescription: "Service Unavailable",
+      }),
+    });
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      {
+        TargetOriginId: "api",
+        LambdaFunctionAssociations: {
+          Quantity: 1,
+          Items: [
+            { EventType: "origin-response", LambdaFunctionARN: versionArn },
+          ],
+        },
+      },
+    );
+
+    // When the same path is asked for twice.
+    const first = await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the error was answered both times, from the Origin both times,
+    // rather than held on to for every request after it.
+    assertResponseStatus(first, 503, await describeResponse(first));
+    assertResponseStatus(second, 503, await describeResponse(second));
+    assertIdentical(reads.count, 2);
   });
 
   it("stores nothing for an Origin error", async () => {

--- a/src/service/cloudfront/controller/content/sim-cf-distribution-cache.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-distribution-cache.iso.test.ts
@@ -1,0 +1,74 @@
+import {
+  assertIdentical,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  countingOrigin,
+  distributionServing,
+  type OriginReads,
+  readNumber,
+  statusSequenceOrigin,
+} from "../../../../../test/cloudfront/cache-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+describe("What a sim CloudFront Distribution caches", () => {
+  it("answers a second request for the same key without reaching the Origin", async () => {
+    // Given a Distribution on CachingOptimized, in front of an Origin that
+    // says which read answered.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+
+    // When the same path is asked for twice.
+    const first = await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the second answer is the first one, and the Origin was read once.
+    assertIdentical(await readNumber(first), 1);
+    assertIdentical(await readNumber(second), 1);
+    assertIdentical(reads.count, 1);
+  });
+
+  it("caches a response that carries no body", async () => {
+    // Given an Origin answering 204 the first time and 200 after that.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await statusSequenceOrigin(simAws, reads, [204, 200]),
+    );
+
+    // When the same path is asked for twice.
+    await simCfSiteRequest(simAws, distributionId, "/beacon");
+    const second = await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // Then the empty answer was held on to and served again.
+    assertResponseStatus(second, 204, await describeResponse(second));
+    assertIdentical(reads.count, 1);
+  });
+
+  it("stores nothing for an Origin error", async () => {
+    // Given an Origin failing the first read and answering the second.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await statusSequenceOrigin(simAws, reads, [500, 200]),
+    );
+
+    // When the failing answer is asked for again.
+    const failed = await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the error was not held on to, and the second read answered.
+    assertResponseStatus(failed, 500, await describeResponse(failed));
+    assertIdentical(await readNumber(second), 2);
+  });
+});

--- a/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
+++ b/src/service/cloudfront/controller/dependency/sim-cf-controller-dependency.ts
@@ -10,6 +10,7 @@ import { SimLambdaEdgeOriginApplicator } from "../edge/sim-lambda-edge-origin-ap
 import { SimAwsCfEdgeFunctions } from "../../edge/sim-aws-cf-edge-functions.js";
 import { SimCloudFrontOriginFetcher } from "../origin/sim-cloudfront-origin-fetcher.js";
 import { SimCfOriginStage } from "../origin/sim-cf-origin-stage.js";
+import { SimCfContentStage } from "../content/sim-cf-content-stage.js";
 import { SimCfCustomErrorResponder } from "../error/sim-cf-custom-error-responder.js";
 import { SimCfResponseHeadersApplicator } from "../response-headers/sim-cf-response-headers-applicator.js";
 import { SimCfWebAclGuard } from "../web-acl/sim-cf-web-acl-guard.js";
@@ -35,8 +36,7 @@ export interface SimCloudFrontControllerDependencies {
   readonly behaviourResolver: SimCloudFrontBehaviorResolver;
   readonly cffApplicator: SimCffApplicator;
   readonly edgeApplicator: SimLambdaEdgeApplicator;
-  readonly originStage: SimCfOriginStage;
-  readonly customErrorResponder: SimCfCustomErrorResponder;
+  readonly contentStage: SimCfContentStage;
   readonly responseHeadersApplicator: SimCfResponseHeadersApplicator;
 }
 
@@ -79,14 +79,15 @@ export class SimCloudFrontControllerDependenciesFactory {
       edgeApplicator:
         properties.edgeApplicator ??
         new SimLambdaEdgeApplicator({ edgeFunctions }),
-      originStage: new SimCfOriginStage(
-        originFetcher,
-        properties.edgeOriginApplicator ??
-          new SimLambdaEdgeOriginApplicator({ edgeFunctions }),
-      ),
-      customErrorResponder:
+      contentStage: new SimCfContentStage(
+        new SimCfOriginStage(
+          originFetcher,
+          properties.edgeOriginApplicator ??
+            new SimLambdaEdgeOriginApplicator({ edgeFunctions }),
+        ),
         properties.customErrorResponder ??
-        new SimCfCustomErrorResponder({ behaviourResolver, originFetcher }),
+          new SimCfCustomErrorResponder({ behaviourResolver, originFetcher }),
+      ),
       responseHeadersApplicator:
         properties.responseHeadersApplicator ??
         new SimCfResponseHeadersApplicator(),

--- a/src/service/cloudfront/controller/origin/sim-cf-origin-stage.ts
+++ b/src/service/cloudfront/controller/origin/sim-cf-origin-stage.ts
@@ -28,8 +28,8 @@ export interface SimCfOriginStageResult {
  * Fetches from the Behavior's Origin, running the Lambda@Edge functions on
  * either side of the fetch.
  *
- * Real CloudFront runs the origin events on a cache miss only. Nothing here
- * caches, so every request is a miss and both events run every time.
+ * Real CloudFront runs the origin events on a cache miss only, and so does
+ * this. A request the Distribution's cache answers never reaches this stage.
  */
 export class SimCfOriginStage {
   constructor(

--- a/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
@@ -1,14 +1,14 @@
 import type { SimCloudFrontControllerDependencies } from "./dependency/sim-cf-controller-dependency.js";
+import { simCfRequestEdge } from "../cache/sim-cf-edge.js";
 import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root-object-request.js";
 
 /**
  * Runs a single simulated CloudFront request through its lifecycle:
- * route to a Distribution, put the request through the Distribution's web ACL,
- * apply the default root object, resolve the matching Behavior, run
- * viewer-request hooks, fetch from the Origin with the origin hooks either
- * side of the fetch, replace an error response with the Distribution's custom
- * error page, apply the Behavior's response headers policy, then run
- * viewer-response hooks where the Origin did not answer with an error.
+ * read the edge it arrived at, route to a Distribution, put the request
+ * through the Distribution's web ACL, apply the default root object, resolve
+ * the matching Behavior, run viewer-request hooks, answer from that edge's
+ * cache or from the Origin, apply the Behavior's response headers policy, then
+ * run viewer-response hooks where the Origin did not answer with an error.
  *
  * A viewer hook is a CloudFront Function or a Lambda@Edge function. A Behavior
  * carries at most one of the two kinds at the viewer events, which
@@ -27,7 +27,11 @@ export class SimCloudFrontRequestPipeline {
    * Process one incoming request and produce the response the caller sees.
    */
   async handle(request: Request): Promise<Response> {
-    let requestReference = request;
+    // The edge is read first and its header taken off the request. A web ACL
+    // rule, an edge function and the Origin therefore never see an instruction
+    // that was addressed to the simulator.
+    const edge = simCfRequestEdge(request);
+    let requestReference = edge.request;
 
     const route = this.stages.distroRouter.routeForRequest(requestReference);
 
@@ -85,23 +89,17 @@ export class SimCloudFrontRequestPipeline {
     }
     requestReference = edgeResult;
 
-    // Fetch from the Origin, running the origin-request and origin-response
-    // Lambda@Edge functions on either side of the fetch. An origin-request
-    // function that answered with a response of its own leaves the Origin
-    // unread, and the response takes the Origin response's place from here on.
-    const originResult = await this.stages.originStage.fetch(
-      requestReference,
-      distro,
+    // Answer from this edge's cache where it holds the key, and from the Origin
+    // where it does not. A miss runs the origin-request and origin-response
+    // Lambda@Edge functions either side of the fetch, has an Origin error
+    // replaced with the Distribution's custom error page, and is stored.
+    const content = await this.stages.contentStage.serve({
+      request: requestReference,
+      cloudFront,
+      distribution: distro,
       behaviour,
-    );
-
-    // Replace an Origin error with the Distribution's custom error page, if it
-    // configures one for that status.
-    const errorResponse = await this.stages.customErrorResponder.apply(
-      requestReference,
-      distro,
-      originResult.response,
-    );
+      edgeId: edge.edgeId,
+    });
 
     // Apply the Behavior's response headers policy, if it names one. CloudFront
     // does this after the response leaves the cache and before the
@@ -110,16 +108,17 @@ export class SimCloudFrontRequestPipeline {
     const response = this.stages.responseHeadersApplicator.apply(
       cloudFront,
       requestReference,
-      errorResponse,
+      content.response,
       behaviour,
     );
 
     // CloudFront runs no viewer-response function when the Origin answered
     // 400 or higher, for either kind of function. The status that decides it
-    // is the one the Origin returned, so neither a custom error response
-    // carrying `ResponseCode: 200` above nor an origin-response function that
-    // replaced the status brings the function back.
-    if (originResult.originStatus >= 400) {
+    // is the one the Origin returned, or the one it returned when the cache
+    // entry being served was stored. Neither a custom error response carrying
+    // `ResponseCode: 200` nor an origin-response function that replaced the
+    // status brings the function back.
+    if (content.originStatus >= 400) {
       return response;
     }
 

--- a/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
+++ b/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
@@ -11,6 +11,7 @@ import {
 import type { SimCloudFrontDistributionConfig } from "../command/create-distribution/create-distribution.command.js";
 import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
 import { SimCloudFrontDistributionNotDisabled } from "../error/sim-cloudfront.error.js";
+import { SimCfDistributionCache } from "../cache/sim-cf-distribution-cache.js";
 
 export type SimCloudFrontDistributionId = Brand<
   string,
@@ -40,6 +41,15 @@ export class SimCloudFrontDistribution {
   public readonly behaviors: SimCloudFrontBehavior[] = [];
   public readonly customErrorResponses: SimCloudFrontCustomErrorResponse[] = [];
   public readonly lastModifiedTime: Date;
+
+  /**
+   * What this Distribution has cached, keyed by cache key.
+   *
+   * A configuration update leaves it alone, as it leaves a real
+   * Distribution's cached objects alone: an object cached under the old
+   * configuration is served until something removes it.
+   */
+  public readonly cache = new SimCfDistributionCache();
 
   #status: SimCloudFrontDistributionStatus;
   #distributionConfig: SimCloudFrontDistributionConfig | undefined;

--- a/src/service/cloudfront/index.ts
+++ b/src/service/cloudfront/index.ts
@@ -7,6 +7,11 @@ export { cloudFrontFunctionSourceFromModule } from "./cff/function-code-module/c
 export type { CloudFrontFunction } from "./typings/cloudfront-functions.namespace.js";
 export type { LambdaAtEdge } from "./typings/lambda-at-edge.namespace.js";
 export type { SimCfRedundantOrigin } from "./origin/sim-cf-redundant-origins.js";
+export {
+  simCfDefaultEdgeId,
+  simCfEdgeHeaderName,
+} from "./cache/sim-cf-edge.js";
+export type { SimCfCachingConfiguration } from "./registry/sim-cloud-front-registry.js";
 export type { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.js";
 export type { SimCfKeyValueStoreCommands } from "./key-value-store/sim-cf-key-value-store-commands.js";
 export type {

--- a/src/service/cloudfront/registry/sim-cloud-front-registry.ts
+++ b/src/service/cloudfront/registry/sim-cloud-front-registry.ts
@@ -5,13 +5,27 @@ import {
 import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
 
 /**
+ * How a simulated AWS caches what its Distributions serve.
+ */
+export interface SimCfCachingConfiguration {
+  readonly enabled: boolean;
+}
+
+/**
  * Simulated CloudFront cross-Account registry of Distribution IDs.
  *
  * CloudFront is not region-scoped, so all region-scoped CloudFront service
  * instances for the same Account should delegate to the same Account-global
  * state.
+ *
+ * Whether Distributions cache what they serve lives here for the same reason.
+ * One registry is built per `SimAws` and shared by every Account and Region,
+ * so turning caching off turns it off for the whole simulated AWS rather than
+ * for one Account's Distributions.
  */
 export class SimCloudFrontRegistry {
+  #cachingEnabled = true;
+
   private readonly distributionAccountIds = new Map<
     SimCloudFrontDistributionId,
     SimAwsAccountId
@@ -26,6 +40,25 @@ export class SimCloudFrontRegistry {
     string,
     SimCloudFrontDistributionId
   >();
+
+  /**
+   * Whether Distributions here cache what they serve.
+   */
+  get cachingEnabled(): boolean {
+    return this.#cachingEnabled;
+  }
+
+  /**
+   * Turn the edge cache on or off for every Distribution in this simulated
+   * AWS.
+   *
+   * Caching is on, as CloudFront's is. Turning it off is for a suite that
+   * repeats a request and wants the Origin read every time, and it is the
+   * behaviour sim CloudFront had before it held a cache at all.
+   */
+  configureCaching(configuration: SimCfCachingConfiguration): void {
+    this.#cachingEnabled = configuration.enabled;
+  }
 
   /**
    * Allocate a globally unique simulated CloudFront Distribution ID.

--- a/src/service/cloudfront/sim-cloudfront-caching.ts
+++ b/src/service/cloudfront/sim-cloudfront-caching.ts
@@ -1,0 +1,45 @@
+import {
+  type SimCfCachingConfiguration,
+  SimCloudFrontRegistry,
+} from "./registry/sim-cloud-front-registry.js";
+import { SimCloudFrontPolicies } from "./sim-cloudfront-policies.js";
+
+/**
+ * The cache one simulated CloudFront's Distributions hold, and whether they
+ * hold one at all.
+ *
+ * The setting lives on `SimCloudFrontRegistry`, which is built once per
+ * `SimAws` and shared by every Account and Region, so a Distribution anywhere
+ * in one simulated AWS caches or does not together with the rest.
+ * `SimCloudFront` extends this, and a caller reaches it on the one service
+ * object.
+ */
+export class SimCloudFrontCaching extends SimCloudFrontPolicies {
+  protected readonly cloudFrontRegistry: SimCloudFrontRegistry;
+
+  constructor(cloudFrontRegistry?: SimCloudFrontRegistry) {
+    super();
+    this.cloudFrontRegistry = cloudFrontRegistry ?? new SimCloudFrontRegistry();
+  }
+
+  /**
+   * Whether Distributions in this simulated AWS cache what they serve.
+   */
+  get cachingEnabled(): boolean {
+    return this.cloudFrontRegistry.cachingEnabled;
+  }
+
+  /**
+   * Turn the edge cache on or off.
+   *
+   * ```typescript
+   * simAws.cloudFront().configureCaching({ enabled: false });
+   * ```
+   *
+   * Caching is on, as CloudFront's is. Turning it off is for a suite that
+   * repeats a request and wants every one of them to reach the Origin.
+   */
+  configureCaching(configuration: SimCfCachingConfiguration): void {
+    this.cloudFrontRegistry.configureCaching(configuration);
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -96,6 +96,15 @@ export type SimCloudFrontDistributionMap = Map<
 >;
 
 /**
+ * The Distributions of one simulated CloudFront, as a caller reading them back
+ * sees them.
+ */
+export type SimCloudFrontDistributionsById = ReadonlyMap<
+  SimCloudFrontDistributionId,
+  SimCloudFrontDistribution
+>;
+
+/**
  * The state every Distribution command works on.
  */
 interface SimCloudFrontDistributionState {

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -45,7 +45,7 @@ import type {
   SimCloudFrontDistribution,
   SimCloudFrontDistributionId,
 } from "./distribution/sim-cloudfront-distribution.js";
-import { SimCloudFrontPolicies } from "./sim-cloudfront-policies.js";
+import { SimCloudFrontCaching } from "./sim-cloudfront-caching.js";
 import type {
   SimCloudFrontOriginAccessControl,
   SimCloudFrontOriginAccessControlId,
@@ -58,6 +58,7 @@ import { SimCloudFrontSdkCommandRouter } from "./sdk/sim-cloudfront-sdk-command-
 import {
   SimCloudFrontCommands,
   type SimCloudFrontDistributionMap,
+  type SimCloudFrontDistributionsById,
   type SimCloudFrontProperties,
   type SimCloudFrontRequestOptions,
 } from "./sim-cloudfront-commands.js";
@@ -70,7 +71,7 @@ export type {
 /**
  * Simulated CloudFront. Handles SDK commands. Emulates AWS behaviour and state.
  */
-export class SimCloudFront extends SimCloudFrontPolicies {
+export class SimCloudFront extends SimCloudFrontCaching {
   private readonly distributions: SimCloudFrontDistributionMap = new Map();
   private readonly cloudFrontFunctions: SimCloudFrontFunctionMap = new Map();
   private readonly originAccessControls =
@@ -84,11 +85,12 @@ export class SimCloudFront extends SimCloudFrontPolicies {
   private readonly sdkRouter = new SimCloudFrontSdkCommandRouter(this);
 
   constructor(properties: SimCloudFrontProperties = {}) {
-    super();
+    super(properties.cloudFrontRegistry);
     this.accountRegionScope =
       properties.accountRegionScope ?? simAwsAccountRegionScopeFactory.make();
     this.commands = new SimCloudFrontCommands({
       ...properties,
+      cloudFrontRegistry: this.cloudFrontRegistry,
       accountId: this.accountRegionScope.accountId,
       distributions: this.distributions,
       cloudFrontFunctions: this.cloudFrontFunctions,
@@ -119,10 +121,7 @@ export class SimCloudFront extends SimCloudFrontPolicies {
   /**
    * Get the simulated Distributions owned by this sim CloudFront service.
    */
-  getDistributions(): ReadonlyMap<
-    SimCloudFrontDistributionId,
-    SimCloudFrontDistribution
-  > {
+  getDistributions(): SimCloudFrontDistributionsById {
     return this.distributions;
   }
 

--- a/test/cloudfront/cache-fixture.ts
+++ b/test/cloudfront/cache-fixture.ts
@@ -1,0 +1,131 @@
+/**
+ * A Distribution in front of an Origin that says which read answered it, for
+ * tests about what its cache serves without reading the Origin again.
+ *
+ * This lives under `test/` for the same reasons as the rest of
+ * `test/cloudfront/`. Eslint rejects an AWS SDK import from `src/` outside a
+ * test file, and more than one suite needs the same steps.
+ */
+
+import {
+  assertNonNullable,
+  assertResponseStatus,
+  assertTypeNumber,
+  describeResponse,
+} from "@kensio/smartass";
+import {
+  CreateDistributionCommand,
+  type DefaultCacheBehavior,
+} from "@aws-sdk/client-cloudfront";
+
+import type { SimPayload2Event } from "../../src/serve/payload-2/sim-payload-2-event.type.js";
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simCfManagedCachePolicyIds } from "../../src/service/cloudfront/cache-policy/sim-cf-managed-cache-policies.js";
+import { customOrigin, functionUrlHostname } from "./edge-origin-fixture.js";
+
+/**
+ * How many times the Origin has been read, which is what a cache hit is
+ * measured in. An answer the Distribution held already leaves this alone.
+ */
+export interface OriginReads {
+  count: number;
+}
+
+/**
+ * An Origin answering with the number of the read that answered, and with the
+ * headers and body it was sent, so a test can tell one read from the next and
+ * see what reached it.
+ */
+export async function countingOrigin(
+  simAws: SimAws,
+  reads: OriginReads,
+): Promise<string> {
+  return await functionUrlHostname(
+    simAws,
+    "counting-origin",
+    (event: SimPayload2Event) => {
+      reads.count += 1;
+
+      return {
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          read: reads.count,
+          headers: event.headers,
+          sent: event.body,
+        }),
+      };
+    },
+  );
+}
+
+/**
+ * A Distribution serving that Origin, whose default Behavior is the one the
+ * test is about. It caches on CachingOptimized unless the test says otherwise.
+ */
+export async function distributionServing(
+  simAws: SimAws,
+  originHostname: string,
+  cacheBehavior: Partial<DefaultCacheBehavior> = {},
+): Promise<string> {
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "cached-distribution",
+        Comment: "Caching CDN",
+        Enabled: true,
+        Origins: {
+          Quantity: 1,
+          Items: [customOrigin("api", originHostname)],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "api",
+          ViewerProtocolPolicy: "allow-all",
+          CachePolicyId: simCfManagedCachePolicyIds.cachingOptimized,
+          ...cacheBehavior,
+        },
+      },
+    }),
+  );
+
+  assertNonNullable(creation.Distribution?.Id, "the Distribution was created");
+
+  return creation.Distribution.Id;
+}
+
+/**
+ * The read number an answer came from, which stays where it was while the
+ * cache is answering.
+ */
+export async function readNumber(response: Response): Promise<number> {
+  assertResponseStatus(response, 200, await describeResponse(response));
+
+  const { read } = (await response.json()) as { read: number };
+
+  assertTypeNumber(read);
+
+  return read;
+}
+
+/**
+ * An Origin answering with a status per read, so that a test can have the
+ * first read fail and the second one answer.
+ */
+export async function statusSequenceOrigin(
+  simAws: SimAws,
+  reads: OriginReads,
+  statusCodes: readonly number[],
+): Promise<string> {
+  return await functionUrlHostname(simAws, "sequence-origin", () => {
+    reads.count += 1;
+
+    const statusCode = statusCodes[reads.count - 1] ?? 200;
+
+    return {
+      statusCode,
+      headers: { "content-type": "application/json" },
+      // A 204 says there is no content, so it answers with none.
+      body: statusCode === 204 ? "" : JSON.stringify({ read: reads.count }),
+    };
+  });
+}


### PR DESCRIPTION
Resolves #1149.

A sim CloudFront Distribution now holds a cache. A request for a key it already holds is answered with the Origin left unread, so a test can tell a hit from a miss and a Behavior on `CachingDisabled` no longer serves the same way as one on `CachingOptimized`. The key is the request path, plus the query strings, headers and cookies the Behavior's cache policy names, plus the normalized `Accept-Encoding` where the policy enables gzip or brotli. The method is in the key as well, and `CachedMethods` decides which methods are cached at all, which is the first thing to read the field the model has recorded all along.

Two rules keep it safe. A response headers policy is applied on the way out of the cache rather than stored with the response, so a policy change takes effect on entries already held. A Behavior whose cache policy this simulation does not hold stores nothing, which covers a Behavior naming no `CachePolicyId`, because the alternative is a guessed TTL.

CloudFront caches per point of presence, so the key carries an opaque edge ID. It defaults to one value and a request sets its own with an `x-sim-aws-cloudfront-edge` header, following the `x-sim-aws-*` convention. Sim CloudFront reads it at the top of the pipeline and takes it off the request, so a web ACL rule, an edge function and the Origin never see it. The header is deliberately outside `simAwsControlHeaderNames`, whose members the HTTP boundary strips before a controller sees them.

**This is a breaking change and wants a major release.** Caching is on by default, as CloudFront's is. A simulation that quietly skipped caching would teach the wrong model, and it would let an invalidation test pass without an invalidation. `simAws.cloudFront().configureCaching({ enabled: false })` restores the previous behaviour for one `SimAws`, following `SimS3.configureMaxKeysPerPage`, with the flag on `SimCloudFrontRegistry` so it covers every Account and Region. The whole suite passes unchanged with caching on.

This is the choke point for the four issues after it. #1150 (expiry on the sim clock), #1151 (origin events on a miss alone, plus `X-Cache` and `Age`), #1152 (`CreateInvalidation`) and #1153 (`ErrorCachingMinTTL`) all read the shapes landed here: `SimCfDistributionCache` on the Distribution, `simCfCacheableKey`, and `SimCfContentStage` under `controller/content/`, which is where the Origin stage and the custom error responder now sit. Nothing expires yet, and an Origin error stays out of the cache rather than being held with no expiry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added realistic CloudFront caching with cache hits, Origin misses, cache policies, request methods, query strings, headers, cookies, encoding, and edge-specific behavior.
  * Added options to enable or disable caching across the simulated environment.
  * Added support for selecting simulated edges and applying current response-header policies to cached responses.
  * Added examples and expanded documentation covering caching behavior and limitations.

* **Bug Fixes**
  * Prevented unsupported methods, disabled caching, zero-TTL policies, and unsuccessful Origin responses from being cached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->