### PR TITLE
feat: serve a stand-in page for an identity provider

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -2036,7 +2036,7 @@ so does one that signed up on the page below.
 
 ### The pages managed login serves
 
-A served domain answers five pages, so a browser in a local development server completes a whole
+A served domain answers six pages, so a browser in a local development server completes a whole
 sign-up, password reset and sign-in without any of it being stubbed out.
 
 `GET /oauth2/authorize` naming no `identity_provider` answers HTML holding the sign-in form. The
@@ -2045,6 +2045,25 @@ posts back to `/oauth2/authorize`. A pool that allows passkeys carries a second 
 The pool's identity providers are links to the same endpoint with `identity_provider` set, so every
 way in is on the one page. Posting the form redirects to the app client's callback URL with the code
 and the `state`, honouring a `code_challenge` the request carried.
+
+Following one of those provider links reaches a page standing in for the provider's own sign-in
+page. Real Cognito sends the browser to Google here, and nothing in this simulation calls Google, so
+the page asks who Google would have said is signing in. It says on its face that it is Yulin rather
+than the provider, twice, because somebody meeting it in a screenshot or a screen recording has to
+be able to tell that no real sign-in happened.
+
+The page asks for the subject and for one field per claim the provider's `AttributeMapping` reads,
+and every field arrives filled in, so the common case is pressing the button. The address it
+pre-fills is on `example.com`, which is reserved, so nothing left unedited reaches a real mailbox.
+Editing the address is what drives a federated sign-up against a pool that already holds one of its
+own users at the same address, which real Cognito keeps as two accounts until
+`AdminLinkProviderForUser` merges them. That operation is unsimulated.
+
+Posting the page carries on into the sign-in the authorize endpoint already runs, ending in the same
+`<ProviderName>_<subject>` user and the same authorization code. Nothing is kept on the provider
+afterwards: a further authorize request asks again, because real Cognito asks the provider afresh
+every time. A provider that `signInAs` has already put somebody at skips the page, which is what
+leaves a test that says who is signing in seeing none of this.
 
 `/signup` is a link from that page. Its form asks for a username, a password and the attributes the
 pool needs, which are the ones its `Schema` made required and the ones its `AutoVerifiedAttributes`
@@ -4678,6 +4697,9 @@ Sim Cognito currently supports:
 - A served sign-in form at `/oauth2/authorize`, a sign-up form at `/signup`, a confirmation form at
   `/confirm`, and the two password reset forms at `/forgotPassword` and `/confirmForgotPassword`,
   each carrying the authorize parameters through to the next
+- A served stand-in for an identity provider's own sign-in page, so a browser completes a federated
+  sign-in on a local development server, with the subject and the mapped claims pre-filled and
+  editable
 - The pool user a federated sign-in creates, named `<ProviderName>_<subject>`, in the
   `EXTERNAL_PROVIDER` status, carrying the `identities` attribute and claim and the attributes the
   provider's `AttributeMapping` named
@@ -5062,7 +5084,10 @@ Current documented limitations:
   `userinfo_endpoint`, where real Cognito names one.
 - Nothing calls an external identity provider. A provider's `ProviderDetails` are recorded and
   validated for presence, and never used. The user a simulated provider signs in is the one
-  `signInAs` put there. That accessor is a divergence for the same reason `confirmationCode` is one.
+  `signInAs` put there, or the one the served stand-in page for that provider posted back. Both are
+  divergences for the same reason `confirmationCode` is one.
+- The stand-in page is served, and an authorize request that reaches `hostedAuthorize` directly is
+  refused instead, naming `signInAs`. Only the serving layer can answer a caller with a page.
 - A custom domain answers on its own hostname with no Route53 record of its own, where real AWS
   needs an alias record to the CloudFront distribution Cognito creates. The distribution name a
   domain reports is a name unserved here.

--- a/src/service/cognito/command/hosted/hosted-auth.command.ts
+++ b/src/service/cognito/command/hosted/hosted-auth.command.ts
@@ -55,6 +55,27 @@ export interface SimCognitoAuthorizeInput {
    * issued when the passkey was asked for.
    */
   readonly passkey_session?: string | undefined;
+
+  /**
+   * The subject the identity provider is signing in, as the stand-in page for
+   * that provider posted it.
+   *
+   * Real Cognito redirects the browser to the provider itself here, and the
+   * provider answers with whoever signed in at it. A test says who that is
+   * with `signInAs`, and a browser on a served domain says it on the page the
+   * simulation stands in with. This is that page coming back.
+   */
+  readonly subject?: string | undefined;
+
+  /**
+   * One claim the provider would have asserted, under its own claim name.
+   *
+   * The stand-in page draws a field per claim the provider's `AttributeMapping`
+   * reads, so the names are the pool's rather than this simulation's, and they
+   * are prefixed to keep them apart from the authorize parameters they are
+   * posted beside.
+   */
+  readonly [claim: `claim_${string}`]: string | undefined;
 }
 
 /**

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-sign-in.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-sign-in.ts
@@ -2,6 +2,7 @@ import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimCognitoManagedLoginRequired } from "../../error/sim-cognito-managed-login.error.js";
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoFederatedSignIn } from "../../user-pool/idp/sim-cognito-federated-sign-in.js";
+import { requireSimCognitoSigningInAt } from "../../user-pool/idp/sim-cognito-presented-external-user.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoFirstFactorChallenge } from "../auth/sim-cognito-first-factor-challenge.js";
@@ -82,6 +83,7 @@ export class SimCognitoHostedSignIn {
       pool,
       client,
       provider,
+      externalUser: requireSimCognitoSigningInAt(provider, input),
       now,
     });
 

--- a/src/service/cognito/error/sim-cognito-managed-login.error.ts
+++ b/src/service/cognito/error/sim-cognito-managed-login.error.ts
@@ -78,3 +78,45 @@ export function isSimCognitoPasskeyRequired(
 ): error is SimCognitoPasskeyRequired {
   return error instanceof SimCognitoPasskeyRequired;
 }
+
+/**
+ * An authorize request naming an identity provider that nobody is signed in
+ * at, and presenting no user of its own.
+ *
+ * Real Cognito redirects the browser to the provider's own sign-in page here,
+ * and the provider answers with whoever signed in at it. Nothing in this
+ * simulation calls a provider, so a served domain answers with a page standing
+ * in for that one, and the person says who is signing in. A test skips the
+ * page by saying it with `signInAs` first.
+ *
+ * It is an OAuth error so that every other caller treats it as one, in the
+ * same way `SimCognitoManagedLoginRequired` is.
+ */
+export class SimCognitoProviderSignInRequired extends SimCognitoOAuthError {
+  /** The provider the page stands in for. */
+  public readonly providerName: string;
+
+  constructor(providerName: string) {
+    super({
+      code: "invalid_request",
+      description:
+        `Nobody is signed in at the ${providerName} identity provider. Real ` +
+        `Cognito would send the user to the provider's own sign-in page, ` +
+        `which this simulation has no equivalent of. Say who is signed in ` +
+        `there with signInAs, or post a subject to the page a served domain ` +
+        `answers this request with.`,
+      redirectable: false,
+    });
+    this.providerName = providerName;
+  }
+}
+
+/**
+ * Whether an authorize request was one a provider's own sign-in page would
+ * have answered.
+ */
+export function isSimCognitoProviderSignInRequired(
+  error: unknown,
+): error is SimCognitoProviderSignInRequired {
+  return error instanceof SimCognitoProviderSignInRequired;
+}

--- a/src/service/cognito/serve/page/sim-cognito-managed-login.ts
+++ b/src/service/cognito/serve/page/sim-cognito-managed-login.ts
@@ -1,6 +1,7 @@
 import {
   isSimCognitoManagedLoginRequired,
   isSimCognitoPasskeyRequired,
+  isSimCognitoProviderSignInRequired,
 } from "../../error/sim-cognito-managed-login.error.js";
 import { isSimCognitoOAuthError } from "../../error/sim-cognito-oauth.error.js";
 import type { SimCognitoDomainRequest } from "../sim-cognito-domain-request.js";
@@ -8,6 +9,7 @@ import { SimCognitoConfirmPage } from "./sim-cognito-confirm-page.js";
 import { SimCognitoForgotPasswordPage } from "./sim-cognito-forgot-password-page.js";
 import { SimCognitoPageForm } from "./sim-cognito-page-form.js";
 import { SimCognitoPasskeyPage } from "./sim-cognito-passkey-page.js";
+import { SimCognitoProviderPage } from "./sim-cognito-provider-page.js";
 import type { SimCognitoPageParameters } from "./sim-cognito-page-markup.js";
 import {
   simCognitoForgotPasswordPath,
@@ -35,6 +37,7 @@ export class SimCognitoManagedLogin {
   private readonly pageRequest = new SimCognitoPageRequest();
   private readonly signInPage = new SimCognitoSignInPage();
   private readonly passkeyPage = new SimCognitoPasskeyPage();
+  private readonly providerPage = new SimCognitoProviderPage();
   private readonly signUpPage = new SimCognitoSignUpPage();
   private readonly confirmPage = new SimCognitoConfirmPage();
   private readonly forgotPasswordPage = new SimCognitoForgotPasswordPage();
@@ -91,6 +94,13 @@ export class SimCognitoManagedLogin {
 
     if (isSimCognitoPasskeyRequired(error)) {
       return this.passkeyPage.render(parameters, error.username, error.session);
+    }
+
+    if (isSimCognitoProviderSignInRequired(error)) {
+      return this.providerPage.render(
+        request.pool.auth.identityProviders.require(error.providerName),
+        parameters,
+      );
     }
 
     if (isSimCognitoOAuthError(error) || !simCognitoIsLocalSignIn(parameters)) {

--- a/src/service/cognito/serve/page/sim-cognito-page-markup.ts
+++ b/src/service/cognito/serve/page/sim-cognito-page-markup.ts
@@ -76,14 +76,18 @@ export class SimCognitoPageMarkup {
 
   /**
    * One labelled input, with the label naming the field it is for.
+   *
+   * A field given a value arrives filled in, which is what lets a page a
+   * person only has to press the button on still carry what it needs.
    */
-  field(name: string, label: string, type = "text"): string {
+  field(name: string, label: string, type = "text", value = ""): string {
     const escapedName = this.escaped(name);
 
     return (
       `<p><label for="${escapedName}">${this.escaped(label)}</label>\n` +
       `<input id="${escapedName}" name="${escapedName}" ` +
-      `type="${this.escaped(type)}" required></p>\n`
+      `type="${this.escaped(type)}" value="${this.escaped(value)}" ` +
+      `required></p>\n`
     );
   }
 

--- a/src/service/cognito/serve/page/sim-cognito-provider-page.iso.test.ts
+++ b/src/service/cognito/serve/page/sim-cognito-provider-page.iso.test.ts
@@ -1,0 +1,215 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringNotIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+  simCognitoLocalUser,
+  simCognitoSignedInAtGoogle,
+  type SimCognitoHostedSetUp,
+} from "../../../../../test/cognito/federation-fixture.js";
+import {
+  simCognitoGetPage,
+  simCognitoPostForm,
+  simCognitoRedirectedTo,
+} from "../../../../../test/cognito/managed-login-fixture.js";
+
+/**
+ * The parameters a browser following the "Sign in with Google" link arrives on.
+ */
+function federatedParameters(
+  setUp: SimCognitoHostedSetUp,
+): Record<string, string> {
+  return {
+    response_type: "code",
+    client_id: setUp.clientId,
+    redirect_uri: simCognitoCallbackUrl,
+    state: "csrf-token",
+    identity_provider: "Google",
+  };
+}
+
+/**
+ * Follow the provider link and answer with the page it lands on.
+ */
+async function providerPage(setUp: SimCognitoHostedSetUp): Promise<string> {
+  const response = await simCognitoGetPage(
+    setUp,
+    "/oauth2/authorize",
+    federatedParameters(setUp),
+  );
+
+  assertIdentical(response.status, 200);
+
+  return await response.text();
+}
+
+/**
+ * The users the pool holds, by username.
+ */
+function usernamesIn(setUp: SimCognitoHostedSetUp): readonly string[] {
+  return setUp.cognito
+    .userPool(setUp.userPoolId)
+    .users.map((user) => String(user.username));
+}
+
+describe("The page a sim Cognito domain stands in for an identity provider with", () => {
+  it("answers an authorize request naming a provider nobody is signed in at", async () => {
+    // Given a pool whose Google provider has nobody signed in at it.
+    const setUp = await simCognitoHosted();
+
+    // When a browser follows the provider link on the sign-in form.
+    const page = await providerPage(setUp);
+
+    // Then it is answered with a form rather than sent back to the
+    // application with an error.
+    assertStringIncludes(page, '<form method="post"');
+    assertStringIncludes(page, 'name="subject"');
+  });
+
+  it("says it is Yulin standing in, in words nobody reads as the real service", async () => {
+    // Given the same pool.
+    const setUp = await simCognitoHosted();
+
+    // When the page is served.
+    const page = await providerPage(setUp);
+
+    // Then it names Yulin and the provider it stands in for, so somebody
+    // meeting it in a screenshot can tell no real sign-in happened.
+    assertStringIncludes(page, "Simulated Google sign-in");
+    assertStringIncludes(page, "This is Yulin standing in for Google");
+    assertStringIncludes(page, "nothing on this page reaches it");
+  });
+
+  it("pre-fills the subject and the claims the attribute mapping reads", async () => {
+    // Given a pool whose Google provider maps the email and given_name claims.
+    const setUp = await simCognitoHosted();
+
+    // When the page is served.
+    const page = await providerPage(setUp);
+
+    // Then a field per mapped claim arrives filled in, with an address on a
+    // domain reserved for the purpose, so pressing the button is enough.
+    assertStringIncludes(page, 'name="claim_email"');
+    assertStringIncludes(page, 'value="someone@example.com"');
+    assertStringIncludes(page, 'name="claim_given_name"');
+    assertStringIncludes(page, 'value="simulated-google-subject"');
+
+    // And a claim the mapping says nothing about is left off, because it would
+    // reach no pool attribute.
+    assertStringNotIncludes(page, 'name="claim_picture"');
+  });
+
+  it("signs a user in and reaches the callback when the page is posted unedited", async () => {
+    // Given a pool whose Google provider has nobody signed in at it.
+    const setUp = await simCognitoHosted();
+
+    // When the page is posted with the values it arrived carrying.
+    const posted = await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...federatedParameters(setUp),
+      subject: "simulated-google-subject",
+      claim_email: "someone@example.com",
+      claim_given_name: "Someone",
+    });
+
+    // Then the browser goes to the app client's callback URL with a code and
+    // the state the application started with.
+    assertIdentical(posted.status, 302);
+
+    const callback = simCognitoRedirectedTo(posted);
+    assertIdentical(callback.origin + callback.pathname, simCognitoCallbackUrl);
+    assertNonNullable(callback.searchParams.get("code"));
+    assertIdentical(callback.searchParams.get("state"), "csrf-token");
+
+    // And the pool holds the federated user the subject names, carrying the
+    // claims the page posted.
+    const user = setUp.cognito
+      .userPool(setUp.userPoolId)
+      .requireUser("Google_simulated-google-subject" as never);
+    assertIdentical(user.attributeValues.get("email"), "someone@example.com");
+    assertIdentical(user.status.value, "EXTERNAL_PROVIDER");
+  });
+
+  it("takes an edited address, beside a local user already holding it", async () => {
+    // Given a pool that already holds one of its own users at an address.
+    const setUp = await simCognitoHosted();
+
+    await simCognitoLocalUser(setUp, {
+      username: "alice",
+      attributes: [{ Name: "email", Value: "alice@example.com" }],
+    });
+
+    // When the page is posted with that same address edited into it.
+    await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...federatedParameters(setUp),
+      subject: "simulated-google-subject",
+      claim_email: "alice@example.com",
+      claim_given_name: "Someone",
+    });
+
+    // Then the pool holds two users at the one address, which is what real
+    // Cognito keeps until something links them.
+    assertArrayLength(usernamesIn(setUp), 2);
+
+    const federated = setUp.cognito
+      .userPool(setUp.userPoolId)
+      .requireUser("Google_simulated-google-subject" as never);
+    assertIdentical(
+      federated.attributeValues.get("email"),
+      "alice@example.com",
+    );
+  });
+
+  it("is skipped where a provider already has somebody signed in at it", async () => {
+    // Given a provider a test has said who is signed in at.
+    const setUp = await simCognitoHosted();
+    simCognitoSignedInAtGoogle(setUp, "google-subject-1", {
+      email: "someone@example.com",
+    });
+
+    // When the browser follows the provider link.
+    const response = await simCognitoGetPage(
+      setUp,
+      "/oauth2/authorize",
+      federatedParameters(setUp),
+    );
+
+    // Then the sign-in completes without the page being drawn, which is what
+    // leaves every test written before this one unchanged.
+    assertIdentical(response.status, 302);
+    assertNonNullable(
+      simCognitoRedirectedTo(response).searchParams.get("code"),
+    );
+    assertUndefined(
+      setUp.cognito
+        .userPool(setUp.userPoolId)
+        .findUser("Google_simulated-google-subject"),
+    );
+  });
+
+  it("asks again on the next request rather than remembering who was posted", async () => {
+    // Given a page that has already been posted once.
+    const setUp = await simCognitoHosted();
+
+    await simCognitoPostForm(setUp, "/oauth2/authorize", {
+      ...federatedParameters(setUp),
+      subject: "simulated-google-subject",
+      claim_email: "someone@example.com",
+      claim_given_name: "Someone",
+    });
+
+    // When a further authorize request names the provider.
+    const page = await providerPage(setUp);
+
+    // Then it asks again, because real Cognito asks the provider afresh every
+    // time and nothing here holds on to what a page posted.
+    assertStringIncludes(page, "Simulated Google sign-in");
+  });
+});

--- a/src/service/cognito/serve/page/sim-cognito-provider-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-provider-page.ts
@@ -1,0 +1,87 @@
+import {
+  simCognitoClaimFieldPrefix,
+  simCognitoDefaultClaim,
+  simCognitoDefaultSubject,
+  simCognitoMappedClaimNames,
+} from "../../user-pool/idp/sim-cognito-presented-external-user.js";
+import type { SimCognitoUserPoolIdentityProvider } from "../../user-pool/idp/sim-cognito-user-pool-identity-provider.js";
+import {
+  SimCognitoPageMarkup,
+  type SimCognitoPageParameters,
+} from "./sim-cognito-page-markup.js";
+import { simCognitoAuthorizePath } from "./sim-cognito-page-paths.js";
+
+/**
+ * The page a browser reaches where real Cognito would have sent it to an
+ * identity provider's own sign-in page.
+ *
+ * Nothing here calls Google, so there is no page to send anybody to and no
+ * password for anybody to type. This stands in for that page: it asks who the
+ * provider would have said is signing in, and the answer goes back to the
+ * authorize endpoint as the subject and the claims a provider asserts. A test
+ * says the same thing with `signInAs` and never sees this.
+ *
+ * It says whose page it is on its face, twice, because somebody meeting it in
+ * a screenshot or a screen recording has to be able to tell at a glance that
+ * no real sign-in happened here.
+ */
+export class SimCognitoProviderPage {
+  private readonly markup = new SimCognitoPageMarkup();
+
+  /**
+   * The page asking who the provider is signing in.
+   *
+   * Every field arrives filled in, so the common case is pressing the button.
+   * Editing the address is what drives a federated sign-up against a pool that
+   * already holds a local user at the same address, which real Cognito keeps
+   * as two accounts.
+   */
+  render(
+    provider: SimCognitoUserPoolIdentityProvider,
+    parameters: SimCognitoPageParameters,
+  ): Response {
+    const body =
+      this.markup.message(
+        `This is Yulin standing in for ${provider.name}. It is not ` +
+          `${provider.name}, nobody has signed in there, and nothing on this ` +
+          `page reaches it. Say who ${provider.name} would have said is ` +
+          `signing in, and the pool signs that user in.`,
+      ) +
+      this.markup.form(
+        simCognitoAuthorizePath,
+        this.markup.hidden(parameters) +
+          this.markup.field(
+            "subject",
+            `Subject, which ${provider.name} identifies the user by`,
+            "text",
+            simCognitoDefaultSubject(provider),
+          ) +
+          this.claimFields(provider) +
+          this.markup.submit(
+            "continue",
+            `Continue as this ${provider.name} user`,
+          ),
+      );
+
+    return this.markup.page(`Simulated ${provider.name} sign-in`, body);
+  }
+
+  /**
+   * One field per claim the provider's attribute mapping reads.
+   *
+   * A claim the mapping says nothing about reaches no pool attribute, so
+   * asking for one would be asking for something to throw away.
+   */
+  private claimFields(provider: SimCognitoUserPoolIdentityProvider): string {
+    return simCognitoMappedClaimNames(provider)
+      .map((claimName) =>
+        this.markup.field(
+          `${simCognitoClaimFieldPrefix}${claimName}`,
+          `${claimName} claim`,
+          "text",
+          simCognitoDefaultClaim(claimName),
+        ),
+      )
+      .join("");
+  }
+}

--- a/src/service/cognito/serve/sim-cognito-authorize-refusals.iso.test.ts
+++ b/src/service/cognito/serve/sim-cognito-authorize-refusals.iso.test.ts
@@ -2,6 +2,7 @@ import {
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
+  assertThrowsErrorAsync,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -264,19 +265,26 @@ describe("Refusals from a sim Cognito authorize endpoint", () => {
     );
   });
 
-  it("refuses a provider with nobody signed in at it", async () => {
+  it("refuses a provider with nobody signed in at it, off the served domain", async () => {
     // Given a pool whose Google provider has nobody signed in at it.
     const setUp = await simCognitoHosted();
 
-    // When an authorize request tries to sign in through it.
-    const response = await authorize(setUp, authorizeParameters(setUp));
+    // When the authorize endpoint is called directly, with no browser for a
+    // page to be drawn for.
+    const error = await assertThrowsErrorAsync(async () => {
+      await setUp.cognito.hostedAuthorize(
+        setUp.cognito.userPool(setUp.userPoolId),
+        authorizeParameters(setUp),
+      );
+    });
 
     // Then it says what to do about it, rather than signing in a user nothing
-    // put there.
-    assertIdentical(response.status, 400);
+    // put there. A served domain answers the same request with the page that
+    // asks, which `The page a sim Cognito domain stands in for an identity
+    // provider with` covers.
     assertStringIncludes(
-      await refusedBody(response),
-      "Say who is signed in there with signInAs first",
+      error.message,
+      "Say who is signed in there with signInAs",
     );
   });
 

--- a/src/service/cognito/user-pool/idp/sim-cognito-federated-sign-in.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-federated-sign-in.ts
@@ -9,6 +9,7 @@ import {
   requireSimCognitoUsername,
   type SimCognitoUsername,
 } from "../user/sim-cognito-username.js";
+import type { SimCognitoExternalUser } from "./sim-cognito-external-user.js";
 import { SimCognitoFederatedIdentity } from "./sim-cognito-federated-identity.js";
 import { SimCognitoFederatedTriggers } from "./sim-cognito-federated-triggers.js";
 import { requireSimCognitoSameFederatedIdentity } from "./sim-cognito-same-federated-identity.js";
@@ -23,6 +24,13 @@ interface SimCognitoFederatedSignInRequest {
   readonly pool: SimCognitoUserPool;
   readonly client: SimCognitoUserPoolClient;
   readonly provider: SimCognitoUserPoolIdentityProvider;
+
+  /**
+   * Who the provider is signing in, which the caller settled before getting
+   * here: the user `signInAs` put at the provider, or the one the stand-in
+   * page for it posted back.
+   */
+  readonly externalUser: SimCognitoExternalUser;
   readonly now: Date;
 }
 
@@ -65,8 +73,7 @@ export class SimCognitoFederatedSignIn {
   async signIn(
     request: SimCognitoFederatedSignInRequest,
   ): Promise<SimCognitoUser> {
-    const { pool, provider } = request;
-    const externalUser = provider.requireSignedInUser();
+    const { pool, provider, externalUser } = request;
     const username = requireSimCognitoUsername(
       `${provider.name}_${externalUser.subject}`,
     );
@@ -74,7 +81,7 @@ export class SimCognitoFederatedSignIn {
     const existing = pool.findUser(username);
 
     if (existing !== undefined) {
-      requireSimCognitoSameFederatedIdentity(existing, provider);
+      requireSimCognitoSameFederatedIdentity(existing, provider, externalUser);
 
       return this.returningUser(request, existing, attributes);
     }
@@ -127,8 +134,7 @@ export class SimCognitoFederatedSignIn {
     username: SimCognitoUsername,
     attributes: readonly SimCognitoAttributeType[],
   ): Promise<SimCognitoUser> {
-    const { pool, client, provider, now } = request;
-    const externalUser = provider.requireSignedInUser();
+    const { pool, client, provider, externalUser, now } = request;
 
     const user = this.userFactory.federated({
       username,

--- a/src/service/cognito/user-pool/idp/sim-cognito-federated-user.iso.test.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-federated-user.iso.test.ts
@@ -147,13 +147,10 @@ describe("The user a sim Cognito pool creates for a federated sign-in", () => {
       .auth.identityProviders.require("Google")
       .signOut();
 
-    // Then a further authorize request is refused rather than signing the same
-    // user in again.
+    // Then a further authorize request asks who is signing in rather than
+    // signing the same user in again.
     const response = await signIn(setUp);
-    assertIdentical(response.status, 400);
-    assertStringIncludes(
-      JSON.stringify(await response.json()),
-      "Nobody is signed in at the Google identity provider",
-    );
+    assertIdentical(response.status, 200);
+    assertStringIncludes(await response.text(), "Simulated Google sign-in");
   });
 });

--- a/src/service/cognito/user-pool/idp/sim-cognito-presented-external-user.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-presented-external-user.ts
@@ -1,0 +1,124 @@
+import type { SimCognitoAuthorizeInput } from "../../command/hosted/hosted-auth.command.js";
+import { SimCognitoProviderSignInRequired } from "../../error/sim-cognito-managed-login.error.js";
+import { SimCognitoExternalUser } from "./sim-cognito-external-user.js";
+import type { SimCognitoUserPoolIdentityProvider } from "./sim-cognito-user-pool-identity-provider.js";
+
+/**
+ * What a claim field is called on the stand-in provider page.
+ *
+ * The names after it are the provider's own claim names, so they are prefixed
+ * to keep them apart from the authorize parameters the form posts beside them.
+ */
+export const simCognitoClaimFieldPrefix = "claim_";
+
+/**
+ * The address a claim the page reads as an email address is pre-filled with.
+ *
+ * `example.com` is reserved for exactly this, so nothing a person leaves
+ * unedited can reach a real mailbox.
+ */
+const defaultAddress = "someone@example.com";
+
+/**
+ * What every other claim is pre-filled with.
+ */
+const defaultClaimValue = "Someone";
+
+/**
+ * The claim names a provider's attribute mapping reads.
+ *
+ * The mapping is keyed by pool attribute and valued by claim, so the values
+ * are what a provider would have asserted and what the page asks for.
+ */
+export function simCognitoMappedClaimNames(
+  provider: SimCognitoUserPoolIdentityProvider,
+): readonly string[] {
+  return [...new Set(Object.values(provider.attributeMapping.toOutput()))];
+}
+
+/**
+ * What one claim field is pre-filled with, so that the page signs a user in
+ * when nobody edits it.
+ *
+ * An address has to look like one, because a pool that verifies or aliases by
+ * email holds it to that. Everything else is a name as far as this knows.
+ */
+export function simCognitoDefaultClaim(claimName: string): string {
+  return claimName.toLowerCase().includes("email")
+    ? defaultAddress
+    : defaultClaimValue;
+}
+
+/**
+ * The subject the page pre-fills, which says on its face where it came from.
+ */
+export function simCognitoDefaultSubject(
+  provider: SimCognitoUserPoolIdentityProvider,
+): string {
+  return `simulated-${provider.name.toLowerCase()}-subject`;
+}
+
+/**
+ * The external user an authorize request presented, where it presented one.
+ *
+ * This is the stand-in page for a provider coming back. Nothing is kept on the
+ * provider afterwards, because real Cognito asks the provider afresh on every
+ * authorize request, and `signInAs` stays what a test says it with.
+ */
+export function simCognitoPresentedExternalUser(
+  input: SimCognitoAuthorizeInput,
+): SimCognitoExternalUser | undefined {
+  const { subject } = input;
+
+  if (subject === undefined || subject === "") {
+    return undefined;
+  }
+
+  return new SimCognitoExternalUser({
+    Subject: subject,
+    Claims: simCognitoPresentedClaims(input),
+  });
+}
+
+/**
+ * Who a provider is signing in for one authorize request.
+ *
+ * A request presenting a subject of its own is the stand-in page for the
+ * provider coming back, and it wins, because real Cognito asks the provider
+ * afresh every time rather than remembering the last answer. Where it presents
+ * none, the user `signInAs` put at the provider signs in. Where there is
+ * neither, the request is refused with what a served domain draws that page
+ * from.
+ */
+export function requireSimCognitoSigningInAt(
+  provider: SimCognitoUserPoolIdentityProvider,
+  input: SimCognitoAuthorizeInput,
+): SimCognitoExternalUser {
+  const presented =
+    simCognitoPresentedExternalUser(input) ?? provider.signedInUser;
+
+  if (presented === undefined) {
+    throw new SimCognitoProviderSignInRequired(provider.name);
+  }
+
+  return presented;
+}
+
+/**
+ * The claims a posted form carried, by the provider's own claim names.
+ */
+function simCognitoPresentedClaims(
+  input: SimCognitoAuthorizeInput,
+): Record<string, string> {
+  const claims: Record<string, string> = {};
+  const fields: readonly (readonly [string, string | undefined])[] =
+    Object.entries(input);
+
+  for (const [name, value] of fields) {
+    if (value !== undefined && name.startsWith(simCognitoClaimFieldPrefix)) {
+      claims[name.slice(simCognitoClaimFieldPrefix.length)] = value;
+    }
+  }
+
+  return claims;
+}

--- a/src/service/cognito/user-pool/idp/sim-cognito-same-federated-identity.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-same-federated-identity.ts
@@ -1,5 +1,6 @@
 import { SimCognitoUsernameExistsException } from "../../error/sim-cognito.error.js";
 import type { SimCognitoUser } from "../user/sim-cognito-user.js";
+import type { SimCognitoExternalUser } from "./sim-cognito-external-user.js";
 import type { SimCognitoUserPoolIdentityProvider } from "./sim-cognito-user-pool-identity-provider.js";
 
 /**
@@ -14,9 +15,9 @@ import type { SimCognitoUserPoolIdentityProvider } from "./sim-cognito-user-pool
 export function requireSimCognitoSameFederatedIdentity(
   existing: SimCognitoUser,
   provider: SimCognitoUserPoolIdentityProvider,
+  externalUser: SimCognitoExternalUser,
 ): void {
   const { identity } = existing;
-  const externalUser = provider.requireSignedInUser();
 
   if (
     identity?.providerName !== provider.name ||

--- a/src/service/cognito/user-pool/idp/sim-cognito-user-pool-identity-provider.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-user-pool-identity-provider.ts
@@ -120,6 +120,16 @@ export class SimCognitoUserPoolIdentityProvider {
   }
 
   /**
+   * The user signed in at this provider, where anything has put one there.
+   *
+   * A request that presents an external user of its own reads this first, to
+   * find out whether it has to ask for one.
+   */
+  get signedInUser(): SimCognitoExternalUser | undefined {
+    return this.externalUser;
+  }
+
+  /**
    * The user this provider signs in, or a refusal.
    *
    * Real Cognito would show the provider's own sign-in page here, and there is


### PR DESCRIPTION
A served domain drew a "Sign in with Google" link and following it in a browser failed, because the user a provider signs in is the one `signInAs` put there and `signInAs` is an in-process accessor a browser has no way to call, so local development stopped at the page the whole federated flow starts from. A served domain now answers that request with a page standing in for the provider's own sign-in page. It says on its face that it is Yulin rather than the provider, so somebody meeting it in a screenshot can tell no real sign-in happened. It asks for the subject and for one field per claim the provider's `AttributeMapping` reads, every field arrives filled in from a reserved domain, and posting it carries on into the sign-in the authorize endpoint already runs, ending in the same `<ProviderName>_<subject>` user and the same authorization code. An edited address reaches the pool user, which is what drives a federated sign-up against a pool already holding a local user at that address. Nothing is kept on the provider afterwards, because real Cognito asks it afresh every time, and a provider `signInAs` has already put somebody at skips the page.

Two existing tests asserted the old behaviour and now assert the new one. A served authorize request naming a provider with nobody signed in was a 400 and is the page; the refusal it used to give is still what `hostedAuthorize` raises when it is called directly, with no browser for a page to be drawn for, and that is what the refusals suite now covers.

Worth a look in review: `SimCognitoAuthorizeInput` gained a `claim_${string}` template index signature so the posted claim fields are typed rather than cast. The alternative was one cast where the form is read, and the index signature seemed the more honest of the two given every other property on that interface is already `string | undefined`.

Resolves #1174
