### PR TITLE
feat: expire a cached CloudFront object

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2631,6 +2631,10 @@ AWS. `s-maxage` is preferred to `max-age`, and `max-age` to `Expires`. Whatever 
 is held between the policy's `MinTTL` and `MaxTTL`. An Origin that asks for nothing gets the greater
 of `MinTTL` and `DefaultTTL`, which is a day on `CachingOptimized`.
 
+An `Expires` header has to carry one of the three date formats HTTP allows. Anything else, a
+locale-formatted date included, is read as an object that expired already, the way any HTTP cache
+reads it.
+
 `no-store`, `no-cache` and `private` keep the answer out of the cache while the policy's `MinTTL` is
 zero. Where it is higher, the floor overrides the Origin and the answer is held for `MinTTL`
 seconds. That last one is CloudFront's own behaviour, and the
@@ -3554,10 +3558,6 @@ Where sim CloudFront knowingly behaves differently from AWS:
   share of real responses carry `Server-Timing`. This simulation adds it to every response once
   `Enabled` is true. A test asserting on it never depends on chance. The header's value is a
   fixed placeholder, since nothing here measures an Origin fetch the way CloudFront's edge does.
-- **A cache policy is recorded and never applied.** Sim CloudFront models no edge caching. A policy
-  holds its three TTLs and the whole of its cache key, and a Behavior's `CachePolicyId` is checked
-  against the policies this simulation holds and reported back. None of it decides anything. Every
-  request reaches the Origin, whatever the policy would have cached on real CloudFront.
 - **An origin request policy is recorded and never applied.** A Behavior's `OriginRequestPolicyId`
   is checked against the policies this simulation holds and reported back. Sim CloudFront forwards
   the viewer's headers, cookies and query string to the Origin whole, whatever the policy would

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2355,7 +2355,8 @@ real CloudFront refuses it.
 
 A Distribution holds a cache. A request for a key it already holds is answered from that cache,
 leaving the Origin unread. The Behavior's cache policy decides the key, and decides whether the
-Behavior has one at all.
+Behavior has one at all. The policy and the Origin's own cache headers together decide how long an
+answer is held.
 
 ```typescript sim-cloudfront-caching
 /**
@@ -2505,8 +2506,136 @@ policy's `MaxTTL` is above zero. That leaves out a Behavior naming a `CachePolic
 account, a Behavior naming none at all, and a Behavior on `CachingDisabled`. The alternative in each
 case would be a guessed TTL.
 
-An Origin error stays out of the cache. Real CloudFront holds one for `ErrorCachingMinTTL`, which
-wants an expiry this simulation has yet to keep.
+An Origin error stays out of the cache. Real CloudFront holds one for the `ErrorCachingMinTTL` its
+custom error response carries, and nothing here reads that yet.
+
+### How long an entry is held
+
+An entry records the instant it expires, taken from the simulation's clock. A request arriving after
+that instant reaches the Origin, and what the Origin answers takes the expired entry's place. So a
+test reaches the moment its content goes stale by advancing simulated time, without waiting for it.
+
+```typescript sim-cloudfront-cache-expiry
+/**
+ * Expiring a cached object by moving simulated time past its cache control.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "news-bucket" }));
+  await simS3.putPublicAccessBlock(
+    new PutPublicAccessBlockCommand({
+      Bucket: "news-bucket",
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "news-bucket",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::news-bucket/*",
+        },
+      }),
+    }),
+  );
+
+  // The Origin holds each version of the page for a minute.
+  const publish = async (body: string): Promise<void> => {
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "news-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        CacheControl: "max-age=60",
+        Body: body,
+      }),
+    );
+  };
+
+  await publish("<h1>First</h1>");
+
+  const distributionCreation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "news-site",
+        Comment: "News site",
+        Enabled: true,
+        DefaultRootObject: "index.html",
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "news-origin",
+              DomainName: "news-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "news-origin",
+          ViewerProtocolPolicy: "allow-all",
+          // CachingOptimized, one of CloudFront's managed policies.
+          CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        },
+      },
+    }),
+  );
+
+  const distroHostname = distributionCreation.Distribution!.DomainName!;
+  const home = srv.localUrl(`http://${distroHostname}/`);
+
+  const first = await fetch(home);
+  console.log(await first.text()); // <h1>First</h1>
+
+  await publish("<h1>Second</h1>");
+
+  // Still inside the minute the Origin asked for.
+  const held = await fetch(home);
+  console.log(await held.text()); // <h1>First</h1>
+
+  // Simulated time moves past it, and the next request reaches the Origin.
+  await simAws.clock().advanceBy({ seconds: 61 });
+
+  const expired = await fetch(home);
+  console.log(await expired.text()); // <h1>Second</h1>
+} finally {
+  await srv.close();
+}
+```
+
+The Origin's own headers and the cache policy settle the TTL between them, the way they settle it in
+AWS. `s-maxage` is preferred to `max-age`, and `max-age` to `Expires`. Whatever the Origin asks for
+is held between the policy's `MinTTL` and `MaxTTL`. An Origin that asks for nothing gets the greater
+of `MinTTL` and `DefaultTTL`, which is a day on `CachingOptimized`.
+
+`no-store`, `no-cache` and `private` keep the answer out of the cache while the policy's `MinTTL` is
+zero. Where it is higher, the floor overrides the Origin and the answer is held for `MinTTL`
+seconds. That last one is CloudFront's own behaviour, and the
+[AWS documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html)
+carries a warning about it.
 
 ### Applying a response headers policy
 
@@ -3272,7 +3401,7 @@ Sim CloudFront currently supports:
 - `AWS::CloudFront::ResponseHeadersPolicy`, for headers a cache Behavior sets on every response
 - `AWS::CloudFront::CachePolicy`, and a Behavior's `CachePolicyId` read back through `GetDistribution`
 - A cache on each Distribution, keyed on the Behavior's cache policy and on the edge the request
-  arrived at
+  arrived at, expiring on the simulation's clock
 - `AWS::CloudFront::OriginRequestPolicy`, and a Behavior's `OriginRequestPolicyId` read back the
   same way
 - `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
@@ -3289,10 +3418,13 @@ whether the simulator needs them to model the requested behaviour safely.
 
 Where sim CloudFront knowingly behaves differently from AWS:
 
-- **A cached entry never expires.** A cache policy's three TTLs decide whether the Behavior caches
-  at all, and a `MaxTTL` of zero turns it off. Any other value stores an entry that is served until
-  the `SimAws` holding it is thrown away. There is no invalidation, and no `X-Cache` or `Age` header
-  on the response.
+- **An expired entry is fetched again rather than revalidated.** Real CloudFront asks the Origin
+  whether the object has changed and takes a `304 Not Modified` as permission to carry on serving
+  what it holds. Here the expired entry is dropped and the Origin's next answer replaces it.
+  `Stale-While-Revalidate` and `Stale-If-Error` are read as no directive at all. Nothing stale is
+  ever served.
+- **A cached entry stays until it expires.** Nothing evicts one to make room, there is no
+  invalidation, and a response carries no `X-Cache` or `Age` header.
 - **A Behavior with no cache policy caches nothing.** Real CloudFront falls back to the legacy
   `ForwardedValues` and the TTLs beside it, and sim CloudFront skips both. Give the Behavior a
   `CachePolicyId`, as CDK and the console both do.

--- a/docs/services/cloudfront/sim-cloudfront-cache-expiry.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-cache-expiry.example.ts
@@ -1,0 +1,108 @@
+/**
+ * Expiring a cached object by moving simulated time past its cache control.
+ */
+
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "news-bucket" }));
+  await simS3.putPublicAccessBlock(
+    new PutPublicAccessBlockCommand({
+      Bucket: "news-bucket",
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "news-bucket",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::news-bucket/*",
+        },
+      }),
+    }),
+  );
+
+  // The Origin holds each version of the page for a minute.
+  const publish = async (body: string): Promise<void> => {
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "news-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        CacheControl: "max-age=60",
+        Body: body,
+      }),
+    );
+  };
+
+  await publish("<h1>First</h1>");
+
+  const distributionCreation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "news-site",
+        Comment: "News site",
+        Enabled: true,
+        DefaultRootObject: "index.html",
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "news-origin",
+              DomainName: "news-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "news-origin",
+          ViewerProtocolPolicy: "allow-all",
+          // CachingOptimized, one of CloudFront's managed policies.
+          CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        },
+      },
+    }),
+  );
+
+  const distroHostname = distributionCreation.Distribution!.DomainName!;
+  const home = srv.localUrl(`http://${distroHostname}/`);
+
+  const first = await fetch(home);
+  console.log(await first.text()); // <h1>First</h1>
+
+  await publish("<h1>Second</h1>");
+
+  // Still inside the minute the Origin asked for.
+  const held = await fetch(home);
+  console.log(await held.text()); // <h1>First</h1>
+
+  // Simulated time moves past it, and the next request reaches the Origin.
+  await simAws.clock().advanceBy({ seconds: 61 });
+
+  const expired = await fetch(home);
+  console.log(await expired.text()); // <h1>Second</h1>
+} finally {
+  await srv.close();
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -227,12 +227,12 @@ a miss alone, the way CloudFront runs it. Which of the two origin events run on 
 Origin stage's own business, since an `origin-request` function answering with a response of its own
 leaves the Origin unread and nothing for `origin-response` to run on.
 
-`simCfCacheableKey` decides whether a request has a key at all. Four things leave it without one.
-Caching may be off for the `SimAws`. The Behavior's `cachePolicyId` may resolve to no policy this
-simulation holds, which covers a Behavior naming none. The policy it resolves to may have a `MaxTTL`
-of zero, which counts as caching nothing. That is the `MaxTTL` `CachingDisabled` carries, and it
-keeps that Behavior reading the Origin every time. And the method may be outside the Behavior's
-`cachedMethods`. Nothing expires yet, and the other two TTLs decide nothing.
+`simCfCacheableRequest` decides whether a request has a key at all, and answers with the policy
+beside it. Four things leave a request without a key. Caching may be off for the `SimAws`. The
+Behavior's `cachePolicyId` may resolve to no policy this simulation holds, which covers a Behavior
+naming none. The policy it resolves to may have a `MaxTTL` of zero, which counts as caching nothing.
+That is the `MaxTTL` `CachingDisabled` carries, and it keeps that Behavior reading the Origin every
+time. And the method may be outside the Behavior's `cachedMethods`.
 
 `simCfCacheEntryKey` builds the key from the request path, the query strings, headers and cookies
 the policy names, the normalized `Accept-Encoding` where the policy enables gzip or brotli, the
@@ -244,14 +244,30 @@ no body.
 and two viewers each need one, so storing hands back a new Response built from what was stored, and
 the pipeline carries on with that. A status HTTP gives no body is rebuilt without one.
 
+`simCfCacheTtlSec` settles how long an entry lives. It reads the Origin's `Cache-Control` through
+`simCfCacheControl`, preferring `s-maxage` to `max-age` and `max-age` to `Expires`, and holds the
+answer between the policy's `MinTTL` and `MaxTTL`. An Origin that asked for nothing gets the greater
+of `MinTTL` and `DefaultTTL`. `no-store`, `no-cache` and `private` are respected where `MinTTL` is
+zero. Where it is higher the floor overrides them, and the AWS
+[expiration documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html)
+carries a warning about that under its table.
+
+An entry records the instant it expires, off the Distribution's clock. `read` drops one that has
+reached that instant, and the request goes to the Origin. What the Origin answers then takes the
+expired entry's place. A test reaches the moment an object goes stale with
+`simAws.clock().advanceBy()`.
+
+`store` takes its seconds from the caller. That is what holds an Origin's answer for as long as its
+cache policy allows, and it leaves room for an error to be held for its own `ErrorCachingMinTTL`.
+
 `simCfRequestEdge` reads `x-sim-aws-cloudfront-edge` and takes it off the request, at the top of the
 pipeline before the web ACL. The name follows the `x-sim-aws-*` convention. The header is
 deliberately outside `simAwsControlHeaderNames`, whose members the HTTP boundary strips before a
 controller sees them. This one has to survive as far as CloudFront.
 
 The response headers policy is applied after the content stage. A policy change therefore takes
-effect on entries already stored. An Origin error is left unstored. Caching one with no expiry
-would have the Distribution answering with it for the length of the test.
+effect on entries already stored. An Origin error is left unstored. Real CloudFront holds one for
+the `ErrorCachingMinTTL` its custom error response carries, and nothing here reads that yet.
 
 Caching is on. `SimCloudFrontRegistry` holds the flag, one registry per `SimAws` across every
 Account and Region, and `SimCloudFront.configureCaching` is how a test turns it off.

--- a/src/service/cloudfront/cache-policy/sim-cf-cache-policy.ts
+++ b/src/service/cloudfront/cache-policy/sim-cf-cache-policy.ts
@@ -27,8 +27,8 @@ interface SimCloudFrontCachePolicyProperties {
  * A cache policy decides what a cache Behavior keys its cache on and how long
  * an object stays there. This simulation holds the policy under its ID, along
  * with its three TTLs and its cache key, and keys the Distribution's cache on
- * it. Nothing expires yet, so a `MaxTTL` of zero is read as a Behavior that
- * caches nothing and the other two TTLs decide nothing.
+ * it. A `MaxTTL` of zero is read as a Behavior that caches nothing, and the
+ * other two settle how long an entry lives against what the Origin asked for.
  *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html
  */

--- a/src/service/cloudfront/cache/sim-cf-cache-control.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-control.ts
@@ -1,0 +1,90 @@
+/**
+ * What an Origin's `Cache-Control` header says about holding the object at an
+ * edge.
+ *
+ * Only the directives that move CloudFront's own cache duration are read.
+ * `stale-while-revalidate` and `stale-if-error` are left out, because serving
+ * a stale object is a behaviour of its own that this simulation does not have.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html
+ */
+export interface SimCfCacheControl {
+  /**
+   * Whether the Origin asked for the object to stay out of a shared cache,
+   * through `no-store`, `no-cache` or `private`.
+   */
+  readonly uncacheable: boolean;
+
+  /** The seconds `s-maxage` names, where it names a usable number of them. */
+  readonly sharedMaxAgeSec: number | undefined;
+
+  /** The seconds `max-age` names, where it names a usable number of them. */
+  readonly maxAgeSec: number | undefined;
+}
+
+/**
+ * The three directives CloudFront and a browser both respect as a refusal.
+ */
+const uncacheableDirectives = ["no-store", "no-cache", "private"];
+
+/**
+ * Read the `Cache-Control` directives a response carries.
+ *
+ * A directive naming something other than a whole number of seconds is read as
+ * absent. `max-age=soon` falls through to whatever the response says next.
+ */
+export function simCfCacheControl(header: string | null): SimCfCacheControl {
+  const directives = cacheControlDirectives(header);
+
+  return {
+    uncacheable: uncacheableDirectives.some((directive) =>
+      directives.has(directive),
+    ),
+    sharedMaxAgeSec: directiveSeconds(directives.get("s-maxage")),
+    maxAgeSec: directiveSeconds(directives.get("max-age")),
+  };
+}
+
+/**
+ * Split a header into its directives, by lower-cased name.
+ *
+ * A directive carrying no value is held under an empty string, which is what
+ * makes `no-store` findable the same way as `max-age=60`.
+ */
+function cacheControlDirectives(header: string | null): Map<string, string> {
+  const directives = new Map<string, string>();
+  const parts = (header ?? "").split(",");
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+
+    if (trimmed.length === 0) {
+      continue;
+    }
+
+    const separator = trimmed.indexOf("=");
+    const name =
+      separator === -1 ? trimmed : trimmed.slice(0, Math.max(0, separator));
+
+    directives.set(
+      name.trim().toLowerCase(),
+      separator === -1 ? "" : trimmed.slice(separator + 1).trim(),
+    );
+  }
+
+  return directives;
+}
+
+/**
+ * The seconds a directive's value names, or none where it names no whole
+ * number of them.
+ */
+function directiveSeconds(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const seconds = value.replace(/^"(.*)"$/, "$1");
+
+  return /^\d+$/.test(seconds) ? Number(seconds) : undefined;
+}

--- a/src/service/cloudfront/cache/sim-cf-cache-ttl.iso.test.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-ttl.iso.test.ts
@@ -129,7 +129,7 @@ describe("How long a sim CloudFront Distribution holds an Origin's answer", () =
     );
   });
 
-  it("reads an Expires header that is not a date as already expired", () => {
+  it("reads an Expires header that is not an HTTP date as already expired", () => {
     // Given a policy that would otherwise hold the answer for a day.
     const policy = new SimCloudFrontCachePolicy({
       name: "BeaconPolicy",
@@ -141,6 +141,36 @@ describe("How long a sim CloudFront Distribution holds an Origin's answer", () =
     // Then the answer is held for no time. An Origin naming no expiry at all
     // would have got the default TTL.
     assertIdentical(heldForSec(policy, { expires: "0" }), 0);
+
+    // And a date in a format HTTP does not allow counts the same way, however
+    // far in the future JavaScript's own parser would put it.
+    assertIdentical(heldForSec(policy, { expires: "12/31/2099" }), 0);
+    assertIdentical(heldForSec(policy, { expires: "2026-08-29T13:00:00Z" }), 0);
+    assertIdentical(
+      heldForSec(policy, { expires: "Sat, 32 Aug 2026 13:00:00 GMT" }),
+      0,
+    );
+  });
+
+  it("reads the two obsolete HTTP date formats as GMT", () => {
+    // Given a policy that grants whatever an Origin asks for.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 86_400,
+      maxTtlSec: 86_400,
+    });
+
+    // Then an RFC 850 date an hour out is an hour, and so is an asctime one,
+    // which states no zone of its own.
+    assertIdentical(
+      heldForSec(policy, { expires: "Saturday, 29-Aug-26 13:00:00 GMT" }),
+      3600,
+    );
+    assertIdentical(
+      heldForSec(policy, { expires: "Sat Aug 29 13:00:00 2026" }),
+      3600,
+    );
   });
 
   it("caps an Expires header at the policy's MaxTTL", () => {

--- a/src/service/cloudfront/cache/sim-cf-cache-ttl.iso.test.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-ttl.iso.test.ts
@@ -1,0 +1,231 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCloudFrontCachePolicy } from "../cache-policy/sim-cf-cache-policy.js";
+import { simCfCacheTtlSec } from "./sim-cf-cache-ttl.js";
+
+const now = new Date("2026-08-29T12:00:00.000Z");
+
+/**
+ * The seconds a policy holds an Origin answer carrying these headers for.
+ */
+function heldForSec(
+  policy: SimCloudFrontCachePolicy,
+  headers: Record<string, string> = {},
+): number {
+  return simCfCacheTtlSec({
+    response: new Response("<h1>Home</h1>", { headers }),
+    policy,
+    now,
+  });
+}
+
+describe("How long a sim CloudFront Distribution holds an Origin's answer", () => {
+  it("holds an answer carrying no cache header for the policy's default TTL", () => {
+    // Given a policy with an hour of default TTL and no floor under it.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 3600,
+      maxTtlSec: 86_400,
+    });
+
+    // Then an Origin that asked for nothing gets the default.
+    assertIdentical(heldForSec(policy), 3600);
+  });
+
+  it("raises an answer carrying no cache header to a MinTTL above the default", () => {
+    // Given a policy whose floor sits above its default TTL.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 7200,
+      defaultTtlSec: 3600,
+      maxTtlSec: 86_400,
+    });
+
+    // Then the floor is what an Origin asking for nothing gets. CloudFront
+    // takes the greater of the two.
+    assertIdentical(heldForSec(policy), 7200);
+  });
+
+  it("takes the max-age an Origin asked for, between the policy's TTLs", () => {
+    // Given a policy holding anything from a minute to a day.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 60,
+      defaultTtlSec: 3600,
+      maxTtlSec: 86_400,
+    });
+
+    // Then an hour asked for inside that range is an hour, a minute asked for
+    // under the floor is the floor, and a week asked for over the ceiling is
+    // the ceiling.
+    assertIdentical(
+      heldForSec(policy, { "cache-control": "max-age=3600" }),
+      3600,
+    );
+    assertIdentical(heldForSec(policy, { "cache-control": "max-age=5" }), 60);
+    assertIdentical(
+      heldForSec(policy, { "cache-control": "max-age=604800" }),
+      86_400,
+    );
+  });
+
+  it("prefers s-maxage to max-age", () => {
+    // Given a policy that grants whatever an Origin asks for.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 3600,
+      maxTtlSec: 86_400,
+    });
+
+    // Then the shared cache directive decides, and the browser's is left to
+    // the browser.
+    assertIdentical(
+      heldForSec(policy, { "cache-control": "max-age=60, s-maxage=600" }),
+      600,
+    );
+  });
+
+  it("prefers max-age to an Expires header", () => {
+    // Given a policy that grants whatever an Origin asks for, and an Origin
+    // naming both a max-age and an hour-away expiry.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 86_400,
+      maxTtlSec: 86_400,
+    });
+
+    // Then the directive decides and the header is left alone.
+    assertIdentical(
+      heldForSec(policy, {
+        "cache-control": "max-age=60",
+        expires: "Sat, 29 Aug 2026 13:00:00 GMT",
+      }),
+      60,
+    );
+  });
+
+  it("holds an answer until the instant its Expires header names", () => {
+    // Given a policy that grants whatever an Origin asks for.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 86_400,
+      maxTtlSec: 86_400,
+    });
+
+    // Then an expiry an hour out is an hour, and one already gone by is no
+    // time at all.
+    assertIdentical(
+      heldForSec(policy, { expires: "Sat, 29 Aug 2026 13:00:00 GMT" }),
+      3600,
+    );
+    assertIdentical(
+      heldForSec(policy, { expires: "Sat, 29 Aug 2026 11:00:00 GMT" }),
+      0,
+    );
+  });
+
+  it("reads an Expires header that is not a date as already expired", () => {
+    // Given a policy that would otherwise hold the answer for a day.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 86_400,
+      maxTtlSec: 86_400,
+    });
+
+    // Then the answer is held for no time. An Origin naming no expiry at all
+    // would have got the default TTL.
+    assertIdentical(heldForSec(policy, { expires: "0" }), 0);
+  });
+
+  it("caps an Expires header at the policy's MaxTTL", () => {
+    // Given a policy holding nothing for longer than a minute.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 60,
+      maxTtlSec: 60,
+    });
+
+    // Then an expiry an hour out is held for the minute the policy allows.
+    assertIdentical(
+      heldForSec(policy, { expires: "Sat, 29 Aug 2026 13:00:00 GMT" }),
+      60,
+    );
+  });
+
+  it("stores nothing an Origin refused, where the policy has no floor", () => {
+    // Given a policy that would otherwise hold an answer for an hour.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 3600,
+      maxTtlSec: 86_400,
+    });
+
+    // Then each of the three refusals is respected, whatever else the Origin
+    // asked for alongside it.
+    assertIdentical(heldForSec(policy, { "cache-control": "no-store" }), 0);
+    assertIdentical(heldForSec(policy, { "cache-control": "no-cache" }), 0);
+    assertIdentical(
+      heldForSec(policy, { "cache-control": "private, max-age=600" }),
+      0,
+    );
+  });
+
+  it("holds an answer an Origin refused for a policy's MinTTL", () => {
+    // Given a policy holding nothing for less than five minutes.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 300,
+      defaultTtlSec: 3600,
+      maxTtlSec: 86_400,
+    });
+
+    // Then the floor overrides the Origin. AWS carries a warning about this.
+    assertIdentical(heldForSec(policy, { "cache-control": "no-store" }), 300);
+  });
+
+  it("reads a directive that names no whole number of seconds as absent", () => {
+    // Given a policy with an hour of default TTL.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 3600,
+      maxTtlSec: 86_400,
+    });
+
+    // Then a max-age naming something other than seconds falls through to the
+    // default, and one naming nothing at all does the same.
+    assertIdentical(
+      heldForSec(policy, { "cache-control": "max-age=soon" }),
+      3600,
+    );
+    assertIdentical(heldForSec(policy, { "cache-control": "max-age=" }), 3600);
+    assertIdentical(
+      heldForSec(policy, { "cache-control": "max-age=-60" }),
+      3600,
+    );
+  });
+
+  it("reads directives whatever their case, spacing and quoting", () => {
+    // Given a policy that grants whatever an Origin asks for.
+    const policy = new SimCloudFrontCachePolicy({
+      name: "BeaconPolicy",
+      minTtlSec: 0,
+      defaultTtlSec: 86_400,
+      maxTtlSec: 86_400,
+    });
+
+    // Then a header CloudFront would read is read the same way here.
+    assertIdentical(
+      heldForSec(policy, { "cache-control": ' Public , S-MaxAge = "600" ,' }),
+      600,
+    );
+  });
+});

--- a/src/service/cloudfront/cache/sim-cf-cache-ttl.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-ttl.ts
@@ -1,0 +1,71 @@
+import type { SimCloudFrontCachePolicy } from "../cache-policy/sim-cf-cache-policy.js";
+import { simCfCacheControl } from "./sim-cf-cache-control.js";
+
+interface SimCfCacheTtlProperties {
+  /** The response the Origin answered with, whose headers carry the ask. */
+  readonly response: Response;
+
+  /** The Behavior's cache policy, whose three TTLs decide the answer. */
+  readonly policy: SimCloudFrontCachePolicy;
+
+  /** Now, off the simulation's clock, which `Expires` is measured from. */
+  readonly now: Date;
+}
+
+/**
+ * How many seconds a Distribution holds this response for. Zero says it holds
+ * it not at all.
+ *
+ * The Origin asks and the policy decides how much of the ask to grant. An
+ * Origin naming a duration gets it held between the policy's `MinTTL` and
+ * `MaxTTL`, and one naming none gets the greater of `MinTTL` and `DefaultTTL`.
+ * `s-maxage` is preferred to `max-age`, and `max-age` to `Expires`, which is
+ * the order CloudFront reads them in.
+ *
+ * `no-store`, `no-cache` and `private` are respected where `MinTTL` is 0, and
+ * held for `MinTTL` where it is higher. That last one is CloudFront's own
+ * surprise. A policy with a floor overrides an Origin that asked for nothing to
+ * be stored.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html
+ */
+export function simCfCacheTtlSec(properties: SimCfCacheTtlProperties): number {
+  const { response, policy, now } = properties;
+  const control = simCfCacheControl(response.headers.get("cache-control"));
+
+  if (control.uncacheable) {
+    return policy.minTtlSec;
+  }
+
+  const asked =
+    control.sharedMaxAgeSec ??
+    control.maxAgeSec ??
+    expiresTtlSec(response, now);
+
+  if (asked === undefined) {
+    return Math.max(policy.minTtlSec, policy.defaultTtlSec);
+  }
+
+  return Math.min(Math.max(asked, policy.minTtlSec), policy.maxTtlSec);
+}
+
+/**
+ * The seconds left until the `Expires` header's instant, or none where the
+ * response carries no such header.
+ *
+ * A date already gone by counts as no seconds, which the policy's `MinTTL`
+ * then raises where it has one. A value that is not a date counts the same
+ * way, following RFC 9111, which reads an unparsable `Expires` as an object
+ * that has already expired.
+ */
+function expiresTtlSec(response: Response, now: Date): number | undefined {
+  const expires = response.headers.get("expires");
+
+  if (expires === null) {
+    return undefined;
+  }
+
+  const instant = Date.parse(expires);
+
+  return Number.isNaN(instant) ? 0 : (instant - now.getTime()) / 1000;
+}

--- a/src/service/cloudfront/cache/sim-cf-cache-ttl.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-ttl.ts
@@ -1,5 +1,6 @@
 import type { SimCloudFrontCachePolicy } from "../cache-policy/sim-cf-cache-policy.js";
 import { simCfCacheControl } from "./sim-cf-cache-control.js";
+import { simCfHttpDateInstant } from "./sim-cf-http-date.js";
 
 interface SimCfCacheTtlProperties {
   /** The response the Origin answered with, whose headers carry the ask. */
@@ -54,9 +55,9 @@ export function simCfCacheTtlSec(properties: SimCfCacheTtlProperties): number {
  * response carries no such header.
  *
  * A date already gone by counts as no seconds, which the policy's `MinTTL`
- * then raises where it has one. A value that is not a date counts the same
- * way, following RFC 9111, which reads an unparsable `Expires` as an object
- * that has already expired.
+ * then raises where it has one. A value that is not an HTTP date counts the
+ * same way, following RFC 9111, which reads an unparsable `Expires` as an
+ * object that has already expired.
  */
 function expiresTtlSec(response: Response, now: Date): number | undefined {
   const expires = response.headers.get("expires");
@@ -65,7 +66,7 @@ function expiresTtlSec(response: Response, now: Date): number | undefined {
     return undefined;
   }
 
-  const instant = Date.parse(expires);
+  const instant = simCfHttpDateInstant(expires.trim());
 
-  return Number.isNaN(instant) ? 0 : (instant - now.getTime()) / 1000;
+  return instant === undefined ? 0 : (instant - now.getTime()) / 1000;
 }

--- a/src/service/cloudfront/cache/sim-cf-cacheable-request.ts
+++ b/src/service/cloudfront/cache/sim-cf-cacheable-request.ts
@@ -1,4 +1,5 @@
 import type { SimCloudFrontBehavior } from "../behaviour/sim-cloud-front-behavior.js";
+import type { SimCloudFrontCachePolicy } from "../cache-policy/sim-cf-cache-policy.js";
 import type { SimCloudFront } from "../sim-cloudfront.js";
 import { simCfCacheEntryKey } from "./sim-cf-cache-entry-key.js";
 
@@ -10,8 +11,22 @@ interface SimCfCacheableRequestProperties {
 }
 
 /**
- * The key this request is cached under, or none where the Behavior caches
- * nothing.
+ * A request the Behavior caches, and what decides for how long.
+ */
+export interface SimCfCacheableRequest {
+  /** The key the request is cached under. */
+  readonly key: string;
+
+  /**
+   * The policy the key came from, whose TTLs settle how long the Origin's
+   * answer is held.
+   */
+  readonly policy: SimCloudFrontCachePolicy;
+}
+
+/**
+ * The key this request is cached under and the policy that decided it, or none
+ * where the Behavior caches nothing.
  *
  * Three things stop a Behavior caching. Its cache policy may be one this
  * simulation does not hold, including the Behavior that names no policy at
@@ -21,9 +36,9 @@ interface SimCfCacheableRequestProperties {
  * be outside the Behavior's `CachedMethods`, which is CloudFront's own rule
  * that a POST is never served from a cache.
  */
-export function simCfCacheableKey(
+export function simCfCacheableRequest(
   properties: SimCfCacheableRequestProperties,
-): string | undefined {
+): SimCfCacheableRequest | undefined {
   const { cloudFront, behaviour, request, edgeId } = properties;
 
   if (!cloudFront.cachingEnabled) {
@@ -43,5 +58,8 @@ export function simCfCacheableKey(
     return undefined;
   }
 
-  return simCfCacheEntryKey({ request, cacheKey: policy.cacheKey, edgeId });
+  return {
+    key: simCfCacheEntryKey({ request, cacheKey: policy.cacheKey, edgeId }),
+    policy,
+  };
 }

--- a/src/service/cloudfront/cache/sim-cf-distribution-cache.ts
+++ b/src/service/cloudfront/cache/sim-cf-distribution-cache.ts
@@ -1,3 +1,5 @@
+import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
+
 /**
  * A response as a Distribution holds it, rather than as a stream something has
  * already read.
@@ -11,6 +13,18 @@ interface SimCfCachedResponse {
   readonly statusText: string;
   readonly headers: readonly (readonly [string, string])[];
   readonly body: Uint8Array;
+
+  /**
+   * When the entry was stored, off the simulation's clock. This is what the
+   * `Age` header a hit carries will be measured from.
+   */
+  readonly storedAt: Date;
+
+  /**
+   * The instant the entry stops being served. A request arriving on or after
+   * it reaches the Origin.
+   */
+  readonly expiresAt: Date;
 }
 
 /**
@@ -26,35 +40,72 @@ const bodylessStatuses = new Set([101, 103, 204, 205, 304]);
  * per Distribution, which the edge in the key stands for. One cache holds an
  * entry per edge, and a request arriving at another edge misses.
  *
- * Nothing expires. There is no TTL here yet, so an entry stays until something
- * removes it, and the cache policy's TTLs decide only whether a Behavior
- * caches at all.
+ * An entry expires on the simulation's clock rather than the host's. A test
+ * reaches the instant an object goes stale by advancing simulated time, with no
+ * waiting. Storing takes its seconds from the caller. An Origin's answer is held
+ * for what its cache policy allows, and an error's own `ErrorCachingMinTTL`
+ * fits the same call.
  */
 export class SimCfDistributionCache {
   private readonly entries = new Map<string, SimCfCachedResponse>();
+  private readonly clock: SimClock;
+
+  /**
+   * A cache built standalone, outside a Distribution, falls back to the real
+   * clock.
+   */
+  constructor(clock: SimClock = new SimRealClock()) {
+    this.clock = clock;
+  }
 
   /**
    * The response cached under a key, or none where the cache does not hold it.
+   *
+   * An entry that has reached its expiry is dropped here. The request then goes
+   * to the Origin, and what the Origin answers replaces the expired entry.
    */
   read(key: string): Response | undefined {
     const entry = this.entries.get(key);
 
-    return entry === undefined ? undefined : cachedResponse(entry);
+    if (entry === undefined) {
+      return undefined;
+    }
+
+    if (this.clock.now().getTime() >= entry.expiresAt.getTime()) {
+      this.entries.delete(key);
+
+      return undefined;
+    }
+
+    return cachedResponse(entry);
   }
 
   /**
-   * Cache a response under a key, and hand back one to carry on with.
+   * Cache a response under a key for a number of seconds, and hand back one to
+   * carry on with.
    *
    * Storing reads the response's body, which can only happen once, so the
    * response the caller continues with is built from the bytes that were
-   * stored rather than being the one passed in.
+   * stored rather than being the one passed in. A TTL of no seconds stores
+   * nothing, and the response passed in is handed straight back unread.
    */
-  async store(key: string, response: Response): Promise<Response> {
+  async store(
+    key: string,
+    response: Response,
+    ttlSec: number,
+  ): Promise<Response> {
+    if (!Number.isFinite(ttlSec) || ttlSec <= 0) {
+      return response;
+    }
+
+    const storedAt = this.clock.now();
     const entry: SimCfCachedResponse = {
       status: response.status,
       statusText: response.statusText,
       headers: [...response.headers],
       body: new Uint8Array(await response.arrayBuffer()),
+      storedAt,
+      expiresAt: new Date(storedAt.getTime() + ttlSec * 1000),
     };
 
     this.entries.set(key, entry);

--- a/src/service/cloudfront/cache/sim-cf-http-date.ts
+++ b/src/service/cloudfront/cache/sim-cf-http-date.ts
@@ -1,0 +1,50 @@
+/**
+ * IMF-fixdate, which every sender is required to use. `Sun, 06 Nov 1994
+ * 08:49:37 GMT`.
+ */
+const imfFixdate =
+  /^[A-Za-z]{3}, \d{2} [A-Za-z]{3} \d{4} \d{2}:\d{2}:\d{2} GMT$/;
+
+/**
+ * The obsolete RFC 850 format, which a recipient still has to read.
+ * `Sunday, 06-Nov-94 08:49:37 GMT`.
+ */
+const rfc850Date =
+  /^[A-Za-z]{6,9}, \d{2}-[A-Za-z]{3}-\d{2} \d{2}:\d{2}:\d{2} GMT$/;
+
+/**
+ * The obsolete asctime format, which carries no zone. `Sun Nov  6 08:49:37
+ * 1994`.
+ */
+const asctimeDate =
+  /^[A-Za-z]{3} ([A-Za-z]{3}) {1,2}(\d{1,2}) (\d{2}:\d{2}:\d{2}) (\d{4})$/;
+
+/**
+ * The instant an HTTP date names, in milliseconds, or none where the value is
+ * not one of the three formats HTTP allows.
+ *
+ * The check matters because `Date.parse` reads far more than HTTP does. It
+ * takes `12/31/2099` as a date in 2099 and `0` as the start of the year 2000,
+ * and an HTTP cache is required to treat both as an object that has already
+ * expired.
+ *
+ * asctime states no zone and HTTP reads it as GMT, while `Date.parse` would
+ * read it in the host's own. It is rewritten with the zone spelled out.
+ *
+ * https://www.rfc-editor.org/rfc/rfc9110#name-date-time-formats
+ */
+export function simCfHttpDateInstant(value: string): number | undefined {
+  const asctime = asctimeDate.exec(value);
+  const parsable =
+    asctime === null
+      ? value
+      : `${asctime[2]} ${asctime[1]} ${asctime[4]} ${asctime[3]} GMT`;
+
+  if (asctime === null && !imfFixdate.test(value) && !rfc850Date.test(value)) {
+    return undefined;
+  }
+
+  const instant = Date.parse(parsable);
+
+  return Number.isNaN(instant) ? undefined : instant;
+}

--- a/src/service/cloudfront/controller/content/sim-cf-cache-expiry.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-cache-expiry.iso.test.ts
@@ -1,0 +1,188 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimCloudFrontCachePolicy } from "../../cache-policy/sim-cf-cache-policy.js";
+import {
+  cacheHeaderOrigin,
+  countingOrigin,
+  distributionServing,
+  type OriginReads,
+  readNumber,
+} from "../../../../../test/cloudfront/cache-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+/**
+ * A policy of the simulation's own, for the TTLs a managed one does not carry.
+ */
+function beaconPolicy(
+  simAws: SimAws,
+  ttls: { minTtlSec: number; defaultTtlSec: number; maxTtlSec: number },
+): string {
+  const policy = new SimCloudFrontCachePolicy({
+    name: "BeaconPolicy",
+    ...ttls,
+  });
+  simAws.cloudFront().addCachePolicy(policy);
+
+  return policy.id;
+}
+
+describe("When a sim CloudFront Distribution's cached object expires", () => {
+  it("reaches the Origin once the max-age it asked for has passed", async () => {
+    // Given a Distribution in front of an Origin holding its answers for a
+    // minute.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await cacheHeaderOrigin(simAws, reads, { "cache-control": "max-age=60" }),
+    );
+    await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // When simulated time moves on by less than that minute.
+    await simAws.clock().advanceBy({ seconds: 59 });
+    const held = await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // Then the cache is still answering.
+    assertIdentical(await readNumber(held), 1);
+    assertIdentical(reads.count, 1);
+
+    // And when simulated time moves past the minute.
+    await simAws.clock().advanceBy({ seconds: 2 });
+    const expired = await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // Then the request reached the Origin.
+    assertIdentical(await readNumber(expired), 2);
+    assertIdentical(reads.count, 2);
+  });
+
+  it("holds an answer carrying no cache header for the policy's default TTL", async () => {
+    // Given a Distribution on CachingOptimized, whose default TTL is a day, in
+    // front of an Origin that asks for nothing.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // When simulated time moves on by less than a day.
+    await simAws.clock().advanceBy({ hours: 23 });
+    const held = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the cache is still answering.
+    assertIdentical(await readNumber(held), 1);
+
+    // And when simulated time moves past the day.
+    await simAws.clock().advanceBy({ hours: 2 });
+    const expired = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the request reached the Origin.
+    assertIdentical(await readNumber(expired), 2);
+  });
+
+  it("replaces the expired entry with what the Origin answers next", async () => {
+    // Given a Distribution whose only cached answer has expired.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await cacheHeaderOrigin(simAws, reads, { "cache-control": "max-age=60" }),
+    );
+    await simCfSiteRequest(simAws, distributionId, "/beacon");
+    await simAws.clock().advanceBy({ seconds: 61 });
+    await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // When the same path is asked for again inside the new minute.
+    await simAws.clock().advanceBy({ seconds: 30 });
+    const served = await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // Then the second read is what the cache holds. The first one is gone.
+    assertIdentical(await readNumber(served), 2);
+    assertIdentical(reads.count, 2);
+  });
+
+  it("stores nothing an Origin refused, where the policy has no floor", async () => {
+    // Given a policy that would hold an answer for an hour, and an Origin
+    // asking for its answers not to be stored.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const originHostname = await cacheHeaderOrigin(simAws, reads, {
+      "cache-control": "no-store",
+    });
+    const distributionId = await distributionServing(simAws, originHostname, {
+      CachePolicyId: beaconPolicy(simAws, {
+        minTtlSec: 0,
+        defaultTtlSec: 3600,
+        maxTtlSec: 86_400,
+      }),
+    });
+
+    // When the same path is asked for twice, with no time passing between.
+    await simCfSiteRequest(simAws, distributionId, "/beacon");
+    const second = await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // Then both requests reached the Origin.
+    assertIdentical(await readNumber(second), 2);
+    assertIdentical(reads.count, 2);
+  });
+
+  it("holds an answer an Origin refused for the policy's MinTTL", async () => {
+    // Given a policy holding nothing for less than five minutes, in front of
+    // an Origin asking for its answers not to be stored.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const originHostname = await cacheHeaderOrigin(simAws, reads, {
+      "cache-control": "no-store",
+    });
+    const distributionId = await distributionServing(simAws, originHostname, {
+      CachePolicyId: beaconPolicy(simAws, {
+        minTtlSec: 300,
+        defaultTtlSec: 3600,
+        maxTtlSec: 86_400,
+      }),
+    });
+    await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // When simulated time moves on by less than the floor.
+    await simAws.clock().advanceBy({ seconds: 299 });
+    const held = await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // Then the floor overrode the Origin, as it does in CloudFront.
+    assertIdentical(await readNumber(held), 1);
+
+    // And when simulated time moves past the floor.
+    await simAws.clock().advanceBy({ seconds: 2 });
+    const expired = await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // Then the request reached the Origin.
+    assertIdentical(await readNumber(expired), 2);
+  });
+
+  it("caps what an Origin asked for at the policy's MaxTTL", async () => {
+    // Given a policy holding nothing for longer than a minute, in front of an
+    // Origin asking for an hour.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const originHostname = await cacheHeaderOrigin(simAws, reads, {
+      "cache-control": "max-age=3600",
+    });
+    const distributionId = await distributionServing(simAws, originHostname, {
+      CachePolicyId: beaconPolicy(simAws, {
+        minTtlSec: 0,
+        defaultTtlSec: 60,
+        maxTtlSec: 60,
+      }),
+    });
+    await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // When simulated time moves past the ceiling but not past the hour.
+    await simAws.clock().advanceBy({ seconds: 61 });
+    const expired = await simCfSiteRequest(simAws, distributionId, "/beacon");
+
+    // Then the request reached the Origin.
+    assertIdentical(await readNumber(expired), 2);
+  });
+});

--- a/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
@@ -1,4 +1,5 @@
-import { simCfCacheableKey } from "../../cache/sim-cf-cacheable-request.js";
+import { simCfCacheableRequest } from "../../cache/sim-cf-cacheable-request.js";
+import { simCfCacheTtlSec } from "../../cache/sim-cf-cache-ttl.js";
 import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
 import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
@@ -27,15 +28,15 @@ export interface SimCfContentRequest {
  * Answers a request from the Distribution's cache, or from the Origin.
  *
  * This is CloudFront's cache lookup and everything behind it. A key the cache
- * already holds is answered with the Origin left unread. A miss goes to the
+ * holds unexpired is answered with the Origin left unread. A miss goes to the
  * Origin, has an error replaced with the Distribution's custom error page, and
- * is stored under the key it missed on.
+ * is stored under the key it missed on for as long as the Origin's headers and
+ * the cache policy between them allow.
  *
  * An error stays out of the cache, whether the Origin answered with it or an
  * origin-response function made one of an Origin's answer. Real CloudFront
- * holds one for `ErrorCachingMinTTL`, which wants a TTL this simulation has yet
- * to keep. Caching an error with no expiry would leave a Distribution answering
- * with it for the length of the test.
+ * holds one for `ErrorCachingMinTTL`, which is a TTL of its own rather than the
+ * one the Origin's headers ask for.
  */
 export class SimCfContentStage {
   constructor(
@@ -48,8 +49,11 @@ export class SimCfContentStage {
    */
   async serve(content: SimCfContentRequest): Promise<SimCfOriginStageResult> {
     const { request, distribution, behaviour } = content;
-    const key = simCfCacheableKey(content);
-    const cached = key === undefined ? undefined : distribution.cache.read(key);
+    const cacheable = simCfCacheableRequest(content);
+    const cached =
+      cacheable === undefined
+        ? undefined
+        : distribution.cache.read(cacheable.key);
 
     // A hit is answered as the Origin answered it when it was stored, so the
     // status the pipeline reads is the cached one and a viewer-response
@@ -70,7 +74,7 @@ export class SimCfContentStage {
     );
 
     if (
-      key === undefined ||
+      cacheable === undefined ||
       originResult.originStatus >= 400 ||
       response.status >= 400
     ) {
@@ -78,7 +82,15 @@ export class SimCfContentStage {
     }
 
     return {
-      response: await distribution.cache.store(key, response),
+      response: await distribution.cache.store(
+        cacheable.key,
+        response,
+        simCfCacheTtlSec({
+          response,
+          policy: cacheable.policy,
+          now: distribution.clock.now(),
+        }),
+      ),
       originStatus: originResult.originStatus,
     };
   }

--- a/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
+++ b/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
@@ -26,8 +26,9 @@ interface SimCloudFrontDistributionProperties {
   readonly accountId?: SimAwsAccountId;
   readonly distributionConfig?: SimCloudFrontDistributionConfig;
   /**
-   * Clock stamping this Distribution's last modified time. A Distribution built
-   * standalone, outside a SimAws instance, falls back to the real clock.
+   * Clock stamping this Distribution's last modified time and expiring what its
+   * cache holds. A Distribution built standalone, outside a SimAws instance,
+   * falls back to the real clock.
    */
   readonly clock?: SimClock;
 }
@@ -43,13 +44,18 @@ export class SimCloudFrontDistribution {
   public readonly lastModifiedTime: Date;
 
   /**
+   * The clock this Distribution reads, which its cache expires on.
+   */
+  public readonly clock: SimClock;
+
+  /**
    * What this Distribution has cached, keyed by cache key.
    *
    * A configuration update leaves it alone, as it leaves a real
    * Distribution's cached objects alone: an object cached under the old
-   * configuration is served until something removes it.
+   * configuration is served until it expires or something removes it.
    */
-  public readonly cache = new SimCfDistributionCache();
+  public readonly cache: SimCfDistributionCache;
 
   #status: SimCloudFrontDistributionStatus;
   #distributionConfig: SimCloudFrontDistributionConfig | undefined;
@@ -70,6 +76,8 @@ export class SimCloudFrontDistribution {
       clock = new SimRealClock(),
     } = properties;
 
+    this.clock = clock;
+    this.cache = new SimCfDistributionCache(clock);
     this.lastModifiedTime = clock.now();
     this.distributionId = distributionId;
     this.#status = status;

--- a/test/cloudfront/cache-fixture.ts
+++ b/test/cloudfront/cache-fixture.ts
@@ -108,6 +108,27 @@ export async function readNumber(response: Response): Promise<number> {
 }
 
 /**
+ * An Origin answering with the number of the read that answered, under the
+ * cache headers the test is about, so that a test can say how long the
+ * Distribution should hold what it gets.
+ */
+export async function cacheHeaderOrigin(
+  simAws: SimAws,
+  reads: OriginReads,
+  headers: Record<string, string>,
+): Promise<string> {
+  return await functionUrlHostname(simAws, "cache-header-origin", () => {
+    reads.count += 1;
+
+    return {
+      statusCode: 200,
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify({ read: reads.count }),
+    };
+  });
+}
+
+/**
  * An Origin answering with a status per read, so that a test can have the
  * first read fail and the second one answer.
  */


### PR DESCRIPTION
Resolves #1150.

A cached object now records the instant it expires, taken from the simulation's clock, and a request arriving after that instant reaches the Origin. Advancing simulated time is all a test needs to watch a page go stale, and an expired entry is replaced by the Origin's next answer rather than served beside it. The TTL comes from the Origin's response and the cache policy together, following the table in [the AWS expiration documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html): `s-maxage` beats `max-age`, `max-age` beats `Expires`, and whatever the Origin asks for is held between the policy's `MinTTL` and `MaxTTL`. An Origin that asks for nothing gets the greater of `MinTTL` and `DefaultTTL`. `no-store`, `no-cache` and `private` keep the answer out of the cache while `MinTTL` is zero, and are overridden by the floor where it is higher, which is the surprise AWS warns about under that table.

`SimCfDistributionCache.store` takes its seconds from the caller rather than reading a policy itself, so #1153 can hold an error for its `ErrorCachingMinTTL` through the same call. The entry records when it was stored alongside when it expires, which is the instant the `Age` header in #1151 will be measured from.

The limitations list gains what is still missing. An expired entry is fetched again rather than revalidated, so there is no conditional request and no `304 Not Modified` path, and `Stale-While-Revalidate` and `Stale-If-Error` are read as no directive at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added realistic CloudFront cache expiration based on origin headers and cache policies.
  - Supports TTL rules for `s-maxage`, `max-age`, `Expires`, and policy minimum/default/maximum limits.
  - Expired cached responses are refetched and replaced automatically.
  - Honors `no-store`, `no-cache`, and `private` directives; error responses remain uncached.
  - Added simulated-clock support for testing and demonstrations.

- **Documentation**
  - Expanded CloudFront caching documentation with expiration behavior, limitations, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->