### PR TITLE
feat: send an Origin only what a policy names

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -3131,8 +3131,10 @@ for it. CDK's `OriginRequestPolicy.ALL_VIEWER` and its seven siblings synthesize
 reaching for one deploys.
 
 Each also carries the three sections AWS publishes for it. A Behavior on `AllViewer` here sends the
-Origin everything the viewer sent, one on `CORS-CustomOrigin` sends the `Origin` header alone, and
-one on `AllViewerExceptHostHeader` sends everything else the viewer sent.
+Origin everything the viewer sent bar its `Host`, which is the Origin's own domain under every
+policy. One on `CORS-CustomOrigin` sends the `Origin` header alone. One on
+`AllViewerExceptHostHeader` sends what `AllViewer` sends, since the `Host` it withholds was never
+the viewer's here.
 
 The managed policies sit in CloudFront's own namespace. A template may create a policy called
 `AllViewer` of its own, and deleting that stack leaves the managed one where it was.

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2931,14 +2931,189 @@ console.log(
 A Behavior records the ID it was given, and `GetDistribution` reports it back for both the default
 Behavior and a named one. An update changing the policy is reported the same way.
 
-Nothing here reads the policy itself. Sim CloudFront forwards the viewer's headers, cookies and
-query string to the Origin whole, whatever the policy would have narrowed them to on real
-CloudFront.
-
 A policy name is unique within an account, as it is in CloudFront. A second
 `AWS::CloudFront::OriginRequestPolicy` claiming a name is refused with
-`OriginRequestPolicyAlreadyExists`. `Name` and `Comment` are the parts of
-`OriginRequestPolicyConfig` the policy carries.
+`OriginRequestPolicyAlreadyExists`.
+
+`HeadersConfig`, `CookiesConfig` and `QueryStringsConfig` are read along with `Name` and `Comment`.
+`CookieBehavior` and `QueryStringBehavior` each take `none`, `whitelist`, `allExcept` and `all`.
+`HeaderBehavior` takes `none`, `whitelist`, `allExcept`, `allViewer` and
+`allViewerAndWhitelistCloudFront`. An absent section falls back to `none`. A section naming a
+behaviour CloudFront does not offer fails the Stack, naming the Resource.
+
+### What a custom Origin is sent
+
+A custom Origin is sent the headers, cookies and query strings the Behavior's cache policy and
+origin request policy name between them, and none of the rest of the viewer's request. That union is
+what real CloudFront sends. The cache policy half is in it because an Origin has to be able to
+answer for the key its response is stored under.
+
+Alongside it CloudFront sends what it sends of its own accord. `Host` is the Origin's own domain,
+whatever the policies name (a viewer's own `Host` never reaches an Origin here, so
+`AllViewerExceptHostHeader` and `AllViewer` reach a Function URL Origin alike).
+`User-Agent` is `Amazon CloudFront` unless the policies carry the viewer's own. `Accept-Encoding` is
+the normalized `gzip`, `br` or `gzip, br` the cache policy's `EnableAcceptEncoding` flags asked for.
+`Content-Length`, `Content-Type` and `Transfer-Encoding` describe the body and travel with it. The
+Origin's custom headers and its origin access control's signing headers are applied on top.
+
+```typescript sim-cloudfront-origin-request-forwarding
+/**
+ * What a custom Origin reads of the viewer's request, with and without an
+ * origin request policy.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+// A function reporting the query string and the user agent it was asked with.
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "search",
+    Role: "arn:aws:iam::111111111111:role/SearchRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: {
+          rawQueryString: string;
+          headers: Record<string, string>;
+        }) => ({
+          query: event.rawQueryString,
+          userAgent: event.headers["user-agent"],
+        }),
+      ),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "search", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /search",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /open/search",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "search",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+// Two Behaviors on the same Origin. The default names no policy, and /open/*
+// names AllViewer, one of CloudFront's managed policies.
+const distributionCreation = await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "search-site",
+      Comment: "Search CDN",
+      Enabled: true,
+      Origins: {
+        Quantity: 1,
+        Items: [
+          {
+            Id: "api-origin",
+            DomainName: new URL(ApiEndpoint).hostname,
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "api-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+      CacheBehaviors: {
+        Quantity: 1,
+        Items: [
+          {
+            PathPattern: "/open/*",
+            TargetOriginId: "api-origin",
+            ViewerProtocolPolicy: "allow-all",
+            OriginRequestPolicyId: "216adef6-5c7f-47e4-b989-5492eafa07d3",
+          },
+        ],
+      },
+    },
+  }),
+);
+
+const distroHostname = distributionCreation.Distribution!.DomainName!;
+const srv = await serveSimAws({ simAws });
+
+try {
+  const withheld = await fetch(
+    srv.localUrl(`http://${distroHostname}/search?q=kettle`),
+    { headers: { "user-agent": "Firefox" } },
+  );
+
+  // {"query":"","userAgent":"Amazon CloudFront"}
+  console.log(await withheld.text());
+
+  const forwarded = await fetch(
+    srv.localUrl(`http://${distroHostname}/open/search?q=kettle`),
+    { headers: { "user-agent": "Firefox" } },
+  );
+
+  // {"query":"q=kettle","userAgent":"Firefox"}
+  console.log(await forwarded.text());
+} finally {
+  await srv.close();
+}
+```
+
+A Behavior naming neither policy sends the path and nothing else. That is a Distribution CloudFront
+would serve the same way, and an Origin reading a query string behind one is a bug worth a failing
+test.
+
+An S3 Origin is unaffected. It reads its Bucket through GetObject and builds no request to narrow.
 
 ### Managed origin request policies
 
@@ -2954,6 +3129,10 @@ Behavior names one without a template creating anything. `AllViewer`
 [AWS publishes](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html)
 for it. CDK's `OriginRequestPolicy.ALL_VIEWER` and its seven siblings synthesize those IDs. A stack
 reaching for one deploys.
+
+Each also carries the three sections AWS publishes for it. A Behavior on `AllViewer` here sends the
+Origin everything the viewer sent, one on `CORS-CustomOrigin` sends the `Origin` header alone, and
+one on `AllViewerExceptHostHeader` sends everything else the viewer sent.
 
 The managed policies sit in CloudFront's own namespace. A template may create a policy called
 `AllViewer` of its own, and deleting that stack leaves the managed one where it was.
@@ -3745,10 +3924,11 @@ Where sim CloudFront knowingly behaves differently from AWS:
   share of real responses carry `Server-Timing`. This simulation adds it to every response once
   `Enabled` is true. A test asserting on it never depends on chance. The header's value is a
   fixed placeholder, since nothing here measures an Origin fetch the way CloudFront's edge does.
-- **An origin request policy is recorded and never applied.** A Behavior's `OriginRequestPolicyId`
-  is checked against the policies this simulation holds and reported back. Sim CloudFront forwards
-  the viewer's headers, cookies and query string to the Origin whole, whatever the policy would
-  have narrowed them to on real CloudFront.
-- **An origin request policy carries its name and its comment, and nothing else.** The
-  `HeadersConfig`, `CookiesConfig` and `QueryStringsConfig` of an
-  `AWS::CloudFront::OriginRequestPolicy` are read past, since nothing here would act on them.
+- **A viewer's `Host` header never reaches an Origin.** Real CloudFront forwards it where a policy
+  names it, which is what `AllViewerExceptHostHeader` exists to stop. Here an Origin request always
+  carries the Origin's own domain as `Host`, since the request has to reach the simulated service
+  its URL names.
+- **CloudFront's own headers are not generated.** `X-Amz-Cf-Id`, `Via`, `X-Forwarded-For` and the
+  `CloudFront-Viewer-*` family are absent from an Origin request, so a policy naming one of them
+  forwards nothing. `Host`, `User-Agent` and the normalized `Accept-Encoding` are the three this
+  simulation sends of its own accord.

--- a/docs/services/cloudfront/sim-cloudfront-origin-request-forwarding.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-origin-request-forwarding.example.ts
@@ -1,0 +1,150 @@
+/**
+ * What a custom Origin reads of the viewer's request, with and without an
+ * origin request policy.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+
+// A function reporting the query string and the user agent it was asked with.
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "search",
+    Role: "arn:aws:iam::111111111111:role/SearchRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: {
+          rawQueryString: string;
+          headers: Record<string, string>;
+        }) => ({
+          query: event.rawQueryString,
+          userAgent: event.headers["user-agent"],
+        }),
+      ),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "search", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /search",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /open/search",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({ ApiId, StageName: "$default", AutoDeploy: true }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "search",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+// Two Behaviors on the same Origin. The default names no policy, and /open/*
+// names AllViewer, one of CloudFront's managed policies.
+const distributionCreation = await simAws.cloudFront().createDistribution(
+  new CreateDistributionCommand({
+    DistributionConfig: {
+      CallerReference: "search-site",
+      Comment: "Search CDN",
+      Enabled: true,
+      Origins: {
+        Quantity: 1,
+        Items: [
+          {
+            Id: "api-origin",
+            DomainName: new URL(ApiEndpoint).hostname,
+            CustomOriginConfig: {
+              HTTPPort: 80,
+              HTTPSPort: 443,
+              OriginProtocolPolicy: "https-only",
+            },
+          },
+        ],
+      },
+      DefaultCacheBehavior: {
+        TargetOriginId: "api-origin",
+        ViewerProtocolPolicy: "allow-all",
+      },
+      CacheBehaviors: {
+        Quantity: 1,
+        Items: [
+          {
+            PathPattern: "/open/*",
+            TargetOriginId: "api-origin",
+            ViewerProtocolPolicy: "allow-all",
+            OriginRequestPolicyId: "216adef6-5c7f-47e4-b989-5492eafa07d3",
+          },
+        ],
+      },
+    },
+  }),
+);
+
+const distroHostname = distributionCreation.Distribution!.DomainName!;
+const srv = await serveSimAws({ simAws });
+
+try {
+  const withheld = await fetch(
+    srv.localUrl(`http://${distroHostname}/search?q=kettle`),
+    { headers: { "user-agent": "Firefox" } },
+  );
+
+  // {"query":"","userAgent":"Amazon CloudFront"}
+  console.log(await withheld.text());
+
+  const forwarded = await fetch(
+    srv.localUrl(`http://${distroHostname}/open/search?q=kettle`),
+    { headers: { "user-agent": "Firefox" } },
+  );
+
+  // {"query":"q=kettle","userAgent":"Firefox"}
+  console.log(await forwarded.text());
+} finally {
+  await srv.close();
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -363,12 +363,11 @@ two `EnableAcceptEncoding` flags, along with the behaviour set each section may 
 `HeadersConfig` is the narrow one, taking `none` and `whitelist` where the other two also take
 `allExcept` and `all`.
 
-`cfn/cache-policy/` reads that half of the Resource. `sim-cfn-cf-cache-policy-section.ts` holds one
-reader for all three sections, along with the field names and the behaviour set each one takes. An
-absent section comes out as `none`, and a behaviour outside the set for its section fails the Stack,
-naming the Resource. `sim-cfn-cf-cache-policy-config.ts` reads the TTLs, giving one the template
-left out the default CloudFront applies, including the two cases where a long `MinTTL` raises the
-`DefaultTTL` and a long `DefaultTTL` raises the `MaxTTL`.
+`cfn/cache-policy/` reads that half of the Resource. `sim-cfn-cf-cache-policy-section.ts` holds the
+field names and the behaviour set each of the three sections takes, and `cfn/policy/` holds the
+reader they share with the origin request policy sections. `sim-cfn-cf-cache-policy-config.ts` reads
+the TTLs, giving one the template left out the default CloudFront applies, including the two cases
+where a long `MinTTL` raises the `DefaultTTL` and a long `DefaultTTL` raises the `MaxTTL`.
 
 `cache/` reads the policy on every request. See the Caching section below.
 
@@ -380,15 +379,32 @@ and update time as the response headers policy refusal does.
 ## Origin request policies
 
 `origin-request-policy/` holds the model and its registry, laid out the same way as the cache
-policies above. A `SimCloudFrontOriginRequestPolicy` is a name, an ID and an optional comment.
-`sim-cf-managed-origin-request-policies.ts` builds CloudFront's eight managed policies under the IDs
-AWS publishes, and the registry keeps them in their own namespace. There is no
+policies above. A `SimCloudFrontOriginRequestPolicy` is a name, an ID, an optional comment and a
+`SimCfOriginRequestForwarding`. `sim-cf-managed-origin-request-policies.ts` builds CloudFront's
+eight managed policies under the IDs AWS publishes, each with the three sections AWS publishes
+beside the ID, and the registry keeps them in their own namespace. There is no
 CreateOriginRequestPolicy command, so `cfn/origin-request-policy/` is the only thing that makes one.
 
-The policy carries nothing of `OriginRequestPolicyConfig` beyond `Name` and `Comment`.
-`HeadersConfig`, `CookiesConfig` and `QueryStringsConfig` decide what an Origin fetch carries, and
-sim CloudFront forwards the viewer's request whole. Recording the ID is what lets a test assert
-which policy a Behavior was given.
+`sim-cf-origin-request-forwarding.ts` holds the three sections of `OriginRequestPolicyConfig` and
+the behaviour set each one may name. `HeadersConfig` is the wide one here, taking `allViewer` and
+`allViewerAndWhitelistCloudFront` on top of the four a cache key section takes.
+
+`cfn/policy/sim-cfn-cf-policy-section.ts` reads one `<name>Config` section for both policy kinds.
+The two write the same fields and differ only in the behaviours each section offers, so
+`cfn/cache-policy/` and `cfn/origin-request-policy/` each hand it their own three specs. An absent
+section comes out as `none`, and a behaviour outside the set for its section fails the Stack, naming
+the Resource.
+
+`sim-cf-forwarded-to-origin.ts` is what an Origin fetch reads. A `SimCfForwardedToOrigin` holds the
+Behavior's cache key and its forwarding together, and answers whether one header, cookie or query
+string travels. CloudFront sends the union of the two, since an Origin has to be able to answer for
+the key its response was stored under. `sim-cf-behavior-forwarded.ts` resolves that pair from a
+Behavior's two policy IDs, per request, as `cache/` resolves the cache policy.
+
+`SimCloudFrontCustomOrigin` holds the two registries and resolves the pair on every fetch, and
+`simCfCustomOriginRequest` narrows the request to it. A Behavior naming neither policy carries
+neither, which is what real CloudFront does with one. The narrowing does not reach
+`SimCloudFrontS3Origin`, which reads its Bucket through GetObject and builds no request to narrow.
 
 `SimCfBehaviorOriginRequestPolicy` refuses an `OriginRequestPolicyId` naming nothing with
 `SimCloudFrontNoSuchOriginRequestPolicy`, at creation and update time as the cache policy refusal

--- a/src/service/cloudfront/cff/sim-cff-search-distribution.fixture.ts
+++ b/src/service/cloudfront/cff/sim-cff-search-distribution.fixture.ts
@@ -5,6 +5,7 @@ import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-ev
 import { simHttpApiLambdaProxyFactory } from "../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { simCfDistroConfigFactory } from "../distribution/sim-cf-distro-config.factory.js";
+import { simCfManagedOriginRequestPolicyIds } from "../origin-request-policy/sim-cf-managed-origin-request-policies.js";
 import { makeCffFunctionCodeInput } from "./function-code-input/cff-function-code-input.js";
 import type { CloudFrontFunction } from "../typings/cloudfront-functions.namespace.js";
 
@@ -50,6 +51,9 @@ export async function searchDistributionUrl(
         DefaultCacheBehavior: {
           TargetOriginId: "SiteOrigin",
           ViewerProtocolPolicy: "allow-all",
+          // The Origin echoes the query it is sent, which reaches it only
+          // where the Behavior forwards it.
+          OriginRequestPolicyId: simCfManagedOriginRequestPolicyIds.allViewer,
           FunctionAssociations: {
             Items: [
               {

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-config.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-config.ts
@@ -3,7 +3,7 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimCloudFrontCachePolicy } from "../../cache-policy/sim-cf-cache-policy.js";
 import { simCfnCfCachePolicyCacheKey } from "./sim-cfn-cf-cache-policy-key.js";
-import type { SimCfnCfCachePolicyRefuse } from "./sim-cfn-cf-cache-policy-section.js";
+import type { SimCfnCfPolicyRefuse } from "../policy/sim-cfn-cf-policy-section.js";
 
 /**
  * Reads an AWS::CloudFront::CachePolicy Resource into a simulated policy.
@@ -21,7 +21,7 @@ export class SimCfnCfCachePolicyConfig {
   /**
    * Refuse this Resource, saying which part of it could not be read.
    */
-  private readonly refuse: SimCfnCfCachePolicyRefuse = (detail) => {
+  private readonly refuse: SimCfnCfPolicyRefuse = (detail) => {
     throw new Error(
       `Invalid AWS::CloudFront::CachePolicy ${this.resource.logicalId}: ${detail}`,
     );
@@ -80,7 +80,7 @@ export class SimCfnCfCachePolicyConfig {
 function ttlSeconds(
   config: Record<string, unknown>,
   field: string,
-  refuse: SimCfnCfCachePolicyRefuse,
+  refuse: SimCfnCfPolicyRefuse,
 ): number | undefined {
   // oxlint-disable-next-line security/detect-object-injection
   const value = config[field];

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-key.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-key.ts
@@ -1,11 +1,13 @@
 import { isRecord } from "../../../../util/type-guard/record.js";
 import { SimCloudFrontCacheKey } from "../../cache-policy/sim-cf-cache-key.js";
 import {
-  simCfnCfCacheKeySection,
+  simCfnCfPolicySection,
+  type SimCfnCfPolicyRefuse,
+} from "../policy/sim-cfn-cf-policy-section.js";
+import {
   simCfnCfCookiesSpec,
   simCfnCfHeadersSpec,
   simCfnCfQueryStringsSpec,
-  type SimCfnCfCachePolicyRefuse,
 } from "./sim-cfn-cf-cache-policy-section.js";
 
 const parametersField = "ParametersInCacheKeyAndForwardedToOrigin";
@@ -19,7 +21,7 @@ const parametersField = "ParametersInCacheKeyAndForwardedToOrigin";
  */
 export function simCfnCfCachePolicyCacheKey(
   config: Record<string, unknown>,
-  refuse: SimCfnCfCachePolicyRefuse,
+  refuse: SimCfnCfPolicyRefuse,
 ): SimCloudFrontCacheKey {
   // oxlint-disable-next-line security/detect-object-injection
   const parameters = config[parametersField];
@@ -32,17 +34,17 @@ export function simCfnCfCachePolicyCacheKey(
     return refuse(`${parametersField} must be an object`);
   }
 
-  const cookies = simCfnCfCacheKeySection(
+  const cookies = simCfnCfPolicySection(
     parameters,
     simCfnCfCookiesSpec,
     refuse,
   );
-  const headers = simCfnCfCacheKeySection(
+  const headers = simCfnCfPolicySection(
     parameters,
     simCfnCfHeadersSpec,
     refuse,
   );
-  const queries = simCfnCfCacheKeySection(
+  const queries = simCfnCfPolicySection(
     parameters,
     simCfnCfQueryStringsSpec,
     refuse,
@@ -67,7 +69,7 @@ export function simCfnCfCachePolicyCacheKey(
 function encodingFlag(
   parameters: Record<string, unknown>,
   encoding: string,
-  refuse: SimCfnCfCachePolicyRefuse,
+  refuse: SimCfnCfPolicyRefuse,
 ): boolean {
   const field = `EnableAcceptEncoding${encoding}`;
   // oxlint-disable-next-line security/detect-object-injection

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-section.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-section.ts
@@ -1,23 +1,15 @@
-import { isRecord } from "../../../../util/type-guard/record.js";
 import {
   simCfCacheKeyCookieBehaviors,
   simCfCacheKeyHeaderBehaviors,
   simCfCacheKeyQueryStringBehaviors,
 } from "../../cache-policy/sim-cf-cache-key.js";
 
-export type SimCfnCfCachePolicyRefuse = (detail: string) => never;
-
-export interface SimCfnCfCacheKeySectionSpec<TBehavior extends string> {
-  readonly section: string;
-  readonly behaviorField: string;
-  readonly itemsField: string;
-  readonly behaviors: readonly TBehavior[];
-  readonly defaultBehavior: TBehavior;
-}
-
 /**
  * The three sections of a cache key, each with the fields CloudFormation
  * names it by and the behaviours CloudFront offers for it.
+ *
+ * An origin request policy writes the same three sections under the same field
+ * names, and `simCfnCfPolicySection` reads either kind from a spec like these.
  */
 export const simCfnCfCookiesSpec = {
   section: "CookiesConfig",
@@ -42,78 +34,3 @@ export const simCfnCfQueryStringsSpec = {
   behaviors: simCfCacheKeyQueryStringBehaviors,
   defaultBehavior: "none",
 } as const;
-
-/**
- * One `<name>Config` section of a cache key, as the behaviour it names and the
- * names that behaviour applies to.
- *
- * An absent section is CloudFront's `none` with an empty list, and so is a
- * section that named no behaviour of its own. A behaviour outside the set
- * CloudFront offers for the section is refused.
- */
-export function simCfnCfCacheKeySection<TBehavior extends string>(
-  parameters: Record<string, unknown>,
-  spec: SimCfnCfCacheKeySectionSpec<TBehavior>,
-  refuse: SimCfnCfCachePolicyRefuse,
-): { behavior: TBehavior; items: readonly string[] } {
-  // oxlint-disable-next-line security/detect-object-injection
-  const section = parameters[spec.section];
-
-  if (section === undefined) {
-    return { behavior: spec.defaultBehavior, items: [] };
-  }
-
-  if (!isRecord(section)) {
-    return refuse(`${spec.section} must be an object`);
-  }
-
-  return {
-    // oxlint-disable-next-line security/detect-object-injection
-    behavior: behaviorNamed(section[spec.behaviorField], spec, refuse),
-    items: namesListed(section, spec, refuse),
-  };
-}
-
-/**
- * The behaviour a section named, refused where CloudFront does not offer it
- * for that section.
- */
-function behaviorNamed<TBehavior extends string>(
-  named: unknown,
-  spec: SimCfnCfCacheKeySectionSpec<TBehavior>,
-  refuse: SimCfnCfCachePolicyRefuse,
-): TBehavior {
-  if (named === undefined) {
-    return spec.defaultBehavior;
-  }
-
-  const offered: readonly string[] = spec.behaviors;
-
-  return typeof named === "string" && offered.includes(named)
-    ? (named as TBehavior)
-    : refuse(
-        `${spec.section} ${spec.behaviorField} must be one of ${offered.join(", ")}`,
-      );
-}
-
-/**
- * The names a section lists, which a `whitelist` keys on and an `allExcept`
- * keys on everything but.
- */
-function namesListed(
-  section: Record<string, unknown>,
-  spec: SimCfnCfCacheKeySectionSpec<string>,
-  refuse: SimCfnCfCachePolicyRefuse,
-): readonly string[] {
-  // oxlint-disable-next-line security/detect-object-injection
-  const listed = section[spec.itemsField];
-
-  if (listed === undefined) {
-    return [];
-  }
-
-  return Array.isArray(listed) &&
-    listed.every((name) => typeof name === "string")
-    ? listed
-    : refuse(`${spec.section} ${spec.itemsField} must be a list of strings`);
-}

--- a/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-config.ts
+++ b/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-config.ts
@@ -2,19 +2,30 @@ import { isRecord } from "../../../../util/type-guard/record.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { SimCloudFrontOriginRequestPolicy } from "../../origin-request-policy/sim-cf-origin-request-policy.js";
+import type { SimCfnCfPolicyRefuse } from "../policy/sim-cfn-cf-policy-section.js";
+import { simCfnCfOriginRequestForwarding } from "./sim-cfn-cf-orp-forwarding.js";
 
 /**
  * Reads an AWS::CloudFront::OriginRequestPolicy Resource into a simulated
  * policy.
  *
- * `Name` and `Comment` are what the policy carries. The header, cookie and
- * query string sections are read past: what they configure is a narrowing of
- * the origin request this simulation has yet to grow. A Resource missing its
- * `Name` is refused, as CloudFormation refuses one.
+ * The policy carries its `Name`, its `Comment` and the three sections that say
+ * what it forwards to the Origin. A section a template left out falls back to
+ * CloudFront's `none`. A Resource missing its `Name` is refused, as
+ * CloudFormation refuses one.
  */
 export class SimCfnCfOriginRequestPolicyConfig {
   private readonly resource: SimCfnResource;
   private readonly properties: SimCfnTemplateValueRecord;
+
+  /**
+   * Refuse this Resource, saying which part of it could not be read.
+   */
+  private readonly refuse: SimCfnCfPolicyRefuse = (detail) => {
+    throw new Error(
+      `Invalid AWS::CloudFront::OriginRequestPolicy ${this.resource.logicalId}: ${detail}`,
+    );
+  };
 
   constructor(properties: {
     readonly resource: SimCfnResource;
@@ -28,16 +39,17 @@ export class SimCfnCfOriginRequestPolicyConfig {
    * Build the simulated policy this Resource describes.
    */
   build(): SimCloudFrontOriginRequestPolicy {
+    const { refuse } = this;
     const config = this.properties["OriginRequestPolicyConfig"];
 
     if (!isRecord(config)) {
-      return this.refuse("OriginRequestPolicyConfig must be an object");
+      return refuse("OriginRequestPolicyConfig must be an object");
     }
 
     const name = config["Name"];
 
     if (typeof name !== "string") {
-      return this.refuse("OriginRequestPolicyConfig needs a string Name");
+      return refuse("OriginRequestPolicyConfig needs a string Name");
     }
 
     const comment = config["Comment"];
@@ -45,15 +57,7 @@ export class SimCfnCfOriginRequestPolicyConfig {
     return new SimCloudFrontOriginRequestPolicy({
       name,
       ...(typeof comment === "string" && { comment }),
+      forwarding: simCfnCfOriginRequestForwarding(config, refuse),
     });
-  }
-
-  /**
-   * Refuse this Resource, saying which part of it could not be read.
-   */
-  private refuse(detail: string): never {
-    throw new Error(
-      `Invalid AWS::CloudFront::OriginRequestPolicy ${this.resource.logicalId}: ${detail}`,
-    );
   }
 }

--- a/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-forwarding.iso.test.ts
+++ b/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-forwarding.iso.test.ts
@@ -1,0 +1,126 @@
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFrontOriginRequestPolicy } from "../../origin-request-policy/sim-cf-origin-request-policy.js";
+import { SimCfnCfOriginRequestPolicyConfig } from "./sim-cfn-cf-orp-config.js";
+
+describe("AWS::CloudFront::OriginRequestPolicy forwarding", () => {
+  /**
+   * The policy an `OriginRequestPolicyConfig` describes, under a Name of its
+   * own so every case here is about the rest of the config.
+   */
+  function build(
+    originRequestPolicyConfig: SimCfnTemplateValueRecord,
+  ): SimCloudFrontOriginRequestPolicy {
+    return new SimCfnCfOriginRequestPolicyConfig({
+      resource: new SimCfnResource({ logicalId: "BeaconPolicy" }),
+      properties: {
+        OriginRequestPolicyConfig: {
+          Name: "BeaconPolicy",
+          ...originRequestPolicyConfig,
+        },
+      },
+    }).build();
+  }
+
+  /**
+   * The message refusing an `OriginRequestPolicyConfig` that could not be read.
+   */
+  function refusal(
+    originRequestPolicyConfig: SimCfnTemplateValueRecord,
+  ): string {
+    return assertThrowsError(() => build(originRequestPolicyConfig)).message;
+  }
+
+  it("records the cookies, headers and query strings a template named", () => {
+    // Given a policy forwarding one of each.
+    const policy = build({
+      CookiesConfig: { CookieBehavior: "whitelist", Cookies: ["session"] },
+      HeadersConfig: { HeaderBehavior: "whitelist", Headers: ["Accept"] },
+      QueryStringsConfig: {
+        QueryStringBehavior: "allExcept",
+        QueryStrings: ["utm_source"],
+      },
+    });
+
+    // Then each section carries its behaviour and the names it applies to.
+    assertIdentical(policy.forwarding.cookieBehavior, "whitelist");
+    assertArrayEquals(policy.forwarding.cookies, ["session"]);
+    assertIdentical(policy.forwarding.headerBehavior, "whitelist");
+    assertArrayEquals(policy.forwarding.headers, ["Accept"]);
+    assertIdentical(policy.forwarding.queryStringBehavior, "allExcept");
+    assertArrayEquals(policy.forwarding.queryStrings, ["utm_source"]);
+  });
+
+  it("forwards nothing where the template named no section at all", () => {
+    // Given a policy with a Name and a Comment and nothing else.
+    const policy = build({ Comment: "Beacons" });
+
+    // Then none of the viewer's request travels, which is CloudFront's `none`.
+    assertIdentical(policy.forwarding.cookieBehavior, "none");
+    assertIdentical(policy.forwarding.headerBehavior, "none");
+    assertIdentical(policy.forwarding.queryStringBehavior, "none");
+  });
+
+  it("takes the header behaviours a cache key has no use for", () => {
+    // Given a policy forwarding every header the viewer sent along with
+    // CloudFront's own, which is no use as a cache key and is what
+    // AllViewerAndCloudFrontHeaders-2022-06 does.
+    const policy = build({
+      HeadersConfig: {
+        HeaderBehavior: "allViewerAndWhitelistCloudFront",
+        Headers: ["CloudFront-Viewer-Country"],
+      },
+    });
+
+    // Then the behaviour is read as written.
+    assertIdentical(
+      policy.forwarding.headerBehavior,
+      "allViewerAndWhitelistCloudFront",
+    );
+    assertArrayEquals(policy.forwarding.headers, ["CloudFront-Viewer-Country"]);
+  });
+
+  it("refuses a header behaviour outside CloudFront's set", () => {
+    // Given a policy naming a behaviour CloudFront does not offer a header
+    // section, which `all` is even though a cookie section takes it.
+    // When it is read, then the refusal names the Resource and the behaviour.
+    const message = refusal({ HeadersConfig: { HeaderBehavior: "all" } });
+
+    assertStringIncludes(message, "BeaconPolicy");
+    assertStringIncludes(
+      message,
+      "HeadersConfig HeaderBehavior must be one of",
+    );
+    assertStringIncludes(message, "allViewerAndWhitelistCloudFront");
+  });
+
+  it("refuses a section that is not an object", () => {
+    // Given a policy whose cookies section is a bare string.
+    // When it is read, then the refusal says what the section should have been.
+    const message = refusal({ CookiesConfig: "all" });
+
+    assertStringIncludes(message, "BeaconPolicy");
+    assertStringIncludes(message, "CookiesConfig must be an object");
+  });
+
+  it("refuses a list of names that is not a list of strings", () => {
+    // Given a policy listing a query string name as a number.
+    // When it is read, then the refusal names the field.
+    const message = refusal({
+      QueryStringsConfig: { QueryStringBehavior: "whitelist", QueryStrings: 1 },
+    });
+
+    assertStringIncludes(message, "BeaconPolicy");
+    assertStringIncludes(
+      message,
+      "QueryStringsConfig QueryStrings must be a list of strings",
+    );
+  });
+});

--- a/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-forwarding.ts
+++ b/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-forwarding.ts
@@ -1,0 +1,67 @@
+import {
+  simCfForwardedCookieBehaviors,
+  simCfForwardedHeaderBehaviors,
+  simCfForwardedQueryStringBehaviors,
+  SimCfOriginRequestForwarding,
+} from "../../origin-request-policy/sim-cf-origin-request-forwarding.js";
+import {
+  simCfnCfPolicySection,
+  type SimCfnCfPolicyRefuse,
+} from "../policy/sim-cfn-cf-policy-section.js";
+
+/**
+ * The three sections of an origin request policy, each with the fields
+ * CloudFormation names it by and the behaviours CloudFront offers for it.
+ *
+ * The fields are the ones a cache policy writes. The header section is where
+ * the two kinds part: an origin request policy can forward every header the
+ * viewer sent, which is no use as a cache key.
+ */
+const cookiesSpec = {
+  section: "CookiesConfig",
+  behaviorField: "CookieBehavior",
+  itemsField: "Cookies",
+  behaviors: simCfForwardedCookieBehaviors,
+  defaultBehavior: "none",
+} as const;
+
+const headersSpec = {
+  section: "HeadersConfig",
+  behaviorField: "HeaderBehavior",
+  itemsField: "Headers",
+  behaviors: simCfForwardedHeaderBehaviors,
+  defaultBehavior: "none",
+} as const;
+
+const queryStringsSpec = {
+  section: "QueryStringsConfig",
+  behaviorField: "QueryStringBehavior",
+  itemsField: "QueryStrings",
+  behaviors: simCfForwardedQueryStringBehaviors,
+  defaultBehavior: "none",
+} as const;
+
+/**
+ * Read the three sections of an `OriginRequestPolicyConfig` into what the
+ * policy forwards.
+ *
+ * A template leaving a section out gets CloudFront's own `none`. A policy that
+ * says nothing forwards nothing.
+ */
+export function simCfnCfOriginRequestForwarding(
+  config: Record<string, unknown>,
+  refuse: SimCfnCfPolicyRefuse,
+): SimCfOriginRequestForwarding {
+  const cookies = simCfnCfPolicySection(config, cookiesSpec, refuse);
+  const headers = simCfnCfPolicySection(config, headersSpec, refuse);
+  const queries = simCfnCfPolicySection(config, queryStringsSpec, refuse);
+
+  return new SimCfOriginRequestForwarding({
+    cookieBehavior: cookies.behavior,
+    cookies: cookies.items,
+    headerBehavior: headers.behavior,
+    headers: headers.items,
+    queryStringBehavior: queries.behavior,
+    queryStrings: queries.items,
+  });
+}

--- a/src/service/cloudfront/cfn/policy/sim-cfn-cf-policy-section.ts
+++ b/src/service/cloudfront/cfn/policy/sim-cfn-cf-policy-section.ts
@@ -1,0 +1,88 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+
+export type SimCfnCfPolicyRefuse = (detail: string) => never;
+
+export interface SimCfnCfPolicySectionSpec<TBehavior extends string> {
+  readonly section: string;
+  readonly behaviorField: string;
+  readonly itemsField: string;
+  readonly behaviors: readonly TBehavior[];
+  readonly defaultBehavior: TBehavior;
+}
+
+/**
+ * One `<name>Config` section of a cache policy or an origin request policy, as
+ * the behaviour it names and the names that behaviour applies to.
+ *
+ * The two policy kinds write these sections the same way, down to the field
+ * names, and differ only in the behaviours each section offers. An absent
+ * section is CloudFront's `none` with an empty list, and so is a section that
+ * named no behaviour of its own. A behaviour outside the set CloudFront offers
+ * for the section is refused.
+ */
+export function simCfnCfPolicySection<TBehavior extends string>(
+  parameters: Record<string, unknown>,
+  spec: SimCfnCfPolicySectionSpec<TBehavior>,
+  refuse: SimCfnCfPolicyRefuse,
+): { behavior: TBehavior; items: readonly string[] } {
+  // oxlint-disable-next-line security/detect-object-injection
+  const section = parameters[spec.section];
+
+  if (section === undefined) {
+    return { behavior: spec.defaultBehavior, items: [] };
+  }
+
+  if (!isRecord(section)) {
+    return refuse(`${spec.section} must be an object`);
+  }
+
+  return {
+    // oxlint-disable-next-line security/detect-object-injection
+    behavior: behaviorNamed(section[spec.behaviorField], spec, refuse),
+    items: namesListed(section, spec, refuse),
+  };
+}
+
+/**
+ * The behaviour a section named, refused where CloudFront does not offer it
+ * for that section.
+ */
+function behaviorNamed<TBehavior extends string>(
+  named: unknown,
+  spec: SimCfnCfPolicySectionSpec<TBehavior>,
+  refuse: SimCfnCfPolicyRefuse,
+): TBehavior {
+  if (named === undefined) {
+    return spec.defaultBehavior;
+  }
+
+  const offered: readonly string[] = spec.behaviors;
+
+  return typeof named === "string" && offered.includes(named)
+    ? (named as TBehavior)
+    : refuse(
+        `${spec.section} ${spec.behaviorField} must be one of ${offered.join(", ")}`,
+      );
+}
+
+/**
+ * The names a section lists, which a `whitelist` applies to and an `allExcept`
+ * applies to everything but.
+ */
+function namesListed(
+  section: Record<string, unknown>,
+  spec: SimCfnCfPolicySectionSpec<string>,
+  refuse: SimCfnCfPolicyRefuse,
+): readonly string[] {
+  // oxlint-disable-next-line security/detect-object-injection
+  const listed = section[spec.itemsField];
+
+  if (listed === undefined) {
+    return [];
+  }
+
+  return Array.isArray(listed) &&
+    listed.every((name) => typeof name === "string")
+    ? listed
+    : refuse(`${spec.section} ${spec.itemsField} must be a list of strings`);
+}

--- a/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-distribution-configurator.factory.ts
@@ -43,6 +43,10 @@ export function makeSimCloudFrontDistributionConfigurator(
     new SimCloudFrontOriginConfigurator(
       properties.s3OriginResolver,
       properties.originAccessControls,
+      {
+        cachePolicies: properties.cachePolicies,
+        originRequestPolicies: properties.originRequestPolicies,
+      },
       properties.customOriginDispatcher,
     ),
     new SimCloudFrontBehaviorConfigurator(behaviorPolicies),

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-origin-configurator.ts
@@ -13,6 +13,7 @@ import type { SimCloudFrontOriginAccessControlRegistry } from "../../origin-acce
 import { assertSimCfOacOriginType } from "../../origin-access-control/sim-cf-oac-origin-type.js";
 import { SimCloudFrontInvalidOriginAccessControl } from "../../error/sim-cloudfront.error.js";
 import { simCfOriginCustomHeaders } from "../../origin/sim-cf-origin-custom-headers.js";
+import type { SimCfBehaviorPolicyRegistries } from "../../origin-request-policy/sim-cf-behavior-forwarded.js";
 
 /**
  * Applies Origin configuration to a sim CloudFront Distribution.
@@ -28,6 +29,7 @@ export class SimCloudFrontOriginConfigurator {
   constructor(
     private readonly s3OriginResolver: SimCloudFrontS3OriginResolver,
     private readonly originAccessControls: SimCloudFrontOriginAccessControlRegistry,
+    private readonly policies: SimCfBehaviorPolicyRegistries,
     private readonly customOriginDispatcher?: SimCfCustomOriginDispatcher,
   ) {}
 
@@ -93,6 +95,7 @@ export class SimCloudFrontOriginConfigurator {
           originPath: origin.OriginPath,
           dispatcher: this.customOriginDispatcher,
           customHeaders,
+          policies: this.policies,
           ...(originAccessControl !== undefined && { originAccessControl }),
         }),
       );

--- a/src/service/cloudfront/origin-request-policy/sim-cf-behavior-forwarded.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-behavior-forwarded.ts
@@ -1,0 +1,43 @@
+import type { SimCloudFrontBehavior } from "../behaviour/sim-cloud-front-behavior.js";
+import type { SimCloudFrontCachePolicyRegistry } from "../cache-policy/sim-cf-cache-policy-registry.js";
+import { SimCfForwardedToOrigin } from "./sim-cf-forwarded-to-origin.js";
+import type { SimCloudFrontOriginRequestPolicyRegistry } from "./sim-cf-origin-request-policy-registry.js";
+
+/**
+ * The two policy registries a Behavior's forwarding is read from.
+ *
+ * They are asked per request rather than when the Distribution was configured,
+ * so a policy a template replaced decides the next Origin request rather than
+ * the one it replaced.
+ */
+export interface SimCfBehaviorPolicyRegistries {
+  readonly cachePolicies: SimCloudFrontCachePolicyRegistry;
+  readonly originRequestPolicies: SimCloudFrontOriginRequestPolicyRegistry;
+}
+
+/**
+ * What one Behavior carries to its Origin, from the two policies it names.
+ *
+ * A Behavior naming a policy this simulation does not hold is read as naming
+ * none, which is the same reading the Distribution's cache takes. Without
+ * either registry there is nothing to read a policy from, and the Behavior
+ * carries the same nothing.
+ */
+export function simCfBehaviorForwardedToOrigin(
+  behaviour: SimCloudFrontBehavior,
+  registries?: SimCfBehaviorPolicyRegistries,
+): SimCfForwardedToOrigin {
+  const cachePolicy =
+    behaviour.cachePolicyId === undefined
+      ? undefined
+      : registries?.cachePolicies.byId(behaviour.cachePolicyId);
+  const originRequestPolicy =
+    behaviour.originRequestPolicyId === undefined
+      ? undefined
+      : registries?.originRequestPolicies.byId(behaviour.originRequestPolicyId);
+
+  return new SimCfForwardedToOrigin({
+    cacheKey: cachePolicy?.cacheKey,
+    forwarding: originRequestPolicy?.forwarding,
+  });
+}

--- a/src/service/cloudfront/origin-request-policy/sim-cf-forwarded-to-origin.iso.test.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-forwarded-to-origin.iso.test.ts
@@ -1,0 +1,180 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCloudFrontCacheKey } from "../cache-policy/sim-cf-cache-key.js";
+import { SimCfForwardedToOrigin } from "./sim-cf-forwarded-to-origin.js";
+import { SimCfOriginRequestForwarding } from "./sim-cf-origin-request-forwarding.js";
+
+describe("What a cache Behavior carries to its Origin", () => {
+  it("carries nothing where the Behavior names neither policy", () => {
+    // Given a Behavior with no cache policy and no origin request policy.
+    const forwarded = new SimCfForwardedToOrigin();
+
+    // Then none of the viewer's request travels.
+    assertFalse(forwarded.forwardsHeader("accept"));
+    assertFalse(forwarded.forwardsCookie("session"));
+    assertFalse(forwarded.forwardsQueryString("page"));
+  });
+
+  it("carries what the cache key names with no origin request policy", () => {
+    // Given a Behavior whose cache policy keys on a header, a cookie and a
+    // query string, and which names no origin request policy.
+    const forwarded = new SimCfForwardedToOrigin({
+      cacheKey: new SimCloudFrontCacheKey({
+        headerBehavior: "whitelist",
+        headers: ["Accept-Language"],
+        cookieBehavior: "whitelist",
+        cookies: ["session"],
+        queryStringBehavior: "whitelist",
+        queryStrings: ["page"],
+      }),
+    });
+
+    // Then the three names it keyed on travel, since an Origin has to be able
+    // to answer for the key it was asked about.
+    assertTrue(forwarded.forwardsHeader("accept-language"));
+    assertTrue(forwarded.forwardsCookie("session"));
+    assertTrue(forwarded.forwardsQueryString("page"));
+
+    // And nothing else does.
+    assertFalse(forwarded.forwardsHeader("accept"));
+    assertFalse(forwarded.forwardsCookie("theme"));
+    assertFalse(forwarded.forwardsQueryString("sort"));
+  });
+
+  it("carries the union of the two policies", () => {
+    // Given a Behavior keying its cache on one query string and forwarding
+    // another, which is the pair CloudFront sends between them.
+    const forwarded = new SimCfForwardedToOrigin({
+      cacheKey: new SimCloudFrontCacheKey({
+        queryStringBehavior: "whitelist",
+        queryStrings: ["page"],
+      }),
+      forwarding: new SimCfOriginRequestForwarding({
+        queryStringBehavior: "whitelist",
+        queryStrings: ["sort"],
+      }),
+    });
+
+    // Then both travel, and a third the viewer sent does not.
+    assertTrue(forwarded.forwardsQueryString("page"));
+    assertTrue(forwarded.forwardsQueryString("sort"));
+    assertFalse(forwarded.forwardsQueryString("utm_source"));
+  });
+
+  it("reads a header name in whichever case it was written", () => {
+    // Given a policy naming a header the way a person writes one.
+    const forwarded = new SimCfForwardedToOrigin({
+      forwarding: new SimCfOriginRequestForwarding({
+        headerBehavior: "whitelist",
+        headers: ["X-Request-Id"],
+      }),
+    });
+
+    // Then a viewer sending it lower case is still sending the same header.
+    assertTrue(forwarded.forwardsHeader("x-request-id"));
+  });
+
+  it("reads a cookie and a query string name case sensitively", () => {
+    // Given a policy naming a cookie and a query string, which CloudFront
+    // reads as written rather than as HTTP reads a header name.
+    const forwarded = new SimCfForwardedToOrigin({
+      forwarding: new SimCfOriginRequestForwarding({
+        cookieBehavior: "whitelist",
+        cookies: ["Session"],
+        queryStringBehavior: "whitelist",
+        queryStrings: ["Page"],
+      }),
+    });
+
+    // Then a viewer sending either in another case is sending another name.
+    assertTrue(forwarded.forwardsCookie("Session"));
+    assertFalse(forwarded.forwardsCookie("session"));
+    assertTrue(forwarded.forwardsQueryString("Page"));
+    assertFalse(forwarded.forwardsQueryString("page"));
+  });
+
+  it("carries every viewer header where the policy says allViewer", () => {
+    // Given a Behavior on a policy forwarding the whole viewer request, which
+    // is what AllViewer does.
+    const forwarded = new SimCfForwardedToOrigin({
+      forwarding: new SimCfOriginRequestForwarding({
+        headerBehavior: "allViewer",
+        cookieBehavior: "all",
+        queryStringBehavior: "all",
+      }),
+    });
+
+    // Then anything the viewer sent travels.
+    assertTrue(forwarded.forwardsHeader("x-anything"));
+    assertTrue(forwarded.forwardsCookie("anything"));
+    assertTrue(forwarded.forwardsQueryString("anything"));
+  });
+
+  it("carries every viewer header where the policy adds CloudFront's own", () => {
+    // Given a Behavior on a policy listing CloudFront headers alongside the
+    // viewer's, which is what AllViewerAndCloudFrontHeaders-2022-06 does. The
+    // list names headers CloudFront generates rather than the viewer's.
+    const forwarded = new SimCfForwardedToOrigin({
+      forwarding: new SimCfOriginRequestForwarding({
+        headerBehavior: "allViewerAndWhitelistCloudFront",
+        headers: ["CloudFront-Viewer-Country"],
+      }),
+    });
+
+    // Then a header the viewer sent travels whether or not it is listed.
+    assertTrue(forwarded.forwardsHeader("x-anything"));
+    assertTrue(forwarded.forwardsHeader("cloudfront-viewer-country"));
+  });
+
+  it("carries everything but the names an allExcept lists", () => {
+    // Given a Behavior on a policy withholding one header and one cookie,
+    // which is how AllViewerExceptHostHeader is written.
+    const forwarded = new SimCfForwardedToOrigin({
+      forwarding: new SimCfOriginRequestForwarding({
+        headerBehavior: "allExcept",
+        headers: ["Host"],
+        cookieBehavior: "allExcept",
+        cookies: ["session"],
+      }),
+    });
+
+    // Then the two named are the only ones left behind.
+    assertFalse(forwarded.forwardsHeader("host"));
+    assertTrue(forwarded.forwardsHeader("accept"));
+    assertFalse(forwarded.forwardsCookie("session"));
+    assertTrue(forwarded.forwardsCookie("theme"));
+  });
+
+  it("asks the Origin for the compression the cache policy keyed on", () => {
+    // Given a Behavior whose cache policy caches gzip and brotli apart, and a
+    // viewer that accepts both along with an encoding the policy left out.
+    const forwarded = new SimCfForwardedToOrigin({
+      cacheKey: new SimCloudFrontCacheKey({
+        enableAcceptEncodingGzip: true,
+        enableAcceptEncodingBrotli: true,
+      }),
+    });
+    const headers = new Headers({ "accept-encoding": "deflate, gzip, br" });
+
+    // Then the Origin is asked for the two the policy keyed on, in the order
+    // CloudFront normalizes them to.
+    assertIdentical(forwarded.normalizedAcceptEncoding(headers), "gzip, br");
+  });
+
+  it("asks the Origin for no compression where the policy keyed on none", () => {
+    // Given a Behavior whose cache policy sets neither compression flag, and a
+    // viewer that accepts gzip anyway.
+    const forwarded = new SimCfForwardedToOrigin();
+    const headers = new Headers({ "accept-encoding": "gzip" });
+
+    // Then there is no normalized header to send, so the Origin is asked for
+    // the object uncompressed.
+    assertUndefined(forwarded.normalizedAcceptEncoding(headers));
+  });
+});

--- a/src/service/cloudfront/origin-request-policy/sim-cf-forwarded-to-origin.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-forwarded-to-origin.ts
@@ -1,0 +1,172 @@
+import { simCfNormalizedAcceptEncoding } from "../cache/sim-cf-accept-encoding.js";
+import { SimCloudFrontCacheKey } from "../cache-policy/sim-cf-cache-key.js";
+import {
+  SimCfOriginRequestForwarding,
+  type SimCfForwardedCookieBehavior,
+  type SimCfForwardedHeaderBehavior,
+} from "./sim-cf-origin-request-forwarding.js";
+
+interface SimCfForwardedToOriginProperties {
+  readonly cacheKey?: SimCloudFrontCacheKey | undefined;
+  readonly forwarding?: SimCfOriginRequestForwarding | undefined;
+}
+
+/**
+ * What a cache Behavior carries to its Origin.
+ *
+ * CloudFront sends the union of two things. The first is what the cache policy
+ * keyed the cache on, since an Origin has to be able to answer for the key it
+ * is asked about. The second is what the origin request policy forwards on
+ * top. A Behavior naming neither policy carries neither, and its Origin reads
+ * only what CloudFront sends of its own accord.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html
+ */
+export class SimCfForwardedToOrigin {
+  private readonly cacheKey: SimCloudFrontCacheKey;
+  private readonly forwarding: SimCfOriginRequestForwarding;
+
+  constructor(properties: SimCfForwardedToOriginProperties = {}) {
+    this.cacheKey = properties.cacheKey ?? new SimCloudFrontCacheKey();
+    this.forwarding =
+      properties.forwarding ?? new SimCfOriginRequestForwarding();
+  }
+
+  /**
+   * Whether one of the viewer's headers travels to the Origin, by a name read
+   * case insensitively as HTTP reads a header name.
+   */
+  forwardsHeader(name: string): boolean {
+    return (
+      (this.cacheKey.headerBehavior === "whitelist" &&
+        namesHeader(this.cacheKey.headers, name)) ||
+      policyForwardsHeader(
+        this.forwarding.headerBehavior,
+        this.forwarding.headers,
+        name,
+      )
+    );
+  }
+
+  /**
+   * The `Accept-Encoding` CloudFront sends where the cache policy keyed on
+   * compression, or none where it did not.
+   *
+   * CloudFront normalizes this header rather than passing the viewer's own on.
+   * An encoding the viewer asked for and the policy left out is left out of
+   * what the Origin is asked for. A policy naming the header outright carries
+   * the viewer's value, and never reaches this.
+   */
+  normalizedAcceptEncoding(headers: Headers): string | undefined {
+    const encodings = simCfNormalizedAcceptEncoding(headers, this.cacheKey);
+    // AWS writes the normalized header with gzip first.
+    const ordered = ["gzip", "br"].filter((encoding) =>
+      encodings.includes(encoding),
+    );
+
+    return ordered.length === 0 ? undefined : ordered.join(", ");
+  }
+
+  /**
+   * Whether one of the viewer's cookies travels to the Origin. CloudFront
+   * reads a cookie name case sensitively.
+   */
+  forwardsCookie(name: string): boolean {
+    return (
+      behaviorNames(
+        this.cacheKey.cookieBehavior,
+        this.cacheKey.cookies,
+        name,
+      ) ||
+      behaviorNames(
+        this.forwarding.cookieBehavior,
+        this.forwarding.cookies,
+        name,
+      )
+    );
+  }
+
+  /**
+   * Whether one of the viewer's query strings travels to the Origin.
+   * CloudFront reads a query string name case sensitively.
+   */
+  forwardsQueryString(name: string): boolean {
+    return (
+      behaviorNames(
+        this.cacheKey.queryStringBehavior,
+        this.cacheKey.queryStrings,
+        name,
+      ) ||
+      behaviorNames(
+        this.forwarding.queryStringBehavior,
+        this.forwarding.queryStrings,
+        name,
+      )
+    );
+  }
+}
+
+/**
+ * Whether a header behaviour carries one header name.
+ *
+ * `allViewerAndWhitelistCloudFront` carries every viewer header, and its list
+ * names CloudFront's own headers rather than the viewer's. Nothing here
+ * generates those, so the list adds nothing to what `allViewer` already
+ * carries.
+ */
+function policyForwardsHeader(
+  behavior: SimCfForwardedHeaderBehavior,
+  headers: readonly string[],
+  name: string,
+): boolean {
+  switch (behavior) {
+    case "allViewer":
+    case "allViewerAndWhitelistCloudFront": {
+      return true;
+    }
+    case "whitelist": {
+      return namesHeader(headers, name);
+    }
+    case "allExcept": {
+      return !namesHeader(headers, name);
+    }
+    case "none": {
+      return false;
+    }
+  }
+}
+
+/**
+ * Whether a cookie or query string behaviour carries one name.
+ *
+ * The cookie behaviours and the query string behaviours are the same four
+ * values in both kinds of policy, so one function reads all of them.
+ */
+function behaviorNames(
+  behavior: SimCfForwardedCookieBehavior,
+  listed: readonly string[],
+  name: string,
+): boolean {
+  switch (behavior) {
+    case "all": {
+      return true;
+    }
+    case "whitelist": {
+      return listed.includes(name);
+    }
+    case "allExcept": {
+      return !listed.includes(name);
+    }
+    case "none": {
+      return false;
+    }
+  }
+}
+
+/**
+ * Whether a list of header names holds one, whatever case either was written
+ * in.
+ */
+function namesHeader(headers: readonly string[], name: string): boolean {
+  return headers.some((header) => header.toLowerCase() === name.toLowerCase());
+}

--- a/src/service/cloudfront/origin-request-policy/sim-cf-forwarded-to-origin.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-forwarded-to-origin.ts
@@ -49,6 +49,21 @@ export class SimCfForwardedToOrigin {
   }
 
   /**
+   * Whether the cache policy keyed on compression, which is either of its two
+   * `EnableAcceptEncoding` flags.
+   *
+   * A policy that did decides the `Accept-Encoding` the Origin is asked for on
+   * its own. AWS says as much: a policy naming the header alongside these
+   * flags has no effect on the Origin request.
+   */
+  get keysOnCompression(): boolean {
+    return (
+      this.cacheKey.enableAcceptEncodingGzip ||
+      this.cacheKey.enableAcceptEncodingBrotli
+    );
+  }
+
+  /**
    * The `Accept-Encoding` CloudFront sends where the cache policy keyed on
    * compression, or none where it did not.
    *

--- a/src/service/cloudfront/origin-request-policy/sim-cf-managed-origin-request-policies.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-managed-origin-request-policies.ts
@@ -1,3 +1,4 @@
+import { SimCfOriginRequestForwarding } from "./sim-cf-origin-request-forwarding.js";
 import {
   SimCloudFrontOriginRequestPolicy,
   type SimCloudFrontOriginRequestPolicyId,
@@ -24,13 +25,53 @@ export const simCfManagedOriginRequestPolicyIds = {
 } as const;
 
 /**
+ * The CloudFront headers `AllViewerAndCloudFrontHeaders-2022-06` adds to the
+ * viewer's own. They are the ones CloudFront had released by June 2022, and
+ * the policy is pinned to that set rather than growing with CloudFront.
+ */
+const cloudFrontHeaders2022 = [
+  "CloudFront-Forwarded-Proto",
+  "CloudFront-Is-Android-Viewer",
+  "CloudFront-Is-Desktop-Viewer",
+  "CloudFront-Is-IOS-Viewer",
+  "CloudFront-Is-Mobile-Viewer",
+  "CloudFront-Is-SmartTV-Viewer",
+  "CloudFront-Is-Tablet-Viewer",
+  "CloudFront-Viewer-Address",
+  "CloudFront-Viewer-ASN",
+  "CloudFront-Viewer-City",
+  "CloudFront-Viewer-Country",
+  "CloudFront-Viewer-Country-Name",
+  "CloudFront-Viewer-Country-Region",
+  "CloudFront-Viewer-Country-Region-Name",
+  "CloudFront-Viewer-Http-Version",
+  "CloudFront-Viewer-Latitude",
+  "CloudFront-Viewer-Longitude",
+  "CloudFront-Viewer-Metro-Code",
+  "CloudFront-Viewer-Postal-Code",
+  "CloudFront-Viewer-Time-Zone",
+  "CloudFront-Viewer-TLS",
+];
+
+/**
+ * The CORS request headers `CORS-S3Origin` forwards, which
+ * `Elemental-MediaTailor-PersonalizedManifests` forwards along with two of its
+ * own.
+ */
+const corsRequestHeaders = [
+  "Origin",
+  "Access-Control-Request-Headers",
+  "Access-Control-Request-Method",
+];
+
+/**
  * The eight managed origin request policies, built fresh for one simulated
  * CloudFront.
  *
  * CloudFront owns these and every account has them, so a Behavior can name one
- * without a template creating anything. Each carries the ID and the name AWS
- * publishes for it. What each one forwards is left out, along with what a
- * policy a template creates forwards.
+ * without a template creating anything. Each carries the ID, the name and the
+ * three sections AWS publishes for it, so an Origin behind `AllViewer` here
+ * reads what one behind `AllViewer` in an account reads.
  *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
  */
@@ -39,34 +80,72 @@ export function simCfManagedOriginRequestPolicies(): SimCloudFrontOriginRequestP
     managedOriginRequestPolicy(
       simCfManagedOriginRequestPolicyIds.allViewer,
       "AllViewer",
+      new SimCfOriginRequestForwarding({
+        cookieBehavior: "all",
+        headerBehavior: "allViewer",
+        queryStringBehavior: "all",
+      }),
     ),
     managedOriginRequestPolicy(
       simCfManagedOriginRequestPolicyIds.allViewerAndCloudFrontHeaders2022,
       "AllViewerAndCloudFrontHeaders-2022-06",
+      new SimCfOriginRequestForwarding({
+        cookieBehavior: "all",
+        headerBehavior: "allViewerAndWhitelistCloudFront",
+        headers: cloudFrontHeaders2022,
+        queryStringBehavior: "all",
+      }),
     ),
     managedOriginRequestPolicy(
       simCfManagedOriginRequestPolicyIds.allViewerExceptHostHeader,
       "AllViewerExceptHostHeader",
+      new SimCfOriginRequestForwarding({
+        cookieBehavior: "all",
+        headerBehavior: "allExcept",
+        headers: ["Host"],
+        queryStringBehavior: "all",
+      }),
     ),
     managedOriginRequestPolicy(
       simCfManagedOriginRequestPolicyIds.corsCustomOrigin,
       "CORS-CustomOrigin",
+      new SimCfOriginRequestForwarding({
+        headerBehavior: "whitelist",
+        headers: ["Origin"],
+      }),
     ),
     managedOriginRequestPolicy(
       simCfManagedOriginRequestPolicyIds.corsS3Origin,
       "CORS-S3Origin",
+      new SimCfOriginRequestForwarding({
+        headerBehavior: "whitelist",
+        headers: corsRequestHeaders,
+      }),
     ),
     managedOriginRequestPolicy(
       simCfManagedOriginRequestPolicyIds.elementalMediaTailorPersonalizedManifests,
       "Elemental-MediaTailor-PersonalizedManifests",
+      new SimCfOriginRequestForwarding({
+        headerBehavior: "whitelist",
+        headers: [...corsRequestHeaders, "User-Agent", "X-Forwarded-For"],
+        queryStringBehavior: "all",
+      }),
     ),
     managedOriginRequestPolicy(
       simCfManagedOriginRequestPolicyIds.hostHeaderOnly,
       "HostHeaderOnly",
+      new SimCfOriginRequestForwarding({
+        headerBehavior: "whitelist",
+        headers: ["Host"],
+      }),
     ),
     managedOriginRequestPolicy(
       simCfManagedOriginRequestPolicyIds.userAgentRefererHeaders,
       "UserAgentRefererHeaders",
+      new SimCfOriginRequestForwarding({
+        headerBehavior: "whitelist",
+        headers: ["User-Agent", "Referer"],
+      }),
     ),
   ];
 
@@ -74,14 +153,16 @@ export function simCfManagedOriginRequestPolicies(): SimCloudFrontOriginRequestP
 }
 
 /**
- * One managed policy, under the ID and the name AWS gives it.
+ * One managed policy, under the ID, the name and the sections AWS gives it.
  */
 function managedOriginRequestPolicy(
   id: string,
   name: string,
+  forwarding: SimCfOriginRequestForwarding,
 ): SimCloudFrontOriginRequestPolicy {
   return new SimCloudFrontOriginRequestPolicy({
     id: id as SimCloudFrontOriginRequestPolicyId,
     name,
+    forwarding,
   });
 }

--- a/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-forwarding.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-forwarding.ts
@@ -1,0 +1,89 @@
+/**
+ * The cookie behaviours an origin request policy may name.
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudfront-originrequestpolicy-cookiesconfig.html
+ */
+export const simCfForwardedCookieBehaviors = [
+  "none",
+  "whitelist",
+  "allExcept",
+  "all",
+] as const;
+
+export type SimCfForwardedCookieBehavior =
+  (typeof simCfForwardedCookieBehaviors)[number];
+
+/**
+ * The header behaviours an origin request policy may name.
+ *
+ * These are the two a cache key offers and three more. A policy can forward
+ * every header the viewer sent, which is no use as a cache key but is what an
+ * Origin behind `AllViewer` receives, and it can add CloudFront's own headers
+ * to that or forward everything but a list.
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudfront-originrequestpolicy-headersconfig.html
+ */
+export const simCfForwardedHeaderBehaviors = [
+  "none",
+  "whitelist",
+  "allViewer",
+  "allViewerAndWhitelistCloudFront",
+  "allExcept",
+] as const;
+
+export type SimCfForwardedHeaderBehavior =
+  (typeof simCfForwardedHeaderBehaviors)[number];
+
+/**
+ * The query string behaviours an origin request policy may name.
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-cloudfront-originrequestpolicy-querystringsconfig.html
+ */
+export const simCfForwardedQueryStringBehaviors = [
+  "none",
+  "whitelist",
+  "allExcept",
+  "all",
+] as const;
+
+export type SimCfForwardedQueryStringBehavior =
+  (typeof simCfForwardedQueryStringBehaviors)[number];
+
+interface SimCfOriginRequestForwardingProperties {
+  readonly cookieBehavior?: SimCfForwardedCookieBehavior;
+  readonly cookies?: readonly string[];
+  readonly headerBehavior?: SimCfForwardedHeaderBehavior;
+  readonly headers?: readonly string[];
+  readonly queryStringBehavior?: SimCfForwardedQueryStringBehavior;
+  readonly queryStrings?: readonly string[];
+}
+
+/**
+ * What an origin request policy carries to the Origin.
+ *
+ * These are the three `<name>Config` sections of an `OriginRequestPolicyConfig`.
+ * Each carries a behaviour and the names it applies to: a `whitelist` forwards
+ * the names listed, an `allExcept` forwards everything but them, and `all`,
+ * `allViewer` and `none` ignore the list. The header section's
+ * `allViewerAndWhitelistCloudFront` forwards every viewer header and the
+ * CloudFront headers it lists on top.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html
+ */
+export class SimCfOriginRequestForwarding {
+  public readonly cookieBehavior: SimCfForwardedCookieBehavior;
+  public readonly cookies: readonly string[];
+  public readonly headerBehavior: SimCfForwardedHeaderBehavior;
+  public readonly headers: readonly string[];
+  public readonly queryStringBehavior: SimCfForwardedQueryStringBehavior;
+  public readonly queryStrings: readonly string[];
+
+  constructor(properties: SimCfOriginRequestForwardingProperties = {}) {
+    this.cookieBehavior = properties.cookieBehavior ?? "none";
+    this.cookies = properties.cookies ?? [];
+    this.headerBehavior = properties.headerBehavior ?? "none";
+    this.headers = properties.headers ?? [];
+    this.queryStringBehavior = properties.queryStringBehavior ?? "none";
+    this.queryStrings = properties.queryStrings ?? [];
+  }
+}

--- a/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-policy.ts
+++ b/src/service/cloudfront/origin-request-policy/sim-cf-origin-request-policy.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { Brand } from "../../../util/brand.type.js";
+import { SimCfOriginRequestForwarding } from "./sim-cf-origin-request-forwarding.js";
 
 export type SimCloudFrontOriginRequestPolicyId = Brand<
   string,
@@ -11,6 +12,7 @@ interface SimCloudFrontOriginRequestPolicyProperties {
   readonly id?: SimCloudFrontOriginRequestPolicyId;
   readonly name: string;
   readonly comment?: string | undefined;
+  readonly forwarding?: SimCfOriginRequestForwarding;
 }
 
 /**
@@ -18,9 +20,12 @@ interface SimCloudFrontOriginRequestPolicyProperties {
  *
  * An origin request policy decides which of the viewer's headers, cookies and
  * query strings a cache Behavior carries to its Origin. This simulation holds
- * the policy under its ID and hands it back. Sim CloudFront forwards the
- * viewer's request whole, so the header, cookie and query string sections
- * belong to a narrowing it has yet to grow.
+ * the policy under its ID, along with the three sections that say what it
+ * forwards, and narrows a custom Origin request to them.
+ *
+ * What reaches the Origin is the union of these sections and the Behavior's
+ * cache key, since CloudFront forwards everything it keyed the cache on as
+ * well.
  *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html
  */
@@ -28,12 +33,15 @@ export class SimCloudFrontOriginRequestPolicy {
   public readonly id: SimCloudFrontOriginRequestPolicyId;
   public readonly name: string;
   public readonly comment: string | undefined;
+  public readonly forwarding: SimCfOriginRequestForwarding;
 
   constructor(properties: SimCloudFrontOriginRequestPolicyProperties) {
     this.id =
       properties.id ?? (randomUUID() as SimCloudFrontOriginRequestPolicyId);
     this.name = properties.name;
     this.comment = properties.comment;
+    this.forwarding =
+      properties.forwarding ?? new SimCfOriginRequestForwarding();
   }
 }
 

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-forwarding.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-forwarding.iso.test.ts
@@ -213,6 +213,21 @@ describe("What a CloudFront custom Origin is sent", () => {
     assertIdentical(read.headers["user-agent"], "Mozilla/5.0");
   });
 
+  it("normalizes the compression an origin request policy also carries", async () => {
+    // Given a Behavior on CachingOptimized and AllViewer, which is a cache
+    // policy keying on compression under a policy forwarding the viewer's own
+    // `Accept-Encoding` as well.
+    const read = await originReads({
+      CachePolicyId: simCfManagedCachePolicyIds.cachingOptimized,
+      OriginRequestPolicyId: simCfManagedOriginRequestPolicyIds.allViewer,
+    });
+
+    // Then the cache policy decides the header on its own, and the viewer's
+    // `deflate` never reaches the Origin. AWS says a policy naming the header
+    // alongside those flags has no effect.
+    assertIdentical(read.headers["accept-encoding"], "gzip, br");
+  });
+
   it("asks the Origin for the compression the cache policy keyed on", async () => {
     // Given a Behavior on CachingOptimized, which caches an object compressed
     // and uncompressed apart.

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-forwarding.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-forwarding.iso.test.ts
@@ -1,0 +1,227 @@
+import { CreateDistributionCommand } from "@aws-sdk/client-cloudfront";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertUndefined,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../../serve/payload-2/sim-payload-2-event.type.js";
+import { simHttpApiLambdaProxyFactory } from "../../../apigatewayv2/api/sim-http-api-lambda-proxy.factory.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simCfManagedCachePolicyIds } from "../../cache-policy/sim-cf-managed-cache-policies.js";
+import { simCfManagedOriginRequestPolicyIds } from "../../origin-request-policy/sim-cf-managed-origin-request-policies.js";
+
+/**
+ * What the Origin read of the request the Distribution sent it.
+ */
+interface OriginRead {
+  readonly query: string;
+  readonly cookies: readonly string[];
+  readonly headers: Record<string, string>;
+}
+
+/**
+ * The policies a Behavior names, which are what decide the answer in every
+ * case here.
+ */
+interface BehaviorPolicies {
+  readonly CachePolicyId?: string;
+  readonly OriginRequestPolicyId?: string;
+}
+
+/**
+ * The viewer request every case sends: two query strings, two cookies, and
+ * headers a policy might name one of.
+ */
+const viewerPath = "/things?page=2&start=10";
+
+const viewerHeaders = {
+  "accept-encoding": "deflate, gzip, br",
+  cookie: "session=abc; theme=dark",
+  origin: "https://viewer.example.com",
+  referer: "https://viewer.example.com/index.html",
+  "user-agent": "Mozilla/5.0",
+  "x-request-id": "request-1",
+};
+
+/**
+ * Send one viewer request through a Distribution whose Behavior names the
+ * given policies, and report what the Origin behind it read.
+ */
+async function originReads(policies: BehaviorPolicies): Promise<OriginRead> {
+  const simAws = new SimAws();
+  const api = await simHttpApiLambdaProxyFactory.make(
+    {
+      handler: (event: SimPayload2Event): unknown => ({
+        query: event.rawQueryString,
+        cookies: event.cookies ?? [],
+        headers: event.headers,
+      }),
+      routeKeys: ["GET /things"],
+    },
+    simAws,
+  );
+
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "origin-request-forwarding",
+        Comment: "Search CDN",
+        Enabled: true,
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "ApiOrigin",
+              DomainName: new URL(api.apiEndpoint).hostname,
+              CustomOriginConfig: {
+                HTTPPort: 80,
+                HTTPSPort: 443,
+                OriginProtocolPolicy: "https-only",
+              },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "ApiOrigin",
+          ViewerProtocolPolicy: "allow-all",
+          ...policies,
+        },
+      },
+    }),
+  );
+
+  const distroHostname = creation.Distribution?.DomainName;
+  assertNonNullable(distroHostname);
+
+  const response = await new SimAwsHttp({ simAws }).fetch(
+    new SimAwsLocalUrl({
+      input: `https://${distroHostname}${viewerPath}`,
+    }).toString(),
+    { headers: viewerHeaders },
+  );
+
+  assertResponseStatus(response, 200, await describeResponse(response));
+
+  return (await response.json()) as OriginRead;
+}
+
+describe("What a CloudFront custom Origin is sent", () => {
+  it("sends none of the viewer's request where the Behavior names no policy", async () => {
+    // Given a Behavior naming neither a cache policy nor an origin request
+    // policy, which is a Distribution that was never told what its Origin
+    // needs.
+    const read = await originReads({});
+
+    // Then the Origin is asked for the path alone, with no query string and no
+    // cookie.
+    assertIdentical(read.query, "");
+    assertArrayEquals(read.cookies, []);
+
+    // And none of the viewer's headers reach it either.
+    assertUndefined(read.headers["x-request-id"]);
+    assertUndefined(read.headers["referer"]);
+
+    // And CloudFront states itself as the user agent, since the viewer's own
+    // did not travel.
+    assertIdentical(read.headers["user-agent"], "Amazon CloudFront");
+  });
+
+  it("sends the whole viewer request under AllViewer", async () => {
+    // Given a Behavior on the managed policy that forwards everything.
+    const read = await originReads({
+      OriginRequestPolicyId: simCfManagedOriginRequestPolicyIds.allViewer,
+    });
+
+    // Then the query string, both cookies and the viewer's own headers travel.
+    assertIdentical(read.query, "page=2&start=10");
+    assertArrayEquals(read.cookies, ["session=abc", "theme=dark"]);
+    assertIdentical(read.headers["x-request-id"], "request-1");
+    assertIdentical(read.headers["user-agent"], "Mozilla/5.0");
+  });
+
+  it("sends the headers a whitelist names and no others", async () => {
+    // Given a Behavior on the managed policy naming two headers.
+    const read = await originReads({
+      OriginRequestPolicyId:
+        simCfManagedOriginRequestPolicyIds.userAgentRefererHeaders,
+    });
+
+    // Then those two travel.
+    assertIdentical(read.headers["user-agent"], "Mozilla/5.0");
+    assertIdentical(
+      read.headers["referer"],
+      "https://viewer.example.com/index.html",
+    );
+
+    // And nothing else the viewer sent does, cookies and query string
+    // included.
+    assertUndefined(read.headers["x-request-id"]);
+    assertUndefined(read.headers["origin"]);
+    assertArrayEquals(read.cookies, []);
+    assertIdentical(read.query, "");
+  });
+
+  it("sends the CORS header a custom Origin needs and nothing more", async () => {
+    // Given a Behavior on the managed policy for a CORS custom Origin.
+    const read = await originReads({
+      OriginRequestPolicyId:
+        simCfManagedOriginRequestPolicyIds.corsCustomOrigin,
+    });
+
+    // Then the Origin can answer for the origin that asked, and reads nothing
+    // else of the viewer.
+    assertIdentical(read.headers["origin"], "https://viewer.example.com");
+    assertUndefined(read.headers["referer"]);
+    assertIdentical(read.query, "");
+  });
+
+  it("sends what the cache policy keyed on with no origin request policy", async () => {
+    // Given a Behavior on a cache policy that keys on the `start` query string
+    // and the `Origin` header, and names no origin request policy.
+    const read = await originReads({
+      CachePolicyId: simCfManagedCachePolicyIds.elementalMediaPackage,
+    });
+
+    // Then the Origin reads what the cache was keyed on, since it has to be
+    // able to answer for the key it was asked about.
+    assertIdentical(read.query, "start=10");
+    assertIdentical(read.headers["origin"], "https://viewer.example.com");
+
+    // And the viewer's own user agent, which the key left out, does not.
+    assertIdentical(read.headers["user-agent"], "Amazon CloudFront");
+  });
+
+  it("sends the union of the cache policy and the origin request policy", async () => {
+    // Given a Behavior keying its cache on the `start` query string and
+    // forwarding the viewer's headers on top.
+    const read = await originReads({
+      CachePolicyId: simCfManagedCachePolicyIds.elementalMediaPackage,
+      OriginRequestPolicyId:
+        simCfManagedOriginRequestPolicyIds.userAgentRefererHeaders,
+    });
+
+    // Then the Origin reads the query string one named and the headers the
+    // other did.
+    assertIdentical(read.query, "start=10");
+    assertIdentical(read.headers["user-agent"], "Mozilla/5.0");
+  });
+
+  it("asks the Origin for the compression the cache policy keyed on", async () => {
+    // Given a Behavior on CachingOptimized, which caches an object compressed
+    // and uncompressed apart.
+    const read = await originReads({
+      CachePolicyId: simCfManagedCachePolicyIds.cachingOptimized,
+    });
+
+    // Then the Origin is asked for the encodings the policy keyed on, rather
+    // than for whatever the viewer happened to accept.
+    assertIdentical(read.headers["accept-encoding"], "gzip, br");
+  });
+});

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-forwarding.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-forwarding.ts
@@ -128,19 +128,25 @@ function applyUserAgent(
 }
 
 /**
- * Ask the Origin for the compression the cache policy keyed on, where the
- * policies did not carry the viewer's own `Accept-Encoding`.
+ * Ask the Origin for the compression the cache policy keyed on.
+ *
+ * A cache policy that set either `EnableAcceptEncoding` flag decides this
+ * header on its own, and the normalized value replaces a viewer's own that an
+ * origin request policy carried. A policy that set neither leaves whatever the
+ * policies carried, which is the viewer's header or no header at all.
  */
 function applyAcceptEncoding(
   viewerHeaders: Headers,
   headers: Headers,
   forwarded: SimCfForwardedToOrigin,
 ): void {
-  if (headers.has("accept-encoding")) {
+  if (!forwarded.keysOnCompression) {
     return;
   }
 
   const acceptEncoding = forwarded.normalizedAcceptEncoding(viewerHeaders);
+
+  headers.delete("accept-encoding");
 
   if (acceptEncoding !== undefined) {
     headers.set("accept-encoding", acceptEncoding);

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-forwarding.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-forwarding.ts
@@ -1,0 +1,148 @@
+import type { SimCfForwardedToOrigin } from "../../origin-request-policy/sim-cf-forwarded-to-origin.js";
+
+/**
+ * The `User-Agent` CloudFront sends when the policies do not carry the
+ * viewer's own.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html
+ */
+const cloudFrontUserAgent = "Amazon CloudFront";
+
+/**
+ * The headers CloudFront sends whatever the policies name.
+ *
+ * These describe the body travelling with the request rather than the viewer
+ * making it, and an Origin that lost them would read the wrong bytes.
+ */
+const bodyHeaders = new Set([
+  "content-length",
+  "content-type",
+  "transfer-encoding",
+]);
+
+/**
+ * The query string the Origin is asked for, holding the names the policies
+ * carry and nothing else.
+ *
+ * The pairs that travel keep the spelling the viewer wrote them in. A query
+ * string re-encoded on the way through is no longer the one the viewer asked
+ * for. A name the viewer repeated is repeated to the Origin, which dropping a
+ * repeat would change.
+ */
+export function simCfForwardedOriginSearch(
+  viewerSearch: string,
+  forwarded: SimCfForwardedToOrigin,
+): string {
+  const forwardedPairs = viewerSearch
+    .replace(/^\?/u, "")
+    .split("&")
+    .filter((pair) => pair.length > 0)
+    .filter((pair) => forwarded.forwardsQueryString(queryStringName(pair)));
+
+  return forwardedPairs.length === 0 ? "" : `?${forwardedPairs.join("&")}`;
+}
+
+/**
+ * The headers the Origin is sent, which are the viewer's narrowed to what the
+ * policies carry plus the ones CloudFront sends regardless.
+ *
+ * `Host` is left to the caller, which is the one part of the Origin request
+ * that comes from the Origin rather than from the viewer or the policies.
+ */
+export function simCfForwardedOriginHeaders(
+  viewerHeaders: Headers,
+  forwarded: SimCfForwardedToOrigin,
+): Headers {
+  const headers = new Headers();
+
+  for (const [name, value] of viewerHeaders) {
+    if (bodyHeaders.has(name) || forwarded.forwardsHeader(name)) {
+      headers.set(name, value);
+    }
+  }
+
+  applyForwardedCookies(viewerHeaders, headers, forwarded);
+  applyUserAgent(headers, forwarded);
+  applyAcceptEncoding(viewerHeaders, headers, forwarded);
+
+  return headers;
+}
+
+/**
+ * The name half of one `name=value` pair, read the way a viewer's own client
+ * wrote it rather than as the bytes it was sent as.
+ */
+function queryStringName(pair: string): string {
+  const [name = ""] = new URLSearchParams(pair).keys();
+
+  return name;
+}
+
+/**
+ * Write the cookies the policies carry into the one `Cookie` header a request
+ * sends them all in, leaving the header off where none of them travels.
+ *
+ * A policy naming `Cookie` in its headers section carries the header whole,
+ * whatever its cookies section says.
+ */
+function applyForwardedCookies(
+  viewerHeaders: Headers,
+  headers: Headers,
+  forwarded: SimCfForwardedToOrigin,
+): void {
+  if (forwarded.forwardsHeader("cookie")) {
+    return;
+  }
+
+  const cookies = (viewerHeaders.get("cookie") ?? "")
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .filter((cookie) => cookie.length > 0)
+    .filter((cookie) => forwarded.forwardsCookie(cookieName(cookie)));
+
+  if (cookies.length > 0) {
+    headers.set("cookie", cookies.join("; "));
+  }
+}
+
+/**
+ * The name half of one `name=value` cookie.
+ */
+function cookieName(cookie: string): string {
+  const [name = ""] = cookie.split("=", 1);
+
+  return name;
+}
+
+/**
+ * State CloudFront as the user agent where the policies do not carry the
+ * viewer's own, as CloudFront states itself.
+ */
+function applyUserAgent(
+  headers: Headers,
+  forwarded: SimCfForwardedToOrigin,
+): void {
+  if (!forwarded.forwardsHeader("user-agent")) {
+    headers.set("user-agent", cloudFrontUserAgent);
+  }
+}
+
+/**
+ * Ask the Origin for the compression the cache policy keyed on, where the
+ * policies did not carry the viewer's own `Accept-Encoding`.
+ */
+function applyAcceptEncoding(
+  viewerHeaders: Headers,
+  headers: Headers,
+  forwarded: SimCfForwardedToOrigin,
+): void {
+  if (headers.has("accept-encoding")) {
+    return;
+  }
+
+  const acceptEncoding = forwarded.normalizedAcceptEncoding(viewerHeaders);
+
+  if (acceptEncoding !== undefined) {
+    headers.set("accept-encoding", acceptEncoding);
+  }
+}

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
@@ -1,10 +1,20 @@
 import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
 import { stripSimAwsControlHeaders } from "../../../iam/request/sim-aws-control-headers.js";
+import type { SimCfForwardedToOrigin } from "../../origin-request-policy/sim-cf-forwarded-to-origin.js";
+import {
+  simCfForwardedOriginHeaders,
+  simCfForwardedOriginSearch,
+} from "./sim-cf-custom-origin-forwarding.js";
 
 interface SimCfCustomOriginRequestProperties {
   readonly domainName: string;
   readonly originPath: string;
   readonly request: Request;
+  /**
+   * What the Behavior's cache policy and origin request policy carry to the
+   * Origin between them.
+   */
+  readonly forwarded: SimCfForwardedToOrigin;
   /**
    * The Origin's own custom headers, keyed by lower-case header name.
    */
@@ -20,16 +30,20 @@ interface SimCfCustomOriginRequestProperties {
 /**
  * Build the request sim CloudFront sends on to a custom Origin.
  *
- * CloudFront keeps the viewer's method, headers, query string and body, sends
- * the Origin's own domain as the host, and prefixes the Origin path to the
- * request path. The Origin domain is rewritten to its Yulin-local form here,
- * so that an AWS endpoint hostname is resolved by the same host handling that
- * serves the simulated environment on localhost.
+ * CloudFront keeps the viewer's method and body, prefixes the Origin path to
+ * the request path, and sends the Origin's own domain as the host. Of the
+ * viewer's headers, cookies and query strings it sends what the Behavior's two
+ * policies name between them and drops the rest. An Origin reads what the
+ * Distribution was configured to tell it.
+ *
+ * The Origin domain is rewritten to its Yulin-local form here, so that an AWS
+ * endpoint hostname is resolved by the same host handling that serves the
+ * simulated environment on localhost.
  */
 export function simCfCustomOriginRequest(
   properties: SimCfCustomOriginRequestProperties,
 ): Request {
-  const { request } = properties;
+  const { request, forwarded } = properties;
   const viewerUrl = new URL(request.url);
 
   const originUrl = new SimAwsLocalUrl({
@@ -39,9 +53,10 @@ export function simCfCustomOriginRequest(
     properties.originPath,
     viewerUrl.pathname,
   );
-  originUrl.search = viewerUrl.search;
+  originUrl.search = simCfForwardedOriginSearch(viewerUrl.search, forwarded);
 
-  const headers = new Headers(request.headers);
+  const headers = simCfForwardedOriginHeaders(request.headers, forwarded);
+
   headers.set("host", originUrl.host);
 
   // Who the Origin request is from is the Origin's business, not the viewer's,

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-signer.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-signer.ts
@@ -87,18 +87,20 @@ export class SimCfCustomOriginSigner {
  * POST or PUT that carried no hash through a signing origin access control is
  * refused at the Origin, which is what real CloudFront and Lambda do with one.
  *
- * A viewer's own header travels with the rest of its headers, so nothing is
- * stated for it here.
+ * The viewer's own header is restated here rather than left to travel with the
+ * rest of them, since the Behavior's policies decide which of the viewer's
+ * headers reach the Origin and a signature is not theirs to withhold.
  *
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-lambda.html
  */
 function payloadDeclaration(viewerRequest: Request): Record<string, string> {
-  if (
-    !bodyCarryingMethods.has(viewerRequest.method.toUpperCase()) ||
-    viewerRequest.headers.has(simIamSigV4ContentSha256Header)
-  ) {
+  if (!bodyCarryingMethods.has(viewerRequest.method.toUpperCase())) {
     return {};
   }
 
-  return { [simIamSigV4ContentSha256Header]: simIamSigV4UnsignedPayload };
+  return {
+    [simIamSigV4ContentSha256Header]:
+      viewerRequest.headers.get(simIamSigV4ContentSha256Header) ??
+      simIamSigV4UnsignedPayload,
+  };
 }

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.iso.test.ts
@@ -24,15 +24,20 @@ import { simHttpApiLambdaProxyFactory } from "../../../apigatewayv2/api/sim-http
 import { SimAws } from "../../../aws/sim-aws.js";
 import { grantPublicObjectRead } from "../../../s3/bucket/sim-s3-public-read.fixture.js";
 import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+import { simCfManagedOriginRequestPolicyIds } from "../../origin-request-policy/sim-cf-managed-origin-request-policies.js";
 import { SimCloudFront } from "../../sim-cloudfront.js";
 
 /**
  * Create a Distribution sending everything to one custom Origin, and return
  * the hostname a viewer reaches it on.
+ *
+ * A Behavior naming no origin request policy carries none of the viewer's
+ * query strings to the Origin, so a test about what the Origin reads names one.
  */
 async function distributionForOrigin(
   simAws: SimAws,
   origin: Origin,
+  originRequestPolicyId?: string,
 ): Promise<string> {
   const creation = await simAws.cloudFront().createDistribution(
     new CreateDistributionCommand({
@@ -49,6 +54,9 @@ async function distributionForOrigin(
             Items: ["GET", "HEAD", "POST"],
             CachedMethods: { Quantity: 2, Items: ["GET", "HEAD"] },
           },
+          ...(originRequestPolicyId !== undefined && {
+            OriginRequestPolicyId: originRequestPolicyId,
+          }),
         },
       },
     }),
@@ -160,17 +168,22 @@ describe("Simulated CloudFront custom Origin", () => {
       simAws,
     );
 
-    // And a Distribution whose Origin adds that prefix.
-    const distroHostname = await distributionForOrigin(simAws, {
-      Id: "api-origin",
-      DomainName: new URL(api.apiEndpoint).hostname,
-      OriginPath: "/v1",
-      CustomOriginConfig: {
-        HTTPPort: 80,
-        HTTPSPort: 443,
-        OriginProtocolPolicy: "https-only",
+    // And a Distribution whose Origin adds that prefix, on a Behavior
+    // forwarding what the viewer sent.
+    const distroHostname = await distributionForOrigin(
+      simAws,
+      {
+        Id: "api-origin",
+        DomainName: new URL(api.apiEndpoint).hostname,
+        OriginPath: "/v1",
+        CustomOriginConfig: {
+          HTTPPort: 80,
+          HTTPSPort: 443,
+          OriginProtocolPolicy: "https-only",
+        },
       },
-    });
+      simCfManagedOriginRequestPolicyIds.allViewer,
+    );
 
     // When a request is made without the prefix.
     const response = await new SimAwsHttp({ simAws }).fetch(

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
@@ -6,6 +6,10 @@ import {
 } from "./sim-cf-custom-origin-edge.js";
 import type { SimCloudFrontOrigin } from "../sim-cloudfront-origin.js";
 import type { SimCloudFrontOriginRequest } from "../sim-cloudfront-request-response.js";
+import {
+  simCfBehaviorForwardedToOrigin,
+  type SimCfBehaviorPolicyRegistries,
+} from "../../origin-request-policy/sim-cf-behavior-forwarded.js";
 import type { SimCfCustomOriginDispatcher } from "./sim-cf-custom-origin-dispatcher.js";
 import { simCfCustomOriginRequest } from "./sim-cf-custom-origin-request.js";
 import { SimCfCustomOriginSigner } from "./sim-cf-custom-origin-signer.js";
@@ -21,6 +25,13 @@ interface SimCloudFrontCustomOriginProperties {
    * keyed by lower-case header name.
    */
   readonly customHeaders?: Readonly<Record<string, string>> | undefined;
+  /**
+   * The policies a Behavior's forwarding is read from, which decide what of
+   * the viewer's request reaches this Origin. Without them a Behavior names no
+   * policy this Origin can read, and carries what CloudFront sends of its own
+   * accord and nothing else.
+   */
+  readonly policies?: SimCfBehaviorPolicyRegistries | undefined;
 }
 
 /**
@@ -56,6 +67,7 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
   private readonly originId: string;
   private readonly dispatcher: SimCfCustomOriginDispatcher;
   private readonly signer: SimCfCustomOriginSigner;
+  private readonly policies: SimCfBehaviorPolicyRegistries | undefined;
 
   constructor(
     private readonly properties: SimCloudFrontCustomOriginProperties,
@@ -67,10 +79,15 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
     this.originAccessControl = properties.originAccessControl;
     this.signer = new SimCfCustomOriginSigner(properties.originAccessControl);
     this.customHeaders = properties.customHeaders ?? {};
+    this.policies = properties.policies;
   }
 
   /**
    * Fetch the request from the simulated service behind this Origin.
+   *
+   * The Behavior the request resolved to decides what of the viewer's headers,
+   * cookies and query strings travels, so the policies are read per request
+   * rather than when the Origin was built.
    *
    * An Origin domain naming nothing in the simulation fails here rather than
    * being sent to the real domain, because a simulated Distribution reaching
@@ -81,6 +98,10 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
       domainName: this.domainName,
       originPath: this.originPath,
       request: request.req,
+      forwarded: simCfBehaviorForwardedToOrigin(
+        request.behavior,
+        this.policies,
+      ),
       customHeaders: this.customHeaders,
       signingHeaders: this.signer.forRequest(request),
     });


### PR DESCRIPTION
A custom Origin request now carries the headers, cookies and query strings the Behavior's cache
policy and origin request policy name between them, along with the `Host`, `User-Agent` and
normalized `Accept-Encoding` CloudFront sends of its own accord. An
`AWS::CloudFront::OriginRequestPolicy` reads its `HeadersConfig`, `CookiesConfig` and
`QueryStringsConfig`, the eight managed policies carry the sections AWS publishes, and the section
reader is now shared with the cache policy. A Behavior naming neither policy sends the path alone,
as real CloudFront does.

Resolves https://github.com/KensioSoftware/yulin/issues/1146

**This wants a major release.** A Distribution that used to forward the viewer's request whole now
forwards what its policies name, so an Origin reading a query string or a header the Behavior was
never told to forward stops seeing it. Two tests in this repository turned red on it and were given
`AllViewer`, which is what the same Distribution would need in an account.

Two things an Origin request still does not carry. A viewer's own `Host` never reaches an Origin,
since the request has to reach the simulated service its URL names, so `AllViewerExceptHostHeader`
and `AllViewer` reach a Function URL Origin alike. And CloudFront's own generated headers
(`X-Amz-Cf-Id`, `Via`, `X-Forwarded-For`, the `CloudFront-Viewer-*` family) are not generated, so a
policy naming one forwards nothing. Both are written up under Limitations in `docs/`.

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CloudFront origin request policy support for custom origins.
  - Custom origins now selectively forward viewer headers, cookies, and query strings according to cache and origin request policies.
  - Added support for managed policies, including `AllViewer`, CORS headers, and normalized compression negotiation.
  - Added validation for policy behaviors and forwarded item lists.
  - Improved SigV4 payload handling for POST and PUT requests.

- **Documentation**
  - Expanded CloudFront guidance with configuration rules, examples, forwarding behavior, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->