### PR TITLE
feat: read metrics out of an Embedded Metric Format log line

### DIFF
--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -806,7 +806,7 @@ console.log(counted.Datapoints?.[0]?.Sum);
 
 Datapoints go in through the same `PutMetricData` an ordinary caller uses, into the CloudWatch of the log group's own Account and Region. A datapoint is stamped from the simulation's clock at the instant the event was written.
 
-A transformation carrying a `defaultValue` publishes that value once for a minute that took log events and matched none of them, which is how real CloudWatch Logs keeps a metric reporting through a quiet stretch. A minute a match landed in publishes the match alone. A transformation with no default value publishes nothing for a minute it matched nothing in, and the metric is then left with no datapoint at all over that stretch.
+A transformation carrying a `defaultValue` publishes that value once for a minute that took log events and matched none of them. That is how real CloudWatch Logs keeps a metric reporting through a quiet stretch. A minute a match landed in publishes the match alone. A transformation with no default value publishes nothing for a minute it matched nothing in, and the metric is then left with no datapoint at all over that stretch.
 
 A transformation carrying dimensions cannot also carry a `defaultValue`, and one carrying both is refused. Real CloudWatch Logs allows one or the other, because a default would have to be reported against every dimension value the filter has ever seen.
 
@@ -816,7 +816,7 @@ A transformation carrying dimensions cannot also carry a `defaultValue`, and one
 
 A `metricValue` or a dimension value naming a field of the matched event (`$.bytes`, `$1`) raises `SimLogsUnsupportedOperationException` at `PutMetricFilter`. Reading one needs the pattern to have been parsed structurally, and the structured pattern syntaxes are absent. A literal value publishes.
 
-A filter whose namespace begins `AWS/` is taken, because CloudWatch Logs takes one. The publication is then refused by `PutMetricData`, which reserves those namespaces exactly as real CloudWatch does. The refusal lands on `simAws.logs().metricFilterFailures` rather than failing the write that produced it, so a filter writing nowhere is something a test can assert on.
+A filter whose namespace begins `AWS/` is taken, because CloudWatch Logs takes one. The publication is then refused by `PutMetricData`, which reserves those namespaces exactly as real CloudWatch does. The refusal lands on `simAws.logs().metricPublicationFailures` rather than failing the write that produced it, so a filter writing nowhere is something a test can assert on.
 
 ### Declaring a metric filter in a template
 
@@ -913,6 +913,89 @@ console.log(MetricAlarms?.[0]?.StateValue);
 ```
 
 `Ref` returns the filter name, and a filter with no `FilterName` is named after the stack and the logical ID. `Dimensions` is a list of `Key` and `Value` pairs in a template and a map through the SDK, and both reach the same filter. Deleting the stack takes the filter with the log group.
+
+## Embedded Metric Format
+
+A log event that is itself an Embedded Metric Format document publishes the metrics it declares. This is how AWS Lambda Powertools counts anything. Its `Metrics` writes an EMF document to the handler's stdout and calls no CloudWatch API at all, and a CDK `NodejsFunction` bundling Powertools does the same in a deployed account.
+
+```typescript sim-logs-embedded-metric-format
+/**
+ * Reading a Powertools style metric out of what a handler printed.
+ */
+
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/lambda/user";
+const logStreamName = "2026/08/30/[$LATEST]0f7c1a";
+const startedAt = new Date("2026-08-30T09:00:00Z");
+
+await simAws.clock().setTo(startedAt);
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+
+// The document Powertools writes to stdout. The metadata names the namespace,
+// the dimension set and the metric, and the body carries the values.
+const document = JSON.stringify({
+  _aws: {
+    Timestamp: startedAt.getTime(),
+    CloudWatchMetrics: [
+      {
+        Namespace: "ChineseBoost",
+        Dimensions: [["service"]],
+        Metrics: [{ Name: "UserRequestFailed", Unit: "Count" }],
+      },
+    ],
+  },
+  service: "user",
+  UserRequestFailed: 1,
+});
+
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [{ timestamp: startedAt.getTime(), message: document }],
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const statistics = new GetMetricStatisticsCommand({
+  Namespace: "ChineseBoost",
+  MetricName: "UserRequestFailed",
+  Dimensions: [{ Name: "service", Value: "user" }],
+  StartTime: startedAt,
+  EndTime: new Date(startedAt.getTime() + 300_000),
+  Period: 300,
+  Statistics: ["Sum"],
+});
+const counted = await simAws.cloudWatch().getMetricStatistics(statistics);
+
+// 1. The metric came out of the log line, with nothing calling PutMetricData.
+console.log(counted.Datapoints?.[0]?.Sum);
+```
+
+A bound Lambda handler needs none of this written by hand. Its output already reaches `/aws/lambda/<name>`. A handler bundling Powertools therefore counts through the same path a deployed one does, and invoking it can drive an alarm over the metric to a state change.
+
+`_aws.CloudWatchMetrics[].Dimensions` is a list of dimension key lists, and each inner list is one whole dimension set. A document declaring two sets publishes each of its metrics once per set, which is what makes them separate identities in CloudWatch. A metric whose value is a list of numbers publishes one datapoint per value.
+
+The timestamp comes from `_aws.Timestamp`, read as milliseconds, and from the instant CloudWatch Logs took the event where the document carries none. A handler running inside a simulated Lambda reads the simulation's clock. A Powertools document therefore stamps itself in simulated time without being told to.
+
+### What is left alone, and what is recorded
+
+A log event is read as a document only where it parses as JSON, comes out as an object, and carries usable `_aws` metadata. Anything else is stored and left alone. A log group is full of lines that were never metrics, and treating a parse failure as an error would make the common case the noisy one.
+
+Two things go on `simAws.logs().metricPublicationFailures` rather than passing quietly. A metric the metadata declares and the document body carries no number under, and a metric asking for `StorageResolution: 1`, which simulated CloudWatch has no period short enough for. A dimension set naming a key the body lacks is dropped whole, because filling in part of a set would publish under an identity no alarm is watching.
 
 ## Permissions
 
@@ -1052,6 +1135,8 @@ console.log(described.logGroups?.[0]?.logGroupArn);
   arrive in time order in a simulation, so this shows up only where a test writes into the past.
 - **Subscription filter destinations other than Lambda**, and `Distribution`. `Distribution` is
   accepted and reported, and with no shards to spread across it has no effect.
+- **EMF arriving by any route other than a log event.** The document has to reach a log group to be
+  read, which is how it reaches CloudWatch in an account.
 - **`AWS::Logs::SubscriptionFilter`.** Recorded as a gap. The log group, the metric filter and the
   three delivery resource types are what simulated CloudFormation deploys here.
 - **`ApplyOnTransformedLogs` and `EmitSystemFieldDimensions` on a metric filter.** Recorded and

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -995,7 +995,11 @@ The timestamp comes from `_aws.Timestamp`, read as milliseconds, and from the in
 
 A log event is read as a document only where it parses as JSON, comes out as an object, and carries usable `_aws` metadata. Anything else is stored and left alone. A log group is full of lines that were never metrics, and treating a parse failure as an error would make the common case the noisy one.
 
-Two things go on `simAws.logs().metricPublicationFailures` rather than passing quietly. A metric the metadata declares and the document body carries no number under, and a metric asking for `StorageResolution: 1`, which simulated CloudWatch has no period short enough for. A dimension set naming a key the body lacks is dropped whole, because filling in part of a set would publish under an identity no alarm is watching.
+Three things go on `simAws.logs().metricPublicationFailures` rather than passing quietly. A metric the metadata declares and the document body carries no number under, a metric asking for `StorageResolution: 1`, which simulated CloudWatch has no period short enough for, and a directive that asked for dimensions and got no usable set of them.
+
+A dimension set is taken whole or dropped whole. One naming a key the body lacks, and one carrying anything but strings, are both dropped, because publishing part of a set would put the datapoint under a narrower identity than the document declared. A directive left with no usable set publishes nothing at all. Falling back to no dimensions would land the datapoint on the undimensioned metric, and that is one an alarm may well be watching.
+
+Each entry on the ledger names its `source`, which is `{ kind: "metricFilter", filterName }` or `{ kind: "embeddedMetricFormat" }`. The two are told apart by kind rather than by name, because a metric filter may be called anything.
 
 ## Permissions
 

--- a/docs/services/logs/sim-logs-embedded-metric-format.example.ts
+++ b/docs/services/logs/sim-logs-embedded-metric-format.example.ts
@@ -1,0 +1,64 @@
+/**
+ * Reading a Powertools style metric out of what a handler printed.
+ */
+
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/lambda/user";
+const logStreamName = "2026/08/30/[$LATEST]0f7c1a";
+const startedAt = new Date("2026-08-30T09:00:00Z");
+
+await simAws.clock().setTo(startedAt);
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+await simAws
+  .logs()
+  .createLogStream(new CreateLogStreamCommand({ logGroupName, logStreamName }));
+
+// The document Powertools writes to stdout. The metadata names the namespace,
+// the dimension set and the metric, and the body carries the values.
+const document = JSON.stringify({
+  _aws: {
+    Timestamp: startedAt.getTime(),
+    CloudWatchMetrics: [
+      {
+        Namespace: "ChineseBoost",
+        Dimensions: [["service"]],
+        Metrics: [{ Name: "UserRequestFailed", Unit: "Count" }],
+      },
+    ],
+  },
+  service: "user",
+  UserRequestFailed: 1,
+});
+
+await simAws.logs().putLogEvents(
+  new PutLogEventsCommand({
+    logGroupName,
+    logStreamName,
+    logEvents: [{ timestamp: startedAt.getTime(), message: document }],
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+const statistics = new GetMetricStatisticsCommand({
+  Namespace: "ChineseBoost",
+  MetricName: "UserRequestFailed",
+  Dimensions: [{ Name: "service", Value: "user" }],
+  StartTime: startedAt,
+  EndTime: new Date(startedAt.getTime() + 300_000),
+  Period: 300,
+  Statistics: ["Sum"],
+});
+const counted = await simAws.cloudWatch().getMetricStatistics(statistics);
+
+// 1. The metric came out of the log line, with nothing calling PutMetricData.
+console.log(counted.Datapoints?.[0]?.Sum);

--- a/src/service/logs/command/metric/sim-logs-metric-filter-commands.ts
+++ b/src/service/logs/command/metric/sim-logs-metric-filter-commands.ts
@@ -54,10 +54,10 @@ export class SimLogsMetricFilterCommands {
    * configuration and publishes nothing is worse than a failure, because the
    * alarm over its metric then reports healthy for ever.
    */
-  async putMetricFilter(
+  putMetricFilter(
     command: SimPutMetricFilterCommand,
     options?: SimLogsRequestOptions,
-  ): Promise<SimPutMetricFilterCommandOutput> {
+  ): SimPutMetricFilterCommandOutput {
     const input = command.input;
     const logGroupName = requiredSimLogsLogGroupName(input.logGroupName);
     const filterName = requiredSimLogsFilterName(input.filterName);
@@ -73,7 +73,7 @@ export class SimLogsMetricFilterCommands {
 
     const group = this.#groups.require(logGroupName);
 
-    await this.#fanOut.checkPublishable();
+    this.#fanOut.checkPublishable();
 
     group.metricFilters.put(
       new SimLogsMetricFilter({

--- a/src/service/logs/index.ts
+++ b/src/service/logs/index.ts
@@ -35,9 +35,11 @@ export type {
   SimLogsMetricDimension,
 } from "./metric/sim-logs-metric-datapoint.js";
 export {
+  metricFilterSource,
   simLogsEmbeddedMetricSource,
   type SimLogsMetricPublicationFailure,
-} from "./metric/sim-logs-metric-fan-out.js";
+  type SimLogsMetricPublicationSource,
+} from "./metric/sim-logs-metric-publication-failure.js";
 export type { SimLogsMetricPublications } from "./metric/sim-logs-metric-publications.js";
 export { simLogsStandardLogGroupClass } from "./command/group/sim-logs-unsimulated-group-input.js";
 export { SimLogsDeliverySource } from "./delivery/sim-logs-delivery-source.js";

--- a/src/service/logs/index.ts
+++ b/src/service/logs/index.ts
@@ -34,11 +34,11 @@ export type {
   SimLogsMetricDatapoint,
   SimLogsMetricDimension,
 } from "./metric/sim-logs-metric-datapoint.js";
-export type { SimLogsMetricPublicationFailure } from "./metric/sim-logs-metric-fan-out.js";
 export {
-  SimLogsNoMetricPublications,
-  type SimLogsMetricPublications,
-} from "./metric/sim-logs-metric-publications.js";
+  simLogsEmbeddedMetricSource,
+  type SimLogsMetricPublicationFailure,
+} from "./metric/sim-logs-metric-fan-out.js";
+export type { SimLogsMetricPublications } from "./metric/sim-logs-metric-publications.js";
 export { simLogsStandardLogGroupClass } from "./command/group/sim-logs-unsimulated-group-input.js";
 export { SimLogsDeliverySource } from "./delivery/sim-logs-delivery-source.js";
 export { SimLogsDeliveryDestination } from "./delivery/sim-logs-delivery-destination.js";

--- a/src/service/logs/metric/cloudwatch/sim-aws-logs-metric-filter-metrics.ts
+++ b/src/service/logs/metric/cloudwatch/sim-aws-logs-metric-filter-metrics.ts
@@ -42,17 +42,10 @@ export class SimAwsLogsMetricFilterMetrics implements SimLogsMetricPublications 
    * Publish the datapoints one log event produced.
    *
    * `PutMetricData` carries one namespace per request, so datapoints are
-   * grouped by the namespace their transformation named. One filter writing
-   * into two namespaces is two requests, as it is on real AWS.
-   *
-   * An empty batch reaches nothing. That is a filter about to be put asking
-   * whether this scope can publish at all, and this scope always can.
+   * grouped by the namespace they were published under. One batch writing into
+   * two namespaces is two requests, as it is on real AWS.
    */
   async publish(datapoints: readonly SimLogsMetricDatapoint[]): Promise<void> {
-    if (datapoints.length === 0) {
-      return;
-    }
-
     const scope = this.#accountRegionScope;
     const cloudWatch = this.#simAws
       .accountRegionScope(scope.accountId, scope.regionName)

--- a/src/service/logs/metric/emf/sim-logs-embedded-metric-datapoints.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metric-datapoints.ts
@@ -1,4 +1,7 @@
-import type { SimLogsMetricDatapoint } from "../sim-logs-metric-datapoint.js";
+import type {
+  SimLogsMetricDatapoint,
+  SimLogsMetricDimension,
+} from "../sim-logs-metric-datapoint.js";
 import {
   simLogsEmbeddedMetricDocument,
   type SimLogsEmbeddedMetricDirective,
@@ -63,6 +66,20 @@ export function simLogsEmbeddedMetricReading(
   return { datapoints, skipped };
 }
 
+/**
+ * Why a directive that asked for dimensions can publish none of its metrics.
+ */
+function unusableDimensions(
+  directive: SimLogsEmbeddedMetricDirective,
+  dimensionSets: readonly (readonly SimLogsMetricDimension[])[],
+): string | undefined {
+  return directive.declaresDimensions && dimensionSets.length === 0
+    ? `The document declares dimensions for ${directive.namespace} and ` +
+        `carries no usable set of them, so there is no identity to publish ` +
+        `under.`
+    : undefined;
+}
+
 function readDirective(
   document: SimLogsEmbeddedMetricDocument,
   directive: SimLogsEmbeddedMetricDirective,
@@ -70,24 +87,32 @@ function readDirective(
 ): SimLogsEmbeddedMetricReading {
   const datapoints: SimLogsMetricDatapoint[] = [];
   const skipped: SimLogsEmbeddedMetricSkip[] = [];
-  const declared = directive.dimensionSets
+  const resolved = directive.dimensionSets
     .map((keys) => embeddedMetricDimensions(document, keys))
     .filter((dimensions) => dimensions !== undefined);
 
-  // A directive naming no dimension set still publishes, undimensioned, which
-  // is what an EMF document with an empty Dimensions list asks for.
-  const dimensionSets = declared.length > 0 ? declared : [[]];
+  // A directive asking for no dimensions publishes undimensioned. One that
+  // asked and got nothing usable publishes nothing at all.
+  const dimensionSets = directive.declaresDimensions ? resolved : [[]];
+  const noIdentity = unusableDimensions(directive, dimensionSets);
+  const skip = (metricName: string, reason: string): void => {
+    skipped.push({
+      metricNamespace: directive.namespace,
+      metricName,
+      reason,
+    });
+  };
 
   for (const metric of directive.metrics) {
     const values = embeddedMetricValues(document, metric);
 
     if (typeof values === "string") {
-      skipped.push({
-        metricNamespace: directive.namespace,
-        metricName: metric.name,
-        reason: values,
-      });
+      skip(metric.name, values);
+      continue;
+    }
 
+    if (noIdentity !== undefined) {
+      skip(metric.name, noIdentity);
       continue;
     }
 

--- a/src/service/logs/metric/emf/sim-logs-embedded-metric-datapoints.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metric-datapoints.ts
@@ -1,0 +1,109 @@
+import type { SimLogsMetricDatapoint } from "../sim-logs-metric-datapoint.js";
+import {
+  simLogsEmbeddedMetricDocument,
+  type SimLogsEmbeddedMetricDirective,
+  type SimLogsEmbeddedMetricDocument,
+} from "./sim-logs-embedded-metric-document.js";
+import {
+  embeddedMetricDimensions,
+  embeddedMetricValues,
+} from "./sim-logs-embedded-metric-values.js";
+
+/**
+ * One metric an EMF document declared and this could not publish.
+ */
+export interface SimLogsEmbeddedMetricSkip {
+  readonly metricNamespace: string;
+  readonly metricName: string;
+  readonly reason: string;
+}
+
+/**
+ * What one log event's EMF document produced.
+ */
+export interface SimLogsEmbeddedMetricReading {
+  readonly datapoints: readonly SimLogsMetricDatapoint[];
+  readonly skipped: readonly SimLogsEmbeddedMetricSkip[];
+}
+
+const nothingRead: SimLogsEmbeddedMetricReading = {
+  datapoints: [],
+  skipped: [],
+};
+
+/**
+ * Read the metrics one log event's message publishes as EMF.
+ *
+ * A message that is not an EMF document reads as nothing at all. The timestamp
+ * comes from the document where it carries one, because a Powertools handler
+ * stamps its own document, and from the instant CloudWatch Logs took the event
+ * where it does not.
+ */
+export function simLogsEmbeddedMetricReading(
+  message: string,
+  ingestionTime: number,
+): SimLogsEmbeddedMetricReading {
+  const document = simLogsEmbeddedMetricDocument(message);
+
+  if (document === undefined) {
+    return nothingRead;
+  }
+
+  const datapoints: SimLogsMetricDatapoint[] = [];
+  const skipped: SimLogsEmbeddedMetricSkip[] = [];
+  const timestamp = document.timestamp ?? ingestionTime;
+
+  for (const directive of document.directives) {
+    const read = readDirective(document, directive, timestamp);
+
+    datapoints.push(...read.datapoints);
+    skipped.push(...read.skipped);
+  }
+
+  return { datapoints, skipped };
+}
+
+function readDirective(
+  document: SimLogsEmbeddedMetricDocument,
+  directive: SimLogsEmbeddedMetricDirective,
+  timestamp: number,
+): SimLogsEmbeddedMetricReading {
+  const datapoints: SimLogsMetricDatapoint[] = [];
+  const skipped: SimLogsEmbeddedMetricSkip[] = [];
+  const declared = directive.dimensionSets
+    .map((keys) => embeddedMetricDimensions(document, keys))
+    .filter((dimensions) => dimensions !== undefined);
+
+  // A directive naming no dimension set still publishes, undimensioned, which
+  // is what an EMF document with an empty Dimensions list asks for.
+  const dimensionSets = declared.length > 0 ? declared : [[]];
+
+  for (const metric of directive.metrics) {
+    const values = embeddedMetricValues(document, metric);
+
+    if (typeof values === "string") {
+      skipped.push({
+        metricNamespace: directive.namespace,
+        metricName: metric.name,
+        reason: values,
+      });
+
+      continue;
+    }
+
+    for (const dimensions of dimensionSets) {
+      for (const value of values) {
+        datapoints.push({
+          namespace: directive.namespace,
+          metricName: metric.name,
+          value,
+          timestamp,
+          unit: metric.unit,
+          dimensions,
+        });
+      }
+    }
+  }
+
+  return { datapoints, skipped };
+}

--- a/src/service/logs/metric/emf/sim-logs-embedded-metric-document.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metric-document.ts
@@ -32,6 +32,17 @@ export interface SimLogsEmbeddedMetricDeclaration {
  */
 export interface SimLogsEmbeddedMetricDirective {
   readonly namespace: string;
+
+  /**
+   * Whether the directive asked for dimensions at all.
+   *
+   * A directive that asked for none publishes undimensioned. One that asked
+   * and whose sets all turn out to be unusable publishes nothing, because
+   * falling back to no dimensions would put the datapoint on a metric the
+   * document never named.
+   */
+  readonly declaresDimensions: boolean;
+
   readonly dimensionSets: readonly (readonly string[])[];
   readonly metrics: readonly SimLogsEmbeddedMetricDeclaration[];
 }
@@ -102,17 +113,35 @@ function directiveOf(
     return undefined;
   }
 
+  const dimensions = entry.get("Dimensions");
+
+  if (dimensions !== undefined && !Array.isArray(dimensions)) {
+    return undefined;
+  }
+
   return {
     namespace,
-    dimensionSets: embeddedMetricList(entry.get("Dimensions"), dimensionSetOf),
+    declaresDimensions: Array.isArray(dimensions) && dimensions.length > 0,
+    dimensionSets: embeddedMetricList(dimensions, dimensionSetOf),
     metrics: embeddedMetricList(entry.get("Metrics"), metricOf),
   };
 }
 
+/**
+ * One dimension set, or undefined where it is not a list of names.
+ *
+ * A member that is not a string takes the whole set with it. Keeping the ones
+ * that were strings would publish under a narrower identity than the document
+ * asked for, which is the same trouble as dropping a single dimension.
+ */
 function dimensionSetOf(value: unknown): readonly string[] | undefined {
-  return Array.isArray(value)
-    ? embeddedMetricList(value, embeddedMetricString)
-    : undefined;
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const names = value.map((name) => embeddedMetricString(name));
+
+  return names.every((name) => name !== undefined) ? names : undefined;
 }
 
 function metricOf(

--- a/src/service/logs/metric/emf/sim-logs-embedded-metric-document.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metric-document.ts
@@ -1,0 +1,133 @@
+import {
+  embeddedMetricList,
+  embeddedMetricNumber,
+  embeddedMetricRecord,
+  embeddedMetricString,
+} from "./sim-logs-embedded-metric-json.js";
+
+/**
+ * The property an Embedded Metric Format document carries its metadata under.
+ *
+ * A log event without it is an ordinary line, and the great majority of lines
+ * in a log group are. Looking for this before parsing anything is what keeps
+ * the check on the write path cheap.
+ */
+export const embeddedMetricMetadataKey = "_aws";
+
+/**
+ * One metric an EMF document declares.
+ */
+export interface SimLogsEmbeddedMetricDeclaration {
+  readonly name: string;
+  readonly unit: string | undefined;
+  readonly storageResolution: number | undefined;
+}
+
+/**
+ * One namespace's worth of an EMF document's metadata.
+ *
+ * `dimensionSets` is a list of dimension key lists, and each inner list is one
+ * whole dimension set. A document declaring two sets publishes each of its
+ * metrics once per set.
+ */
+export interface SimLogsEmbeddedMetricDirective {
+  readonly namespace: string;
+  readonly dimensionSets: readonly (readonly string[])[];
+  readonly metrics: readonly SimLogsEmbeddedMetricDeclaration[];
+}
+
+/**
+ * An Embedded Metric Format document read out of one log event.
+ *
+ * `values` is every top-level property of the document, which is where both
+ * the metric values and the dimension values live. The metadata names them,
+ * and the document body carries them.
+ */
+export interface SimLogsEmbeddedMetricDocument {
+  readonly timestamp: number | undefined;
+  readonly directives: readonly SimLogsEmbeddedMetricDirective[];
+  readonly values: ReadonlyMap<string, unknown>;
+}
+
+/**
+ * Read a log event's message as an EMF document, or answer undefined.
+ *
+ * Anything that is not JSON, is not an object, or carries no usable `_aws`
+ * metadata is an ordinary log line. It is stored and left alone rather than
+ * refused, because a log group is full of lines that were never metrics.
+ */
+export function simLogsEmbeddedMetricDocument(
+  message: string,
+): SimLogsEmbeddedMetricDocument | undefined {
+  if (!message.includes(embeddedMetricMetadataKey)) {
+    return undefined;
+  }
+
+  const parsed = parseObject(message);
+  const metadata = embeddedMetricRecord(parsed?.get(embeddedMetricMetadataKey));
+
+  if (parsed === undefined || metadata === undefined) {
+    return undefined;
+  }
+
+  const directives = embeddedMetricList(
+    metadata.get("CloudWatchMetrics"),
+    directiveOf,
+  );
+
+  return directives.length === 0
+    ? undefined
+    : {
+        timestamp: embeddedMetricNumber(metadata.get("Timestamp")),
+        directives,
+        values: parsed,
+      };
+}
+
+function parseObject(message: string): Map<string, unknown> | undefined {
+  try {
+    return embeddedMetricRecord(JSON.parse(message));
+  } catch {
+    return undefined;
+  }
+}
+
+function directiveOf(
+  value: unknown,
+): SimLogsEmbeddedMetricDirective | undefined {
+  const entry = embeddedMetricRecord(value);
+  const namespace = embeddedMetricString(entry?.get("Namespace"));
+
+  if (entry === undefined || namespace === undefined) {
+    return undefined;
+  }
+
+  return {
+    namespace,
+    dimensionSets: embeddedMetricList(entry.get("Dimensions"), dimensionSetOf),
+    metrics: embeddedMetricList(entry.get("Metrics"), metricOf),
+  };
+}
+
+function dimensionSetOf(value: unknown): readonly string[] | undefined {
+  return Array.isArray(value)
+    ? embeddedMetricList(value, embeddedMetricString)
+    : undefined;
+}
+
+function metricOf(
+  value: unknown,
+): SimLogsEmbeddedMetricDeclaration | undefined {
+  const entry = embeddedMetricRecord(value);
+  const name = embeddedMetricString(entry?.get("Name"));
+
+  if (entry === undefined || name === undefined) {
+    return undefined;
+  }
+
+  return {
+    name,
+    unit: embeddedMetricString(entry.get("Unit")),
+    storageResolution: embeddedMetricNumber(entry.get("StorageResolution")),
+  };
+}

--- a/src/service/logs/metric/emf/sim-logs-embedded-metric-json.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metric-json.ts
@@ -1,0 +1,51 @@
+/**
+ * The JSON readers an Embedded Metric Format document is taken apart with.
+ *
+ * A document is written by whatever produced the log line, so nothing about
+ * its shape can be assumed. Each of these answers undefined for a value that
+ * is not what the format calls for, and the caller decides whether that makes
+ * the document unreadable or just that one metric unpublishable.
+ */
+
+/**
+ * An object's own properties as a map, or undefined for anything else.
+ */
+export function embeddedMetricRecord(
+  value: unknown,
+): Map<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? new Map(Object.entries(value))
+    : undefined;
+}
+
+/**
+ * A string, or undefined for anything else.
+ */
+export function embeddedMetricString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * A finite number, or undefined for anything else.
+ */
+export function embeddedMetricNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+/**
+ * Read every entry of a list through a reader, dropping the unreadable ones.
+ */
+export function embeddedMetricList<T>(
+  value: unknown,
+  read: (entry: unknown) => T | undefined,
+): readonly T[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => read(entry))
+    .filter((entry) => entry !== undefined);
+}

--- a/src/service/logs/metric/emf/sim-logs-embedded-metric-refusals.iso.test.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metric-refusals.iso.test.ts
@@ -1,0 +1,293 @@
+import { ListMetricsCommand } from "@aws-sdk/client-cloudwatch";
+import { PutMetricFilterCommand } from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayIncludes,
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  countedFailures as counted,
+  embeddedMetricDocument as embeddedDocument,
+  emfLogGroupName as logGroupName,
+  simAwsWithEmfLogStream as simAwsWithLogStream,
+  writeEmfLines as write,
+} from "../../../../../test/logs/embedded-metric-fixture.js";
+
+describe("Embedded Metric Format documents this cannot publish", () => {
+  it("leaves an ordinary log line alone", async () => {
+    // Given a log group with a stream in it.
+    const simAws = await simAwsWithLogStream();
+
+    // When lines that are not EMF documents are written.
+    await write(
+      simAws,
+      "INFO handling a request",
+      JSON.stringify({ level: "INFO", message: "handling a request" }),
+      "{ not json at all",
+      JSON.stringify({ _aws: "a property that happens to be named that" }),
+    );
+
+    // Then nothing was published and nothing was recorded as a failure. A log
+    // group is full of lines that were never metrics.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({}));
+
+    assertArrayLength(Metrics ?? [], 0);
+    assertArrayLength(simAws.logs().metricPublicationFailures, 0);
+  });
+
+  it("records a metric the document declared and carries no value for", async () => {
+    // Given a document naming a metric its body has no number under.
+    const simAws = await simAwsWithLogStream();
+
+    await write(simAws, embeddedDocument({ UserRequestFailed: "one" }));
+
+    // Then it published nothing, and said so rather than passing quietly.
+    const failures = simAws.logs().metricPublicationFailures;
+
+    assertArrayLength(failures, 1);
+    assertIdentical(failures.at(0)?.metricName, "UserRequestFailed");
+    assertIdentical(failures.at(0)?.source.kind, "embeddedMetricFormat");
+    assertStringIncludes(failures.at(0)?.reason ?? "", "no value to publish");
+  });
+
+  it("records a high resolution metric it cannot hold", async () => {
+    // Given a document asking for a one second metric.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      embeddedDocument(
+        {},
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: [["service"]],
+              Metrics: [{ Name: "UserRequestFailed", StorageResolution: 1 }],
+            },
+          ],
+        },
+      ),
+    );
+
+    // Then it is on the ledger rather than published at the wrong resolution.
+    // Every period in this simulated CloudWatch is a whole number of minutes.
+    const failures = simAws.logs().metricPublicationFailures;
+
+    assertArrayLength(failures, 1);
+    assertStringIncludes(failures.at(0)?.reason ?? "", "StorageResolution 1");
+  });
+
+  it("drops a dimension set naming a property the document lacks", async () => {
+    // Given a document whose dimension set names a key its body has not got.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      embeddedDocument(
+        {},
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: [["service"], ["missing"]],
+              Metrics: [{ Name: "UserRequestFailed" }],
+            },
+          ],
+        },
+      ),
+    );
+
+    // Then the set it could fill in published and the other did not. Dropping
+    // one key and keeping the rest would put the datapoint under an identity
+    // no alarm is watching.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({ Namespace: "ChineseBoost" }));
+
+    assertArrayLength(Metrics ?? [], 1);
+    assertIdentical(await counted(simAws), 1);
+  });
+
+  it("reads past metadata it cannot make sense of", async () => {
+    // Given documents whose metadata is the right shape in name only.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      // Not JSON at all, but carrying the key that makes this worth parsing.
+      '{"_aws": broken',
+      // Metadata that is not a list of directives.
+      JSON.stringify({ _aws: { CloudWatchMetrics: "one of them" } }),
+      // A directive with no namespace to publish into.
+      JSON.stringify({
+        _aws: { CloudWatchMetrics: [{ Metrics: [{ Name: "Failed" }] }] },
+        Failed: 1,
+      }),
+      // A metric with no name to publish under, in a directive that has one.
+      JSON.stringify({
+        _aws: {
+          CloudWatchMetrics: [{ Namespace: "ChineseBoost", Metrics: [{}] }],
+        },
+      }),
+    );
+
+    // Then none of them published, and none of them was recorded. Each is a
+    // log line this cannot read as metrics rather than a metric it failed to
+    // write.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({}));
+
+    assertArrayLength(Metrics ?? [], 0);
+    assertArrayLength(simAws.logs().metricPublicationFailures, 0);
+  });
+
+  it("publishes nothing where the only dimension set cannot be filled in", async () => {
+    // Given a document declaring one dimension set, naming a key its body has
+    // not got.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      embeddedDocument(
+        {},
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: [["missing"]],
+              Metrics: [{ Name: "UserRequestFailed" }],
+            },
+          ],
+        },
+      ),
+    );
+
+    // Then nothing published under an identity the document never declared.
+    // Falling back to no dimensions here would put the datapoint where an
+    // alarm watching the undimensioned metric would pick it up.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({}));
+
+    assertArrayLength(Metrics ?? [], 0);
+    assertArrayLength(simAws.logs().metricPublicationFailures, 1);
+  });
+
+  it("rejects a dimension set carrying anything but strings", async () => {
+    // Given a document whose dimension set has a number in it.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      embeddedDocument(
+        {},
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: [["service", 1]],
+              Metrics: [{ Name: "UserRequestFailed" }],
+            },
+          ],
+        },
+      ),
+    );
+
+    // Then the whole set goes. Keeping the members that were strings would
+    // publish under a narrower identity than the document asked for.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({}));
+
+    assertArrayLength(Metrics ?? [], 0);
+  });
+
+  it("tells its failures apart from a filter named after it", async () => {
+    // Given a metric filter whose name is the other kind of source, writing
+    // into a namespace PutMetricData will not take, on a group that also takes
+    // an unpublishable embedded document.
+    const simAws = await simAwsWithLogStream();
+
+    await simAws.logs().putMetricFilter(
+      new PutMetricFilterCommand({
+        logGroupName,
+        filterName: "embeddedMetricFormat",
+        filterPattern: "ERROR",
+        metricTransformations: [
+          {
+            metricNamespace: "AWS/Lambda",
+            metricName: "Errors",
+            metricValue: "1",
+          },
+        ],
+      }),
+    );
+
+    // When one line trips the filter and another is a document with no value.
+    await write(
+      simAws,
+      "ERROR order failed",
+      embeddedDocument({ UserRequestFailed: "one" }),
+    );
+
+    // Then the two failures are told apart by their kind rather than by a
+    // name a caller happens to have chosen.
+    const kinds = simAws
+      .logs()
+      .metricPublicationFailures.map((failure) => failure.source.kind);
+
+    assertArrayLength(kinds, 2);
+    assertArrayIncludes(kinds, "metricFilter");
+    assertArrayIncludes(kinds, "embeddedMetricFormat");
+  });
+
+  it("rejects a directive whose Dimensions is not a list of sets", async () => {
+    // Given documents whose Dimensions is the wrong shape twice over.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      // Dimensions is not a list at all.
+      embeddedDocument(
+        {},
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: "service",
+              Metrics: [{ Name: "UserRequestFailed" }],
+            },
+          ],
+        },
+      ),
+      // Dimensions is a list, and one of its sets is not.
+      embeddedDocument(
+        {},
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: ["service"],
+              Metrics: [{ Name: "UserRequestFailed" }],
+            },
+          ],
+        },
+      ),
+    );
+
+    // Then neither published. Reading a malformed envelope as a request for no
+    // dimensions would put the datapoint on the undimensioned metric.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({}));
+
+    assertArrayLength(Metrics ?? [], 0);
+  });
+});

--- a/src/service/logs/metric/emf/sim-logs-embedded-metric-values.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metric-values.ts
@@ -1,0 +1,68 @@
+import type { SimLogsMetricDimension } from "../sim-logs-metric-datapoint.js";
+import type {
+  SimLogsEmbeddedMetricDeclaration,
+  SimLogsEmbeddedMetricDocument,
+} from "./sim-logs-embedded-metric-document.js";
+
+/**
+ * The resolution real CloudWatch reads as a high resolution metric.
+ */
+const highStorageResolution = 1;
+
+/**
+ * Why a metric an EMF document declared could not be published.
+ */
+export type SimLogsEmbeddedMetricRefusal = string;
+
+/**
+ * The values a metric declaration names, or the reason there are none.
+ *
+ * EMF carries a metric's value as a top-level property of the same document,
+ * either as one number or as a list of them.
+ */
+export function embeddedMetricValues(
+  document: SimLogsEmbeddedMetricDocument,
+  metric: SimLogsEmbeddedMetricDeclaration,
+): readonly number[] | SimLogsEmbeddedMetricRefusal {
+  if (metric.storageResolution === highStorageResolution) {
+    return (
+      "StorageResolution 1 asks for a high resolution metric, and every " +
+      "period in this simulated CloudWatch is a whole number of minutes."
+    );
+  }
+
+  const raw = document.values.get(metric.name);
+  const values = (Array.isArray(raw) ? raw : [raw]).filter(
+    (value) => typeof value === "number" && Number.isFinite(value),
+  );
+
+  return values.length === 0
+    ? `The document declares ${metric.name} and carries no number under that ` +
+        `name, so there is no value to publish.`
+    : values;
+}
+
+/**
+ * One dimension set, or undefined where the document names a key it lacks.
+ *
+ * A dimension quietly dropped would put the datapoint under an identity no
+ * alarm is watching, so the whole set goes rather than part of it.
+ */
+export function embeddedMetricDimensions(
+  document: SimLogsEmbeddedMetricDocument,
+  keys: readonly string[],
+): readonly SimLogsMetricDimension[] | undefined {
+  const dimensions: SimLogsMetricDimension[] = [];
+
+  for (const name of keys) {
+    const value = document.values.get(name);
+
+    if (typeof value !== "string") {
+      return undefined;
+    }
+
+    dimensions.push({ name, value });
+  }
+
+  return dimensions;
+}

--- a/src/service/logs/metric/emf/sim-logs-embedded-metrics.iso.test.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metrics.iso.test.ts
@@ -11,103 +11,20 @@ import {
   assertArrayEquals,
   assertArrayLength,
   assertIdentical,
-  assertStringIncludes,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
-import { SimAws } from "../../../aws/sim-aws.js";
 import { SimLogs } from "../../sim-logs.js";
-
-const logGroupName = "/aws/lambda/user";
-const logStreamName = "2026/08/30/[$LATEST]0f7c1a";
-const startedAt = new Date("2026-08-30T09:00:00.000Z");
-
-/**
- * One EMF document in the shape Powertools writes, as a log line.
- *
- * The metadata names the namespace, the dimension set and the metric, and the
- * body of the same document carries the values both refer to by name.
- */
-function embeddedDocument(
-  overrides: Record<string, unknown> = {},
-  metadata: Record<string, unknown> = {},
-): string {
-  return JSON.stringify({
-    _aws: {
-      Timestamp: startedAt.getTime(),
-      CloudWatchMetrics: [
-        {
-          Namespace: "ChineseBoost",
-          Dimensions: [["service"]],
-          Metrics: [{ Name: "UserRequestFailed", Unit: "Count" }],
-        },
-      ],
-      ...metadata,
-    },
-    service: "user",
-    UserRequestFailed: 1,
-    ...overrides,
-  });
-}
-
-/** A simulation with a stopped clock and a log group with a stream in it. */
-async function simAwsWithLogStream(): Promise<SimAws> {
-  const simAws = new SimAws();
-
-  await simAws.clock().setTo(startedAt);
-  await simAws
-    .logs()
-    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
-  await simAws
-    .logs()
-    .createLogStream(
-      new CreateLogStreamCommand({ logGroupName, logStreamName }),
-    );
-
-  return simAws;
-}
-
-/** Write log lines and let the reading run. */
-async function write(
-  simAws: SimAws,
-  ...messages: readonly string[]
-): Promise<void> {
-  await simAws.logs().putLogEvents(
-    new PutLogEventsCommand({
-      logGroupName,
-      logStreamName,
-      logEvents: messages.map((message) => ({
-        message,
-        timestamp: startedAt.getTime(),
-      })),
-    }),
-  );
-  await simAws.backgroundTasksComplete();
-}
-
-/** The `Sum` of the handler's failure metric over the window. */
-async function counted(
-  simAws: SimAws,
-  dimensions: { Name: string; Value: string }[] = [
-    { Name: "service", Value: "user" },
-  ],
-): Promise<number | undefined> {
-  const statistics = new GetMetricStatisticsCommand({
-    Namespace: "ChineseBoost",
-    MetricName: "UserRequestFailed",
-    Dimensions: dimensions,
-    StartTime: startedAt,
-    EndTime: new Date(startedAt.getTime() + 300_000),
-    Period: 300,
-    Statistics: ["Sum"],
-  });
-  const { Datapoints } = await simAws
-    .cloudWatch()
-    .getMetricStatistics(statistics);
-
-  return Datapoints?.at(0)?.Sum;
-}
+import {
+  countedFailures as counted,
+  embeddedMetricDocument as embeddedDocument,
+  emfLogGroupName as logGroupName,
+  emfLogStreamName as logStreamName,
+  emfStartedAt as startedAt,
+  simAwsWithEmfLogStream as simAwsWithLogStream,
+  writeEmfLines as write,
+} from "../../../../../test/logs/embedded-metric-fixture.js";
 
 describe("Embedded Metric Format in simulated CloudWatch Logs", () => {
   it("publishes the metrics a log event carries", async () => {
@@ -223,103 +140,6 @@ describe("Embedded Metric Format in simulated CloudWatch Logs", () => {
     assertIdentical(await counted(simAws), 6);
   });
 
-  it("leaves an ordinary log line alone", async () => {
-    // Given a log group with a stream in it.
-    const simAws = await simAwsWithLogStream();
-
-    // When lines that are not EMF documents are written.
-    await write(
-      simAws,
-      "INFO handling a request",
-      JSON.stringify({ level: "INFO", message: "handling a request" }),
-      "{ not json at all",
-      JSON.stringify({ _aws: "a property that happens to be named that" }),
-    );
-
-    // Then nothing was published and nothing was recorded as a failure. A log
-    // group is full of lines that were never metrics.
-    const { Metrics } = await simAws
-      .cloudWatch()
-      .listMetrics(new ListMetricsCommand({}));
-
-    assertArrayLength(Metrics ?? [], 0);
-    assertArrayLength(simAws.logs().metricPublicationFailures, 0);
-  });
-
-  it("records a metric the document declared and carries no value for", async () => {
-    // Given a document naming a metric its body has no number under.
-    const simAws = await simAwsWithLogStream();
-
-    await write(simAws, embeddedDocument({ UserRequestFailed: "one" }));
-
-    // Then it published nothing, and said so rather than passing quietly.
-    const failures = simAws.logs().metricPublicationFailures;
-
-    assertArrayLength(failures, 1);
-    assertIdentical(failures.at(0)?.metricName, "UserRequestFailed");
-    assertIdentical(failures.at(0)?.source, "embedded metric format");
-    assertStringIncludes(failures.at(0)?.reason ?? "", "no value to publish");
-  });
-
-  it("records a high resolution metric it cannot hold", async () => {
-    // Given a document asking for a one second metric.
-    const simAws = await simAwsWithLogStream();
-
-    await write(
-      simAws,
-      embeddedDocument(
-        {},
-        {
-          CloudWatchMetrics: [
-            {
-              Namespace: "ChineseBoost",
-              Dimensions: [["service"]],
-              Metrics: [{ Name: "UserRequestFailed", StorageResolution: 1 }],
-            },
-          ],
-        },
-      ),
-    );
-
-    // Then it is on the ledger rather than published at the wrong resolution.
-    // Every period in this simulated CloudWatch is a whole number of minutes.
-    const failures = simAws.logs().metricPublicationFailures;
-
-    assertArrayLength(failures, 1);
-    assertStringIncludes(failures.at(0)?.reason ?? "", "StorageResolution 1");
-  });
-
-  it("drops a dimension set naming a property the document lacks", async () => {
-    // Given a document whose dimension set names a key its body has not got.
-    const simAws = await simAwsWithLogStream();
-
-    await write(
-      simAws,
-      embeddedDocument(
-        {},
-        {
-          CloudWatchMetrics: [
-            {
-              Namespace: "ChineseBoost",
-              Dimensions: [["service"], ["missing"]],
-              Metrics: [{ Name: "UserRequestFailed" }],
-            },
-          ],
-        },
-      ),
-    );
-
-    // Then the set it could fill in published and the other did not. Dropping
-    // one key and keeping the rest would put the datapoint under an identity
-    // no alarm is watching.
-    const { Metrics } = await simAws
-      .cloudWatch()
-      .listMetrics(new ListMetricsCommand({ Namespace: "ChineseBoost" }));
-
-    assertArrayLength(Metrics ?? [], 1);
-    assertIdentical(await counted(simAws), 1);
-  });
-
   it("reads no embedded metrics on a CloudWatch Logs built on its own", async () => {
     // Given a simulated CloudWatch Logs with no CloudWatch to publish into.
     const simLogs = new SimLogs();
@@ -356,37 +176,27 @@ describe("Embedded Metric Format in simulated CloudWatch Logs", () => {
     assertIdentical(await counted(simAws), 1);
   });
 
-  it("reads past metadata it cannot make sense of", async () => {
-    // Given documents whose metadata is the right shape in name only.
+  it("publishes undimensioned where the document declares no dimensions", async () => {
+    // Given a document with no Dimensions at all, and one with an empty set.
     const simAws = await simAwsWithLogStream();
 
     await write(
       simAws,
-      // Not JSON at all, but carrying the key that makes this worth parsing.
-      '{"_aws": broken',
-      // Metadata that is not a list of directives.
-      JSON.stringify({ _aws: { CloudWatchMetrics: "one of them" } }),
-      // A directive with no namespace to publish into.
-      JSON.stringify({
-        _aws: { CloudWatchMetrics: [{ Metrics: [{ Name: "Failed" }] }] },
-        Failed: 1,
-      }),
-      // A metric with no name to publish under, in a directive that has one.
       JSON.stringify({
         _aws: {
-          CloudWatchMetrics: [{ Namespace: "ChineseBoost", Metrics: [{}] }],
+          Timestamp: startedAt.getTime(),
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Metrics: [{ Name: "UserRequestFailed" }],
+            },
+          ],
         },
+        UserRequestFailed: 1,
       }),
     );
 
-    // Then none of them published, and none of them was recorded. Each is a
-    // log line this cannot read as metrics rather than a metric it failed to
-    // write.
-    const { Metrics } = await simAws
-      .cloudWatch()
-      .listMetrics(new ListMetricsCommand({}));
-
-    assertArrayLength(Metrics ?? [], 0);
-    assertArrayLength(simAws.logs().metricPublicationFailures, 0);
+    // Then it published without dimensions, which is what it asked for.
+    assertIdentical(await counted(simAws, []), 1);
   });
 });

--- a/src/service/logs/metric/emf/sim-logs-embedded-metrics.iso.test.ts
+++ b/src/service/logs/metric/emf/sim-logs-embedded-metrics.iso.test.ts
@@ -1,0 +1,392 @@
+import {
+  GetMetricStatisticsCommand,
+  ListMetricsCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLogs } from "../../sim-logs.js";
+
+const logGroupName = "/aws/lambda/user";
+const logStreamName = "2026/08/30/[$LATEST]0f7c1a";
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+
+/**
+ * One EMF document in the shape Powertools writes, as a log line.
+ *
+ * The metadata names the namespace, the dimension set and the metric, and the
+ * body of the same document carries the values both refer to by name.
+ */
+function embeddedDocument(
+  overrides: Record<string, unknown> = {},
+  metadata: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    _aws: {
+      Timestamp: startedAt.getTime(),
+      CloudWatchMetrics: [
+        {
+          Namespace: "ChineseBoost",
+          Dimensions: [["service"]],
+          Metrics: [{ Name: "UserRequestFailed", Unit: "Count" }],
+        },
+      ],
+      ...metadata,
+    },
+    service: "user",
+    UserRequestFailed: 1,
+    ...overrides,
+  });
+}
+
+/** A simulation with a stopped clock and a log group with a stream in it. */
+async function simAwsWithLogStream(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+  await simAws
+    .logs()
+    .createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+  await simAws
+    .logs()
+    .createLogStream(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+
+  return simAws;
+}
+
+/** Write log lines and let the reading run. */
+async function write(
+  simAws: SimAws,
+  ...messages: readonly string[]
+): Promise<void> {
+  await simAws.logs().putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName,
+      logStreamName,
+      logEvents: messages.map((message) => ({
+        message,
+        timestamp: startedAt.getTime(),
+      })),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+/** The `Sum` of the handler's failure metric over the window. */
+async function counted(
+  simAws: SimAws,
+  dimensions: { Name: string; Value: string }[] = [
+    { Name: "service", Value: "user" },
+  ],
+): Promise<number | undefined> {
+  const statistics = new GetMetricStatisticsCommand({
+    Namespace: "ChineseBoost",
+    MetricName: "UserRequestFailed",
+    Dimensions: dimensions,
+    StartTime: startedAt,
+    EndTime: new Date(startedAt.getTime() + 300_000),
+    Period: 300,
+    Statistics: ["Sum"],
+  });
+  const { Datapoints } = await simAws
+    .cloudWatch()
+    .getMetricStatistics(statistics);
+
+  return Datapoints?.at(0)?.Sum;
+}
+
+describe("Embedded Metric Format in simulated CloudWatch Logs", () => {
+  it("publishes the metrics a log event carries", async () => {
+    // Given a log group with a stream in it.
+    const simAws = await simAwsWithLogStream();
+
+    // When a handler writes an EMF document to it, as Powertools does.
+    await write(simAws, embeddedDocument());
+
+    // Then the metric exists, under the dimension set the document named.
+    assertIdentical(await counted(simAws), 1);
+  });
+
+  it("reads the unit the document declared", async () => {
+    // Given a log group that took an EMF document naming a unit.
+    const simAws = await simAwsWithLogStream();
+
+    await write(simAws, embeddedDocument());
+
+    // When the metric is read back filtered by that unit.
+    const statistics = new GetMetricStatisticsCommand({
+      Namespace: "ChineseBoost",
+      MetricName: "UserRequestFailed",
+      Dimensions: [{ Name: "service", Value: "user" }],
+      StartTime: startedAt,
+      EndTime: new Date(startedAt.getTime() + 300_000),
+      Period: 300,
+      Statistics: ["Sum"],
+      Unit: "Count",
+    });
+    const { Datapoints } = await simAws
+      .cloudWatch()
+      .getMetricStatistics(statistics);
+
+    // Then it is there, so the unit reached the datapoint.
+    assertIdentical(Datapoints?.at(0)?.Sum, 1);
+  });
+
+  it("takes the timestamp from the document rather than the clock", async () => {
+    // Given a log group, and a document stamped five minutes before the write.
+    const stampedAt = new Date(startedAt.getTime() - 300_000);
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      embeddedDocument({}, { Timestamp: stampedAt.getTime() }),
+    );
+
+    // Then the datapoint sits in the document's own window. Powertools stamps
+    // its document when it publishes, and the log line can reach CloudWatch
+    // Logs later.
+    const statistics = new GetMetricStatisticsCommand({
+      Namespace: "ChineseBoost",
+      MetricName: "UserRequestFailed",
+      Dimensions: [{ Name: "service", Value: "user" }],
+      StartTime: stampedAt,
+      EndTime: startedAt,
+      Period: 300,
+      Statistics: ["Sum"],
+    });
+    const { Datapoints } = await simAws
+      .cloudWatch()
+      .getMetricStatistics(statistics);
+
+    assertIdentical(Datapoints?.at(0)?.Sum, 1);
+    assertUndefined(await counted(simAws));
+  });
+
+  it("publishes one datapoint per dimension set", async () => {
+    // Given a document declaring two dimension sets over one metric.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      embeddedDocument(
+        { environment: "production" },
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: [["service"], ["environment"]],
+              Metrics: [{ Name: "UserRequestFailed" }],
+            },
+          ],
+        },
+      ),
+    );
+
+    // Then each set got its own metric, which is what makes them separate
+    // identities in CloudWatch.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({ Namespace: "ChineseBoost" }));
+
+    assertArrayEquals(
+      (Metrics ?? []).flatMap((metric) =>
+        metric.Dimensions.map(
+          (dimension) => `${dimension.Name}=${dimension.Value}`,
+        ),
+      ),
+      ["service=user", "environment=production"],
+    );
+  });
+
+  it("publishes one datapoint per value where a metric carries a list", async () => {
+    // Given a document whose metric value is a list, as Powertools writes one
+    // when a handler counts the same metric more than once.
+    const simAws = await simAwsWithLogStream();
+
+    await write(simAws, embeddedDocument({ UserRequestFailed: [1, 2, 3] }));
+
+    // Then every value counted.
+    assertIdentical(await counted(simAws), 6);
+  });
+
+  it("leaves an ordinary log line alone", async () => {
+    // Given a log group with a stream in it.
+    const simAws = await simAwsWithLogStream();
+
+    // When lines that are not EMF documents are written.
+    await write(
+      simAws,
+      "INFO handling a request",
+      JSON.stringify({ level: "INFO", message: "handling a request" }),
+      "{ not json at all",
+      JSON.stringify({ _aws: "a property that happens to be named that" }),
+    );
+
+    // Then nothing was published and nothing was recorded as a failure. A log
+    // group is full of lines that were never metrics.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({}));
+
+    assertArrayLength(Metrics ?? [], 0);
+    assertArrayLength(simAws.logs().metricPublicationFailures, 0);
+  });
+
+  it("records a metric the document declared and carries no value for", async () => {
+    // Given a document naming a metric its body has no number under.
+    const simAws = await simAwsWithLogStream();
+
+    await write(simAws, embeddedDocument({ UserRequestFailed: "one" }));
+
+    // Then it published nothing, and said so rather than passing quietly.
+    const failures = simAws.logs().metricPublicationFailures;
+
+    assertArrayLength(failures, 1);
+    assertIdentical(failures.at(0)?.metricName, "UserRequestFailed");
+    assertIdentical(failures.at(0)?.source, "embedded metric format");
+    assertStringIncludes(failures.at(0)?.reason ?? "", "no value to publish");
+  });
+
+  it("records a high resolution metric it cannot hold", async () => {
+    // Given a document asking for a one second metric.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      embeddedDocument(
+        {},
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: [["service"]],
+              Metrics: [{ Name: "UserRequestFailed", StorageResolution: 1 }],
+            },
+          ],
+        },
+      ),
+    );
+
+    // Then it is on the ledger rather than published at the wrong resolution.
+    // Every period in this simulated CloudWatch is a whole number of minutes.
+    const failures = simAws.logs().metricPublicationFailures;
+
+    assertArrayLength(failures, 1);
+    assertStringIncludes(failures.at(0)?.reason ?? "", "StorageResolution 1");
+  });
+
+  it("drops a dimension set naming a property the document lacks", async () => {
+    // Given a document whose dimension set names a key its body has not got.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      embeddedDocument(
+        {},
+        {
+          CloudWatchMetrics: [
+            {
+              Namespace: "ChineseBoost",
+              Dimensions: [["service"], ["missing"]],
+              Metrics: [{ Name: "UserRequestFailed" }],
+            },
+          ],
+        },
+      ),
+    );
+
+    // Then the set it could fill in published and the other did not. Dropping
+    // one key and keeping the rest would put the datapoint under an identity
+    // no alarm is watching.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({ Namespace: "ChineseBoost" }));
+
+    assertArrayLength(Metrics ?? [], 1);
+    assertIdentical(await counted(simAws), 1);
+  });
+
+  it("reads no embedded metrics on a CloudWatch Logs built on its own", async () => {
+    // Given a simulated CloudWatch Logs with no CloudWatch to publish into.
+    const simLogs = new SimLogs();
+
+    await simLogs.createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+    await simLogs.createLogStream(
+      new CreateLogStreamCommand({ logGroupName, logStreamName }),
+    );
+
+    // When a Powertools log line is written to it.
+    await simLogs.putLogEvents(
+      new PutLogEventsCommand({
+        logGroupName,
+        logStreamName,
+        logEvents: [
+          { message: embeddedDocument(), timestamp: startedAt.getTime() },
+        ],
+      }),
+    );
+
+    // Then the write took it and nothing was recorded. A log line here is a
+    // log line, and a user who wanted metrics would have reached CloudWatch
+    // Logs through a SimAws scope.
+    assertArrayLength(simLogs.metricPublicationFailures, 0);
+  });
+
+  it("stamps from the write where the document carries no timestamp", async () => {
+    // Given a document with no _aws.Timestamp of its own.
+    const simAws = await simAwsWithLogStream();
+
+    await write(simAws, embeddedDocument({}, { Timestamp: undefined }));
+
+    // Then the instant CloudWatch Logs took the event is what stamps it.
+    assertIdentical(await counted(simAws), 1);
+  });
+
+  it("reads past metadata it cannot make sense of", async () => {
+    // Given documents whose metadata is the right shape in name only.
+    const simAws = await simAwsWithLogStream();
+
+    await write(
+      simAws,
+      // Not JSON at all, but carrying the key that makes this worth parsing.
+      '{"_aws": broken',
+      // Metadata that is not a list of directives.
+      JSON.stringify({ _aws: { CloudWatchMetrics: "one of them" } }),
+      // A directive with no namespace to publish into.
+      JSON.stringify({
+        _aws: { CloudWatchMetrics: [{ Metrics: [{ Name: "Failed" }] }] },
+        Failed: 1,
+      }),
+      // A metric with no name to publish under, in a directive that has one.
+      JSON.stringify({
+        _aws: {
+          CloudWatchMetrics: [{ Namespace: "ChineseBoost", Metrics: [{}] }],
+        },
+      }),
+    );
+
+    // Then none of them published, and none of them was recorded. Each is a
+    // log line this cannot read as metrics rather than a metric it failed to
+    // write.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({}));
+
+    assertArrayLength(Metrics ?? [], 0);
+    assertArrayLength(simAws.logs().metricPublicationFailures, 0);
+  });
+});

--- a/src/service/logs/metric/emf/sim-logs-powertools-alarm.loc.test.ts
+++ b/src/service/logs/metric/emf/sim-logs-powertools-alarm.loc.test.ts
@@ -1,0 +1,121 @@
+import { build } from "esbuild";
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { makeLambdaCodeZip } from "../../../lambda/function/code/make-lambda-code-zip.js";
+
+const functionName = "user";
+const alarmName = "UserRequestsFailing";
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+
+/**
+ * A handler using AWS Lambda Powertools the way a deployed one does. The
+ * metrics are constructed at module scope so a warm container reuses them, and
+ * Powertools is bundled into the deployment package rather than provided by
+ * the runtime.
+ *
+ * Nothing here calls PutMetricData. Powertools counts by writing an Embedded
+ * Metric Format document to stdout, and CloudWatch reads the metric out of the
+ * log group, which is what this is here to exercise.
+ */
+const handlerSource = `
+import { Metrics, MetricUnit } from "@aws-lambda-powertools/metrics";
+
+const metrics = new Metrics({ namespace: "ChineseBoost", serviceName: "user" });
+
+export const handler = async () => {
+  metrics.addMetric("UserRequestFailed", MetricUnit.Count, 1);
+  metrics.publishStoredMetrics();
+
+  return { handled: false };
+};
+`;
+
+describe("an alarm over a metric a Powertools handler writes as EMF", () => {
+  it("fires on what the handler counted, with nothing publishing by hand", async () => {
+    // Given a function bundling Powertools, and an alarm over the metric the
+    // handler counts.
+    const simAws = new SimAws();
+
+    await simAws.clock().setTo(startedAt);
+    const zipFile = makeLambdaCodeZip(await bundleHandler());
+
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: functionName,
+        Role: `arn:aws:iam::${simAws.defaultAccountId}:role/UserRole`,
+        Handler: "index.handler",
+        Code: { ZipFile: zipFile },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.cloudWatch().putMetricAlarm(
+      new PutMetricAlarmCommand({
+        AlarmName: alarmName,
+        Namespace: "ChineseBoost",
+        MetricName: "UserRequestFailed",
+        Dimensions: [{ Name: "service", Value: "user" }],
+        Statistic: "Sum",
+        Period: 300,
+        EvaluationPeriods: 3,
+        DatapointsToAlarm: 1,
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        TreatMissingData: "notBreaching",
+      }),
+    );
+
+    // When the handler runs and counts a failure.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: functionName }));
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ minutes: 6 });
+
+    // Then the alarm fired on the datapoint the EMF document carried, which
+    // reached CloudWatch through the handler's own log group.
+    const { MetricAlarms } = await simAws
+      .cloudWatch()
+      .describeAlarms(new DescribeAlarmsCommand({ AlarmNames: [alarmName] }));
+
+    assertIdentical(MetricAlarms?.at(0)?.StateValue, "ALARM");
+    assertArrayLength(simAws.logs().metricPublicationFailures, 0);
+    assertArrayLength(simAws.cloudWatch().alarmActionFailures, 0);
+  });
+});
+
+/**
+ * Bundle the handler into one CommonJS module, as a deployment package build
+ * does, so the archive carries Powertools rather than the runtime providing it.
+ */
+async function bundleHandler(): Promise<string> {
+  const bundled = await build({
+    stdin: {
+      contents: handlerSource,
+      loader: "ts",
+      resolveDir: import.meta.dirname,
+      sourcefile: "index.ts",
+    },
+    bundle: true,
+    write: false,
+    platform: "node",
+    target: "node24",
+    format: "cjs",
+  });
+
+  const output = bundled.outputFiles[0];
+
+  assertNonNullable(output);
+
+  return output.text;
+}

--- a/src/service/logs/metric/sim-logs-metric-fan-out.ts
+++ b/src/service/logs/metric/sim-logs-metric-fan-out.ts
@@ -4,29 +4,13 @@ import type { SimLogsStoredEvent } from "../event/sim-logs-event.js";
 import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
 import { simLogsEmbeddedMetricReading } from "./emf/sim-logs-embedded-metric-datapoints.js";
 import type { SimLogsMetricDatapoint } from "./sim-logs-metric-datapoint.js";
+import {
+  metricFilterSource,
+  simLogsEmbeddedMetricSource,
+  type SimLogsMetricPublicationFailure,
+  type SimLogsMetricPublicationSource,
+} from "./sim-logs-metric-publication-failure.js";
 import type { SimLogsMetricPublications } from "./sim-logs-metric-publications.js";
-
-/**
- * What the ledger calls a datapoint an EMF document produced.
- *
- * A metric filter has a name to be known by and an embedded document has none,
- * so the two are told apart by this.
- */
-export const simLogsEmbeddedMetricSource = "embedded metric format";
-
-/**
- * One datapoint a log group could not turn into a metric.
- *
- * `source` is the name of the metric filter that asked for it, or
- * `simLogsEmbeddedMetricSource` where the log event carried its own metrics.
- */
-export interface SimLogsMetricPublicationFailure {
-  readonly logGroupName: string;
-  readonly source: string;
-  readonly metricNamespace: string;
-  readonly metricName: string;
-  readonly reason: string;
-}
 
 interface SimLogsMetricFanOutProperties {
   readonly publications: SimLogsMetricPublications | undefined;
@@ -106,7 +90,11 @@ export class SimLogsMetricFanOut {
       const datapoints = filter.datapoints(events);
 
       if (datapoints.length > 0) {
-        this.schedule(group.logGroupName, filter.filterName, datapoints);
+        this.schedule(
+          group.logGroupName,
+          metricFilterSource(filter.filterName),
+          datapoints,
+        );
       }
     }
 
@@ -146,7 +134,7 @@ export class SimLogsMetricFanOut {
 
   private schedule(
     logGroupName: string,
-    source: string,
+    source: SimLogsMetricPublicationSource,
     datapoints: readonly SimLogsMetricDatapoint[],
   ): void {
     this.#background.schedule(async () => {
@@ -160,7 +148,7 @@ export class SimLogsMetricFanOut {
 
   private recordFailure(
     logGroupName: string,
-    source: string,
+    source: SimLogsMetricPublicationSource,
     datapoints: readonly SimLogsMetricDatapoint[],
     error: unknown,
   ): void {

--- a/src/service/logs/metric/sim-logs-metric-fan-out.ts
+++ b/src/service/logs/metric/sim-logs-metric-fan-out.ts
@@ -1,37 +1,53 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
+import { SimLogsUnsupportedOperationException } from "../error/sim-logs.error.js";
 import type { SimLogsStoredEvent } from "../event/sim-logs-event.js";
 import type { SimLogsLogGroup } from "../group/sim-logs-log-group.js";
+import { simLogsEmbeddedMetricReading } from "./emf/sim-logs-embedded-metric-datapoints.js";
 import type { SimLogsMetricDatapoint } from "./sim-logs-metric-datapoint.js";
 import type { SimLogsMetricPublications } from "./sim-logs-metric-publications.js";
 
 /**
- * One datapoint a metric filter could not publish.
+ * What the ledger calls a datapoint an EMF document produced.
+ *
+ * A metric filter has a name to be known by and an embedded document has none,
+ * so the two are told apart by this.
+ */
+export const simLogsEmbeddedMetricSource = "embedded metric format";
+
+/**
+ * One datapoint a log group could not turn into a metric.
+ *
+ * `source` is the name of the metric filter that asked for it, or
+ * `simLogsEmbeddedMetricSource` where the log event carried its own metrics.
  */
 export interface SimLogsMetricPublicationFailure {
   readonly logGroupName: string;
-  readonly filterName: string;
+  readonly source: string;
   readonly metricNamespace: string;
   readonly metricName: string;
   readonly reason: string;
 }
 
 interface SimLogsMetricFanOutProperties {
-  readonly publications: SimLogsMetricPublications;
+  readonly publications: SimLogsMetricPublications | undefined;
   readonly background: BackgroundScheduler;
 }
 
 /**
- * Turns events written to a log group into the metric datapoints its metric
- * filters ask for.
+ * Turns events written to a log group into metric datapoints.
+ *
+ * Two things ask for them. A metric filter on the group counts the events it
+ * matches, and an event that is itself an Embedded Metric Format document
+ * carries its own. Real CloudWatch reads both without being asked.
  *
  * Publication happens on the background scheduler, for the reason subscription
  * delivery does. Real CloudWatch Logs answers `PutLogEvents` whether or not
- * the metric behind a filter took the datapoint, and a metric that cannot be
- * written must not fail the write that produced it.
- * `simAws.backgroundTasksComplete()` is what waits for it.
+ * the metric took the datapoint, and a metric that cannot be written must not
+ * fail the write that produced it. `simAws.backgroundTasksComplete()` is what
+ * waits for it.
  */
 export class SimLogsMetricFanOut {
-  readonly #publications: SimLogsMetricPublications;
+  readonly #publications: SimLogsMetricPublications | undefined;
   readonly #background: BackgroundScheduler;
   readonly #failures: SimLogsMetricPublicationFailure[] = [];
 
@@ -45,7 +61,7 @@ export class SimLogsMetricFanOut {
    *
    * A failed publication is invisible in an account, where it becomes a metric
    * nobody is watching. Keeping it is what lets a test find out that the
-   * metric filter it set up never wrote anything.
+   * metrics it set up never wrote anything.
    */
   get failures(): readonly SimLogsMetricPublicationFailure[] {
     return this.#failures;
@@ -54,22 +70,38 @@ export class SimLogsMetricFanOut {
   /**
    * Check a metric filter could publish at all, before one is put.
    *
-   * Publishing nothing is the question. A CloudWatch that is there takes an
-   * empty batch and does nothing with it, and a simulated CloudWatch Logs
-   * built on its own refuses it, which is the answer the caller needs.
+   * A simulated CloudWatch Logs built on its own has no CloudWatch to write
+   * into, and a filter that accepts its configuration and publishes nothing is
+   * the hardest kind of thing to find.
    */
-  async checkPublishable(): Promise<void> {
-    await this.#publications.publish([]);
+  checkPublishable(): void {
+    if (this.#publications === undefined) {
+      throw new SimLogsUnsupportedOperationException(
+        "This simulated CloudWatch Logs has no simulated CloudWatch to " +
+          "publish a metric filter's datapoints into. Reach CloudWatch Logs " +
+          "through a SimAws Account Region scope for a metric filter to " +
+          "publish.",
+      );
+    }
   }
 
   /**
-   * Schedule the datapoints every metric filter on the group wants from these
-   * events.
+   * Schedule the datapoints a batch of events produced.
    *
-   * The whole batch goes to each filter at once, because a filter aggregates
-   * its default value over a period rather than over one event.
+   * A whole batch goes to each metric filter at once, because a filter
+   * aggregates its default value over a period rather than over one event. An
+   * embedded document is read one event at a time, because each carries its
+   * own metrics and its own timestamp.
+   *
+   * A CloudWatch Logs with nowhere to publish reads nothing. It can hold no
+   * metric filter, and a Powertools log line written to one is an ordinary log
+   * line rather than a failure worth recording.
    */
   written(group: SimLogsLogGroup, events: readonly SimLogsStoredEvent[]): void {
+    if (this.#publications === undefined) {
+      return;
+    }
+
     for (const filter of group.metricFilters.all) {
       const datapoints = filter.datapoints(events);
 
@@ -77,25 +109,58 @@ export class SimLogsMetricFanOut {
         this.schedule(group.logGroupName, filter.filterName, datapoints);
       }
     }
+
+    this.writtenEmbedded(group.logGroupName, events);
+  }
+
+  /**
+   * Schedule the datapoints the events carried as EMF documents.
+   */
+  private writtenEmbedded(
+    logGroupName: string,
+    events: readonly SimLogsStoredEvent[],
+  ): void {
+    const datapoints: SimLogsMetricDatapoint[] = [];
+
+    for (const event of events) {
+      const reading = simLogsEmbeddedMetricReading(
+        event.message,
+        event.ingestionTime,
+      );
+
+      datapoints.push(...reading.datapoints);
+
+      for (const skip of reading.skipped) {
+        this.#failures.push({
+          logGroupName,
+          source: simLogsEmbeddedMetricSource,
+          ...skip,
+        });
+      }
+    }
+
+    if (datapoints.length > 0) {
+      this.schedule(logGroupName, simLogsEmbeddedMetricSource, datapoints);
+    }
   }
 
   private schedule(
     logGroupName: string,
-    filterName: string,
+    source: string,
     datapoints: readonly SimLogsMetricDatapoint[],
   ): void {
     this.#background.schedule(async () => {
       try {
-        await this.#publications.publish(datapoints);
+        await this.#publications?.publish(datapoints);
       } catch (error) {
-        this.recordFailure(logGroupName, filterName, datapoints, error);
+        this.recordFailure(logGroupName, source, datapoints, error);
       }
     });
   }
 
   private recordFailure(
     logGroupName: string,
-    filterName: string,
+    source: string,
     datapoints: readonly SimLogsMetricDatapoint[],
     error: unknown,
   ): void {
@@ -104,7 +169,7 @@ export class SimLogsMetricFanOut {
     for (const datapoint of datapoints) {
       this.#failures.push({
         logGroupName,
-        filterName,
+        source,
         metricNamespace: datapoint.namespace,
         metricName: datapoint.metricName,
         reason,

--- a/src/service/logs/metric/sim-logs-metric-filter-alarm.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filter-alarm.iso.test.ts
@@ -118,6 +118,6 @@ describe("an alarm over a metric a CloudWatch Logs metric filter writes", () => 
     // reached its topic.
     assertIdentical(await alarmState(simAws), "ALARM");
     assertArrayLength(simAws.cloudWatch().alarmActionFailures, 0);
-    assertArrayLength(simAws.logs().metricFilterFailures, 0);
+    assertArrayLength(simAws.logs().metricPublicationFailures, 0);
   });
 });

--- a/src/service/logs/metric/sim-logs-metric-filters.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filters.iso.test.ts
@@ -244,7 +244,12 @@ describe("sim CloudWatch Logs metric filters", () => {
     const failures = simAws.logs().metricPublicationFailures;
 
     assertArrayLength(failures, 1);
-    assertIdentical(failures.at(0)?.source, "handler-errors");
+
+    const source = failures.at(0)?.source;
+
+    assertNonNullable(source);
+    assertIdentical(source.kind, "metricFilter");
+    assertIdentical(source.filterName, "handler-errors");
     assertIdentical(failures.at(0)?.metricNamespace, "AWS/Lambda");
     assertStringIncludes(failures.at(0)?.reason ?? "", "reserved");
   });

--- a/src/service/logs/metric/sim-logs-metric-filters.iso.test.ts
+++ b/src/service/logs/metric/sim-logs-metric-filters.iso.test.ts
@@ -241,10 +241,10 @@ describe("sim CloudWatch Logs metric filters", () => {
 
     // Then the write succeeded and the publication it could not make is on the
     // ledger, rather than being lost the way it is in an account.
-    const failures = simAws.logs().metricFilterFailures;
+    const failures = simAws.logs().metricPublicationFailures;
 
     assertArrayLength(failures, 1);
-    assertIdentical(failures.at(0)?.filterName, "handler-errors");
+    assertIdentical(failures.at(0)?.source, "handler-errors");
     assertIdentical(failures.at(0)?.metricNamespace, "AWS/Lambda");
     assertStringIncludes(failures.at(0)?.reason ?? "", "reserved");
   });

--- a/src/service/logs/metric/sim-logs-metric-publication-failure.ts
+++ b/src/service/logs/metric/sim-logs-metric-publication-failure.ts
@@ -1,0 +1,37 @@
+/**
+ * What asked for a datapoint the log group could not publish.
+ *
+ * A discriminated pair rather than a name, because a metric filter may be
+ * called anything a caller likes. A filter named after the other kind would
+ * otherwise be indistinguishable from it on the ledger.
+ */
+export type SimLogsMetricPublicationSource =
+  | { readonly kind: "metricFilter"; readonly filterName: string }
+  | { readonly kind: "embeddedMetricFormat" };
+
+/**
+ * The source of a datapoint an embedded metric document asked for.
+ */
+export const simLogsEmbeddedMetricSource: SimLogsMetricPublicationSource = {
+  kind: "embeddedMetricFormat",
+};
+
+/**
+ * The source of a datapoint a metric filter asked for.
+ */
+export function metricFilterSource(
+  filterName: string,
+): SimLogsMetricPublicationSource {
+  return { kind: "metricFilter", filterName };
+}
+
+/**
+ * One datapoint a log group could not turn into a metric.
+ */
+export interface SimLogsMetricPublicationFailure {
+  readonly logGroupName: string;
+  readonly source: SimLogsMetricPublicationSource;
+  readonly metricNamespace: string;
+  readonly metricName: string;
+  readonly reason: string;
+}

--- a/src/service/logs/metric/sim-logs-metric-publications.ts
+++ b/src/service/logs/metric/sim-logs-metric-publications.ts
@@ -1,41 +1,12 @@
-import { SimLogsUnsupportedOperationException } from "../error/sim-logs.error.js";
 import type { SimLogsMetricDatapoint } from "./sim-logs-metric-datapoint.js";
 
 /**
- * Where a metric filter's datapoints are published.
+ * Where a log group's metric datapoints are published.
  *
- * One method, and publishing nothing is how a filter about to be put asks
- * whether publishing would work at all. Real CloudWatch Logs takes a metric
- * filter whatever else is in the account, because the metric it writes into is
- * made by the first write. The question here is about this simulation instead.
- * A `SimLogs` with no CloudWatch to publish into would hold a filter and drop
- * every datapoint, and a filter that accepts its configuration and publishes
- * nothing is the hardest kind of thing to find.
+ * A simulated CloudWatch Logs reached through a `SimAws` Account Region scope
+ * has one of these, pointing at that scope's own CloudWatch. One built on its
+ * own has none, and reads no metrics out of what is written to it.
  */
 export interface SimLogsMetricPublications {
   publish(datapoints: readonly SimLogsMetricDatapoint[]): Promise<void>;
-}
-
-/**
- * The publications a simulated CloudWatch Logs built on its own can make,
- * which is none.
- *
- * A standalone SimLogs has no simulated CloudWatch to put a datapoint into, so
- * a metric filter on one is refused when it is put rather than accepted and
- * left publishing nowhere.
- */
-export class SimLogsNoMetricPublications implements SimLogsMetricPublications {
-  /**
-   * Refuse every publication, explaining how to get one.
-   */
-  publish(): Promise<void> {
-    return Promise.reject(
-      new SimLogsUnsupportedOperationException(
-        "This simulated CloudWatch Logs has no simulated CloudWatch to " +
-          "publish a metric filter's datapoints into. Reach CloudWatch Logs " +
-          "through a SimAws Account Region scope for a metric filter to " +
-          "publish.",
-      ),
-    );
-  }
 }

--- a/src/service/logs/sim-logs-commands.ts
+++ b/src/service/logs/sim-logs-commands.ts
@@ -32,10 +32,7 @@ import {
   type SimLogsSubscriptionDestinations,
 } from "./subscription/sim-logs-subscription-destinations.js";
 import { SimLogsMetricFanOut } from "./metric/sim-logs-metric-fan-out.js";
-import {
-  SimLogsNoMetricPublications,
-  type SimLogsMetricPublications,
-} from "./metric/sim-logs-metric-publications.js";
+import type { SimLogsMetricPublications } from "./metric/sim-logs-metric-publications.js";
 import { SimLogsSubscriptionFanOut } from "./subscription/sim-logs-subscription-fan-out.js";
 import { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
 
@@ -59,9 +56,10 @@ export interface SimLogsProperties {
   readonly deliverySourceResources?: SimLogsDeliverySourceResources;
 
   /**
-   * Where a metric filter's datapoints are published. A SimLogs built on its
-   * own has no simulated CloudWatch to write into, so it refuses a metric
-   * filter rather than holding one that publishes nowhere.
+   * Where a log group's metric datapoints are published. A SimLogs built on
+   * its own has no simulated CloudWatch to write into. It refuses a metric
+   * filter rather than holding one that publishes nowhere, and it reads no
+   * embedded metrics out of what is written to it.
    */
   readonly metricPublications?: SimLogsMetricPublications;
 }
@@ -103,7 +101,6 @@ export class SimLogsCommands {
       background = new BackgroundTasks(),
       subscriptionDestinations = new SimLogsNoSubscriptionDestinations(),
       deliverySourceResources = new SimLogsUncheckedDeliverySourceResources(),
-      metricPublications = new SimLogsNoMetricPublications(),
     } = properties;
 
     const iam = simIamInRegion(properties.iam, accountRegionScope.regionName);
@@ -117,7 +114,7 @@ export class SimLogsCommands {
       background,
     });
     const metricFanOut = new SimLogsMetricFanOut({
-      publications: metricPublications,
+      publications: properties.metricPublications,
       background,
     });
 

--- a/src/service/logs/sim-logs-metric-operations.ts
+++ b/src/service/logs/sim-logs-metric-operations.ts
@@ -1,0 +1,56 @@
+import type * as simLogsCommands from "./command/sim-logs-command.types.js";
+import type { SimLogsRequestOptions } from "./command/sim-logs-request-options.js";
+import type { SimLogsMetricPublicationFailure } from "./metric/sim-logs-metric-fan-out.js";
+import { SimLogsDeliveryOperations } from "./sim-logs-delivery-operations.js";
+import type { SimLogsCommands } from "./sim-logs-commands.js";
+
+/**
+ * The metric commands of the simulated CloudWatch Logs facade.
+ *
+ * They sit here for the reason the delivery commands do. SimLogs grows by one
+ * delegating method per simulated operation and is at the length this codebase
+ * allows. These belong together as the half of CloudWatch Logs that turns what
+ * is written into CloudWatch metrics.
+ */
+export abstract class SimLogsMetricOperations extends SimLogsDeliveryOperations {
+  protected abstract override readonly commands: SimLogsCommands;
+
+  /**
+   * Every metric publication this scope could not make, whether a metric
+   * filter or an embedded metric document asked for it.
+   *
+   * A failed publication is invisible in an account, where it becomes a metric
+   * nobody is watching. Keeping it is what lets a test find out that the
+   * metrics it set up never wrote a datapoint.
+   */
+  get metricPublicationFailures(): readonly SimLogsMetricPublicationFailure[] {
+    return this.commands.metricFanOut.failures;
+  }
+
+  /** Handle a PutMetricFilter Command from the SDK. */
+  async putMetricFilter(
+    command: simLogsCommands.SimPutMetricFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimPutMetricFilterCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.metricFilters.putMetricFilter(command, options);
+  }
+
+  /** Handle a DescribeMetricFilters Command from the SDK. */
+  async describeMetricFilters(
+    command: simLogsCommands.SimDescribeMetricFiltersCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDescribeMetricFiltersCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.metricFilters.describeMetricFilters(command, options);
+  }
+
+  /** Handle a DeleteMetricFilter Command from the SDK. */
+  async deleteMetricFilter(
+    command: simLogsCommands.SimDeleteMetricFilterCommand,
+    options?: SimLogsRequestOptions,
+  ): Promise<simLogsCommands.SimDeleteMetricFilterCommandOutput> {
+    await this.commands.background.sequence();
+    return this.commands.metricFilters.deleteMetricFilter(command, options);
+  }
+}

--- a/src/service/logs/sim-logs-metric-operations.ts
+++ b/src/service/logs/sim-logs-metric-operations.ts
@@ -1,6 +1,6 @@
 import type * as simLogsCommands from "./command/sim-logs-command.types.js";
 import type { SimLogsRequestOptions } from "./command/sim-logs-request-options.js";
-import type { SimLogsMetricPublicationFailure } from "./metric/sim-logs-metric-fan-out.js";
+import type { SimLogsMetricPublicationFailure } from "./metric/sim-logs-metric-publication-failure.js";
 import { SimLogsDeliveryOperations } from "./sim-logs-delivery-operations.js";
 import type { SimLogsCommands } from "./sim-logs-commands.js";
 

--- a/src/service/logs/sim-logs.ts
+++ b/src/service/logs/sim-logs.ts
@@ -8,8 +8,7 @@ import {
   SimLogsCommands,
   type SimLogsProperties,
 } from "./sim-logs-commands.js";
-import { SimLogsDeliveryOperations } from "./sim-logs-delivery-operations.js";
-import type { SimLogsMetricPublicationFailure } from "./metric/sim-logs-metric-fan-out.js";
+import { SimLogsMetricOperations } from "./sim-logs-metric-operations.js";
 import type { SimLogsSubscriptionFailure } from "./subscription/sim-logs-subscription-fan-out.js";
 import type { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
 
@@ -26,11 +25,12 @@ import type { SimLogsServiceWriter } from "./write/sim-logs-service-writer.js";
  * an event expire, and what teams get wrong about retention is the value they
  * deployed rather than the deletion that eventually follows from it.
  *
- * The delivery operations are held apart in `SimLogsDeliveryOperations`, which
+ * The delivery and metric operations are held apart in
+ * `SimLogsDeliveryOperations` and `SimLogsMetricOperations`, which
  * this extends, because this file grows by one delegating method per simulated
  * operation and is at the length this codebase allows.
  */
-export class SimLogs extends SimLogsDeliveryOperations {
+export class SimLogs extends SimLogsMetricOperations {
   protected readonly commands: SimLogsCommands;
 
   readonly #sdkRouter = new SimLogsSdkCommandRouter(this);
@@ -238,50 +238,6 @@ export class SimLogs extends SimLogsDeliveryOperations {
       command,
       options,
     );
-  }
-
-  /**
-   * Every metric filter publication this scope could not make.
-   *
-   * A failed publication is invisible in an account, where it becomes a metric
-   * nobody is watching. Keeping it is what lets a test find out that the
-   * metric filter it set up never wrote a datapoint.
-   */
-  get metricFilterFailures(): readonly SimLogsMetricPublicationFailure[] {
-    return this.commands.metricFanOut.failures;
-  }
-
-  /**
-   * Handle a PutMetricFilter Command from the SDK.
-   */
-  async putMetricFilter(
-    command: simLogsCommands.SimPutMetricFilterCommand,
-    options?: SimLogsRequestOptions,
-  ): Promise<simLogsCommands.SimPutMetricFilterCommandOutput> {
-    await this.commands.background.sequence();
-    return await this.commands.metricFilters.putMetricFilter(command, options);
-  }
-
-  /**
-   * Handle a DescribeMetricFilters Command from the SDK.
-   */
-  async describeMetricFilters(
-    command: simLogsCommands.SimDescribeMetricFiltersCommand,
-    options?: SimLogsRequestOptions,
-  ): Promise<simLogsCommands.SimDescribeMetricFiltersCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.metricFilters.describeMetricFilters(command, options);
-  }
-
-  /**
-   * Handle a DeleteMetricFilter Command from the SDK.
-   */
-  async deleteMetricFilter(
-    command: simLogsCommands.SimDeleteMetricFilterCommand,
-    options?: SimLogsRequestOptions,
-  ): Promise<simLogsCommands.SimDeleteMetricFilterCommandOutput> {
-    await this.commands.background.sequence();
-    return this.commands.metricFilters.deleteMetricFilter(command, options);
   }
 
   /**

--- a/test/logs/embedded-metric-fixture.ts
+++ b/test/logs/embedded-metric-fixture.ts
@@ -1,0 +1,115 @@
+/**
+ * The Embedded Metric Format documents the EMF tests write to a log group.
+ *
+ * A document has to be self consistent to publish anything: the metadata names
+ * a namespace, a set of dimension keys and a set of metric names, and the body
+ * of the same document carries a value under each of those names. Building one
+ * by hand in every case would put that agreement in a dozen places.
+ */
+
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import {
+  CreateLogGroupCommand,
+  CreateLogStreamCommand,
+  PutLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+
+/** The log group these tests write to, as a Lambda function's own. */
+export const emfLogGroupName = "/aws/lambda/user";
+
+/** The stream inside it, in the shape a Lambda execution environment opens. */
+export const emfLogStreamName = "2026/08/30/[$LATEST]0f7c1a";
+
+/** The instant the clock is stopped at. */
+export const emfStartedAt = new Date("2026-08-30T09:00:00.000Z");
+
+/**
+ * One EMF document in the shape Powertools writes, as a log line.
+ *
+ * `overrides` replaces top-level properties of the document body, and
+ * `metadata` replaces parts of the `_aws` envelope.
+ */
+export function embeddedMetricDocument(
+  overrides: Record<string, unknown> = {},
+  metadata: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    _aws: {
+      Timestamp: emfStartedAt.getTime(),
+      CloudWatchMetrics: [
+        {
+          Namespace: "ChineseBoost",
+          Dimensions: [["service"]],
+          Metrics: [{ Name: "UserRequestFailed", Unit: "Count" }],
+        },
+      ],
+      ...metadata,
+    },
+    service: "user",
+    UserRequestFailed: 1,
+    ...overrides,
+  });
+}
+
+/** A simulation with a stopped clock and a log group with a stream in it. */
+export async function simAwsWithEmfLogStream(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(emfStartedAt);
+  await simAws
+    .logs()
+    .createLogGroup(
+      new CreateLogGroupCommand({ logGroupName: emfLogGroupName }),
+    );
+  await simAws.logs().createLogStream(
+    new CreateLogStreamCommand({
+      logGroupName: emfLogGroupName,
+      logStreamName: emfLogStreamName,
+    }),
+  );
+
+  return simAws;
+}
+
+/** Write log lines to the stream and let the reading run. */
+export async function writeEmfLines(
+  simAws: SimAws,
+  ...messages: readonly string[]
+): Promise<void> {
+  await simAws.logs().putLogEvents(
+    new PutLogEventsCommand({
+      logGroupName: emfLogGroupName,
+      logStreamName: emfLogStreamName,
+      logEvents: messages.map((message) => ({
+        message,
+        timestamp: emfStartedAt.getTime(),
+      })),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+/** The `Sum` of the handler's failure metric over the window. */
+export async function countedFailures(
+  simAws: SimAws,
+  dimensions: { Name: string; Value: string }[] = [
+    { Name: "service", Value: "user" },
+  ],
+): Promise<number | undefined> {
+  const statistics = new GetMetricStatisticsCommand({
+    Namespace: "ChineseBoost",
+    MetricName: "UserRequestFailed",
+    Dimensions: dimensions,
+    StartTime: emfStartedAt,
+    EndTime: new Date(emfStartedAt.getTime() + 300_000),
+    Period: 300,
+    Statistics: ["Sum"],
+  });
+  const { Datapoints } = await simAws
+    .cloudWatch()
+    .getMetricStatistics(statistics);
+
+  return Datapoints?.at(0)?.Sum;
+}


### PR DESCRIPTION
A log event that is itself an EMF document publishes the metrics it declares, which is how AWS Lambda Powertools counts without calling any CloudWatch API. Each entry in `_aws.CloudWatchMetrics` names a namespace, its dimension sets and its metrics, and the values come from the top-level properties of the same document. A handler bundling Powertools therefore drives an alarm over its own metric through the log group its output already reaches.

A line that is not a readable document is stored and left alone, because a log group is full of lines that were never metrics. A metric the metadata declares and the body carries no number under, and one asking for a resolution shorter than a minute, go on the publication ledger instead. That ledger now covers both metric filters and embedded documents, so its entries name their source and it is read through `metricPublicationFailures`.

Resolves #1168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting and publishing Embedded Metric Format (EMF) metrics from log events.
  * Added handling for metric values, dimensions, timestamps, units, and publication failures.
  * Added an executable EMF simulation example.
  * Added access to metric publication failures and improved metric operation support.

* **Documentation**
  * Clarified metric-filter defaults, failure reporting, and EMF processing behavior.
  * Added guidance and examples for EMF log events.

* **Tests**
  * Added comprehensive EMF, CloudWatch alarm, validation, and failure-handling coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->