### PR TITLE
feat: drive an alarm on an AWS/ metric from a test

### DIFF
--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -10,9 +10,10 @@ it was to assert that the SDK client had been called. That proves the call was m
 measured goes untested.
 
 Most of what lives here is custom metrics. Simulated Lambda publishes its own `AWS/Lambda`
-`Invocations`, `Errors` and `Duration`, and no other simulated service publishes into an `AWS/`
-namespace yet. A query for one nothing measures comes back empty, in place of a number that was
-never taken.
+`Invocations`, `Errors`, `Duration` and `IteratorAge`, and no other simulated service publishes into
+an `AWS/` namespace yet. A query for one nothing measures comes back empty, in place of a number
+that was never taken. A test can stand a datapoint up for one of those itself, which is what drives
+an alarm on a service metric to a state change.
 
 A custom metric's datapoints arrive either from `PutMetricData` or from a CloudWatch Logs metric
 filter counting matching log events. See the [CloudWatch Logs docs](../logs/README.md) for the
@@ -213,9 +214,76 @@ const { MetricAlarms } = await simAws
 console.log(MetricAlarms?.[0]?.StateValue);
 ```
 
-`PutMetricData` still refuses a namespace beginning `AWS/`, exactly as an account does, so a test cannot seed these by hand. A simulated service reaches the metric store by a route a caller has none of.
+`Duration` is measured on the simulation's clock rather than the host's, so it is a number a test can assert on. A handler that moves the clock reports the time it moved, and one that returns without touching it reports nothing spent. `IteratorAge` is measured the same way, and the Lambda documentation covers what a stream event source mapping reports.
 
-`Duration` is measured on the simulation's clock rather than the host's, so it is a number a test can assert on. A handler that moves the clock reports the time it moved, and one that returns without touching it reports nothing spent.
+## Seeding a metric AWS publishes
+
+`PutMetricData` refuses a namespace beginning `AWS/`, exactly as an account does. An alarm watching a metric no simulated service publishes therefore sits in `INSUFFICIENT_DATA`, and its arithmetic goes untested however carefully the alarm itself is declared.
+
+The service writer is the way in. It is the same route simulated Lambda's own metrics take, reached from a test through `cloudWatch().serviceWriter()`, and it stands a datapoint up in any namespace.
+
+```typescript sim-cloudwatch-seed-service-metric
+/**
+ * Driving an alarm on a metric nothing in the simulation publishes.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.clock().setTo(new Date("2026-08-30T09:00:00Z"));
+
+await simAws.cloudWatch().putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "SignInsThrottling",
+    Namespace: "AWS/Cognito",
+    MetricName: "SignInThrottles",
+    Dimensions: [{ Name: "UserPool", Value: "eu-west-1_pool" }],
+    Statistic: "Sum",
+    Period: 300,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 1,
+    Threshold: 0,
+    ComparisonOperator: "GreaterThanThreshold",
+    TreatMissingData: "notBreaching",
+  }),
+);
+
+// The pool would have published this. Nothing here does, so the test does.
+simAws
+  .cloudWatch()
+  .serviceWriter()
+  .publish([
+    {
+      namespace: "AWS/Cognito",
+      metricName: "SignInThrottles",
+      dimensions: [{ Name: "UserPool", Value: "eu-west-1_pool" }],
+      value: 4,
+      unit: "Count",
+    },
+  ]);
+
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(
+    new DescribeAlarmsCommand({ AlarmNames: ["SignInsThrottling"] }),
+  );
+
+// ALARM.
+console.log(MetricAlarms?.[0]?.StateValue);
+```
+
+A datapoint arriving without a `timestamp` is stamped with the simulation's clock. One carrying its own lands where it says, which fills a window without the clock having to be walked through it.
+
+`PutMetricData` is untouched by any of this. A caller naming a reserved namespace is refused exactly as before, and only the account's own machinery and a test reach the store this way.
 
 ## Alarms
 
@@ -466,8 +534,10 @@ await simAws.cloudWatch().putMetricData(
   with evaluation on the simulation's clock and SNS notifications on a state change.
 - IAM authorization on each action, including the `cloudwatch:namespace` condition key and
   alarm-ARN resources.
-- `AWS/Lambda` `Invocations`, `Errors` and `Duration`, published by simulated Lambda itself and read
-  back the way a custom metric is.
+- `AWS/Lambda` `Invocations`, `Errors`, `Duration` and `IteratorAge`, published by simulated Lambda
+  itself and read back the way a custom metric is.
+- Seeding a metric AWS publishes, through `cloudWatch().serviceWriter()`, so an alarm on one can be
+  driven to a state change from a test.
 - `AWS::CloudWatch::Alarm` in simulated CloudFormation, deployed through `PutMetricAlarm` and taken
   down with the stack.
 
@@ -489,11 +559,12 @@ test still passes and no longer means what it says.
   comes back at the period its query asked for.
 - **Cross-account metrics.** `IncludeLinkedAccounts` and `OwningAccount` are refused. There is no
   monitoring account.
-- **Most metrics AWS publishes.** `AWS/Lambda` `Invocations`, `Errors` and `Duration` are the only
-  ones a simulated service writes. `Throttles` and `ConcurrentExecutions` need concurrency limits,
-  which simulated Lambda has none of, and every other `AWS/` namespace needs a source event built
-  before a metric can come from one. A CloudWatch Logs metric filter naming a reserved namespace is
-  refused when it publishes, as `PutMetricData` refuses a caller naming one.
+- **Most metrics AWS publishes.** `AWS/Lambda` `Invocations`, `Errors`, `Duration` and `IteratorAge`
+  are the only ones a simulated service writes. `Throttles` and `ConcurrentExecutions` need
+  concurrency limits, which simulated Lambda has none of, and every other `AWS/` namespace needs a
+  source event built before a metric can come from one. A test seeds what it needs from one of those
+  through the service writer. A CloudWatch Logs metric filter naming a reserved namespace is refused
+  when it publishes, as `PutMetricData` refuses a caller naming one.
 
 Two divergences are deliberate, and not refusals. Real CloudWatch rejects a datapoint more than two
 weeks old or more than two hours in the future, and this accepts any timestamp, letting a test seed

--- a/docs/services/cloudwatch/sim-cloudwatch-seed-service-metric.example.ts
+++ b/docs/services/cloudwatch/sim-cloudwatch-seed-service-metric.example.ts
@@ -1,0 +1,56 @@
+/**
+ * Driving an alarm on a metric nothing in the simulation publishes.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.clock().setTo(new Date("2026-08-30T09:00:00Z"));
+
+await simAws.cloudWatch().putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "SignInsThrottling",
+    Namespace: "AWS/Cognito",
+    MetricName: "SignInThrottles",
+    Dimensions: [{ Name: "UserPool", Value: "eu-west-1_pool" }],
+    Statistic: "Sum",
+    Period: 300,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 1,
+    Threshold: 0,
+    ComparisonOperator: "GreaterThanThreshold",
+    TreatMissingData: "notBreaching",
+  }),
+);
+
+// The pool would have published this. Nothing here does, so the test does.
+simAws
+  .cloudWatch()
+  .serviceWriter()
+  .publish([
+    {
+      namespace: "AWS/Cognito",
+      metricName: "SignInThrottles",
+      dimensions: [{ Name: "UserPool", Value: "eu-west-1_pool" }],
+      value: 4,
+      unit: "Count",
+    },
+  ]);
+
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(
+    new DescribeAlarmsCommand({ AlarmNames: ["SignInsThrottling"] }),
+  );
+
+// ALARM.
+console.log(MetricAlarms?.[0]?.StateValue);

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2763,6 +2763,13 @@ refuses the `AWS/Lambda` namespace, exactly as an account does. See the
 `Duration` is measured on the simulation's clock. A handler that moves the clock reports the time it
 moved, and one that returns without touching it reports nothing spent.
 
+A stream event source mapping publishes `IteratorAge` as well, in milliseconds, once a batch of
+DynamoDB Streams or Kinesis records has been handled. It is the distance between the newest record
+in the batch and the moment the batch finished, measured on the simulation's clock. A test that lets
+records age before anything reads them gets back the interval it let pass. A batch whose handler
+threw is counted too, because the retry leaves the function further behind rather than caught up. A
+queue mapping publishes none of it, and neither does a direct invocation.
+
 `Throttles` and `ConcurrentExecutions` are absent. Both count what a concurrency limit turned away,
 and this simulation applies none.
 

--- a/src/service/cloudwatch/index.ts
+++ b/src/service/cloudwatch/index.ts
@@ -106,6 +106,10 @@ export {
   type SimCloudWatchTimeRange,
 } from "./metric/sim-cloudwatch-time-range.js";
 export {
+  SimCloudWatchServiceWriter,
+  type SimCloudWatchServiceDatum,
+} from "./write/sim-cloudwatch-service-writer.js";
+export {
   SimCloudWatchError,
   type SimCloudWatchErrorMetadata,
   SimCloudWatchInvalidParameterCombinationException,

--- a/src/service/cloudwatch/write/sim-cloudwatch-service-writer.iso.test.ts
+++ b/src/service/cloudwatch/write/sim-cloudwatch-service-writer.iso.test.ts
@@ -1,0 +1,185 @@
+import {
+  DescribeAlarmsCommand,
+  GetMetricStatisticsCommand,
+  PutMetricAlarmCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimCloudWatchInvalidParameterValueException } from "../error/sim-cloudwatch.error.js";
+
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+const dimensions = [{ Name: "UserPool", Value: "eu-west-1_pool" }];
+
+/** A simulation with a stopped clock. */
+async function simAwsAtStartedAt(): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+
+  return simAws;
+}
+
+/** The `Sum` of one AWS/Cognito metric over the five minutes from the start. */
+async function seeded(simAws: SimAws): Promise<number | undefined> {
+  const statistics = new GetMetricStatisticsCommand({
+    Namespace: "AWS/Cognito",
+    MetricName: "SignInThrottles",
+    Dimensions: dimensions,
+    StartTime: startedAt,
+    EndTime: new Date(startedAt.getTime() + 300_000),
+    Period: 300,
+    Statistics: ["Sum"],
+  });
+  const { Datapoints } = await simAws
+    .cloudWatch()
+    .getMetricStatistics(statistics);
+
+  return Datapoints?.at(0)?.Sum;
+}
+
+describe("SimCloudWatchServiceWriter", () => {
+  it("seeds a metric a caller may not write into", async () => {
+    // Given a simulation whose clock is stopped.
+    const simAws = await simAwsAtStartedAt();
+
+    // When a datapoint is published into a reserved namespace.
+    simAws
+      .cloudWatch()
+      .serviceWriter()
+      .publish([
+        {
+          namespace: "AWS/Cognito",
+          metricName: "SignInThrottles",
+          dimensions,
+          value: 4,
+          unit: "Count",
+        },
+      ]);
+
+    // Then a query reads it back the way it reads a custom metric.
+    assertIdentical(await seeded(simAws), 4);
+  });
+
+  it("stamps a datapoint with the simulation's clock", async () => {
+    // Given a simulation whose clock is stopped.
+    const simAws = await simAwsAtStartedAt();
+
+    // When a datapoint arrives carrying no timestamp of its own.
+    simAws
+      .cloudWatch()
+      .serviceWriter()
+      .publish([
+        {
+          namespace: "AWS/Cognito",
+          metricName: "SignInThrottles",
+          dimensions,
+          value: 1,
+        },
+      ]);
+
+    // Then it landed at the instant the clock is stopped at, which is what
+    // puts it inside a window a test asks for.
+    assertIdentical(await seeded(simAws), 1);
+  });
+
+  it("honours a timestamp a datapoint carries", async () => {
+    // Given a simulation whose clock has moved past the window.
+    const simAws = await simAwsAtStartedAt();
+
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    // When a datapoint names an instant back inside it.
+    simAws
+      .cloudWatch()
+      .serviceWriter()
+      .publish([
+        {
+          namespace: "AWS/Cognito",
+          metricName: "SignInThrottles",
+          dimensions,
+          value: 7,
+          timestamp: startedAt.getTime(),
+        },
+      ]);
+
+    // Then it landed where it said rather than where the clock is, which is
+    // how a test seeds a window without arranging the clock around it.
+    assertIdentical(await seeded(simAws), 7);
+  });
+
+  it("leaves PutMetricData refusing the same namespace", async () => {
+    // Given a simulation whose clock is stopped.
+    const simAws = await simAwsAtStartedAt();
+
+    // When a caller tries to write the datapoint the service writer just did.
+    const data = new PutMetricDataCommand({
+      Namespace: "AWS/Cognito",
+      MetricData: [
+        { MetricName: "SignInThrottles", Dimensions: dimensions, Value: 4 },
+      ],
+    });
+    const error = await assertThrowsErrorAsync(
+      async () => await simAws.cloudWatch().putMetricData(data),
+    );
+
+    // Then it is refused, as real CloudWatch refuses it. Seeding is a route a
+    // caller has none of.
+    assertInstanceOf(error, SimCloudWatchInvalidParameterValueException);
+    assertIdentical(error.name, "InvalidParameterValueException");
+  });
+
+  it("drives an alarm on a reserved metric to ALARM", async () => {
+    // Given an alarm watching a metric nothing in the simulation publishes.
+    const simAws = await simAwsAtStartedAt();
+
+    await simAws.cloudWatch().putMetricAlarm(
+      new PutMetricAlarmCommand({
+        AlarmName: "SignInsThrottling",
+        Namespace: "AWS/Cognito",
+        MetricName: "SignInThrottles",
+        Dimensions: dimensions,
+        Statistic: "Sum",
+        Period: 300,
+        EvaluationPeriods: 3,
+        DatapointsToAlarm: 1,
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        TreatMissingData: "notBreaching",
+      }),
+    );
+
+    // When a datapoint is seeded and the clock passes the period.
+    simAws
+      .cloudWatch()
+      .serviceWriter()
+      .publish([
+        {
+          namespace: "AWS/Cognito",
+          metricName: "SignInThrottles",
+          dimensions,
+          value: 4,
+          unit: "Count",
+        },
+      ]);
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ minutes: 6 });
+
+    // Then the alarm went off, which is the arithmetic a test could not reach
+    // while the datapoint had no way in.
+    const described = new DescribeAlarmsCommand({
+      AlarmNames: ["SignInsThrottling"],
+    });
+    const { MetricAlarms } = await simAws
+      .cloudWatch()
+      .describeAlarms(described);
+
+    assertIdentical(MetricAlarms?.at(0)?.StateValue, "ALARM");
+  });
+});

--- a/src/service/cloudwatch/write/sim-cloudwatch-service-writer.ts
+++ b/src/service/cloudwatch/write/sim-cloudwatch-service-writer.ts
@@ -1,15 +1,22 @@
 import type { SimClock } from "../../../util/clock/sim-clock.js";
-import type { SimCloudWatchDimension } from "../metric/sim-cloudwatch-dimension.js";
+import {
+  requiredSimCloudWatchDimensions,
+  type SimCloudWatchDimensionInput,
+} from "../metric/sim-cloudwatch-dimension.js";
 import type { SimCloudWatchMetricStore } from "../metric/sim-cloudwatch-metric-store.js";
 import type { SimCloudWatchUnit } from "../metric/sim-cloudwatch-unit.js";
 
 /**
- * One metric a simulated service publishes about itself.
+ * One observation of a metric AWS publishes.
+ *
+ * The dimensions are written the way an SDK command writes them, with a
+ * capital `Name` and `Value`, because a test seeding a datapoint reaches for
+ * the same shape it passes to `PutMetricData` and `PutMetricAlarm`.
  */
 export interface SimCloudWatchServiceDatum {
   readonly namespace: string;
   readonly metricName: string;
-  readonly dimensions: readonly SimCloudWatchDimension[];
+  readonly dimensions: readonly SimCloudWatchDimensionInput[];
   readonly value: number;
   readonly unit?: SimCloudWatchUnit | undefined;
 
@@ -26,16 +33,20 @@ interface SimCloudWatchServiceWriterProperties {
 }
 
 /**
- * How the rest of the simulation publishes the metrics AWS publishes.
+ * How a metric AWS publishes reaches the store.
  *
  * This is not the CloudWatch API. A simulated service counting its own work is
  * the account's own machinery rather than a caller making a request, so
- * nothing here validates a request or authorizes one. Real CloudWatch does not
- * put Lambda's own `Invocations` through `PutMetricData` either.
+ * nothing here authorizes one. Real CloudWatch does not put Lambda's own
+ * `Invocations` through `PutMetricData` either.
  *
  * The reserved namespace rule is the point of the separation. `PutMetricData`
  * refuses a namespace beginning `AWS/`, exactly as an account does, and the
  * services whose metrics those are reach the store through here instead.
+ *
+ * A test reaches it too, through `cloudWatch().serviceWriter()`, to stand up a
+ * datapoint for a metric nothing in the simulation publishes. That is how an
+ * alarm on one is driven to a state change.
  */
 export class SimCloudWatchServiceWriter {
   readonly #metrics: SimCloudWatchMetricStore;
@@ -51,6 +62,9 @@ export class SimCloudWatchServiceWriter {
    *
    * A whole batch goes in together so one invocation's metrics land at the
    * same instant, whatever the clock does next.
+   *
+   * Dimensions are read the way a command reads them, which is what keys a
+   * seeded datapoint to the same metric a query and an alarm look for.
    */
   publish(data: readonly SimCloudWatchServiceDatum[]): void {
     const now = this.#clock.now().getTime();
@@ -60,7 +74,7 @@ export class SimCloudWatchServiceWriter {
         .ensure({
           namespace: datum.namespace,
           metricName: datum.metricName,
-          dimensions: datum.dimensions,
+          dimensions: requiredSimCloudWatchDimensions(datum.dimensions),
         })
         .record({
           timestamp: datum.timestamp ?? now,

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
@@ -3,6 +3,8 @@ import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-
 import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
 import type { SimLambdaKinesisStreamRecord } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
 import { SimLambdaStreamCascadeGuard } from "../../stream/sim-lambda-stream-cascade-guard.js";
+import { countSimLambdaKinesisIteratorAge } from "../sim-lambda-stream-iterator-age.js";
+import { simLambdaStreamSequenceNumbers } from "../sim-lambda-stream-sequence-numbers.js";
 import type { SimLambdaStreamBatchOutcome } from "../sim-lambda-stream-batch-outcome.js";
 import { SimLambdaStreamBatchResponse } from "../sim-lambda-stream-batch-response.js";
 import { SimLambdaKinesisStreamEventBuilder } from "./sim-lambda-kinesis-stream-event.js";
@@ -85,26 +87,19 @@ export class SimLambdaKinesisStreamDelivery {
       // As on real Lambda, the handler error goes to the function's logs. What
       // the stream sees is the batch being tried again.
       return this.batchResponse.failed();
+    } finally {
+      countSimLambdaKinesisIteratorAge(simFunction, records);
     }
   }
 }
 
 /**
- * The sequence numbers a batch's records can be named by, in stream order.
- *
- * A Kinesis batch item failure names a record by its sequence number, the way a
- * DynamoDB one does, rather than by the `eventID` the event carried.
+ * The sequence numbers this batch's records can be named by.
  */
 function sequenceNumbersOf(
   records: readonly SimLambdaKinesisStreamRecord[],
 ): readonly string[] {
-  return records.flatMap((record) => {
-    const sequenceNumber = record.SequenceNumber;
-
-    if (sequenceNumber === undefined || sequenceNumber === "") {
-      return [];
-    }
-
-    return [sequenceNumber];
-  });
+  return simLambdaStreamSequenceNumbers(
+    records.map((one) => one.SequenceNumber),
+  );
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
@@ -4,6 +4,8 @@ import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda
 import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaStreamCascadeGuard } from "../stream/sim-lambda-stream-cascade-guard.js";
 import { SimLambdaDynamoDbStreamEventBuilder } from "./sim-lambda-dynamodb-stream-event.js";
+import { countSimLambdaDynamoDbIteratorAge } from "./sim-lambda-stream-iterator-age.js";
+import { simLambdaStreamSequenceNumbers } from "./sim-lambda-stream-sequence-numbers.js";
 import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 import { SimLambdaStreamBatchResponse } from "./sim-lambda-stream-batch-response.js";
 
@@ -83,23 +85,19 @@ export class SimLambdaDynamoDbStreamDelivery {
       // As on real Lambda, the handler error goes to the function's logs. What
       // the table sees is the batch being tried again.
       return this.batchResponse.failed();
+    } finally {
+      countSimLambdaDynamoDbIteratorAge(simFunction, records);
     }
   }
 }
 
 /**
- * The sequence numbers a batch's records can be named by, in stream order.
+ * The sequence numbers this batch's records can be named by.
  */
 function sequenceNumbersOf(
   records: readonly SimLambdaEventSourceStreamRecord[],
 ): readonly string[] {
-  return records.flatMap((record) => {
-    const sequenceNumber = record.dynamodb?.SequenceNumber;
-
-    if (sequenceNumber === undefined || sequenceNumber === "") {
-      return [];
-    }
-
-    return [sequenceNumber];
-  });
+  return simLambdaStreamSequenceNumbers(
+    records.map((one) => one.dynamodb?.SequenceNumber),
+  );
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-iterator-age.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-iterator-age.ts
@@ -1,0 +1,51 @@
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaKinesisStreamRecord } from "../stream/kinesis/sim-lambda-kinesis-streams.js";
+import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
+
+/**
+ * Count what a finished DynamoDB Streams batch left on the clock.
+ */
+export function countSimLambdaDynamoDbIteratorAge(
+  simFunction: SimLambdaFunction,
+  records: readonly SimLambdaEventSourceStreamRecord[],
+): void {
+  simFunction.metrics.iteratorAge.count(
+    simFunction.name,
+    newestOf(records.map((one) => one.dynamodb?.ApproximateCreationDateTime)),
+  );
+}
+
+/**
+ * Count what a finished Kinesis batch left on the clock.
+ */
+export function countSimLambdaKinesisIteratorAge(
+  simFunction: SimLambdaFunction,
+  records: readonly SimLambdaKinesisStreamRecord[],
+): void {
+  simFunction.metrics.iteratorAge.count(
+    simFunction.name,
+    newestOf(records.map((one) => one.ApproximateArrivalTimestamp)),
+  );
+}
+
+/**
+ * The latest of the times given, if any of them is a time.
+ *
+ * This is what `IteratorAge` is measured back from. Records reach a poller in
+ * stream order, and the whole batch is read anyway because a record carrying
+ * no time would otherwise decide the answer by where it sits.
+ *
+ * A batch whose records all arrive without a time has no answer, and the
+ * metric is left uncounted rather than measured from nothing.
+ */
+function newestOf(times: readonly (Date | undefined)[]): Date | undefined {
+  let newest: Date | undefined;
+
+  for (const time of times) {
+    if (time !== undefined && (newest === undefined || time > newest)) {
+      newest = time;
+    }
+  }
+
+  return newest;
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-sequence-numbers.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-sequence-numbers.ts
@@ -1,0 +1,16 @@
+/**
+ * The sequence numbers a batch's records can be named by, in stream order.
+ *
+ * A batch item failure names a record by its sequence number, on Kinesis the
+ * same way as on DynamoDB Streams, rather than by the `eventID` a DynamoDB
+ * event carries. Both pollers read the same list out of whatever their own
+ * records call the field. A record without a sequence number cannot be named,
+ * and it is left out rather than reported as an empty name.
+ */
+export function simLambdaStreamSequenceNumbers(
+  values: readonly (string | undefined)[],
+): readonly string[] {
+  return values.flatMap((value) =>
+    value === undefined || value === "" ? [] : [value],
+  );
+}

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -20,7 +20,7 @@ import { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
 import { SimLambdaFunctionLogging } from "./logging/sim-lambda-function-logging.js";
 import { SimLambdaFunctionPolicy } from "./policy/sim-lambda-function-policy.js";
 import { SimLambdaHandlerRunner } from "./invoke/sim-lambda-handler-runner.js";
-import { SimLambdaInvocationMetrics } from "../metric/sim-lambda-invocation-metrics.js";
+import { SimLambdaFunctionMetrics } from "../metric/sim-lambda-function-metrics.js";
 import { SimLambdaInvokeContextBuilder } from "./invoke/sim-lambda-invoke-context-builder.js";
 import { runSimLambdaInHostScope } from "./invoke/sim-lambda-host-scope.js";
 import type { SimLambdaOutboundHttp } from "./outbound/sim-lambda-outbound-http.js";
@@ -80,6 +80,9 @@ export class SimLambdaFunction {
    */
   public readonly resourcePolicy = new SimLambdaFunctionPolicy();
 
+  /** What this function publishes about its own work into `AWS/Lambda`. */
+  public readonly metrics: SimLambdaFunctionMetrics;
+
   #state: SimLambdaFunctionState;
   #code: SimLambdaExecutableCode;
   private readonly properties: SimLambdaFunctionProperties;
@@ -88,7 +91,6 @@ export class SimLambdaFunction {
   private readonly clock: SimClock;
   private readonly logging: SimLambdaFunctionLogging;
   private readonly outboundHttp: SimLambdaOutboundHttp | undefined;
-  private readonly metrics: SimLambdaInvocationMetrics;
 
   constructor(properties: SimLambdaFunctionProperties) {
     const {
@@ -135,7 +137,7 @@ export class SimLambdaFunction {
     this.deadLetterTargetArn = deadLetterTargetArn;
     this.runAsOwner = runAsOwner;
     this.outboundHttp = outboundHttp;
-    this.metrics = new SimLambdaInvocationMetrics({ metrics, clock });
+    this.metrics = new SimLambdaFunctionMetrics({ metrics, clock });
     this.logging = new SimLambdaFunctionLogging({
       functionName: name,
       logs,

--- a/src/service/lambda/metric/sim-lambda-function-metrics.ts
+++ b/src/service/lambda/metric/sim-lambda-function-metrics.ts
@@ -3,11 +3,11 @@ import type {
   SimCloudWatchServiceDatum,
   SimCloudWatchServiceWriter,
 } from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
-
-/**
- * The namespace real Lambda publishes what it counts about a function under.
- */
-export const simLambdaMetricNamespace = "AWS/Lambda";
+import { SimLambdaIteratorAge } from "./sim-lambda-iterator-age.js";
+import {
+  simLambdaFunctionDimensions,
+  simLambdaMetricNamespace,
+} from "./sim-lambda-metrics.js";
 
 /**
  * How one invocation went, as the metrics read it.
@@ -22,13 +22,13 @@ export interface SimLambdaInvocationOutcome {
   readonly failed: boolean;
 }
 
-interface SimLambdaInvocationMetricsProperties {
+interface SimLambdaFunctionMetricsProperties {
   readonly metrics: SimCloudWatchServiceWriter | undefined;
   readonly clock: SimClock;
 }
 
 /**
- * What a simulated Lambda function publishes about its own invocations.
+ * What a simulated Lambda function publishes about its own work.
  *
  * Real Lambda publishes these without being asked and without a caller needing
  * any permission, so they go in through simulated CloudWatch's service writer
@@ -38,13 +38,17 @@ interface SimLambdaInvocationMetricsProperties {
  * A function built on its own, outside a `SimAws` instance, has no CloudWatch
  * to publish into and counts nothing.
  */
-export class SimLambdaInvocationMetrics {
+export class SimLambdaFunctionMetrics {
+  /** How far behind its stream a finished batch left this function. */
+  readonly iteratorAge: SimLambdaIteratorAge;
+
   readonly #metrics: SimCloudWatchServiceWriter | undefined;
   readonly #clock: SimClock;
 
-  constructor(properties: SimLambdaInvocationMetricsProperties) {
+  constructor(properties: SimLambdaFunctionMetricsProperties) {
     this.#metrics = properties.metrics;
     this.#clock = properties.clock;
+    this.iteratorAge = new SimLambdaIteratorAge(properties);
   }
 
   /**
@@ -86,7 +90,7 @@ export class SimLambdaInvocationMetrics {
 function invocationData(
   outcome: SimLambdaInvocationOutcome,
 ): readonly SimCloudWatchServiceDatum[] {
-  const dimensions = [{ name: "FunctionName", value: outcome.functionName }];
+  const dimensions = simLambdaFunctionDimensions(outcome.functionName);
   const data: SimCloudWatchServiceDatum[] = [
     {
       namespace: simLambdaMetricNamespace,

--- a/src/service/lambda/metric/sim-lambda-iterator-age.iso.test.ts
+++ b/src/service/lambda/metric/sim-lambda-iterator-age.iso.test.ts
@@ -1,0 +1,205 @@
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+  InvokeCommand,
+} from "@aws-sdk/client-lambda";
+import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { makeKinesisPollingRole } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import {
+  makeSourceStream,
+  makeStreamPollingRole,
+  simAwsWithStreamEventSource,
+} from "../../../../test/lambda/stream-event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simKinesisStreamFactory } from "../../kinesis/stream/sim-kinesis-stream.factory.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../function/sim-lambda-handler.type.js";
+
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+const projectorName = "projector";
+
+/** The `Maximum` IteratorAge the function reported over the hour from the start. */
+async function iteratorAge(
+  simAws: SimAws,
+  functionName: string,
+): Promise<number | undefined> {
+  const statistics = new GetMetricStatisticsCommand({
+    Namespace: "AWS/Lambda",
+    MetricName: "IteratorAge",
+    Dimensions: [{ Name: "FunctionName", Value: functionName }],
+    StartTime: startedAt,
+    EndTime: new Date(startedAt.getTime() + 3_600_000),
+    Period: 3600,
+    Statistics: ["Maximum"],
+  });
+  const { Datapoints } = await simAws
+    .cloudWatch()
+    .getMetricStatistics(statistics);
+
+  return Datapoints?.at(0)?.Maximum;
+}
+
+/** Bind a function the mappings below deliver to. */
+async function makeProjector(
+  simAws: SimAws,
+  roleArn: string,
+  handler: SimLambdaHandler = () => "done",
+): Promise<void> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: projectorName,
+      Role: roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+}
+
+/** Map a source onto the projector, reading from the start of the stream. */
+async function mapToProjector(
+  simAws: SimAws,
+  eventSourceArn: string,
+): Promise<void> {
+  await simAws.lambda().createEventSourceMapping(
+    new CreateEventSourceMappingCommand({
+      EventSourceArn: eventSourceArn,
+      FunctionName: projectorName,
+      StartingPosition: "TRIM_HORIZON",
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("AWS/Lambda IteratorAge a stream event source publishes", () => {
+  it("counts nothing spent for a consumer that is caught up", async () => {
+    // Given a table's stream mapped to a function, with the clock stopped.
+    const { simAws, tableName, functionName } =
+      await simAwsWithStreamEventSource();
+
+    await simAws.clock().setTo(startedAt);
+
+    // When an item is written and delivered without time moving.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the batch finished at the instant its record was written.
+    assertIdentical(await iteratorAge(simAws, functionName), 0);
+  });
+
+  it("counts how far behind the stream a batch left the function", async () => {
+    // Given a record written to a table's stream ten minutes before anything
+    // was mapped to read it.
+    const simAws = new SimAws();
+
+    await simAws.clock().setTo(startedAt);
+
+    const { tableName, streamArn } = await makeSourceStream(simAws);
+
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // When a mapping starts reading from the beginning of the stream.
+    await makeProjector(simAws, await makeStreamPollingRole(simAws, streamArn));
+    await mapToProjector(simAws, streamArn);
+
+    // Then the age is the ten minutes the record spent waiting, measured on
+    // the simulation's clock.
+    assertIdentical(await iteratorAge(simAws, projectorName), 600_000);
+  });
+
+  it("counts a Kinesis batch the same way", async () => {
+    // Given a record put onto a Kinesis stream ten minutes before anything was
+    // mapped to read it.
+    const simAws = new SimAws();
+
+    await simAws.clock().setTo(startedAt);
+
+    const stream = await simKinesisStreamFactory.make(
+      { streamName: "orders" },
+      simAws,
+    );
+
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        Data: new TextEncoder().encode("order-1"),
+        PartitionKey: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ minutes: 10 });
+
+    // When a mapping starts reading from the beginning of the stream.
+    await makeProjector(
+      simAws,
+      await makeKinesisPollingRole(simAws, stream.arn),
+    );
+    await mapToProjector(simAws, stream.arn);
+
+    // Then the same ten minutes are reported, because the metric belongs to
+    // the mapping rather than to the source behind it.
+    assertIdentical(await iteratorAge(simAws, projectorName), 600_000);
+  });
+
+  it("counts a batch whose handler threw", async () => {
+    // Given a projector that fails on everything it is given.
+    const { simAws, tableName, functionName } =
+      await simAwsWithStreamEventSource({
+        handlerResult: () => {
+          throw new Error("no projection for this order");
+        },
+      });
+
+    await simAws.clock().setTo(startedAt);
+
+    // When an item is written and the batch fails.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the age was still counted, because a failed batch is retried and
+    // leaves the function further behind rather than caught up.
+    assertIdentical(await iteratorAge(simAws, functionName), 0);
+  });
+
+  it("counts nothing for an invocation that read no stream", async () => {
+    // Given a function invoked directly rather than by a mapping.
+    const simAws = new SimAws();
+
+    await simAws.clock().setTo(startedAt);
+    await makeProjector(
+      simAws,
+      `arn:aws:iam::${simAws.defaultAccountId}:role/ProjectorRole`,
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the function is invoked.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: projectorName }));
+    await simAws.backgroundTasksComplete();
+
+    // Then there is no age to report, because IteratorAge belongs to a stream
+    // batch and this invocation read no stream.
+    assertUndefined(await iteratorAge(simAws, projectorName));
+  });
+});

--- a/src/service/lambda/metric/sim-lambda-iterator-age.ts
+++ b/src/service/lambda/metric/sim-lambda-iterator-age.ts
@@ -1,0 +1,56 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimCloudWatchServiceWriter } from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
+import {
+  simLambdaFunctionDimensions,
+  simLambdaMetricNamespace,
+} from "./sim-lambda-metrics.js";
+
+interface SimLambdaIteratorAgeProperties {
+  readonly metrics: SimCloudWatchServiceWriter | undefined;
+  readonly clock: SimClock;
+}
+
+/**
+ * How far behind its stream a finished batch left a function.
+ *
+ * Real Lambda publishes `IteratorAge` when a function finishes processing a
+ * batch of stream records, as the distance between the newest record in the
+ * batch and the moment the batch finished. A batch that failed is counted too,
+ * because the retry leaves the function further behind rather than caught up.
+ *
+ * The age is measured on the simulation's clock, so a test that lets records
+ * age before anything reads them gets back the interval it let pass.
+ */
+export class SimLambdaIteratorAge {
+  readonly #metrics: SimCloudWatchServiceWriter | undefined;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimLambdaIteratorAgeProperties) {
+    this.#metrics = properties.metrics;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Count one finished batch.
+   *
+   * A batch whose records carry no creation time is left uncounted, because
+   * there is nothing to measure the age from.
+   */
+  count(functionName: string, newestRecordAt: Date | undefined): void {
+    if (newestRecordAt === undefined) {
+      return;
+    }
+
+    const age = this.#clock.now().getTime() - newestRecordAt.getTime();
+
+    this.#metrics?.publish([
+      {
+        namespace: simLambdaMetricNamespace,
+        metricName: "IteratorAge",
+        dimensions: simLambdaFunctionDimensions(functionName),
+        value: Math.max(0, age),
+        unit: "Milliseconds",
+      },
+    ]);
+  }
+}

--- a/src/service/lambda/metric/sim-lambda-metrics.ts
+++ b/src/service/lambda/metric/sim-lambda-metrics.ts
@@ -1,0 +1,18 @@
+import type { SimCloudWatchDimensionInput } from "../../cloudwatch/metric/sim-cloudwatch-dimension.js";
+
+/**
+ * The namespace real Lambda publishes what it counts about a function under.
+ */
+export const simLambdaMetricNamespace = "AWS/Lambda";
+
+/**
+ * The dimensions every metric here carries.
+ *
+ * Real Lambda dimensions a function's own metrics by `FunctionName`, and an
+ * alarm a stack declares on one names the function the same way.
+ */
+export function simLambdaFunctionDimensions(
+  functionName: string,
+): readonly SimCloudWatchDimensionInput[] {
+  return [{ Name: "FunctionName", Value: functionName }];
+}


### PR DESCRIPTION
A test can now stand a datapoint up in a reserved namespace through the CloudWatch service writer, reached from `cloudWatch().serviceWriter()`. That is what drives an alarm on a metric no simulated service publishes to a state change, which until now sat in `INSUFFICIENT_DATA` however carefully the alarm was declared. `PutMetricData` carries on refusing an `AWS/` namespace exactly as before, and the writer takes SDK-cased `{ Name, Value }` dimensions so a seeded datapoint keys to the metric a query and an alarm look for. `SimCloudWatchServiceWriter` and `SimCloudWatchServiceDatum` are exported from `@kensio/yulin/cloudwatch`, and the writer has its own test the way `SimLogsServiceWriter` does. A stream event source mapping also publishes an `IteratorAge` of its own on both the DynamoDB Streams and the Kinesis path, measured on the simulation's clock when a batch finishes. An alarm on a lagging consumer needs no seed at all.

Two pieces of housekeeping came with it. `SimLambdaInvocationMetrics` is now `SimLambdaFunctionMetrics`, because it counts what a stream batch left behind as well as what an invocation did. The two stream deliveries were each carrying their own copy of the sequence-number reader, and they now share one.

`AWS/Cognito` `SignInThrottles` stays uncovered by anything but a seed. Nothing rate limits a user pool request, and #1180 and #1181 cover what publishing those would take.

Resolves #1179
