### PR TITLE
feat: count a simulated Lambda invocation in AWS/Lambda

### DIFF
--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -9,8 +9,10 @@ Code that publishes a business metric is code teams already have, and until now 
 it was to assert that the SDK client had been called. That proves the call was made. What it
 measured goes untested.
 
-Only custom metrics live here. This simulation publishes into no `AWS/` namespace. A query for
-`AWS/Lambda` `Invocations` comes back empty, in place of a number that was never measured.
+Most of what lives here is custom metrics. Simulated Lambda publishes its own `AWS/Lambda`
+`Invocations`, `Errors` and `Duration`, and no other simulated service publishes into an `AWS/`
+namespace yet. A query for one nothing measures comes back empty, in place of a number that was
+never taken.
 
 A custom metric's datapoints arrive either from `PutMetricData` or from a CloudWatch Logs metric
 filter counting matching log events. See the [CloudWatch Logs docs](../logs/README.md) for the
@@ -146,6 +148,74 @@ console.log(read.MetricDataResults?.at(0)?.Values);
 
 `ListMetrics` reads `RecentlyActive: "PT3H"` against the same clock, so advancing time past the
 window drops a metric out of the listing without anything having to expire it.
+
+## Metrics a simulated service publishes
+
+Real CloudWatch holds two kinds of metric. A caller publishes a custom one through `PutMetricData`, and AWS publishes its own under a namespace beginning `AWS/` that no caller may write into. Both kinds are read the same way.
+
+Simulated Lambda publishes three of its own. Every invocation counts `Invocations` and a `Duration`, and one whose handler threw counts an `Errors` alongside them, all under `AWS/Lambda` and dimensioned by `FunctionName`. Nothing has to be turned on, and no execution Role needs a permission for it, which is how real Lambda behaves.
+
+```typescript sim-cloudwatch-lambda-errors
+/**
+ * An alarm firing on the errors a failing function counted.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.clock().setTo(new Date("2026-08-30T09:00:00Z"));
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        throw new Error("order has no items");
+      }),
+    },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await simAws.cloudWatch().putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "OrdersFailing",
+    Namespace: "AWS/Lambda",
+    MetricName: "Errors",
+    Dimensions: [{ Name: "FunctionName", Value: "orders" }],
+    Statistic: "Sum",
+    Period: 300,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 1,
+    Threshold: 0,
+    ComparisonOperator: "GreaterThanThreshold",
+    TreatMissingData: "notBreaching",
+  }),
+);
+
+await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(new DescribeAlarmsCommand({ AlarmNames: ["OrdersFailing"] }));
+
+// ALARM. The invocation counted its own error.
+console.log(MetricAlarms?.[0]?.StateValue);
+```
+
+`PutMetricData` still refuses a namespace beginning `AWS/`, exactly as an account does, so a test cannot seed these by hand. A simulated service reaches the metric store by a route a caller has none of.
+
+`Duration` is measured on the simulation's clock rather than the host's, so it is a number a test can assert on. A handler that moves the clock reports the time it moved, and one that returns without touching it reports nothing spent.
 
 ## Alarms
 
@@ -396,6 +466,8 @@ await simAws.cloudWatch().putMetricData(
   with evaluation on the simulation's clock and SNS notifications on a state change.
 - IAM authorization on each action, including the `cloudwatch:namespace` condition key and
   alarm-ARN resources.
+- `AWS/Lambda` `Invocations`, `Errors` and `Duration`, published by simulated Lambda itself and read
+  back the way a custom metric is.
 - `AWS::CloudWatch::Alarm` in simulated CloudFormation, deployed through `PutMetricAlarm` and taken
   down with the stack.
 
@@ -417,9 +489,11 @@ test still passes and no longer means what it says.
   comes back at the period its query asked for.
 - **Cross-account metrics.** `IncludeLinkedAccounts` and `OwningAccount` are refused. There is no
   monitoring account.
-- **Metrics AWS publishes.** No simulated service writes its own `AWS/` metrics. A CloudWatch Logs
-  metric filter naming a reserved namespace is refused here when it publishes, as `PutMetricData`
-  refuses a caller naming one.
+- **Most metrics AWS publishes.** `AWS/Lambda` `Invocations`, `Errors` and `Duration` are the only
+  ones a simulated service writes. `Throttles` and `ConcurrentExecutions` need concurrency limits,
+  which simulated Lambda has none of, and every other `AWS/` namespace needs a source event built
+  before a metric can come from one. A CloudWatch Logs metric filter naming a reserved namespace is
+  refused when it publishes, as `PutMetricData` refuses a caller naming one.
 
 Two divergences are deliberate, and not refusals. Real CloudWatch rejects a datapoint more than two
 weeks old or more than two hours in the future, and this accepts any timestamp, letting a test seed

--- a/docs/services/cloudwatch/sim-cloudwatch-lambda-errors.example.ts
+++ b/docs/services/cloudwatch/sim-cloudwatch-lambda-errors.example.ts
@@ -1,0 +1,55 @@
+/**
+ * An alarm firing on the errors a failing function counted.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.clock().setTo(new Date("2026-08-30T09:00:00Z"));
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "orders",
+    Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        throw new Error("order has no items");
+      }),
+    },
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await simAws.cloudWatch().putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "OrdersFailing",
+    Namespace: "AWS/Lambda",
+    MetricName: "Errors",
+    Dimensions: [{ Name: "FunctionName", Value: "orders" }],
+    Statistic: "Sum",
+    Period: 300,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 1,
+    Threshold: 0,
+    ComparisonOperator: "GreaterThanThreshold",
+    TreatMissingData: "notBreaching",
+  }),
+);
+
+await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "orders" }));
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(new DescribeAlarmsCommand({ AlarmNames: ["OrdersFailing"] }));
+
+// ALARM. The invocation counted its own error.
+console.log(MetricAlarms?.[0]?.StateValue);

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2748,6 +2748,27 @@ otherwise. A time read at module scope is therefore read too early, exactly as i
 variables. See [simulated time](https://yulinsim.dev/time/) for the whole picture, including where real
 AWS puts the time on the event.
 
+## What an invocation counts in CloudWatch
+
+Every invocation publishes `Invocations` and a `Duration` into `AWS/Lambda`, dimensioned by
+`FunctionName`. One whose handler threw publishes an `Errors` beside them. Real Lambda counts a
+failed invocation under both, so an alarm reading one against the other gets a failure rate.
+
+Nothing has to be turned on for it, and the execution Role needs no permission, which is how real
+Lambda behaves. An alarm on `AWS/Lambda` `Errors` can therefore be driven to a state change by
+invoking a function that fails, rather than by publishing a datapoint by hand. `PutMetricData` still
+refuses the `AWS/Lambda` namespace, exactly as an account does. See the
+[CloudWatch docs](../cloudwatch/README.md) for an alarm reading these.
+
+`Duration` is measured on the simulation's clock. A handler that moves the clock reports the time it
+moved, and one that returns without touching it reports nothing spent.
+
+`Throttles` and `ConcurrentExecutions` are absent. Both count what a concurrency limit turned away,
+and this simulation applies none.
+
+A function built outside a `SimAws` instance has no simulated CloudWatch to publish into. It runs and
+counts nothing.
+
 ## CloudFormation functions
 
 Sim CloudFormation can create Lambda functions from `AWS::Lambda::Function`, typically alongside a

--- a/src/service/aws/factory/sim-aws-lambda-collaborators.ts
+++ b/src/service/aws/factory/sim-aws-lambda-collaborators.ts
@@ -8,6 +8,7 @@ import { SimSdkLambdaVmModuleProvider } from "../../lambda/function/code/vm/sdk/
 import { makeSimLambdaOutboundHttp } from "../../lambda/function/outbound/sim-lambda-outbound-http.factory.js";
 import type { SimLambdaOutboundHttp } from "../../lambda/function/outbound/sim-lambda-outbound-http.js";
 import type { SimLambdaUrlRegistry } from "../../lambda/registry/sim-lambda-url-registry.js";
+import type { SimCloudWatchServiceWriter } from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
 import type { SimLogsServiceWriter } from "../../logs/write/sim-logs-service-writer.js";
 import type { SimAwsScopedServiceRegistries } from "./sim-aws-scoped-service-registries.js";
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
@@ -34,6 +35,7 @@ interface SimAwsLambdaCollaborators {
   readonly vmSdkModuleProvider: SimSdkLambdaVmModuleProvider;
   readonly outboundHttp: SimLambdaOutboundHttp;
   readonly logs: SimLogsServiceWriter;
+  readonly metrics: SimCloudWatchServiceWriter;
   readonly destinations: SimAwsLambdaDestinations;
 }
 
@@ -82,6 +84,9 @@ export function simAwsLambdaCollaborators(
     runAsOwner: simAws,
     destinations: new SimAwsLambdaDestinations({ simAws }),
     logs: scope.logs().serviceWriter(),
+    // A function's AWS/Lambda metrics belong to the Account and Region it is
+    // in, which real Lambda gives no way to point elsewhere.
+    metrics: scope.cloudWatch().serviceWriter(),
     urlRegistry: properties.urlRegistry,
     codeStore: new SimS3LambdaCodeStore({ s3: scope.s3() }),
     containerImages: new SimEcrLambdaContainerImages({

--- a/src/service/cloudwatch/sim-cloudwatch-commands.ts
+++ b/src/service/cloudwatch/sim-cloudwatch-commands.ts
@@ -22,6 +22,7 @@ import { SimCloudWatchGetMetricData } from "./command/query/sim-cloudwatch-get-m
 import { SimCloudWatchGetMetricStatistics } from "./command/query/sim-cloudwatch-get-metric-statistics.js";
 import { SimCloudWatchListMetrics } from "./command/query/sim-cloudwatch-list-metrics.js";
 import { SimCloudWatchMetricStore } from "./metric/sim-cloudwatch-metric-store.js";
+import { SimCloudWatchServiceWriter } from "./write/sim-cloudwatch-service-writer.js";
 
 export interface SimCloudWatchProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -45,6 +46,7 @@ export interface SimCloudWatchProperties {
  */
 export class SimCloudWatchCommands {
   readonly metrics: SimCloudWatchMetricStore;
+  readonly serviceWriter: SimCloudWatchServiceWriter;
   readonly putMetricData: SimCloudWatchPutMetricData;
   readonly listMetrics: SimCloudWatchListMetrics;
   readonly getMetricStatistics: SimCloudWatchGetMetricStatistics;
@@ -67,6 +69,11 @@ export class SimCloudWatchCommands {
 
     const authorizer = new SimCloudWatchAuthorizer({ iam, accountRegionScope });
     const metrics = new SimCloudWatchMetricStore();
+
+    this.serviceWriter = new SimCloudWatchServiceWriter({
+      metrics,
+      clock: background,
+    });
     const alarms = new SimCloudWatchAlarmStore();
     const alarmActions = new SimCloudWatchAlarmActions({
       targets: alarmTargets,

--- a/src/service/cloudwatch/sim-cloudwatch.ts
+++ b/src/service/cloudwatch/sim-cloudwatch.ts
@@ -6,6 +6,7 @@ import type { SimCloudWatchAlarmActionFailure } from "./alarm/action/sim-cloudwa
 import type { SimCloudWatchAlarm } from "./alarm/sim-cloudwatch-alarm.js";
 import type { SimCloudWatchMetric } from "./metric/sim-cloudwatch-metric.js";
 import { SimCloudWatchSdkCommandRouter } from "./sdk/sim-cloudwatch-sdk-command-router.js";
+import type { SimCloudWatchServiceWriter } from "./write/sim-cloudwatch-service-writer.js";
 import {
   SimCloudWatchCommands,
   type SimCloudWatchProperties,
@@ -42,6 +43,17 @@ export class SimCloudWatch {
    */
   allMetrics(): readonly SimCloudWatchMetric[] {
     return this.#commands.metrics.all;
+  }
+
+  /**
+   * How the rest of the simulation publishes the metrics AWS publishes.
+   *
+   * A simulated service counting its own work reaches the metric store through
+   * here rather than through `PutMetricData`, which refuses a reserved `AWS/`
+   * namespace exactly as an account does.
+   */
+  serviceWriter(): SimCloudWatchServiceWriter {
+    return this.#commands.serviceWriter;
   }
 
   /**

--- a/src/service/cloudwatch/write/sim-cloudwatch-service-writer.ts
+++ b/src/service/cloudwatch/write/sim-cloudwatch-service-writer.ts
@@ -1,0 +1,75 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimCloudWatchDimension } from "../metric/sim-cloudwatch-dimension.js";
+import type { SimCloudWatchMetricStore } from "../metric/sim-cloudwatch-metric-store.js";
+import type { SimCloudWatchUnit } from "../metric/sim-cloudwatch-unit.js";
+
+/**
+ * One metric a simulated service publishes about itself.
+ */
+export interface SimCloudWatchServiceDatum {
+  readonly namespace: string;
+  readonly metricName: string;
+  readonly dimensions: readonly SimCloudWatchDimension[];
+  readonly value: number;
+  readonly unit?: SimCloudWatchUnit | undefined;
+
+  /**
+   * When the observation was made. The simulation's clock stamps one that
+   * arrives without it.
+   */
+  readonly timestamp?: number | undefined;
+}
+
+interface SimCloudWatchServiceWriterProperties {
+  readonly metrics: SimCloudWatchMetricStore;
+  readonly clock: SimClock;
+}
+
+/**
+ * How the rest of the simulation publishes the metrics AWS publishes.
+ *
+ * This is not the CloudWatch API. A simulated service counting its own work is
+ * the account's own machinery rather than a caller making a request, so
+ * nothing here validates a request or authorizes one. Real CloudWatch does not
+ * put Lambda's own `Invocations` through `PutMetricData` either.
+ *
+ * The reserved namespace rule is the point of the separation. `PutMetricData`
+ * refuses a namespace beginning `AWS/`, exactly as an account does, and the
+ * services whose metrics those are reach the store through here instead.
+ */
+export class SimCloudWatchServiceWriter {
+  readonly #metrics: SimCloudWatchMetricStore;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimCloudWatchServiceWriterProperties) {
+    this.#metrics = properties.metrics;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Record one observation of each metric given.
+   *
+   * A whole batch goes in together so one invocation's metrics land at the
+   * same instant, whatever the clock does next.
+   */
+  publish(data: readonly SimCloudWatchServiceDatum[]): void {
+    const now = this.#clock.now().getTime();
+
+    for (const datum of data) {
+      this.#metrics
+        .ensure({
+          namespace: datum.namespace,
+          metricName: datum.metricName,
+          dimensions: datum.dimensions,
+        })
+        .record({
+          timestamp: datum.timestamp ?? now,
+          sampleCount: 1,
+          sum: datum.value,
+          minimum: datum.value,
+          maximum: datum.value,
+          unit: datum.unit,
+        });
+    }
+  }
+}

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -16,6 +16,7 @@ import { SimLambdaCodeResolver } from "../../function/code/sim-lambda-code-resol
 import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type { SimCloudWatchServiceWriter } from "../../../cloudwatch/write/sim-cloudwatch-service-writer.js";
 import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-outbound-http.js";
 import { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
@@ -50,6 +51,7 @@ interface CreateFunctionCommandHandlerProperties {
   vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
   environmentConflicts?: SimLambdaEnvironmentConflicts;
   logs?: SimLogsServiceWriter | undefined;
+  metrics?: SimCloudWatchServiceWriter | undefined;
   outboundHttp?: SimLambdaOutboundHttp | undefined;
 }
 
@@ -74,6 +76,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
   private readonly codeResolver: SimLambdaCodeResolver;
   private readonly environmentConflicts: SimLambdaEnvironmentConflicts;
   private readonly logs: SimLogsServiceWriter | undefined;
+  private readonly metrics: SimCloudWatchServiceWriter | undefined;
   private readonly outboundHttp: SimLambdaOutboundHttp | undefined;
 
   constructor(properties: CreateFunctionCommandHandlerProperties) {
@@ -88,6 +91,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       vmSdkModuleProvider,
       environmentConflicts = new SimLambdaEnvironmentConflicts(),
       logs,
+      metrics,
       outboundHttp,
     } = properties;
     this.accountRegionScope = accountRegionScope;
@@ -106,6 +110,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
     });
     this.environmentConflicts = environmentConflicts;
     this.logs = logs;
+    this.metrics = metrics;
     this.outboundHttp = outboundHttp;
   }
 
@@ -152,6 +157,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       runAsOwner: this.runAsOwner,
       clock: this.background,
       logs: this.logs,
+      metrics: this.metrics,
       outboundHttp: this.outboundHttp,
     });
 

--- a/src/service/lambda/command/function/sim-lambda-function-commands.ts
+++ b/src/service/lambda/command/function/sim-lambda-function-commands.ts
@@ -6,6 +6,7 @@ import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-int
 import type { SimLambdaContainerImages } from "../../function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type { SimCloudWatchServiceWriter } from "../../../cloudwatch/write/sim-cloudwatch-service-writer.js";
 import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-outbound-http.js";
 import type { SimLambdaDestinationTargets } from "../../destination/sim-lambda-destination-targets.js";
@@ -67,6 +68,7 @@ interface SimLambdaFunctionCommandsProperties {
   readonly containerImages?: SimLambdaContainerImages | undefined;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
   readonly logs?: SimLogsServiceWriter | undefined;
+  readonly metrics?: SimCloudWatchServiceWriter | undefined;
   readonly outboundHttp?: SimLambdaOutboundHttp | undefined;
 }
 

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -20,6 +20,7 @@ import { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
 import { SimLambdaFunctionLogging } from "./logging/sim-lambda-function-logging.js";
 import { SimLambdaFunctionPolicy } from "./policy/sim-lambda-function-policy.js";
 import { SimLambdaHandlerRunner } from "./invoke/sim-lambda-handler-runner.js";
+import { SimLambdaInvocationMetrics } from "../metric/sim-lambda-invocation-metrics.js";
 import { SimLambdaInvokeContextBuilder } from "./invoke/sim-lambda-invoke-context-builder.js";
 import { runSimLambdaInHostScope } from "./invoke/sim-lambda-host-scope.js";
 import type { SimLambdaOutboundHttp } from "./outbound/sim-lambda-outbound-http.js";
@@ -87,6 +88,7 @@ export class SimLambdaFunction {
   private readonly clock: SimClock;
   private readonly logging: SimLambdaFunctionLogging;
   private readonly outboundHttp: SimLambdaOutboundHttp | undefined;
+  private readonly metrics: SimLambdaInvocationMetrics;
 
   constructor(properties: SimLambdaFunctionProperties) {
     const {
@@ -107,6 +109,7 @@ export class SimLambdaFunction {
       version = SIM_LAMBDA_LATEST_VERSION,
       clock = new SimRealClock(),
       logs,
+      metrics,
       outboundHttp,
     } = properties;
     this.properties = properties;
@@ -132,6 +135,7 @@ export class SimLambdaFunction {
     this.deadLetterTargetArn = deadLetterTargetArn;
     this.runAsOwner = runAsOwner;
     this.outboundHttp = outboundHttp;
+    this.metrics = new SimLambdaInvocationMetrics({ metrics, clock });
     this.logging = new SimLambdaFunctionLogging({
       functionName: name,
       logs,
@@ -253,24 +257,26 @@ export class SimLambdaFunction {
 
     this.logging.recordFrom(this.#code);
 
-    return await simAwsRunAsContext.run(
-      this.runAsOwner,
-      { kind: "arn", arn: this.roleArn },
-      async () =>
-        await this.environment.runWith(
-          async () =>
-            await this.runInHostScope(
-              async () =>
-                await this.logging.around(
-                  async () =>
-                    await this.runner.run(
-                      this.#code.handlerFunction(),
-                      event,
-                      contextBuilder,
-                    ),
-                ),
-            ),
-        ),
+    return await this.metrics.around(String(this.name), async () =>
+      simAwsRunAsContext.run(
+        this.runAsOwner,
+        { kind: "arn", arn: this.roleArn },
+        async () =>
+          await this.environment.runWith(
+            async () =>
+              await this.runInHostScope(
+                async () =>
+                  await this.logging.around(
+                    async () =>
+                      await this.runner.run(
+                        this.#code.handlerFunction(),
+                        event,
+                        contextBuilder,
+                      ),
+                  ),
+              ),
+          ),
+      ),
     );
   }
 

--- a/src/service/lambda/function/sim-lambda-function.type.ts
+++ b/src/service/lambda/function/sim-lambda-function.type.ts
@@ -2,6 +2,7 @@ import type { Brand } from "../../../util/brand.type.js";
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimAwsRunAsOwner } from "../../aws/caller/sim-aws-run-as-context.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCloudWatchServiceWriter } from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
 import type { SimLogsServiceWriter } from "../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaExecutableCode } from "./code/sim-lambda-executable-code.js";
 import type { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
@@ -53,6 +54,12 @@ export interface SimLambdaFunctionProperties {
    * only to the host streams.
    */
   logs?: SimLogsServiceWriter | undefined;
+  /**
+   * Where this function's invocations are counted. A function built
+   * standalone, outside a SimAws instance, has no simulated CloudWatch to
+   * publish `AWS/Lambda` metrics into and counts nothing.
+   */
+  metrics?: SimCloudWatchServiceWriter | undefined;
   /**
    * Where the HTTP requests this function's code makes to hostnames the
    * simulation serves are answered. A function built standalone, outside a

--- a/src/service/lambda/metric/sim-lambda-errors-alarm.iso.test.ts
+++ b/src/service/lambda/metric/sim-lambda-errors-alarm.iso.test.ts
@@ -1,0 +1,123 @@
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateTopicCommand, SubscribeCommand } from "@aws-sdk/client-sns";
+import {
+  CreateQueueCommand,
+  ReceiveMessageCommand,
+  SetQueueAttributesCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+
+const functionName = "orders";
+const alarmName = "OrdersFailing";
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+
+describe("an alarm over the AWS/Lambda Errors a function publishes", () => {
+  it("fires on a failing invocation and notifies its topic", async () => {
+    // Given a failing function, an alarm on its errors, and a queue standing
+    // in for whoever the alarm's topic tells.
+    const simAws = new SimAws();
+
+    await simAws.clock().setTo(startedAt);
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: functionName,
+        Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            throw new Error("order has no items");
+          }),
+        },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    const topic = await simAws
+      .sns()
+      .createTopic(new CreateTopicCommand({ Name: "orders-alerts" }));
+    const queue = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "alerts" }));
+
+    assertNonNullable(topic.TopicArn);
+    assertNonNullable(queue.QueueUrl);
+
+    // The queue's own policy has to admit SNS, exactly as in an account.
+    await simAws.sqs().setQueueAttributes(
+      new SetQueueAttributesCommand({
+        QueueUrl: queue.QueueUrl,
+        Attributes: {
+          Policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "sns.amazonaws.com" },
+                Action: "sqs:SendMessage",
+                Resource: "*",
+              },
+            ],
+          }),
+        },
+      }),
+    );
+    await simAws.sns().subscribe(
+      new SubscribeCommand({
+        TopicArn: topic.TopicArn,
+        Protocol: "sqs",
+        Endpoint: `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:alerts`,
+      }),
+    );
+    await simAws.cloudWatch().putMetricAlarm(
+      new PutMetricAlarmCommand({
+        AlarmName: alarmName,
+        Namespace: "AWS/Lambda",
+        MetricName: "Errors",
+        Dimensions: [{ Name: "FunctionName", Value: functionName }],
+        Statistic: "Sum",
+        Period: 300,
+        EvaluationPeriods: 3,
+        DatapointsToAlarm: 1,
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        TreatMissingData: "notBreaching",
+        AlarmActions: [topic.TopicArn],
+      }),
+    );
+
+    // When the handler fails and the clock passes the period.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: functionName }));
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ minutes: 6 });
+
+    // Then the alarm fired on a metric nothing published by hand, and the
+    // notification reached the queue behind the topic.
+    const { MetricAlarms } = await simAws
+      .cloudWatch()
+      .describeAlarms(new DescribeAlarmsCommand({ AlarmNames: [alarmName] }));
+
+    assertIdentical(MetricAlarms?.at(0)?.StateValue, "ALARM");
+    assertArrayLength(simAws.cloudWatch().alarmActionFailures, 0);
+
+    const received = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }));
+
+    assertArrayLength(received.Messages ?? [], 1);
+    assertStringIncludes(received.Messages?.at(0)?.Body ?? "", alarmName);
+  });
+});

--- a/src/service/lambda/metric/sim-lambda-invocation-metrics.iso.test.ts
+++ b/src/service/lambda/metric/sim-lambda-invocation-metrics.iso.test.ts
@@ -1,0 +1,246 @@
+import {
+  GetMetricDataCommand,
+  GetMetricStatisticsCommand,
+  ListMetricsCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimCloudWatchInvalidParameterValueException } from "../../cloudwatch/error/sim-cloudwatch.error.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import { SimLambda } from "../sim-lambda.js";
+import type { SimLambdaHandler } from "../function/sim-lambda-handler.type.js";
+
+const functionName = "orders";
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+
+/** A simulation with a stopped clock and one function bound to a handler. */
+async function simAwsWithFunction(
+  handler: SimLambdaHandler = () => "done",
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/OrdersRole`,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simAws;
+}
+
+/** The `Sum` of one AWS/Lambda metric for the function over the window. */
+async function counted(
+  simAws: SimAws,
+  metricName: string,
+): Promise<number | undefined> {
+  const statistics = new GetMetricStatisticsCommand({
+    Namespace: "AWS/Lambda",
+    MetricName: metricName,
+    Dimensions: [{ Name: "FunctionName", Value: functionName }],
+    StartTime: startedAt,
+    EndTime: new Date(startedAt.getTime() + 300_000),
+    Period: 300,
+    Statistics: ["Sum"],
+  });
+  const { Datapoints } = await simAws
+    .cloudWatch()
+    .getMetricStatistics(statistics);
+
+  return Datapoints?.at(0)?.Sum;
+}
+
+describe("AWS/Lambda metrics a simulated invocation publishes", () => {
+  it("counts an invocation that returned", async () => {
+    // Given a function bound to a handler that returns.
+    const simAws = await simAwsWithFunction();
+
+    // When it is invoked.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: functionName }));
+    await simAws.backgroundTasksComplete();
+
+    // Then it counted one invocation, and no error.
+    assertIdentical(await counted(simAws, "Invocations"), 1);
+    assertUndefined(await counted(simAws, "Errors"));
+  });
+
+  it("counts an error where the handler threw", async () => {
+    // Given a function whose handler throws.
+    const simAws = await simAwsWithFunction(() => {
+      throw new Error("order has no items");
+    });
+
+    // When it is invoked.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: functionName }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the failure counted as an error, and as an invocation too, which is
+    // how real Lambda counts one.
+    assertIdentical(await counted(simAws, "Errors"), 1);
+    assertIdentical(await counted(simAws, "Invocations"), 1);
+  });
+
+  it("counts an asynchronous invocation the same way", async () => {
+    // Given a function whose handler throws.
+    const simAws = await simAwsWithFunction(() => {
+      throw new Error("order has no items");
+    });
+
+    // When it is invoked as an Event, which answers before the handler runs.
+    await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: functionName,
+        InvocationType: "Event",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the invocation counted once it had actually run.
+    assertIdentical(await counted(simAws, "Errors"), 1);
+    assertIdentical(await counted(simAws, "Invocations"), 1);
+  });
+
+  it("measures duration on the simulation's clock", async () => {
+    // Given a handler that takes two seconds of simulated time.
+    const simAws = await simAwsWithFunction(async () => {
+      await simAws.clock().advanceBy({ seconds: 2 });
+
+      return "done";
+    });
+
+    // When it is invoked.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: functionName }));
+    await simAws.backgroundTasksComplete();
+
+    // Then the duration is the simulated time it took, rather than however
+    // long the host happened to spend on it.
+    assertIdentical(await counted(simAws, "Duration"), 2000);
+  });
+
+  it("publishes under the function's name, and nothing undimensioned", async () => {
+    // Given an invoked function.
+    const simAws = await simAwsWithFunction();
+
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: functionName }));
+    await simAws.backgroundTasksComplete();
+
+    // Then every metric it published carries the function's name, which is the
+    // dimension a CDK alarm on a function reads.
+    const { Metrics } = await simAws
+      .cloudWatch()
+      .listMetrics(new ListMetricsCommand({ Namespace: "AWS/Lambda" }));
+
+    assertArrayEquals(
+      (Metrics ?? []).map((metric) => metric.MetricName),
+      ["Invocations", "Duration"],
+    );
+    assertArrayEquals(
+      (Metrics ?? []).flatMap((metric) =>
+        metric.Dimensions.map(
+          (dimension) => `${dimension.Name}=${dimension.Value}`,
+        ),
+      ),
+      [`FunctionName=${functionName}`, `FunctionName=${functionName}`],
+    );
+  });
+
+  it("answers a GetMetricData query the way a custom metric does", async () => {
+    // Given an invoked function.
+    const simAws = await simAwsWithFunction();
+
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: functionName }));
+    await simAws.backgroundTasksComplete();
+
+    // When the metric is read through GetMetricData.
+    const query = new GetMetricDataCommand({
+      StartTime: startedAt,
+      EndTime: new Date(startedAt.getTime() + 300_000),
+      MetricDataQueries: [
+        {
+          Id: "invocations",
+          MetricStat: {
+            Metric: {
+              Namespace: "AWS/Lambda",
+              MetricName: "Invocations",
+              Dimensions: [{ Name: "FunctionName", Value: functionName }],
+            },
+            Period: 300,
+            Stat: "Sum",
+          },
+        },
+      ],
+    });
+    const { MetricDataResults } = await simAws
+      .cloudWatch()
+      .getMetricData(query);
+
+    // Then it comes back, so nothing about a reserved namespace changes how a
+    // metric in one is read.
+    assertArrayEquals(MetricDataResults?.at(0)?.Values, [1]);
+  });
+
+  it("still refuses a caller putting into the reserved namespace", async () => {
+    // Given a simulation.
+    const simAws = await simAwsWithFunction();
+
+    // When a caller tries to publish an AWS/Lambda metric of its own.
+    const error = await assertThrowsErrorAsync(
+      async () =>
+        await simAws.cloudWatch().putMetricData(
+          new PutMetricDataCommand({
+            Namespace: "AWS/Lambda",
+            MetricData: [{ MetricName: "Errors", Value: 1 }],
+          }),
+        ),
+    );
+
+    // Then it is refused, as an account refuses one. Lambda's own metrics
+    // reach the store by a route a caller has no access to.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+  });
+
+  it("runs on a simulated Lambda with no CloudWatch to count into", async () => {
+    // Given a simulated Lambda built on its own.
+    const simLambda = new SimLambda();
+
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: functionName,
+        Role: "arn:aws:iam::888888888888:role/OrdersRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "done") },
+      }),
+    );
+
+    // When it is invoked.
+    const result = await simLambda.invoke(
+      new InvokeCommand({ FunctionName: functionName }),
+    );
+
+    // Then the invocation ran and answered. Counting is what it does without,
+    // rather than something it fails for the want of.
+    assertIdentical(result.StatusCode, 200);
+  });
+});

--- a/src/service/lambda/metric/sim-lambda-invocation-metrics.ts
+++ b/src/service/lambda/metric/sim-lambda-invocation-metrics.ts
@@ -1,0 +1,118 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type {
+  SimCloudWatchServiceDatum,
+  SimCloudWatchServiceWriter,
+} from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
+
+/**
+ * The namespace real Lambda publishes what it counts about a function under.
+ */
+export const simLambdaMetricNamespace = "AWS/Lambda";
+
+/**
+ * How one invocation went, as the metrics read it.
+ */
+export interface SimLambdaInvocationOutcome {
+  readonly functionName: string;
+
+  /** How far the simulation's clock moved while the handler ran. */
+  readonly durationMilliseconds: number;
+
+  /** Whether the handler threw, which is what real Lambda counts an error. */
+  readonly failed: boolean;
+}
+
+interface SimLambdaInvocationMetricsProperties {
+  readonly metrics: SimCloudWatchServiceWriter | undefined;
+  readonly clock: SimClock;
+}
+
+/**
+ * What a simulated Lambda function publishes about its own invocations.
+ *
+ * Real Lambda publishes these without being asked and without a caller needing
+ * any permission, so they go in through simulated CloudWatch's service writer
+ * rather than through `PutMetricData`, which refuses the `AWS/Lambda`
+ * namespace exactly as an account does.
+ *
+ * A function built on its own, outside a `SimAws` instance, has no CloudWatch
+ * to publish into and counts nothing.
+ */
+export class SimLambdaInvocationMetrics {
+  readonly #metrics: SimCloudWatchServiceWriter | undefined;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimLambdaInvocationMetricsProperties) {
+    this.#metrics = properties.metrics;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Run one invocation and count how it went.
+   *
+   * `Invocations` counts every invocation, including one that failed, which is
+   * how real Lambda counts them. `Errors` counts the ones that threw, so an
+   * alarm reading one against the other gets a failure rate.
+   *
+   * The duration is measured on the simulation's clock rather than the host's,
+   * so it is a number a test can assert on. A handler that moves the clock
+   * reports the time it moved, and one that does not reports nothing spent.
+   */
+  async around<T>(functionName: string, run: () => Promise<T>): Promise<T> {
+    const startedAt = this.#clock.now().getTime();
+    let failed = true;
+
+    try {
+      const result = await run();
+
+      failed = false;
+
+      return result;
+    } finally {
+      this.#metrics?.publish(
+        invocationData({
+          functionName,
+          durationMilliseconds: this.#clock.now().getTime() - startedAt,
+          failed,
+        }),
+      );
+    }
+  }
+}
+
+/**
+ * The datapoints one finished invocation produced.
+ */
+function invocationData(
+  outcome: SimLambdaInvocationOutcome,
+): readonly SimCloudWatchServiceDatum[] {
+  const dimensions = [{ name: "FunctionName", value: outcome.functionName }];
+  const data: SimCloudWatchServiceDatum[] = [
+    {
+      namespace: simLambdaMetricNamespace,
+      metricName: "Invocations",
+      dimensions,
+      value: 1,
+      unit: "Count",
+    },
+    {
+      namespace: simLambdaMetricNamespace,
+      metricName: "Duration",
+      dimensions,
+      value: outcome.durationMilliseconds,
+      unit: "Milliseconds",
+    },
+  ];
+
+  if (outcome.failed) {
+    data.push({
+      namespace: simLambdaMetricNamespace,
+      metricName: "Errors",
+      dimensions,
+      value: 1,
+      unit: "Count",
+    });
+  }
+
+  return data;
+}

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -29,6 +29,7 @@ import {
 } from "./function/code/image/sim-lambda-container-images.js";
 import type { SimLambdaCodeStore } from "./function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "./function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
+import type { SimCloudWatchServiceWriter } from "../cloudwatch/write/sim-cloudwatch-service-writer.js";
 import type { SimLogsServiceWriter } from "../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutboundHttp } from "./function/outbound/sim-lambda-outbound-http.js";
 import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
@@ -56,6 +57,7 @@ export interface SimLambdaProperties {
   readonly containerImages?: SimLambdaContainerImages;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider;
   readonly logs?: SimLogsServiceWriter | undefined;
+  readonly metrics?: SimCloudWatchServiceWriter | undefined;
   /**
    * Where the HTTP requests this simulated Lambda's function code makes to
    * hostnames the simulation serves are answered. A standalone SimLambda has
@@ -118,6 +120,7 @@ export class SimLambdaCommands {
       codeStore,
       vmSdkModuleProvider,
       logs,
+      metrics,
       outboundHttp,
       // A standalone SimLambda is not reachable over HTTP, so its own registry
       // is enough; a SimAws-created one shares the environment-wide registry
@@ -216,6 +219,7 @@ export class SimLambdaCommands {
       containerImages,
       vmSdkModuleProvider,
       logs,
+      metrics,
       outboundHttp,
     });
   }


### PR DESCRIPTION
Every invocation publishes `Invocations` and a `Duration` under `AWS/Lambda`, dimensioned by `FunctionName`, and one whose handler threw publishes an `Errors` beside them. An alarm on a function's errors can therefore be driven to a state change by invoking a function that fails, rather than sitting in `INSUFFICIENT_DATA` for want of a datapoint a test has no way to write.

The metrics reach the store through a service writer rather than through `PutMetricData`, which carries on refusing a namespace beginning `AWS/` the way an account does. `Duration` is measured on the simulation's clock, so a handler that moves the clock reports the time it moved and one that does not reports nothing spent. A Lambda built outside a `SimAws` instance has no CloudWatch to publish into and counts nothing.

Resolves #1169


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simulated Lambda functions now publish CloudWatch `AWS/Lambda` metrics for invocations, errors, and duration.
  - Metrics reflect simulated clock time and include function dimensions.
  - CloudWatch alarms can detect failed Lambda invocations and trigger configured notifications.
  - Added examples demonstrating Lambda failures and alarm transitions.

- **Documentation**
  - Documented supported Lambda metrics, limitations, permissions, and unsupported metrics.

- **Tests**
  - Added coverage for successful, failed, synchronous, and asynchronous invocations, metric queries, alarms, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->