### PR TITLE
fix: refuse an S3 replication config AWS rejects

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -3401,9 +3401,11 @@ Three things are still refused outright, and fail the Resource:
 - A value the simulated service itself refuses, in the same words an SDK caller gets. An
   `AWS::SQS::Queue` with `FifoQueue: true` is one. A FIFO queue is named `<name>.fifo`, which
   simulated SQS refuses, leaving no queue to create under the name the template gave it.
-- A value real AWS answers with a 400, on a property that is skipped. The property is still recorded
-  and nothing acts on it, and what it says is read far enough to catch a template CloudFormation
-  will reject. An `AWS::S3::Bucket` `ReplicationConfiguration` is the one that does this today. See
+- A value real AWS answers with a 400, on a property that is skipped. Nothing acts on the property
+  either way, and what it says is read far enough to catch a template CloudFormation will reject. A
+  value that passes is recorded like any other skipped property. One that fails takes the Resource
+  with it, before anything is recorded against it. An `AWS::S3::Bucket` `ReplicationConfiguration`
+  is the one that does this today. See
   [Buckets from CloudFormation](https://yulinsim.dev/services/s3/#buckets-from-cloudformation "Buckets from CloudFormation").
 
 Properties nothing simulated could tell apart are left off the list. There is no simulated KMS and

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -3393,7 +3393,7 @@ A property name AWS has never had is recorded the same way, and never fails the 
 property AWS added after this simulator read the docs look identical from here, and a Resource that
 deploys with the unread name reported is more useful than a stack that fails over either.
 
-Two things are still refused outright, and fail the Resource:
+Three things are still refused outright, and fail the Resource:
 
 - A property that leaves nothing coherent to create, such as an `AWS::S3::Bucket` whose `BucketName`
   is some type other than a string, or an `AWS::DynamoDB::GlobalTable` whose replica list omits the
@@ -3401,6 +3401,10 @@ Two things are still refused outright, and fail the Resource:
 - A value the simulated service itself refuses, in the same words an SDK caller gets. An
   `AWS::SQS::Queue` with `FifoQueue: true` is one. A FIFO queue is named `<name>.fifo`, which
   simulated SQS refuses, leaving no queue to create under the name the template gave it.
+- A value real AWS answers with a 400, on a property that is skipped. The property is still recorded
+  and nothing acts on it, and what it says is read far enough to catch a template CloudFormation
+  will reject. An `AWS::S3::Bucket` `ReplicationConfiguration` is the one that does this today. See
+  [Buckets from CloudFormation](https://yulinsim.dev/services/s3/#buckets-from-cloudformation "Buckets from CloudFormation").
 
 Properties nothing simulated could tell apart are left off the list. There is no simulated KMS and
 Object bytes are stored as they arrive. An `AWS::S3::Bucket` carrying `BucketEncryption` and `Tags`,

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1717,6 +1717,16 @@ One of the five given in the wrong shape still fails the stack, and so does a `B
 something other than a string. There is no Bucket to create under a name nothing else in the
 template refers to.
 
+A `ReplicationConfiguration` fails the stack as well, for a different reason. Replication is not
+simulated and the property is recorded like any other, and the value is still read for the
+constraints real S3 enforces on it. Those are a `Metrics.EventThreshold` with no `ReplicationTime`
+at `Status: Enabled`, a rule stating a `Filter` without the `DeleteMarkerReplication`, `Priority` and
+`Status` that S3 requires alongside one, and a source Bucket whose template never enabled
+versioning. Real S3 answers each of them with a 400 and CloudFormation rolls the stack back, and the
+CloudFormation resource schema states none of them, so cfn-lint passes a template carrying any one.
+A deploy here that reported them as working would be the last check between a repository and that
+rollback.
+
 `BucketEncryption` and `Tags` are read, ignored and left out of the record, because nothing this
 simulator models can tell the difference. There is no simulated KMS, Object bytes are stored as they
 arrive, and no simulated service reads a Bucket tag. CDK puts both on almost every Bucket it synthesizes, and

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1718,14 +1718,16 @@ something other than a string. There is no Bucket to create under a name nothing
 template refers to.
 
 A `ReplicationConfiguration` fails the stack as well, for a different reason. Replication is not
-simulated and the property is recorded like any other, and the value is still read for the
-constraints real S3 enforces on it. Those are a `Metrics.EventThreshold` with no `ReplicationTime`
-at `Status: Enabled`, a rule stating a `Filter` without the `DeleteMarkerReplication`, `Priority` and
-`Status` that S3 requires alongside one, and a source Bucket whose template never enabled
-versioning. Real S3 answers each of them with a 400 and CloudFormation rolls the stack back, and the
-CloudFormation resource schema states none of them, so cfn-lint passes a template carrying any one.
-A deploy here that reported them as working would be the last check between a repository and that
-rollback.
+simulated and nothing acts on the property, and the value is still read for the constraints real S3
+enforces on it. Those are a `Metrics.EventThreshold` with no `ReplicationTime` at `Status: Enabled`,
+a rule stating a `Filter` without the `DeleteMarkerReplication`, `Priority` and `Status` that S3
+requires alongside one, and a source Bucket whose template never enabled versioning. Real S3 answers
+each of them with a 400 and CloudFormation rolls the stack back, and the CloudFormation resource
+schema states none of them, so cfn-lint passes a template carrying any one. A deploy here that
+reported them as working would be the last check between a repository and that rollback.
+
+A configuration passing all three is recorded like any other skipped property. One that fails takes
+the Bucket with it and is never recorded, because the Resource is refused before it is created.
 
 `BucketEncryption` and `Tags` are read, ignored and left out of the record, because nothing this
 simulator models can tell the difference. There is no simulated KMS, Object bytes are stored as they

--- a/src/service/s3/cfn/bucket/replication/sim-cfn-s3-bucket-replication-rules.ts
+++ b/src/service/s3/cfn/bucket/replication/sim-cfn-s3-bucket-replication-rules.ts
@@ -1,0 +1,157 @@
+import { isRecord } from "../../../../../util/type-guard/record.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { s3BucketResourceError } from "../error/sim-cfn-s3-bucket-error.js";
+
+/**
+ * The AWS::S3::Bucket ReplicationConfiguration constraints real S3 enforces.
+ *
+ * Replication itself is not simulated. The property is recorded against the
+ * Resource and the Bucket is created without it, and no Object is ever copied.
+ * What the value says is still read, because a configuration real S3 answers
+ * with a 400 otherwise deploys here and reaches CREATE_COMPLETE. A test
+ * standing on that deployment reports a template AWS refuses as working, which
+ * is the one failure a local deploy of a real template exists to catch.
+ *
+ * These are the constraints the S3 API documents and the CloudFormation
+ * Resource schema leaves out, so cfn-lint passes a template failing any of
+ * them.
+ */
+export function validateSimCfnS3BucketReplication(
+  logicalId: string,
+  properties: SimCfnTemplateValueRecord,
+): void {
+  const declared = properties["ReplicationConfiguration"];
+
+  if (!isRecord(declared)) {
+    return;
+  }
+
+  refuseUnversionedSource(logicalId, properties);
+
+  const rules = declared["Rules"];
+
+  if (!Array.isArray(rules)) {
+    return;
+  }
+
+  rules.forEach((rule, index) => {
+    validateRule(logicalId, rule, `ReplicationConfiguration Rules[${index}]`);
+  });
+}
+
+/**
+ * Refuse replication on a Bucket that keeps one version of an Object.
+ *
+ * Real S3 requires versioning on the source Bucket and on the destination.
+ * Only the source is checked, and it is read from the template rather than
+ * from the Bucket, because `VersioningConfiguration` is skipped too and no
+ * simulated Bucket carries a versioning state to read. The destination is a
+ * Bucket ARN that may belong to another Stack or another Account, so there is
+ * nothing here to read it from at all.
+ */
+function refuseUnversionedSource(
+  logicalId: string,
+  properties: SimCfnTemplateValueRecord,
+): void {
+  const versioning = properties["VersioningConfiguration"];
+
+  if (isRecord(versioning) && versioning["Status"] === "Enabled") {
+    return;
+  }
+
+  throw s3BucketResourceError(
+    logicalId,
+    "Versioning must be Enabled on the Bucket to apply a " +
+      "ReplicationConfiguration",
+  );
+}
+
+function validateRule(
+  logicalId: string,
+  declared: SimCfnTemplateValue,
+  path: string,
+): void {
+  if (!isRecord(declared)) {
+    return;
+  }
+
+  refuseEventThresholdWithoutReplicationTime(logicalId, declared, path);
+  refuseFilterWithoutItsCompanions(logicalId, declared, path);
+}
+
+/**
+ * Refuse a replication metrics threshold on a rule that has not turned
+ * Replication Time Control on.
+ *
+ * `Metrics.EventThreshold` says when to raise
+ * `s3:Replication:OperationMissedThreshold`, which only S3 RTC measures
+ * against. CDK renders `ReplicationTimeValue.FIFTEEN_MINUTES` passed as
+ * `metrics` into the threshold on its own, so this reaches a template through
+ * an ordinary L2 call.
+ */
+function refuseEventThresholdWithoutReplicationTime(
+  logicalId: string,
+  rule: SimCfnTemplateValueRecord,
+  path: string,
+): void {
+  const destination = rule["Destination"];
+
+  if (!isRecord(destination)) {
+    return;
+  }
+
+  const metrics = destination["Metrics"];
+
+  if (!isRecord(metrics) || metrics["EventThreshold"] === undefined) {
+    return;
+  }
+
+  const replicationTime = destination["ReplicationTime"];
+
+  if (isRecord(replicationTime) && replicationTime["Status"] === "Enabled") {
+    return;
+  }
+
+  throw s3BucketResourceError(
+    logicalId,
+    `${path} Destination Metrics cannot contain an event threshold when ` +
+      "ReplicationTime is not specified or Disabled",
+  );
+}
+
+/**
+ * Refuse a rule stating a Filter without the fields S3 requires alongside one.
+ *
+ * The S3 API documents `DeleteMarkerReplication`, `Status` and `Priority` as
+ * required alongside `Filter`. A rule carrying the older `Prefix` instead needs
+ * none of them, so the check is on `Filter` rather than on the rule.
+ */
+function refuseFilterWithoutItsCompanions(
+  logicalId: string,
+  rule: SimCfnTemplateValueRecord,
+  path: string,
+): void {
+  if (rule["Filter"] === undefined) {
+    return;
+  }
+
+  const missing = [
+    ["DeleteMarkerReplication", rule["DeleteMarkerReplication"]] as const,
+    ["Priority", rule["Priority"]] as const,
+    ["Status", rule["Status"]] as const,
+  ]
+    .filter(([, value]) => value === undefined)
+    .map(([name]) => name);
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  throw s3BucketResourceError(
+    logicalId,
+    `${path} states a Filter, which requires ${missing.join(", ")} as well`,
+  );
+}

--- a/src/service/s3/cfn/bucket/replication/sim-cfn-s3-bucket-replication.iso.test.ts
+++ b/src/service/s3/cfn/bucket/replication/sim-cfn-s3-bucket-replication.iso.test.ts
@@ -1,0 +1,267 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnDeployedStack } from "../../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const replicationRole = "arn:aws:iam::111111111111:role/replication";
+const replicaBucketArn = "arn:aws:s3:::recordings-replica";
+
+/**
+ * A Bucket template carrying versioning and the given replication
+ * configuration, which is what a replicated Bucket looks like.
+ */
+function bucketProperties(
+  replication: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return {
+    BucketName: "recordings",
+    VersioningConfiguration: { Status: "Enabled" },
+    ReplicationConfiguration: replication,
+  };
+}
+
+/**
+ * One replication rule with the fields the V2 schema requires, so a test can
+ * change the one field it is about.
+ */
+function replicationRule(
+  fields: SimCfnTemplateValueRecord,
+): SimCfnTemplateValueRecord {
+  return {
+    Status: "Enabled",
+    Priority: 1,
+    Filter: { Prefix: "recordings/" },
+    DeleteMarkerReplication: { Status: "Enabled" },
+    Destination: { Bucket: replicaBucketArn },
+    ...fields,
+  };
+}
+
+async function deployBucket(
+  properties: SimCfnTemplateValueRecord,
+): Promise<SimCfnDeployedStack> {
+  const stack = await new SimAws().cloudFormation().deployTemplate({
+    stackName: "recordings-stack",
+    template: {
+      Resources: {
+        SiteBucket: { Type: "AWS::S3::Bucket", Properties: properties },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+async function deployFailing(
+  properties: SimCfnTemplateValueRecord,
+): Promise<Error> {
+  return await assertThrowsErrorAsync(async () => {
+    await deployBucket(properties);
+  });
+}
+
+describe("AWS::S3::Bucket ReplicationConfiguration rules", () => {
+  it("deploys a Bucket without the replication its template asked for", async () => {
+    // Given a template asking for a replication rule real S3 accepts.
+    // When the template is deployed.
+    const stack = await deployBucket(
+      bucketProperties({
+        Role: replicationRole,
+        Rules: [replicationRule({})],
+      }),
+    );
+
+    // Then the Bucket is created, replicating nothing, and both properties it
+    // was created without are recorded against the Resource.
+    assertTrue(stack.getResource("SiteBucket")?.deployed);
+    assertArrayLength(stack.ignoredProperties, 2);
+    assertIdentical(
+      stack.ignoredProperties.map((entry) => entry.path).join(", "),
+      "VersioningConfiguration, ReplicationConfiguration",
+    );
+  });
+
+  it("refuses a metrics event threshold with no Replication Time Control", async () => {
+    // Given a rule asking for replication metrics through CDK's `metrics`
+    // property, which renders an EventThreshold on its own. Real S3 answers
+    // that with a 400 and CloudFormation rolls the stack back.
+    // When the template is deployed.
+    const error = await deployFailing(
+      bucketProperties({
+        Role: replicationRole,
+        Rules: [
+          replicationRule({
+            Destination: {
+              Bucket: replicaBucketArn,
+              Metrics: { Status: "Enabled", EventThreshold: { Minutes: 15 } },
+            },
+          }),
+        ],
+      }),
+    );
+
+    // Then the Stack fails here too, in the words S3 refuses it with.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::S3::Bucket Resource SiteBucket: ReplicationConfiguration " +
+        "Rules[0] Destination Metrics cannot contain an event threshold when " +
+        "ReplicationTime is not specified or Disabled",
+    );
+  });
+
+  it("deploys replication metrics alongside Replication Time Control", async () => {
+    // Given the same threshold on a rule that turns RTC on, which is the
+    // configuration the threshold is measured against.
+    // When the template is deployed.
+    const stack = await deployBucket(
+      bucketProperties({
+        Role: replicationRole,
+        Rules: [
+          replicationRule({
+            Destination: {
+              Bucket: replicaBucketArn,
+              ReplicationTime: { Status: "Enabled", Time: { Minutes: 15 } },
+              Metrics: { Status: "Enabled", EventThreshold: { Minutes: 15 } },
+            },
+          }),
+        ],
+      }),
+    );
+
+    // Then the Bucket deploys, with replication recorded as unsimulated.
+    assertTrue(stack.getResource("SiteBucket")?.deployed);
+  });
+
+  it("deploys metrics with no event threshold at all", async () => {
+    // Given the shape S3 documents for replication metrics without RTC, which
+    // is the status on its own.
+    // When the template is deployed.
+    const stack = await deployBucket(
+      bucketProperties({
+        Role: replicationRole,
+        Rules: [
+          replicationRule({
+            Destination: {
+              Bucket: replicaBucketArn,
+              Metrics: { Status: "Enabled" },
+            },
+          }),
+        ],
+      }),
+    );
+
+    // Then the Bucket deploys.
+    assertTrue(stack.getResource("SiteBucket")?.deployed);
+  });
+
+  it("refuses a rule that filters without the fields a filter requires", async () => {
+    // Given a rule stating a Filter and neither the Priority nor the delete
+    // marker setting S3 requires alongside one.
+    // When the template is deployed.
+    const error = await deployFailing(
+      bucketProperties({
+        Role: replicationRole,
+        Rules: [
+          {
+            Status: "Enabled",
+            Filter: { Prefix: "recordings/" },
+            Destination: { Bucket: replicaBucketArn },
+          },
+        ],
+      }),
+    );
+
+    // Then the Stack fails naming both fields that were missing.
+    assertStringIncludes(
+      error.message,
+      "ReplicationConfiguration Rules[0] states a Filter, which requires " +
+        "DeleteMarkerReplication, Priority as well",
+    );
+  });
+
+  it("deploys an older rule that selects objects by Prefix", async () => {
+    // Given a V1 rule, which carries a Prefix instead of a Filter and needs
+    // none of the fields a Filter requires.
+    // When the template is deployed.
+    const stack = await deployBucket(
+      bucketProperties({
+        Role: replicationRole,
+        Rules: [
+          {
+            Status: "Enabled",
+            Prefix: "recordings/",
+            Destination: { Bucket: replicaBucketArn },
+          },
+        ],
+      }),
+    );
+
+    // Then the Bucket deploys.
+    assertTrue(stack.getResource("SiteBucket")?.deployed);
+  });
+
+  it("refuses replication on a Bucket that keeps one version of an Object", async () => {
+    // Given a replicated Bucket whose template never enabled versioning.
+    // When the template is deployed.
+    const error = await deployFailing({
+      BucketName: "recordings",
+      ReplicationConfiguration: {
+        Role: replicationRole,
+        Rules: [replicationRule({})],
+      },
+    });
+
+    // Then the Stack fails, as real S3 refuses replication on an unversioned
+    // Bucket.
+    assertStringIncludes(
+      error.message,
+      "Versioning must be Enabled on the Bucket to apply a " +
+        "ReplicationConfiguration",
+    );
+  });
+
+  it("refuses replication on a Bucket whose versioning was suspended", async () => {
+    // Given a template that states versioning and turns it off, which is a
+    // Bucket that keeps one version of an Object as surely as one that never
+    // stated versioning at all.
+    // When the template is deployed.
+    const error = await deployFailing({
+      BucketName: "recordings",
+      VersioningConfiguration: { Status: "Suspended" },
+      ReplicationConfiguration: {
+        Role: replicationRole,
+        Rules: [replicationRule({})],
+      },
+    });
+
+    // Then the Stack fails.
+    assertStringIncludes(error.message, "Versioning must be Enabled");
+  });
+
+  it("deploys a Bucket whose ReplicationConfiguration is not an object", async () => {
+    // Given a misshapen configuration, which is a template error this rule has
+    // no opinion about.
+    // When the template is deployed.
+    const stack = await deployBucket({
+      BucketName: "recordings",
+      ReplicationConfiguration: "replicate-everything",
+    });
+
+    // Then the Bucket is still created and the property is recorded, as it was
+    // before any of this validated anything.
+    assertArrayLength(stack.ignoredProperties, 1);
+    const ignored = stack.ignoredProperties[0];
+    assertNonNullable(ignored);
+    assertStringIncludes(ignored.reason, "Bucket replication is not simulated");
+  });
+});

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.ts
@@ -1,6 +1,7 @@
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
 import { s3BucketResourceError } from "./error/sim-cfn-s3-bucket-error.js";
+import { validateSimCfnS3BucketReplication } from "./replication/sim-cfn-s3-bucket-replication-rules.js";
 import {
   inertPropertyNames,
   simulatedPropertyNames,
@@ -18,9 +19,12 @@ interface SimCfnS3BucketPropertyRulesProperties {
  *
  * Simulated CloudFormation deploys what it can, so a property this simulation
  * cannot act on does not stop the Bucket being created. It is left out and
- * recorded against the Resource, where a test can find it. Refusing is kept for
- * the one case where there is nothing coherent to create: a BucketName that is
- * not a name.
+ * recorded against the Resource, where a test can find it.
+ *
+ * Refusing is kept for two cases. There is nothing coherent to create, as a
+ * BucketName that is not a name leaves. Or the value is one real S3 answers
+ * with a 400, which a skipped property can carry as readily as a simulated
+ * one, and deploying it here would report a template AWS refuses as working.
  *
  * A property this simulation has never heard of is treated the same way. It may
  * be a typo, or a property AWS added since this list was written, and a Bucket
@@ -39,11 +43,12 @@ export class SimCfnS3BucketPropertyRules {
   }
 
   /**
-   * Record everything about this Resource that is not simulated, refusing only
-   * what leaves nothing to create.
+   * Record everything about this Resource that is not simulated, refusing
+   * what leaves nothing to create and what real S3 answers with a 400.
    */
   apply(): void {
     this.refuseUnusableBucketName();
+    validateSimCfnS3BucketReplication(this.logicalId, this.properties);
 
     for (const name of Object.keys(this.properties)) {
       this.applyToProperty(name);


### PR DESCRIPTION
Simulated S3 skips `ReplicationConfiguration` and records it against the Resource, and until now it never read what the value said. A configuration real S3 answers with a 400 therefore deployed here and reached `CREATE_COMPLETE`, and a test standing on that deploy reported a template CloudFormation rolls back as working. The three constraints the S3 API documents and the CloudFormation resource schema leaves out are now checked before the Bucket is created. Those are a `Metrics.EventThreshold` with no `ReplicationTime` enabled, a rule stating a `Filter` without the `DeleteMarkerReplication`, `Priority` and `Status` that S3 requires alongside one, and a source Bucket whose template never enabled versioning. Replication itself stays unsimulated, no Object is copied, and a valid configuration is still recorded on `ignoredProperties`.

The versioning constraint reads `VersioningConfiguration` from the template rather than from the Bucket, because that property is skipped too and no simulated Bucket carries a versioning state until #1183 lands. Only the source Bucket is checked. The destination is an ARN that may belong to another Stack or another Account, so there is nothing here to read it from.

Resolves #1186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added CloudFormation validation for S3 bucket replication configurations.
  - Deployments now correctly fail for invalid replication metrics, incomplete replication rules, missing source-bucket versioning, and invalid replication-time settings.
  - Unsupported or absent replication configurations continue to be handled without blocking deployment.

- **Documentation**
  - Updated CloudFormation and S3 documentation to describe replication validation and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->