### PR TITLE
feat: count log events into a metric with a metric filter

### DIFF
--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -12,6 +12,10 @@ measured goes untested.
 Only custom metrics live here. This simulation publishes into no `AWS/` namespace. A query for
 `AWS/Lambda` `Invocations` comes back empty, in place of a number that was never measured.
 
+A custom metric's datapoints arrive either from `PutMetricData` or from a CloudWatch Logs metric
+filter counting matching log events. See the [CloudWatch Logs docs](../logs/README.md) for the
+second route.
+
 CloudWatch specific types are imported from the `@kensio/yulin/cloudwatch` subpath.
 
 ## Publishing and reading back a metric
@@ -413,7 +417,9 @@ test still passes and no longer means what it says.
   comes back at the period its query asked for.
 - **Cross-account metrics.** `IncludeLinkedAccounts` and `OwningAccount` are refused. There is no
   monitoring account.
-- **Metrics AWS publishes.** No simulated service writes its own `AWS/` metrics.
+- **Metrics AWS publishes.** No simulated service writes its own `AWS/` metrics. A CloudWatch Logs
+  metric filter naming a reserved namespace is refused here when it publishes, as `PutMetricData`
+  refuses a caller naming one.
 
 Two divergences are deliberate, and not refusals. Real CloudWatch rejects a datapoint more than two
 weeks old or more than two hours in the future, and this accepts any timestamp, letting a test seed

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -806,7 +806,9 @@ console.log(counted.Datapoints?.[0]?.Sum);
 
 Datapoints go in through the same `PutMetricData` an ordinary caller uses, into the CloudWatch of the log group's own Account and Region. A datapoint is stamped from the simulation's clock at the instant the event was written.
 
-A transformation carrying a `defaultValue` publishes that value for an event its pattern did not match, which is how real CloudWatch Logs keeps a metric reporting through a period where the term never appeared. A transformation without one publishes nothing for an event that missed, and a filter that matched nothing over a whole period leaves the metric with no datapoint at all.
+A transformation carrying a `defaultValue` publishes that value once for a minute that took log events and matched none of them, which is how real CloudWatch Logs keeps a metric reporting through a quiet stretch. A minute a match landed in publishes the match alone. A transformation with no default value publishes nothing for a minute it matched nothing in, and the metric is then left with no datapoint at all over that stretch.
+
+A transformation carrying dimensions cannot also carry a `defaultValue`, and one carrying both is refused. Real CloudWatch Logs allows one or the other, because a default would have to be reported against every dimension value the filter has ever seen.
 
 `DescribeLogGroups` reports how many filters a group has as `metricFilterCount`. `DescribeMetricFilters` takes an optional `logGroupName`. A request naming none, and giving a `metricNamespace` and `metricName`, finds every filter in the Region writing to that metric.
 
@@ -1041,8 +1043,13 @@ console.log(described.logGroups?.[0]?.logGroupArn);
 ## Limitations
 
 - **Events never expire.** Retention is stored and reported, never acted on.
-- **A metric filter reading a field of the log event.** A `metricValue` or a dimension value beginning `$` is refused where the filter is put. Both need a structured filter pattern, and neither structured syntax is simulated.
-- **`defaultValue` per event rather than per period.** A transformation carrying one publishes it for every event its pattern did not match, which is what the API documents. Real CloudWatch reports the default over a period with no matching event, so `Sum` and `Maximum` agree here and `SampleCount` and `Average` can differ.
+- **A metric filter reading a field of the log event.** A `metricValue` or a dimension value
+  beginning `$` is refused where the filter is put. Both need a structured filter pattern, and
+  neither structured syntax is simulated.
+- **How far back a `defaultValue` looks.** A filter remembers the most recent minute it matched
+  something in. A later write into that same minute publishes no default over the top, and a write
+  landing in an earlier minute a match was already seen in does publish one. Events
+  arrive in time order in a simulation, so this shows up only where a test writes into the past.
 - **Subscription filter destinations other than Lambda**, and `Distribution`. `Distribution` is
   accepted and reported, and with no shards to spread across it has no effect.
 - **`AWS::Logs::SubscriptionFilter`.** Recorded as a gap. The log group, the metric filter and the

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -730,6 +730,188 @@ await simAws.backgroundTasksComplete();
 A qualifier naming no version and no alias is refused where the filter is put, the way a missing
 function is. `UpdateAlias` moves what the filter reaches, and the filter stays as it is.
 
+## Metric filters
+
+A metric filter turns matching log events into CloudWatch metric datapoints. It is how a log line becomes something an alarm can watch, with no handler publishing a metric of its own.
+
+```typescript sim-logs-metric-filter
+/**
+ * Counting matching log lines into a CloudWatch metric.
+ */
+
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutMetricFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/30/[$LATEST]0f7c1a";
+const startedAt = new Date("2026-08-30T09:00:00Z");
+
+await simAws.clock().setTo(startedAt);
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+
+await simAws.logs().putMetricFilter(
+  new PutMetricFilterCommand({
+    logGroupName,
+    filterName: "handler-errors",
+    filterPattern: "ERROR",
+    metricTransformations: [
+      {
+        metricNamespace: "Orders",
+        metricName: "HandlerErrors",
+        metricValue: "1",
+        unit: "Count",
+      },
+    ],
+  }),
+);
+
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [
+      { timestamp: startedAt.getTime(), message: "INFO starting" },
+      { timestamp: startedAt.getTime(), message: "ERROR order has no items" },
+    ],
+  }),
+);
+
+// Publication happens after the write is answered, as it does in an account.
+await simAws.backgroundTasksComplete();
+
+const statistics = new GetMetricStatisticsCommand({
+  Namespace: "Orders",
+  MetricName: "HandlerErrors",
+  StartTime: startedAt,
+  EndTime: new Date(startedAt.getTime() + 60_000),
+  Period: 60,
+  Statistics: ["Sum"],
+});
+const counted = await simAws.cloudWatch().getMetricStatistics(statistics);
+
+// 1. The ERROR line counted and the INFO line did not.
+console.log(counted.Datapoints?.[0]?.Sum);
+```
+
+Datapoints go in through the same `PutMetricData` an ordinary caller uses, into the CloudWatch of the log group's own Account and Region. A datapoint is stamped from the simulation's clock at the instant the event was written.
+
+A transformation carrying a `defaultValue` publishes that value for an event its pattern did not match, which is how real CloudWatch Logs keeps a metric reporting through a period where the term never appeared. A transformation without one publishes nothing for an event that missed, and a filter that matched nothing over a whole period leaves the metric with no datapoint at all.
+
+`DescribeLogGroups` reports how many filters a group has as `metricFilterCount`. `DescribeMetricFilters` takes an optional `logGroupName`. A request naming none, and giving a `metricNamespace` and `metricName`, finds every filter in the Region writing to that metric.
+
+### Values a filter cannot read out of the event
+
+A `metricValue` or a dimension value naming a field of the matched event (`$.bytes`, `$1`) raises `SimLogsUnsupportedOperationException` at `PutMetricFilter`. Reading one needs the pattern to have been parsed structurally, and the structured pattern syntaxes are absent. A literal value publishes.
+
+A filter whose namespace begins `AWS/` is taken, because CloudWatch Logs takes one. The publication is then refused by `PutMetricData`, which reserves those namespaces exactly as real CloudWatch does. The refusal lands on `simAws.logs().metricFilterFailures` rather than failing the write that produced it, so a filter writing nowhere is something a test can assert on.
+
+### Declaring a metric filter in a template
+
+`AWS::Logs::MetricFilter` deploys through the same `PutMetricFilter`, so a stack's own alarm reads a metric its own log group produced.
+
+```typescript sim-cfn-logs-metric-filter
+/**
+ * Deploying a metric filter and an alarm over the metric it writes.
+ */
+
+import { DescribeAlarmsCommand } from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/30/[$LATEST]0f7c1a";
+
+await simAws.clock().setTo(new Date("2026-08-30T09:00:00Z"));
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersLogs: {
+        Type: "AWS::Logs::LogGroup",
+        Properties: { LogGroupName: logGroupName },
+      },
+      OrdersErrors: {
+        Type: "AWS::Logs::MetricFilter",
+        Properties: {
+          LogGroupName: { Ref: "OrdersLogs" },
+          FilterName: "handler-errors",
+          FilterPattern: "ERROR",
+          MetricTransformations: [
+            {
+              MetricNamespace: "Orders",
+              MetricName: "HandlerErrors",
+              MetricValue: "1",
+              Dimensions: [{ Key: "service", Value: "orders" }],
+            },
+          ],
+        },
+      },
+      OrdersFailing: {
+        Type: "AWS::CloudWatch::Alarm",
+        Properties: {
+          AlarmName: "OrdersFailing",
+          Namespace: "Orders",
+          MetricName: "HandlerErrors",
+          Dimensions: [{ Name: "service", Value: "orders" }],
+          Statistic: "Sum",
+          Period: 60,
+          EvaluationPeriods: 3,
+          DatapointsToAlarm: 1,
+          Threshold: 0,
+          ComparisonOperator: "GreaterThanThreshold",
+          TreatMissingData: "notBreaching",
+        },
+      },
+    },
+  },
+});
+
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [
+      {
+        timestamp: simAws.clock().now().getTime(),
+        message: "ERROR order has no items",
+      },
+    ],
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 2 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(new DescribeAlarmsCommand({ AlarmNames: ["OrdersFailing"] }));
+
+// ALARM. One log line drove it, with nothing publishing a metric by hand.
+console.log(MetricAlarms?.[0]?.StateValue);
+```
+
+`Ref` returns the filter name, and a filter with no `FilterName` is named after the stack and the logical ID. `Dimensions` is a list of `Key` and `Value` pairs in a template and a map through the SDK, and both reach the same filter. Deleting the stack takes the filter with the log group.
+
 ## Permissions
 
 Every operation goes through simulated IAM. An operation on a named log group authorizes against
@@ -859,11 +1041,14 @@ console.log(described.logGroups?.[0]?.logGroupArn);
 ## Limitations
 
 - **Events never expire.** Retention is stored and reported, never acted on.
-- **Metric filters.** Absent, so `metricFilterCount` is always zero.
+- **A metric filter reading a field of the log event.** A `metricValue` or a dimension value beginning `$` is refused where the filter is put. Both need a structured filter pattern, and neither structured syntax is simulated.
+- **`defaultValue` per event rather than per period.** A transformation carrying one publishes it for every event its pattern did not match, which is what the API documents. Real CloudWatch reports the default over a period with no matching event, so `Sum` and `Maximum` agree here and `SampleCount` and `Average` can differ.
 - **Subscription filter destinations other than Lambda**, and `Distribution`. `Distribution` is
   accepted and reported, and with no shards to spread across it has no effect.
-- **`AWS::Logs::SubscriptionFilter` and `AWS::Logs::MetricFilter`.** Both are recorded as gaps. The
-  log group and the three delivery resource types are what simulated CloudFormation deploys here.
+- **`AWS::Logs::SubscriptionFilter`.** Recorded as a gap. The log group, the metric filter and the
+  three delivery resource types are what simulated CloudFormation deploys here.
+- **`ApplyOnTransformedLogs` and `EmitSystemFieldDimensions` on a metric filter.** Recorded and
+  acted on by nothing. Log transformers are absent, so there is no transformed event to read.
 - **Nothing is actually delivered.** A delivery records that a source was joined to a destination
   and how the records would be written. No access log file ever reaches the bucket.
 - **`GetDeliverySource`, `GetDeliveryDestination` and `GetDelivery`.** Absent as SDK operations. The

--- a/docs/services/logs/sim-cfn-logs-metric-filter.example.ts
+++ b/docs/services/logs/sim-cfn-logs-metric-filter.example.ts
@@ -1,0 +1,87 @@
+/**
+ * Deploying a metric filter and an alarm over the metric it writes.
+ */
+
+import { DescribeAlarmsCommand } from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/30/[$LATEST]0f7c1a";
+
+await simAws.clock().setTo(new Date("2026-08-30T09:00:00Z"));
+
+await simAws.cloudFormation().deployTemplate({
+  stackName: "orders",
+  template: {
+    Resources: {
+      OrdersLogs: {
+        Type: "AWS::Logs::LogGroup",
+        Properties: { LogGroupName: logGroupName },
+      },
+      OrdersErrors: {
+        Type: "AWS::Logs::MetricFilter",
+        Properties: {
+          LogGroupName: { Ref: "OrdersLogs" },
+          FilterName: "handler-errors",
+          FilterPattern: "ERROR",
+          MetricTransformations: [
+            {
+              MetricNamespace: "Orders",
+              MetricName: "HandlerErrors",
+              MetricValue: "1",
+              Dimensions: [{ Key: "service", Value: "orders" }],
+            },
+          ],
+        },
+      },
+      OrdersFailing: {
+        Type: "AWS::CloudWatch::Alarm",
+        Properties: {
+          AlarmName: "OrdersFailing",
+          Namespace: "Orders",
+          MetricName: "HandlerErrors",
+          Dimensions: [{ Name: "service", Value: "orders" }],
+          Statistic: "Sum",
+          Period: 60,
+          EvaluationPeriods: 3,
+          DatapointsToAlarm: 1,
+          Threshold: 0,
+          ComparisonOperator: "GreaterThanThreshold",
+          TreatMissingData: "notBreaching",
+        },
+      },
+    },
+  },
+});
+
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [
+      {
+        timestamp: simAws.clock().now().getTime(),
+        message: "ERROR order has no items",
+      },
+    ],
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 2 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(new DescribeAlarmsCommand({ AlarmNames: ["OrdersFailing"] }));
+
+// ALARM. One log line drove it, with nothing publishing a metric by hand.
+console.log(MetricAlarms?.[0]?.StateValue);

--- a/docs/services/logs/sim-logs-metric-filter.example.ts
+++ b/docs/services/logs/sim-logs-metric-filter.example.ts
@@ -1,0 +1,67 @@
+/**
+ * Counting matching log lines into a CloudWatch metric.
+ */
+
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutMetricFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/30/[$LATEST]0f7c1a";
+const startedAt = new Date("2026-08-30T09:00:00Z");
+
+await simAws.clock().setTo(startedAt);
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+
+await simAws.logs().putMetricFilter(
+  new PutMetricFilterCommand({
+    logGroupName,
+    filterName: "handler-errors",
+    filterPattern: "ERROR",
+    metricTransformations: [
+      {
+        metricNamespace: "Orders",
+        metricName: "HandlerErrors",
+        metricValue: "1",
+        unit: "Count",
+      },
+    ],
+  }),
+);
+
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [
+      { timestamp: startedAt.getTime(), message: "INFO starting" },
+      { timestamp: startedAt.getTime(), message: "ERROR order has no items" },
+    ],
+  }),
+);
+
+// Publication happens after the write is answered, as it does in an account.
+await simAws.backgroundTasksComplete();
+
+const statistics = new GetMetricStatisticsCommand({
+  Namespace: "Orders",
+  MetricName: "HandlerErrors",
+  StartTime: startedAt,
+  EndTime: new Date(startedAt.getTime() + 60_000),
+  Period: 60,
+  Statistics: ["Sum"],
+});
+const counted = await simAws.cloudWatch().getMetricStatistics(statistics);
+
+// 1. The ERROR line counted and the INFO line did not.
+console.log(counted.Datapoints?.[0]?.Sum);

--- a/src/service/aws/factory/sim-aws-logs-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-logs-collaborators.ts
@@ -1,5 +1,7 @@
 import { SimAwsLogsDeliveryDistributions } from "../../logs/delivery/cloudfront/sim-aws-logs-delivery-distributions.js";
 import type { SimLogsDeliverySourceResources } from "../../logs/delivery/sim-logs-delivery-source-resources.js";
+import { SimAwsLogsMetricFilterMetrics } from "../../logs/metric/cloudwatch/sim-aws-logs-metric-filter-metrics.js";
+import type { SimLogsMetricPublications } from "../../logs/metric/sim-logs-metric-publications.js";
 import { SimAwsLogsSubscriptionFunctions } from "../../logs/subscription/lambda/sim-aws-logs-subscription-functions.js";
 import type { SimLogsSubscriptionDestinations } from "../../logs/subscription/sim-logs-subscription-destinations.js";
 import type { SimAwsAccountRegionScope } from "../sim-aws-account-region-scope.js";
@@ -11,6 +13,7 @@ import type { SimAws } from "../sim-aws.js";
 interface SimAwsLogsCollaborators {
   readonly subscriptionDestinations: SimLogsSubscriptionDestinations;
   readonly deliverySourceResources: SimLogsDeliverySourceResources;
+  readonly metricPublications: SimLogsMetricPublications;
 }
 
 /**
@@ -27,6 +30,11 @@ interface SimAwsLogsCollaborators {
  * A delivery source names the resource its logs come from by ARN. CloudFront
  * is the one delivered service whose resources are resolved, and its resolver
  * takes the same scope to read the account segment of that ARN against.
+ *
+ * A metric filter publishes into the CloudWatch of the log group's own Account
+ * and Region, which real CloudWatch Logs gives no way to point elsewhere. The
+ * CloudWatch is reached when a datapoint is published rather than now, for the
+ * reason the destination function is.
  */
 export function simAwsLogsCollaborators(
   simAws: SimAws,
@@ -38,6 +46,10 @@ export function simAwsLogsCollaborators(
       accountRegionScope,
     }),
     deliverySourceResources: new SimAwsLogsDeliveryDistributions({
+      simAws,
+      accountRegionScope,
+    }),
+    metricPublications: new SimAwsLogsMetricFilterMetrics({
       simAws,
       accountRegionScope,
     }),

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-cfn-value-adapter.ts
@@ -2,6 +2,7 @@ import { SimLogsDeliveryDestination } from "../../../../logs/delivery/sim-logs-d
 import { SimLogsDeliverySource } from "../../../../logs/delivery/sim-logs-delivery-source.js";
 import { SimLogsDelivery } from "../../../../logs/delivery/sim-logs-delivery.js";
 import { SimLogsLogGroup } from "../../../../logs/group/sim-logs-log-group.js";
+import { SimLogsMetricFilter } from "../../../../logs/metric/sim-logs-metric-filter.js";
 import type {
   SimCfnResourceValueAdapterProperties,
   SimCfnServiceValueAdapter,
@@ -10,6 +11,7 @@ import { SimLogsDeliveryDestinationCfn } from "./sim-logs-delivery-destination-c
 import { SimLogsDeliverySourceCfn } from "./sim-logs-delivery-source-cfn.js";
 import { SimLogsDeliveryCfn } from "./sim-logs-delivery-cfn.js";
 import { SimLogsLogGroupCfn } from "./sim-logs-log-group-cfn.js";
+import { SimLogsMetricFilterCfn } from "./sim-logs-metric-filter-cfn.js";
 
 /**
  * The CloudFormation-facing value adapter for a simulated CloudWatch Logs
@@ -25,6 +27,13 @@ export function logsValueAdapter(
     simResource instanceof SimLogsLogGroup
   ) {
     return new SimLogsLogGroupCfn({ group: simResource });
+  }
+
+  if (
+    type === "AWS::Logs::MetricFilter" &&
+    simResource instanceof SimLogsMetricFilter
+  ) {
+    return new SimLogsMetricFilterCfn({ filter: simResource });
   }
 
   if (

--- a/src/service/cloudformation/resource/cfn/logs/sim-logs-metric-filter-cfn.ts
+++ b/src/service/cloudformation/resource/cfn/logs/sim-logs-metric-filter-cfn.ts
@@ -1,0 +1,35 @@
+import type { SimLogsMetricFilter } from "../../../../logs/metric/sim-logs-metric-filter.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type { SimCfnResourceValueAdapter } from "../sim-cfn-resource-value-adapter.js";
+
+interface SimLogsMetricFilterCfnProperties {
+  readonly filter: SimLogsMetricFilter;
+}
+
+/**
+ * CloudFormation-facing values for a simulated CloudWatch Logs metric filter.
+ */
+export class SimLogsMetricFilterCfn implements SimCfnResourceValueAdapter {
+  readonly #filter: SimLogsMetricFilter;
+
+  constructor(properties: SimLogsMetricFilterCfnProperties) {
+    this.#filter = properties.filter;
+  }
+
+  /**
+   * AWS::Logs::MetricFilter Ref returns the filter name.
+   */
+  refValue(): SimCfnTemplateValue {
+    return this.#filter.filterName;
+  }
+
+  /**
+   * AWS::Logs::MetricFilter attributes, of which real CloudFormation returns
+   * none.
+   */
+  attributeValue(attributeName: string): SimCfnTemplateValue {
+    throw new Error(
+      `Unsupported AWS::Logs::MetricFilter attribute ${attributeName}`,
+    );
+  }
+}

--- a/src/service/logs/README.md
+++ b/src/service/logs/README.md
@@ -214,10 +214,15 @@ shares.
 
 ## What is not simulated
 
-Nothing expires, as above. Metric filters, Logs Insights queries, export tasks, tagging, encryption
-and data protection policies are all absent, and `metricFilterCount` is always zero. A stream's
-`storedBytes` is always zero too, which matches real CloudWatch Logs: it stopped reporting the
-figure per stream in 2019.
+Nothing expires, as above. Logs Insights queries, export tasks, tagging, encryption and data
+protection policies are all absent. A stream's `storedBytes` is always zero too, which matches
+real CloudWatch Logs: it stopped reporting the figure per stream in 2019.
+
+Metric filters are here, in `metric/`, and publish into the simulated CloudWatch of the log
+group's own Account and Region. What they cannot do is read a value out of the matched event. A
+`metricValue` or a dimension value beginning `$` needs the pattern to have been parsed
+structurally, and `SimLogsFilterPattern` refuses both structured syntaxes, so such a filter is
+refused where it is put.
 
 No log file is ever delivered. A delivery records that a source was joined to a destination and how
 the records would be written, which is what a test of a construct that sets logging up has to assert

--- a/src/service/logs/cfn/metric/sim-cfn-metric-dimension-values.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-dimension-values.ts
@@ -1,0 +1,50 @@
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  metricFilterList,
+  metricFilterPropertyError,
+  metricFilterRecord,
+  metricFilterRequiredString,
+} from "./sim-cfn-metric-filter-value.js";
+
+/**
+ * Read a transformation's dimensions into the map shape the API uses.
+ *
+ * The template carries them as a list of Key and Value pairs, and the SDK
+ * carries the same thing as a map, so both routes reach one implementation.
+ * An empty list is refused, because CloudFormation takes one to three entries.
+ */
+export function simCfnMetricDimensions(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+): Readonly<Record<string, string>> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const listed = metricFilterList(logicalId, value, "Dimensions");
+
+  if (listed.length === 0) {
+    throw metricFilterPropertyError(
+      logicalId,
+      "MetricTransformations Dimensions must have at least one entry",
+    );
+  }
+
+  return Object.fromEntries(listed.map((entry) => pair(logicalId, entry)));
+}
+
+function pair(
+  logicalId: string,
+  entry: SimCfnTemplateValue,
+): readonly [string, string] {
+  const dimension = metricFilterRecord(logicalId, entry, "Dimensions entry");
+
+  return [
+    metricFilterRequiredString(logicalId, dimension["Key"], "Dimensions Key"),
+    metricFilterRequiredString(
+      logicalId,
+      dimension["Value"],
+      "Dimensions Value",
+    ),
+  ];
+}

--- a/src/service/logs/cfn/metric/sim-cfn-metric-filter-creator.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-filter-creator.ts
@@ -1,0 +1,86 @@
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLogsMetricFilter } from "../../metric/sim-logs-metric-filter.js";
+import type { SimLogs } from "../../sim-logs.js";
+import { SimCfnMetricFilterProperties } from "./sim-cfn-metric-filter-properties.js";
+
+interface SimCfnMetricFilterCreatorProperties {
+  readonly logs: SimLogs;
+}
+
+/**
+ * Creates simulated metric filters from AWS::Logs::MetricFilter Resources.
+ *
+ * The command is the one an SDK caller would have used, so a deployment
+ * without `logs:PutMetricFilter` fails here the way it fails on a real deploy.
+ * The log group has to be there already, which real CloudFormation also
+ * requires: a template declaring a filter over a group it does not also
+ * declare depends on something the stack never made.
+ */
+export class SimCfnMetricFilterCreator {
+  readonly #logs: SimLogs;
+
+  constructor(properties: SimCfnMetricFilterCreatorProperties) {
+    this.#logs = properties.logs;
+  }
+
+  /**
+   * Create a metric filter from an AWS::Logs::MetricFilter Resource.
+   */
+  async create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<SimLogsMetricFilter> {
+    const filterProperties = new SimCfnMetricFilterProperties({
+      resource,
+      properties,
+    });
+    const logGroupName = filterProperties.logGroupName();
+    const filterName = filterProperties.filterName();
+
+    filterProperties.recordIgnoredProperties();
+
+    await this.#logs.putMetricFilter(
+      {
+        input: {
+          logGroupName,
+          filterName,
+          filterPattern: filterProperties.filterPattern(),
+          metricTransformations: filterProperties.metricTransformations(),
+        },
+      },
+      options,
+    );
+
+    const group = this.#logs.findLogGroup(logGroupName);
+    const filter = group?.metricFilters.find(filterName);
+
+    assertDefined(
+      filter,
+      `sim metric filter ${filterName} after CloudFormation creation`,
+    );
+
+    return filter;
+  }
+
+  /**
+   * Delete a metric filter created from an AWS::Logs::MetricFilter Resource.
+   */
+  async delete(
+    filter: SimLogsMetricFilter,
+    options?: SimCfnResourceCallerOptions,
+  ): Promise<void> {
+    await this.#logs.deleteMetricFilter(
+      {
+        input: {
+          logGroupName: filter.logGroupName,
+          filterName: filter.filterName,
+        },
+      },
+      options,
+    );
+  }
+}

--- a/src/service/logs/cfn/metric/sim-cfn-metric-filter-properties.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-filter-properties.ts
@@ -1,0 +1,92 @@
+import { SimCfnGeneratedResourceName } from "../../../cloudformation/resource/name/sim-cfn-generated-resource-name.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLogsMetricTransformationInput } from "../../command/metric/metric-filter.command.js";
+import { SimCfnMetricFilterPropertyRules } from "./sim-cfn-metric-filter-property-rules.js";
+import { metricFilterRequiredString } from "./sim-cfn-metric-filter-value.js";
+import { simCfnMetricTransformations } from "./sim-cfn-metric-transformation-values.js";
+
+const maximumNameLength = 512;
+
+interface SimCfnMetricFilterPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly properties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Reads AWS::Logs::MetricFilter CloudFormation properties.
+ */
+export class SimCfnMetricFilterProperties {
+  readonly #resource: SimCfnResource;
+  readonly #properties: SimCfnTemplateValueRecord;
+  readonly #rules: SimCfnMetricFilterPropertyRules;
+
+  constructor(properties: SimCfnMetricFilterPropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#properties = properties.properties;
+    this.#rules = new SimCfnMetricFilterPropertyRules({
+      properties: properties.properties,
+      ignorer: properties.resource,
+    });
+  }
+
+  /**
+   * The log group the filter watches.
+   */
+  logGroupName(): string {
+    return this.required(this.#properties["LogGroupName"], "LogGroupName");
+  }
+
+  /**
+   * The filter's name.
+   *
+   * An unnamed filter is named after the stack and the logical ID, as real
+   * CloudFormation names one. CDK's `MetricFilter` construct leaves the
+   * property off unless a name is given.
+   */
+  filterName(): string {
+    const name = this.#properties["FilterName"];
+
+    if (name === undefined) {
+      return new SimCfnGeneratedResourceName({
+        stackName: this.#resource.stackName,
+        logicalId: this.#resource.logicalId,
+        maximumLength: maximumNameLength,
+      }).value;
+    }
+
+    return this.required(name, "FilterName");
+  }
+
+  /**
+   * The pattern deciding which events the filter counts.
+   */
+  filterPattern(): string {
+    return this.required(this.#properties["FilterPattern"], "FilterPattern");
+  }
+
+  /**
+   * The transformations the filter publishes through.
+   */
+  metricTransformations(): readonly SimLogsMetricTransformationInput[] {
+    return simCfnMetricTransformations(
+      this.#resource.logicalId,
+      this.#properties["MetricTransformations"],
+    );
+  }
+
+  /**
+   * Record the properties the metric filter is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    this.#rules.apply();
+  }
+
+  private required(value: unknown, name: string): string {
+    return metricFilterRequiredString(
+      this.#resource.logicalId,
+      value as never,
+      name,
+    );
+  }
+}

--- a/src/service/logs/cfn/metric/sim-cfn-metric-filter-property-rules.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-filter-property-rules.ts
@@ -1,0 +1,62 @@
+import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { unsimulatedPropertyReasons } from "./sim-cfn-metric-filter-unsimulated-properties.js";
+
+/** The properties a metric filter Resource is actually created from. */
+const actedOnProperties = new Set([
+  "LogGroupName",
+  "FilterName",
+  "FilterPattern",
+  "MetricTransformations",
+]);
+
+interface SimCfnMetricFilterPropertyRulesProperties {
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly ignorer: SimCfnPropertyIgnorer;
+}
+
+/**
+ * What a metric filter Resource is created without acting on.
+ */
+export class SimCfnMetricFilterPropertyRules {
+  readonly #properties: SimCfnTemplateValueRecord;
+  readonly #ignorer: SimCfnPropertyIgnorer;
+
+  constructor(properties: SimCfnMetricFilterPropertyRulesProperties) {
+    this.#properties = properties.properties;
+    this.#ignorer = properties.ignorer;
+  }
+
+  /**
+   * Record every property the metric filter is created without.
+   */
+  apply(): void {
+    for (const name of Object.keys(this.#properties)) {
+      this.applyToProperty(name);
+    }
+  }
+
+  private applyToProperty(name: string): void {
+    if (actedOnProperties.has(name)) {
+      return;
+    }
+
+    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+
+    if (unsimulatedReason === undefined) {
+      this.#ignorer.ignoreProperty(
+        name,
+        `${name} is not a property simulated CloudWatch Logs knows about, so ` +
+          `the metric filter is created without it`,
+      );
+
+      return;
+    }
+
+    this.#ignorer.ignoreProperty(
+      name,
+      `${name} is a real AWS::Logs::MetricFilter property simulated ` +
+        `CloudWatch Logs does not act on: ${unsimulatedReason}`,
+    );
+  }
+}

--- a/src/service/logs/cfn/metric/sim-cfn-metric-filter-unsimulated-properties.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-filter-unsimulated-properties.ts
@@ -1,0 +1,17 @@
+/**
+ * The real AWS::Logs::MetricFilter properties this simulation records rather
+ * than acts on, and why each one is left alone.
+ */
+export const unsimulatedPropertyReasons = new Map<string, string>([
+  [
+    "ApplyOnTransformedLogs",
+    "log transformers are absent, so there is no transformed version of an " +
+      "event for a filter to read and every filter here matches what was " +
+      "written",
+  ],
+  [
+    "EmitSystemFieldDimensions",
+    "the system fields a log event carries in an account are absent here, so " +
+      "there is nothing to emit them from",
+  ],
+]);

--- a/src/service/logs/cfn/metric/sim-cfn-metric-filter-unsimulated-properties.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-filter-unsimulated-properties.ts
@@ -10,6 +10,12 @@ export const unsimulatedPropertyReasons = new Map<string, string>([
       "written",
   ],
   [
+    "FieldSelectionCriteria",
+    "it selects events by system field, such as the source account or the " +
+      "source Region of a cross-account log group, and neither is carried on " +
+      "an event here",
+  ],
+  [
     "EmitSystemFieldDimensions",
     "the system fields a log event carries in an account are absent here, so " +
       "there is nothing to emit them from",

--- a/src/service/logs/cfn/metric/sim-cfn-metric-filter-value.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-filter-value.ts
@@ -1,0 +1,101 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/**
+ * A refusal naming the Resource whose properties could not be read.
+ */
+export function metricFilterPropertyError(
+  logicalId: string,
+  reason: string,
+): Error {
+  return new Error(
+    `Invalid sim CloudWatch Logs CloudFormation Resource ${logicalId}: ${reason}`,
+  );
+}
+
+/**
+ * Read a template value that has to be an object.
+ */
+export function metricFilterRecord(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+  name: string,
+): SimCfnTemplateValueRecord {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw metricFilterPropertyError(logicalId, `${name} must be an object`);
+  }
+
+  return value;
+}
+
+/**
+ * Read a template value that has to be a list.
+ */
+export function metricFilterList(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+  name: string,
+): readonly SimCfnTemplateValue[] {
+  if (!Array.isArray(value)) {
+    throw metricFilterPropertyError(logicalId, `${name} must be a list`);
+  }
+
+  return value;
+}
+
+/**
+ * Read an optional template value that has to be a string.
+ */
+export function metricFilterString(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+  name: string,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    throw metricFilterPropertyError(logicalId, `${name} must be a string`);
+  }
+
+  return value;
+}
+
+/**
+ * Read an optional template value that has to be a number.
+ */
+export function metricFilterNumber(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+  name: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number") {
+    throw metricFilterPropertyError(logicalId, `${name} must be a number`);
+  }
+
+  return value;
+}
+
+/**
+ * Read a template value the Resource cannot be created without.
+ */
+export function metricFilterRequiredString(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+  name: string,
+): string {
+  const read = metricFilterString(logicalId, value, name);
+
+  if (read === undefined) {
+    throw metricFilterPropertyError(logicalId, `${name} is required`);
+  }
+
+  return read;
+}

--- a/src/service/logs/cfn/metric/sim-cfn-metric-transformation-values.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-transformation-values.ts
@@ -1,10 +1,10 @@
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimLogsMetricTransformationInput } from "../../command/metric/metric-filter.command.js";
+import { simCfnMetricDimensions } from "./sim-cfn-metric-dimension-values.js";
 import {
   metricFilterList,
   metricFilterNumber,
   metricFilterRecord,
-  metricFilterRequiredString,
   metricFilterString,
 } from "./sim-cfn-metric-filter-value.js";
 
@@ -48,50 +48,6 @@ function transformation(
       "DefaultValue",
     ),
     unit: metricFilterString(logicalId, read["Unit"], "Unit"),
-    dimensions: dimensions(logicalId, read["Dimensions"]),
+    dimensions: simCfnMetricDimensions(logicalId, read["Dimensions"]),
   };
-}
-
-/**
- * Read a transformation's dimensions into the map shape the API uses.
- *
- * The template carries them as a list of Key and Value pairs, and the SDK
- * carries the same thing as a map, so both routes reach one implementation.
- */
-function dimensions(
-  logicalId: string,
-  value: SimCfnTemplateValue | undefined,
-): Readonly<Record<string, string>> | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  const listed = metricFilterList(
-    logicalId,
-    value,
-    "MetricTransformations Dimensions",
-  );
-
-  return Object.fromEntries(
-    listed.map((entry) => {
-      const dimension = metricFilterRecord(
-        logicalId,
-        entry,
-        "Dimensions entry",
-      );
-
-      return [
-        metricFilterRequiredString(
-          logicalId,
-          dimension["Key"],
-          "Dimensions Key",
-        ),
-        metricFilterRequiredString(
-          logicalId,
-          dimension["Value"],
-          "Dimensions Value",
-        ),
-      ];
-    }),
-  );
 }

--- a/src/service/logs/cfn/metric/sim-cfn-metric-transformation-values.ts
+++ b/src/service/logs/cfn/metric/sim-cfn-metric-transformation-values.ts
@@ -1,0 +1,97 @@
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLogsMetricTransformationInput } from "../../command/metric/metric-filter.command.js";
+import {
+  metricFilterList,
+  metricFilterNumber,
+  metricFilterRecord,
+  metricFilterRequiredString,
+  metricFilterString,
+} from "./sim-cfn-metric-filter-value.js";
+
+/**
+ * Read the MetricTransformations of an AWS::Logs::MetricFilter Resource.
+ */
+export function simCfnMetricTransformations(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+): readonly SimLogsMetricTransformationInput[] {
+  return metricFilterList(logicalId, value, "MetricTransformations").map(
+    (entry) => transformation(logicalId, entry),
+  );
+}
+
+function transformation(
+  logicalId: string,
+  value: SimCfnTemplateValue,
+): SimLogsMetricTransformationInput {
+  const read = metricFilterRecord(
+    logicalId,
+    value,
+    "MetricTransformations entry",
+  );
+
+  return {
+    metricName: metricFilterString(logicalId, read["MetricName"], "MetricName"),
+    metricNamespace: metricFilterString(
+      logicalId,
+      read["MetricNamespace"],
+      "MetricNamespace",
+    ),
+    metricValue: metricFilterString(
+      logicalId,
+      read["MetricValue"],
+      "MetricValue",
+    ),
+    defaultValue: metricFilterNumber(
+      logicalId,
+      read["DefaultValue"],
+      "DefaultValue",
+    ),
+    unit: metricFilterString(logicalId, read["Unit"], "Unit"),
+    dimensions: dimensions(logicalId, read["Dimensions"]),
+  };
+}
+
+/**
+ * Read a transformation's dimensions into the map shape the API uses.
+ *
+ * The template carries them as a list of Key and Value pairs, and the SDK
+ * carries the same thing as a map, so both routes reach one implementation.
+ */
+function dimensions(
+  logicalId: string,
+  value: SimCfnTemplateValue | undefined,
+): Readonly<Record<string, string>> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const listed = metricFilterList(
+    logicalId,
+    value,
+    "MetricTransformations Dimensions",
+  );
+
+  return Object.fromEntries(
+    listed.map((entry) => {
+      const dimension = metricFilterRecord(
+        logicalId,
+        entry,
+        "Dimensions entry",
+      );
+
+      return [
+        metricFilterRequiredString(
+          logicalId,
+          dimension["Key"],
+          "Dimensions Key",
+        ),
+        metricFilterRequiredString(
+          logicalId,
+          dimension["Value"],
+          "Dimensions Value",
+        ),
+      ];
+    }),
+  );
+}

--- a/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-delivery-refusals.iso.test.ts
@@ -268,7 +268,7 @@ describe("AWS::Logs delivery Resource refusals", () => {
   });
 
   it("still records a CloudWatch Logs Resource type it has none for", async () => {
-    // Given a template declaring a delivery source and a metric filter.
+    // Given a template declaring a delivery source and a subscription filter.
     const simAws = new SimAws();
     const stack = await simAws.cloudFormation().deployTemplate({
       stackName: "site-logging",
@@ -279,20 +279,27 @@ describe("AWS::Logs delivery Resource refusals", () => {
             Type: "AWS::Logs::DeliverySource",
             Properties: sourceProperties,
           },
-          SiteMetrics: {
-            Type: "AWS::Logs::MetricFilter",
-            Properties: { LogGroupName: "/site", FilterPattern: "ERROR" },
+          SiteErrors: {
+            Type: "AWS::Logs::SubscriptionFilter",
+            Properties: {
+              LogGroupName: "/site",
+              FilterPattern: "ERROR",
+              DestinationArn:
+                "arn:aws:lambda:eu-west-2:123456789012:function:t",
+            },
           },
         },
       },
     });
 
-    // Then the delivery source deploys and the metric filter is recorded as a
-    // gap, which is what adding delivery to this factory must not change.
+    // Then the delivery source deploys and the subscription filter is
+    // recorded as a gap, which is what adding delivery to this factory must
+    // not change.
     assertArrayLength(stack.skippedResources, 1);
     assertStringIncludes(
       stack.skippedResources.at(0)?.skippedReason ?? "",
-      "Unsupported sim CloudWatch Logs CloudFormation Resource MetricFilter",
+      "Unsupported sim CloudWatch Logs CloudFormation Resource " +
+        "SubscriptionFilter",
     );
   });
 });

--- a/src/service/logs/cfn/sim-cfn-log-group.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-log-group.iso.test.ts
@@ -188,22 +188,23 @@ describe("AWS::Logs::LogGroup", () => {
 
     // When a Resource type this simulation has none for is created or deleted.
     const created = await assertThrowsErrorAsync(async () =>
-      factory.create("MetricFilter", {} as never, {} as never),
+      factory.create("SubscriptionFilter", {} as never, {} as never),
     );
     const deleted = await assertThrowsErrorAsync(async () =>
-      factory.delete("MetricFilter", {} as never, {} as never),
+      factory.delete("SubscriptionFilter", {} as never, {} as never),
     );
 
     // Then both are reported as unsupported, which the Stack records as a
     // skip rather than a failure.
     assertIdentical(
       created.message,
-      "Unsupported sim CloudWatch Logs CloudFormation Resource MetricFilter",
+      "Unsupported sim CloudWatch Logs CloudFormation Resource " +
+        "SubscriptionFilter",
     );
     assertIdentical(
       deleted.message,
-      "Unsupported sim CloudWatch Logs CloudFormation Resource MetricFilter " +
-        "deletion",
+      "Unsupported sim CloudWatch Logs CloudFormation Resource " +
+        "SubscriptionFilter deletion",
     );
   });
 

--- a/src/service/logs/cfn/sim-cfn-metric-filter.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-metric-filter.iso.test.ts
@@ -1,0 +1,229 @@
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import { DeleteStackCommand } from "@aws-sdk/client-cloudformation";
+import {
+  CreateLogStreamCommand,
+  DescribeMetricFiltersCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/30/[$LATEST]abc";
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+
+/** The transformation most of these cases deploy. */
+const countErrors: SimCfnTemplateValueRecord = {
+  MetricNamespace: "Orders",
+  MetricName: "HandlerErrors",
+  MetricValue: "1",
+};
+
+/**
+ * Deploy a stack declaring a log group and a metric filter over it.
+ */
+async function deployMetricFilter(
+  properties: SimCfnTemplateValueRecord,
+): Promise<{ readonly simAws: SimAws; readonly stack: SimCfnDeployedStack }> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        OrdersLogs: {
+          Type: "AWS::Logs::LogGroup",
+          Properties: { LogGroupName: logGroupName },
+        },
+        OrdersErrors: {
+          Type: "AWS::Logs::MetricFilter",
+          Properties: { LogGroupName: { Ref: "OrdersLogs" }, ...properties },
+        },
+      },
+      Outputs: { FilterName: { Value: { Ref: "OrdersErrors" } } },
+    },
+  });
+
+  return { simAws, stack };
+}
+
+describe("AWS::Logs::MetricFilter", () => {
+  it("deploys a filter that counts what the log group is written", async () => {
+    // Given a deployed stack declaring a log group and a filter over it.
+    const { simAws } = await deployMetricFilter({
+      FilterName: "handler-errors",
+      FilterPattern: "ERROR",
+      MetricTransformations: [countErrors],
+    });
+
+    // When a matching line is written to the group.
+    await simAws
+      .logs()
+      .createLogStream(
+        new CreateLogStreamCommand({ logGroupName, logStreamName }),
+      );
+    await simAws.logs().putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [
+          { message: "ERROR order failed", timestamp: startedAt.getTime() },
+        ],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the deployed filter counted it, so a stack's own alarm has a
+    // datapoint to read.
+    const endTime = new Date(startedAt.getTime() + 60_000);
+    const statistics = new GetMetricStatisticsCommand({
+      Namespace: "Orders",
+      MetricName: "HandlerErrors",
+      StartTime: startedAt,
+      EndTime: endTime,
+      Period: 60,
+      Statistics: ["Sum"],
+    });
+    const { Datapoints } = await simAws
+      .cloudWatch()
+      .getMetricStatistics(statistics);
+
+    assertIdentical(Datapoints?.at(0)?.Sum, 1);
+  });
+
+  it("resolves Ref to the filter name", async () => {
+    // Given a deployed stack whose output Refs the filter.
+    const { stack } = await deployMetricFilter({
+      FilterName: "handler-errors",
+      FilterPattern: "ERROR",
+      MetricTransformations: [countErrors],
+    });
+
+    // Then Ref is the name, as real CloudFormation returns it.
+    assertIdentical(stack.output("FilterName"), "handler-errors");
+  });
+
+  it("names an unnamed filter after the stack and the logical ID", async () => {
+    // Given a deployed stack whose filter carries no FilterName, which is what
+    // the CDK MetricFilter construct emits unless one is given.
+    const { simAws, stack } = await deployMetricFilter({
+      FilterPattern: "ERROR",
+      MetricTransformations: [countErrors],
+    });
+
+    // Then it was named for the stack and the logical ID, and that is the name
+    // the group holds it under.
+    const generated = stack.output("FilterName");
+
+    assertStringIncludes(generated, "orders");
+    assertStringIncludes(generated, "OrdersErrors");
+
+    const { metricFilters } = await simAws
+      .logs()
+      .describeMetricFilters(
+        new DescribeMetricFiltersCommand({ logGroupName }),
+      );
+
+    assertIdentical(metricFilters?.at(0)?.filterName, generated);
+  });
+
+  it("reads a transformation's dimensions from the template's list shape", async () => {
+    // Given a filter whose transformation carries Dimensions, which the
+    // template holds as Key and Value pairs rather than as a map.
+    const { simAws } = await deployMetricFilter({
+      FilterName: "handler-errors",
+      FilterPattern: "ERROR",
+      MetricTransformations: [
+        {
+          ...countErrors,
+          Unit: "Count",
+          DefaultValue: 0,
+          Dimensions: [{ Key: "service", Value: "orders" }],
+        },
+      ],
+    });
+
+    // Then the deployed filter carries them the way the API reports them.
+    const { metricFilters } = await simAws
+      .logs()
+      .describeMetricFilters(
+        new DescribeMetricFiltersCommand({ logGroupName }),
+      );
+    const transformation = metricFilters?.at(0)?.metricTransformations.at(0);
+
+    assertNonNullable(transformation);
+    assertIdentical(transformation.dimensions?.["service"], "orders");
+    assertIdentical(transformation.unit, "Count");
+    assertIdentical(transformation.defaultValue, 0);
+  });
+
+  it("takes the filter down with the stack", async () => {
+    // Given a deployed stack with a filter on a log group.
+    const { simAws } = await deployMetricFilter({
+      FilterName: "handler-errors",
+      FilterPattern: "ERROR",
+      MetricTransformations: [countErrors],
+    });
+
+    // When the stack is deleted.
+    await simAws
+      .cloudFormation()
+      .deleteStack(new DeleteStackCommand({ StackName: "orders" }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the group and the filter on it went with it, as in an account.
+    assertArrayLength(simAws.logs().allLogGroups(), 0);
+  });
+
+  it("records the properties it does not act on", async () => {
+    // Given a filter declaring a property this simulation leaves alone.
+    const { stack } = await deployMetricFilter({
+      FilterName: "handler-errors",
+      FilterPattern: "ERROR",
+      ApplyOnTransformedLogs: true,
+      MetricTransformations: [countErrors],
+    });
+
+    // Then it deployed, and the property it stepped over is recorded so a
+    // reader can see what the filter is not doing.
+    const resource = stack.resources.find(
+      (deployed) => deployed.logicalId === "OrdersErrors",
+    );
+
+    assertNonNullable(resource);
+    assertArrayLength(resource.ignoredProperties, 1);
+    assertStringIncludes(
+      resource.ignoredProperties.at(0)?.reason ?? "",
+      "log transformers are absent",
+    );
+  });
+
+  it("fails the Resource where a transformation cannot be read", async () => {
+    // When a template declares a transformation that is not a list.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await deployMetricFilter({
+          FilterName: "handler-errors",
+          FilterPattern: "ERROR",
+          MetricTransformations: countErrors,
+        }),
+    );
+
+    // Then the Resource fails rather than deploying a filter that counts
+    // nothing, and the message names the Resource and what was wrong.
+    assertStringIncludes(error.message, "OrdersErrors");
+    assertStringIncludes(error.message, "MetricTransformations must be a list");
+  });
+});

--- a/src/service/logs/cfn/sim-cfn-metric-filter.iso.test.ts
+++ b/src/service/logs/cfn/sim-cfn-metric-filter.iso.test.ts
@@ -149,7 +149,6 @@ describe("AWS::Logs::MetricFilter", () => {
         {
           ...countErrors,
           Unit: "Count",
-          DefaultValue: 0,
           Dimensions: [{ Key: "service", Value: "orders" }],
         },
       ],
@@ -166,7 +165,22 @@ describe("AWS::Logs::MetricFilter", () => {
     assertNonNullable(transformation);
     assertIdentical(transformation.dimensions?.["service"], "orders");
     assertIdentical(transformation.unit, "Count");
-    assertIdentical(transformation.defaultValue, 0);
+  });
+
+  it("fails the Resource where Dimensions is an empty list", async () => {
+    // When a template gives Dimensions with nothing in it, which
+    // CloudFormation refuses because the list takes one to three entries.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await deployMetricFilter({
+          FilterName: "handler-errors",
+          FilterPattern: "ERROR",
+          MetricTransformations: [{ ...countErrors, Dimensions: [] }],
+        }),
+    );
+
+    // Then the Resource fails rather than deploying an undimensioned filter.
+    assertStringIncludes(error.message, "at least one entry");
   });
 
   it("takes the filter down with the stack", async () => {
@@ -193,20 +207,25 @@ describe("AWS::Logs::MetricFilter", () => {
       FilterName: "handler-errors",
       FilterPattern: "ERROR",
       ApplyOnTransformedLogs: true,
+      FieldSelectionCriteria: '@aws.account = "888888888888"',
       MetricTransformations: [countErrors],
     });
 
-    // Then it deployed, and the property it stepped over is recorded so a
-    // reader can see what the filter is not doing.
+    // Then it deployed, and each real property it stepped over is recorded as
+    // one, so a reader can see what the filter is not doing.
     const resource = stack.resources.find(
       (deployed) => deployed.logicalId === "OrdersErrors",
     );
 
     assertNonNullable(resource);
-    assertArrayLength(resource.ignoredProperties, 1);
+    assertArrayLength(resource.ignoredProperties, 2);
     assertStringIncludes(
       resource.ignoredProperties.at(0)?.reason ?? "",
       "log transformers are absent",
+    );
+    assertStringIncludes(
+      resource.ignoredProperties.at(1)?.reason ?? "",
+      "real AWS::Logs::MetricFilter property",
     );
   });
 

--- a/src/service/logs/cfn/sim-logs-cfn-resource-deleter.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-deleter.ts
@@ -4,15 +4,18 @@ import type { SimLogsDeliveryDestination } from "../delivery/sim-logs-delivery-d
 import type { SimLogsDeliverySource } from "../delivery/sim-logs-delivery-source.js";
 import type { SimLogsDelivery } from "../delivery/sim-logs-delivery.js";
 import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
+import type { SimLogsMetricFilter } from "../metric/sim-logs-metric-filter.js";
 import type { SimCfnDeliveryCreator } from "./delivery/sim-cfn-delivery-creator.js";
 import type { SimCfnDeliveryDestinationCreator } from "./delivery/sim-cfn-delivery-destination-creator.js";
 import type { SimCfnDeliverySourceCreator } from "./delivery/sim-cfn-delivery-source-creator.js";
 import type { SimCfnLogGroupCreator } from "./group/sim-cfn-log-group-creator.js";
+import type { SimCfnMetricFilterCreator } from "./metric/sim-cfn-metric-filter-creator.js";
 import { unsupportedSimLogsResourceType } from "./sim-logs-cfn-unsupported-resource.js";
 import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
 interface SimLogsCfnResourceDeleterProperties {
   readonly logGroups: SimCfnLogGroupCreator;
+  readonly metricFilters: SimCfnMetricFilterCreator;
   readonly deliverySources: SimCfnDeliverySourceCreator;
   readonly deliveryDestinations: SimCfnDeliveryDestinationCreator;
   readonly deliveries: SimCfnDeliveryCreator;
@@ -43,6 +46,14 @@ export class SimLogsCfnResourceDeleter {
       case "LogGroup": {
         await this.#creators.logGroups.delete(
           created<SimLogsLogGroup>(resource),
+          options,
+        );
+
+        return;
+      }
+      case "MetricFilter": {
+        await this.#creators.metricFilters.delete(
+          created<SimLogsMetricFilter>(resource),
           options,
         );
 

--- a/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
+++ b/src/service/logs/cfn/sim-logs-cfn-resource-factory.ts
@@ -13,6 +13,7 @@ import { SimCfnDeliveryCreator } from "./delivery/sim-cfn-delivery-creator.js";
 import { SimCfnDeliveryDestinationCreator } from "./delivery/sim-cfn-delivery-destination-creator.js";
 import { SimCfnDeliverySourceCreator } from "./delivery/sim-cfn-delivery-source-creator.js";
 import { SimCfnLogGroupCreator } from "./group/sim-cfn-log-group-creator.js";
+import { SimCfnMetricFilterCreator } from "./metric/sim-cfn-metric-filter-creator.js";
 import { SimLogsCfnResourceDeleter } from "./sim-logs-cfn-resource-deleter.js";
 import { unsupportedSimLogsResourceType } from "./sim-logs-cfn-unsupported-resource.js";
 
@@ -30,12 +31,15 @@ interface SimLogsCfnResourceFactoryProperties {
  * logging property of its own, and a stack that turns logging on is made of
  * those three Resources and nothing else.
  *
- * Subscription filters and metric filters are not created here. Both need
- * machinery this simulation does not have yet, and a stack declaring one
- * records it as a skip.
+ * Metric filters are created here too, and publish into the simulated
+ * CloudWatch of the log group's own Account and Region.
+ *
+ * Subscription filters are not. `PutSubscriptionFilter` holds one, and a stack
+ * declaring `AWS::Logs::SubscriptionFilter` records it as a skip.
  */
 export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
   readonly #logGroups: SimCfnLogGroupCreator;
+  readonly #metricFilters: SimCfnMetricFilterCreator;
   readonly #deliverySources: SimCfnDeliverySourceCreator;
   readonly #deliveryDestinations: SimCfnDeliveryDestinationCreator;
   readonly #deliveries: SimCfnDeliveryCreator;
@@ -48,11 +52,13 @@ export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
     };
 
     this.#logGroups = new SimCfnLogGroupCreator(properties);
+    this.#metricFilters = new SimCfnMetricFilterCreator(properties);
     this.#deliverySources = new SimCfnDeliverySourceCreator(delivery);
     this.#deliveryDestinations = new SimCfnDeliveryDestinationCreator(delivery);
     this.#deliveries = new SimCfnDeliveryCreator(delivery);
     this.#deleter = new SimLogsCfnResourceDeleter({
       logGroups: this.#logGroups,
+      metricFilters: this.#metricFilters,
       deliverySources: this.#deliverySources,
       deliveryDestinations: this.#deliveryDestinations,
       deliveries: this.#deliveries,
@@ -74,6 +80,9 @@ export class SimLogsCfnResourceFactory implements SimCfnServiceResourceFactory {
     switch (resourceTypeName) {
       case "LogGroup": {
         return await this.#logGroups.create(resource, values, options);
+      }
+      case "MetricFilter": {
+        return await this.#metricFilters.create(resource, values, options);
       }
       case "DeliverySource": {
         return await this.#deliverySources.create(resource, values, options);

--- a/src/service/logs/command/event/sim-logs-put-log-events.ts
+++ b/src/service/logs/command/event/sim-logs-put-log-events.ts
@@ -6,6 +6,7 @@ import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.
 import { requiredSimLogsLogStreamName } from "../../stream/sim-logs-log-stream-name.js";
 import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
 import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import type { SimLogsMetricFanOut } from "../../metric/sim-logs-metric-fan-out.js";
 import type { SimLogsSubscriptionFanOut } from "../../subscription/sim-logs-subscription-fan-out.js";
 import type {
   SimPutLogEventsCommand,
@@ -20,6 +21,9 @@ interface SimLogsPutLogEventsProperties {
 
   /** Where written events are handed on to subscription filters. */
   readonly fanOut: SimLogsSubscriptionFanOut;
+
+  /** Where written events are handed on to metric filters. */
+  readonly metricFanOut: SimLogsMetricFanOut;
 }
 
 /**
@@ -31,6 +35,7 @@ export class SimLogsPutLogEvents {
   readonly #eventIds: SimLogsEventIds;
   readonly #clock: SimClock;
   readonly #fanOut: SimLogsSubscriptionFanOut;
+  readonly #metricFanOut: SimLogsMetricFanOut;
 
   constructor(properties: SimLogsPutLogEventsProperties) {
     this.#groups = properties.groups;
@@ -38,6 +43,7 @@ export class SimLogsPutLogEvents {
     this.#eventIds = properties.eventIds;
     this.#clock = properties.clock;
     this.#fanOut = properties.fanOut;
+    this.#metricFanOut = properties.metricFanOut;
   }
 
   /**
@@ -74,6 +80,7 @@ export class SimLogsPutLogEvents {
 
     stream.append(batch.events, ingestionTime);
     this.#fanOut.written(group, logStreamName, batch.events);
+    this.#metricFanOut.written(group, batch.events);
 
     return { $metadata: {}, nextSequenceToken: stream.uploadSequenceToken };
   }

--- a/src/service/logs/command/group/sim-logs-log-group-commands.ts
+++ b/src/service/logs/command/group/sim-logs-log-group-commands.ts
@@ -123,15 +123,15 @@ export class SimLogsLogGroupCommands {
 /**
  * What DescribeLogGroups reports about one log group.
  *
- * `metricFilterCount` is always zero: metric filters are a CloudWatch metrics
- * feature, and no simulated CloudWatch Logs operation here creates one.
+ * `metricFilterCount` is how many metric filters `PutMetricFilter` has put on
+ * the group.
  */
 function logGroupDetail(group: SimLogsLogGroup): SimLogsLogGroupDetail {
   return {
     logGroupName: group.logGroupName,
     creationTime: group.creationTime,
     retentionInDays: group.retentionInDays,
-    metricFilterCount: 0,
+    metricFilterCount: group.metricFilters.count,
     storedBytes: group.storedBytes,
     arn: group.arn,
     logGroupArn: group.logGroupArn,

--- a/src/service/logs/command/metric/metric-filter.command.ts
+++ b/src/service/logs/command/metric/metric-filter.command.ts
@@ -1,0 +1,92 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * One metric transformation as the API takes and reports it.
+ *
+ * `dimensions` is a map of dimension name to value, which is the shape the SDK
+ * uses. The CloudFormation Resource carries the same thing as a list of
+ * Key/Value pairs.
+ */
+export interface SimLogsMetricTransformationInput {
+  readonly metricName?: string | undefined;
+  readonly metricNamespace?: string | undefined;
+  readonly metricValue?: string | undefined;
+  readonly defaultValue?: number | undefined;
+  readonly dimensions?: Readonly<Record<string, string>> | undefined;
+  readonly unit?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs PutMetricFilter command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/PutMetricFilterCommand/
+ */
+export interface SimPutMetricFilterCommand {
+  readonly input: SimPutMetricFilterCommandInput;
+}
+
+export interface SimPutMetricFilterCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly filterName?: string | undefined;
+  readonly filterPattern?: string | undefined;
+  readonly metricTransformations?:
+    | readonly SimLogsMetricTransformationInput[]
+    | undefined;
+}
+
+export interface SimPutMetricFilterCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DescribeMetricFilters command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DescribeMetricFiltersCommand/
+ */
+export interface SimDescribeMetricFiltersCommand {
+  readonly input: SimDescribeMetricFiltersCommandInput;
+}
+
+export interface SimDescribeMetricFiltersCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly filterNamePrefix?: string | undefined;
+  readonly metricName?: string | undefined;
+  readonly metricNamespace?: string | undefined;
+  readonly limit?: number | undefined;
+  readonly nextToken?: string | undefined;
+}
+
+export interface SimDescribeMetricFiltersCommandOutput {
+  readonly metricFilters?: readonly SimLogsMetricFilterDetail[] | undefined;
+  readonly nextToken?: string | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * What DescribeMetricFilters reports about one filter.
+ */
+export interface SimLogsMetricFilterDetail {
+  readonly filterName: string;
+  readonly logGroupName: string;
+  readonly filterPattern: string;
+  readonly metricTransformations: readonly SimLogsMetricTransformationInput[];
+  readonly creationTime: number;
+}
+
+/**
+ * Minimal structural sim CloudWatch Logs DeleteMetricFilter command.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudwatch-logs/command/DeleteMetricFilterCommand/
+ */
+export interface SimDeleteMetricFilterCommand {
+  readonly input: SimDeleteMetricFilterCommandInput;
+}
+
+export interface SimDeleteMetricFilterCommandInput {
+  readonly logGroupName?: string | undefined;
+  readonly filterName?: string | undefined;
+}
+
+export interface SimDeleteMetricFilterCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/logs/command/metric/sim-logs-metric-filter-commands.ts
+++ b/src/service/logs/command/metric/sim-logs-metric-filter-commands.ts
@@ -1,0 +1,170 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { requiredSimLogsLogGroupName } from "../../group/sim-logs-log-group-name.js";
+import type { SimLogsLogGroupStore } from "../../group/sim-logs-log-group-store.js";
+import type { SimLogsMetricFanOut } from "../../metric/sim-logs-metric-fan-out.js";
+import { SimLogsMetricFilter } from "../../metric/sim-logs-metric-filter.js";
+import { simLogsSelectedMetricFilters } from "../../metric/sim-logs-metric-filter-selection.js";
+import type { SimLogsAuthorizer } from "../authorize/sim-logs-authorizer.js";
+import { SimLogsPage } from "../sim-logs-page.js";
+import type { SimLogsRequestOptions } from "../sim-logs-request-options.js";
+import { requiredSimLogsFilterName } from "../subscription/sim-logs-subscription-input.js";
+import {
+  requiredSimLogsMetricTransformations,
+  simLogsMetricFilterDetail,
+} from "./sim-logs-metric-filter-input.js";
+import type {
+  SimDeleteMetricFilterCommand,
+  SimDeleteMetricFilterCommandOutput,
+  SimDescribeMetricFiltersCommand,
+  SimDescribeMetricFiltersCommandOutput,
+  SimPutMetricFilterCommand,
+  SimPutMetricFilterCommandOutput,
+} from "./metric-filter.command.js";
+
+const maximumDescribeLimit = 50;
+
+interface SimLogsMetricFilterCommandsProperties {
+  readonly groups: SimLogsLogGroupStore;
+  readonly authorizer: SimLogsAuthorizer;
+  readonly fanOut: SimLogsMetricFanOut;
+  readonly clock: SimClock;
+}
+
+/**
+ * The commands that put, describe and remove metric filters.
+ */
+export class SimLogsMetricFilterCommands {
+  readonly #groups: SimLogsLogGroupStore;
+  readonly #authorizer: SimLogsAuthorizer;
+  readonly #fanOut: SimLogsMetricFanOut;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimLogsMetricFilterCommandsProperties) {
+    this.#groups = properties.groups;
+    this.#authorizer = properties.authorizer;
+    this.#fanOut = properties.fanOut;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Put a metric filter on a log group.
+   *
+   * Whether the datapoints could go anywhere is checked here, the way
+   * `PutSubscriptionFilter` checks its destination. A filter that takes its
+   * configuration and publishes nothing is worse than a failure, because the
+   * alarm over its metric then reports healthy for ever.
+   */
+  async putMetricFilter(
+    command: SimPutMetricFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<SimPutMetricFilterCommandOutput> {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+    const filterName = requiredSimLogsFilterName(input.filterName);
+    const transformations = requiredSimLogsMetricTransformations(
+      input.metricTransformations,
+    );
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:PutMetricFilter",
+      logGroupName,
+      options?.caller,
+    );
+
+    const group = this.#groups.require(logGroupName);
+
+    await this.#fanOut.checkPublishable();
+
+    group.metricFilters.put(
+      new SimLogsMetricFilter({
+        filterName,
+        logGroupName,
+        filterPattern: input.filterPattern,
+        transformations,
+        creationTime: this.#clock.now().getTime(),
+      }),
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Describe metric filters, on one log group or across them all.
+   *
+   * Real CloudWatch Logs takes `logGroupName` as optional here, unlike
+   * `DescribeSubscriptionFilters`. Leaving it off is how a caller finds every
+   * filter writing to a metric it has an alarm on.
+   */
+  describeMetricFilters(
+    command: SimDescribeMetricFiltersCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDescribeMetricFiltersCommandOutput {
+    const input = command.input;
+    const page = new SimLogsPage({
+      listed: this.selected(input, options),
+      limit: input.limit,
+      nextToken: input.nextToken,
+      maximumLimit: maximumDescribeLimit,
+    });
+
+    return {
+      $metadata: {},
+      metricFilters: page.items.map((filter) =>
+        simLogsMetricFilterDetail(filter),
+      ),
+      nextToken: page.nextToken,
+    };
+  }
+
+  /**
+   * Remove a metric filter from a log group.
+   */
+  deleteMetricFilter(
+    command: SimDeleteMetricFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): SimDeleteMetricFilterCommandOutput {
+    const input = command.input;
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+    const filterName = requiredSimLogsFilterName(input.filterName);
+
+    this.#authorizer.authorizeLogGroup(
+      "logs:DeleteMetricFilter",
+      logGroupName,
+      options?.caller,
+    );
+
+    this.#groups.require(logGroupName).metricFilters.delete(filterName);
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * The filters one describe request selects, authorized for what it reaches.
+   *
+   * A request naming no log group reaches every one in the scope, so it is
+   * authorized against them all rather than against any single group.
+   */
+  private selected(
+    input: SimDescribeMetricFiltersCommand["input"],
+    options: SimLogsRequestOptions | undefined,
+  ): readonly SimLogsMetricFilter[] {
+    const action = "logs:DescribeMetricFilters";
+
+    if (input.logGroupName === undefined) {
+      this.#authorizer.authorizeAnyLogGroup(action, options?.caller);
+
+      return this.#groups.all.flatMap((group) =>
+        simLogsSelectedMetricFilters(group.metricFilters.all, input),
+      );
+    }
+
+    const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
+
+    this.#authorizer.authorizeLogGroup(action, logGroupName, options?.caller);
+
+    return simLogsSelectedMetricFilters(
+      this.#groups.require(logGroupName).metricFilters.all,
+      input,
+    );
+  }
+}

--- a/src/service/logs/command/metric/sim-logs-metric-filter-input.ts
+++ b/src/service/logs/command/metric/sim-logs-metric-filter-input.ts
@@ -1,0 +1,118 @@
+import { SimLogsInvalidParameterException } from "../../error/sim-logs.error.js";
+import type { SimLogsMetricDimension } from "../../metric/sim-logs-metric-datapoint.js";
+import type { SimLogsMetricFilter } from "../../metric/sim-logs-metric-filter.js";
+import { SimLogsMetricTransformation } from "../../metric/sim-logs-metric-transformation.js";
+import type {
+  SimLogsMetricFilterDetail,
+  SimLogsMetricTransformationInput,
+} from "./metric-filter.command.js";
+
+/**
+ * How many transformations real CloudWatch Logs allows on one metric filter.
+ *
+ * One. The field is a list because the API has always shaped it that way, and
+ * an account refuses a second entry.
+ */
+const maximumTransformations = 1;
+
+/**
+ * Read the transformations a metric filter publishes through.
+ */
+export function requiredSimLogsMetricTransformations(
+  transformations?: readonly SimLogsMetricTransformationInput[],
+): readonly SimLogsMetricTransformation[] {
+  if (transformations === undefined || transformations.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      "1 validation error detected: Value at 'metricTransformations' failed " +
+        "to satisfy constraint: Member must not be null",
+    );
+  }
+
+  if (transformations.length > maximumTransformations) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value at 'metricTransformations' failed ` +
+        `to satisfy constraint: Member must have length less than or equal ` +
+        `to ${maximumTransformations}`,
+    );
+  }
+
+  return transformations.map((transformation) =>
+    metricTransformation(transformation),
+  );
+}
+
+/**
+ * Read one transformation, refusing what real CloudWatch Logs refuses.
+ */
+function metricTransformation(
+  input: SimLogsMetricTransformationInput,
+): SimLogsMetricTransformation {
+  return new SimLogsMetricTransformation({
+    metricNamespace: requiredTransformationField(
+      "metricNamespace",
+      input.metricNamespace,
+    ),
+    metricName: requiredTransformationField("metricName", input.metricName),
+    metricValue: requiredTransformationField("metricValue", input.metricValue),
+    defaultValue: input.defaultValue,
+    unit: input.unit,
+    dimensions: metricDimensions(input.dimensions),
+  });
+}
+
+/**
+ * Read a transformation field the API requires.
+ */
+function requiredTransformationField(
+  name: string,
+  value: string | undefined,
+): string {
+  if (value === undefined || value.length === 0) {
+    throw new SimLogsInvalidParameterException(
+      `1 validation error detected: Value at ` +
+        `'metricTransformations.member.${name}' failed to satisfy ` +
+        `constraint: Member must not be null`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Read a transformation's dimensions from the map the SDK carries them in.
+ */
+function metricDimensions(
+  dimensions: Readonly<Record<string, string>> | undefined,
+): readonly SimLogsMetricDimension[] {
+  return Object.entries(dimensions ?? {}).map(([name, value]) => ({
+    name,
+    value,
+  }));
+}
+
+/**
+ * What DescribeMetricFilters reports about one filter.
+ */
+export function simLogsMetricFilterDetail(
+  filter: SimLogsMetricFilter,
+): SimLogsMetricFilterDetail {
+  return {
+    filterName: filter.filterName,
+    logGroupName: filter.logGroupName,
+    filterPattern: filter.filterPatternText,
+    metricTransformations: filter.transformations.map((transformation) => ({
+      metricName: transformation.metricName,
+      metricNamespace: transformation.metricNamespace,
+      metricValue: transformation.metricValue,
+      defaultValue: transformation.defaultValue,
+      unit: transformation.unit,
+      dimensions: Object.fromEntries(
+        transformation.dimensions.map((dimension) => [
+          dimension.name,
+          dimension.value,
+        ]),
+      ),
+    })),
+    creationTime: filter.creationTime,
+  };
+}

--- a/src/service/logs/command/sim-logs-command.types.ts
+++ b/src/service/logs/command/sim-logs-command.types.ts
@@ -43,6 +43,19 @@ export type {
   SimPutLogEventsCommandOutput,
 } from "./event/event.command.js";
 export type {
+  SimDeleteMetricFilterCommand,
+  SimDeleteMetricFilterCommandInput,
+  SimDeleteMetricFilterCommandOutput,
+  SimDescribeMetricFiltersCommand,
+  SimDescribeMetricFiltersCommandInput,
+  SimDescribeMetricFiltersCommandOutput,
+  SimLogsMetricFilterDetail,
+  SimLogsMetricTransformationInput,
+  SimPutMetricFilterCommand,
+  SimPutMetricFilterCommandInput,
+  SimPutMetricFilterCommandOutput,
+} from "./metric/metric-filter.command.js";
+export type {
   SimDeleteSubscriptionFilterCommand,
   SimDeleteSubscriptionFilterCommandInput,
   SimDeleteSubscriptionFilterCommandOutput,

--- a/src/service/logs/group/sim-logs-log-group.ts
+++ b/src/service/logs/group/sim-logs-log-group.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
 import { SimLogsLogStreamStore } from "../stream/sim-logs-log-stream-store.js";
+import { SimLogsMetricFilterStore } from "../metric/sim-logs-metric-filter-store.js";
 import { SimLogsSubscriptionFilterStore } from "../subscription/sim-logs-subscription-filter-store.js";
 import {
   simLogsLogGroupArn,
@@ -33,6 +34,12 @@ export class SimLogsLogGroup {
    * written to it onward.
    */
   readonly subscriptionFilters = new SimLogsSubscriptionFilterStore();
+
+  /**
+   * The metric filters watching this group, which turn what is written to it
+   * into CloudWatch metric datapoints.
+   */
+  readonly metricFilters = new SimLogsMetricFilterStore();
 
   readonly #streams: SimLogsLogStreamStore;
   #retentionInDays: number | undefined;

--- a/src/service/logs/index.ts
+++ b/src/service/logs/index.ts
@@ -24,6 +24,21 @@ export {
 } from "./event/sim-logs-event.js";
 export { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
 export { SimLogsFilterPattern } from "./event/sim-logs-filter-pattern.js";
+export { SimLogsMetricFilter } from "./metric/sim-logs-metric-filter.js";
+export { SimLogsMetricFilterStore } from "./metric/sim-logs-metric-filter-store.js";
+export {
+  SimLogsMetricTransformation,
+  simLogsMaximumMetricDimensions,
+} from "./metric/sim-logs-metric-transformation.js";
+export type {
+  SimLogsMetricDatapoint,
+  SimLogsMetricDimension,
+} from "./metric/sim-logs-metric-datapoint.js";
+export type { SimLogsMetricPublicationFailure } from "./metric/sim-logs-metric-fan-out.js";
+export {
+  SimLogsNoMetricPublications,
+  type SimLogsMetricPublications,
+} from "./metric/sim-logs-metric-publications.js";
 export { simLogsStandardLogGroupClass } from "./command/group/sim-logs-unsimulated-group-input.js";
 export { SimLogsDeliverySource } from "./delivery/sim-logs-delivery-source.js";
 export { SimLogsDeliveryDestination } from "./delivery/sim-logs-delivery-destination.js";

--- a/src/service/logs/metric/cloudwatch/sim-aws-logs-metric-filter-metrics.ts
+++ b/src/service/logs/metric/cloudwatch/sim-aws-logs-metric-filter-metrics.ts
@@ -91,8 +91,10 @@ function byNamespace(
 /**
  * One datapoint as PutMetricData takes it.
  *
- * The timestamp is left off so simulated CloudWatch stamps it from the
- * simulation's clock, which is the same instant the event was written.
+ * The timestamp is the instant CloudWatch Logs took the event, rather than the
+ * instant this runs. Publication happens on the background scheduler, and a
+ * clock that moved in between would otherwise file the datapoint under a later
+ * period than the log line it counts.
  */
 function metricDatum(
   datapoint: SimLogsMetricDatapoint,
@@ -100,6 +102,7 @@ function metricDatum(
   return {
     MetricName: datapoint.metricName,
     Value: datapoint.value,
+    Timestamp: new Date(datapoint.timestamp),
     Unit: datapoint.unit,
     Dimensions: datapoint.dimensions.map((dimension) => ({
       Name: dimension.name,

--- a/src/service/logs/metric/cloudwatch/sim-aws-logs-metric-filter-metrics.ts
+++ b/src/service/logs/metric/cloudwatch/sim-aws-logs-metric-filter-metrics.ts
@@ -1,0 +1,109 @@
+import { makeSimAwsAccountRootPrincipal } from "../../../aws/caller/sim-aws-account-root-principal.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCloudWatchMetricDatumInput } from "../../../cloudwatch/command/data/data.command.js";
+import type { SimLogsMetricDatapoint } from "../sim-logs-metric-datapoint.js";
+import type { SimLogsMetricPublications } from "../sim-logs-metric-publications.js";
+
+interface SimAwsLogsMetricFilterMetricsProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+}
+
+/**
+ * The simulated CloudWatch a metric filter's datapoints are published into.
+ *
+ * Real CloudWatch Logs publishes a filter's metric in the Account and Region
+ * of the log group, and there is no way to point one at another Region, so
+ * this scope's own CloudWatch is the one to write to.
+ *
+ * Publication goes through the ordinary `PutMetricData` path, which keeps one
+ * route into the metric store rather than a private one. A filter naming a
+ * reserved `AWS/` namespace is therefore refused exactly as a caller putting
+ * into one is.
+ *
+ * The Account root is named as the caller rather than left to be resolved.
+ * Real CloudWatch Logs publishes a filter's datapoint itself, and no policy
+ * anybody writes gates it. Leaving the caller off would pick up the ambient
+ * one, so a filter over a Lambda function's log group would publish as that
+ * function's execution role and be denied for a metric the role has no reason
+ * to name.
+ */
+export class SimAwsLogsMetricFilterMetrics implements SimLogsMetricPublications {
+  readonly #simAws: SimAws;
+  readonly #accountRegionScope: SimAwsAccountRegionScope;
+
+  constructor(properties: SimAwsLogsMetricFilterMetricsProperties) {
+    this.#simAws = properties.simAws;
+    this.#accountRegionScope = properties.accountRegionScope;
+  }
+
+  /**
+   * Publish the datapoints one log event produced.
+   *
+   * `PutMetricData` carries one namespace per request, so datapoints are
+   * grouped by the namespace their transformation named. One filter writing
+   * into two namespaces is two requests, as it is on real AWS.
+   *
+   * An empty batch reaches nothing. That is a filter about to be put asking
+   * whether this scope can publish at all, and this scope always can.
+   */
+  async publish(datapoints: readonly SimLogsMetricDatapoint[]): Promise<void> {
+    if (datapoints.length === 0) {
+      return;
+    }
+
+    const scope = this.#accountRegionScope;
+    const cloudWatch = this.#simAws
+      .accountRegionScope(scope.accountId, scope.regionName)
+      .cloudWatch();
+
+    const caller = makeSimAwsAccountRootPrincipal(scope.accountId);
+
+    for (const [namespace, data] of byNamespace(datapoints)) {
+      // oxlint-disable-next-line no-await-in-loop -- one request per namespace, in order
+      await cloudWatch.putMetricData(
+        { input: { Namespace: namespace, MetricData: data } },
+        { caller },
+      );
+    }
+  }
+}
+
+/**
+ * The datapoints grouped into one PutMetricData request per namespace.
+ */
+function byNamespace(
+  datapoints: readonly SimLogsMetricDatapoint[],
+): ReadonlyMap<string, readonly SimCloudWatchMetricDatumInput[]> {
+  const grouped = new Map<string, SimCloudWatchMetricDatumInput[]>();
+
+  for (const datapoint of datapoints) {
+    const data = grouped.get(datapoint.namespace) ?? [];
+
+    data.push(metricDatum(datapoint));
+    grouped.set(datapoint.namespace, data);
+  }
+
+  return grouped;
+}
+
+/**
+ * One datapoint as PutMetricData takes it.
+ *
+ * The timestamp is left off so simulated CloudWatch stamps it from the
+ * simulation's clock, which is the same instant the event was written.
+ */
+function metricDatum(
+  datapoint: SimLogsMetricDatapoint,
+): SimCloudWatchMetricDatumInput {
+  return {
+    MetricName: datapoint.metricName,
+    Value: datapoint.value,
+    Unit: datapoint.unit,
+    Dimensions: datapoint.dimensions.map((dimension) => ({
+      Name: dimension.name,
+      Value: dimension.value,
+    })),
+  };
+}

--- a/src/service/logs/metric/sim-logs-metric-datapoint.ts
+++ b/src/service/logs/metric/sim-logs-metric-datapoint.ts
@@ -1,0 +1,24 @@
+/**
+ * One dimension on a metric a metric filter publishes.
+ */
+export interface SimLogsMetricDimension {
+  readonly name: string;
+  readonly value: string;
+}
+
+/**
+ * One metric datapoint a metric filter's transformation produced from a log
+ * event.
+ *
+ * This is what simulated CloudWatch Logs hands to simulated CloudWatch, and it
+ * carries no timestamp. Real CloudWatch stamps a filter's datapoint with the
+ * time the event was ingested, and the simulation's clock is what both
+ * services already read that from.
+ */
+export interface SimLogsMetricDatapoint {
+  readonly namespace: string;
+  readonly metricName: string;
+  readonly value: number;
+  readonly unit: string | undefined;
+  readonly dimensions: readonly SimLogsMetricDimension[];
+}

--- a/src/service/logs/metric/sim-logs-metric-datapoint.ts
+++ b/src/service/logs/metric/sim-logs-metric-datapoint.ts
@@ -10,15 +10,17 @@ export interface SimLogsMetricDimension {
  * One metric datapoint a metric filter's transformation produced from a log
  * event.
  *
- * This is what simulated CloudWatch Logs hands to simulated CloudWatch, and it
- * carries no timestamp. Real CloudWatch stamps a filter's datapoint with the
- * time the event was ingested, and the simulation's clock is what both
- * services already read that from.
+ * This is what simulated CloudWatch Logs hands to simulated CloudWatch. The
+ * timestamp is the instant CloudWatch Logs took the event, rather than the
+ * instant the datapoint reaches the metric store. Publication happens on the
+ * background scheduler, so a clock that moved in between would otherwise put
+ * the datapoint in a later period than the log line it counts.
  */
 export interface SimLogsMetricDatapoint {
   readonly namespace: string;
   readonly metricName: string;
   readonly value: number;
+  readonly timestamp: number;
   readonly unit: string | undefined;
   readonly dimensions: readonly SimLogsMetricDimension[];
 }

--- a/src/service/logs/metric/sim-logs-metric-fan-out.ts
+++ b/src/service/logs/metric/sim-logs-metric-fan-out.ts
@@ -65,12 +65,13 @@ export class SimLogsMetricFanOut {
   /**
    * Schedule the datapoints every metric filter on the group wants from these
    * events.
+   *
+   * The whole batch goes to each filter at once, because a filter aggregates
+   * its default value over a period rather than over one event.
    */
   written(group: SimLogsLogGroup, events: readonly SimLogsStoredEvent[]): void {
     for (const filter of group.metricFilters.all) {
-      const datapoints = events.flatMap((event) =>
-        filter.datapoints(event.message),
-      );
+      const datapoints = filter.datapoints(events);
 
       if (datapoints.length > 0) {
         this.schedule(group.logGroupName, filter.filterName, datapoints);

--- a/src/service/logs/metric/sim-logs-metric-fan-out.ts
+++ b/src/service/logs/metric/sim-logs-metric-fan-out.ts
@@ -1,0 +1,113 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimLogsStoredEvent } from "../event/sim-logs-event.js";
+import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
+import type { SimLogsMetricDatapoint } from "./sim-logs-metric-datapoint.js";
+import type { SimLogsMetricPublications } from "./sim-logs-metric-publications.js";
+
+/**
+ * One datapoint a metric filter could not publish.
+ */
+export interface SimLogsMetricPublicationFailure {
+  readonly logGroupName: string;
+  readonly filterName: string;
+  readonly metricNamespace: string;
+  readonly metricName: string;
+  readonly reason: string;
+}
+
+interface SimLogsMetricFanOutProperties {
+  readonly publications: SimLogsMetricPublications;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Turns events written to a log group into the metric datapoints its metric
+ * filters ask for.
+ *
+ * Publication happens on the background scheduler, for the reason subscription
+ * delivery does. Real CloudWatch Logs answers `PutLogEvents` whether or not
+ * the metric behind a filter took the datapoint, and a metric that cannot be
+ * written must not fail the write that produced it.
+ * `simAws.backgroundTasksComplete()` is what waits for it.
+ */
+export class SimLogsMetricFanOut {
+  readonly #publications: SimLogsMetricPublications;
+  readonly #background: BackgroundScheduler;
+  readonly #failures: SimLogsMetricPublicationFailure[] = [];
+
+  constructor(properties: SimLogsMetricFanOutProperties) {
+    this.#publications = properties.publications;
+    this.#background = properties.background;
+  }
+
+  /**
+   * Every publication this scope could not make.
+   *
+   * A failed publication is invisible in an account, where it becomes a metric
+   * nobody is watching. Keeping it is what lets a test find out that the
+   * metric filter it set up never wrote anything.
+   */
+  get failures(): readonly SimLogsMetricPublicationFailure[] {
+    return this.#failures;
+  }
+
+  /**
+   * Check a metric filter could publish at all, before one is put.
+   *
+   * Publishing nothing is the question. A CloudWatch that is there takes an
+   * empty batch and does nothing with it, and a simulated CloudWatch Logs
+   * built on its own refuses it, which is the answer the caller needs.
+   */
+  async checkPublishable(): Promise<void> {
+    await this.#publications.publish([]);
+  }
+
+  /**
+   * Schedule the datapoints every metric filter on the group wants from these
+   * events.
+   */
+  written(group: SimLogsLogGroup, events: readonly SimLogsStoredEvent[]): void {
+    for (const filter of group.metricFilters.all) {
+      const datapoints = events.flatMap((event) =>
+        filter.datapoints(event.message),
+      );
+
+      if (datapoints.length > 0) {
+        this.schedule(group.logGroupName, filter.filterName, datapoints);
+      }
+    }
+  }
+
+  private schedule(
+    logGroupName: string,
+    filterName: string,
+    datapoints: readonly SimLogsMetricDatapoint[],
+  ): void {
+    this.#background.schedule(async () => {
+      try {
+        await this.#publications.publish(datapoints);
+      } catch (error) {
+        this.recordFailure(logGroupName, filterName, datapoints, error);
+      }
+    });
+  }
+
+  private recordFailure(
+    logGroupName: string,
+    filterName: string,
+    datapoints: readonly SimLogsMetricDatapoint[],
+    error: unknown,
+  ): void {
+    const reason = error instanceof Error ? error.message : String(error);
+
+    for (const datapoint of datapoints) {
+      this.#failures.push({
+        logGroupName,
+        filterName,
+        metricNamespace: datapoint.namespace,
+        metricName: datapoint.metricName,
+        reason,
+      });
+    }
+  }
+}

--- a/src/service/logs/metric/sim-logs-metric-filter-alarm.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter-alarm.iso.test.ts
@@ -1,0 +1,123 @@
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+  PutMetricFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import { CreateTopicCommand } from "@aws-sdk/client-sns";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/30/[$LATEST]abc";
+const alarmName = "OrdersHandlerErrors";
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+
+/**
+ * The state one alarm is reporting.
+ */
+async function alarmState(simAws: SimAws): Promise<string | undefined> {
+  const { MetricAlarms } = await simAws
+    .cloudWatch()
+    .describeAlarms(new DescribeAlarmsCommand({ AlarmNames: [alarmName] }));
+
+  return MetricAlarms?.at(0)?.StateValue;
+}
+
+/**
+ * Write one line to the log group and let the filters and the clock catch up.
+ */
+async function log(simAws: SimAws, message: string): Promise<void> {
+  await simAws.logs().putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName,
+      logStreamName,
+      logEvents: [{ message, timestamp: simAws.clock().now().getTime() }],
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("an alarm over a metric a CloudWatch Logs metric filter writes", () => {
+  it("fires when the log lines it counts arrive", async () => {
+    // Given a log group whose metric filter counts ERROR lines into
+    // Orders/HandlerErrors, and an alarm watching that metric.
+    const simAws = new SimAws();
+
+    await simAws.clock().setTo(startedAt);
+
+    const topic = await simAws
+      .sns()
+      .createTopic(new CreateTopicCommand({ Name: "orders-alerts" }));
+
+    assertNonNullable(topic.TopicArn);
+
+    await simAws
+      .logs()
+      .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+    await simAws
+      .logs()
+      .createLogStream(
+        new CreateLogStreamCommand({ logGroupName, logStreamName }),
+      );
+    await simAws.logs().putMetricFilter(
+      new PutMetricFilterCommand({
+        logGroupName,
+        filterName: "handler-errors",
+        filterPattern: "ERROR",
+        metricTransformations: [
+          {
+            metricNamespace: "Orders",
+            metricName: "HandlerErrors",
+            metricValue: "1",
+          },
+        ],
+      }),
+    );
+    await simAws.cloudWatch().putMetricAlarm(
+      new PutMetricAlarmCommand({
+        AlarmName: alarmName,
+        Namespace: "Orders",
+        MetricName: "HandlerErrors",
+        Statistic: "Sum",
+        Period: 60,
+        EvaluationPeriods: 3,
+        DatapointsToAlarm: 1,
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        TreatMissingData: "notBreaching",
+        AlarmActions: [topic.TopicArn],
+      }),
+    );
+
+    // Then it starts out with nothing to read.
+    assertIdentical(await alarmState(simAws), "INSUFFICIENT_DATA");
+
+    // And log lines it does not match leave it healthy, because a filter that
+    // matched nothing publishes nothing and the alarm treats that as fine.
+    await log(simAws, "INFO order handled");
+    await simAws.clock().advanceBy({ minutes: 4 });
+
+    assertIdentical(await alarmState(simAws), "OK");
+
+    // When a line it does match is written, and the clock passes the period.
+    await log(simAws, "ERROR order failed");
+    await simAws.clock().advanceBy({ minutes: 2 });
+
+    // Then the alarm fired on a datapoint nothing published by hand, and it
+    // reached its topic.
+    assertIdentical(await alarmState(simAws), "ALARM");
+    assertArrayLength(simAws.cloudWatch().alarmActionFailures, 0);
+    assertArrayLength(simAws.logs().metricFilterFailures, 0);
+  });
+});

--- a/src/service/logs/metric/sim-logs-metric-filter-publication.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter-publication.iso.test.ts
@@ -140,11 +140,28 @@ describe("sim CloudWatch Logs metric filter publication", () => {
     assertArrayLength(Metrics ?? [], 0);
   });
 
-  it("publishes a default value for an event that matched nothing", async () => {
+  it("publishes a default value once for a period that matched nothing", async () => {
     // Given a filter whose transformation carries a default value.
     const simAws = await simAwsWithMetricFilter({ defaultValue: 0 });
 
-    // When one matching line and two that do not match are written.
+    // When two lines it does not match are written in the same minute.
+    await write(simAws, "INFO order handled", "INFO order handled again");
+
+    // Then the period reports the default once, rather than once per line.
+    // Real CloudWatch Logs reports the default for a minute that took records
+    // and matched none, which is what keeps a metric reporting through a quiet
+    // stretch without inflating its sample count.
+    const { sum, samples } = await counted(simAws);
+
+    assertIdentical(sum, 0);
+    assertIdentical(samples, 1);
+  });
+
+  it("publishes no default for a period a match landed in", async () => {
+    // Given the same filter.
+    const simAws = await simAwsWithMetricFilter({ defaultValue: 0 });
+
+    // When one matching line and two that do not match share a minute.
     await write(
       simAws,
       "ERROR order failed",
@@ -152,13 +169,28 @@ describe("sim CloudWatch Logs metric filter publication", () => {
       "INFO order handled again",
     );
 
-    // Then the sum is the one match, over three samples: real CloudWatch Logs
-    // emits the default value for an event a pattern did not match, which is
-    // what keeps the metric reporting through a quiet period.
+    // Then the minute counts the one match alone. Publishing a default beside
+    // it would inflate the sample count and change what an alarm decides.
     const { sum, samples } = await counted(simAws);
 
     assertIdentical(sum, 1);
-    assertIdentical(samples, 3);
+    assertIdentical(samples, 1);
+  });
+
+  it("publishes no default over a write that follows a match in its minute", async () => {
+    // Given the same filter, with a match already written this minute.
+    const simAws = await simAwsWithMetricFilter({ defaultValue: 0 });
+
+    await write(simAws, "ERROR order failed");
+
+    // When a second write in the same minute matches nothing.
+    await write(simAws, "INFO order handled");
+
+    // Then the minute still counts the one match, as it does in an account.
+    const { sum, samples } = await counted(simAws);
+
+    assertIdentical(sum, 1);
+    assertIdentical(samples, 1);
   });
 
   it("publishes under the transformation's dimensions and unit", async () => {
@@ -195,7 +227,7 @@ describe("sim CloudWatch Logs metric filter publication", () => {
     );
   });
 
-  it("stamps the datapoint from the simulation's clock", async () => {
+  it("stamps the datapoint with the instant the line was written", async () => {
     // Given the filter, with the clock stopped.
     const simAws = await simAwsWithMetricFilter();
 
@@ -205,6 +237,32 @@ describe("sim CloudWatch Logs metric filter publication", () => {
 
     // Then the datapoint sits in the minute the line was written, rather than
     // the minute the assertion reads it in.
+    const { sum } = await counted(simAws);
+
+    assertIdentical(sum, 1);
+  });
+
+  it("keeps the write's minute when the clock moves before publication", async () => {
+    // Given the filter, and a matching line written but not yet published.
+    const simAws = await simAwsWithMetricFilter();
+
+    await simAws.logs().putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [
+          { message: "ERROR order failed", timestamp: startedAt.getTime() },
+        ],
+      }),
+    );
+
+    // When the clock advances past the period before the publication runs.
+    await simAws.clock().advanceBy({ minutes: 10 });
+    await simAws.backgroundTasksComplete();
+
+    // Then the datapoint is still in the minute of the write. Publication
+    // happens on the background scheduler, and stamping it when it runs would
+    // file a log line under a period it never happened in.
     const { sum } = await counted(simAws);
 
     assertIdentical(sum, 1);

--- a/src/service/logs/metric/sim-logs-metric-filter-publication.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter-publication.iso.test.ts
@@ -1,0 +1,267 @@
+/* oxlint-disable no-console -- printing is what the bound handler is here to do. */
+import {
+  type Dimension,
+  GetMetricStatisticsCommand,
+  ListMetricsCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  type MetricTransformation,
+  PutLogEventsCommand,
+  PutMetricFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/30/[$LATEST]abc";
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+
+/**
+ * A simulation with a stopped clock, a log group with a stream in it, and one
+ * metric filter counting `ERROR` lines into `Orders`/`HandlerErrors`.
+ */
+async function simAwsWithMetricFilter(
+  transformation: Partial<MetricTransformation> = {},
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+  await simAws
+    .logs()
+    .createLogStream(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+  await simAws.logs().putMetricFilter(
+    new PutMetricFilterCommand({
+      logGroupName,
+      filterName: "handler-errors",
+      filterPattern: "ERROR",
+      metricTransformations: [
+        {
+          metricNamespace: "Orders",
+          metricName: "HandlerErrors",
+          metricValue: "1",
+          ...transformation,
+        },
+      ],
+    }),
+  );
+
+  return simAws;
+}
+
+/** Write log lines to the stream and let the filters run. */
+async function write(
+  simAws: SimAws,
+  ...messages: readonly string[]
+): Promise<void> {
+  await simAws.logs().putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName,
+      logStreamName,
+      logEvents: messages.map((message) => ({
+        message,
+        timestamp: startedAt.getTime(),
+      })),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+/** The `Sum` and `SampleCount` of `Orders`/`HandlerErrors` over the window. */
+async function counted(
+  simAws: SimAws,
+  dimensions: Dimension[] = [],
+): Promise<{ sum: number | undefined; samples: number | undefined }> {
+  const endTime = new Date(startedAt.getTime() + 60_000);
+  const command = new GetMetricStatisticsCommand({
+    Namespace: "Orders",
+    MetricName: "HandlerErrors",
+    Dimensions: dimensions,
+    StartTime: startedAt,
+    EndTime: endTime,
+    Period: 60,
+    Statistics: ["Sum", "SampleCount"],
+  });
+  const { Datapoints } = await simAws.cloudWatch().getMetricStatistics(command);
+
+  return {
+    sum: Datapoints?.at(0)?.Sum,
+    samples: Datapoints?.at(0)?.SampleCount,
+  };
+}
+
+describe("sim CloudWatch Logs metric filter publication", () => {
+  it("publishes a datapoint for each matching log event", async () => {
+    // Given a log group whose metric filter counts ERROR lines.
+    const simAws = await simAwsWithMetricFilter();
+
+    // When two matching lines and one that does not match are written.
+    await write(
+      simAws,
+      "ERROR order failed",
+      "INFO order handled",
+      "ERROR order failed again",
+    );
+
+    // Then the metric counts the two that matched, and nothing for the third.
+    const { sum, samples } = await counted(simAws);
+
+    assertIdentical(sum, 2);
+    assertIdentical(samples, 2);
+  });
+
+  it("publishes nothing at all where no event matches", async () => {
+    // Given the same filter.
+    const simAws = await simAwsWithMetricFilter();
+
+    // When only lines it does not match are written.
+    await write(simAws, "INFO order handled");
+
+    // Then the metric was never made, rather than made and left at zero.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({ Namespace: "Orders" }));
+
+    assertArrayLength(Metrics ?? [], 0);
+  });
+
+  it("publishes a default value for an event that matched nothing", async () => {
+    // Given a filter whose transformation carries a default value.
+    const simAws = await simAwsWithMetricFilter({ defaultValue: 0 });
+
+    // When one matching line and two that do not match are written.
+    await write(
+      simAws,
+      "ERROR order failed",
+      "INFO order handled",
+      "INFO order handled again",
+    );
+
+    // Then the sum is the one match, over three samples: real CloudWatch Logs
+    // emits the default value for an event a pattern did not match, which is
+    // what keeps the metric reporting through a quiet period.
+    const { sum, samples } = await counted(simAws);
+
+    assertIdentical(sum, 1);
+    assertIdentical(samples, 3);
+  });
+
+  it("publishes under the transformation's dimensions and unit", async () => {
+    // Given a filter publishing under a dimension, in a named unit.
+    const simAws = await simAwsWithMetricFilter({
+      dimensions: { service: "orders" },
+      unit: "Count",
+    });
+
+    // When a matching line is written.
+    await write(simAws, "ERROR order failed");
+
+    // Then the datapoint is under that dimension set, and nothing landed on
+    // the undimensioned metric.
+    const dimensioned = await counted(simAws, [
+      { Name: "service", Value: "orders" },
+    ]);
+    const undimensioned = await counted(simAws);
+
+    assertIdentical(dimensioned.sum, 1);
+    assertUndefined(undimensioned.sum);
+
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({ Namespace: "Orders" }));
+
+    assertArrayEquals(
+      (Metrics ?? []).flatMap((metric) =>
+        metric.Dimensions.map(
+          (dimension) => `${dimension.Name}=${dimension.Value}`,
+        ),
+      ),
+      ["service=orders"],
+    );
+  });
+
+  it("stamps the datapoint from the simulation's clock", async () => {
+    // Given the filter, with the clock stopped.
+    const simAws = await simAwsWithMetricFilter();
+
+    // When a matching line is written and the clock then moves on.
+    await write(simAws, "ERROR order failed");
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // Then the datapoint sits in the minute the line was written, rather than
+    // the minute the assertion reads it in.
+    const { sum } = await counted(simAws);
+
+    assertIdentical(sum, 1);
+  });
+
+  it("counts a bound Lambda handler's own error lines", async () => {
+    // Given a function bound to an in-process handler that prints an error,
+    // and a metric filter over the log group that handler writes to.
+    const simAws = new SimAws();
+    const functionName = "orders";
+    const handlerLogGroupName = `/aws/lambda/${functionName}`;
+
+    await simAws.clock().setTo(startedAt);
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: functionName,
+        Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            console.error("ERROR order failed");
+
+            return "done";
+          }),
+        },
+      },
+    });
+    await simAws.backgroundTasksComplete();
+    await simAws
+      .logs()
+      .createLogGroup(
+        new CreateLogGroupCommand({ logGroupName: handlerLogGroupName }),
+      );
+    await simAws.logs().putMetricFilter(
+      new PutMetricFilterCommand({
+        logGroupName: handlerLogGroupName,
+        filterName: "handler-errors",
+        filterPattern: "ERROR",
+        metricTransformations: [
+          {
+            metricNamespace: "Orders",
+            metricName: "HandlerErrors",
+            metricValue: "1",
+          },
+        ],
+      }),
+    );
+
+    // When the handler runs.
+    await simAws.lambda().invoke({ input: { FunctionName: functionName } });
+    await simAws.backgroundTasksComplete();
+
+    // Then the metric counted the line it printed. That output reaches the log
+    // group through the simulation's own writer rather than through
+    // PutLogEvents, so the filter has to run on both paths.
+    const { sum } = await counted(simAws);
+
+    assertNonNullable(sum);
+    assertIdentical(sum, 1);
+  });
+});

--- a/src/service/logs/metric/sim-logs-metric-filter-refusals.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter-refusals.iso.test.ts
@@ -190,4 +190,33 @@ describe("sim CloudWatch Logs metric filter refusals", () => {
     assertInstanceOf(error, SimLogsUnsupportedOperationException);
     assertStringIncludes(error.message, "SimAws Account Region scope");
   });
+
+  it("refuses a default value on a transformation that has dimensions", async () => {
+    // Given a log group.
+    const simAws = await simAwsWithLogGroup();
+
+    // When a filter would carry both.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putMetricFilter(
+          new PutMetricFilterCommand({
+            logGroupName,
+            filterName: "handler-errors",
+            filterPattern: "ERROR",
+            metricTransformations: [
+              countErrors({
+                defaultValue: 0,
+                dimensions: { service: "orders" },
+              }),
+            ],
+          }),
+        ),
+    );
+
+    // Then it is refused. CloudWatch Logs allows one or the other, because a
+    // default would have to be reported against every dimension value the
+    // filter has ever seen.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+    assertStringIncludes(error.message, "defaultValue");
+  });
 });

--- a/src/service/logs/metric/sim-logs-metric-filter-refusals.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter-refusals.iso.test.ts
@@ -1,0 +1,193 @@
+import {
+  CreateLogGroupCommand,
+  type MetricTransformation,
+  PutMetricFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimLogs } from "../sim-logs.js";
+import {
+  SimLogsInvalidParameterException,
+  SimLogsUnsupportedOperationException,
+} from "../error/sim-logs.error.js";
+
+const logGroupName = "/aws/lambda/orders";
+
+/** A simulation holding one empty log group. */
+async function simAwsWithLogGroup(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+  return simAws;
+}
+
+/** One transformation counting a match into `Orders`/`HandlerErrors`. */
+function countErrors(
+  overrides: Partial<MetricTransformation> = {},
+): MetricTransformation {
+  return {
+    metricNamespace: "Orders",
+    metricName: "HandlerErrors",
+    metricValue: "1",
+    ...overrides,
+  };
+}
+
+describe("sim CloudWatch Logs metric filter refusals", () => {
+  it("refuses a metricValue naming a field of the log event", async () => {
+    // Given a log group.
+    const simAws = await simAwsWithLogGroup();
+
+    // When a filter would read its value out of the matched event.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putMetricFilter(
+          new PutMetricFilterCommand({
+            logGroupName,
+            filterName: "bytes",
+            filterPattern: "transfer",
+            metricTransformations: [countErrors({ metricValue: "$.bytes" })],
+          }),
+        ),
+    );
+
+    // Then it is refused, because reading one needs a structured pattern and
+    // neither structured syntax is simulated.
+    assertInstanceOf(error, SimLogsUnsupportedOperationException);
+    assertStringIncludes(error.message, "$.bytes");
+  });
+
+  it("refuses a dimension naming a field of the log event", async () => {
+    // Given a log group.
+    const simAws = await simAwsWithLogGroup();
+
+    // When a filter would take a dimension value out of the matched event.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putMetricFilter(
+          new PutMetricFilterCommand({
+            logGroupName,
+            filterName: "by-route",
+            filterPattern: "ERROR",
+            metricTransformations: [
+              countErrors({ dimensions: { route: "$.route" } }),
+            ],
+          }),
+        ),
+    );
+
+    // Then it is refused rather than publishing under a dimension set no alarm
+    // is watching.
+    assertInstanceOf(error, SimLogsUnsupportedOperationException);
+    assertStringIncludes(error.message, "route");
+  });
+
+  it("refuses a metricValue that is no kind of number", async () => {
+    // Given a log group.
+    const simAws = await simAwsWithLogGroup();
+
+    // When a filter would publish something that is not a value.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putMetricFilter(
+          new PutMetricFilterCommand({
+            logGroupName,
+            filterName: "handler-errors",
+            filterPattern: "ERROR",
+            metricTransformations: [countErrors({ metricValue: "lots" })],
+          }),
+        ),
+    );
+
+    // Then it is refused when it is put.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+    assertStringIncludes(error.message, "lots");
+  });
+
+  it("refuses more dimensions than a transformation may carry", async () => {
+    // Given a log group.
+    const simAws = await simAwsWithLogGroup();
+
+    // When a filter names four dimensions, one more than AWS allows.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().putMetricFilter(
+          new PutMetricFilterCommand({
+            logGroupName,
+            filterName: "handler-errors",
+            filterPattern: "ERROR",
+            metricTransformations: [
+              countErrors({
+                dimensions: { a: "1", b: "2", c: "3", d: "4" },
+              }),
+            ],
+          }),
+        ),
+    );
+
+    // Then it is refused, as an account refuses it.
+    assertInstanceOf(error, SimLogsInvalidParameterException);
+    assertStringIncludes(error.message, "at most 3 dimensions");
+  });
+
+  it("refuses a filter with no transformation, and one with two", async () => {
+    // Given a log group.
+    const simAws = await simAwsWithLogGroup();
+    const put = async (
+      metricTransformations: MetricTransformation[],
+    ): Promise<Error> =>
+      await assertThrowsErrorAsync(
+        async () =>
+          await simAws.logs().putMetricFilter(
+            new PutMetricFilterCommand({
+              logGroupName,
+              filterName: "handler-errors",
+              filterPattern: "ERROR",
+              metricTransformations,
+            }),
+          ),
+      );
+
+    // Then both are refused, as an account refuses them.
+    assertInstanceOf(await put([]), SimLogsInvalidParameterException);
+    assertInstanceOf(
+      await put([countErrors(), countErrors({ metricName: "Second" })]),
+      SimLogsInvalidParameterException,
+    );
+  });
+
+  it("refuses a filter on a CloudWatch Logs with nowhere to publish", async () => {
+    // Given a simulated CloudWatch Logs built on its own, which has no
+    // simulated CloudWatch to write a datapoint into.
+    const simLogs = new SimLogs();
+
+    await simLogs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+    // When a metric filter is put on it.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simLogs.putMetricFilter(
+          new PutMetricFilterCommand({
+            logGroupName,
+            filterName: "handler-errors",
+            filterPattern: "ERROR",
+            metricTransformations: [countErrors()],
+          }),
+        ),
+    );
+
+    // Then it is refused when it is put, rather than held and publishing
+    // nowhere for the rest of the test.
+    assertInstanceOf(error, SimLogsUnsupportedOperationException);
+    assertStringIncludes(error.message, "SimAws Account Region scope");
+  });
+});

--- a/src/service/logs/metric/sim-logs-metric-filter-selection.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter-selection.ts
@@ -1,0 +1,41 @@
+import type { SimLogsMetricFilter } from "./sim-logs-metric-filter.js";
+
+/**
+ * What a DescribeMetricFilters request is selecting on, beyond the log group.
+ */
+export interface SimLogsMetricFilterSelection {
+  readonly filterNamePrefix?: string | undefined;
+  readonly metricName?: string | undefined;
+  readonly metricNamespace?: string | undefined;
+}
+
+/**
+ * The filters a request selects, by name prefix and by the metric they write.
+ *
+ * Selecting on the metric is what makes a request naming no log group useful.
+ * It is how a caller finds every filter writing to a metric it has an alarm
+ * on, wherever in the account those filters were put.
+ */
+export function simLogsSelectedMetricFilters(
+  filters: readonly SimLogsMetricFilter[],
+  selection: SimLogsMetricFilterSelection,
+): readonly SimLogsMetricFilter[] {
+  return filters.filter(
+    (filter) =>
+      filter.filterName.startsWith(selection.filterNamePrefix ?? "") &&
+      writesTheMetric(filter, selection),
+  );
+}
+
+function writesTheMetric(
+  filter: SimLogsMetricFilter,
+  selection: SimLogsMetricFilterSelection,
+): boolean {
+  return filter.transformations.some(
+    (transformation) =>
+      (selection.metricNamespace === undefined ||
+        transformation.metricNamespace === selection.metricNamespace) &&
+      (selection.metricName === undefined ||
+        transformation.metricName === selection.metricName),
+  );
+}

--- a/src/service/logs/metric/sim-logs-metric-filter-store.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter-store.ts
@@ -1,0 +1,56 @@
+import { SimLogsResourceNotFoundException } from "../error/sim-logs.error.js";
+import type { SimLogsMetricFilter } from "./sim-logs-metric-filter.js";
+
+/**
+ * The metric filters on one log group.
+ *
+ * They belong to the group the way its subscription filters and its streams
+ * do. A metric filter has no identity outside the group it watches, and
+ * deleting the group takes its filters with it.
+ */
+export class SimLogsMetricFilterStore {
+  readonly #filters = new Map<string, SimLogsMetricFilter>();
+
+  /**
+   * Every filter on this group, in the order they were put.
+   */
+  get all(): readonly SimLogsMetricFilter[] {
+    return this.#filters.values().toArray();
+  }
+
+  /**
+   * How many filters this group has, which is what `DescribeLogGroups` reports
+   * as `metricFilterCount`.
+   */
+  get count(): number {
+    return this.#filters.size;
+  }
+
+  /**
+   * Find a filter on this group by name.
+   */
+  find(filterName: string): SimLogsMetricFilter | undefined {
+    return this.#filters.get(filterName);
+  }
+
+  /**
+   * Put a filter, replacing one of the same name.
+   *
+   * Putting a filter already there by name is an update rather than a second
+   * filter, which is what makes `PutMetricFilter` the way to change a pattern.
+   */
+  put(filter: SimLogsMetricFilter): void {
+    this.#filters.set(filter.filterName, filter);
+  }
+
+  /**
+   * Remove a filter by name, refusing one that was never there.
+   */
+  delete(filterName: string): void {
+    if (!this.#filters.delete(filterName)) {
+      throw new SimLogsResourceNotFoundException(
+        "The specified metric filter does not exist.",
+      );
+    }
+  }
+}

--- a/src/service/logs/metric/sim-logs-metric-filter.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter.ts
@@ -1,0 +1,62 @@
+import { SimLogsFilterPattern } from "../event/sim-logs-filter-pattern.js";
+import type { SimLogsMetricDatapoint } from "./sim-logs-metric-datapoint.js";
+import type { SimLogsMetricTransformation } from "./sim-logs-metric-transformation.js";
+
+interface SimLogsMetricFilterProperties {
+  readonly filterName: string;
+  readonly logGroupName: string;
+  readonly filterPattern: string | undefined;
+  readonly transformations: readonly SimLogsMetricTransformation[];
+  readonly creationTime: number;
+}
+
+/**
+ * One metric filter on a log group.
+ *
+ * The pattern is compiled once, when the filter is put, the way a subscription
+ * filter's is. A pattern this simulator cannot read is refused there rather
+ * than on the first event that happens to arrive.
+ */
+export class SimLogsMetricFilter {
+  readonly filterName: string;
+  readonly logGroupName: string;
+  readonly filterPatternText: string;
+  readonly transformations: readonly SimLogsMetricTransformation[];
+  readonly creationTime: number;
+
+  readonly #pattern: SimLogsFilterPattern;
+
+  constructor(properties: SimLogsMetricFilterProperties) {
+    this.filterName = properties.filterName;
+    this.logGroupName = properties.logGroupName;
+    this.filterPatternText = properties.filterPattern ?? "";
+    this.transformations = properties.transformations;
+    this.creationTime = properties.creationTime;
+    this.#pattern = new SimLogsFilterPattern(properties.filterPattern);
+  }
+
+  /**
+   * Whether this filter matches an event's message.
+   */
+  matches(message: string): boolean {
+    return this.#pattern.matches(message);
+  }
+
+  /**
+   * The datapoints one log event publishes through this filter.
+   *
+   * A matching event publishes one datapoint per transformation. An event that
+   * matched nothing publishes a transformation's default value where it sets
+   * one, which is how real CloudWatch Logs keeps a metric reporting zero over
+   * a period where the term never appeared.
+   */
+  datapoints(message: string): readonly SimLogsMetricDatapoint[] {
+    const matched = this.matches(message);
+
+    return this.transformations
+      .map((transformation) =>
+        matched ? transformation.matched() : transformation.unmatched(),
+      )
+      .filter((datapoint) => datapoint !== undefined);
+  }
+}

--- a/src/service/logs/metric/sim-logs-metric-filter.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter.ts
@@ -1,6 +1,16 @@
+import type { SimLogsStoredEvent } from "../event/sim-logs-event.js";
 import { SimLogsFilterPattern } from "../event/sim-logs-filter-pattern.js";
 import type { SimLogsMetricDatapoint } from "./sim-logs-metric-datapoint.js";
 import type { SimLogsMetricTransformation } from "./sim-logs-metric-transformation.js";
+
+/**
+ * How long a metric filter's aggregation period is.
+ *
+ * Real CloudWatch Logs aggregates and reports a filter's metric every minute,
+ * and the default value is what it reports for a minute that took log events
+ * and matched none of them.
+ */
+const periodMilliseconds = 60_000;
 
 interface SimLogsMetricFilterProperties {
   readonly filterName: string;
@@ -26,6 +36,15 @@ export class SimLogsMetricFilter {
 
   readonly #pattern: SimLogsFilterPattern;
 
+  /**
+   * The most recent period this filter matched something in.
+   *
+   * One period is remembered rather than all of them, so a filter cannot grow
+   * without bound over a long run. It is what stops a second write in a minute
+   * a match already landed in from publishing a default value over the top.
+   */
+  #matchedPeriod: number | undefined;
+
   constructor(properties: SimLogsMetricFilterProperties) {
     this.filterName = properties.filterName;
     this.logGroupName = properties.logGroupName;
@@ -43,20 +62,75 @@ export class SimLogsMetricFilter {
   }
 
   /**
-   * The datapoints one log event publishes through this filter.
+   * The datapoints a batch of log events publishes through this filter.
    *
-   * A matching event publishes one datapoint per transformation. An event that
-   * matched nothing publishes a transformation's default value where it sets
-   * one, which is how real CloudWatch Logs keeps a metric reporting zero over
-   * a period where the term never appeared.
+   * A matching event publishes one datapoint per transformation, stamped with
+   * the instant CloudWatch Logs took it.
+   *
+   * A default value is published once for a period that took events and
+   * matched none of them, rather than once per event that missed. That is what
+   * real CloudWatch Logs reports: a minute with two records and one match
+   * counts one, and a minute with two records and no match reports the default
+   * once. Publishing per event would inflate `SampleCount` and change what an
+   * alarm over the metric decides.
    */
-  datapoints(message: string): readonly SimLogsMetricDatapoint[] {
-    const matched = this.matches(message);
+  datapoints(
+    events: readonly SimLogsStoredEvent[],
+  ): readonly SimLogsMetricDatapoint[] {
+    const published: SimLogsMetricDatapoint[] = [];
+
+    for (const [period, inPeriod] of byPeriod(events)) {
+      published.push(...this.periodDatapoints(period, inPeriod));
+    }
+
+    return published;
+  }
+
+  /**
+   * What one period of events publishes.
+   */
+  private periodDatapoints(
+    period: number,
+    events: readonly SimLogsStoredEvent[],
+  ): readonly SimLogsMetricDatapoint[] {
+    const matched = events.filter((event) => this.matches(event.message));
+
+    if (matched.length > 0) {
+      this.#matchedPeriod = period;
+
+      return matched.flatMap((event) =>
+        this.transformations.map((transformation) =>
+          transformation.matched(event.ingestionTime),
+        ),
+      );
+    }
+
+    if (this.#matchedPeriod === period) {
+      return [];
+    }
 
     return this.transformations
-      .map((transformation) =>
-        matched ? transformation.matched() : transformation.unmatched(),
-      )
+      .map((transformation) => transformation.unmatched(period))
       .filter((datapoint) => datapoint !== undefined);
   }
+}
+
+/**
+ * A batch's events grouped into the aggregation periods they were taken in.
+ */
+function byPeriod(
+  events: readonly SimLogsStoredEvent[],
+): ReadonlyMap<number, readonly SimLogsStoredEvent[]> {
+  const grouped = new Map<number, SimLogsStoredEvent[]>();
+
+  for (const event of events) {
+    const period =
+      Math.floor(event.ingestionTime / periodMilliseconds) * periodMilliseconds;
+    const inPeriod = grouped.get(period) ?? [];
+
+    inPeriod.push(event);
+    grouped.set(period, inPeriod);
+  }
+
+  return grouped;
 }

--- a/src/service/logs/metric/sim-logs-metric-filters.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filters.iso.test.ts
@@ -1,0 +1,251 @@
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  DeleteMetricFilterCommand,
+  DescribeLogGroupsCommand,
+  DescribeMetricFiltersCommand,
+  type MetricTransformation,
+  PutLogEventsCommand,
+  PutMetricFilterCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimLogsResourceNotFoundException } from "../error/sim-logs.error.js";
+
+const logGroupName = "/aws/lambda/orders";
+const logStreamName = "2026/08/30/[$LATEST]abc";
+
+/** A simulation holding one empty log group. */
+async function simAwsWithLogGroup(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+  return simAws;
+}
+
+/** One transformation counting a match into `Orders`/`HandlerErrors`. */
+function countErrors(
+  overrides: Partial<MetricTransformation> = {},
+): MetricTransformation {
+  return {
+    metricNamespace: "Orders",
+    metricName: "HandlerErrors",
+    metricValue: "1",
+    ...overrides,
+  };
+}
+
+describe("sim CloudWatch Logs metric filters", () => {
+  it("puts a filter, describes it and deletes it", async () => {
+    // Given a log group.
+    const simAws = await simAwsWithLogGroup();
+
+    // When a metric filter is put on it.
+    await simAws.logs().putMetricFilter(
+      new PutMetricFilterCommand({
+        logGroupName,
+        filterName: "handler-errors",
+        filterPattern: "ERROR",
+        metricTransformations: [countErrors()],
+      }),
+    );
+
+    // Then it comes back with what it was put with.
+    const { metricFilters } = await simAws
+      .logs()
+      .describeMetricFilters(
+        new DescribeMetricFiltersCommand({ logGroupName }),
+      );
+    const filter = metricFilters?.at(0);
+
+    assertNonNullable(filter);
+    assertIdentical(filter.filterName, "handler-errors");
+    assertIdentical(filter.logGroupName, logGroupName);
+    assertIdentical(filter.filterPattern, "ERROR");
+    assertIdentical(
+      filter.metricTransformations.at(0)?.metricName,
+      "HandlerErrors",
+    );
+
+    // And deleting it takes it off the group.
+    await simAws.logs().deleteMetricFilter(
+      new DeleteMetricFilterCommand({
+        logGroupName,
+        filterName: "handler-errors",
+      }),
+    );
+
+    const { metricFilters: remaining } = await simAws
+      .logs()
+      .describeMetricFilters(
+        new DescribeMetricFiltersCommand({ logGroupName }),
+      );
+
+    assertArrayLength(remaining ?? [], 0);
+  });
+
+  it("reports how many filters a log group has", async () => {
+    // Given a log group with no metric filter on it.
+    const simAws = await simAwsWithLogGroup();
+    const described = async (): Promise<number | undefined> => {
+      const { logGroups } = await simAws
+        .logs()
+        .describeLogGroups(new DescribeLogGroupsCommand({}));
+
+      return logGroups?.at(0)?.metricFilterCount;
+    };
+
+    // Then DescribeLogGroups counts none.
+    assertIdentical(await described(), 0);
+
+    // And when a filter is put, it counts that one.
+    await simAws.logs().putMetricFilter(
+      new PutMetricFilterCommand({
+        logGroupName,
+        filterName: "handler-errors",
+        filterPattern: "ERROR",
+        metricTransformations: [countErrors()],
+      }),
+    );
+
+    assertIdentical(await described(), 1);
+  });
+
+  it("replaces a filter of the same name rather than adding a second", async () => {
+    // Given a log group carrying a metric filter.
+    const simAws = await simAwsWithLogGroup();
+
+    for (const filterPattern of ["ERROR", "FATAL"]) {
+      // oxlint-disable-next-line no-await-in-loop -- the second put replaces the first
+      await simAws.logs().putMetricFilter(
+        new PutMetricFilterCommand({
+          logGroupName,
+          filterName: "handler-errors",
+          filterPattern,
+          metricTransformations: [countErrors()],
+        }),
+      );
+    }
+
+    // When the group is described.
+    const { metricFilters } = await simAws
+      .logs()
+      .describeMetricFilters(
+        new DescribeMetricFiltersCommand({ logGroupName }),
+      );
+
+    // Then one filter is there, carrying the second pattern.
+    assertArrayLength(metricFilters ?? [], 1);
+    assertIdentical(metricFilters?.at(0)?.filterPattern, "FATAL");
+  });
+
+  it("finds filters across every log group by the metric they write", async () => {
+    // Given two log groups, each with a filter, writing different metrics.
+    const simAws = await simAwsWithLogGroup();
+
+    await simAws
+      .logs()
+      .createLogGroup(new CreateLogGroupCommand({ logGroupName: "/site" }));
+    await simAws.logs().putMetricFilter(
+      new PutMetricFilterCommand({
+        logGroupName,
+        filterName: "handler-errors",
+        filterPattern: "ERROR",
+        metricTransformations: [countErrors()],
+      }),
+    );
+    await simAws.logs().putMetricFilter(
+      new PutMetricFilterCommand({
+        logGroupName: "/site",
+        filterName: "site-404s",
+        filterPattern: "404",
+        metricTransformations: [countErrors({ metricName: "NotFound" })],
+      }),
+    );
+
+    // When one metric is asked about with no log group named.
+    const { metricFilters } = await simAws.logs().describeMetricFilters(
+      new DescribeMetricFiltersCommand({
+        metricNamespace: "Orders",
+        metricName: "NotFound",
+      }),
+    );
+
+    // Then only the filter writing it comes back.
+    assertArrayEquals(
+      (metricFilters ?? []).map((filter) => filter.filterName),
+      ["site-404s"],
+    );
+  });
+
+  it("refuses deleting a filter that was never there", async () => {
+    // Given a log group with no metric filter on it.
+    const simAws = await simAwsWithLogGroup();
+
+    // When a filter nothing put is deleted.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.logs().deleteMetricFilter(
+          new DeleteMetricFilterCommand({
+            logGroupName,
+            filterName: "handler-errors",
+          }),
+        ),
+    );
+
+    // Then it is refused rather than passing quietly.
+    assertInstanceOf(error, SimLogsResourceNotFoundException);
+  });
+
+  it("records a publication a reserved namespace turned away", async () => {
+    // Given a filter writing into a namespace PutMetricData will not take,
+    // which CloudWatch Logs itself accepts at PutMetricFilter.
+    const simAws = await simAwsWithLogGroup();
+
+    await simAws.logs().putMetricFilter(
+      new PutMetricFilterCommand({
+        logGroupName,
+        filterName: "handler-errors",
+        filterPattern: "ERROR",
+        metricTransformations: [countErrors({ metricNamespace: "AWS/Lambda" })],
+      }),
+    );
+    await simAws
+      .logs()
+      .createLogStream(
+        new CreateLogStreamCommand({ logGroupName, logStreamName }),
+      );
+
+    // When a matching line is written.
+    await simAws.logs().putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ message: "ERROR order failed", timestamp: Date.now() }],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the write succeeded and the publication it could not make is on the
+    // ledger, rather than being lost the way it is in an account.
+    const failures = simAws.logs().metricFilterFailures;
+
+    assertArrayLength(failures, 1);
+    assertIdentical(failures.at(0)?.filterName, "handler-errors");
+    assertIdentical(failures.at(0)?.metricNamespace, "AWS/Lambda");
+    assertStringIncludes(failures.at(0)?.reason ?? "", "reserved");
+  });
+});

--- a/src/service/logs/metric/sim-logs-metric-publications.ts
+++ b/src/service/logs/metric/sim-logs-metric-publications.ts
@@ -1,0 +1,41 @@
+import { SimLogsUnsupportedOperationException } from "../error/sim-logs.error.js";
+import type { SimLogsMetricDatapoint } from "./sim-logs-metric-datapoint.js";
+
+/**
+ * Where a metric filter's datapoints are published.
+ *
+ * One method, and publishing nothing is how a filter about to be put asks
+ * whether publishing would work at all. Real CloudWatch Logs takes a metric
+ * filter whatever else is in the account, because the metric it writes into is
+ * made by the first write. The question here is about this simulation instead.
+ * A `SimLogs` with no CloudWatch to publish into would hold a filter and drop
+ * every datapoint, and a filter that accepts its configuration and publishes
+ * nothing is the hardest kind of thing to find.
+ */
+export interface SimLogsMetricPublications {
+  publish(datapoints: readonly SimLogsMetricDatapoint[]): Promise<void>;
+}
+
+/**
+ * The publications a simulated CloudWatch Logs built on its own can make,
+ * which is none.
+ *
+ * A standalone SimLogs has no simulated CloudWatch to put a datapoint into, so
+ * a metric filter on one is refused when it is put rather than accepted and
+ * left publishing nowhere.
+ */
+export class SimLogsNoMetricPublications implements SimLogsMetricPublications {
+  /**
+   * Refuse every publication, explaining how to get one.
+   */
+  publish(): Promise<void> {
+    return Promise.reject(
+      new SimLogsUnsupportedOperationException(
+        "This simulated CloudWatch Logs has no simulated CloudWatch to " +
+          "publish a metric filter's datapoints into. Reach CloudWatch Logs " +
+          "through a SimAws Account Region scope for a metric filter to " +
+          "publish.",
+      ),
+    );
+  }
+}

--- a/src/service/logs/metric/sim-logs-metric-transformation.ts
+++ b/src/service/logs/metric/sim-logs-metric-transformation.ts
@@ -1,0 +1,152 @@
+import {
+  SimLogsInvalidParameterException,
+  SimLogsUnsupportedOperationException,
+} from "../error/sim-logs.error.js";
+import type {
+  SimLogsMetricDatapoint,
+  SimLogsMetricDimension,
+} from "./sim-logs-metric-datapoint.js";
+
+/**
+ * The character real CloudWatch Logs reads as naming a field of the log event
+ * rather than as part of a literal.
+ *
+ * `$1` names the first field of a space delimited pattern and `$.level` a JSON
+ * property. Both need the pattern to have been read structurally.
+ */
+const eventFieldPrefix = "$";
+
+/**
+ * How many dimensions real CloudWatch Logs allows on one transformation.
+ */
+export const simLogsMaximumMetricDimensions = 3;
+
+export interface SimLogsMetricTransformationProperties {
+  readonly metricNamespace: string;
+  readonly metricName: string;
+  readonly metricValue: string;
+  readonly defaultValue: number | undefined;
+  readonly unit: string | undefined;
+  readonly dimensions: readonly SimLogsMetricDimension[];
+}
+
+/**
+ * How one metric filter turns a log event into a metric datapoint.
+ *
+ * The value is read once, when the filter is put, so a value this simulator
+ * cannot produce is refused there rather than on the first event that happens
+ * to match. Real CloudWatch Logs validates a transformation at
+ * `PutMetricFilter` too.
+ */
+export class SimLogsMetricTransformation {
+  readonly metricNamespace: string;
+  readonly metricName: string;
+  readonly metricValue: string;
+  readonly defaultValue: number | undefined;
+  readonly unit: string | undefined;
+  readonly dimensions: readonly SimLogsMetricDimension[];
+
+  readonly #matchedValue: number;
+
+  constructor(properties: SimLogsMetricTransformationProperties) {
+    this.metricNamespace = properties.metricNamespace;
+    this.metricName = properties.metricName;
+    this.metricValue = properties.metricValue;
+    this.defaultValue = properties.defaultValue;
+    this.unit = properties.unit;
+    this.dimensions = refuseFieldDimensions(properties.dimensions);
+    this.#matchedValue = literalMetricValue(properties.metricValue);
+  }
+
+  /**
+   * The datapoint one matching log event publishes.
+   */
+  matched(): SimLogsMetricDatapoint {
+    return this.datapoint(this.#matchedValue);
+  }
+
+  /**
+   * The datapoint one log event that matched nothing publishes, where the
+   * transformation sets a default value.
+   *
+   * A transformation with no default value publishes nothing for an event it
+   * did not match, which is what leaves the metric with no datapoint at all
+   * over a quiet period.
+   */
+  unmatched(): SimLogsMetricDatapoint | undefined {
+    return this.defaultValue === undefined
+      ? undefined
+      : this.datapoint(this.defaultValue);
+  }
+
+  private datapoint(value: number): SimLogsMetricDatapoint {
+    return {
+      namespace: this.metricNamespace,
+      metricName: this.metricName,
+      value,
+      unit: this.unit,
+      dimensions: this.dimensions,
+    };
+  }
+}
+
+/**
+ * Read a metric value this simulation can publish.
+ *
+ * Real CloudWatch Logs takes either a number or a reference to a field of the
+ * matched event. A field reference needs the pattern to have been read
+ * structurally, and `SimLogsFilterPattern` refuses both structured syntaxes,
+ * so a filter naming one is refused here rather than publishing a number that
+ * was never in the log line.
+ */
+function literalMetricValue(metricValue: string): number {
+  if (metricValue.startsWith(eventFieldPrefix)) {
+    throw new SimLogsUnsupportedOperationException(
+      `Simulated CloudWatch Logs does not support a metricValue naming a ` +
+        `field of the log event yet: ${metricValue}. Reading one needs a JSON ` +
+        `property or space delimited filter pattern, and neither is ` +
+        `simulated. A literal number publishes.`,
+    );
+  }
+
+  const value = Number(metricValue);
+
+  if (!Number.isFinite(value)) {
+    throw new SimLogsInvalidParameterException(
+      `Invalid metric value ${metricValue}: a metricValue must be a number or ` +
+        `a reference to a field of the log event.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Refuse dimensions this simulation cannot fill in.
+ *
+ * A dimension value naming a field of the event has the same problem a metric
+ * value naming one has, and a dimension quietly dropped would put the
+ * datapoint under an identity no alarm is watching.
+ */
+function refuseFieldDimensions(
+  dimensions: readonly SimLogsMetricDimension[],
+): readonly SimLogsMetricDimension[] {
+  if (dimensions.length > simLogsMaximumMetricDimensions) {
+    throw new SimLogsInvalidParameterException(
+      `A metric filter transformation may have at most ` +
+        `${simLogsMaximumMetricDimensions} dimensions.`,
+    );
+  }
+
+  for (const dimension of dimensions) {
+    if (dimension.value.startsWith(eventFieldPrefix)) {
+      throw new SimLogsUnsupportedOperationException(
+        `Simulated CloudWatch Logs does not support a dimension naming a ` +
+          `field of the log event yet: ${dimension.name} is ` +
+          `${dimension.value}. A literal value publishes.`,
+      );
+    }
+  }
+
+  return dimensions;
+}

--- a/src/service/logs/metric/sim-logs-metric-transformation.ts
+++ b/src/service/logs/metric/sim-logs-metric-transformation.ts
@@ -56,34 +56,37 @@ export class SimLogsMetricTransformation {
     this.unit = properties.unit;
     this.dimensions = refuseFieldDimensions(properties.dimensions);
     this.#matchedValue = literalMetricValue(properties.metricValue);
+
+    refuseDefaultValueWithDimensions(properties);
   }
 
   /**
    * The datapoint one matching log event publishes.
    */
-  matched(): SimLogsMetricDatapoint {
-    return this.datapoint(this.#matchedValue);
+  matched(timestamp: number): SimLogsMetricDatapoint {
+    return this.datapoint(this.#matchedValue, timestamp);
   }
 
   /**
-   * The datapoint one log event that matched nothing publishes, where the
+   * The datapoint one period that matched nothing publishes, where the
    * transformation sets a default value.
    *
-   * A transformation with no default value publishes nothing for an event it
-   * did not match, which is what leaves the metric with no datapoint at all
-   * over a quiet period.
+   * A transformation with no default value publishes nothing for a period it
+   * matched nothing in, which is what leaves the metric with no datapoint at
+   * all over a quiet stretch.
    */
-  unmatched(): SimLogsMetricDatapoint | undefined {
+  unmatched(timestamp: number): SimLogsMetricDatapoint | undefined {
     return this.defaultValue === undefined
       ? undefined
-      : this.datapoint(this.defaultValue);
+      : this.datapoint(this.defaultValue, timestamp);
   }
 
-  private datapoint(value: number): SimLogsMetricDatapoint {
+  private datapoint(value: number, timestamp: number): SimLogsMetricDatapoint {
     return {
       namespace: this.metricNamespace,
       metricName: this.metricName,
       value,
+      timestamp,
       unit: this.unit,
       dimensions: this.dimensions,
     };
@@ -119,6 +122,27 @@ function literalMetricValue(metricValue: string): number {
   }
 
   return value;
+}
+
+/**
+ * Refuse a default value on a transformation that also has dimensions.
+ *
+ * Real CloudWatch Logs allows one or the other. A metric a filter gives
+ * dimensions to cannot have a default value, because the default would have to
+ * be reported against every dimension value the filter has ever seen.
+ */
+function refuseDefaultValueWithDimensions(
+  properties: SimLogsMetricTransformationProperties,
+): void {
+  if (
+    properties.defaultValue !== undefined &&
+    properties.dimensions.length > 0
+  ) {
+    throw new SimLogsInvalidParameterException(
+      "A metric filter transformation carrying dimensions cannot also carry " +
+        "a defaultValue. CloudWatch Logs allows one or the other.",
+    );
+  }
 }
 
 /**

--- a/src/service/logs/sdk/sim-logs-sdk-command-router.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-command-router.ts
@@ -35,6 +35,11 @@ import type {
   SimDescribeDeliveriesCommand,
 } from "../command/delivery/delivery.command.js";
 import type {
+  SimDeleteMetricFilterCommand,
+  SimDescribeMetricFiltersCommand,
+  SimPutMetricFilterCommand,
+} from "../command/metric/metric-filter.command.js";
+import type {
   SimDeleteSubscriptionFilterCommand,
   SimDescribeSubscriptionFiltersCommand,
   SimPutSubscriptionFilterCommand,
@@ -142,6 +147,30 @@ export class SimLogsSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simLogs.deleteSubscriptionFilter(
             command as SimDeleteSubscriptionFilterCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "PutMetricFilterCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.putMetricFilter(
+            command as SimPutMetricFilterCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeMetricFiltersCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.describeMetricFilters(
+            command as SimDescribeMetricFiltersCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteMetricFilterCommand",
+        async (command, context): Promise<unknown> =>
+          await simLogs.deleteMetricFilter(
+            command as SimDeleteMetricFilterCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
+++ b/src/service/logs/sdk/sim-logs-sdk-routing.iso.test.ts
@@ -13,6 +13,9 @@ import {
   PutSubscriptionFilterCommand,
   DescribeSubscriptionFiltersCommand,
   DeleteSubscriptionFilterCommand,
+  PutMetricFilterCommand,
+  DescribeMetricFiltersCommand,
+  DeleteMetricFilterCommand,
   CreateDeliveryCommand,
   DeleteDeliveryCommand,
   DeleteDeliveryDestinationCommand,
@@ -68,6 +71,9 @@ describe("SimLogsSdkCommandRouter", () => {
       "PutSubscriptionFilterCommand",
       "DescribeSubscriptionFiltersCommand",
       "DeleteSubscriptionFilterCommand",
+      "PutMetricFilterCommand",
+      "DescribeMetricFiltersCommand",
+      "DeleteMetricFilterCommand",
       "PutDeliverySourceCommand",
       "DescribeDeliverySourcesCommand",
       "DeleteDeliverySourceCommand",
@@ -213,11 +219,47 @@ describe("CloudWatch Logs SDK interception", () => {
       }),
     );
 
+    await client.send(
+      new PutMetricFilterCommand({
+        logGroupName: "/aws/lambda/billing",
+        filterName: "billing-errors",
+        filterPattern: "ERROR",
+        metricTransformations: [
+          {
+            metricNamespace: "Billing",
+            metricName: "Errors",
+            metricValue: "1",
+          },
+        ],
+      }),
+    );
+    const metricFilters = await client.send(
+      new DescribeMetricFiltersCommand({
+        logGroupName: "/aws/lambda/billing",
+      }),
+    );
+    await client.send(
+      new DeleteMetricFilterCommand({
+        logGroupName: "/aws/lambda/billing",
+        filterName: "billing-errors",
+      }),
+    );
+    const afterDeleteMetricFilters = await client.send(
+      new DescribeMetricFiltersCommand({
+        logGroupName: "/aws/lambda/billing",
+      }),
+    );
+
     assertArrayEquals(
       filters.subscriptionFilters?.map((filter) => filter.filterName),
       ["errors"],
     );
     assertArrayLength(afterDeleteFilters.subscriptionFilters ?? [], 0);
+    assertArrayEquals(
+      metricFilters.metricFilters?.map((filter) => filter.filterName),
+      ["billing-errors"],
+    );
+    assertArrayLength(afterDeleteMetricFilters.metricFilters ?? [], 0);
 
     // Then each one reached simulated CloudWatch Logs.
     assertIdentical(withRetention.logGroups?.at(0)?.retentionInDays, 14);

--- a/src/service/logs/sim-logs-commands.ts
+++ b/src/service/logs/sim-logs-commands.ts
@@ -22,6 +22,7 @@ import { SimLogsGetLogEvents } from "./command/event/sim-logs-get-log-events.js"
 import { SimLogsPutLogEvents } from "./command/event/sim-logs-put-log-events.js";
 import { SimLogsLogGroupCommands } from "./command/group/sim-logs-log-group-commands.js";
 import { SimLogsRetentionCommands } from "./command/group/sim-logs-retention-commands.js";
+import { SimLogsMetricFilterCommands } from "./command/metric/sim-logs-metric-filter-commands.js";
 import { SimLogsLogStreamCommands } from "./command/stream/sim-logs-log-stream-commands.js";
 import { SimLogsSubscriptionCommands } from "./command/subscription/sim-logs-subscription-commands.js";
 import { SimLogsEventIds } from "./event/sim-logs-event-ids.js";
@@ -30,6 +31,11 @@ import {
   SimLogsNoSubscriptionDestinations,
   type SimLogsSubscriptionDestinations,
 } from "./subscription/sim-logs-subscription-destinations.js";
+import { SimLogsMetricFanOut } from "./metric/sim-logs-metric-fan-out.js";
+import {
+  SimLogsNoMetricPublications,
+  type SimLogsMetricPublications,
+} from "./metric/sim-logs-metric-publications.js";
 import { SimLogsSubscriptionFanOut } from "./subscription/sim-logs-subscription-fan-out.js";
 import { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
 
@@ -51,6 +57,13 @@ export interface SimLogsProperties {
    * takes any ARN, the way it always did.
    */
   readonly deliverySourceResources?: SimLogsDeliverySourceResources;
+
+  /**
+   * Where a metric filter's datapoints are published. A SimLogs built on its
+   * own has no simulated CloudWatch to write into, so it refuses a metric
+   * filter rather than holding one that publishes nowhere.
+   */
+  readonly metricPublications?: SimLogsMetricPublications;
 }
 
 /**
@@ -74,6 +87,8 @@ export class SimLogsCommands {
   readonly subscriptions: SimLogsSubscriptionCommands;
   readonly serviceWriter: SimLogsServiceWriter;
   readonly fanOut: SimLogsSubscriptionFanOut;
+  readonly metricFanOut: SimLogsMetricFanOut;
+  readonly metricFilters: SimLogsMetricFilterCommands;
   readonly deliverySourceStore: SimLogsDeliverySourceStore;
   readonly deliveryDestinationStore: SimLogsDeliveryDestinationStore;
   readonly deliveryStore: SimLogsDeliveryStore;
@@ -88,6 +103,7 @@ export class SimLogsCommands {
       background = new BackgroundTasks(),
       subscriptionDestinations = new SimLogsNoSubscriptionDestinations(),
       deliverySourceResources = new SimLogsUncheckedDeliverySourceResources(),
+      metricPublications = new SimLogsNoMetricPublications(),
     } = properties;
 
     const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
@@ -100,12 +116,17 @@ export class SimLogsCommands {
       accountRegionScope,
       background,
     });
+    const metricFanOut = new SimLogsMetricFanOut({
+      publications: metricPublications,
+      background,
+    });
 
     this.authorizer = authorizer;
     this.accountRegionScope = accountRegionScope;
     this.background = background;
     this.groups = groups;
     this.fanOut = fanOut;
+    this.metricFanOut = metricFanOut;
     this.logGroups = new SimLogsLogGroupCommands({
       groups,
       authorizer,
@@ -123,6 +144,7 @@ export class SimLogsCommands {
       eventIds,
       clock: background,
       fanOut,
+      metricFanOut,
     });
     this.getLogEvents = new SimLogsGetLogEvents({ groups, authorizer });
     this.filterLogEvents = new SimLogsFilterLogEvents({ groups, authorizer });
@@ -132,11 +154,18 @@ export class SimLogsCommands {
       destinations: subscriptionDestinations,
       clock: background,
     });
+    this.metricFilters = new SimLogsMetricFilterCommands({
+      groups,
+      authorizer,
+      fanOut: metricFanOut,
+      clock: background,
+    });
     this.serviceWriter = new SimLogsServiceWriter({
       groups,
       eventIds,
       clock: background,
       fanOut,
+      metricFanOut,
     });
 
     const deliverySources = new SimLogsDeliverySourceStore();

--- a/src/service/logs/sim-logs.ts
+++ b/src/service/logs/sim-logs.ts
@@ -9,6 +9,7 @@ import {
   type SimLogsProperties,
 } from "./sim-logs-commands.js";
 import { SimLogsDeliveryOperations } from "./sim-logs-delivery-operations.js";
+import type { SimLogsMetricPublicationFailure } from "./metric/sim-logs-metric-fan-out.js";
 import type { SimLogsSubscriptionFailure } from "./subscription/sim-logs-subscription-fan-out.js";
 import type { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
 
@@ -237,6 +238,50 @@ export class SimLogs extends SimLogsDeliveryOperations {
       command,
       options,
     );
+  }
+
+  /**
+   * Every metric filter publication this scope could not make.
+   *
+   * A failed publication is invisible in an account, where it becomes a metric
+   * nobody is watching. Keeping it is what lets a test find out that the
+   * metric filter it set up never wrote a datapoint.
+   */
+  get metricFilterFailures(): readonly SimLogsMetricPublicationFailure[] {
+    return this.commands.metricFanOut.failures;
+  }
+
+  /**
+   * Handle a PutMetricFilter Command from the SDK.
+   */
+  async putMetricFilter(
+    command: simLogsCommands.SimPutMetricFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimPutMetricFilterCommandOutput> {
+    await this.commands.background.sequence();
+    return await this.commands.metricFilters.putMetricFilter(command, options);
+  }
+
+  /**
+   * Handle a DescribeMetricFilters Command from the SDK.
+   */
+  async describeMetricFilters(
+    command: simLogsCommands.SimDescribeMetricFiltersCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDescribeMetricFiltersCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.metricFilters.describeMetricFilters(command, options);
+  }
+
+  /**
+   * Handle a DeleteMetricFilter Command from the SDK.
+   */
+  async deleteMetricFilter(
+    command: simLogsCommands.SimDeleteMetricFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDeleteMetricFilterCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.metricFilters.deleteMetricFilter(command, options);
   }
 
   /**

--- a/src/service/logs/write/sim-logs-service-writer.ts
+++ b/src/service/logs/write/sim-logs-service-writer.ts
@@ -4,6 +4,7 @@ import type { SimLogsEventIds } from "../event/sim-logs-event-ids.js";
 import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
 import type { SimLogsLogGroupStore } from "../group/sim-logs-log-group-store.js";
 import type { SimLogsLogStream } from "../stream/sim-logs-log-stream.js";
+import type { SimLogsMetricFanOut } from "../metric/sim-logs-metric-fan-out.js";
 import type { SimLogsSubscriptionFanOut } from "../subscription/sim-logs-subscription-fan-out.js";
 
 interface SimLogsServiceWriterProperties {
@@ -13,6 +14,9 @@ interface SimLogsServiceWriterProperties {
 
   /** Where events written here are handed on to subscription filters. */
   readonly fanOut: SimLogsSubscriptionFanOut;
+
+  /** Where events written here are handed on to metric filters. */
+  readonly metricFanOut: SimLogsMetricFanOut;
 }
 
 /**
@@ -34,12 +38,14 @@ export class SimLogsServiceWriter {
   readonly #eventIds: SimLogsEventIds;
   readonly #clock: SimClock;
   readonly #fanOut: SimLogsSubscriptionFanOut;
+  readonly #metricFanOut: SimLogsMetricFanOut;
 
   constructor(properties: SimLogsServiceWriterProperties) {
     this.#groups = properties.groups;
     this.#eventIds = properties.eventIds;
     this.#clock = properties.clock;
     this.#fanOut = properties.fanOut;
+    this.#metricFanOut = properties.metricFanOut;
   }
 
   /**
@@ -98,7 +104,10 @@ export class SimLogsServiceWriter {
       message,
     }));
 
+    const group = this.logGroup(logGroupName);
+
     stream.append(events, now);
-    this.#fanOut.written(this.logGroup(logGroupName), logStreamName, events);
+    this.#fanOut.written(group, logStreamName, events);
+    this.#metricFanOut.written(group, events);
   }
 }


### PR DESCRIPTION
A metric filter on a log group turns matching events into CloudWatch metric datapoints, on both the `PutLogEvents` path and the path a bound Lambda handler's own output takes. Datapoints go in through the same `PutMetricData` an ordinary caller uses, into the CloudWatch of the log group's own Account and Region, so an alarm over the metric can be driven to a state change by a log line. `AWS::Logs::MetricFilter` deploys through the same command rather than being recorded as a skip, and `DescribeLogGroups` reports a real `metricFilterCount`. A `metricValue` or a dimension value naming a field of the matched event is refused where the filter is put, because reading one needs a structured filter pattern and neither structured syntax is simulated.

Resolves #1167


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulation support for CloudWatch Logs metric filters, including creation, description, deletion, matching events, transformations, dimensions, default values, and metric counts.
  * Metric filters now publish datapoints asynchronously to CloudWatch and can drive alarms.
  * Added CloudFormation deployment support, SDK command routing, and runnable examples.
  * Added reporting for metric publication failures and unsupported configurations.

* **Documentation**
  * Expanded CloudWatch Logs and CloudWatch documentation with metric-filter behavior, limitations, and deployment guidance.

* **Tests**
  * Added comprehensive coverage for metric filtering, publication, alarms, CloudFormation, routing, validation, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->