### PR TITLE
feat: invalidate what a Distribution has cached

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2520,6 +2520,188 @@ therefore serves what it already holds under the new one, with no invalidation.
 in one `SimAws`, across every Account and Region. Caching is on by default, as CloudFront's is. A
 suite that repeats a request and wants each one to reach the Origin can turn it off in setup.
 
+## Invalidations
+
+`CreateInvalidation` clears what a Distribution has cached. The next request for a cleared path
+reaches the Origin. This is the step a deploy takes once it has published new files, and it decides
+whether anyone sees them.
+
+```typescript sim-cloudfront-invalidation
+/**
+ * Clearing what a Distribution has cached, and reading the invalidation back.
+ */
+
+import {
+  CreateDistributionCommand,
+  CreateInvalidationCommand,
+  GetInvalidationCommand,
+  ListInvalidationsCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(
+    new CreateBucketCommand({ Bucket: "release-bucket" }),
+  );
+  await simS3.putPublicAccessBlock(
+    new PutPublicAccessBlockCommand({
+      Bucket: "release-bucket",
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "release-bucket",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::release-bucket/*",
+        },
+      }),
+    }),
+  );
+
+  const publish = async (body: string): Promise<void> => {
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "release-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: body,
+      }),
+    );
+  };
+
+  await publish("<h1>First</h1>");
+
+  const simCloudFront = simAws.cloudFront();
+  const distributionCreation = await simCloudFront.createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "released-site",
+        Comment: "Released site",
+        Enabled: true,
+        DefaultRootObject: "index.html",
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "release-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          // CachingOptimized, one of CloudFront's managed policies.
+          CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        },
+      },
+    }),
+  );
+
+  const distributionId = distributionCreation.Distribution!.Id!;
+  const distroHostname = distributionCreation.Distribution!.DomainName!;
+  const home = srv.localUrl(`http://${distroHostname}/`);
+
+  const first = await fetch(home);
+  console.log(await first.text()); // <h1>First</h1>
+
+  // The deploy publishes a new page, which the Distribution is still holding
+  // the old version of.
+  await publish("<h1>Second</h1>");
+
+  const stale = await fetch(home);
+  console.log(await stale.text()); // <h1>First</h1>
+
+  const creation = await simCloudFront.createInvalidation(
+    new CreateInvalidationCommand({
+      DistributionId: distributionId,
+      InvalidationBatch: {
+        CallerReference: "deployment-1",
+        Paths: { Quantity: 1, Items: ["/*"] },
+      },
+    }),
+  );
+
+  console.log(creation.Invalidation!.Status); // InProgress
+
+  const released = await fetch(home);
+  console.log(await released.text()); // <h1>Second</h1>
+
+  // The invalidation finishes on the background scheduler.
+  await simAws.backgroundTasksComplete();
+
+  const invalidation = await simCloudFront.getInvalidation(
+    new GetInvalidationCommand({
+      DistributionId: distributionId,
+      Id: creation.Invalidation!.Id,
+    }),
+  );
+
+  console.log(invalidation.Invalidation!.Status); // Completed
+
+  const listing = await simCloudFront.listInvalidations(
+    new ListInvalidationsCommand({ DistributionId: distributionId }),
+  );
+
+  console.log(listing.InvalidationList!.Quantity); // 1
+} finally {
+  await srv.close();
+}
+```
+
+### The paths a batch names
+
+A path names one object. A path ending in a wildcard names everything below what comes before it.
+`/images/*` clears the images and leaves `/index.html` where it was, and `/*` clears everything the
+Distribution holds. A path arriving without its leading slash is read as though it had one. The
+bare `*` a console user types is the same batch as `/*`.
+
+An invalidation reaches every edge. A page cached at three points of presence is cleared at all
+three, whichever edge the requests that filled them arrived at.
+
+The entries go as the invalidation is created. Real CloudFront clears each point of presence over
+the following seconds, and a test waiting for that before asking again would be waiting on the
+simulator.
+
+### Reading an invalidation back
+
+An invalidation starts `InProgress` and reaches `Completed` on the background scheduler, the way a
+Distribution reaches `Deployed`. `GetDistribution` counts the running ones as
+`InProgressInvalidationBatches`.
+
+`GetInvalidation` answers with the batch of paths the invalidation was created from.
+`ListInvalidations` answers with the Distribution's whole list, most recently created first. An
+invalidation ID the Distribution has never held is `NoSuchInvalidation`.
+
+### Repeating a batch
+
+`CallerReference` makes a batch idempotent. Sending one twice with the same paths answers with the
+invalidation that reference already created, and clears nothing a second time. Sending it with
+different paths is `InvalidationBatchAlreadyExists`.
+
 ## Origin request policies
 
 An origin request policy decides which of the viewer's headers, cookies and query strings a cache
@@ -3273,6 +3455,8 @@ Sim CloudFront currently supports:
 - `AWS::CloudFront::CachePolicy`, and a Behavior's `CachePolicyId` read back through `GetDistribution`
 - A cache on each Distribution, keyed on the Behavior's cache policy and on the edge the request
   arrived at
+- `CreateInvalidationCommand`, `GetInvalidationCommand` and `ListInvalidationsCommand`, clearing
+  what a Distribution holds and reading the batches back
 - `AWS::CloudFront::OriginRequestPolicy`, and a Behavior's `OriginRequestPolicyId` read back the
   same way
 - `AWS::CloudFront::KeyValueStore`, and `KeyValueStoreAssociations` on `AWS::CloudFront::Function`
@@ -3291,8 +3475,11 @@ Where sim CloudFront knowingly behaves differently from AWS:
 
 - **A cached entry never expires.** A cache policy's three TTLs decide whether the Behavior caches
   at all, and a `MaxTTL` of zero turns it off. Any other value stores an entry that is served until
-  the `SimAws` holding it is thrown away. There is no invalidation, and no `X-Cache` or `Age` header
-  on the response.
+  an invalidation clears it or the `SimAws` holding it is thrown away. The response carries no
+  `X-Cache` or `Age` header.
+- **An invalidation listing is never paged.** `ListInvalidations` echoes the `Marker` and `MaxItems`
+  it was sent and answers with every invalidation the Distribution holds. `IsTruncated` is always
+  false and no `NextMarker` comes back. Real CloudFront pages at 100.
 - **A Behavior with no cache policy caches nothing.** Real CloudFront falls back to the legacy
   `ForwardedValues` and the TTLs beside it, and sim CloudFront skips both. Give the Behavior a
   `CachePolicyId`, as CDK and the console both do.

--- a/docs/services/cloudfront/sim-cloudfront-invalidation.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-invalidation.example.ts
@@ -1,0 +1,143 @@
+/**
+ * Clearing what a Distribution has cached, and reading the invalidation back.
+ */
+
+import {
+  CreateDistributionCommand,
+  CreateInvalidationCommand,
+  GetInvalidationCommand,
+  ListInvalidationsCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  CreateBucketCommand,
+  PutBucketPolicyCommand,
+  PutObjectCommand,
+  PutPublicAccessBlockCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const srv = await serveSimAws({ simAws });
+
+try {
+  const simS3 = simAws.s3();
+
+  await simS3.createBucket(
+    new CreateBucketCommand({ Bucket: "release-bucket" }),
+  );
+  await simS3.putPublicAccessBlock(
+    new PutPublicAccessBlockCommand({
+      Bucket: "release-bucket",
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+      },
+    }),
+  );
+  await simS3.putBucketPolicy(
+    new PutBucketPolicyCommand({
+      Bucket: "release-bucket",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: "*",
+          Action: "s3:GetObject",
+          Resource: "arn:aws:s3:::release-bucket/*",
+        },
+      }),
+    }),
+  );
+
+  const publish = async (body: string): Promise<void> => {
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "release-bucket",
+        Key: "index.html",
+        ContentType: "text/html",
+        Body: body,
+      }),
+    );
+  };
+
+  await publish("<h1>First</h1>");
+
+  const simCloudFront = simAws.cloudFront();
+  const distributionCreation = await simCloudFront.createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "released-site",
+        Comment: "Released site",
+        Enabled: true,
+        DefaultRootObject: "index.html",
+        Origins: {
+          Quantity: 1,
+          Items: [
+            {
+              Id: "site-origin",
+              DomainName: "release-bucket.s3.amazonaws.com",
+              S3OriginConfig: { OriginAccessIdentity: "" },
+            },
+          ],
+        },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          // CachingOptimized, one of CloudFront's managed policies.
+          CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6",
+        },
+      },
+    }),
+  );
+
+  const distributionId = distributionCreation.Distribution!.Id!;
+  const distroHostname = distributionCreation.Distribution!.DomainName!;
+  const home = srv.localUrl(`http://${distroHostname}/`);
+
+  const first = await fetch(home);
+  console.log(await first.text()); // <h1>First</h1>
+
+  // The deploy publishes a new page, which the Distribution is still holding
+  // the old version of.
+  await publish("<h1>Second</h1>");
+
+  const stale = await fetch(home);
+  console.log(await stale.text()); // <h1>First</h1>
+
+  const creation = await simCloudFront.createInvalidation(
+    new CreateInvalidationCommand({
+      DistributionId: distributionId,
+      InvalidationBatch: {
+        CallerReference: "deployment-1",
+        Paths: { Quantity: 1, Items: ["/*"] },
+      },
+    }),
+  );
+
+  console.log(creation.Invalidation!.Status); // InProgress
+
+  const released = await fetch(home);
+  console.log(await released.text()); // <h1>Second</h1>
+
+  // The invalidation finishes on the background scheduler.
+  await simAws.backgroundTasksComplete();
+
+  const invalidation = await simCloudFront.getInvalidation(
+    new GetInvalidationCommand({
+      DistributionId: distributionId,
+      Id: creation.Invalidation!.Id,
+    }),
+  );
+
+  console.log(invalidation.Invalidation!.Status); // Completed
+
+  const listing = await simCloudFront.listInvalidations(
+    new ListInvalidationsCommand({ DistributionId: distributionId }),
+  );
+
+  console.log(listing.InvalidationList!.Quantity); // 1
+} finally {
+  await srv.close();
+}

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -256,6 +256,33 @@ would have the Distribution answering with it for the length of the test.
 Caching is on. `SimCloudFrontRegistry` holds the flag, one registry per `SimAws` across every
 Account and Region, and `SimCloudFront.configureCaching` is how a test turns it off.
 
+## Invalidations
+
+`invalidation/` holds an invalidation and the collection a Distribution keeps them in.
+`command/invalidation/` holds the three commands, grouped as `SimCfInvalidationCommands` the way the
+Function commands are. `SimCfInvalidationAccess` resolves the Distribution each one names. It
+authorizes the action against the Distribution's ARN before it reads the Distribution map, and the
+ARN is built from the ID the caller gave. An unauthorized caller therefore learns nothing about
+which Distribution IDs exist.
+
+`SimCfDistributionCache.clearPaths` clears the entries. It reads the path back out of each key with
+`simCfCacheEntryKeyPath`. Matching a batch is then one pass over the keys, and the entry map needs
+no second index from path to entry. The edge in the key is ignored, because an invalidation reaches
+every point of presence.
+
+The entries go as the invalidation is created, and the invalidation reaches `Completed` on the
+background scheduler afterwards. Clearing on completion would leave a test waiting on the simulator
+before it could ask for the path again.
+
+`SimCfInvalidations` hangs off the Distribution, alongside the cache, and outlives a configuration
+update. Its `inProgressCount` is what `simCloudFrontDistributionView` reports as
+`InProgressInvalidationBatches`. The invalidations are held in creation order, and the listing
+reverses them.
+
+A `CallerReference` is looked up on that same collection. The paths are compared in the order they
+were sent, each one read the way `simCfInvalidationPath` reads it. `*` and `/*` are therefore one
+batch.
+
 ## CloudFront Functions
 
 Sim CloudFront Function support lives under `cff/`.

--- a/src/service/cloudfront/cache/sim-cf-cache-entry-key-path.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-entry-key-path.ts
@@ -1,0 +1,26 @@
+/**
+ * Where the request path sits in a cache entry key.
+ */
+const cacheEntryKeyPathIndex = 2;
+
+/**
+ * The request path one cache entry was keyed under.
+ *
+ * `simCfCacheEntryKey` builds the key as a JSON array with the path third in
+ * it, and this reads that element back out. An invalidation matches entries by
+ * path this way, and the cache keeps its one map keyed on the whole key.
+ *
+ * A key of another shape answers with nothing. An invalidation then leaves the
+ * entry where it is.
+ */
+export function simCfCacheEntryKeyPath(key: string): string | undefined {
+  const parts: unknown = JSON.parse(key);
+
+  if (!Array.isArray(parts)) {
+    return undefined;
+  }
+
+  const path: unknown = parts.at(cacheEntryKeyPathIndex);
+
+  return typeof path === "string" ? path : undefined;
+}

--- a/src/service/cloudfront/cache/sim-cf-cache-entry-key.iso.test.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-entry-key.iso.test.ts
@@ -1,8 +1,9 @@
-import { assertIdentical, assertTrue } from "@kensio/smartass";
+import { assertIdentical, assertTrue, assertUndefined } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimCloudFrontCacheKey } from "../cache-policy/sim-cf-cache-key.js";
 import { simCfCacheEntryKey } from "./sim-cf-cache-entry-key.js";
+import { simCfCacheEntryKeyPath } from "./sim-cf-cache-entry-key-path.js";
 
 const edgeId = "default";
 const site = "https://d111111abcdef8.cloudfront.net";
@@ -189,6 +190,25 @@ describe("A sim CloudFront cache key", () => {
       keyFor("/one.html", new SimCloudFrontCacheKey(), { method: "HEAD" }) !==
         keyFor("/one.html"),
     );
+  });
+
+  it("carries the path back out of the key", () => {
+    // Given a request keyed under a path.
+    // When the path is read back out of the key.
+    // Then it is the one the request asked for, which is what an
+    // invalidation matches against.
+    assertIdentical(
+      simCfCacheEntryKeyPath(keyFor("/images/logo.png")),
+      "/images/logo.png",
+    );
+  });
+
+  it("carries no path out of something that is not a key", () => {
+    // Given JSON that is not one of these keys.
+    // When a path is read out of it.
+    // Then there is none, so an invalidation leaves the entry alone.
+    assertUndefined(simCfCacheEntryKeyPath(JSON.stringify("not-a-key")));
+    assertUndefined(simCfCacheEntryKeyPath(JSON.stringify([1, 2, 3])));
   });
 
   it("keys two edges apart", () => {

--- a/src/service/cloudfront/cache/sim-cf-cache-entry-key.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-entry-key.ts
@@ -28,6 +28,9 @@ interface SimCfCacheEntryKeyProperties {
  * only in something the policy leaves out share one entry, which is the whole
  * point of a cache key.
  *
+ * The path sits third in the key, which `simCfCacheEntryKeyPath` reads it back
+ * out of when an invalidation matches an entry.
+ *
  * The method is part of the key here because a HEAD response carries no body
  * and a GET response does, so serving one from the other would answer with the
  * wrong thing.

--- a/src/service/cloudfront/cache/sim-cf-distribution-cache.ts
+++ b/src/service/cloudfront/cache/sim-cf-distribution-cache.ts
@@ -1,3 +1,6 @@
+import { simCfInvalidationBatchCovers } from "../invalidation/sim-cf-invalidation-path.js";
+import { simCfCacheEntryKeyPath } from "./sim-cf-cache-entry-key-path.js";
+
 /**
  * A response as a Distribution holds it, rather than as a stream something has
  * already read.
@@ -26,9 +29,9 @@ const bodylessStatuses = new Set([101, 103, 204, 205, 304]);
  * per Distribution, which the edge in the key stands for. One cache holds an
  * entry per edge, and a request arriving at another edge misses.
  *
- * Nothing expires. There is no TTL here yet, so an entry stays until something
- * removes it, and the cache policy's TTLs decide only whether a Behavior
- * caches at all.
+ * Nothing expires. There is no TTL here yet, so an entry stays until an
+ * invalidation clears it, and the cache policy's TTLs decide only whether a
+ * Behavior caches at all.
  */
 export class SimCfDistributionCache {
   private readonly entries = new Map<string, SimCfCachedResponse>();
@@ -60,6 +63,25 @@ export class SimCfDistributionCache {
     this.entries.set(key, entry);
 
     return cachedResponse(entry);
+  }
+
+  /**
+   * Forget every entry an invalidation's paths name, at every edge.
+   *
+   * The path an entry was cached under is read back out of its key, so
+   * matching a batch costs a pass over the keys rather than a second map from
+   * path to entry. Nothing here is keyed on the edge, because an invalidation
+   * reaches every point of presence rather than the one a viewer happened to
+   * arrive at.
+   */
+  clearPaths(paths: readonly string[]): void {
+    for (const key of this.entries.keys()) {
+      const path = simCfCacheEntryKeyPath(key);
+
+      if (path !== undefined && simCfInvalidationBatchCovers(paths, path)) {
+        this.entries.delete(key);
+      }
+    }
   }
 }
 

--- a/src/service/cloudfront/command/invalidation/sim-cf-create-invalidation.ts
+++ b/src/service/cloudfront/command/invalidation/sim-cf-create-invalidation.ts
@@ -1,0 +1,96 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCfInvalidation } from "../../invalidation/sim-cf-invalidation.js";
+import {
+  simCfInvalidationLocation,
+  simCfInvalidationView,
+} from "../../invalidation/sim-cf-invalidation-view.js";
+import { simCfRepeatedInvalidation } from "../../invalidation/sim-cf-repeated-invalidation.js";
+import { assertConsistentQuantity } from "../sim-cf-list-quantity.js";
+import type { SimCfInvalidationAccess } from "./sim-cf-invalidation-access.js";
+import type {
+  SimCreateInvalidationCommand,
+  SimCreateInvalidationCommandOutput,
+} from "./sim-cf-invalidation-command.types.js";
+
+/**
+ * Simulated CloudFront CreateInvalidation command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/CreateInvalidationCommand/
+ */
+export class SimCfCreateInvalidation {
+  private static readonly action = "cloudfront:CreateInvalidation";
+
+  constructor(private readonly access: SimCfInvalidationAccess) {}
+
+  /**
+   * Clear what a batch of paths names. The next request for one of them
+   * reaches the Origin.
+   *
+   * The entries go as the invalidation is created. Real CloudFront clears each
+   * point of presence over the following seconds, and a test waiting for that
+   * before asking again would be waiting on the simulator.
+   */
+  async handle(
+    command: SimCreateInvalidationCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimCreateInvalidationCommandOutput> {
+    const batch = command.input.InvalidationBatch;
+    assertDefined(batch, "CreateInvalidationCommand.InvalidationBatch");
+    const callerReference = batch.CallerReference;
+    assertDefined(
+      callerReference,
+      "CreateInvalidationCommand.InvalidationBatch.CallerReference",
+    );
+    assertConsistentQuantity("InvalidationBatch.Paths", batch.Paths);
+
+    await this.access.background.sequence();
+
+    const distribution = this.access.authorizedDistribution(
+      SimCfCreateInvalidation.action,
+      command.input.DistributionId,
+      options?.caller,
+    );
+    const paths = batch.Paths?.Items ?? [];
+    const invalidation =
+      simCfRepeatedInvalidation(distribution, callerReference, paths) ??
+      this.invalidate(distribution, callerReference, paths);
+
+    return {
+      Location: simCfInvalidationLocation(
+        distribution.distributionId,
+        invalidation.invalidationId,
+      ),
+      Invalidation: simCfInvalidationView(invalidation),
+      $metadata: {},
+    };
+  }
+
+  /**
+   * Create an invalidation, clear what it names, and start it running.
+   */
+  private invalidate(
+    distribution: SimCloudFrontDistribution,
+    callerReference: string,
+    paths: readonly string[],
+  ): SimCfInvalidation {
+    const invalidation = new SimCfInvalidation({
+      invalidationId: distribution.invalidations.allocateInvalidationId(),
+      callerReference,
+      paths,
+      createTime: this.access.background.now(),
+    });
+
+    distribution.invalidations.add(invalidation);
+    distribution.cache.clearPaths(paths);
+
+    // The invalidation reaches Completed in the background, the way a
+    // Distribution reaches Deployed.
+    this.access.background.schedule(async () =>
+      invalidation.completeInvalidation(),
+    );
+
+    return invalidation;
+  }
+}

--- a/src/service/cloudfront/command/invalidation/sim-cf-get-invalidation.ts
+++ b/src/service/cloudfront/command/invalidation/sim-cf-get-invalidation.ts
@@ -1,0 +1,51 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimCloudFrontNoSuchInvalidation } from "../../error/sim-cf-invalidation.error.js";
+import { simCfInvalidationView } from "../../invalidation/sim-cf-invalidation-view.js";
+import type { SimCfInvalidationAccess } from "./sim-cf-invalidation-access.js";
+import type {
+  SimGetInvalidationCommand,
+  SimGetInvalidationCommandOutput,
+} from "./sim-cf-invalidation-command.types.js";
+
+/**
+ * Simulated CloudFront GetInvalidation command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/GetInvalidationCommand/
+ */
+export class SimCfGetInvalidation {
+  private static readonly action = "cloudfront:GetInvalidation";
+
+  constructor(private readonly access: SimCfInvalidationAccess) {}
+
+  /**
+   * Read one invalidation of a Distribution back.
+   */
+  async handle(
+    command: SimGetInvalidationCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimGetInvalidationCommandOutput> {
+    const invalidationId = command.input.Id;
+    assertDefined(invalidationId, "GetInvalidationCommand.Id");
+
+    await this.access.background.sequence();
+
+    const distribution = this.access.authorizedDistribution(
+      SimCfGetInvalidation.action,
+      command.input.DistributionId,
+      options?.caller,
+    );
+    const invalidation = distribution.invalidations.byId(invalidationId);
+
+    if (invalidation === undefined) {
+      throw new SimCloudFrontNoSuchInvalidation(
+        `No sim CloudFront invalidation with ID ${invalidationId} on Distribution ${distribution.distributionId}`,
+      );
+    }
+
+    return {
+      Invalidation: simCfInvalidationView(invalidation),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/cloudfront/command/invalidation/sim-cf-invalidation-access.ts
+++ b/src/service/cloudfront/command/invalidation/sim-cf-invalidation-access.ts
@@ -1,0 +1,83 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimCloudFrontDistribution,
+  SimCloudFrontDistributionId,
+} from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.error.js";
+import { simCfAuthorize } from "../../sim-cf-authorize.js";
+
+interface SimCfInvalidationAccessProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly distributions: Map<
+    SimCloudFrontDistributionId,
+    SimCloudFrontDistribution
+  >;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * What every invalidation command needs: the Distributions, IAM, and the
+ * clock.
+ *
+ * The three commands all name a Distribution, authorize against its ARN and
+ * resolve it the same way, so that happens here once rather than in each of
+ * them.
+ */
+export class SimCfInvalidationAccess {
+  public readonly background: BackgroundScheduler;
+
+  private readonly accountId: SimAwsAccountId;
+  private readonly distributions: Map<
+    SimCloudFrontDistributionId,
+    SimCloudFrontDistribution
+  >;
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimCfInvalidationAccessProperties) {
+    this.accountId = properties.accountId;
+    this.distributions = properties.distributions;
+    this.iam = properties.iam;
+    this.background = properties.background;
+  }
+
+  /**
+   * Resolve the Distribution an invalidation command names, having authorized
+   * the action against its ARN.
+   *
+   * The ARN is built from the ID the caller gave, so authorization happens
+   * before the Distribution map is read and an unauthorized caller learns
+   * nothing about which IDs exist.
+   */
+  authorizedDistribution(
+    action: string,
+    distributionId: string | undefined,
+    caller?: SimAwsCaller,
+  ): SimCloudFrontDistribution {
+    assertDefined(distributionId, `${action} DistributionId`);
+
+    simCfAuthorize({
+      iam: this.iam,
+      action,
+      resource: `arn:aws:cloudfront::${this.accountId}:distribution/${distributionId}`,
+      caller,
+    });
+
+    const distribution = this.distributions.get(
+      distributionId as SimCloudFrontDistributionId,
+    );
+
+    if (distribution === undefined) {
+      throw new SimCloudFrontNoSuchDistribution(
+        `No sim CloudFront Distribution with ID ${distributionId}`,
+      );
+    }
+
+    return distribution;
+  }
+}

--- a/src/service/cloudfront/command/invalidation/sim-cf-invalidation-command.types.ts
+++ b/src/service/cloudfront/command/invalidation/sim-cf-invalidation-command.types.ts
@@ -1,0 +1,97 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimCfInvalidationSummaryView,
+  SimCfInvalidationView,
+} from "../../invalidation/sim-cf-invalidation-view.js";
+
+/**
+ * Minimal structural sim CloudFront invalidation batch, as a caller sends it.
+ */
+export interface SimCfInvalidationBatchInput {
+  readonly CallerReference?: string | undefined;
+  readonly Paths?:
+    | {
+        readonly Quantity?: number | undefined;
+        readonly Items?: readonly string[] | undefined;
+      }
+    | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront CreateInvalidation command.
+ */
+export interface SimCreateInvalidationCommand {
+  readonly input: SimCreateInvalidationCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFront CreateInvalidation input.
+ */
+export interface SimCreateInvalidationCommandInput {
+  readonly DistributionId?: string | undefined;
+  readonly InvalidationBatch?: SimCfInvalidationBatchInput | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront CreateInvalidation output.
+ */
+export interface SimCreateInvalidationCommandOutput {
+  readonly Location?: string | undefined;
+  readonly Invalidation?: SimCfInvalidationView | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudFront GetInvalidation command.
+ */
+export interface SimGetInvalidationCommand {
+  readonly input: SimGetInvalidationCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFront GetInvalidation input.
+ */
+export interface SimGetInvalidationCommandInput {
+  readonly DistributionId?: string | undefined;
+  readonly Id?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront GetInvalidation output.
+ */
+export interface SimGetInvalidationCommandOutput {
+  readonly Invalidation?: SimCfInvalidationView | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudFront ListInvalidations command.
+ */
+export interface SimListInvalidationsCommand {
+  readonly input: SimListInvalidationsCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFront ListInvalidations input.
+ */
+export interface SimListInvalidationsCommandInput {
+  readonly DistributionId?: string | undefined;
+  readonly Marker?: string | undefined;
+  readonly MaxItems?: number | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFront ListInvalidations output.
+ */
+export interface SimListInvalidationsCommandOutput {
+  readonly InvalidationList?:
+    | {
+        readonly Marker: string;
+        readonly MaxItems: number;
+        readonly IsTruncated: boolean;
+        readonly Quantity: number;
+        readonly Items: readonly SimCfInvalidationSummaryView[];
+      }
+    | undefined;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudfront/command/invalidation/sim-cf-invalidation-commands.ts
+++ b/src/service/cloudfront/command/invalidation/sim-cf-invalidation-commands.ts
@@ -1,0 +1,85 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimCloudFrontDistribution,
+  SimCloudFrontDistributionId,
+} from "../../distribution/sim-cloudfront-distribution.js";
+import { SimCfCreateInvalidation } from "./sim-cf-create-invalidation.js";
+import { SimCfGetInvalidation } from "./sim-cf-get-invalidation.js";
+import { SimCfInvalidationAccess } from "./sim-cf-invalidation-access.js";
+import { SimCfListInvalidations } from "./sim-cf-list-invalidations.js";
+import type {
+  SimCreateInvalidationCommand,
+  SimCreateInvalidationCommandOutput,
+  SimGetInvalidationCommand,
+  SimGetInvalidationCommandOutput,
+  SimListInvalidationsCommand,
+  SimListInvalidationsCommandOutput,
+} from "./sim-cf-invalidation-command.types.js";
+
+interface SimCfInvalidationCommandsProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly distributions: Map<
+    SimCloudFrontDistributionId,
+    SimCloudFrontDistribution
+  >;
+  readonly iam: SimIamInterServiceAuthZ;
+  readonly background: BackgroundScheduler;
+}
+
+interface InvalidationRequestOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * The invalidation commands on the CloudFront client.
+ *
+ * They are grouped here, the way the Function commands are, because all three
+ * work on state a Distribution holds of its own and share the lookup that
+ * reaches it.
+ */
+export class SimCfInvalidationCommands {
+  private readonly access: SimCfInvalidationAccess;
+
+  constructor(properties: SimCfInvalidationCommandsProperties) {
+    this.access = new SimCfInvalidationAccess(properties);
+  }
+
+  /**
+   * Handle a Create Invalidation Command from the SDK.
+   */
+  async createInvalidation(
+    command: SimCreateInvalidationCommand,
+    options?: InvalidationRequestOptions,
+  ): Promise<SimCreateInvalidationCommandOutput> {
+    return await new SimCfCreateInvalidation(this.access).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Get Invalidation Command from the SDK.
+   */
+  async getInvalidation(
+    command: SimGetInvalidationCommand,
+    options?: InvalidationRequestOptions,
+  ): Promise<SimGetInvalidationCommandOutput> {
+    return await new SimCfGetInvalidation(this.access).handle(command, options);
+  }
+
+  /**
+   * Handle a List Invalidations Command from the SDK.
+   */
+  async listInvalidations(
+    command: SimListInvalidationsCommand,
+    options?: InvalidationRequestOptions,
+  ): Promise<SimListInvalidationsCommandOutput> {
+    return await new SimCfListInvalidations(this.access).handle(
+      command,
+      options,
+    );
+  }
+}

--- a/src/service/cloudfront/command/invalidation/sim-cf-invalidation-iam.iso.test.ts
+++ b/src/service/cloudfront/command/invalidation/sim-cf-invalidation-iam.iso.test.ts
@@ -1,0 +1,110 @@
+import {
+  CreateDistributionCommand,
+  CreateInvalidationCommand,
+  GetInvalidationCommand,
+  ListInvalidationsCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+
+/**
+ * A Distribution to authorize against, with no Origins because nothing here
+ * serves a request.
+ */
+async function distributionId(simCloudFront: SimCloudFront): Promise<string> {
+  const creation = await simCloudFront.createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "invalidation-authorization",
+        Comment: "Authorized invalidations",
+        Enabled: true,
+        Origins: { Quantity: 0, Items: [] },
+        DefaultCacheBehavior: {
+          TargetOriginId: "origin-a",
+          ViewerProtocolPolicy: "allow-all",
+        },
+      },
+    }),
+  );
+
+  assertNonNullable(creation.Distribution?.Id);
+
+  return creation.Distribution.Id;
+}
+
+describe("CloudFront invalidation IAM authorization", () => {
+  it("denies a caller the action on the Distribution ARN", async () => {
+    // Given a Distribution in a known simulated AWS Account.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simCloudFront = simAws.account(accountId).cloudFront();
+    const distribution = await distributionId(simCloudFront);
+
+    // When an anonymous caller asks for an invalidation of it.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simCloudFront.createInvalidation(
+          new CreateInvalidationCommand({
+            DistributionId: distribution,
+            InvalidationBatch: {
+              CallerReference: "denied",
+              Paths: { Quantity: 1, Items: ["/*"] },
+            },
+          }),
+          { caller: { kind: "anonymous" } },
+        ),
+    );
+
+    // Then IAM denies the action against the Distribution's own ARN.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.action, "cloudfront:CreateInvalidation");
+    assertIdentical(
+      error.resource,
+      `arn:aws:cloudfront::${accountId}:distribution/${distribution}`,
+    );
+  });
+
+  it("does not reveal a missing Distribution to an unauthorized caller", async () => {
+    // Given a simulated CloudFront holding no Distributions.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const simCloudFront = simAws.account(accountId).cloudFront();
+
+    // When an anonymous caller reads invalidations of an ID that does not
+    // exist.
+    const read = await assertThrowsErrorAsync(
+      async () =>
+        await simCloudFront.getInvalidation(
+          new GetInvalidationCommand({
+            DistributionId: "EMISSINGDISTRIB",
+            Id: "IMISSINGINVALID",
+          }),
+          { caller: { kind: "anonymous" } },
+        ),
+    );
+    const listed = await assertThrowsErrorAsync(
+      async () =>
+        await simCloudFront.listInvalidations(
+          new ListInvalidationsCommand({ DistributionId: "EMISSINGDISTRIB" }),
+          { caller: { kind: "anonymous" } },
+        ),
+    );
+
+    // Then IAM denies both before CloudFront can say the Distribution is
+    // absent.
+    assertInstanceOf(read, SimIamAccessDenied);
+    assertIdentical(read.action, "cloudfront:GetInvalidation");
+    assertInstanceOf(listed, SimIamAccessDenied);
+    assertIdentical(listed.action, "cloudfront:ListInvalidations");
+  });
+});

--- a/src/service/cloudfront/command/invalidation/sim-cf-invalidation.iso.test.ts
+++ b/src/service/cloudfront/command/invalidation/sim-cf-invalidation.iso.test.ts
@@ -1,0 +1,380 @@
+import {
+  CreateInvalidationCommand,
+  GetDistributionCommand,
+  GetInvalidationCommand,
+  ListInvalidationsCommand,
+} from "@aws-sdk/client-cloudfront";
+import {
+  assertArrayEquals,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  countingOrigin,
+  distributionServing,
+  type OriginReads,
+  readNumber,
+} from "../../../../../test/cloudfront/cache-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simCfEdgeHeaderName } from "../../cache/sim-cf-edge.js";
+import {
+  SimCloudFrontInvalidationBatchAlreadyExists,
+  SimCloudFrontNoSuchInvalidation,
+} from "../../error/sim-cf-invalidation.error.js";
+import { SimCloudFrontNoSuchDistribution } from "../../error/sim-cloudfront.error.js";
+
+/**
+ * Ask a Distribution to clear a batch of paths.
+ */
+async function invalidatePaths(
+  simAws: SimAws,
+  distributionId: string,
+  paths: readonly string[],
+  callerReference = "deployment-1",
+): Promise<string> {
+  const invalidation = await simAws.cloudFront().createInvalidation(
+    new CreateInvalidationCommand({
+      DistributionId: distributionId,
+      InvalidationBatch: {
+        CallerReference: callerReference,
+        Paths: { Quantity: paths.length, Items: [...paths] },
+      },
+    }),
+  );
+
+  assertNonNullable(invalidation.Invalidation?.Id);
+
+  return invalidation.Invalidation.Id;
+}
+
+/**
+ * A Distribution caching what an Origin that counts its reads serves.
+ */
+async function cachingDistribution(
+  simAws: SimAws,
+  reads: OriginReads,
+): Promise<string> {
+  return await distributionServing(simAws, await countingOrigin(simAws, reads));
+}
+
+describe("Invalidating what a sim CloudFront Distribution has cached", () => {
+  it("clears the entry a path names, so the next request reaches the Origin", async () => {
+    // Given a page the Distribution has cached.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+
+    await simCfSiteRequest(simAws, distributionId, "/index.html");
+    const cached = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // When the path it was cached under is invalidated.
+    await invalidatePaths(simAws, distributionId, ["/index.html"]);
+
+    // Then the next request for it reaches the Origin, where the one before
+    // the invalidation did not.
+    const afterwards = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    assertIdentical(await readNumber(cached), 1);
+    assertIdentical(await readNumber(afterwards), 2);
+  });
+
+  it("clears the entries below a wildcard and leaves the others", async () => {
+    // Given two paths the Distribution has cached.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+
+    await simCfSiteRequest(simAws, distributionId, "/images/logo.png");
+    await simCfSiteRequest(simAws, distributionId, "/index.html");
+
+    // When one of the two is invalidated by a wildcard above it.
+    await invalidatePaths(simAws, distributionId, ["/images/*"]);
+
+    const image = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/images/logo.png",
+    );
+    const page = await simCfSiteRequest(simAws, distributionId, "/index.html");
+
+    // Then the image was read again and the page is still the cached one.
+    assertIdentical(await readNumber(image), 3);
+    assertIdentical(await readNumber(page), 2);
+  });
+
+  it("clears everything the Distribution holds", async () => {
+    // Given two paths the Distribution has cached.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+
+    await simCfSiteRequest(simAws, distributionId, "/index.html");
+    await simCfSiteRequest(simAws, distributionId, "/about.html");
+
+    // When the whole Distribution is invalidated.
+    await invalidatePaths(simAws, distributionId, ["/*"]);
+
+    await simCfSiteRequest(simAws, distributionId, "/index.html");
+    await simCfSiteRequest(simAws, distributionId, "/about.html");
+
+    // Then both were read from the Origin again.
+    assertIdentical(reads.count, 4);
+  });
+
+  it("clears a path at every edge", async () => {
+    // Given the same page cached at two points of presence.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+    const atSecondEdge = {
+      headers: { [simCfEdgeHeaderName]: "second-edge" },
+    };
+
+    await simCfSiteRequest(simAws, distributionId, "/index.html");
+    await simCfSiteRequest(simAws, distributionId, "/index.html", atSecondEdge);
+
+    // When the path is invalidated.
+    await invalidatePaths(simAws, distributionId, ["/index.html"]);
+
+    await simCfSiteRequest(simAws, distributionId, "/index.html");
+    await simCfSiteRequest(simAws, distributionId, "/index.html", atSecondEdge);
+
+    // Then both edges read the Origin again, since an invalidation reaches
+    // every one of them rather than the edge that asked for it.
+    assertIdentical(reads.count, 4);
+  });
+
+  it("starts InProgress and reaches Completed in the background", async () => {
+    // Given a deployed Distribution.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+    await simAws.backgroundTasksComplete();
+
+    // When an invalidation is created.
+    const creation = await simAws.cloudFront().createInvalidation(
+      new CreateInvalidationCommand({
+        DistributionId: distributionId,
+        InvalidationBatch: {
+          CallerReference: "deployment-1",
+          Paths: { Quantity: 1, Items: ["/*"] },
+        },
+      }),
+    );
+    const running = await simAws
+      .cloudFront()
+      .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+
+    // Then it is running, and the Distribution counts it, until the
+    // background scheduler finishes it.
+    assertIdentical(creation.Invalidation?.Status, "InProgress");
+    assertIdentical(running.Distribution?.InProgressInvalidationBatches, 1);
+
+    await simAws.backgroundTasksComplete();
+
+    assertNonNullable(creation.Invalidation.Id);
+    const completed = await simAws.cloudFront().getInvalidation(
+      new GetInvalidationCommand({
+        DistributionId: distributionId,
+        Id: creation.Invalidation.Id,
+      }),
+    );
+    const settled = await simAws
+      .cloudFront()
+      .getDistribution(new GetDistributionCommand({ Id: distributionId }));
+
+    assertIdentical(completed.Invalidation?.Status, "Completed");
+    assertIdentical(settled.Distribution?.InProgressInvalidationBatches, 0);
+  });
+
+  it("reads an invalidation back with the batch it was created from", async () => {
+    // Given an invalidation of two paths.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+    const invalidationId = await invalidatePaths(simAws, distributionId, [
+      "/index.html",
+      "/images/*",
+    ]);
+
+    // When it is read back.
+    const got = await simAws.cloudFront().getInvalidation(
+      new GetInvalidationCommand({
+        DistributionId: distributionId,
+        Id: invalidationId,
+      }),
+    );
+
+    // Then the paths and the caller reference are the ones it was given.
+    assertIdentical(got.Invalidation?.Id, invalidationId);
+    assertIdentical(
+      got.Invalidation.InvalidationBatch.CallerReference,
+      "deployment-1",
+    );
+    assertIdentical(got.Invalidation.InvalidationBatch.Paths.Quantity, 2);
+    assertArrayEquals(got.Invalidation.InvalidationBatch.Paths.Items, [
+      "/index.html",
+      "/images/*",
+    ]);
+  });
+
+  it("refuses an invalidation ID the Distribution does not hold", async () => {
+    // Given a Distribution with no invalidations.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+
+    // When an invalidation ID is asked for.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudFront().getInvalidation(
+          new GetInvalidationCommand({
+            DistributionId: distributionId,
+            Id: "INOSUCHINVALID",
+          }),
+        ),
+    );
+
+    // Then CloudFront answers that there is no such invalidation.
+    assertInstanceOf(error, SimCloudFrontNoSuchInvalidation);
+  });
+
+  it("lists a Distribution's invalidations, newest first", async () => {
+    // Given two invalidations of one Distribution.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+    const first = await invalidatePaths(
+      simAws,
+      distributionId,
+      ["/index.html"],
+      "deployment-1",
+    );
+    const second = await invalidatePaths(
+      simAws,
+      distributionId,
+      ["/about.html"],
+      "deployment-2",
+    );
+
+    // When they are listed.
+    const listing = await simAws
+      .cloudFront()
+      .listInvalidations(
+        new ListInvalidationsCommand({ DistributionId: distributionId }),
+      );
+
+    // Then the most recent one is first, and the listing is not truncated.
+    assertIdentical(listing.InvalidationList?.Quantity, 2);
+    assertFalse(listing.InvalidationList.IsTruncated);
+    assertArrayEquals(
+      listing.InvalidationList.Items.map((invalidation) => invalidation.Id),
+      [second, first],
+    );
+  });
+
+  it("answers a repeated CallerReference with the invalidation it created", async () => {
+    // Given an invalidation, and a page cached since it ran.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+    const invalidationId = await invalidatePaths(simAws, distributionId, [
+      "/index.html",
+    ]);
+    await simCfSiteRequest(simAws, distributionId, "/index.html");
+
+    // When the same batch is sent again.
+    const repeated = await invalidatePaths(simAws, distributionId, [
+      "/index.html",
+    ]);
+    const afterwards = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+    const listing = await simAws
+      .cloudFront()
+      .listInvalidations(
+        new ListInvalidationsCommand({ DistributionId: distributionId }),
+      );
+
+    // Then it answers with the invalidation already created, one exists, and
+    // nothing was cleared a second time.
+    assertIdentical(repeated, invalidationId);
+    assertIdentical(listing.InvalidationList?.Quantity, 1);
+    assertIdentical(await readNumber(afterwards), 1);
+  });
+
+  it("refuses a repeated CallerReference naming different paths", async () => {
+    // Given an invalidation of one path.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+    await invalidatePaths(simAws, distributionId, ["/index.html"]);
+
+    // When the same caller reference names another path.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await invalidatePaths(simAws, distributionId, ["/about.html"]),
+    );
+
+    // Then the batch is refused, since the reference no longer names one
+    // batch.
+    assertInstanceOf(error, SimCloudFrontInvalidationBatchAlreadyExists);
+  });
+
+  it("takes a batch naming no paths, and clears nothing", async () => {
+    // Given a page the Distribution has cached.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await cachingDistribution(simAws, reads);
+    await simCfSiteRequest(simAws, distributionId, "/index.html");
+
+    // When an invalidation naming no paths at all is created.
+    const creation = await simAws.cloudFront().createInvalidation(
+      new CreateInvalidationCommand({
+        DistributionId: distributionId,
+        InvalidationBatch: {
+          CallerReference: "empty-batch",
+          Paths: undefined,
+        },
+      }),
+    );
+    const afterwards = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/index.html",
+    );
+
+    // Then it was created, and the cache still holds what it held.
+    assertIdentical(creation.Invalidation?.InvalidationBatch.Paths.Quantity, 0);
+    assertIdentical(await readNumber(afterwards), 1);
+  });
+
+  it("refuses an invalidation of a Distribution that does not exist", async () => {
+    // Given a simulated CloudFront holding no Distributions.
+    const simAws = new SimAws();
+
+    // When an invalidation names one.
+    const error = await assertThrowsErrorAsync(
+      async () => await invalidatePaths(simAws, "ENOSUCHDISTRIB", ["/*"]),
+    );
+
+    // Then CloudFront answers that there is no such Distribution.
+    assertInstanceOf(error, SimCloudFrontNoSuchDistribution);
+  });
+});

--- a/src/service/cloudfront/command/invalidation/sim-cf-list-invalidations.ts
+++ b/src/service/cloudfront/command/invalidation/sim-cf-list-invalidations.ts
@@ -1,0 +1,57 @@
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { simCfInvalidationSummary } from "../../invalidation/sim-cf-invalidation-view.js";
+import type { SimCfInvalidationAccess } from "./sim-cf-invalidation-access.js";
+import type {
+  SimListInvalidationsCommand,
+  SimListInvalidationsCommandOutput,
+} from "./sim-cf-invalidation-command.types.js";
+
+/**
+ * What CloudFront reports as `MaxItems` for a listing that asks for none.
+ */
+const defaultMaxItems = 100;
+
+/**
+ * Simulated CloudFront ListInvalidations command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudfront/command/ListInvalidationsCommand/
+ */
+export class SimCfListInvalidations {
+  private static readonly action = "cloudfront:ListInvalidations";
+
+  constructor(private readonly access: SimCfInvalidationAccess) {}
+
+  /**
+   * List a Distribution's invalidations, most recently created first.
+   *
+   * The whole list comes back. `Marker` and `MaxItems` are the paging every
+   * other simulated listing leaves out, so the answer is never truncated and
+   * carries no `NextMarker`.
+   */
+  async handle(
+    command: SimListInvalidationsCommand,
+    options?: { readonly caller?: SimAwsCaller },
+  ): Promise<SimListInvalidationsCommandOutput> {
+    await this.access.background.sequence();
+
+    const distribution = this.access.authorizedDistribution(
+      SimCfListInvalidations.action,
+      command.input.DistributionId,
+      options?.caller,
+    );
+    const invalidations = distribution.invalidations.newestFirst();
+
+    return {
+      InvalidationList: {
+        Marker: command.input.Marker ?? "",
+        MaxItems: command.input.MaxItems ?? defaultMaxItems,
+        IsTruncated: false,
+        Quantity: invalidations.length,
+        Items: invalidations.map((invalidation) =>
+          simCfInvalidationSummary(invalidation),
+        ),
+      },
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/cloudfront/distribution/sim-cf-distribution-view.ts
+++ b/src/service/cloudfront/distribution/sim-cf-distribution-view.ts
@@ -28,7 +28,7 @@ export function simCloudFrontDistributionView(
     ARN: simCloudFrontDistributionArn(distribution),
     Status: distribution.status,
     LastModifiedTime: distribution.lastModifiedTime,
-    InProgressInvalidationBatches: 0,
+    InProgressInvalidationBatches: distribution.invalidations.inProgressCount,
     DomainName: `${distribution.distributionId.toLowerCase()}.cloudfront.net`,
     DistributionConfig: distribution.distributionConfig,
   };

--- a/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
+++ b/src/service/cloudfront/distribution/sim-cloudfront-distribution.ts
@@ -12,6 +12,7 @@ import type { SimCloudFrontDistributionConfig } from "../command/create-distribu
 import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
 import { SimCloudFrontDistributionNotDisabled } from "../error/sim-cloudfront.error.js";
 import { SimCfDistributionCache } from "../cache/sim-cf-distribution-cache.js";
+import { SimCfInvalidations } from "../invalidation/sim-cf-invalidations.js";
 
 export type SimCloudFrontDistributionId = Brand<
   string,
@@ -50,6 +51,15 @@ export class SimCloudFrontDistribution {
    * configuration is served until something removes it.
    */
   public readonly cache = new SimCfDistributionCache();
+
+  /**
+   * The invalidations this Distribution has been asked for.
+   *
+   * They outlive a configuration update, as the cache does, since an
+   * invalidation is a record of what was cleared rather than part of the
+   * Distribution's configuration.
+   */
+  public readonly invalidations = new SimCfInvalidations();
 
   #status: SimCloudFrontDistributionStatus;
   #distributionConfig: SimCloudFrontDistributionConfig | undefined;

--- a/src/service/cloudfront/error/sim-cf-invalidation.error.ts
+++ b/src/service/cloudfront/error/sim-cf-invalidation.error.ts
@@ -1,0 +1,30 @@
+import { SimCloudFrontError } from "./sim-cloudfront.error.js";
+
+/**
+ * Simulated CloudFront NoSuchInvalidation error.
+ *
+ * What CloudFront answers when an invalidation ID names nothing on the
+ * Distribution it was asked for.
+ */
+export class SimCloudFrontNoSuchInvalidation extends SimCloudFrontError {
+  public override readonly name = "NoSuchInvalidation";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated CloudFront InvalidationBatchAlreadyExists error.
+ *
+ * A `CallerReference` makes an invalidation batch idempotent. Repeating one
+ * with the paths it was created with answers with that invalidation, and
+ * repeating it with different paths is refused rather than clearing anything.
+ */
+export class SimCloudFrontInvalidationBatchAlreadyExists extends SimCloudFrontError {
+  public override readonly name = "InvalidationBatchAlreadyExists";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}

--- a/src/service/cloudfront/invalidation/sim-cf-invalidation-path.iso.test.ts
+++ b/src/service/cloudfront/invalidation/sim-cf-invalidation-path.iso.test.ts
@@ -1,0 +1,48 @@
+import { assertFalse, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simCfInvalidationCovers } from "./sim-cf-invalidation-path.js";
+
+describe("A sim CloudFront invalidation path", () => {
+  it("covers the one object it names", () => {
+    // Given a path naming one object.
+    // When it is matched against that object and against another.
+    // Then it covers the one it names alone.
+    assertTrue(simCfInvalidationCovers("/index.html", "/index.html"));
+    assertFalse(simCfInvalidationCovers("/index.html", "/about.html"));
+  });
+
+  it("covers everything below a trailing wildcard", () => {
+    // Given a path ending in a wildcard.
+    // When it is matched against objects inside and outside it.
+    // Then it covers what is below it and leaves the rest alone.
+    assertTrue(simCfInvalidationCovers("/images/*", "/images/logo.png"));
+    assertTrue(simCfInvalidationCovers("/images/*", "/images/icons/up.svg"));
+    assertFalse(simCfInvalidationCovers("/images/*", "/index.html"));
+  });
+
+  it("covers the paths a partial name starts", () => {
+    // Given a wildcard part way through a name.
+    // When it is matched against two objects starting with it.
+    // Then both are covered, as CloudFront covers them.
+    assertTrue(simCfInvalidationCovers("/index*", "/index.html"));
+    assertTrue(simCfInvalidationCovers("/index*", "/index.json"));
+    assertFalse(simCfInvalidationCovers("/index*", "/about.html"));
+  });
+
+  it("covers everything under the whole-Distribution wildcard", () => {
+    // Given the path that clears a Distribution.
+    // When it is matched against anything at all.
+    // Then it covers it.
+    assertTrue(simCfInvalidationCovers("/*", "/"));
+    assertTrue(simCfInvalidationCovers("/*", "/deep/page.html"));
+  });
+
+  it("reads a path missing its leading slash as though it had one", () => {
+    // Given the bare wildcard a caller types without a slash.
+    // When it is matched against an object.
+    // Then it is read as the path CloudFront takes, with the slash.
+    assertTrue(simCfInvalidationCovers("*", "/index.html"));
+    assertTrue(simCfInvalidationCovers("index.html", "/index.html"));
+  });
+});

--- a/src/service/cloudfront/invalidation/sim-cf-invalidation-path.ts
+++ b/src/service/cloudfront/invalidation/sim-cf-invalidation-path.ts
@@ -1,0 +1,44 @@
+/**
+ * One path as an invalidation names it.
+ *
+ * CloudFront takes a path relative to the Distribution, beginning with a
+ * slash. One arriving without a leading slash is read as though it had one, so
+ * the bare `*` that clears everything is the same batch as `/*`.
+ */
+export function simCfInvalidationPath(path: string): string {
+  const named = path.trim();
+
+  return named.startsWith("/") ? named : `/${named}`;
+}
+
+/**
+ * Whether a path an invalidation names covers a path the Distribution has
+ * cached.
+ *
+ * A path on its own names one object. A path ending in a wildcard names
+ * everything below what comes before it, so `/images/*` covers
+ * `/images/logo.png` and leaves `/index.html` alone, and `/*` covers
+ * everything the Distribution holds.
+ */
+export function simCfInvalidationCovers(
+  invalidationPath: string,
+  path: string,
+): boolean {
+  const named = simCfInvalidationPath(invalidationPath);
+
+  return named.endsWith("*")
+    ? path.startsWith(named.slice(0, -1))
+    : path === named;
+}
+
+/**
+ * Whether any path in a batch covers a path the Distribution has cached.
+ */
+export function simCfInvalidationBatchCovers(
+  invalidationPaths: readonly string[],
+  path: string,
+): boolean {
+  return invalidationPaths.some((invalidationPath) =>
+    simCfInvalidationCovers(invalidationPath, path),
+  );
+}

--- a/src/service/cloudfront/invalidation/sim-cf-invalidation-view.ts
+++ b/src/service/cloudfront/invalidation/sim-cf-invalidation-view.ts
@@ -1,0 +1,77 @@
+import type { SimCfInvalidation } from "./sim-cf-invalidation.js";
+
+/**
+ * The batch of paths an invalidation was created from, as the API returns it.
+ */
+export interface SimCfInvalidationBatchView {
+  readonly Paths: {
+    readonly Quantity: number;
+    readonly Items: readonly string[];
+  };
+  readonly CallerReference: string;
+}
+
+/**
+ * Minimal structural sim CloudFront invalidation, as the API returns it.
+ *
+ * CreateInvalidation and GetInvalidation both answer with this shape.
+ */
+export interface SimCfInvalidationView {
+  readonly Id: string;
+  readonly Status: string;
+  readonly CreateTime: Date;
+  readonly InvalidationBatch: SimCfInvalidationBatchView;
+}
+
+/**
+ * One invalidation as ListInvalidations returns it, which leaves out the
+ * batch of paths.
+ */
+export interface SimCfInvalidationSummaryView {
+  readonly Id: string;
+  readonly CreateTime: Date;
+  readonly Status: string;
+}
+
+/**
+ * Build the API view of a sim CloudFront invalidation.
+ */
+export function simCfInvalidationView(
+  invalidation: SimCfInvalidation,
+): SimCfInvalidationView {
+  return {
+    Id: invalidation.invalidationId,
+    Status: invalidation.status,
+    CreateTime: invalidation.createTime,
+    InvalidationBatch: {
+      Paths: {
+        Quantity: invalidation.paths.length,
+        Items: invalidation.paths,
+      },
+      CallerReference: invalidation.callerReference,
+    },
+  };
+}
+
+/**
+ * Build the listing view of a sim CloudFront invalidation.
+ */
+export function simCfInvalidationSummary(
+  invalidation: SimCfInvalidation,
+): SimCfInvalidationSummaryView {
+  return {
+    Id: invalidation.invalidationId,
+    CreateTime: invalidation.createTime,
+    Status: invalidation.status,
+  };
+}
+
+/**
+ * The URL CreateInvalidation reports the new invalidation at.
+ */
+export function simCfInvalidationLocation(
+  distributionId: string,
+  invalidationId: string,
+): string {
+  return `https://cloudfront.amazonaws.com/2020-05-31/distribution/${distributionId}/invalidation/${invalidationId}`;
+}

--- a/src/service/cloudfront/invalidation/sim-cf-invalidation.ts
+++ b/src/service/cloudfront/invalidation/sim-cf-invalidation.ts
@@ -1,0 +1,89 @@
+import { faker } from "@faker-js/faker";
+
+import type { Brand } from "../../../util/brand.type.js";
+import { simCfInvalidationPath } from "./sim-cf-invalidation-path.js";
+
+export type SimCfInvalidationId = Brand<string, "SimCfInvalidationId">;
+
+/**
+ * How far an invalidation has got.
+ *
+ * CloudFront answers CreateInvalidation with `InProgress` and moves the
+ * invalidation to `Completed` once every edge has been told, the way a
+ * Distribution reaches `Deployed`.
+ */
+export type SimCfInvalidationStatus = "InProgress" | "Completed";
+
+interface SimCfInvalidationProperties {
+  readonly invalidationId: SimCfInvalidationId;
+  readonly callerReference: string;
+  readonly paths: readonly string[];
+  readonly createTime: Date;
+}
+
+/**
+ * One simulated CloudFront invalidation.
+ *
+ * An invalidation is the batch of paths a caller asked to be cleared, plus
+ * where clearing them has got to. It belongs to the Distribution it was
+ * created against, which is what GetInvalidation and ListInvalidations read it
+ * back from.
+ */
+export class SimCfInvalidation {
+  public readonly invalidationId: SimCfInvalidationId;
+  public readonly callerReference: string;
+  public readonly paths: readonly string[];
+  public readonly createTime: Date;
+
+  #status: SimCfInvalidationStatus = "InProgress";
+
+  constructor(properties: SimCfInvalidationProperties) {
+    this.invalidationId = properties.invalidationId;
+    this.callerReference = properties.callerReference;
+    this.paths = properties.paths;
+    this.createTime = properties.createTime;
+  }
+
+  /**
+   * Whether this invalidation is still running.
+   */
+  get status(): SimCfInvalidationStatus {
+    return this.#status;
+  }
+
+  /**
+   * Move this invalidation into Completed status.
+   */
+  completeInvalidation(): Promise<void> {
+    this.#status = "Completed";
+
+    return Promise.resolve();
+  }
+
+  /**
+   * Whether a batch names the same paths as this one did.
+   *
+   * This is what decides whether a repeated `CallerReference` answers with the
+   * invalidation already created or is refused. The paths are compared in the
+   * order they were sent, since that is the batch CloudFront was given, and
+   * each one is read the way an invalidation reads it, so `*` and `/*` are the
+   * same batch.
+   */
+  namesSamePaths(paths: readonly string[]): boolean {
+    const named = paths.map((path) => simCfInvalidationPath(path));
+
+    return (
+      this.paths.length === named.length &&
+      this.paths.every(
+        (path, index) => simCfInvalidationPath(path) === named.at(index),
+      )
+    );
+  }
+}
+
+/**
+ * Generate a fake sim CloudFront invalidation ID.
+ */
+export function makeSimCfInvalidationId(): SimCfInvalidationId {
+  return faker.helpers.fromRegExp(/I[0-9A-Z]{13}/) as SimCfInvalidationId;
+}

--- a/src/service/cloudfront/invalidation/sim-cf-invalidations.ts
+++ b/src/service/cloudfront/invalidation/sim-cf-invalidations.ts
@@ -1,0 +1,79 @@
+import {
+  makeSimCfInvalidationId,
+  type SimCfInvalidation,
+  type SimCfInvalidationId,
+} from "./sim-cf-invalidation.js";
+
+/**
+ * The invalidations one simulated Distribution has been asked for.
+ *
+ * An invalidation is scoped to its Distribution, so this hangs off the
+ * Distribution rather than off the service. It holds them in the order they
+ * were created, which is the order the counts and the listing are read back
+ * from.
+ */
+export class SimCfInvalidations {
+  private readonly invalidations: SimCfInvalidation[] = [];
+
+  /**
+   * Allocate an invalidation ID no invalidation of this Distribution holds.
+   */
+  allocateInvalidationId(): SimCfInvalidationId {
+    let invalidationId = makeSimCfInvalidationId();
+
+    while (this.byId(invalidationId) !== undefined) {
+      /* v8 ignore next -- does not happen in practice */
+      invalidationId = makeSimCfInvalidationId();
+    }
+
+    return invalidationId;
+  }
+
+  /**
+   * Hold on to an invalidation.
+   */
+  add(invalidation: SimCfInvalidation): void {
+    this.invalidations.push(invalidation);
+  }
+
+  /**
+   * Get an invalidation by ID.
+   */
+  byId(
+    invalidationId: SimCfInvalidationId | string,
+  ): SimCfInvalidation | undefined {
+    return this.invalidations.find(
+      (invalidation) => invalidation.invalidationId === invalidationId,
+    );
+  }
+
+  /**
+   * Get the invalidation created under a `CallerReference`, if there is one.
+   *
+   * A `CallerReference` is what makes a batch idempotent, so this is what a
+   * repeated one is answered from.
+   */
+  byCallerReference(callerReference: string): SimCfInvalidation | undefined {
+    return this.invalidations.find(
+      (invalidation) => invalidation.callerReference === callerReference,
+    );
+  }
+
+  /**
+   * The invalidations of this Distribution, most recently created first, as
+   * CloudFront lists them.
+   */
+  newestFirst(): readonly SimCfInvalidation[] {
+    return this.invalidations.toReversed();
+  }
+
+  /**
+   * How many invalidations of this Distribution are still running, which is
+   * what GetDistribution reports as `InProgressInvalidationBatches`.
+   */
+  get inProgressCount(): number {
+    return this.invalidations.filter(
+      (invalidation) => invalidation.status === "InProgress",
+    ).length;
+  }
+}

--- a/src/service/cloudfront/invalidation/sim-cf-repeated-invalidation.ts
+++ b/src/service/cloudfront/invalidation/sim-cf-repeated-invalidation.ts
@@ -1,0 +1,36 @@
+import type { SimCloudFrontDistribution } from "../distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontInvalidationBatchAlreadyExists } from "../error/sim-cf-invalidation.error.js";
+import type { SimCfInvalidation } from "./sim-cf-invalidation.js";
+
+/**
+ * The invalidation a `CallerReference` already created, where a batch repeats
+ * it.
+ *
+ * A `CallerReference` makes a batch idempotent. A repeat naming the same paths
+ * is answered with what it created the first time, and nothing is cleared
+ * again. A repeat naming different paths is refused, since the reference then
+ * names two batches.
+ *
+ * A reference this Distribution has never seen answers with nothing, and the
+ * caller creates an invalidation for it.
+ */
+export function simCfRepeatedInvalidation(
+  distribution: SimCloudFrontDistribution,
+  callerReference: string,
+  paths: readonly string[],
+): SimCfInvalidation | undefined {
+  const existing =
+    distribution.invalidations.byCallerReference(callerReference);
+
+  if (existing === undefined) {
+    return undefined;
+  }
+
+  if (!existing.namesSamePaths(paths)) {
+    throw new SimCloudFrontInvalidationBatchAlreadyExists(
+      `Sim CloudFront invalidation batch ${existing.invalidationId} on Distribution ${distribution.distributionId} was created with CallerReference ${callerReference} and different paths`,
+    );
+  }
+
+  return existing;
+}

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.iso.test.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.iso.test.ts
@@ -9,7 +9,10 @@ import {
   DescribeFunctionCommand,
   GetDistributionCommand,
   GetFunctionCommand,
+  GetInvalidationCommand,
+  ListDistributionsCommand,
   ListFunctionsCommand,
+  ListInvalidationsCommand,
   UpdateDistributionCommand,
 } from "@aws-sdk/client-cloudfront";
 import { CreateBucketCommand } from "@aws-sdk/client-s3";
@@ -183,24 +186,82 @@ describe("simulated CloudFront SDK Command routing", () => {
     assertIdentical(Buffer.from(got.FunctionCode).toString(), functionCode);
   });
 
+  it("round-trips invalidation Commands through an intercepted client", async () => {
+    using simSdk = new SimSdk();
+    await simSdk.simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "invalidated-bucket" }));
+
+    const client = new CloudFrontClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    const distroCreation = await client.send(
+      new CreateDistributionCommand({
+        DistributionConfig: {
+          CallerReference: "sdk-invalidation-ref-1",
+          Origins: {
+            Items: [
+              {
+                Id: "origin1",
+                DomainName: "invalidated-bucket.s3.amazonaws.com",
+                S3OriginConfig: { OriginAccessIdentity: "" },
+              },
+            ],
+            Quantity: 1,
+          },
+          DefaultCacheBehavior: {
+            TargetOriginId: "origin1",
+            ViewerProtocolPolicy: "redirect-to-https",
+          },
+          Comment: "SDK intercepted invalidations",
+          Enabled: true,
+        },
+      }),
+    );
+
+    assertNonNullable(distroCreation.Distribution?.Id);
+    const distributionId = distroCreation.Distribution.Id;
+
+    const invalidation = await client.send(
+      new CreateInvalidationCommand({
+        DistributionId: distributionId,
+        InvalidationBatch: {
+          CallerReference: "sdk-invalidation-batch-1",
+          Paths: { Quantity: 1, Items: ["/*"] },
+        },
+      }),
+    );
+
+    assertNonNullable(invalidation.Invalidation?.Id);
+
+    const got = await client.send(
+      new GetInvalidationCommand({
+        DistributionId: distributionId,
+        Id: invalidation.Invalidation.Id,
+      }),
+    );
+    const listing = await client.send(
+      new ListInvalidationsCommand({ DistributionId: distributionId }),
+    );
+
+    assertIdentical(got.Invalidation?.Id, invalidation.Invalidation.Id);
+    assertIdentical(listing.InvalidationList?.Quantity, 1);
+    assertIdentical(
+      listing.InvalidationList.Items?.[0]?.Id,
+      invalidation.Invalidation.Id,
+    );
+  });
+
   it("rejects a Command simulated CloudFront does not support", async () => {
     using simSdk = new SimSdk();
     const client = new CloudFrontClient({ region: "us-east-1" });
     simSdk.intercept(client);
 
     const error = await assertThrowsErrorAsync(async () => {
-      await client.send(
-        new CreateInvalidationCommand({
-          DistributionId: "D123",
-          InvalidationBatch: {
-            CallerReference: "unsupported",
-            Paths: { Quantity: 1, Items: ["/*"] },
-          },
-        }),
-      );
+      await client.send(new ListDistributionsCommand({}));
     });
 
-    assertStringIncludes(error.message, "CreateInvalidationCommand");
+    assertStringIncludes(error.message, "ListDistributionsCommand");
     assertStringIncludes(error.message, "CreateDistributionCommand");
   });
 });

--- a/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
+++ b/src/service/cloudfront/sdk/sim-cloudfront-sdk-command-router.ts
@@ -14,6 +14,11 @@ import type {
 } from "../command/function/sim-cf-function-command.types.js";
 import type { SimGetDistributionCommand } from "../command/get-distribution/get-distribution.command.js";
 import type {
+  SimCreateInvalidationCommand,
+  SimGetInvalidationCommand,
+  SimListInvalidationsCommand,
+} from "../command/invalidation/sim-cf-invalidation-command.types.js";
+import type {
   SimCreateKeyValueStoreCommand,
   SimDeleteKeyValueStoreCommand,
   SimDescribeKeyValueStoreCommand,
@@ -93,6 +98,30 @@ export class SimCloudFrontSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simCloudFront.getDistribution(
             command as SimGetDistributionCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateInvalidationCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.createInvalidation(
+            command as SimCreateInvalidationCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "GetInvalidationCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.getInvalidation(
+            command as SimGetInvalidationCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListInvalidationsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFront.listInvalidations(
+            command as SimListInvalidationsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/cloudfront/sim-cloudfront-caching.ts
+++ b/src/service/cloudfront/sim-cloudfront-caching.ts
@@ -2,7 +2,7 @@ import {
   type SimCfCachingConfiguration,
   SimCloudFrontRegistry,
 } from "./registry/sim-cloud-front-registry.js";
-import { SimCloudFrontPolicies } from "./sim-cloudfront-policies.js";
+import { SimCloudFrontOriginAccessControls } from "./sim-cloudfront-origin-access-controls.js";
 
 /**
  * The cache one simulated CloudFront's Distributions hold, and whether they
@@ -14,7 +14,7 @@ import { SimCloudFrontPolicies } from "./sim-cloudfront-policies.js";
  * `SimCloudFront` extends this, and a caller reaches it on the one service
  * object.
  */
-export class SimCloudFrontCaching extends SimCloudFrontPolicies {
+export class SimCloudFrontCaching extends SimCloudFrontOriginAccessControls {
   protected readonly cloudFrontRegistry: SimCloudFrontRegistry;
 
   constructor(cloudFrontRegistry?: SimCloudFrontRegistry) {

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -55,6 +55,7 @@ import { SimCloudFrontKeyValueStoreRegistry } from "./key-value-store/sim-cf-key
 import { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.js";
 import { SimCffKeyValueStoreUsers } from "./cff/kvs/sim-cff-key-value-store-users.js";
 import { SimCfFunctionCommands } from "./cff/sim-cf-function-commands.js";
+import { SimCfInvalidationCommands } from "./command/invalidation/sim-cf-invalidation-commands.js";
 
 /**
  * How one simulated CloudFront is put together.
@@ -147,6 +148,11 @@ export class SimCloudFrontCommands {
    */
   public readonly functions: SimCfFunctionCommands;
 
+  /**
+   * The invalidation commands, and the Distributions they clear.
+   */
+  public readonly invalidations: SimCfInvalidationCommands;
+
   private readonly distributionState: SimCloudFrontDistributionState;
   private readonly configurationState: SimCfDistributionConfigurationState;
 
@@ -183,6 +189,12 @@ export class SimCloudFrontCommands {
       iam,
       background,
       keyValueStores,
+    });
+    this.invalidations = new SimCfInvalidationCommands({
+      accountId,
+      distributions,
+      iam,
+      background,
     });
     this.configurationState = {
       s3OriginResolver,

--- a/src/service/cloudfront/sim-cloudfront-distributions.ts
+++ b/src/service/cloudfront/sim-cloudfront-distributions.ts
@@ -1,0 +1,38 @@
+import type {
+  SimCloudFrontDistribution,
+  SimCloudFrontDistributionId,
+} from "./distribution/sim-cloudfront-distribution.js";
+import { SimCloudFrontCaching } from "./sim-cloudfront-caching.js";
+import type {
+  SimCloudFrontDistributionMap,
+  SimCloudFrontDistributionsById,
+} from "./sim-cloudfront-commands.js";
+
+/**
+ * The Distributions one simulated CloudFront holds.
+ *
+ * The commands work on this map, and a test reads it back through these
+ * accessors. `SimCloudFront` extends this, and a caller reaches the
+ * Distributions on the one service object.
+ */
+export class SimCloudFrontDistributions extends SimCloudFrontCaching {
+  protected readonly distributions: SimCloudFrontDistributionMap = new Map();
+
+  /**
+   * Get the simulated Distributions owned by this sim CloudFront service.
+   */
+  getDistributions(): SimCloudFrontDistributionsById {
+    return this.distributions;
+  }
+
+  /**
+   * Get a simulated CloudFront Distribution by ID.
+   */
+  getSimDistributionById(
+    distributionId: SimCloudFrontDistributionId | string,
+  ): SimCloudFrontDistribution | undefined {
+    return this.distributions.get(
+      distributionId as SimCloudFrontDistributionId,
+    );
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront-origin-access-controls.ts
+++ b/src/service/cloudfront/sim-cloudfront-origin-access-controls.ts
@@ -1,0 +1,50 @@
+import type {
+  SimCloudFrontOriginAccessControl,
+  SimCloudFrontOriginAccessControlId,
+} from "./origin-access-control/sim-cf-origin-access-control.js";
+import { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
+import { SimCloudFrontPolicies } from "./sim-cloudfront-policies.js";
+
+/**
+ * The origin access controls one simulated CloudFront holds.
+ *
+ * An Origin names one by ID, and this is where it is found. There is no
+ * CreateOriginAccessControl command in this simulation, so CloudFormation is
+ * the only thing that makes one, and these methods are how it hands one over.
+ * `SimCloudFront` extends this, and a caller reaches them on the one service
+ * object.
+ */
+export class SimCloudFrontOriginAccessControls extends SimCloudFrontPolicies {
+  protected readonly originAccessControls =
+    new SimCloudFrontOriginAccessControlRegistry();
+
+  /**
+   * Store a simulated origin access control.
+   *
+   * A name another origin access control already holds is refused, as
+   * CloudFront refuses one.
+   */
+  addOriginAccessControl(
+    originAccessControl: SimCloudFrontOriginAccessControl,
+  ): void {
+    this.originAccessControls.add(originAccessControl);
+  }
+
+  /**
+   * Forget a simulated origin access control.
+   */
+  removeOriginAccessControl(
+    originAccessControlId: SimCloudFrontOriginAccessControlId,
+  ): void {
+    this.originAccessControls.remove(originAccessControlId);
+  }
+
+  /**
+   * Get a simulated origin access control by ID.
+   */
+  getOriginAccessControlById(
+    originAccessControlId: SimCloudFrontOriginAccessControlId | string,
+  ): SimCloudFrontOriginAccessControl | undefined {
+    return this.originAccessControls.byId(originAccessControlId);
+  }
+}

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -38,27 +38,24 @@ import type {
   SimGetDistributionCommandOutput,
 } from "./command/get-distribution/get-distribution.command.js";
 import type {
+  SimCreateInvalidationCommand,
+  SimCreateInvalidationCommandOutput,
+  SimGetInvalidationCommand,
+  SimGetInvalidationCommandOutput,
+  SimListInvalidationsCommand,
+  SimListInvalidationsCommandOutput,
+} from "./command/invalidation/sim-cf-invalidation-command.types.js";
+import type {
   SimUpdateDistributionCommand,
   SimUpdateDistributionCommandOutput,
 } from "./command/update-distribution/update-distribution.command.js";
-import type {
-  SimCloudFrontDistribution,
-  SimCloudFrontDistributionId,
-} from "./distribution/sim-cloudfront-distribution.js";
-import { SimCloudFrontCaching } from "./sim-cloudfront-caching.js";
-import type {
-  SimCloudFrontOriginAccessControl,
-  SimCloudFrontOriginAccessControlId,
-} from "./origin-access-control/sim-cf-origin-access-control.js";
-import { SimCloudFrontOriginAccessControlRegistry } from "./origin-access-control/sim-cf-origin-access-control-registry.js";
+import { SimCloudFrontDistributions } from "./sim-cloudfront-distributions.js";
 import type { SimCfKeyValueStoreCommands } from "./key-value-store/sim-cf-key-value-store-commands.js";
 import type { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.js";
 import { simCffNameInArn } from "./cff/sim-cff-arn.js";
 import { SimCloudFrontSdkCommandRouter } from "./sdk/sim-cloudfront-sdk-command-router.js";
 import {
   SimCloudFrontCommands,
-  type SimCloudFrontDistributionMap,
-  type SimCloudFrontDistributionsById,
   type SimCloudFrontProperties,
   type SimCloudFrontRequestOptions,
 } from "./sim-cloudfront-commands.js";
@@ -71,11 +68,8 @@ export type {
 /**
  * Simulated CloudFront. Handles SDK commands. Emulates AWS behaviour and state.
  */
-export class SimCloudFront extends SimCloudFrontCaching {
-  private readonly distributions: SimCloudFrontDistributionMap = new Map();
+export class SimCloudFront extends SimCloudFrontDistributions {
   private readonly cloudFrontFunctions: SimCloudFrontFunctionMap = new Map();
-  private readonly originAccessControls =
-    new SimCloudFrontOriginAccessControlRegistry();
 
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly commands: SimCloudFrontCommands;
@@ -119,24 +113,6 @@ export class SimCloudFront extends SimCloudFrontCaching {
   }
 
   /**
-   * Get the simulated Distributions owned by this sim CloudFront service.
-   */
-  getDistributions(): SimCloudFrontDistributionsById {
-    return this.distributions;
-  }
-
-  /**
-   * Get a simulated CloudFront Distribution by ID.
-   */
-  getSimDistributionById(
-    distributionId: SimCloudFrontDistributionId | string,
-  ): SimCloudFrontDistribution | undefined {
-    return this.distributions.get(
-      distributionId as SimCloudFrontDistributionId,
-    );
-  }
-
-  /**
    * Handle a Create Distribution Command from the SDK.
    */
   async createDistribution(
@@ -174,6 +150,42 @@ export class SimCloudFront extends SimCloudFrontCaching {
     options?: SimCloudFrontRequestOptions,
   ): Promise<SimDeleteDistributionCommandOutput> {
     return await this.commands.deleteDistribution(command, options);
+  }
+
+  /**
+   * Handle a Create Invalidation Command from the SDK.
+   */
+  async createInvalidation(
+    command: SimCreateInvalidationCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimCreateInvalidationCommandOutput> {
+    return await this.commands.invalidations.createInvalidation(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Handle a Get Invalidation Command from the SDK.
+   */
+  async getInvalidation(
+    command: SimGetInvalidationCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimGetInvalidationCommandOutput> {
+    return await this.commands.invalidations.getInvalidation(command, options);
+  }
+
+  /**
+   * Handle a List Invalidations Command from the SDK.
+   */
+  async listInvalidations(
+    command: SimListInvalidationsCommand,
+    options?: SimCloudFrontRequestOptions,
+  ): Promise<SimListInvalidationsCommandOutput> {
+    return await this.commands.invalidations.listInvalidations(
+      command,
+      options,
+    );
   }
 
   /**
@@ -249,38 +261,6 @@ export class SimCloudFront extends SimCloudFrontCaching {
     return this.cloudFrontFunctions.get(
       cloudFrontFunctionName as SimCloudFrontFunctionName,
     );
-  }
-
-  /**
-   * Store a simulated origin access control.
-   *
-   * There is no CreateOriginAccessControl command here, so CloudFormation is
-   * the only thing that makes one, and this is how it hands it over. A name
-   * another origin access control already holds is refused, as CloudFront
-   * refuses one.
-   */
-  addOriginAccessControl(
-    originAccessControl: SimCloudFrontOriginAccessControl,
-  ): void {
-    this.originAccessControls.add(originAccessControl);
-  }
-
-  /**
-   * Forget a simulated origin access control.
-   */
-  removeOriginAccessControl(
-    originAccessControlId: SimCloudFrontOriginAccessControlId,
-  ): void {
-    this.originAccessControls.remove(originAccessControlId);
-  }
-
-  /**
-   * Get a simulated origin access control by ID.
-   */
-  getOriginAccessControlById(
-    originAccessControlId: SimCloudFrontOriginAccessControlId | string,
-  ): SimCloudFrontOriginAccessControl | undefined {
-    return this.originAccessControls.byId(originAccessControlId);
   }
 
   /**


### PR DESCRIPTION
CreateInvalidation clears the entries a batch of paths names, and the next request for one of them reaches the Origin. A path ending in a wildcard clears everything below it, and `/*` clears the whole Distribution. Clearing reaches every edge, since an invalidation is not scoped to the point of presence the batch was created against. An invalidation starts `InProgress` and reaches `Completed` on the background scheduler, and GetDistribution now counts the running ones as `InProgressInvalidationBatches`. GetInvalidation and ListInvalidations read them back, an unknown ID is `NoSuchInvalidation`, and a repeated `CallerReference` answers with the invalidation it already created or is refused with `InvalidationBatchAlreadyExists` where the paths differ. All three commands route through `SimCloudFrontSdkCommandRouter`. `SimCloudFront` hands its Distribution map and its origin access controls to two new classes in its chain, keeping the file under the line limit.

Resolves #1152