### PR TITLE
feat: run a pool's triggers on a federated sign-in

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2752,6 +2752,98 @@ try {
 Cognito. Neither fires for `REFRESH_TOKEN_AUTH`, as neither does on real Cognito, where
 `PreTokenGeneration` does.
 
+### Federated sign-in triggers
+
+A user arriving from an identity provider runs the pool's triggers too, and which ones it runs
+depends on whether the pool has met the subject before. AWS documents the split, and this is what it
+comes to:
+
+| Sign-in event  | Trigger              | Source                              |
+| -------------- | -------------------- | ----------------------------------- |
+| First sign-in  | `PreSignUp`          | `PreSignUp_ExternalProvider`        |
+|                | `PostConfirmation`   | `PostConfirmation_ConfirmSignUp`    |
+|                | `PreTokenGeneration` | `TokenGeneration_HostedAuth`        |
+| Later sign-ins | `PreAuthentication`  | `PreAuthentication_Authentication`  |
+|                | `PostAuthentication` | `PostAuthentication_Authentication` |
+|                | `PreTokenGeneration` | `TokenGeneration_HostedAuth`        |
+
+That split is what an application hangs its own user record off. `PostConfirmation` runs the first
+time a Google user arrives and never again, which is the same place a local sign-up's record is
+written from, so one handler covers both ways in.
+
+```typescript sim-cognito-federated-triggers
+/**
+ * A PostConfirmation trigger that runs on a federated user's first sign-in.
+ */
+
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import type { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The part of the PostConfirmation event this handler reads.
+ */
+interface PostConfirmationEvent {
+  readonly triggerSource: string;
+  readonly userName: string;
+}
+
+// A pool with a domain, a Google provider and an app client, as
+// [the hosted domain example](#signing-in-through-a-hosted-domain) builds one.
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+declare const callbackUrl: string;
+
+const written: string[] = [];
+
+// A record is written here. A deployed handler writes it to DynamoDB.
+const handler = (event: PostConfirmationEvent): unknown => {
+  written.push(`${event.triggerSource} ${event.userName}`);
+
+  return event;
+};
+
+// The function the pool's `LambdaConfig` names in its `PostConfirmation`.
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "post-confirmation",
+    Role: "arn:aws:iam::123456789012:role/TriggerRole",
+    Code: { ZipFile: makeLambdaZipFileInput(handler) },
+  }),
+);
+
+const cognito = simAws.cognitoIdentityProvider();
+const pool = cognito.userPool(userPoolId);
+
+pool.auth.identityProviders.require("Google").signInAs({
+  Subject: "108412093487519382745",
+  Claims: { email: "someone@example.com" },
+});
+
+const authorize = {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: callbackUrl,
+  identity_provider: "Google",
+};
+
+// The first sign-in creates the pool's user for the subject.
+await cognito.hostedAuthorize(pool, authorize);
+console.log(written);
+// ["PostConfirmation_ConfirmSignUp Google_108412093487519382745"]
+
+// The second reaches the same user, and the sign-up triggers stay unfired.
+await cognito.hostedAuthorize(pool, authorize);
+console.log(written.length); // 1
+```
+
+A handler that throws from `PreSignUp` refuses the sign-in, and the pool is left without the user,
+because that trigger runs before the user is added. `autoVerifyEmail` and `autoVerifyPhone` are
+applied the way they are for a sign-up. `autoConfirmUser` has nothing to do, as a federated user is
+created in `EXTERNAL_PROVIDER` and never passes through `UNCONFIRMED`.
+
 ### The event, and what a failure gets back
 
 Every event carries `version`, `region`, `userPoolId`, `userName`, the `triggerSource` naming the
@@ -4516,6 +4608,9 @@ Sim Cognito currently supports:
 - The pool user a federated sign-in creates, named `<ProviderName>_<subject>`, in the
   `EXTERNAL_PROVIDER` status, carrying the `identities` attribute and claim and the attributes the
   provider's `AttributeMapping` named
+- The triggers a federated sign-in runs, being `PreSignUp` and `PostConfirmation` on a first
+  sign-in, `PreAuthentication` and `PostAuthentication` on every one after it, and
+  `PreTokenGeneration` under `TokenGeneration_HostedAuth` when the code is exchanged
 - A `REGIONAL` web ACL in front of the pool, attached by `AssociateWebACL` on simulated WAFv2 and
   evaluated against every request the hosted domain and the two `.well-known` documents answer
 - App client OAuth settings: `AllowedOAuthFlowsUserPoolClient`, `AllowedOAuthFlows`,
@@ -4754,9 +4849,9 @@ Current documented limitations:
   and `CustomMessage` are the only Lambda triggers that run. Every other `LambdaConfig` key is
   refused when the pool is created or updated, naming the trigger, because a pool that accepted one
   would never call the function the template named. The custom challenge triggers would need a
-  challenge loop this simulation lacks, and the migration and federation triggers have no external
-  directory to reach. A simulated identity provider answers with the user `signInAs` put there,
-  beyond the reach of a trigger.
+  challenge loop this simulation lacks, and the migration and inbound federation triggers have no
+  external directory to reach. A simulated identity provider answers with the user `signInAs` put
+  there, beyond the reach of a trigger.
 - `AdminCreateUser` leaves `PostConfirmation` unfired, here and on real Cognito. It is the tempting
   place to hang the trigger and the wrong one. A project relying on it would pass here and write no
   record in production.
@@ -4766,8 +4861,20 @@ Current documented limitations:
 - A `PreSignUp` handler asking to verify an attribute the sign-up did not carry refuses the sign-up
   with `InvalidParameterException`. Real Cognito refuses it too, and what it names the error has not
   been checked against a live account.
-- `PreSignUp_ExternalProvider` goes unreached too. A federated sign-in creates the pool's user
-  directly rather than through the sign-up path a trigger hangs off.
+- A federated first sign-in reports `PreSignUp_ExternalProvider` and then
+  `PostConfirmation_ConfirmSignUp`, and every sign-in after it reports
+  `PreAuthentication_Authentication` and `PostAuthentication_Authentication`. That is the split AWS
+  documents for a federated user, and it is what makes a handler that hangs a profile record off a
+  first sign-in run once for a Google user.
+- `autoConfirmUser` has nothing to do on a federated sign-in. The user is created in
+  `EXTERNAL_PROVIDER` and never passes through `UNCONFIRMED`, so there is no confirmation for a
+  handler to skip. `autoVerifyEmail` and `autoVerifyPhone` are applied there as they are for a
+  sign-up.
+- A code exchanged at the token endpoint reports `TokenGeneration_HostedAuth` where the sign-in
+  happened at an identity provider, and `TokenGeneration_Authentication` where the pool signed in
+  one of its own users. Real Cognito reports the same two. A browser signed in from the managed
+  login session it was already holding reports the local source whichever way that session started,
+  because the session records nothing about the method that began it.
 - A `PostConfirmation` or `PostAuthentication` handler that throws fails the request, and what it
   ran after stands. A confirmed user stays confirmed and the tokens a pool issued stay issued, as
   they do on real Cognito.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2776,9 +2776,18 @@ written from, so one handler covers both ways in.
  * A PostConfirmation trigger that runs on a federated user's first sign-in.
  */
 
-import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  CreateIdentityProviderCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  CreateUserPoolDomainCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 
-import type { SimAws } from "@kensio/yulin";
+import { SimAws } from "@kensio/yulin";
 import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
 
 /**
@@ -2789,32 +2798,84 @@ interface PostConfirmationEvent {
   readonly userName: string;
 }
 
-// A pool with a domain, a Google provider and an app client, as
-// [the hosted domain example](#signing-in-through-a-hosted-domain) builds one.
-declare const simAws: SimAws;
-declare const userPoolId: string;
-declare const clientId: string;
-declare const callbackUrl: string;
-
 const written: string[] = [];
 
 // A record is written here. A deployed handler writes it to DynamoDB.
-const handler = (event: PostConfirmationEvent): unknown => {
+const postConfirmation = (event: PostConfirmationEvent): unknown => {
   written.push(`${event.triggerSource} ${event.userName}`);
 
   return event;
 };
 
-// The function the pool's `LambdaConfig` names in its `PostConfirmation`.
-await simAws.lambda().createFunction(
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+const callbackUrl = "https://www.example.com/user/callback";
+
+// The function comes first, because the pool names it by ARN.
+const functionArn =
+  `arn:aws:lambda:eu-west-2:${simAws.defaultAccountId}` +
+  `:function:post-confirmation`;
+await lambda.createFunction(
   new CreateFunctionCommand({
     FunctionName: "post-confirmation",
-    Role: "arn:aws:iam::123456789012:role/TriggerRole",
-    Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
+    Code: { ZipFile: makeLambdaZipFileInput(postConfirmation) },
   }),
 );
 
-const cognito = simAws.cognitoIdentityProvider();
+const created = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: { PostConfirmation: functionArn },
+  }),
+);
+const userPoolId = created.UserPool?.Id ?? "";
+
+// The permission a CDK `addTrigger` emits, which lets Cognito invoke it.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "post-confirmation",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: created.UserPool?.Arn,
+  }),
+);
+
+await cognito.createIdentityProvider(
+  new CreateIdentityProviderCommand({
+    UserPoolId: userPoolId,
+    ProviderName: "Google",
+    ProviderType: "Google",
+    ProviderDetails: {
+      client_id: "google-client-id",
+      client_secret: "google-client-secret",
+      authorize_scopes: "openid email",
+    },
+    AttributeMapping: { email: "email" },
+  }),
+);
+
+const client = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    AllowedOAuthFlowsUserPoolClient: true,
+    AllowedOAuthFlows: ["code"],
+    AllowedOAuthScopes: ["openid", "email"],
+    CallbackURLs: [callbackUrl],
+    SupportedIdentityProviders: ["Google"],
+  }),
+);
+
+await cognito.createUserPoolDomain(
+  new CreateUserPoolDomainCommand({
+    UserPoolId: userPoolId,
+    Domain: "myapp-login",
+  }),
+);
+
 const pool = cognito.userPool(userPoolId);
 
 pool.auth.identityProviders.require("Google").signInAs({
@@ -2824,7 +2885,7 @@ pool.auth.identityProviders.require("Google").signInAs({
 
 const authorize = {
   response_type: "code",
-  client_id: clientId,
+  client_id: client.UserPoolClient?.ClientId ?? "",
   redirect_uri: callbackUrl,
   identity_provider: "Google",
 };

--- a/docs/services/cognito/sim-cognito-federated-triggers.example.ts
+++ b/docs/services/cognito/sim-cognito-federated-triggers.example.ts
@@ -1,0 +1,65 @@
+/**
+ * A PostConfirmation trigger that runs on a federated user's first sign-in.
+ */
+
+import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+
+import type { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+/**
+ * The part of the PostConfirmation event this handler reads.
+ */
+interface PostConfirmationEvent {
+  readonly triggerSource: string;
+  readonly userName: string;
+}
+
+// A pool with a domain, a Google provider and an app client, as
+// [the hosted domain example](#signing-in-through-a-hosted-domain) builds one.
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+declare const callbackUrl: string;
+
+const written: string[] = [];
+
+// A record is written here. A deployed handler writes it to DynamoDB.
+const handler = (event: PostConfirmationEvent): unknown => {
+  written.push(`${event.triggerSource} ${event.userName}`);
+
+  return event;
+};
+
+// The function the pool's `LambdaConfig` names in its `PostConfirmation`.
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "post-confirmation",
+    Role: "arn:aws:iam::123456789012:role/TriggerRole",
+    Code: { ZipFile: makeLambdaZipFileInput(handler) },
+  }),
+);
+
+const cognito = simAws.cognitoIdentityProvider();
+const pool = cognito.userPool(userPoolId);
+
+pool.auth.identityProviders.require("Google").signInAs({
+  Subject: "108412093487519382745",
+  Claims: { email: "someone@example.com" },
+});
+
+const authorize = {
+  response_type: "code",
+  client_id: clientId,
+  redirect_uri: callbackUrl,
+  identity_provider: "Google",
+};
+
+// The first sign-in creates the pool's user for the subject.
+await cognito.hostedAuthorize(pool, authorize);
+console.log(written);
+// ["PostConfirmation_ConfirmSignUp Google_108412093487519382745"]
+
+// The second reaches the same user, and the sign-up triggers stay unfired.
+await cognito.hostedAuthorize(pool, authorize);
+console.log(written.length); // 1

--- a/docs/services/cognito/sim-cognito-federated-triggers.example.ts
+++ b/docs/services/cognito/sim-cognito-federated-triggers.example.ts
@@ -2,9 +2,18 @@
  * A PostConfirmation trigger that runs on a federated user's first sign-in.
  */
 
-import { CreateFunctionCommand } from "@aws-sdk/client-lambda";
+import {
+  CreateIdentityProviderCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+  CreateUserPoolDomainCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
 
-import type { SimAws } from "@kensio/yulin";
+import { SimAws } from "@kensio/yulin";
 import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
 
 /**
@@ -15,32 +24,84 @@ interface PostConfirmationEvent {
   readonly userName: string;
 }
 
-// A pool with a domain, a Google provider and an app client, as
-// [the hosted domain example](#signing-in-through-a-hosted-domain) builds one.
-declare const simAws: SimAws;
-declare const userPoolId: string;
-declare const clientId: string;
-declare const callbackUrl: string;
-
 const written: string[] = [];
 
 // A record is written here. A deployed handler writes it to DynamoDB.
-const handler = (event: PostConfirmationEvent): unknown => {
+const postConfirmation = (event: PostConfirmationEvent): unknown => {
   written.push(`${event.triggerSource} ${event.userName}`);
 
   return event;
 };
 
-// The function the pool's `LambdaConfig` names in its `PostConfirmation`.
-await simAws.lambda().createFunction(
+const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+const lambda = simAws.lambda();
+const cognito = simAws.cognitoIdentityProvider();
+const callbackUrl = "https://www.example.com/user/callback";
+
+// The function comes first, because the pool names it by ARN.
+const functionArn =
+  `arn:aws:lambda:eu-west-2:${simAws.defaultAccountId}` +
+  `:function:post-confirmation`;
+await lambda.createFunction(
   new CreateFunctionCommand({
     FunctionName: "post-confirmation",
-    Role: "arn:aws:iam::123456789012:role/TriggerRole",
-    Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
+    Code: { ZipFile: makeLambdaZipFileInput(postConfirmation) },
   }),
 );
 
-const cognito = simAws.cognitoIdentityProvider();
+const created = await cognito.createUserPool(
+  new CreateUserPoolCommand({
+    PoolName: "myapp-users",
+    LambdaConfig: { PostConfirmation: functionArn },
+  }),
+);
+const userPoolId = created.UserPool?.Id ?? "";
+
+// The permission a CDK `addTrigger` emits, which lets Cognito invoke it.
+await lambda.addPermission(
+  new AddPermissionCommand({
+    FunctionName: "post-confirmation",
+    StatementId: "AllowCognito",
+    Action: "lambda:InvokeFunction",
+    Principal: "cognito-idp.amazonaws.com",
+    SourceArn: created.UserPool?.Arn,
+  }),
+);
+
+await cognito.createIdentityProvider(
+  new CreateIdentityProviderCommand({
+    UserPoolId: userPoolId,
+    ProviderName: "Google",
+    ProviderType: "Google",
+    ProviderDetails: {
+      client_id: "google-client-id",
+      client_secret: "google-client-secret",
+      authorize_scopes: "openid email",
+    },
+    AttributeMapping: { email: "email" },
+  }),
+);
+
+const client = await cognito.createUserPoolClient(
+  new CreateUserPoolClientCommand({
+    UserPoolId: userPoolId,
+    ClientName: "web",
+    AllowedOAuthFlowsUserPoolClient: true,
+    AllowedOAuthFlows: ["code"],
+    AllowedOAuthScopes: ["openid", "email"],
+    CallbackURLs: [callbackUrl],
+    SupportedIdentityProviders: ["Google"],
+  }),
+);
+
+await cognito.createUserPoolDomain(
+  new CreateUserPoolDomainCommand({
+    UserPoolId: userPoolId,
+    Domain: "myapp-login",
+  }),
+);
+
 const pool = cognito.userPool(userPoolId);
 
 pool.auth.identityProviders.require("Google").signInAs({
@@ -50,7 +111,7 @@ pool.auth.identityProviders.require("Google").signInAs({
 
 const authorize = {
   response_type: "code",
-  client_id: clientId,
+  client_id: client.UserPoolClient?.ClientId ?? "",
   redirect_uri: callbackUrl,
   identity_provider: "Google",
 };

--- a/src/service/cognito/command/hosted/sim-cognito-authorize-endpoint.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-authorize-endpoint.ts
@@ -50,11 +50,11 @@ export class SimCognitoAuthorizeEndpoint {
    * `presentedSession` is the managed login session the browser carried, which
    * the serving layer reads out of the `cognito` cookie.
    */
-  handle(
+  async handle(
     pool: SimCognitoUserPool,
     input: SimCognitoAuthorizeInput,
     presentedSession?: string,
-  ): SimCognitoHostedRedirect {
+  ): Promise<SimCognitoHostedRedirect> {
     const client = this.hostedClient.forAuthorize(pool, input.client_id);
     const redirectUri = this.hostedClient.requiredRedirectUri(
       client,
@@ -69,7 +69,12 @@ export class SimCognitoAuthorizeEndpoint {
     this.request.requireChallengeMethod(input);
 
     const scopes = new SimCognitoGrantedScopes(client, input.scope);
-    const signedIn = this.signIn.signIn(pool, client, input, presentedSession);
+    const signedIn = await this.signIn.signIn(
+      pool,
+      client,
+      input,
+      presentedSession,
+    );
     const { user } = signedIn;
 
     const code = new SimCognitoAuthorizationCode({
@@ -79,6 +84,7 @@ export class SimCognitoAuthorizeEndpoint {
       scopes: scopes.values,
       issuedAt: this.clock.now(),
       codeChallenge: input.code_challenge,
+      federated: signedIn.federated,
     });
 
     pool.auth.addAuthorizationCode(code);

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-commands.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-commands.ts
@@ -1,6 +1,7 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimCognitoFederatedSignIn } from "../../user-pool/idp/sim-cognito-federated-sign-in.js";
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
 import type { SimCognitoFirstFactorChallenge } from "../auth/sim-cognito-first-factor-challenge.js";
 import { SimCognitoAuthorizeEndpoint } from "./sim-cognito-authorize-endpoint.js";
@@ -11,6 +12,12 @@ import { SimCognitoTokenEndpoint } from "./sim-cognito-token-endpoint.js";
 interface SimCognitoHostedCommandsProperties {
   readonly tokenIssuer: SimCognitoTokenIssuer;
   readonly userFactory: SimCognitoUserFactory;
+
+  /**
+   * The trigger runner the API operations use, which a federated sign-in runs
+   * the pool's sign-up and sign-in triggers through.
+   */
+  readonly triggers: SimCognitoUserPoolTriggers;
 
   /**
    * What asks a user for a passkey, shared with the API sign-ins so a passkey
@@ -35,11 +42,14 @@ export class SimCognitoHostedCommands {
   public readonly logout = new SimCognitoLogoutEndpoint();
 
   constructor(properties: SimCognitoHostedCommandsProperties) {
-    const { tokenIssuer, userFactory, challenge, clock } = properties;
+    const { tokenIssuer, userFactory, triggers, challenge, clock } = properties;
 
     this.authorize = new SimCognitoAuthorizeEndpoint({
       signIn: new SimCognitoHostedSignIn({
-        federatedSignIn: new SimCognitoFederatedSignIn({ userFactory }),
+        federatedSignIn: new SimCognitoFederatedSignIn({
+          userFactory,
+          triggers,
+        }),
         challenge,
         clock,
       }),

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-sign-in.ts
@@ -54,12 +54,12 @@ export class SimCognitoHostedSignIn {
    * The user this request signs in, at a provider, in the pool itself, or from
    * the managed login session the browser presented.
    */
-  signIn(
+  async signIn(
     pool: SimCognitoUserPool,
     client: SimCognitoUserPoolClient,
     input: SimCognitoAuthorizeInput,
     presentedSession: string | undefined,
-  ): SimCognitoHostedSignedIn {
+  ): Promise<SimCognitoHostedSignedIn> {
     const provider = this.request.signInProvider(pool, client, input);
 
     if (provider === undefined) {
@@ -67,9 +67,14 @@ export class SimCognitoHostedSignIn {
     }
 
     const now = this.clock.now();
-    const user = this.federatedSignIn.signIn({ pool, provider, now });
+    const user = await this.federatedSignIn.signIn({
+      pool,
+      client,
+      provider,
+      now,
+    });
 
-    return this.browserSession.start(pool, user, now);
+    return this.browserSession.start(pool, user, now).asFederated();
   }
 
   /**

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-signed-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-signed-in.ts
@@ -4,22 +4,48 @@ import type { SimCognitoSessionChange } from "./sim-cognito-session-change.js";
 interface SimCognitoHostedSignedInProperties {
   readonly user: SimCognitoUser;
   readonly session: SimCognitoSessionChange;
+
+  /**
+   * Whether this request signed the user in at an identity provider.
+   *
+   * The tokens a federated sign-in hands out report a `PreTokenGeneration`
+   * source of their own, and the code the endpoint issues is what carries the
+   * answer as far as the token endpoint.
+   */
+  readonly federated?: boolean | undefined;
 }
 
 /**
  * Who an authorize request signed in, and what it did to the browser's managed
  * login session on the way.
  *
- * The two travel together because the endpoint needs both: the user is who the
- * authorization code is issued for, and the session change is what the
- * response tells the browser to hold.
+ * These travel together because the endpoint needs all of them. The user is
+ * who the authorization code is issued for, the session change is what the
+ * response tells the browser to hold, and the federated flag is what the code
+ * remembers about how the sign-in happened.
  */
 export class SimCognitoHostedSignedIn {
   public readonly user: SimCognitoUser;
   public readonly session: SimCognitoSessionChange;
+  public readonly federated: boolean;
 
   constructor(properties: SimCognitoHostedSignedInProperties) {
     this.user = properties.user;
     this.session = properties.session;
+    this.federated = properties.federated ?? false;
+  }
+
+  /**
+   * The same sign-in, marked as having happened at an identity provider.
+   *
+   * The browser session is started the same way whichever way the user signed
+   * in, so this is applied afterwards by the one path that federates.
+   */
+  asFederated(): SimCognitoHostedSignedIn {
+    return new SimCognitoHostedSignedIn({
+      user: this.user,
+      session: this.session,
+      federated: true,
+    });
   }
 }

--- a/src/service/cognito/command/hosted/sim-cognito-token-grants.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-token-grants.ts
@@ -40,6 +40,11 @@ export class SimCognitoTokenGrants {
    * The code is spent whether or not the rest of the request turns out to be
    * right, as real Cognito spends one, so nothing can be retried with a code
    * that has already been presented.
+   *
+   * The `PreTokenGeneration` source says which sign-in the grant came from.
+   * A code from an identity provider reports `TokenGeneration_HostedAuth`, and
+   * one from the pool's own sign-in form reports the
+   * `TokenGeneration_Authentication` its API sign-in reports.
    */
   async exchangeCode(
     pool: SimCognitoUserPool,
@@ -57,7 +62,9 @@ export class SimCognitoTokenGrants {
       pool,
       client,
       user,
-      occasion: SimCognitoTriggerOccasion.tokenGeneration,
+      occasion: code.federated
+        ? SimCognitoTriggerOccasion.hostedTokenGeneration
+        : SimCognitoTriggerOccasion.tokenGeneration,
       scopes: code.scopes,
     });
 

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -223,6 +223,7 @@ export class SimCognitoCommands {
     this.hosted = new SimCognitoHostedCommands({
       tokenIssuer,
       userFactory,
+      triggers,
       challenge: firstFactor,
       clock,
     });

--- a/src/service/cognito/user-pool/auth/sim-cognito-authorization-code.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-authorization-code.ts
@@ -24,6 +24,15 @@ interface SimCognitoAuthorizationCodeProperties {
    * has to produce the verifier for.
    */
   readonly codeChallenge?: string | undefined;
+
+  /**
+   * Whether the sign-in this code came from happened at an identity provider.
+   *
+   * The token endpoint reads it to pick the `PreTokenGeneration` source, which
+   * real Cognito reports as `TokenGeneration_HostedAuth` for a federated grant
+   * and `TokenGeneration_Authentication` for a local one.
+   */
+  readonly federated?: boolean | undefined;
 }
 
 /**
@@ -41,6 +50,7 @@ export class SimCognitoAuthorizationCode {
   public readonly redirectUri: string;
   public readonly scopes: readonly string[];
   public readonly issuedAt: Date;
+  public readonly federated: boolean;
 
   private readonly codeChallenge: string | undefined;
 
@@ -51,6 +61,7 @@ export class SimCognitoAuthorizationCode {
     this.redirectUri = properties.redirectUri;
     this.scopes = properties.scopes;
     this.issuedAt = properties.issuedAt;
+    this.federated = properties.federated ?? false;
     this.codeChallenge = properties.codeChallenge;
   }
 

--- a/src/service/cognito/user-pool/idp/sim-cognito-federated-sign-in.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-federated-sign-in.ts
@@ -1,17 +1,26 @@
-import { SimCognitoUsernameExistsException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import type { SimCognitoUserPoolTriggers } from "../trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+import type { SimCognitoAttributeType } from "../user/sim-cognito-user-attributes.js";
 import type { SimCognitoUserFactory } from "../user/sim-cognito-user-factory.js";
-import { requireSimCognitoUsername } from "../user/sim-cognito-username.js";
+import {
+  requireSimCognitoUsername,
+  type SimCognitoUsername,
+} from "../user/sim-cognito-username.js";
 import { SimCognitoFederatedIdentity } from "./sim-cognito-federated-identity.js";
+import { SimCognitoFederatedTriggers } from "./sim-cognito-federated-triggers.js";
+import { requireSimCognitoSameFederatedIdentity } from "./sim-cognito-same-federated-identity.js";
 import type { SimCognitoUserPoolIdentityProvider } from "./sim-cognito-user-pool-identity-provider.js";
 
 interface SimCognitoFederatedSignInProperties {
   readonly userFactory: SimCognitoUserFactory;
+  readonly triggers: SimCognitoUserPoolTriggers;
 }
 
 interface SimCognitoFederatedSignInRequest {
   readonly pool: SimCognitoUserPool;
+  readonly client: SimCognitoUserPoolClient;
   readonly provider: SimCognitoUserPoolIdentityProvider;
   readonly now: Date;
 }
@@ -30,47 +39,32 @@ interface SimCognitoFederatedSignInRequest {
  * The provider's claims reach the user through the provider's attribute
  * mapping, on every sign-in rather than only the first, because real Cognito
  * updates a mapped attribute when the value at the provider changes.
+ *
+ * Which triggers fire depends on whether the pool has met this subject before.
+ * A first sign-in is a sign-up, and runs `PreSignUp` and `PostConfirmation`.
+ * Every sign-in after it is an authentication, and runs `PreAuthentication`
+ * and `PostAuthentication`. That is the split AWS documents for federated
+ * users, and it means a handler creating a profile record on first sight of a
+ * user runs once for a Google user rather than on every visit.
  */
 export class SimCognitoFederatedSignIn {
   private readonly userFactory: SimCognitoUserFactory;
+  private readonly triggers: SimCognitoFederatedTriggers;
 
   constructor(properties: SimCognitoFederatedSignInProperties) {
     this.userFactory = properties.userFactory;
-  }
-
-  /**
-   * Refuse a sign-in that would take over a user it did not create.
-   *
-   * A username is only reserved by being taken, and a pool's own user may
-   * validly be called `Google_1234`, so the user found by name is only the
-   * federated one when its identity says so. Signing in as it otherwise would
-   * hand an application a token for someone else's account, which is worth
-   * refusing rather than guessing at.
-   */
-  private static requireSameIdentity(
-    existing: SimCognitoUser,
-    provider: SimCognitoUserPoolIdentityProvider,
-  ): void {
-    const { identity } = existing;
-    const externalUser = provider.requireSignedInUser();
-
-    if (
-      identity?.providerName !== provider.name ||
-      identity.userId !== externalUser.subject
-    ) {
-      throw new SimCognitoUsernameExistsException(
-        `User ${existing.username} already exists in user pool ` +
-          `${provider.userPoolId} and is not the ${provider.name} user this ` +
-          `sign-in is for.`,
-      );
-    }
+    this.triggers = new SimCognitoFederatedTriggers({
+      triggers: properties.triggers,
+    });
   }
 
   /**
    * Sign the user signed in at the provider in to the pool.
    */
-  signIn(request: SimCognitoFederatedSignInRequest): SimCognitoUser {
-    const { pool, provider, now } = request;
+  async signIn(
+    request: SimCognitoFederatedSignInRequest,
+  ): Promise<SimCognitoUser> {
+    const { pool, provider } = request;
     const externalUser = provider.requireSignedInUser();
     const username = requireSimCognitoUsername(
       `${provider.name}_${externalUser.subject}`,
@@ -79,11 +73,55 @@ export class SimCognitoFederatedSignIn {
     const existing = pool.findUser(username);
 
     if (existing !== undefined) {
-      SimCognitoFederatedSignIn.requireSameIdentity(existing, provider);
-      existing.updateAttributes(attributes);
+      requireSimCognitoSameFederatedIdentity(existing, provider);
 
-      return existing;
+      return this.returningUser(request, existing, attributes);
     }
+
+    return this.newUser(request, username, attributes);
+  }
+
+  /**
+   * Sign in a subject the pool already holds a user for.
+   *
+   * `PreAuthentication` runs before the mapped attributes are brought up to
+   * date, so a handler that refuses the sign-in leaves the user as it was.
+   */
+  private async returningUser(
+    request: SimCognitoFederatedSignInRequest,
+    user: SimCognitoUser,
+    attributes: readonly SimCognitoAttributeType[],
+  ): Promise<SimCognitoUser> {
+    const { pool, client } = request;
+
+    await this.triggers.beforeSignIn({ pool, client, user });
+
+    user.updateAttributes(attributes);
+
+    await this.triggers.afterSignIn({ pool, client, user });
+
+    return user;
+  }
+
+  /**
+   * Build and sign in the pool's user for a subject it has never seen.
+   *
+   * The order is the sign-up's order. `PreSignUp` runs on a user that is not
+   * in the pool yet, so a handler that throws leaves the pool without it, and
+   * `PostConfirmation` runs on the user the pool now holds.
+   *
+   * `autoConfirmUser` has nothing to do here. A federated user is created in
+   * `EXTERNAL_PROVIDER` and never passes through `UNCONFIRMED`, so there is no
+   * confirmation for a handler to skip. `autoVerifyEmail` and `autoVerifyPhone`
+   * are applied, as they are for a sign-up.
+   */
+  private async newUser(
+    request: SimCognitoFederatedSignInRequest,
+    username: SimCognitoUsername,
+    attributes: readonly SimCognitoAttributeType[],
+  ): Promise<SimCognitoUser> {
+    const { pool, client, provider, now } = request;
+    const externalUser = provider.requireSignedInUser();
 
     const user = this.userFactory.federated({
       username,
@@ -98,7 +136,12 @@ export class SimCognitoFederatedSignIn {
       }),
     });
 
+    const preSignUp = await this.triggers.beforeSignUp({ pool, client, user });
+
+    preSignUp.verifyAttributesOf(user);
     pool.addUser(user);
+
+    await this.triggers.afterSignUp({ pool, client, user });
 
     return user;
   }

--- a/src/service/cognito/user-pool/idp/sim-cognito-federated-sign-in.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-federated-sign-in.ts
@@ -1,3 +1,4 @@
+import { requireSimCognitoEnabled } from "../auth/sim-cognito-sign-in.js";
 import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
 import type { SimCognitoUserPoolTriggers } from "../trigger/sim-cognito-user-pool-triggers.js";
@@ -86,6 +87,10 @@ export class SimCognitoFederatedSignIn {
    *
    * `PreAuthentication` runs before the mapped attributes are brought up to
    * date, so a handler that refuses the sign-in leaves the user as it was.
+   *
+   * A disabled user is refused after that trigger and not before it, which is
+   * the order the API sign-ins use: real Cognito hands the trigger the user to
+   * decide about, and a sign-in the pool is going to refuse reaches it too.
    */
   private async returningUser(
     request: SimCognitoFederatedSignInRequest,
@@ -95,6 +100,8 @@ export class SimCognitoFederatedSignIn {
     const { pool, client } = request;
 
     await this.triggers.beforeSignIn({ pool, client, user });
+
+    requireSimCognitoEnabled(user);
 
     user.updateAttributes(attributes);
 

--- a/src/service/cognito/user-pool/idp/sim-cognito-federated-triggers.iso.test.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-federated-triggers.iso.test.ts
@@ -1,0 +1,268 @@
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../../aws/sim-aws-account.js";
+import {
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+  simCognitoSignedInAtGoogle,
+  type SimCognitoHostedSetUp,
+} from "../../../../../test/cognito/federation-fixture.js";
+import {
+  answeringTriggerHandler,
+  recordingTriggerHandler,
+} from "../../../../../test/cognito/trigger-handler-fixture.js";
+import { triggerFunctionArnIn } from "../../../../../test/cognito/trigger-fixture.js";
+
+/**
+ * The ARN of the trigger function in the region the hosted fixture builds in.
+ */
+const functionArn = triggerFunctionArnIn(
+  "eu-west-2",
+  DEFAULT_SIM_AWS_ACCOUNT_ID,
+);
+
+/**
+ * Sign the user the Google provider holds in, and answer with the
+ * authorization code the browser was sent back with.
+ */
+async function federatedSignIn(setUp: SimCognitoHostedSetUp): Promise<string> {
+  const redirect = await setUp.cognito.hostedAuthorize(
+    setUp.cognito.userPool(setUp.userPoolId),
+    {
+      response_type: "code",
+      client_id: setUp.clientId,
+      redirect_uri: simCognitoCallbackUrl,
+      identity_provider: "Google",
+    },
+  );
+
+  const code = new URL(redirect.location).searchParams.get("code");
+  assertNonNullable(code);
+
+  return code;
+}
+
+/**
+ * The `triggerSource` of every event a handler recorded, in the order it ran.
+ */
+function sourcesOf(events: readonly unknown[]): readonly string[] {
+  return events.map(
+    (event) => (event as { triggerSource: string }).triggerSource,
+  );
+}
+
+describe("The Lambda triggers a sim Cognito federated sign-in runs", () => {
+  it("runs PreSignUp under the external provider source on a first sign-in", async () => {
+    // Given a pool whose PreSignUp trigger records what it is given, and a
+    // Google provider holding a subject the pool has never seen.
+    const events: unknown[] = [];
+    const setUp = await simCognitoHosted({
+      triggers: { PreSignUp: functionArn },
+      handler: recordingTriggerHandler(events),
+    });
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+      given_name: "Sam",
+    });
+
+    // When that subject signs in for the first time.
+    await federatedSignIn(setUp);
+
+    // Then the handler was given the source real Cognito reports for a
+    // federated first sign-in, carrying the attributes the provider's mapping
+    // produced.
+    assertObjectMatches(events[0], {
+      triggerSource: "PreSignUp_ExternalProvider",
+      userPoolId: setUp.userPoolId,
+      userName: "Google_google-subject-1",
+      callerContext: { clientId: setUp.clientId },
+      request: {
+        userAttributes: { email: "someone@example.com", given_name: "Sam" },
+      },
+    });
+    assertArrayLength(events, 1);
+  });
+
+  it("runs PostConfirmation on the federated user the pool now holds", async () => {
+    // Given a pool whose PostConfirmation trigger records what it is given.
+    const events: unknown[] = [];
+    const setUp = await simCognitoHosted({
+      triggers: { PostConfirmation: functionArn },
+      handler: recordingTriggerHandler(events),
+    });
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+
+    // When the subject signs in for the first time.
+    await federatedSignIn(setUp);
+
+    // Then the handler ran under the source real Cognito reports, on a user
+    // carrying the `sub` the pool allocated. That `sub` is what an application
+    // hangs its own record off.
+    assertArrayEquals(sourcesOf(events), ["PostConfirmation_ConfirmSignUp"]);
+
+    const user = setUp.cognito
+      .userPool(setUp.userPoolId)
+      .requireUser("Google_google-subject-1" as never);
+    assertObjectMatches(events[0], {
+      request: { userAttributes: { sub: user.sub } },
+    });
+  });
+
+  it("runs the authentication triggers rather than the sign-up ones on a later sign-in", async () => {
+    // Given a pool naming all four triggers, and a subject that has signed in
+    // once already.
+    const events: unknown[] = [];
+    const setUp = await simCognitoHosted({
+      triggers: {
+        PreSignUp: functionArn,
+        PostConfirmation: functionArn,
+        PreAuthentication: functionArn,
+        PostAuthentication: functionArn,
+      },
+      handler: recordingTriggerHandler(events),
+    });
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+    await federatedSignIn(setUp);
+    events.length = 0;
+
+    // When the same subject signs in again.
+    await federatedSignIn(setUp);
+
+    // Then the sign-in triggers ran and neither sign-up trigger did, which is
+    // the split AWS documents for a federated user. A handler creating a
+    // profile record on first sight runs once rather than on every visit.
+    assertArrayEquals(sourcesOf(events), [
+      "PreAuthentication_Authentication",
+      "PostAuthentication_Authentication",
+    ]);
+  });
+
+  it("refuses the sign-in and creates no user where PreSignUp throws", async () => {
+    // Given a pool whose PreSignUp trigger refuses everybody.
+    const setUp = await simCognitoHosted({
+      triggers: { PreSignUp: functionArn },
+      handler: () => {
+        throw new Error("This address is not allowed to sign up.");
+      },
+    });
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+
+    // When the subject signs in for the first time.
+    const error = await assertThrowsErrorAsync(async () => {
+      await federatedSignIn(setUp);
+    });
+
+    // Then the sign-in is refused carrying what the handler threw, and the
+    // pool holds no user for the subject: PreSignUp runs before the user is
+    // added, here as on real Cognito.
+    assertStringIncludes(
+      error.message,
+      "This address is not allowed to sign up.",
+    );
+    assertUndefined(
+      setUp.cognito
+        .userPool(setUp.userPoolId)
+        .findUser("Google_google-subject-1"),
+    );
+  });
+
+  it("verifies the attributes a PreSignUp handler asked to verify", async () => {
+    // Given a pool whose PreSignUp trigger auto-verifies an email address.
+    const setUp = await simCognitoHosted({
+      triggers: { PreSignUp: functionArn },
+      handler: answeringTriggerHandler({ autoVerifyEmail: true }),
+    });
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+
+    // When the subject signs in for the first time.
+    await federatedSignIn(setUp);
+
+    // Then the federated user's address is verified, as it is for a sign-up
+    // the same handler answers.
+    const attributes = setUp.cognito
+      .userPool(setUp.userPoolId)
+      .requireUser("Google_google-subject-1" as never).attributeValues;
+    assertIdentical(attributes.get("email_verified"), "true");
+  });
+});
+
+describe("The PreTokenGeneration source a sim Cognito hosted grant reports", () => {
+  it("is TokenGeneration_HostedAuth for a code from an identity provider", async () => {
+    // Given a pool whose PreTokenGeneration trigger records what it is given.
+    const events: unknown[] = [];
+    const setUp = await simCognitoHosted({
+      triggers: { PreTokenGeneration: functionArn },
+      handler: recordingTriggerHandler(events),
+    });
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+
+    // When a federated sign-in's code is exchanged for tokens.
+    const code = await federatedSignIn(setUp);
+    await setUp.cognito.hostedToken(setUp.cognito.userPool(setUp.userPoolId), {
+      grant_type: "authorization_code",
+      client_id: setUp.clientId,
+      code,
+      redirect_uri: simCognitoCallbackUrl,
+    });
+
+    // Then the handler read the source real Cognito reports for tokens a
+    // federated sign-in hands out.
+    assertArrayEquals(sourcesOf(events), ["TokenGeneration_HostedAuth"]);
+  });
+
+  it("is TokenGeneration_Authentication for a code from the pool's own form", async () => {
+    // Given the same pool, and a user of the pool's own.
+    const events: unknown[] = [];
+    const setUp = await simCognitoHosted({
+      triggers: { PreTokenGeneration: functionArn },
+      handler: recordingTriggerHandler(events),
+    });
+    await simCognitoLocalUser(setUp);
+
+    // When that user signs in at the authorize endpoint and the code is
+    // exchanged.
+    const pool = setUp.cognito.userPool(setUp.userPoolId);
+    const redirect = await setUp.cognito.hostedAuthorize(pool, {
+      response_type: "code",
+      client_id: setUp.clientId,
+      redirect_uri: simCognitoCallbackUrl,
+      username: simCognitoLocalUsername,
+      password: simCognitoLocalPassword,
+    });
+    const code = new URL(redirect.location).searchParams.get("code");
+    assertNonNullable(code);
+    await setUp.cognito.hostedToken(pool, {
+      grant_type: "authorization_code",
+      client_id: setUp.clientId,
+      code,
+      redirect_uri: simCognitoCallbackUrl,
+    });
+
+    // Then it read the source an API sign-in reports, which is what real
+    // Cognito reports for a local user at managed login.
+    assertArrayEquals(sourcesOf(events), ["TokenGeneration_Authentication"]);
+  });
+});

--- a/src/service/cognito/user-pool/idp/sim-cognito-federated-triggers.iso.test.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-federated-triggers.iso.test.ts
@@ -1,3 +1,4 @@
+import { AdminDisableUserCommand } from "@aws-sdk/client-cognito-identity-provider";
 import {
   assertArrayEquals,
   assertArrayLength,
@@ -204,6 +205,63 @@ describe("The Lambda triggers a sim Cognito federated sign-in runs", () => {
       .userPool(setUp.userPoolId)
       .requireUser("Google_google-subject-1" as never).attributeValues;
     assertIdentical(attributes.get("email_verified"), "true");
+  });
+});
+
+describe("A disabled sim Cognito federated user", () => {
+  it("is refused the sign-in its provider would otherwise complete", async () => {
+    // Given a subject that has signed in once, disabled since.
+    const setUp = await simCognitoHosted();
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+    await federatedSignIn(setUp);
+    await setUp.cognito.adminDisableUser(
+      new AdminDisableUserCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: "Google_google-subject-1",
+      }),
+    );
+
+    // When it signs in at the provider again.
+    const error = await assertThrowsErrorAsync(async () => {
+      await federatedSignIn(setUp);
+    });
+
+    // Then the pool refuses it the way it refuses every other disabled
+    // sign-in, rather than issuing a code for it.
+    assertStringIncludes(error.message, "User is disabled.");
+  });
+
+  it("reaches PreAuthentication before the pool refuses it", async () => {
+    // Given the same disabled user, in a pool whose PreAuthentication trigger
+    // records what it is given.
+    const events: unknown[] = [];
+    const setUp = await simCognitoHosted({
+      triggers: { PreAuthentication: functionArn },
+      handler: recordingTriggerHandler(events),
+    });
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+    await federatedSignIn(setUp);
+    await setUp.cognito.adminDisableUser(
+      new AdminDisableUserCommand({
+        UserPoolId: setUp.userPoolId,
+        Username: "Google_google-subject-1",
+      }),
+    );
+    events.length = 0;
+
+    // When it signs in again.
+    await assertThrowsErrorAsync(async () => {
+      await federatedSignIn(setUp);
+    });
+
+    // Then the trigger ran first, as it does for an API sign-in the pool is
+    // about to refuse. The handler is given the user to decide about, so it
+    // sees the ones the pool turns away as well.
+    assertArrayEquals(sourcesOf(events), ["PreAuthentication_Authentication"]);
   });
 });
 

--- a/src/service/cognito/user-pool/idp/sim-cognito-federated-triggers.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-federated-triggers.ts
@@ -1,0 +1,80 @@
+import type { SimCognitoUserPoolClient } from "../client/sim-cognito-user-pool-client.js";
+import type { SimCognitoUserPool } from "../sim-cognito-user-pool.js";
+import type { SimCognitoPreSignUpResponse } from "../trigger/sim-cognito-pre-sign-up-response.js";
+import { SimCognitoTriggerOccasion } from "../trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoUserPoolTriggers } from "../trigger/sim-cognito-user-pool-triggers.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+
+interface SimCognitoFederatedTriggersProperties {
+  readonly triggers: SimCognitoUserPoolTriggers;
+}
+
+interface SimCognitoFederatedTriggerContext {
+  readonly pool: SimCognitoUserPool;
+  readonly client: SimCognitoUserPoolClient;
+  readonly user: SimCognitoUser;
+}
+
+/**
+ * The triggers a sign-in at an identity provider runs, in the order they run.
+ *
+ * AWS documents two sets. A subject the pool has never seen is signing up, and
+ * runs `PreSignUp` and then `PostConfirmation`. A subject it already holds a
+ * user for is authenticating, and runs `PreAuthentication` and then
+ * `PostAuthentication`. Keeping the pair here rather than in the sign-in makes
+ * the two sequences the whole of what this says.
+ */
+export class SimCognitoFederatedTriggers {
+  private readonly triggers: SimCognitoUserPoolTriggers;
+
+  constructor(properties: SimCognitoFederatedTriggersProperties) {
+    this.triggers = properties.triggers;
+  }
+
+  /**
+   * Run the trigger that guards a first sign-in, and answer with what its
+   * handler asked for.
+   *
+   * It runs on a user the pool has yet to be given, so a handler that throws
+   * leaves the pool without it.
+   */
+  async beforeSignUp(
+    context: SimCognitoFederatedTriggerContext,
+  ): Promise<SimCognitoPreSignUpResponse> {
+    return this.triggers.preSignUp(
+      SimCognitoTriggerOccasion.externalProviderSignUp,
+      context,
+    );
+  }
+
+  /**
+   * Run the trigger that follows a first sign-in, on the user the pool now
+   * holds.
+   *
+   * The source is the one a local confirmation reports, so an application
+   * writing its own user record from that handler writes one for a federated
+   * user without adding anything.
+   */
+  async afterSignUp(context: SimCognitoFederatedTriggerContext): Promise<void> {
+    await this.triggers.postConfirmation(
+      SimCognitoTriggerOccasion.confirmSignUp,
+      context,
+    );
+  }
+
+  /**
+   * Run the trigger that guards a sign-in by a subject the pool already knows.
+   */
+  async beforeSignIn(
+    context: SimCognitoFederatedTriggerContext,
+  ): Promise<void> {
+    await this.triggers.preAuthentication(context);
+  }
+
+  /**
+   * Run the trigger that follows one.
+   */
+  async afterSignIn(context: SimCognitoFederatedTriggerContext): Promise<void> {
+    await this.triggers.postAuthentication(context);
+  }
+}

--- a/src/service/cognito/user-pool/idp/sim-cognito-same-federated-identity.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-same-federated-identity.ts
@@ -1,0 +1,31 @@
+import { SimCognitoUsernameExistsException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+import type { SimCognitoUserPoolIdentityProvider } from "./sim-cognito-user-pool-identity-provider.js";
+
+/**
+ * Refuse a federated sign-in that would take over a user it did not create.
+ *
+ * A username is only reserved by being taken, and a pool's own user may validly
+ * be called `Google_1234`, so the user found by name is the federated one only
+ * when its identity says so. Signing in as it otherwise would hand an
+ * application a token for someone else's account, which is worth refusing
+ * rather than guessing at.
+ */
+export function requireSimCognitoSameFederatedIdentity(
+  existing: SimCognitoUser,
+  provider: SimCognitoUserPoolIdentityProvider,
+): void {
+  const { identity } = existing;
+  const externalUser = provider.requireSignedInUser();
+
+  if (
+    identity?.providerName !== provider.name ||
+    identity.userId !== externalUser.subject
+  ) {
+    throw new SimCognitoUsernameExistsException(
+      `User ${existing.username} already exists in user pool ` +
+        `${provider.userPoolId} and is not the ${provider.name} user this ` +
+        `sign-in is for.`,
+    );
+  }
+}

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-name.ts
@@ -3,8 +3,9 @@
  *
  * These are the ones that fire around a sign-up, around a sign-in, around a
  * message, and over the tokens a sign-in hands out, which is the part of a
- * user's life this simulation has. A pool federates with nobody, so the
- * federation triggers would never run whatever a pool named for them.
+ * user's life this simulation has. A federated sign-in reaches four of them,
+ * under the sources real Cognito reports for a user arriving from an identity
+ * provider.
  */
 export const simCognitoTriggerNames = [
   "PreSignUp",

--- a/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
+++ b/src/service/cognito/user-pool/trigger/sim-cognito-trigger-occasion.ts
@@ -35,6 +35,19 @@ export class SimCognitoTriggerOccasion {
   );
 
   /**
+   * An external subject signing in at an identity provider for the first time.
+   *
+   * Real Cognito builds the pool's own user for a federated subject through
+   * the sign-up path, so the trigger that guards a sign-up guards this too.
+   * The attributes it carries are the ones the provider's `AttributeMapping`
+   * produced, which is what the handler has to decide on.
+   */
+  public static readonly externalProviderSignUp = new SimCognitoTriggerOccasion(
+    "PreSignUp",
+    "PreSignUp_ExternalProvider",
+  );
+
+  /**
    * A signed-up user reaching `CONFIRMED`.
    *
    * `ConfirmSignUp`, `AdminConfirmSignUp` and a `PreSignUp` handler that
@@ -80,6 +93,18 @@ export class SimCognitoTriggerOccasion {
   public static readonly tokenGeneration = new SimCognitoTriggerOccasion(
     "PreTokenGeneration",
     "TokenGeneration_Authentication",
+  );
+
+  /**
+   * The tokens a sign-in at an identity provider hands out.
+   *
+   * Real Cognito reports this source for a federated grant alone. A local
+   * user signing in at managed login reports `TokenGeneration_Authentication`,
+   * the same source its API sign-in reports.
+   */
+  public static readonly hostedTokenGeneration = new SimCognitoTriggerOccasion(
+    "PreTokenGeneration",
+    "TokenGeneration_HostedAuth",
   );
 
   /**
@@ -163,29 +188,32 @@ export class SimCognitoTriggerOccasion {
   /**
    * The `CustomMessage` occasion a message is being sent on.
    *
-   * One trigger covers all three, and the source is the only thing telling a
+   * One trigger covers all five, and the source is the only thing telling a
    * handler which it is firing for, so an application customising one message
    * and not another branches on it.
    */
   static customMessage(
     occasion: SimCognitoMessageOccasion,
   ): SimCognitoTriggerOccasion {
-    switch (occasion) {
-      case "SignUp": {
-        return this.customMessageSignUp;
-      }
-      case "ResendCode": {
-        return this.customMessageResendCode;
-      }
-      case "AdminCreateUser": {
-        return this.customMessageAdminCreateUser;
-      }
-      case "Authentication": {
-        return this.customMessageAuthentication;
-      }
-      case "ForgotPassword": {
-        return this.customMessageForgotPassword;
-      }
-    }
+    // The key is one of a closed union, so the record has an entry for it and
+    // the type checker is what says so.
+    // oxlint-disable-next-line security/detect-object-injection
+    return simCognitoMessageOccasions[occasion];
   }
 }
+
+/**
+ * The `CustomMessage` occasion each message occasion fires under.
+ *
+ * A record rather than a switch, so that adding a message occasion is a line
+ * here and the type checker names every gap.
+ */
+const simCognitoMessageOccasions: Readonly<
+  Record<SimCognitoMessageOccasion, SimCognitoTriggerOccasion>
+> = {
+  SignUp: SimCognitoTriggerOccasion.customMessageSignUp,
+  ResendCode: SimCognitoTriggerOccasion.customMessageResendCode,
+  AdminCreateUser: SimCognitoTriggerOccasion.customMessageAdminCreateUser,
+  Authentication: SimCognitoTriggerOccasion.customMessageAuthentication,
+  ForgotPassword: SimCognitoTriggerOccasion.customMessageForgotPassword,
+};

--- a/test/cognito/federation-fixture.ts
+++ b/test/cognito/federation-fixture.ts
@@ -10,7 +10,6 @@
  */
 
 import type {
-  AttributeType,
   PreventUserExistenceErrorTypes,
   SchemaAttributeType,
   UsernameAttributeType,
@@ -18,8 +17,6 @@ import type {
   VerifiedAttributeType,
 } from "@aws-sdk/client-cognito-identity-provider";
 import {
-  AdminCreateUserCommand,
-  AdminSetUserPasswordCommand,
   CreateIdentityProviderCommand,
   CreateUserPoolClientCommand,
   CreateUserPoolCommand,
@@ -27,7 +24,19 @@ import {
 } from "@aws-sdk/client-cognito-identity-provider";
 import { assertNonNullable } from "@kensio/smartass";
 
+export {
+  simCognitoLocalPassword,
+  simCognitoLocalUser,
+  simCognitoLocalUsername,
+  type SimCognitoLocalUserOptions,
+} from "./federation-local-user-fixture.js";
+
 import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+import {
+  makeTriggerFunction,
+  permitCognitoTrigger,
+} from "./trigger-fixture.js";
 import { SimAwsHttp } from "../../src/serve/http/sim-aws-http.js";
 import type { SimCognitoIdentityProvider } from "../../src/service/cognito/index.js";
 
@@ -102,27 +111,17 @@ export interface SimCognitoHostedSetUpOptions {
    * the attribute instead.
    */
   readonly usernameAttributes?: readonly UsernameAttributeType[];
-}
 
-/**
- * The username the pool's own user in these tests holds.
- */
-export const simCognitoLocalUsername = "alice";
+  /**
+   * The `LambdaConfig` the pool is created with, none by default.
+   *
+   * A pool given one gets the fixture's trigger function created first and
+   * permitted afterwards, in the order a real deployment needs.
+   */
+  readonly triggers?: Readonly<Record<string, string>>;
 
-/**
- * The password that user signs in with.
- */
-export const simCognitoLocalPassword = "Sup3rSecret!";
-
-export interface SimCognitoLocalUserOptions {
-  /** The username the user holds, `alice` by default. */
-  readonly username?: string;
-
-  /** The password it signs in with. */
-  readonly password?: string;
-
-  /** The attributes it is created with, an email address by default. */
-  readonly attributes?: AttributeType[];
+  /** What that function does when a trigger invokes it. */
+  readonly handler?: SimLambdaHandler;
 }
 
 /**
@@ -141,9 +140,14 @@ export async function simCognitoHosted(
   const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
   const cognito = simAws.cognitoIdentityProvider();
 
+  if (options.triggers !== undefined) {
+    await makeTriggerFunction(simAws, { handler: options.handler });
+  }
+
   const pool = await cognito.createUserPool(
     new CreateUserPoolCommand({
       PoolName: "myapp-users",
+      ...(options.triggers !== undefined && { LambdaConfig: options.triggers }),
       ...(options.mfaConfiguration !== undefined && {
         MfaConfiguration: options.mfaConfiguration,
       }),
@@ -157,7 +161,12 @@ export async function simCognitoHosted(
     }),
   );
   assertNonNullable(pool.UserPool?.Id);
+  assertNonNullable(pool.UserPool.Arn);
   const userPoolId = pool.UserPool.Id;
+
+  if (options.triggers !== undefined) {
+    await permitCognitoTrigger(simAws, pool.UserPool.Arn);
+  }
 
   await cognito.createIdentityProvider(
     new CreateIdentityProviderCommand({
@@ -248,40 +257,6 @@ export async function simCognitoAuthorizationCode(
   assertNonNullable(code);
 
   return code;
-}
-
-/**
- * A confirmed user of the pool's own, holding a password it signs in with.
- *
- * An admin creates it and sets a permanent password on it, which is the
- * shortest route to a user in `CONFIRMED`. The sign-up route to the same place
- * is what the sign-up tests drive.
- */
-export async function simCognitoLocalUser(
-  setUp: SimCognitoHostedSetUp,
-  options: SimCognitoLocalUserOptions = {},
-): Promise<void> {
-  const {
-    username = simCognitoLocalUsername,
-    password = simCognitoLocalPassword,
-    attributes = [{ Name: "email", Value: `${username}@example.com` }],
-  } = options;
-
-  await setUp.cognito.adminCreateUser(
-    new AdminCreateUserCommand({
-      UserPoolId: setUp.userPoolId,
-      Username: username,
-      UserAttributes: attributes,
-    }),
-  );
-  await setUp.cognito.adminSetUserPassword(
-    new AdminSetUserPasswordCommand({
-      UserPoolId: setUp.userPoolId,
-      Username: username,
-      Password: password,
-      Permanent: true,
-    }),
-  );
 }
 
 /**

--- a/test/cognito/federation-local-user-fixture.ts
+++ b/test/cognito/federation-local-user-fixture.ts
@@ -1,0 +1,71 @@
+/**
+ * A user of the pool's own, for the hosted domain suites that sign one in
+ * beside the federated users.
+ *
+ * It is apart from `federation-fixture.ts` because the pool, the domain and the
+ * provider are one arrangement and this is another, and because that file is at
+ * the length the linter allows.
+ */
+
+import type { AttributeType } from "@aws-sdk/client-cognito-identity-provider";
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+import type { SimCognitoHostedSetUp } from "./federation-fixture.js";
+
+/**
+ * The username the pool's own user in these tests holds.
+ */
+export const simCognitoLocalUsername = "alice";
+
+/**
+ * The password that user signs in with.
+ */
+export const simCognitoLocalPassword = "Sup3rSecret!";
+
+export interface SimCognitoLocalUserOptions {
+  /** The username the user holds, `alice` by default. */
+  readonly username?: string;
+
+  /** The password it signs in with. */
+  readonly password?: string;
+
+  /** The attributes it is created with, an email address by default. */
+  readonly attributes?: AttributeType[];
+}
+
+/**
+ * A confirmed user of the pool's own, holding a password it signs in with.
+ *
+ * An admin creates it and sets a permanent password on it, which is the
+ * shortest route to a user in `CONFIRMED`. The sign-up route to the same place
+ * is what the sign-up tests drive.
+ */
+export async function simCognitoLocalUser(
+  setUp: SimCognitoHostedSetUp,
+  options: SimCognitoLocalUserOptions = {},
+): Promise<void> {
+  const {
+    username = simCognitoLocalUsername,
+    password = simCognitoLocalPassword,
+    attributes = [{ Name: "email", Value: `${username}@example.com` }],
+  } = options;
+
+  await setUp.cognito.adminCreateUser(
+    new AdminCreateUserCommand({
+      UserPoolId: setUp.userPoolId,
+      Username: username,
+      UserAttributes: attributes,
+    }),
+  );
+  await setUp.cognito.adminSetUserPassword(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: setUp.userPoolId,
+      Username: username,
+      Password: password,
+      Permanent: true,
+    }),
+  );
+}

--- a/test/cognito/trigger-fixture.ts
+++ b/test/cognito/trigger-fixture.ts
@@ -19,25 +19,25 @@ import {
   type UserPoolMfaType,
   type VerifiedAttributeType,
 } from "@aws-sdk/client-cognito-identity-provider";
-import {
-  AddPermissionCommand,
-  CreateFunctionCommand,
-} from "@aws-sdk/client-lambda";
 import { assertNonNullable } from "@kensio/smartass";
 
 import { SimAws } from "../../src/service/aws/sim-aws.js";
-import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../src/service/aws/sim-aws-account.js";
-import { DEFAULT_SIM_AWS_REGION_NAME } from "../../src/service/aws/sim-aws-region.js";
 import type { SimSignUpCommandOutput } from "../../src/service/cognito/command/user/sign-up.command.js";
 import type { SimCognitoIdentityProvider } from "../../src/service/cognito/index.js";
-import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
-import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+import {
+  makeTriggerFunction,
+  permitCognitoTrigger,
+  triggerFunctionArn,
+  type SimCognitoTriggerFunctionInput,
+} from "./trigger-function-fixture.js";
 
-/**
- * A trigger handler that hands the event back untouched, which is what a
- * handler with nothing to say has to do.
- */
-const passThroughHandler: SimLambdaHandler = (event: unknown) => event;
+export {
+  makeTriggerFunction,
+  permitCognitoTrigger,
+  triggerFunctionArn,
+  triggerFunctionArnIn,
+  triggerFunctionName,
+} from "./trigger-function-fixture.js";
 
 /** The user every suite in the fixture signs up, creates or signs in. */
 export const triggerUsername = "alice";
@@ -45,13 +45,10 @@ export const triggerUsername = "alice";
 /** The password the fixture's user signs in with. */
 export const triggerPassword = "Sup3rSecret!";
 
-/** The name of the function every trigger in the fixture points at. */
-export const triggerFunctionName = "auth-trigger";
-
 /**
  * What a test asks for when it wants a pool with a Lambda trigger on it.
  */
-export interface SimCognitoTriggerPoolInput {
+export interface SimCognitoTriggerPoolInput extends SimCognitoTriggerFunctionInput {
   /** The `LambdaConfig` the pool is created with. */
   readonly triggers: Readonly<Record<string, string>>;
 
@@ -63,26 +60,6 @@ export interface SimCognitoTriggerPoolInput {
    * takes a fresh one.
    */
   readonly simAws?: SimAws | undefined;
-
-  /**
-   * What the function does when a trigger invokes it, as a handler function.
-   *
-   * This is the quick way to say what a trigger does, and it is ignored when
-   * `code` is given as well: the two are alternatives, and the archive wins.
-   */
-  readonly handler?: SimLambdaHandler | undefined;
-
-  /**
-   * A real code archive to run instead of a handler function.
-   *
-   * Function code that calls another simulated service has to be an archive,
-   * because that is what runs in the Lambda vm with the runtime's own AWS SDK
-   * provided to it.
-   */
-  readonly code?: Uint8Array | undefined;
-
-  /** The execution Role the function runs as, and its SDK calls are made as. */
-  readonly roleArn?: string | undefined;
 
   /**
    * Whether the function's resource policy admits `cognito-idp.amazonaws.com`
@@ -113,17 +90,6 @@ export interface SimCognitoTriggerPool {
 }
 
 /**
- * The ARN the fixture's trigger function has.
- *
- * A `LambdaConfig` names the function before the pool exists, so the ARN has to
- * be known before anything is created, which is why it is stated rather than
- * read back off the created function.
- */
-export const triggerFunctionArn =
-  `arn:aws:lambda:${DEFAULT_SIM_AWS_REGION_NAME}:${DEFAULT_SIM_AWS_ACCOUNT_ID}` +
-  `:function:${triggerFunctionName}`;
-
-/**
  * Build a pool running the triggers a test named.
  *
  * The order is the one a real deployment has to use: the function first,
@@ -135,23 +101,7 @@ export async function makeTriggerPool(
 ): Promise<SimCognitoTriggerPool> {
   const simAws = input.simAws ?? new SimAws();
 
-  await simAws.lambda().createFunction(
-    new CreateFunctionCommand({
-      FunctionName: triggerFunctionName,
-      Role:
-        input.roleArn ??
-        `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
-      // A real archive needs the handler naming the module and export the way
-      // a deployed function does. A stowed handler function is its own entry
-      // point and needs none.
-      ...(input.code !== undefined && { Handler: "index.handler" }),
-      Code: {
-        ZipFile:
-          input.code ??
-          makeLambdaZipFileInput(input.handler ?? passThroughHandler),
-      },
-    }),
-  );
+  await makeTriggerFunction(simAws, input);
 
   const cognito = simAws.cognitoIdentityProvider();
   const pool = await cognito.createUserPool(
@@ -174,15 +124,7 @@ export async function makeTriggerPool(
   const userPoolArn = pool.UserPool.Arn;
 
   if (input.permitted ?? true) {
-    await simAws.lambda().addPermission(
-      new AddPermissionCommand({
-        FunctionName: triggerFunctionName,
-        StatementId: "AllowCognito",
-        Action: "lambda:InvokeFunction",
-        Principal: "cognito-idp.amazonaws.com",
-        SourceArn: userPoolArn,
-      }),
-    );
+    await permitCognitoTrigger(simAws, userPoolArn);
   }
 
   return {

--- a/test/cognito/trigger-function-fixture.ts
+++ b/test/cognito/trigger-function-fixture.ts
@@ -1,0 +1,129 @@
+/**
+ * The function a user pool's `LambdaConfig` names, and the permission that lets
+ * Cognito invoke it.
+ *
+ * This is the half of the trigger arrangement that has nothing to do with the
+ * pool, so the federation fixture reaches for it without taking the pool
+ * `trigger-fixture.ts` builds.
+ */
+
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import type { SimAws } from "../../src/service/aws/sim-aws.js";
+import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../src/service/aws/sim-aws-account.js";
+import { DEFAULT_SIM_AWS_REGION_NAME } from "../../src/service/aws/sim-aws-region.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../../src/service/lambda/function/sim-lambda-handler.type.js";
+
+/**
+ * A trigger handler that hands the event back untouched, which is what a
+ * handler with nothing to say has to do.
+ */
+export const passThroughHandler: SimLambdaHandler = (event: unknown) => event;
+
+/** The name of the function every trigger in the fixture points at. */
+export const triggerFunctionName = "auth-trigger";
+
+/**
+ * What a test says about the function behind its triggers.
+ */
+export interface SimCognitoTriggerFunctionInput {
+  /**
+   * What the function does when a trigger invokes it, as a handler function.
+   *
+   * This is the quick way to say what a trigger does, and it is ignored when
+   * `code` is given as well: the two are alternatives, and the archive wins.
+   */
+  readonly handler?: SimLambdaHandler | undefined;
+
+  /**
+   * A real code archive to run instead of a handler function.
+   *
+   * Function code that calls another simulated service has to be an archive,
+   * because that is what runs in the Lambda vm with the runtime's own AWS SDK
+   * provided to it.
+   */
+  readonly code?: Uint8Array | undefined;
+
+  /** The execution Role the function runs as, and its SDK calls are made as. */
+  readonly roleArn?: string | undefined;
+}
+
+/**
+ * The ARN the fixture's trigger function has in one region.
+ *
+ * A suite running in a region of its own names the function with this, because
+ * a `LambdaConfig` ARN Cognito accepts is one in the pool's own region.
+ */
+export function triggerFunctionArnIn(
+  regionName: string,
+  accountId: string,
+): string {
+  return (
+    `arn:aws:lambda:${regionName}:${accountId}` +
+    `:function:${triggerFunctionName}`
+  );
+}
+
+/**
+ * The ARN the fixture's trigger function has.
+ *
+ * A `LambdaConfig` names the function before the pool exists, so the ARN has to
+ * be known before anything is created, which is why it is stated rather than
+ * read back off the created function.
+ */
+export const triggerFunctionArn = triggerFunctionArnIn(
+  DEFAULT_SIM_AWS_REGION_NAME,
+  DEFAULT_SIM_AWS_ACCOUNT_ID,
+);
+
+/**
+ * Create the function a pool's `LambdaConfig` names.
+ *
+ * The function comes first in a real deployment, because the pool names it by
+ * ARN, so it comes first here.
+ */
+export async function makeTriggerFunction(
+  simAws: SimAws,
+  input: SimCognitoTriggerFunctionInput = {},
+): Promise<void> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: triggerFunctionName,
+      Role:
+        input.roleArn ??
+        `arn:aws:iam::${simAws.defaultAccountId}:role/TriggerRole`,
+      // A real archive needs the handler naming the module and export the way
+      // a deployed function does. A stowed handler function is its own entry
+      // point and needs none.
+      ...(input.code !== undefined && { Handler: "index.handler" }),
+      Code: {
+        ZipFile:
+          input.code ??
+          makeLambdaZipFileInput(input.handler ?? passThroughHandler),
+      },
+    }),
+  );
+}
+
+/**
+ * Let Cognito invoke the trigger function on one pool's behalf, which is what a
+ * CDK `addTrigger` emits an `AWS::Lambda::Permission` for.
+ */
+export async function permitCognitoTrigger(
+  simAws: SimAws,
+  userPoolArn: string,
+): Promise<void> {
+  await simAws.lambda().addPermission(
+    new AddPermissionCommand({
+      FunctionName: triggerFunctionName,
+      StatementId: "AllowCognito",
+      Action: "lambda:InvokeFunction",
+      Principal: "cognito-idp.amazonaws.com",
+      SourceArn: userPoolArn,
+    }),
+  );
+}


### PR DESCRIPTION
A sign-in at a simulated identity provider ran none of the pool's Lambda triggers, so an application that hangs its own user record off `PostConfirmation` got that record for a local sign-up and nothing for a Google user. The four triggers now fire under the sources AWS documents for a federated user. A first sign-in runs `PreSignUp` as `PreSignUp_ExternalProvider` and then `PostConfirmation` as `PostConfirmation_ConfirmSignUp`, and every sign-in after it runs `PreAuthentication` and `PostAuthentication`, so a handler writing a profile record on first sight runs once. A handler that throws from `PreSignUp` refuses the sign-in and leaves the pool without the user, and `autoVerifyEmail` and `autoVerifyPhone` are applied as they are for a sign-up. `autoConfirmUser` has nothing to do, because a federated user is created in `EXTERNAL_PROVIDER` and never passes through `UNCONFIRMED`. A code exchanged at the token endpoint now reports `TokenGeneration_HostedAuth` where the sign-in happened at a provider, leaving the local sign-in on the `TokenGeneration_Authentication` real Cognito reports for it.

Two things are worth a second look. A browser signed in from the managed login session it was already holding reports the local token source whichever way that session started, because the session records nothing about the method that began it, which is a limitation the docs already carried. And `sim-cognito-trigger-occasion.ts` swapped its `CustomMessage` switch for a keyed record to get back under the FTA threshold the two new occasions pushed it over, which needed the `detect-object-injection` suppression the Terraform files already use for the same shape.

Resolves #1172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added federated sign-in trigger support for first-time and returning sign-ins.
  * Added support for provider-specific user attributes, automatic email verification, and federated token generation.
  * Added identity validation to prevent mismatched federated accounts.

* **Documentation**
  * Documented federated trigger behavior, execution order, failure handling, and limitations.
  * Added an example demonstrating first-time versus returning federated sign-ins.

* **Tests**
  * Added coverage for federated triggers, token flows, user creation, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->