### PR TITLE
feat: say whether a Distribution's cache answered

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1554,6 +1554,10 @@ error status. It runs on whatever the Origin answered, including a 400 and above
 origin events differ from the viewer events, and CloudFront documents it. Returning a response
 replaces what the viewer gets.
 
+Both origin events run on a cache miss alone. A hit answers the viewer without either of them, as
+does a request a web ACL blocked or a viewer-request function answered. An `origin-request` function
+returning a response leaves the Origin unread, with no `origin-response` event after it.
+
 At both origin events the `host` header holds the Origin's own domain name. A viewer event shows the
 domain the viewer used.
 
@@ -2450,6 +2454,7 @@ try {
   const home = srv.localUrl(`http://${distroHostname}/`);
 
   const first = await fetch(home);
+  console.log(first.headers.get("x-cache")); // Miss from cloudfront
   console.log(await first.text()); // <h1>First</h1>
 
   // The Bucket holds a new page, which the Distribution has not been told
@@ -2457,7 +2462,14 @@ try {
   await publish("<h1>Second</h1>");
 
   const second = await fetch(home);
+  console.log(second.headers.get("x-cache")); // Hit from cloudfront
   console.log(await second.text()); // <h1>First</h1>
+
+  // The entry goes on ageing while simulated time moves.
+  await simAws.clock().advanceBy({ seconds: 30 });
+
+  const aged = await fetch(home);
+  console.log(aged.headers.get("age")); // 30
 
   // Another point of presence has nothing cached under that key.
   const coldEdge = await fetch(home, {
@@ -2640,6 +2652,21 @@ zero. Where it is higher, the floor overrides the Origin and the answer is held 
 seconds. That last one is CloudFront's own behaviour, and the
 [AWS documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html)
 carries a warning about it.
+
+### Telling a hit from a miss
+
+Every answer carries `X-Cache`. It reads `Hit from cloudfront` where the Distribution held the
+object and `Miss from cloudfront` where the Origin answered. A hit carries `Age` as well, the whole
+seconds the entry has been held, counted on the simulation's clock from the moment the Origin
+answered. Advancing simulated time by a minute adds 60 to the age the next hit reports.
+
+Both headers go on ahead of the Behavior's response headers policy and the viewer-response event. A
+policy listing `X-Cache` among its headers to remove takes it off, and a viewer-response CloudFront
+Function or Lambda@Edge function reads both in its event.
+
+A hit is answered without running either origin event. `origin-request` and `origin-response` run on
+the miss that filled the cache and on nothing after it, as they do on AWS. The viewer events run
+either way, and so does the Behavior's response headers policy.
 
 ### Applying a response headers policy
 
@@ -3793,17 +3820,17 @@ Where sim CloudFront knowingly behaves differently from AWS:
   `Stale-While-Revalidate` and `Stale-If-Error` are read as no directive at all. Nothing stale is
   ever served.
 - **A cached entry stays until it expires or an invalidation clears it.** Nothing evicts one to make
-  room, and the response carries no `X-Cache` or `Age` header.
+  room.
+- **`X-Cache` says Hit or Miss and nothing else.** Real CloudFront also reports `RefreshHit`,
+  `Error`, `Redirect`, `LambdaGeneratedResponse` and `FunctionGeneratedResponse` there. A response
+  answered before the cache was reached (one a web ACL blocked, or one a viewer-request function
+  returned) carries no `X-Cache` at all.
 - **An invalidation listing is never paged.** `ListInvalidations` echoes the `Marker` and `MaxItems`
   it was sent and answers with every invalidation the Distribution holds. `IsTruncated` is always
   false and no `NextMarker` comes back. Real CloudFront pages at 100.
 - **A Behavior with no cache policy caches nothing.** Real CloudFront falls back to the legacy
   `ForwardedValues` and the TTLs beside it, and sim CloudFront skips both. Give the Behavior a
   `CachePolicyId`, as CDK and the console both do.
-- **The origin events run on a cache miss, and every request that reaches the Origin is one.** A
-  request a web ACL blocked or a viewer-request function answered reaches neither event, and an
-  `origin-request` function that returns a response leaves the Origin unread with no
-  `origin-response` event after it.
 - **An Origin keeps its kind and its Bucket through an origin-request function.** Real CloudFront
   lets a handler hand back `origin.s3` where it was given `origin.custom`, or point an S3 Origin at
   another Bucket. Both need something a simulated Origin does not hold, the dispatcher that reaches

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -2655,10 +2655,12 @@ carries a warning about it.
 
 ### Telling a hit from a miss
 
-Every answer carries `X-Cache`. It reads `Hit from cloudfront` where the Distribution held the
-object and `Miss from cloudfront` where the Origin answered. A hit carries `Age` as well, the whole
-seconds the entry has been held, counted on the simulation's clock from the moment the Origin
-answered. Advancing simulated time by a minute adds 60 to the age the next hit reports.
+An answer the cache or the Origin produced carries `X-Cache`. It reads `Hit from cloudfront` where
+the Distribution held the object and `Miss from cloudfront` where the Origin answered. A response
+returned earlier in the pipeline (one a web ACL blocked, or one a viewer-request function answered
+with) carries none. A hit carries `Age` as well, the whole seconds the entry has been held, counted
+on the simulation's clock from the moment the Origin answered. Advancing simulated time by a minute
+adds 60 to the age the next hit reports.
 
 Both headers go on ahead of the Behavior's response headers policy and the viewer-response event. A
 policy listing `X-Cache` among its headers to remove takes it off, and a viewer-response CloudFront

--- a/docs/services/cloudfront/sim-cloudfront-caching.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-caching.example.ts
@@ -89,6 +89,7 @@ try {
   const home = srv.localUrl(`http://${distroHostname}/`);
 
   const first = await fetch(home);
+  console.log(first.headers.get("x-cache")); // Miss from cloudfront
   console.log(await first.text()); // <h1>First</h1>
 
   // The Bucket holds a new page, which the Distribution has not been told
@@ -96,7 +97,14 @@ try {
   await publish("<h1>Second</h1>");
 
   const second = await fetch(home);
+  console.log(second.headers.get("x-cache")); // Hit from cloudfront
   console.log(await second.text()); // <h1>First</h1>
+
+  // The entry goes on ageing while simulated time moves.
+  await simAws.clock().advanceBy({ seconds: 30 });
+
+  const aged = await fetch(home);
+  console.log(aged.headers.get("age")); // 30
 
   // Another point of presence has nothing cached under that key.
   const coldEdge = await fetch(home, {

--- a/src/service/cloudfront/cache/sim-cf-cache-status.ts
+++ b/src/service/cloudfront/cache/sim-cf-cache-status.ts
@@ -1,0 +1,63 @@
+/**
+ * What CloudFront tells the viewer about the cache that answered.
+ *
+ * `X-Cache` says whether the Distribution held the object, and `Age` says how
+ * long it has held it. Both go on ahead of the Behavior's response headers
+ * policy and the viewer-response event. A policy can take either off, and a
+ * viewer-response function sees them.
+ *
+ * Real CloudFront writes several other values into `X-Cache` (`RefreshHit` and
+ * `LambdaGeneratedResponse` among them). A hit and a miss are the two this
+ * simulation reaches, and a response answered before the cache was consulted
+ * carries no `X-Cache` at all.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html
+ */
+const xCacheHeaderName = "x-cache";
+
+/**
+ * The header a hit carries its age in, in seconds.
+ */
+export const simCfAgeHeaderName = "age";
+
+/**
+ * What `X-Cache` reads when the Distribution's cache answered.
+ */
+export const simCfCacheHit = "Hit from cloudfront";
+
+/**
+ * What `X-Cache` reads when the Origin answered.
+ */
+export const simCfCacheMiss = "Miss from cloudfront";
+
+/**
+ * The response with `X-Cache` saying which of the two answered it.
+ *
+ * An `X-Cache` an Origin sent is replaced, the way CloudFront replaces one.
+ */
+export function simCfCacheStatusResponse(
+  response: Response,
+  hit: boolean,
+): Response {
+  const headers = new Headers(response.headers);
+
+  headers.set(xCacheHeaderName, hit ? simCfCacheHit : simCfCacheMiss);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+/**
+ * How long an entry stored at one instant has been held at another, in whole
+ * seconds.
+ *
+ * Both instants come off the simulation's clock. A test reaches any age it
+ * wants by advancing simulated time. A clock wound backwards would give a
+ * negative age, and HTTP has no such thing, so zero is the floor.
+ */
+export function simCfCacheAgeSec(storedAt: Date, now: Date): number {
+  return Math.max(0, Math.floor((now.getTime() - storedAt.getTime()) / 1000));
+}

--- a/src/service/cloudfront/cache/sim-cf-distribution-cache.ts
+++ b/src/service/cloudfront/cache/sim-cf-distribution-cache.ts
@@ -1,5 +1,6 @@
 import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
 import { simCfInvalidationBatchCovers } from "../invalidation/sim-cf-invalidation-path.js";
+import { simCfAgeHeaderName, simCfCacheAgeSec } from "./sim-cf-cache-status.js";
 import { simCfCacheEntryKeyPath } from "./sim-cf-cache-entry-key-path.js";
 
 /**
@@ -17,8 +18,8 @@ interface SimCfCachedResponse {
   readonly body: Uint8Array;
 
   /**
-   * When the entry was stored, off the simulation's clock. This is what the
-   * `Age` header a hit carries will be measured from.
+   * When the entry was stored, off the simulation's clock. The `Age` header a
+   * hit carries is measured from this.
    */
   readonly storedAt: Date;
 
@@ -68,6 +69,10 @@ export class SimCfDistributionCache {
    *
    * An entry that has reached its expiry is dropped here. The request then goes
    * to the Origin, and what the Origin answers replaces the expired entry.
+   *
+   * What comes back carries `Age`, counted on the simulation's clock from the
+   * instant the Origin's answer was stored. An `Age` the Origin sent is
+   * replaced by the Distribution's own, as CloudFront replaces one.
    */
   read(key: string): Response | undefined {
     const entry = this.entries.get(key);
@@ -76,13 +81,22 @@ export class SimCfDistributionCache {
       return undefined;
     }
 
-    if (this.clock.now().getTime() >= entry.expiresAt.getTime()) {
+    const now = this.clock.now();
+
+    if (now.getTime() >= entry.expiresAt.getTime()) {
       this.entries.delete(key);
 
       return undefined;
     }
 
-    return cachedResponse(entry);
+    const response = cachedResponse(entry);
+
+    response.headers.set(
+      simCfAgeHeaderName,
+      String(simCfCacheAgeSec(entry.storedAt, now)),
+    );
+
+    return response;
   }
 
   /**
@@ -140,6 +154,9 @@ export class SimCfDistributionCache {
 
 /**
  * Build a response from a cached one, which every read needs its own of.
+ *
+ * No `Age` goes on here. A response on its way into the cache has been held
+ * for no time at all, and only one leaving it has an age to report.
  */
 function cachedResponse(entry: SimCfCachedResponse): Response {
   return new Response(bodylessStatuses.has(entry.status) ? null : entry.body, {

--- a/src/service/cloudfront/controller/content/sim-cf-cache-hit-events.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-cache-hit-events.iso.test.ts
@@ -1,0 +1,169 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simCfManagedResponseHeadersPolicyIds } from "../../response-headers-policy/sim-cf-managed-response-headers-policies.js";
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import { makeEdgeFunctionVersionArn } from "../../../../../test/cloudfront/edge-function-fixture.js";
+import {
+  countingOrigin,
+  distributionServing,
+  type OriginReads,
+} from "../../../../../test/cloudfront/cache-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+/**
+ * How many times an edge function has run, which is what says whether the
+ * event fired for a request the cache answered.
+ */
+interface EventRuns {
+  count: number;
+}
+
+describe("Which sim CloudFront events a cache hit runs", () => {
+  it("runs neither origin event on a hit", async () => {
+    // Given a Behavior counting both of its origin events, in front of an
+    // Origin counting its reads.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const requestRuns: EventRuns = { count: 0 };
+    const responseRuns: EventRuns = { count: 0 };
+
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      {
+        TargetOriginId: "api",
+        LambdaFunctionAssociations: {
+          Quantity: 2,
+          Items: [
+            {
+              EventType: "origin-request",
+              LambdaFunctionARN: await makeEdgeFunctionVersionArn({
+                simAws,
+                functionName: "counting-origin-request",
+                handler: (event: LambdaAtEdge.OriginRequestEvent) => {
+                  requestRuns.count += 1;
+
+                  return event.Records[0].cf.request;
+                },
+              }),
+            },
+            {
+              EventType: "origin-response",
+              LambdaFunctionARN: await makeEdgeFunctionVersionArn({
+                simAws,
+                functionName: "counting-origin-response",
+                handler: (event: LambdaAtEdge.ResponseEvent) => {
+                  responseRuns.count += 1;
+
+                  return event.Records[0].cf.response;
+                },
+              }),
+            },
+          ],
+        },
+      },
+    );
+
+    // When the same path is asked for twice.
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const hit = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then only the miss ran them, and only the miss reached the Origin.
+    assertIdentical(hit.headers.get("x-cache"), "Hit from cloudfront");
+    assertIdentical(requestRuns.count, 1);
+    assertIdentical(responseRuns.count, 1);
+    assertIdentical(reads.count, 1);
+  });
+
+  it("runs both viewer events on a hit", async () => {
+    // Given a Behavior counting both of its viewer events, whose
+    // viewer-response function marks what it saw.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const requestRuns: EventRuns = { count: 0 };
+
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      {
+        TargetOriginId: "api",
+        LambdaFunctionAssociations: {
+          Quantity: 2,
+          Items: [
+            {
+              EventType: "viewer-request",
+              LambdaFunctionARN: await makeEdgeFunctionVersionArn({
+                simAws,
+                functionName: "counting-viewer-request",
+                handler: (event: LambdaAtEdge.RequestEvent) => {
+                  requestRuns.count += 1;
+
+                  return event.Records[0].cf.request;
+                },
+              }),
+            },
+            {
+              EventType: "viewer-response",
+              LambdaFunctionARN: await makeEdgeFunctionVersionArn({
+                simAws,
+                functionName: "marking-viewer-response",
+                handler: (event: LambdaAtEdge.ResponseEvent) => {
+                  const { response } = event.Records[0].cf;
+                  response.headers ??= {};
+                  response.headers["x-viewer-response"] = [
+                    {
+                      key: "X-Viewer-Response",
+                      value: response.headers["x-cache"]?.[0]?.value ?? "none",
+                    },
+                  ];
+
+                  return response;
+                },
+              }),
+            },
+          ],
+        },
+      },
+    );
+
+    // When the same path is asked for twice.
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const hit = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the viewer-request function ran for both, and the viewer-response
+    // function ran on the hit and saw the hit it was.
+    assertIdentical(requestRuns.count, 2);
+    assertIdentical(
+      hit.headers.get("x-viewer-response"),
+      "Hit from cloudfront",
+    );
+    assertIdentical(reads.count, 1);
+  });
+
+  it("applies the Behavior's response headers policy to a hit", async () => {
+    // Given a Behavior on the managed SecurityHeadersPolicy, in front of an
+    // Origin that sends none of its headers.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      {
+        TargetOriginId: "api",
+        ResponseHeadersPolicyId:
+          simCfManagedResponseHeadersPolicyIds.securityHeaders,
+      },
+    );
+
+    // When the same path is asked for twice.
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const hit = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the policy is on the cached answer as it was on the Origin's.
+    assertIdentical(hit.headers.get("x-cache"), "Hit from cloudfront");
+    assertIdentical(hit.headers.get("x-frame-options"), "SAMEORIGIN");
+    assertIdentical(reads.count, 1);
+  });
+});

--- a/src/service/cloudfront/controller/content/sim-cf-cache-status.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-cache-status.iso.test.ts
@@ -1,0 +1,78 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import {
+  countingOrigin,
+  distributionServing,
+  type OriginReads,
+} from "../../../../../test/cloudfront/cache-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+describe("What a sim CloudFront answer says about the cache", () => {
+  it("calls the first answer a miss and the second one a hit", async () => {
+    // Given a Distribution on CachingOptimized, in front of an Origin.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+
+    // When the same path is asked for twice.
+    const first = await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the Origin's answer is a miss and the cache's is a hit.
+    assertIdentical(first.headers.get("x-cache"), "Miss from cloudfront");
+    assertIdentical(second.headers.get("x-cache"), "Hit from cloudfront");
+  });
+
+  it("calls every answer a miss while caching is off", async () => {
+    // Given a simulation with caching turned off.
+    const simAws = new SimAws();
+    simAws.cloudFront().configureCaching({ enabled: false });
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+
+    // When the same path is asked for twice.
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the second answer came from the Origin as the first one did.
+    assertIdentical(second.headers.get("x-cache"), "Miss from cloudfront");
+    assertIdentical(reads.count, 2);
+  });
+
+  it("ages a hit on the simulation's clock", async () => {
+    // Given a path the Distribution has answered once and cached.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+    );
+    const miss = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the Origin's own answer carries no age.
+    assertIdentical(miss.headers.get("age"), null);
+
+    // And when simulated time moves on by half a minute.
+    await simAws.clock().advanceBy({ seconds: 30 });
+    const held = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the hit has been held for that long.
+    assertIdentical(held.headers.get("age"), "30");
+
+    // And when simulated time moves on again.
+    await simAws.clock().advanceBy({ seconds: 45 });
+    const older = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the age has grown with it, and the Origin was read once.
+    assertIdentical(older.headers.get("age"), "75");
+    assertIdentical(reads.count, 1);
+  });
+});

--- a/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
@@ -25,6 +25,17 @@ export interface SimCfContentRequest {
 }
 
 /**
+ * What the content stage produced, and which of the two produced it.
+ */
+export interface SimCfContentStageResult extends SimCfOriginStageResult {
+  /**
+   * Whether the Distribution's cache answered, which the pipeline reports to
+   * the viewer in `X-Cache`.
+   */
+  readonly cacheHit: boolean;
+}
+
+/**
  * Answers a request from the Distribution's cache, or from the Origin.
  *
  * This is CloudFront's cache lookup and everything behind it. A key the cache
@@ -47,7 +58,7 @@ export class SimCfContentStage {
   /**
    * Answer one request, reading the Origin only where the cache cannot.
    */
-  async serve(content: SimCfContentRequest): Promise<SimCfOriginStageResult> {
+  async serve(content: SimCfContentRequest): Promise<SimCfContentStageResult> {
     const { request, distribution, behaviour } = content;
     const cacheable = simCfCacheableRequest(content);
     const cached =
@@ -59,7 +70,7 @@ export class SimCfContentStage {
     // status the pipeline reads is the cached one and a viewer-response
     // function runs on a hit as it ran on the miss that filled the cache.
     if (cached !== undefined) {
-      return { response: cached, originStatus: cached.status };
+      return { response: cached, originStatus: cached.status, cacheHit: true };
     }
 
     const originResult = await this.originStage.fetch(
@@ -78,7 +89,11 @@ export class SimCfContentStage {
       originResult.originStatus >= 400 ||
       response.status >= 400
     ) {
-      return { response, originStatus: originResult.originStatus };
+      return {
+        response,
+        originStatus: originResult.originStatus,
+        cacheHit: false,
+      };
     }
 
     return {
@@ -92,6 +107,7 @@ export class SimCfContentStage {
         }),
       ),
       originStatus: originResult.originStatus,
+      cacheHit: false,
     };
   }
 }

--- a/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
+++ b/src/service/cloudfront/controller/sim-cloudfront-request-pipeline.ts
@@ -1,4 +1,5 @@
 import type { SimCloudFrontControllerDependencies } from "./dependency/sim-cf-controller-dependency.js";
+import { simCfCacheStatusResponse } from "../cache/sim-cf-cache-status.js";
 import { simCfRequestEdge } from "../cache/sim-cf-edge.js";
 import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root-object-request.js";
 
@@ -7,8 +8,9 @@ import { simCfDefaultRootObjectRequest } from "./root-object/sim-cf-default-root
  * read the edge it arrived at, route to a Distribution, put the request
  * through the Distribution's web ACL, apply the default root object, resolve
  * the matching Behavior, run viewer-request hooks, answer from that edge's
- * cache or from the Origin, apply the Behavior's response headers policy, then
- * run viewer-response hooks where the Origin did not answer with an error.
+ * cache or from the Origin, say which of the two answered in `X-Cache`, apply
+ * the Behavior's response headers policy, then run viewer-response hooks where
+ * the Origin did not answer with an error.
  *
  * A viewer hook is a CloudFront Function or a Lambda@Edge function. A Behavior
  * carries at most one of the two kinds at the viewer events, which
@@ -101,6 +103,12 @@ export class SimCloudFrontRequestPipeline {
       edgeId: edge.edgeId,
     });
 
+    // Say whether the cache or the Origin answered, as CloudFront says it. A
+    // hit already carries the `Age` the cache measured. Both go on ahead of the
+    // response headers policy and the viewer-response event. A policy can take
+    // either off, and a viewer-response function sees them.
+    const served = simCfCacheStatusResponse(content.response, content.cacheHit);
+
     // Apply the Behavior's response headers policy, if it names one. CloudFront
     // does this after the response leaves the cache and before the
     // viewer-response event, so the custom error page above carries the
@@ -108,7 +116,7 @@ export class SimCloudFrontRequestPipeline {
     const response = this.stages.responseHeadersApplicator.apply(
       cloudFront,
       requestReference,
-      content.response,
+      served,
       behaviour,
     );
 


### PR DESCRIPTION
Resolves #1151.

A response now carries `X-Cache`, reading `Hit from cloudfront` where the Distribution's cache answered and `Miss from cloudfront` where the Origin did, and a hit carries the `Age` the cache measured on the simulation's clock from the instant the Origin's answer was stored. `SimCfContentStage.serve` reports which of the two answered on a new `cacheHit` field of `SimCfContentStageResult`, and the pipeline writes both headers ahead of the Behavior's response headers policy and the viewer-response event. Tests cover the origin events staying unrun on a hit, the viewer events and the response headers policy still running on one, and the age growing as simulated time moves. The Limitations entry about the origin events comes out of the CloudFront docs.

Two of the issue's acceptance criteria were already met by #1160, which put the origin stage behind the cache lookup. Those two now have tests behind them.

### Note for #1153

`SimCfContentStage.serve` returns `SimCfContentStageResult` in place of `SimCfOriginStageResult`. It is the same shape with `cacheHit: boolean` added, and every one of `serve`'s three return points sets it. The error branch (`originStatus >= 400 || response.status >= 400`) is one of them, so a rewrite of that branch for `ErrorCachingMinTTL` needs `cacheHit` on whatever it returns. Whoever lands second rebases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CloudFront cache-status reporting with `X-Cache` hit/miss indicators and response `Age` values.
  - Cached responses now preserve accurate simulated aging and clearly identify whether the cache or origin responded.
  - Viewer request and response processing now reflects cache hits, while origin processing occurs only on misses.

- **Documentation**
  - Expanded caching examples and guidance for cache headers, response policies, viewer events, WAF-blocked requests, and cache expiration or invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->