### PR TITLE
feat: hold an error for its ErrorCachingMinTTL

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -262,9 +262,12 @@ fetching it, as in CloudFront.
 A viewer-response function never sees a custom error page. CloudFront runs no viewer-response
 function once the Origin has answered 400 or higher, and simulated CloudFront does the same, for a
 CloudFront Function and a Lambda@Edge function alike. The status the Origin returned is what decides
-that, whatever `ResponseCode` puts in its place. `ErrorCachingMinTTL` is accepted and ignored, along
-with a rule that sets nothing else. An Origin error is never cached here, so there is no TTL for it
-to shorten.
+that, whatever `ResponseCode` puts in its place.
+
+`ErrorCachingMinTTL` says how many seconds the Distribution holds the error for before it reads the
+Origin again. A rule carrying it alone, with no `ResponsePagePath`, configures error caching for a
+status the Distribution serves no page for. See
+[What a Distribution stores](#what-a-distribution-stores).
 
 ## Serve simulated CloudFront on localhost
 
@@ -2518,8 +2521,12 @@ policy's `MaxTTL` is above zero. That leaves out a Behavior naming a `CachePolic
 account, a Behavior naming none at all, and a Behavior on `CachingDisabled`. The alternative in each
 case would be a guessed TTL.
 
-An Origin error stays out of the cache. Real CloudFront holds one for the `ErrorCachingMinTTL` its
-custom error response carries, and nothing here reads that yet.
+An error is held for a TTL of its own. It comes from the `ErrorCachingMinTTL` of the custom error
+response matching the status, and from CloudFront's ten seconds where the Distribution configures no
+rule for that status. The Origin's cache headers and the Behavior's cache policy have no say in it.
+A rule with `ErrorCachingMinTTL: 0` holds the error for no time at all, and every failing request
+reaches the Origin. A rule is matched on the status the Origin answered with. A 404 the Distribution
+serves as a 200 error page is held for the seconds the 404's own rule allows.
 
 ### How long an entry is held
 
@@ -3833,6 +3840,10 @@ Where sim CloudFront knowingly behaves differently from AWS:
 - **A Behavior with no cache policy caches nothing.** Real CloudFront falls back to the legacy
   `ForwardedValues` and the TTLs beside it, and sim CloudFront skips both. Give the Behavior a
   `CachePolicyId`, as CDK and the console both do.
+- **Every error status is held for its error TTL.** Real CloudFront caches 404, 414, 500, 501, 502,
+  503 and 504, and caches 400, 403 and 405 only where the Origin sent a `Cache-Control max-age` or
+  `s-maxage` header. It then holds the error for the longer of that header and `ErrorCachingMinTTL`.
+  Here every status of 400 and above is held for `ErrorCachingMinTTL` alone.
 - **An Origin keeps its kind and its Bucket through an origin-request function.** Real CloudFront
   lets a handler hand back `origin.s3` where it was given `origin.custom`, or point an S3 Origin at
   another Bucket. Both need something a simulated Origin does not hold, the dispatcher that reaches

--- a/src/service/cloudfront/cache/sim-cf-error-cache-ttl.ts
+++ b/src/service/cloudfront/cache/sim-cf-error-cache-ttl.ts
@@ -1,0 +1,57 @@
+import {
+  simCloudFrontDefaultErrorCachingMinTtlSec,
+  type SimCloudFrontCustomErrorResponse,
+} from "../custom-error/sim-cloudfront-custom-error-response.js";
+
+interface SimCfErrorCacheTtlProperties {
+  /**
+   * The status the Origin answered with, before an origin-response function
+   * or a custom error page could replace it.
+   */
+  readonly originStatus: number;
+
+  /** The response carrying on towards the viewer. */
+  readonly response: Response;
+
+  /**
+   * The Distribution's custom error responses, whose `ErrorCachingMinTTL`
+   * decides.
+   */
+  readonly customErrorResponses: readonly SimCloudFrontCustomErrorResponse[];
+}
+
+/**
+ * How many seconds a Distribution holds an error for, or none where this
+ * answer is no error at all.
+ *
+ * An error has a TTL of its own, and the Origin's cache headers and the
+ * Behavior's cache policy have no say in it. It comes from the custom error
+ * response matching the status, and from CloudFront's ten seconds where the
+ * Distribution configures no rule for that status. An `ErrorCachingMinTTL` of
+ * zero holds the error for no time at all, which is how a Distribution turns
+ * error caching off.
+ *
+ * The Origin's status is what a rule is matched against. A 404 the
+ * Distribution answers with a 200 error page is still held as the error it
+ * was, for the seconds the 404's own rule allows. An error that only an
+ * origin-response function made has no Origin error behind it, and its own
+ * status stands in.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html
+ */
+export function simCfErrorCacheTtlSec(
+  properties: SimCfErrorCacheTtlProperties,
+): number | undefined {
+  const { originStatus, response, customErrorResponses } = properties;
+  const errorStatus = originStatus >= 400 ? originStatus : response.status;
+
+  if (errorStatus < 400) {
+    return undefined;
+  }
+
+  return (
+    customErrorResponses.find(
+      (customErrorResponse) => customErrorResponse.errorCode === errorStatus,
+    )?.errorCachingMinTtlSec ?? simCloudFrontDefaultErrorCachingMinTtlSec
+  );
+}

--- a/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-error-pages.iso.test.ts
+++ b/src/service/cloudfront/cfn/distro/sim-cfn-cf-distro-error-pages.iso.test.ts
@@ -13,6 +13,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { grantPublicObjectRead } from "../../../s3/bucket/sim-s3-public-read.fixture.js";
 import { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
+import { simCfManagedCachePolicyIds } from "../../cache-policy/sim-cf-managed-cache-policies.js";
 import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
 
 describe("CloudFormation Distribution error pages and root object", () => {
@@ -103,6 +104,90 @@ describe("CloudFormation Distribution error pages and root object", () => {
     // Then the error page is served with the status the template asked for.
     assertResponseStatus(missing, 404, await describeResponse(missing));
     assertIdentical(await missing.text(), "<h1>Not found</h1>");
+  });
+
+  it("holds an error for an ErrorCachingMinTTL a template wrote as a string", async () => {
+    // Given a template configuring error caching alone, with the seconds
+    // written as a string, as a template can carry any scalar as one.
+    const simAws = new SimAws();
+
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "error-caching-stack",
+      template: {
+        Resources: {
+          SiteBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: { BucketName: "error-caching-bucket" },
+          },
+          SiteDistribution: {
+            Type: "AWS::CloudFront::Distribution",
+            DependsOn: "SiteBucket",
+            Properties: {
+              DistributionConfig: {
+                CustomErrorResponses: [
+                  { ErrorCode: 404, ErrorCachingMinTTL: "30" },
+                ],
+                Origins: [
+                  {
+                    Id: "SiteOrigin",
+                    DomainName: "error-caching-bucket.s3.amazonaws.com",
+                    S3OriginConfig: {},
+                  },
+                ],
+                DefaultCacheBehavior: {
+                  TargetOriginId: "SiteOrigin",
+                  ViewerProtocolPolicy: "redirect-to-https",
+                  CachePolicyId: simCfManagedCachePolicyIds.cachingOptimized,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const resource = stack.getResource("SiteDistribution");
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimCloudFrontDistribution);
+    const distributionId = resource.simResource.distributionId;
+
+    const simS3 = simAws.s3();
+    await grantPublicObjectRead(simS3, "error-caching-bucket");
+
+    // And a page the Bucket has no object for yet.
+    const missing = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/page.html",
+    );
+    assertResponseStatus(missing, 404, await describeResponse(missing));
+
+    // When the page is published and asked for inside the half minute.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "error-caching-bucket",
+        Key: "page.html",
+        ContentType: "text/html",
+        Body: "<h1>Published</h1>",
+      }),
+    );
+    await simAws.clock().advanceBy({ seconds: 29 });
+    const held = await simCfSiteRequest(simAws, distributionId, "/page.html");
+
+    // Then the cache is still answering with the 404 the template's seconds
+    // asked for.
+    assertResponseStatus(held, 404, await describeResponse(held));
+
+    // And when simulated time moves past the half minute.
+    await simAws.clock().advanceBy({ seconds: 2 });
+    const published = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/page.html",
+    );
+
+    // Then the request reached the Bucket, which now holds the page.
+    assertIdentical(await published.text(), "<h1>Published</h1>");
   });
 
   it("fails the stack for an unusable default root object", async () => {

--- a/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-content-stage.ts
@@ -1,5 +1,6 @@
 import { simCfCacheableRequest } from "../../cache/sim-cf-cacheable-request.js";
 import { simCfCacheTtlSec } from "../../cache/sim-cf-cache-ttl.js";
+import { simCfErrorCacheTtlSec } from "../../cache/sim-cf-error-cache-ttl.js";
 import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
 import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
@@ -44,10 +45,10 @@ export interface SimCfContentStageResult extends SimCfOriginStageResult {
  * is stored under the key it missed on for as long as the Origin's headers and
  * the cache policy between them allow.
  *
- * An error stays out of the cache, whether the Origin answered with it or an
- * origin-response function made one of an Origin's answer. Real CloudFront
- * holds one for `ErrorCachingMinTTL`, which is a TTL of its own rather than the
- * one the Origin's headers ask for.
+ * An error is stored for a TTL of its own. The `ErrorCachingMinTTL` of the
+ * custom error response matching the status decides it, whether the Origin
+ * answered with the error or an origin-response function made one of an
+ * Origin's answer.
  */
 export class SimCfContentStage {
   constructor(
@@ -84,11 +85,7 @@ export class SimCfContentStage {
       originResult.response,
     );
 
-    if (
-      cacheable === undefined ||
-      originResult.originStatus >= 400 ||
-      response.status >= 400
-    ) {
+    if (cacheable === undefined) {
       return {
         response,
         originStatus: originResult.originStatus,
@@ -96,15 +93,22 @@ export class SimCfContentStage {
       };
     }
 
+    const errorTtlSec = simCfErrorCacheTtlSec({
+      originStatus: originResult.originStatus,
+      response,
+      customErrorResponses: distribution.customErrorResponses,
+    });
+
     return {
       response: await distribution.cache.store(
         cacheable.key,
         response,
-        simCfCacheTtlSec({
-          response,
-          policy: cacheable.policy,
-          now: distribution.clock.now(),
-        }),
+        errorTtlSec ??
+          simCfCacheTtlSec({
+            response,
+            policy: cacheable.policy,
+            now: distribution.clock.now(),
+          }),
       ),
       originStatus: originResult.originStatus,
       cacheHit: false,

--- a/src/service/cloudfront/controller/content/sim-cf-distribution-cache.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-distribution-cache.iso.test.ts
@@ -6,8 +6,6 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
-import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
-import { makeEdgeFunctionVersionArn } from "../../../../../test/cloudfront/edge-function-fixture.js";
 import {
   countingOrigin,
   distributionServing,
@@ -54,64 +52,5 @@ describe("What a sim CloudFront Distribution caches", () => {
     // Then the empty answer was held on to and served again.
     assertResponseStatus(second, 204, await describeResponse(second));
     assertIdentical(reads.count, 1);
-  });
-
-  it("stores nothing an origin-response function turned into an error", async () => {
-    // Given a Behavior whose origin-response function answers 503 for the
-    // Origin's 200.
-    const simAws = new SimAws();
-    const reads: OriginReads = { count: 0 };
-    const versionArn = await makeEdgeFunctionVersionArn({
-      simAws,
-      functionName: "failing-origin-response",
-      handler: (
-        event: LambdaAtEdge.OriginResponseEvent,
-      ): LambdaAtEdge.Response => ({
-        ...event.Records[0].cf.response,
-        status: "503",
-        statusDescription: "Service Unavailable",
-      }),
-    });
-    const distributionId = await distributionServing(
-      simAws,
-      await countingOrigin(simAws, reads),
-      {
-        TargetOriginId: "api",
-        LambdaFunctionAssociations: {
-          Quantity: 1,
-          Items: [
-            { EventType: "origin-response", LambdaFunctionARN: versionArn },
-          ],
-        },
-      },
-    );
-
-    // When the same path is asked for twice.
-    const first = await simCfSiteRequest(simAws, distributionId, "/greeting");
-    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
-
-    // Then the error was answered both times, from the Origin both times,
-    // rather than held on to for every request after it.
-    assertResponseStatus(first, 503, await describeResponse(first));
-    assertResponseStatus(second, 503, await describeResponse(second));
-    assertIdentical(reads.count, 2);
-  });
-
-  it("stores nothing for an Origin error", async () => {
-    // Given an Origin failing the first read and answering the second.
-    const simAws = new SimAws();
-    const reads: OriginReads = { count: 0 };
-    const distributionId = await distributionServing(
-      simAws,
-      await statusSequenceOrigin(simAws, reads, [500, 200]),
-    );
-
-    // When the failing answer is asked for again.
-    const failed = await simCfSiteRequest(simAws, distributionId, "/greeting");
-    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
-
-    // Then the error was not held on to, and the second read answered.
-    assertResponseStatus(failed, 500, await describeResponse(failed));
-    assertIdentical(await readNumber(second), 2);
   });
 });

--- a/src/service/cloudfront/controller/content/sim-cf-error-caching.iso.test.ts
+++ b/src/service/cloudfront/controller/content/sim-cf-error-caching.iso.test.ts
@@ -1,0 +1,225 @@
+import {
+  assertIdentical,
+  assertResponseStatus,
+  assertStringIncludes,
+  assertStringNotIncludes,
+  describeResponse,
+} from "@kensio/smartass";
+import { DeleteObjectCommand } from "@aws-sdk/client-s3";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { LambdaAtEdge } from "../../typings/lambda-at-edge.namespace.js";
+import { makeEdgeFunctionVersionArn } from "../../../../../test/cloudfront/edge-function-fixture.js";
+import { simCfManagedCachePolicyIds } from "../../cache-policy/sim-cf-managed-cache-policies.js";
+import {
+  countingOrigin,
+  distributionServing,
+  type OriginReads,
+  readNumber,
+  statusSequenceOrigin,
+} from "../../../../../test/cloudfront/cache-fixture.js";
+import {
+  simCfSiteBucket,
+  simCfSiteDistributionConfig,
+  simCfSiteDistributionId,
+  simCfSiteRequest,
+} from "../../../../../test/cloudfront/site-fixture.js";
+
+describe("How long a sim CloudFront Distribution holds an error", () => {
+  it("holds an Origin error for its custom error response's ErrorCachingMinTTL", async () => {
+    // Given a Distribution holding a 500 for half a minute, in front of an
+    // Origin failing its first read.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await statusSequenceOrigin(simAws, reads, [500, 200]),
+      {},
+      {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [{ ErrorCode: 500, ErrorCachingMinTTL: 30 }],
+        },
+      },
+    );
+    const failed = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // When the same path is asked for inside that half minute.
+    await simAws.clock().advanceBy({ seconds: 29 });
+    const held = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the cache answered with the error, and the Origin was left alone.
+    assertResponseStatus(failed, 500, await describeResponse(failed));
+    assertResponseStatus(held, 500, await describeResponse(held));
+    assertIdentical(reads.count, 1);
+
+    // And when simulated time moves past the half minute.
+    await simAws.clock().advanceBy({ seconds: 2 });
+    const recovered = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/greeting",
+    );
+
+    // Then the request reached the Origin, which had recovered.
+    assertIdentical(await readNumber(recovered), 2);
+  });
+
+  it("holds an error it has no custom error response for, for ten seconds", async () => {
+    // Given a Distribution configuring no custom error response at all, in
+    // front of an Origin failing its first read.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await statusSequenceOrigin(simAws, reads, [503, 200]),
+    );
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // When the same path is asked for inside CloudFront's ten seconds.
+    await simAws.clock().advanceBy({ seconds: 9 });
+    const held = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the cache answered with the error.
+    assertResponseStatus(held, 503, await describeResponse(held));
+    assertIdentical(reads.count, 1);
+
+    // And when simulated time moves past the ten seconds.
+    await simAws.clock().advanceBy({ seconds: 2 });
+    const recovered = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/greeting",
+    );
+
+    // Then the request reached the Origin.
+    assertIdentical(await readNumber(recovered), 2);
+  });
+
+  it("sends every request to the Origin where ErrorCachingMinTTL is zero", async () => {
+    // Given a Distribution turning error caching off for a 500, in front of an
+    // Origin failing twice.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const distributionId = await distributionServing(
+      simAws,
+      await statusSequenceOrigin(simAws, reads, [500, 500]),
+      {},
+      {
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [{ ErrorCode: 500, ErrorCachingMinTTL: 0 }],
+        },
+      },
+    );
+
+    // When the same path is asked for three times, with no time passing.
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const second = await simCfSiteRequest(simAws, distributionId, "/greeting");
+    const third = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then every request reached the Origin, and the third one got its answer.
+    assertResponseStatus(second, 500, await describeResponse(second));
+    assertIdentical(await readNumber(third), 3);
+    assertIdentical(reads.count, 3);
+  });
+
+  it("holds an error an origin-response function made of an Origin's answer", async () => {
+    // Given a Behavior whose origin-response function answers 503 for the
+    // Origin's 200.
+    const simAws = new SimAws();
+    const reads: OriginReads = { count: 0 };
+    const versionArn = await makeEdgeFunctionVersionArn({
+      simAws,
+      functionName: "failing-origin-response",
+      handler: (
+        event: LambdaAtEdge.OriginResponseEvent,
+      ): LambdaAtEdge.Response => ({
+        ...event.Records[0].cf.response,
+        status: "503",
+        statusDescription: "Service Unavailable",
+      }),
+    });
+    const distributionId = await distributionServing(
+      simAws,
+      await countingOrigin(simAws, reads),
+      {
+        TargetOriginId: "api",
+        LambdaFunctionAssociations: {
+          Quantity: 1,
+          Items: [
+            { EventType: "origin-response", LambdaFunctionARN: versionArn },
+          ],
+        },
+      },
+    );
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // When the same path is asked for inside CloudFront's ten seconds.
+    await simAws.clock().advanceBy({ seconds: 9 });
+    const held = await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the error the function made was answered from the cache.
+    assertResponseStatus(held, 503, await describeResponse(held));
+    assertIdentical(reads.count, 1);
+
+    // And when simulated time moves past the ten seconds.
+    await simAws.clock().advanceBy({ seconds: 2 });
+    await simCfSiteRequest(simAws, distributionId, "/greeting");
+
+    // Then the request reached the Origin again.
+    assertIdentical(reads.count, 2);
+  });
+
+  it("holds a custom error page for the rule that serves it", async () => {
+    // Given a site serving one error page for a missing object, held for five
+    // seconds.
+    const simAws = new SimAws();
+    await simCfSiteBucket(simAws, "held-error-site", {
+      "404.html": "<h1>Not found here</h1>",
+    });
+    const distributionId = await simCfSiteDistributionId(
+      simAws,
+      simCfSiteDistributionConfig("held-error-site", {
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+          CachePolicyId: simCfManagedCachePolicyIds.cachingOptimized,
+        },
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [
+            {
+              ErrorCode: 404,
+              ResponsePagePath: "/404.html",
+              ResponseCode: "404",
+              ErrorCachingMinTTL: 5,
+            },
+          ],
+        },
+      }),
+    );
+    await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // When the error page is taken out of the Bucket and the path is asked for
+    // again inside the five seconds.
+    await simAws.s3().deleteObject(
+      new DeleteObjectCommand({
+        Bucket: "held-error-site",
+        Key: "404.html",
+      }),
+    );
+    const held = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the page came from the cache.
+    assertStringIncludes(await held.text(), "Not found here");
+
+    // And when simulated time moves past the five seconds.
+    await simAws.clock().advanceBy({ seconds: 6 });
+    const expired = await simCfSiteRequest(simAws, distributionId, "/missing");
+
+    // Then the Distribution went back to the Origin, where the page has gone.
+    assertStringNotIncludes(await expired.text(), "Not found here");
+  });
+});

--- a/src/service/cloudfront/controller/error/sim-cf-custom-error-responder.ts
+++ b/src/service/cloudfront/controller/error/sim-cf-custom-error-responder.ts
@@ -1,7 +1,7 @@
 import type { SimCloudFrontBehaviorResolver } from "../../resolver/sim-cloud-front-behavior-resolver.js";
 import type { SimCloudFrontOriginFetcher } from "../origin/sim-cloudfront-origin-fetcher.js";
 import type { SimCloudFrontDistribution } from "../../distribution/sim-cloudfront-distribution.js";
-import type { SimCloudFrontCustomErrorResponse } from "../../custom-error/sim-cloudfront-custom-error-response.js";
+import type { SimCloudFrontCustomErrorPage } from "../../custom-error/sim-cloudfront-custom-error-response.js";
 
 interface SimCfCustomErrorResponderProperties {
   readonly behaviourResolver: SimCloudFrontBehaviorResolver;
@@ -15,6 +15,10 @@ interface SimCfCustomErrorResponderProperties {
  * matching the response page path decides which Origin it comes from. That is
  * what lets a Distribution keep its error pages somewhere other than the
  * content that failed, as CloudFront does.
+ *
+ * A rule carrying `ErrorCachingMinTTL` alone has no page. The Origin's error
+ * reaches the viewer, and the rule says how long the Distribution holds it
+ * for.
  */
 export class SimCfCustomErrorResponder {
   private readonly behaviourResolver: SimCloudFrontBehaviorResolver;
@@ -34,23 +38,23 @@ export class SimCfCustomErrorResponder {
     distribution: SimCloudFrontDistribution,
     response: Response,
   ): Promise<Response> {
-    const customErrorResponse = distribution.customErrorResponses.find(
+    const page = distribution.customErrorResponses.find(
       (candidate) => candidate.errorCode === response.status,
-    );
+    )?.page;
 
-    if (customErrorResponse === undefined) {
+    if (page === undefined) {
       return response;
     }
 
-    return await this.responsePage(request, distribution, customErrorResponse);
+    return await this.responsePage(request, distribution, page);
   }
 
   private async responsePage(
     request: Request,
     distribution: SimCloudFrontDistribution,
-    customErrorResponse: SimCloudFrontCustomErrorResponse,
+    page: SimCloudFrontCustomErrorPage,
   ): Promise<Response> {
-    const pageRequest = this.pageRequest(request, customErrorResponse);
+    const pageRequest = this.pageRequest(request, page);
     const behaviour = this.behaviourResolver.resolve(pageRequest, distribution);
     const pageResponse = await this.originFetcher.fetch(
       pageRequest,
@@ -65,17 +69,17 @@ export class SimCfCustomErrorResponder {
     }
 
     return new Response(pageResponse.body, {
-      status: customErrorResponse.responseCode,
+      status: page.responseCode,
       headers: pageResponse.headers,
     });
   }
 
   private pageRequest(
     request: Request,
-    customErrorResponse: SimCloudFrontCustomErrorResponse,
+    page: SimCloudFrontCustomErrorPage,
   ): Request {
     const url = new URL(request.url);
-    url.pathname = customErrorResponse.responsePagePath;
+    url.pathname = page.responsePagePath;
     url.search = "";
 
     // The response page is fetched without a body, whatever the viewer sent,

--- a/src/service/cloudfront/custom-error/sim-cloudfront-custom-error-response.ts
+++ b/src/service/cloudfront/custom-error/sim-cloudfront-custom-error-response.ts
@@ -15,14 +15,34 @@ export const simCloudFrontCustomErrorResponseCodes: ReadonlySet<number> =
   new Set([200, ...simCloudFrontCustomErrorCodes]);
 
 /**
+ * How long CloudFront holds an error for where a rule names no
+ * `ErrorCachingMinTTL`, and where a Distribution configures no rule for the
+ * status at all.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html
+ */
+export const simCloudFrontDefaultErrorCachingMinTtlSec = 10;
+
+/**
+ * The page a custom error response serves in place of the Origin's error.
+ *
+ * CloudFront pairs `ResponsePagePath` and `ResponseCode`. A rule carries both
+ * or neither.
+ */
+export interface SimCloudFrontCustomErrorPage {
+  readonly responsePagePath: string;
+  readonly responseCode: number;
+}
+
+/**
  * A custom error response of a sim CloudFront Distribution.
  *
- * Only a rule with a response page reaches this model. A rule carrying nothing
- * but `ErrorCode` and `ErrorCachingMinTTL` configures error caching, which the
- * simulator has nothing to cache with.
+ * A rule carrying nothing but `ErrorCode` and `ErrorCachingMinTTL` configures
+ * how long the Origin's own error is held for. It has no page, and the viewer
+ * gets what the Origin answered.
  */
 export interface SimCloudFrontCustomErrorResponse {
   readonly errorCode: number;
-  readonly responsePagePath: string;
-  readonly responseCode: number;
+  readonly errorCachingMinTtlSec: number;
+  readonly page?: SimCloudFrontCustomErrorPage | undefined;
 }

--- a/src/service/cloudfront/distribution/configurator/sim-cf-custom-error-config.iso.test.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cf-custom-error-config.iso.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from "vitest";
 import {
+  assertIdentical,
   assertInstanceOf,
+  assertNonNullable,
   assertStringIncludes,
+  assertUndefined,
   assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import {
@@ -10,6 +13,7 @@ import {
 } from "@aws-sdk/client-cloudfront";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCloudFrontCustomErrorResponse } from "../../custom-error/sim-cloudfront-custom-error-response.js";
 import {
   SimCloudFrontInvalidArgument,
   SimCloudFrontInvalidErrorCode,
@@ -44,6 +48,46 @@ async function refusedCustomErrorResponse(
         }),
       ),
   );
+}
+
+/**
+ * Create a Distribution carrying one custom error response, returning the rule
+ * it was configured with.
+ */
+async function configuredCustomErrorResponse(
+  customErrorResponse: CustomErrorResponse,
+): Promise<SimCloudFrontCustomErrorResponse> {
+  const simAws = new SimAws();
+  const creation = await simAws.cloudFront().createDistribution(
+    new CreateDistributionCommand({
+      DistributionConfig: {
+        CallerReference: "custom-error-config",
+        Comment: "Custom error response config",
+        Enabled: true,
+        Origins: { Quantity: 0, Items: [] },
+        DefaultCacheBehavior: {
+          TargetOriginId: "site-origin",
+          ViewerProtocolPolicy: "allow-all",
+        },
+        CustomErrorResponses: {
+          Quantity: 1,
+          Items: [customErrorResponse],
+        },
+      },
+    }),
+  );
+
+  assertNonNullable(creation.Distribution?.Id);
+
+  const distribution = simAws
+    .cloudFront()
+    .getSimDistributionById(creation.Distribution.Id);
+
+  assertNonNullable(distribution);
+  const [configured] = distribution.customErrorResponses;
+  assertNonNullable(configured);
+
+  return configured;
 }
 
 describe("Sim CloudFront custom error response configuration", () => {
@@ -138,5 +182,19 @@ describe("Sim CloudFront custom error response configuration", () => {
     // failing on the request that would serve the page.
     assertInstanceOf(error, SimCloudFrontInvalidResponseCode);
     assertStringIncludes(error.message, "204");
+  });
+
+  it("holds an error for ten seconds where the seconds are no number", async () => {
+    // Given a rule for a status the Distribution serves no page for, whose
+    // ErrorCachingMinTTL a template left empty.
+    const configured = await configuredCustomErrorResponse({
+      ErrorCode: 500,
+      ErrorCachingMinTTL: "" as unknown as number,
+    });
+
+    // Then CloudFront's own ten seconds stand in, and the rule is configured
+    // with no page.
+    assertIdentical(configured.errorCachingMinTtlSec, 10);
+    assertUndefined(configured.page);
   });
 });

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-custom-error-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-custom-error-configurator.ts
@@ -79,16 +79,20 @@ export class SimCloudFrontCustomErrorConfigurator {
    * How long the rule holds its error for, which CloudFront defaults to ten
    * seconds.
    *
-   * A value a template wrote as something other than a number falls back to
-   * the same default. The alternative would be a stack that fails to deploy
-   * over the seconds an error is held for.
+   * A template can write a number as a string, and that one is read as the
+   * seconds it spells. Anything else falls back to the default. The
+   * alternative would be a stack that fails to deploy over the seconds an
+   * error is held for.
    */
-  private errorCachingMinTtlSec(
-    errorCachingMinTtl: number | undefined,
-  ): number {
-    const seconds = Number(errorCachingMinTtl);
+  private errorCachingMinTtlSec(errorCachingMinTtl: unknown): number {
+    const seconds =
+      typeof errorCachingMinTtl === "string" && errorCachingMinTtl.trim() !== ""
+        ? Number(errorCachingMinTtl)
+        : errorCachingMinTtl;
 
-    return Number.isFinite(seconds) && seconds >= 0
+    return typeof seconds === "number" &&
+      Number.isFinite(seconds) &&
+      seconds >= 0
       ? seconds
       : simCloudFrontDefaultErrorCachingMinTtlSec;
   }

--- a/src/service/cloudfront/distribution/configurator/sim-cloud-front-custom-error-configurator.ts
+++ b/src/service/cloudfront/distribution/configurator/sim-cloud-front-custom-error-configurator.ts
@@ -3,6 +3,7 @@ import type { SimCloudFrontDistribution } from "../sim-cloudfront-distribution.j
 import {
   simCloudFrontCustomErrorCodes,
   simCloudFrontCustomErrorResponseCodes,
+  simCloudFrontDefaultErrorCachingMinTtlSec,
 } from "../../custom-error/sim-cloudfront-custom-error-response.js";
 import {
   SimCloudFrontInvalidArgument,
@@ -14,10 +15,10 @@ import {
  * Applies custom error response configuration to a sim CloudFront
  * Distribution.
  *
- * CloudFront pairs `ResponsePagePath` and `ResponseCode`: a rule carrying one
+ * CloudFront pairs `ResponsePagePath` and `ResponseCode`. A rule carrying one
  * without the other is refused rather than half applied. A rule carrying
- * neither only configures error caching, which this simulator does not model,
- * so it is accepted and left out of the Distribution's request handling.
+ * neither configures error caching alone, and it reaches the Distribution with
+ * no page for the viewer to be sent.
  */
 export class SimCloudFrontCustomErrorConfigurator {
   /**
@@ -39,6 +40,9 @@ export class SimCloudFrontCustomErrorConfigurator {
 
     const responsePagePath = customErrorResponse.ResponsePagePath;
     const responseCode = this.responseCode(customErrorResponse.ResponseCode);
+    const errorCachingMinTtlSec = this.errorCachingMinTtlSec(
+      customErrorResponse.ErrorCachingMinTTL,
+    );
 
     if (responsePagePath === undefined || responsePagePath === "") {
       if (responseCode !== undefined) {
@@ -46,6 +50,8 @@ export class SimCloudFrontCustomErrorConfigurator {
           `CloudFront CustomErrorResponse for ${String(errorCode)} has a ResponseCode without a ResponsePagePath`,
         );
       }
+
+      distribution.addCustomErrorResponse({ errorCode, errorCachingMinTtlSec });
 
       return;
     }
@@ -64,9 +70,27 @@ export class SimCloudFrontCustomErrorConfigurator {
 
     distribution.addCustomErrorResponse({
       errorCode,
-      responsePagePath,
-      responseCode,
+      errorCachingMinTtlSec,
+      page: { responsePagePath, responseCode },
     });
+  }
+
+  /**
+   * How long the rule holds its error for, which CloudFront defaults to ten
+   * seconds.
+   *
+   * A value a template wrote as something other than a number falls back to
+   * the same default. The alternative would be a stack that fails to deploy
+   * over the seconds an error is held for.
+   */
+  private errorCachingMinTtlSec(
+    errorCachingMinTtl: number | undefined,
+  ): number {
+    const seconds = Number(errorCachingMinTtl);
+
+    return Number.isFinite(seconds) && seconds >= 0
+      ? seconds
+      : simCloudFrontDefaultErrorCachingMinTtlSec;
   }
 
   private responseCode(

--- a/test/cloudfront/cache-fixture.ts
+++ b/test/cloudfront/cache-fixture.ts
@@ -16,6 +16,7 @@ import {
 import {
   CreateDistributionCommand,
   type DefaultCacheBehavior,
+  type DistributionConfig,
 } from "@aws-sdk/client-cloudfront";
 
 import type { SimPayload2Event } from "../../src/serve/payload-2/sim-payload-2-event.type.js";
@@ -62,11 +63,16 @@ export async function countingOrigin(
 /**
  * A Distribution serving that Origin, whose default Behavior is the one the
  * test is about. It caches on CachingOptimized unless the test says otherwise.
+ *
+ * Both overrides are merged shallowly over what is built here. Pass
+ * `distributionConfig` for the Distribution settings a test is about, such as
+ * its `CustomErrorResponses`.
  */
 export async function distributionServing(
   simAws: SimAws,
   originHostname: string,
   cacheBehavior: Partial<DefaultCacheBehavior> = {},
+  distributionConfig: Partial<DistributionConfig> = {},
 ): Promise<string> {
   const creation = await simAws.cloudFront().createDistribution(
     new CreateDistributionCommand({
@@ -84,6 +90,7 @@ export async function distributionServing(
           CachePolicyId: simCfManagedCachePolicyIds.cachingOptimized,
           ...cacheBehavior,
         },
+        ...distributionConfig,
       },
     }),
   );


### PR DESCRIPTION
A Distribution now holds an error response the way it holds anything else it serves, for the `ErrorCachingMinTTL` of the custom error response matching the status and for CloudFront's ten seconds where it configures no rule for that status. A second request inside that window is answered from the cache, and one after it reaches the Origin again. A rule carrying `ErrorCachingMinTTL: 0` holds nothing, and a rule carrying `ErrorCachingMinTTL` with no `ResponsePagePath` now reaches the Distribution rather than being dropped for having no page.

Resolves #1153

## What changed in `SimCfContentStage.serve`

Issue #1151 is being implemented in parallel and touches the same method. The change here is the smallest one that would do:

- The early return that skipped the cache for `originStatus >= 400 || response.status >= 400` is gone. What remains of it is `if (cacheable === undefined)`, the guard that was already inside it.
- The `store` call takes `errorTtlSec ?? simCfCacheTtlSec(...)`, where `errorTtlSec` comes from the new `simCfErrorCacheTtlSec`. That function answers `undefined` where the response is no error, which is what leaves the ordinary path alone.
- The return shape is untouched. `serve` still answers `{ response, originStatus }` from both return points.

## Elsewhere

`SimCloudFrontCustomErrorResponse` carries `errorCachingMinTtlSec`, and its `responsePagePath` and `responseCode` move into an optional `page`. That is what lets a rule configuring error caching alone reach the Distribution with no page for the responder to serve. The configurator records it, defaulting the seconds to ten and falling back to the same default for a value a template wrote as something other than a number.

Two tests in `sim-cf-distribution-cache.iso.test.ts` asserted that an error stays out of the cache. That is the behaviour this issue changes, so both cases moved to the new suite and assert the caching instead.

## What this does not do

Real CloudFront caches 404, 414, 500, 501, 502, 503 and 504, and caches 400, 403 and 405 only where the Origin sent a `Cache-Control max-age` or `s-maxage` header. It then holds the error for the longer of that header and `ErrorCachingMinTTL`. Here every status of 400 and above is held for `ErrorCachingMinTTL` alone, which is what the issue's acceptance criteria describe. The gap is recorded in the CloudFront Limitations list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CloudFront now caches origin errors according to each custom error rule’s `ErrorCachingMinTTL`.
  - Unmatched errors use a default 10-second cache duration.
  - Error caching works independently of origin headers and cache policies.
  - Custom error rules can cache errors without serving a replacement error page.
  - Cached error responses expire and revalidate against the origin as configured.

- **Documentation**
  - Clarified error-caching behavior, defaults, supported status codes, and page-less custom error rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->