### PR TITLE
feat: count a user pool's requests in AWS/Cognito

### DIFF
--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -10,10 +10,11 @@ it was to assert that the SDK client had been called. That proves the call was m
 measured goes untested.
 
 Most of what lives here is custom metrics. Simulated Lambda publishes its own `AWS/Lambda`
-`Invocations`, `Errors`, `Duration` and `IteratorAge`, and no other simulated service publishes into
-an `AWS/` namespace yet. A query for one nothing measures comes back empty, in place of a number
-that was never taken. A test can stand a datapoint up for one of those itself, which is what drives
-an alarm on a service metric to a state change.
+`Invocations`, `Errors`, `Duration` and `IteratorAge`, simulated Cognito publishes a pool's
+`AWS/Cognito` counts, and no other simulated service publishes into an `AWS/` namespace yet. A
+query for one nothing measures comes back empty, in place of a number that was never taken. A test
+can stand a datapoint up for one of those itself, which is what drives an alarm on a service metric
+to a state change.
 
 A custom metric's datapoints arrive either from `PutMetricData` or from a CloudWatch Logs metric
 filter counting matching log events. See the [CloudWatch Logs docs](../logs/README.md) for the
@@ -153,6 +154,8 @@ window drops a metric out of the listing without anything having to expire it.
 ## Metrics a simulated service publishes
 
 Real CloudWatch holds two kinds of metric. A caller publishes a custom one through `PutMetricData`, and AWS publishes its own under a namespace beginning `AWS/` that no caller may write into. Both kinds are read the same way.
+
+Two services publish their own. Simulated Cognito counts what a user pool was asked to do, under `AWS/Cognito` and dimensioned by `UserPool` and `UserPoolClient`, which the [Cognito docs](../cognito/README.md) cover.
 
 Simulated Lambda publishes three of its own. Every invocation counts `Invocations` and a `Duration`, and one whose handler threw counts an `Errors` alongside them, all under `AWS/Lambda` and dimensioned by `FunctionName`. Nothing has to be turned on, and no execution Role needs a permission for it, which is how real Lambda behaves.
 
@@ -536,6 +539,8 @@ await simAws.cloudWatch().putMetricData(
   alarm-ARN resources.
 - `AWS/Lambda` `Invocations`, `Errors`, `Duration` and `IteratorAge`, published by simulated Lambda
   itself and read back the way a custom metric is.
+- `AWS/Cognito` `SignInSuccesses`, `SignUpSuccesses`, `TokenRefreshSuccesses` and
+  `FederationSuccesses`, published by a simulated user pool.
 - Seeding a metric AWS publishes, through `cloudWatch().serviceWriter()`, so an alarm on one can be
   driven to a state change from a test.
 - `AWS::CloudWatch::Alarm` in simulated CloudFormation, deployed through `PutMetricAlarm` and taken
@@ -559,10 +564,10 @@ test still passes and no longer means what it says.
   comes back at the period its query asked for.
 - **Cross-account metrics.** `IncludeLinkedAccounts` and `OwningAccount` are refused. There is no
   monitoring account.
-- **Most metrics AWS publishes.** `AWS/Lambda` `Invocations`, `Errors`, `Duration` and `IteratorAge`
-  are the only ones a simulated service writes. `Throttles` and `ConcurrentExecutions` need
-  concurrency limits, which simulated Lambda has none of, and every other `AWS/` namespace needs a
-  source event built before a metric can come from one. A test seeds what it needs from one of those
+- **Most metrics AWS publishes.** The `AWS/Lambda` and `AWS/Cognito` metrics above are the only ones
+  a simulated service writes. `Throttles` and `ConcurrentExecutions` need concurrency limits, which
+  simulated Lambda has none of, and every other `AWS/` namespace needs a source event built before a
+  metric can come from one. A test seeds what it needs from one of those
   through the service writer. A CloudWatch Logs metric filter naming a reserved namespace is refused
   when it publishes, as `PutMetricData` refuses a caller naming one.
 

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3194,6 +3194,80 @@ and the timestamps on tokens issued after it, but a verifier reading the host cl
 token it already holds by host time. Signing in in the past is what produces a token such a verifier
 refuses.
 
+## What a pool counts in CloudWatch
+
+A pool publishes into `AWS/Cognito` what real Cognito publishes about the requests it handles, dimensioned by `UserPool` and `UserPoolClient`. Nothing has to be turned on for it, and no caller needs a permission. Real Cognito behaves the same way.
+
+Four counts are kept. `SignInSuccesses` counts every authentication request, `SignUpSuccesses` every registration, `TokenRefreshSuccesses` every renewal from a refresh token, and `FederationSuccesses` every sign-in through an identity provider. Each is a 1 where the request issued tokens and a 0 where it did not, so `Sum` is how many succeeded, `SampleCount` is how many were made, and `Average` between them is the success rate. That is how the AWS documentation says to read them.
+
+```typescript sim-cognito-metrics
+/**
+ * An alarm on the rate at which a pool is turning sign-ins away.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { InitiateAuthCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+await simAws.cloudWatch().putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "SignInsFailing",
+    Namespace: "AWS/Cognito",
+    MetricName: "SignInSuccesses",
+    Dimensions: [
+      { Name: "UserPool", Value: userPoolId },
+      { Name: "UserPoolClient", Value: clientId },
+    ],
+    Statistic: "Average",
+    Period: 300,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 1,
+    Threshold: 0.5,
+    ComparisonOperator: "LessThanThreshold",
+    TreatMissingData: "notBreaching",
+  }),
+);
+
+// Two of these three fail, so the average falls under the threshold.
+for (const password of ["Wr0ng!", "AlsoWr0ng!", "Sup3rSecret!"]) {
+  const attempt = new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: password },
+  });
+
+  try {
+    await simAws.cognitoIdentityProvider().initiateAuth(attempt);
+  } catch {
+    // A refused sign-in is counted as a zero rather than going uncounted.
+  }
+}
+
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(
+    new DescribeAlarmsCommand({ AlarmNames: ["SignInsFailing"] }),
+  );
+
+// ALARM.
+console.log(MetricAlarms?.[0]?.StateValue);
+```
+
+Two `UserPoolClient` values are fixed names rather than ids. A user an administrator registers through `AdminCreateUser` reaches the pool through no app client and counts against `Admin`. An admin authentication request naming a client the pool has none of counts against `Invalid`, and the id it gave is left out.
+
+A token refresh stays out of `SignInSuccesses` and lands in `TokenRefreshSuccesses`, whether it arrived as a `REFRESH_TOKEN_AUTH` flow or as `GetTokensFromRefreshToken`. A federated sign-in counts where its tokens are issued, at the token endpoint, rather than at the authorization code the provider sent the browser back with.
+
 ## Pool ARNs and IAM policies
 
 A pool ARN is the pool id after `userpool/`, and the region appears twice:
@@ -4738,6 +4812,13 @@ Sim Cognito currently supports:
 
 Current documented limitations:
 
+- `SignInSuccesses`, `SignUpSuccesses`, `TokenRefreshSuccesses` and `FederationSuccesses` are the
+  `AWS/Cognito` metrics a pool publishes. The `*Throttles` metrics beside them count what a rate
+  limit turned away, and this simulation applies none. A test that needs an alarm on one seeds the
+  datapoint through simulated CloudWatch's service writer. `CallCount` and `ThrottleCount` under
+  `AWS/Usage` are absent for the same reason. A client-side request naming an app client the pool
+  has none of counts nothing at all, because the app client id is what finds the pool and an unknown
+  one reaches no pool to report against.
 - Five authentication flows run: `ADMIN_USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` through
   `AdminInitiateAuth`, `USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` through `InitiateAuth`, and
   `USER_AUTH` through either. SRP, custom authentication and device tracking are outside the

--- a/docs/services/cognito/sim-cognito-metrics.example.ts
+++ b/docs/services/cognito/sim-cognito-metrics.example.ts
@@ -1,0 +1,61 @@
+/**
+ * An alarm on the rate at which a pool is turning sign-ins away.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { InitiateAuthCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+await simAws.cloudWatch().putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "SignInsFailing",
+    Namespace: "AWS/Cognito",
+    MetricName: "SignInSuccesses",
+    Dimensions: [
+      { Name: "UserPool", Value: userPoolId },
+      { Name: "UserPoolClient", Value: clientId },
+    ],
+    Statistic: "Average",
+    Period: 300,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 1,
+    Threshold: 0.5,
+    ComparisonOperator: "LessThanThreshold",
+    TreatMissingData: "notBreaching",
+  }),
+);
+
+// Two of these three fail, so the average falls under the threshold.
+for (const password of ["Wr0ng!", "AlsoWr0ng!", "Sup3rSecret!"]) {
+  const attempt = new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: { USERNAME: "alice", PASSWORD: password },
+  });
+
+  try {
+    await simAws.cognitoIdentityProvider().initiateAuth(attempt);
+  } catch {
+    // A refused sign-in is counted as a zero rather than going uncounted.
+  }
+}
+
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(
+    new DescribeAlarmsCommand({ AlarmNames: ["SignInsFailing"] }),
+  );
+
+// ALARM.
+console.log(MetricAlarms?.[0]?.StateValue);

--- a/src/service/aws/factory/sim-aws-account-region-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-account-region-service-builder.ts
@@ -156,6 +156,9 @@ export class SimAwsAccountRegionServiceBuilder {
       // A web ACL protecting a pool is in the same Account and Region as the
       // pool, as it is on AWS, so this scope's own WAFv2 is the one to ask.
       webAcls: scope.wafV2().protection(),
+      // A pool's AWS/Cognito metrics belong to the Account and Region it is
+      // in, the way every metric does.
+      metrics: scope.cloudWatch().serviceWriter(),
     });
   }
 

--- a/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
@@ -1,4 +1,6 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { countedSimCognitoAuth } from "../../metric/sim-cognito-counted-request.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
 import type { SimCognitoChallengeResponses } from "./sim-cognito-challenge-responses.js";
@@ -9,6 +11,7 @@ import type {
 } from "./auth.command.js";
 
 interface SimCognitoAdminRespondToChallengeProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly authResolver: SimCognitoAuthResolver;
   readonly responses: SimCognitoChallengeResponses;
 }
@@ -25,11 +28,13 @@ interface SimCognitoCommandOptions {
  * pool.
  */
 export class SimCognitoAdminRespondToChallenge {
+  private readonly poolMetrics: SimCognitoPoolMetrics;
   private readonly authResolver: SimCognitoAuthResolver;
   private readonly responses: SimCognitoChallengeResponses;
   private readonly unsimulatedOptions = new SimCognitoUnsimulatedAuthOptions();
 
   constructor(properties: SimCognitoAdminRespondToChallengeProperties) {
+    this.poolMetrics = properties.poolMetrics;
     this.authResolver = properties.authResolver;
     this.responses = properties.responses;
   }
@@ -49,15 +54,25 @@ export class SimCognitoAdminRespondToChallenge {
     );
 
     this.unsimulatedOptions.refuseInAdminResponse(input);
-    return await this.responses.handle(input.ChallengeName, {
-      pool,
-      client,
-      parameters: new SimCognitoAuthParameters(
-        "ChallengeResponses",
-        input.ChallengeResponses,
-      ),
-      session: input.Session,
-      clientMetadata: input.ClientMetadata,
-    });
+
+    // Counted here rather than in the shared responder, so that a response
+    // counts as the one request it is, the way `RespondToAuthChallenge`
+    // counts its own.
+    return await countedSimCognitoAuth(
+      this.poolMetrics,
+      "SignInSuccesses",
+      { pool, client },
+      async () =>
+        await this.responses.handle(input.ChallengeName, {
+          pool,
+          client,
+          parameters: new SimCognitoAuthParameters(
+            "ChallengeResponses",
+            input.ChallengeResponses,
+          ),
+          session: input.Session,
+          clientMetadata: input.ClientMetadata,
+        }),
+    );
   }
 }

--- a/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-commands.ts
@@ -6,6 +6,7 @@ import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cog
 import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
 import { SimCognitoAdminInitiateAuth } from "./sim-cognito-admin-initiate-auth.js";
 import { SimCognitoAdminRespondToChallenge } from "./sim-cognito-admin-respond-to-challenge.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import { SimCognitoAuthFlowRunner } from "./sim-cognito-auth-flow-runner.js";
 import { SimCognitoGetTokensFromRefreshToken } from "./sim-cognito-get-tokens-from-refresh-token.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
@@ -52,6 +53,9 @@ interface SimCognitoAuthCommandsProperties {
    * a passkey presented at either answers the same kind of challenge.
    */
   readonly firstFactor: SimCognitoFirstFactorChallenge;
+
+  /** What counts this pool's requests into `AWS/Cognito`. */
+  readonly poolMetrics: SimCognitoPoolMetrics;
 }
 
 /**
@@ -103,6 +107,7 @@ export class SimCognitoAuthCommands {
       triggers,
     });
     const flowRunner = new SimCognitoAuthFlowRunner({
+      poolMetrics: properties.poolMetrics,
       passwordSignIn,
       refreshSignIn: new SimCognitoRefreshSignIn({ refreshedTokens, clock }),
       userAuthSignIn: new SimCognitoUserAuthSignIn({
@@ -133,6 +138,7 @@ export class SimCognitoAuthCommands {
       flowRunner,
     });
     this.adminRespondToChallenge = new SimCognitoAdminRespondToChallenge({
+      poolMetrics: properties.poolMetrics,
       authResolver,
       responses,
     });
@@ -141,10 +147,12 @@ export class SimCognitoAuthCommands {
       flowRunner,
     });
     this.respondToChallenge = new SimCognitoRespondToChallenge({
+      poolMetrics: properties.poolMetrics,
       authResolver,
       responses,
     });
     this.getTokensFromRefreshToken = new SimCognitoGetTokensFromRefreshToken({
+      poolMetrics: properties.poolMetrics,
       authResolver,
       refreshedTokens,
       clock,

--- a/src/service/cognito/command/auth/sim-cognito-auth-flow-runner.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-flow-runner.ts
@@ -1,3 +1,5 @@
+import { countedSimCognitoAuth } from "../../metric/sim-cognito-counted-request.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import type { SimCognitoAuthFlow } from "./sim-cognito-auth-flow.js";
 import type {
   SimCognitoPasswordSignIn,
@@ -8,6 +10,7 @@ import type { SimCognitoUserAuthSignIn } from "./sim-cognito-user-auth-sign-in.j
 import type { SimCognitoAuthenticationOutput } from "./auth.command.js";
 
 interface SimCognitoAuthFlowRunnerProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly passwordSignIn: SimCognitoPasswordSignIn;
   readonly refreshSignIn: SimCognitoRefreshSignIn;
   readonly userAuthSignIn: SimCognitoUserAuthSignIn;
@@ -26,20 +29,40 @@ interface SimCognitoAuthFlowRunnerProperties {
  * issues tokens.
  */
 export class SimCognitoAuthFlowRunner {
+  private readonly poolMetrics: SimCognitoPoolMetrics;
   private readonly passwordSignIn: SimCognitoPasswordSignIn;
   private readonly refreshSignIn: SimCognitoRefreshSignIn;
   private readonly userAuthSignIn: SimCognitoUserAuthSignIn;
 
   constructor(properties: SimCognitoAuthFlowRunnerProperties) {
+    this.poolMetrics = properties.poolMetrics;
     this.passwordSignIn = properties.passwordSignIn;
     this.refreshSignIn = properties.refreshSignIn;
     this.userAuthSignIn = properties.userAuthSignIn;
   }
 
   /**
-   * Run a flow the app client is configured for.
+   * Run a flow the app client is configured for, and count the request.
+   *
+   * Real Cognito keeps a token refresh out of `SignInSuccesses` and counts it
+   * under `TokenRefreshSuccesses` instead, so which metric a request lands in
+   * follows the flow it ran. A request answered with a challenge issued no
+   * tokens and counts as a 0, and so does one the pool refused outright. The
+   * response that finishes a challenged sign-in is counted where it completes.
    */
   async run(
+    flow: SimCognitoAuthFlow,
+    request: SimCognitoAuthRequest,
+  ): Promise<SimCognitoAuthenticationOutput> {
+    return await countedSimCognitoAuth(
+      this.poolMetrics,
+      flow.exchangesRefreshToken ? "TokenRefreshSuccesses" : "SignInSuccesses",
+      request,
+      async () => await this.ran(flow, request),
+    );
+  }
+
+  private async ran(
     flow: SimCognitoAuthFlow,
     request: SimCognitoAuthRequest,
   ): Promise<SimCognitoAuthenticationOutput> {

--- a/src/service/cognito/command/auth/sim-cognito-auth-resolver.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-resolver.ts
@@ -6,12 +6,15 @@ import type {
   SimCognitoClientInPool,
   SimCognitoUserPoolStore,
 } from "../../user-pool/sim-cognito-user-pool-store.js";
+import { simCognitoInvalidClientDimension } from "../../metric/sim-cognito-metrics.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
 import type { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
 
 interface SimCognitoAuthResolverProperties {
   readonly resolver: SimCognitoRequestResolver;
   readonly pools: SimCognitoUserPoolStore;
+  readonly poolMetrics: SimCognitoPoolMetrics;
 }
 
 interface SimCognitoCommandOptions {
@@ -39,10 +42,12 @@ export type SimCognitoAuthenticatingClient = SimCognitoClientInPool;
 export class SimCognitoAuthResolver {
   private readonly resolver: SimCognitoRequestResolver;
   private readonly pools: SimCognitoUserPoolStore;
+  private readonly poolMetrics: SimCognitoPoolMetrics;
 
   constructor(properties: SimCognitoAuthResolverProperties) {
     this.resolver = properties.resolver;
     this.pools = properties.pools;
+    this.poolMetrics = properties.poolMetrics;
   }
 
   /**
@@ -59,12 +64,26 @@ export class SimCognitoAuthResolver {
   ): SimCognitoAuthenticatingClient {
     const pool = this.resolver.pool(action, input.UserPoolId, options);
 
-    return {
-      pool,
-      client: pool.requireClient(
-        requireSimCognitoUserPoolClientId(input.ClientId),
-      ),
-    };
+    try {
+      return {
+        pool,
+        client: pool.requireClient(
+          requireSimCognitoUserPoolClientId(input.ClientId),
+        ),
+      };
+    } catch (error) {
+      // Real Cognito counts a request naming an app client the pool has none
+      // of, reporting a fixed name in the client's place rather than the id
+      // the request gave. The request still fails.
+      this.poolMetrics.count(
+        "SignInSuccesses",
+        pool.id,
+        simCognitoInvalidClientDimension,
+        false,
+      );
+
+      throw error;
+    }
   }
 
   /**

--- a/src/service/cognito/command/auth/sim-cognito-get-tokens-from-refresh-token.ts
+++ b/src/service/cognito/command/auth/sim-cognito-get-tokens-from-refresh-token.ts
@@ -1,8 +1,13 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { requireSimCognitoRefreshTokenInput } from "../../user-pool/auth/sim-cognito-refresh-token-input.js";
 import { requireSimCognitoClientSecret } from "../../user-pool/client/sim-cognito-client-secret.js";
+import { countedSimCognitoAuth } from "../../metric/sim-cognito-counted-request.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import { SimCognitoUnsimulatedInput } from "../sim-cognito-unsimulated-input.js";
-import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
+import type {
+  SimCognitoAuthenticatingClient,
+  SimCognitoAuthResolver,
+} from "./sim-cognito-auth-resolver.js";
 import type { SimCognitoRefreshedTokens } from "./sim-cognito-refreshed-tokens.js";
 import type {
   SimGetTokensFromRefreshTokenCommand,
@@ -10,6 +15,7 @@ import type {
 } from "./auth.command.js";
 
 interface SimCognitoGetTokensFromRefreshTokenProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly authResolver: SimCognitoAuthResolver;
   readonly refreshedTokens: SimCognitoRefreshedTokens;
   readonly clock: SimClock;
@@ -29,6 +35,7 @@ interface SimCognitoGetTokensFromRefreshTokenProperties {
  * than a hash computed over a username it does not have.
  */
 export class SimCognitoGetTokensFromRefreshToken {
+  private readonly poolMetrics: SimCognitoPoolMetrics;
   private readonly authResolver: SimCognitoAuthResolver;
   private readonly refreshedTokens: SimCognitoRefreshedTokens;
   private readonly clock: SimClock;
@@ -37,6 +44,7 @@ export class SimCognitoGetTokensFromRefreshToken {
   );
 
   constructor(properties: SimCognitoGetTokensFromRefreshTokenProperties) {
+    this.poolMetrics = properties.poolMetrics;
     this.authResolver = properties.authResolver;
     this.refreshedTokens = properties.refreshedTokens;
     this.clock = properties.clock;
@@ -44,12 +52,29 @@ export class SimCognitoGetTokensFromRefreshToken {
 
   /**
    * Renew a session from the refresh token it holds.
+   *
+   * Real Cognito counts this under `TokenRefreshSuccesses`, the same metric an
+   * `InitiateAuth` running `REFRESH_TOKEN_AUTH` lands in.
    */
   async handle(
     command: SimGetTokensFromRefreshTokenCommand,
   ): Promise<SimGetTokensFromRefreshTokenCommandOutput> {
     const { input } = command;
-    const { pool, client } = this.authResolver.client(input.ClientId);
+    const scope = this.authResolver.client(input.ClientId);
+
+    return await countedSimCognitoAuth(
+      this.poolMetrics,
+      "TokenRefreshSuccesses",
+      scope,
+      async () => await this.renewed(command, scope),
+    );
+  }
+
+  private async renewed(
+    command: SimGetTokensFromRefreshTokenCommand,
+    { pool, client }: SimCognitoAuthenticatingClient,
+  ): Promise<SimGetTokensFromRefreshTokenCommandOutput> {
+    const { input } = command;
 
     this.unsimulated.refuse(
       "DeviceKey",

--- a/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.ts
@@ -1,3 +1,5 @@
+import { countedSimCognitoAuth } from "../../metric/sim-cognito-counted-request.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import { SimCognitoAuthParameters } from "./sim-cognito-auth-parameters.js";
 import type { SimCognitoAuthResolver } from "./sim-cognito-auth-resolver.js";
 import type { SimCognitoChallengeResponses } from "./sim-cognito-challenge-responses.js";
@@ -8,6 +10,7 @@ import type {
 } from "./auth.command.js";
 
 interface SimCognitoRespondToChallengeProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly authResolver: SimCognitoAuthResolver;
   readonly responses: SimCognitoChallengeResponses;
 }
@@ -20,11 +23,13 @@ interface SimCognitoRespondToChallengeProperties {
  * as real Cognito needs none for it.
  */
 export class SimCognitoRespondToChallenge {
+  private readonly poolMetrics: SimCognitoPoolMetrics;
   private readonly authResolver: SimCognitoAuthResolver;
   private readonly responses: SimCognitoChallengeResponses;
   private readonly unsimulatedOptions = new SimCognitoUnsimulatedAuthOptions();
 
   constructor(properties: SimCognitoRespondToChallengeProperties) {
+    this.poolMetrics = properties.poolMetrics;
     this.authResolver = properties.authResolver;
     this.responses = properties.responses;
   }
@@ -39,15 +44,25 @@ export class SimCognitoRespondToChallenge {
     const { pool, client } = this.authResolver.client(input.ClientId);
 
     this.unsimulatedOptions.refuseInResponse(input);
-    return await this.responses.handle(input.ChallengeName, {
-      pool,
-      client,
-      parameters: new SimCognitoAuthParameters(
-        "ChallengeResponses",
-        input.ChallengeResponses,
-      ),
-      session: input.Session,
-      clientMetadata: input.ClientMetadata,
-    });
+
+    // A challenge response is an authentication request of its own, the way
+    // real Cognito counts one, so it is counted here rather than where the
+    // sign-in it belongs to started.
+    return await countedSimCognitoAuth(
+      this.poolMetrics,
+      "SignInSuccesses",
+      { pool, client },
+      async () =>
+        await this.responses.handle(input.ChallengeName, {
+          pool,
+          client,
+          parameters: new SimCognitoAuthParameters(
+            "ChallengeResponses",
+            input.ChallengeResponses,
+          ),
+          session: input.Session,
+          clientMetadata: input.ClientMetadata,
+        }),
+    );
   }
 }

--- a/src/service/cognito/command/hosted/sim-cognito-hosted-commands.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-hosted-commands.ts
@@ -1,3 +1,4 @@
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimCognitoFederatedSignIn } from "../../user-pool/idp/sim-cognito-federated-sign-in.js";
 import type { SimCognitoTokenIssuer } from "../../user-pool/token/sim-cognito-token-issuer.js";
@@ -10,6 +11,7 @@ import { SimCognitoLogoutEndpoint } from "./sim-cognito-logout-endpoint.js";
 import { SimCognitoTokenEndpoint } from "./sim-cognito-token-endpoint.js";
 
 interface SimCognitoHostedCommandsProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly tokenIssuer: SimCognitoTokenIssuer;
   readonly userFactory: SimCognitoUserFactory;
 
@@ -56,6 +58,10 @@ export class SimCognitoHostedCommands {
       }),
       clock,
     });
-    this.token = new SimCognitoTokenEndpoint({ tokenIssuer, clock });
+    this.token = new SimCognitoTokenEndpoint({
+      poolMetrics: properties.poolMetrics,
+      tokenIssuer,
+      clock,
+    });
   }
 }

--- a/src/service/cognito/command/hosted/sim-cognito-token-endpoint.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-token-endpoint.ts
@@ -1,3 +1,4 @@
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimCognitoOAuthError } from "../../error/sim-cognito-oauth.error.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
@@ -17,6 +18,7 @@ const refreshTokenGrant = "refresh_token";
 const clientCredentialsGrant = "client_credentials";
 
 interface SimCognitoTokenEndpointProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly tokenIssuer: SimCognitoTokenIssuer;
   readonly clock: SimClock;
 }

--- a/src/service/cognito/command/hosted/sim-cognito-token-grants.ts
+++ b/src/service/cognito/command/hosted/sim-cognito-token-grants.ts
@@ -1,3 +1,5 @@
+import { countedSimCognitoFederation } from "../../metric/sim-cognito-counted-request.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
@@ -11,6 +13,7 @@ import type {
 } from "./hosted-auth.command.js";
 
 interface SimCognitoTokenGrantsProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly tokenIssuer: SimCognitoTokenIssuer;
   readonly clock: SimClock;
 }
@@ -24,12 +27,14 @@ interface SimCognitoTokenGrantsProperties {
  * pool the same way.
  */
 export class SimCognitoTokenGrants {
+  private readonly poolMetrics: SimCognitoPoolMetrics;
   private readonly tokenIssuer: SimCognitoTokenIssuer;
   private readonly clock: SimClock;
   private readonly presented = new SimCognitoPresentedGrant();
   private readonly granted = new SimCognitoGrantedTokens();
 
   constructor(properties: SimCognitoTokenGrantsProperties) {
+    this.poolMetrics = properties.poolMetrics;
     this.tokenIssuer = properties.tokenIssuer;
     this.clock = properties.clock;
   }
@@ -58,17 +63,25 @@ export class SimCognitoTokenGrants {
       now: this.clock.now(),
     });
     const user = this.presented.user(pool, code.username);
-    const issued = await this.tokenIssuer.issue({
-      pool,
-      client,
-      user,
-      occasion: code.federated
-        ? SimCognitoTriggerOccasion.hostedTokenGeneration
-        : SimCognitoTriggerOccasion.tokenGeneration,
-      scopes: code.scopes,
-    });
 
-    return this.granted.body(issued, code.scopes);
+    return await countedSimCognitoFederation(
+      this.poolMetrics,
+      { pool, client },
+      code.federated,
+      async () =>
+        this.granted.body(
+          await this.tokenIssuer.issue({
+            pool,
+            client,
+            user,
+            occasion: code.federated
+              ? SimCognitoTriggerOccasion.hostedTokenGeneration
+              : SimCognitoTriggerOccasion.tokenGeneration,
+            scopes: code.scopes,
+          }),
+          code.scopes,
+        ),
+    );
   }
 
   /**

--- a/src/service/cognito/command/sim-cognito-commands.ts
+++ b/src/service/cognito/command/sim-cognito-commands.ts
@@ -7,6 +7,8 @@ import { SimCognitoRegistrations } from "../user-pool/sim-cognito-registrations.
 import { SimCognitoUserPoolFactory } from "../user-pool/sim-cognito-user-pool-factory.js";
 import type { SimCognitoUserPoolStore } from "../user-pool/sim-cognito-user-pool-store.js";
 import type { SimAwsMessageLog } from "../../aws/message/sim-aws-message-log.js";
+import type { SimCloudWatchServiceWriter } from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
+import { SimCognitoPoolMetrics } from "../metric/sim-cognito-pool-metrics.js";
 import { SimCognitoPoolMessenger } from "../user-pool/message/sim-cognito-pool-messenger.js";
 import type { SimCognitoEmailSenders } from "../user-pool/message/sim-cognito-email-senders.js";
 import { SimCognitoPoolEmailDelivery } from "../user-pool/message/sim-cognito-pool-email-delivery.js";
@@ -30,6 +32,7 @@ import { SimCognitoListGroups } from "./group/sim-cognito-list-groups.js";
 import { SimCognitoUserPoolClientCommands } from "./client/sim-cognito-user-pool-client-commands.js";
 import { SimCognitoListUsers } from "./user/sim-cognito-list-users.js";
 import { SimCognitoPasswordResetCommands } from "./user/sim-cognito-password-reset-commands.js";
+import { SimCognitoConfirmSignUpCommands } from "./user/sim-cognito-confirm-sign-up-commands.js";
 import { SimCognitoSignUpCommands } from "./user/sim-cognito-sign-up-commands.js";
 import { SimCognitoTokenUser } from "./user/sim-cognito-token-user.js";
 import { SimCognitoUserCommands } from "./user/sim-cognito-user-commands.js";
@@ -51,6 +54,9 @@ interface SimCognitoCommandsProperties {
   readonly emailSenders: SimCognitoEmailSenders;
   readonly webAcls: SimWafProtection;
   readonly messageLog: SimAwsMessageLog;
+
+  /** Where this scope's `AWS/Cognito` metrics go, if anywhere. */
+  readonly metrics?: SimCloudWatchServiceWriter | undefined;
 }
 
 /**
@@ -70,6 +76,7 @@ export class SimCognitoCommands {
   public readonly userMfa: SimCognitoUserMfaCommands;
   public readonly webAuthn: SimCognitoWebAuthnCommands;
   public readonly signUp: SimCognitoSignUpCommands;
+  public readonly confirmSignUp: SimCognitoConfirmSignUpCommands;
   public readonly passwordReset: SimCognitoPasswordResetCommands;
   public readonly userUpdates: SimCognitoUserUpdateCommands;
   public readonly listUsers: SimCognitoListUsers;
@@ -109,7 +116,14 @@ export class SimCognitoCommands {
 
     const authorizer = new SimCognitoAuthorizer({ iam, accountRegionScope });
     const resolver = new SimCognitoRequestResolver({ pools, authorizer });
-    const authResolver = new SimCognitoAuthResolver({ resolver, pools });
+    const poolMetrics = new SimCognitoPoolMetrics({
+      metrics: properties.metrics,
+    });
+    const authResolver = new SimCognitoAuthResolver({
+      resolver,
+      pools,
+      poolMetrics,
+    });
     const userFactory = new SimCognitoUserFactory({ clock });
     // One trigger runner serves every command, because a pool's LambdaConfig
     // is one set of functions whichever operation reaches it.
@@ -164,6 +178,7 @@ export class SimCognitoCommands {
     });
     this.listClients = new SimCognitoListUserPoolClients({ pools, authorizer });
     this.users = new SimCognitoUserCommands({
+      poolMetrics,
       resolver,
       tokenUser,
       userFactory,
@@ -177,9 +192,15 @@ export class SimCognitoCommands {
     });
     this.webAuthn = new SimCognitoWebAuthnCommands({ tokenUser, clock });
     this.signUp = new SimCognitoSignUpCommands({
+      poolMetrics,
+      authResolver,
+      userFactory,
+      triggers,
+      messenger,
+    });
+    this.confirmSignUp = new SimCognitoConfirmSignUpCommands({
       authResolver,
       resolver,
-      userFactory,
       triggers,
       messenger,
     });
@@ -206,6 +227,7 @@ export class SimCognitoCommands {
       tokenIssuer,
       messenger,
       firstFactor,
+      poolMetrics,
     });
     this.domains = new SimCognitoDomainCommands({
       pools,
@@ -221,6 +243,7 @@ export class SimCognitoCommands {
     // create pool users the same way a sign-up does, so they are given the
     // same collaborators rather than ones of their own.
     this.hosted = new SimCognitoHostedCommands({
+      poolMetrics,
       tokenIssuer,
       userFactory,
       triggers,

--- a/src/service/cognito/command/user/sim-cognito-confirm-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-confirm-sign-up-commands.ts
@@ -1,0 +1,182 @@
+import { requireSimCognitoSecretHash } from "../../user-pool/auth/sim-cognito-secret-hash.js";
+import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
+import type { SimCognitoPoolMessenger } from "../../user-pool/message/sim-cognito-pool-messenger.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
+import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
+import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
+import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
+import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
+import type { SimCognitoAuthResolver } from "../auth/sim-cognito-auth-resolver.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
+import { SimCognitoUnsimulatedSignUpOptions } from "./sim-cognito-unsimulated-sign-up-options.js";
+import type {
+  SimAdminConfirmSignUpCommand,
+  SimAdminConfirmSignUpCommandOutput,
+  SimConfirmSignUpCommand,
+  SimConfirmSignUpCommandOutput,
+  SimCognitoSignUpCommandInput,
+  SimResendConfirmationCodeCommand,
+  SimResendConfirmationCodeCommandOutput,
+} from "./sign-up.command.js";
+
+interface SimCognitoConfirmSignUpCommandsProperties {
+  readonly authResolver: SimCognitoAuthResolver;
+  readonly resolver: SimCognitoRequestResolver;
+  readonly triggers: SimCognitoUserPoolTriggers;
+  readonly messenger: SimCognitoPoolMessenger;
+}
+
+interface SimCognitoCommandOptions {
+  readonly caller?: SimAwsCaller;
+}
+
+/**
+ * Confirming a sign-up, and the code that confirms one.
+ *
+ * Held apart from the registration commands because the two halves of signing
+ * up share nothing but the pool: registering makes a user and sends it a code,
+ * and confirming reads a code back and runs `PostConfirmation`. An
+ * administrator can do the second without the first ever having sent
+ * anything.
+ */
+export class SimCognitoConfirmSignUpCommands {
+  private readonly authResolver: SimCognitoAuthResolver;
+  private readonly resolver: SimCognitoRequestResolver;
+  private readonly triggers: SimCognitoUserPoolTriggers;
+  private readonly messenger: SimCognitoPoolMessenger;
+  private readonly unsimulatedOptions =
+    new SimCognitoUnsimulatedSignUpOptions();
+
+  constructor(properties: SimCognitoConfirmSignUpCommandsProperties) {
+    this.authResolver = properties.authResolver;
+    this.resolver = properties.resolver;
+    this.triggers = properties.triggers;
+    this.messenger = properties.messenger;
+  }
+
+  /**
+   * Confirm a sign-up with the code the pool issued.
+   *
+   * The user reaches `CONFIRMED` and can sign in from then on. The pool's
+   * `AutoVerifiedAttributes` are marked verified here, because answering with
+   * the code is what shows the address the code went to is the user's. The
+   * pool's `PostConfirmation` trigger runs last, on the confirmed user.
+   */
+  async confirmSignUp(
+    command: SimConfirmSignUpCommand,
+  ): Promise<SimConfirmSignUpCommandOutput> {
+    const { input } = command;
+    const { pool, client } = this.authResolver.client(input.ClientId);
+
+    this.unsimulatedOptions.refuseInConfirm(input);
+
+    const user = this.signingUpUser(pool, client, input);
+
+    user.confirmSignUp(input.ConfirmationCode);
+    user.verifyAttributes(pool.settings.autoVerifiedAttributes.names);
+
+    await this.triggers.postConfirmation(
+      SimCognitoTriggerOccasion.confirmSignUp,
+      {
+        pool,
+        client,
+        user,
+        clientMetadata: input.ClientMetadata,
+      },
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Issue a fresh confirmation code for a user waiting to be confirmed.
+   *
+   * The code the user had stops working, as it does on real Cognito, so a
+   * test holding the earlier one has to read the new one from the pool. The
+   * pool records a second message carrying the fresh code, and a
+   * `CustomMessage` handler tells this occasion from a sign-up by its
+   * `CustomMessage_ResendCode` trigger source.
+   */
+  async resendConfirmationCode(
+    command: SimResendConfirmationCodeCommand,
+  ): Promise<SimResendConfirmationCodeCommandOutput> {
+    const { input } = command;
+    const { pool, client } = this.authResolver.client(input.ClientId);
+
+    this.unsimulatedOptions.refuseInResend(input);
+
+    const user = this.signingUpUser(pool, client, input);
+
+    user.resendConfirmationCode();
+
+    await this.messenger.send({
+      pool,
+      user,
+      client,
+      occasion: "ResendCode",
+      code: user.confirmationCode,
+      clientMetadata: input.ClientMetadata,
+    });
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Confirm a sign-up as an administrator, with no code involved.
+   *
+   * Nothing is verified by this. Real Cognito leaves `email_verified` and
+   * `phone_number_verified` alone here even on a pool with
+   * `AutoVerifiedAttributes`, because an admin confirming a user says nothing
+   * about whether the address is really theirs.
+   *
+   * The `PostConfirmation` trigger still runs, and reports the same
+   * `PostConfirmation_ConfirmSignUp` source `ConfirmSignUp` does, because the
+   * user being confirmed signed itself up either way. There is no app client
+   * in the request, so the handler reads `CLIENT_ID_NOT_APPLICABLE`.
+   */
+  async adminConfirmSignUp(
+    command: SimAdminConfirmSignUpCommand,
+    options?: SimCognitoCommandOptions,
+  ): Promise<SimAdminConfirmSignUpCommandOutput> {
+    const { input } = command;
+
+    const { pool, user } = this.resolver.poolUser(
+      "cognito-idp:AdminConfirmSignUp",
+      input,
+      options,
+    );
+
+    user.confirm();
+
+    await this.triggers.postConfirmation(
+      SimCognitoTriggerOccasion.confirmSignUp,
+      {
+        pool,
+        user,
+        clientMetadata: input.ClientMetadata,
+      },
+    );
+
+    return { $metadata: {} };
+  }
+
+  /**
+   * Resolve the user a client-side sign-up operation names.
+   *
+   * The `SECRET_HASH` covers the username, so it is checked as soon as the
+   * username is known and before anything looks the user up, which is the
+   * order the sign-in commands check it in too.
+   */
+  private signingUpUser(
+    pool: SimCognitoUserPool,
+    client: SimCognitoUserPoolClient,
+    input: SimCognitoSignUpCommandInput,
+  ): SimCognitoUser {
+    const username = requireSimCognitoUsername(input.Username);
+
+    requireSimCognitoSecretHash(username, client, input.SecretHash);
+
+    return pool.requireUser(username);
+  }
+}

--- a/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
@@ -1,39 +1,28 @@
-import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { requireSimCognitoSecretHash } from "../../user-pool/auth/sim-cognito-secret-hash.js";
-import type { SimCognitoUserPoolClient } from "../../user-pool/client/sim-cognito-user-pool-client.js";
 import type { SimCognitoPoolMessenger } from "../../user-pool/message/sim-cognito-pool-messenger.js";
-import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-trigger-occasion.js";
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
-import type { SimCognitoUser } from "../../user-pool/user/sim-cognito-user.js";
 import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
 import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
-import type { SimCognitoAuthResolver } from "../auth/sim-cognito-auth-resolver.js";
-import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
+import { countedSimCognitoCompletion } from "../../metric/sim-cognito-counted-request.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
+import type {
+  SimCognitoAuthenticatingClient,
+  SimCognitoAuthResolver,
+} from "../auth/sim-cognito-auth-resolver.js";
 import { simCognitoValidationData } from "../sim-cognito-validation-data.js";
 import { SimCognitoUnsimulatedSignUpOptions } from "./sim-cognito-unsimulated-sign-up-options.js";
 import type {
-  SimAdminConfirmSignUpCommand,
-  SimAdminConfirmSignUpCommandOutput,
-  SimCognitoSignUpCommandInput,
-  SimConfirmSignUpCommand,
-  SimConfirmSignUpCommandOutput,
-  SimResendConfirmationCodeCommand,
-  SimResendConfirmationCodeCommandOutput,
   SimSignUpCommand,
   SimSignUpCommandOutput,
 } from "./sign-up.command.js";
 
 interface SimCognitoSignUpCommandsProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly authResolver: SimCognitoAuthResolver;
-  readonly resolver: SimCognitoRequestResolver;
   readonly userFactory: SimCognitoUserFactory;
   readonly triggers: SimCognitoUserPoolTriggers;
   readonly messenger: SimCognitoPoolMessenger;
-}
-
-interface SimCognitoCommandOptions {
-  readonly caller?: SimAwsCaller;
 }
 
 /**
@@ -51,8 +40,8 @@ interface SimCognitoCommandOptions {
  * and the message the pool would have sent it in is recorded on the pool.
  */
 export class SimCognitoSignUpCommands {
+  private readonly poolMetrics: SimCognitoPoolMetrics;
   private readonly authResolver: SimCognitoAuthResolver;
-  private readonly resolver: SimCognitoRequestResolver;
   private readonly userFactory: SimCognitoUserFactory;
   private readonly triggers: SimCognitoUserPoolTriggers;
   private readonly messenger: SimCognitoPoolMessenger;
@@ -60,8 +49,8 @@ export class SimCognitoSignUpCommands {
     new SimCognitoUnsimulatedSignUpOptions();
 
   constructor(properties: SimCognitoSignUpCommandsProperties) {
+    this.poolMetrics = properties.poolMetrics;
     this.authResolver = properties.authResolver;
-    this.resolver = properties.resolver;
     this.userFactory = properties.userFactory;
     this.triggers = properties.triggers;
     this.messenger = properties.messenger;
@@ -88,8 +77,21 @@ export class SimCognitoSignUpCommands {
    * a code, so real Cognito sends it none.
    */
   async signUp(command: SimSignUpCommand): Promise<SimSignUpCommandOutput> {
+    const scope = this.authResolver.client(command.input.ClientId);
+
+    return await countedSimCognitoCompletion(
+      this.poolMetrics,
+      "SignUpSuccesses",
+      scope,
+      async () => await this.registered(command, scope),
+    );
+  }
+
+  private async registered(
+    command: SimSignUpCommand,
+    { pool, client }: SimCognitoAuthenticatingClient,
+  ): Promise<SimSignUpCommandOutput> {
     const { input } = command;
-    const { pool, client } = this.authResolver.client(input.ClientId);
 
     this.unsimulatedOptions.refuseInSignUp(input);
     pool.settings.adminCreateUserConfig.requireSelfServiceSignUp();
@@ -158,130 +160,5 @@ export class SimCognitoSignUpCommands {
       UserConfirmed: preSignUp.autoConfirmUser,
       UserSub: user.sub,
     };
-  }
-
-  /**
-   * Confirm a sign-up with the code the pool issued.
-   *
-   * The user reaches `CONFIRMED` and can sign in from then on. The pool's
-   * `AutoVerifiedAttributes` are marked verified here, because answering with
-   * the code is what shows the address the code went to is the user's. The
-   * pool's `PostConfirmation` trigger runs last, on the confirmed user.
-   */
-  async confirmSignUp(
-    command: SimConfirmSignUpCommand,
-  ): Promise<SimConfirmSignUpCommandOutput> {
-    const { input } = command;
-    const { pool, client } = this.authResolver.client(input.ClientId);
-
-    this.unsimulatedOptions.refuseInConfirm(input);
-
-    const user = this.signingUpUser(pool, client, input);
-
-    user.confirmSignUp(input.ConfirmationCode);
-    user.verifyAttributes(pool.settings.autoVerifiedAttributes.names);
-
-    await this.triggers.postConfirmation(
-      SimCognitoTriggerOccasion.confirmSignUp,
-      {
-        pool,
-        client,
-        user,
-        clientMetadata: input.ClientMetadata,
-      },
-    );
-
-    return { $metadata: {} };
-  }
-
-  /**
-   * Issue a fresh confirmation code for a user waiting to be confirmed.
-   *
-   * The code the user had stops working, as it does on real Cognito, so a
-   * test holding the earlier one has to read the new one from the pool. The
-   * pool records a second message carrying the fresh code, and a
-   * `CustomMessage` handler tells this occasion from a sign-up by its
-   * `CustomMessage_ResendCode` trigger source.
-   */
-  async resendConfirmationCode(
-    command: SimResendConfirmationCodeCommand,
-  ): Promise<SimResendConfirmationCodeCommandOutput> {
-    const { input } = command;
-    const { pool, client } = this.authResolver.client(input.ClientId);
-
-    this.unsimulatedOptions.refuseInResend(input);
-
-    const user = this.signingUpUser(pool, client, input);
-
-    user.resendConfirmationCode();
-
-    await this.messenger.send({
-      pool,
-      user,
-      client,
-      occasion: "ResendCode",
-      code: user.confirmationCode,
-      clientMetadata: input.ClientMetadata,
-    });
-
-    return { $metadata: {} };
-  }
-
-  /**
-   * Confirm a sign-up as an administrator, with no code involved.
-   *
-   * Nothing is verified by this. Real Cognito leaves `email_verified` and
-   * `phone_number_verified` alone here even on a pool with
-   * `AutoVerifiedAttributes`, because an admin confirming a user says nothing
-   * about whether the address is really theirs.
-   *
-   * The `PostConfirmation` trigger still runs, and reports the same
-   * `PostConfirmation_ConfirmSignUp` source `ConfirmSignUp` does, because the
-   * user being confirmed signed itself up either way. There is no app client
-   * in the request, so the handler reads `CLIENT_ID_NOT_APPLICABLE`.
-   */
-  async adminConfirmSignUp(
-    command: SimAdminConfirmSignUpCommand,
-    options?: SimCognitoCommandOptions,
-  ): Promise<SimAdminConfirmSignUpCommandOutput> {
-    const { input } = command;
-
-    const { pool, user } = this.resolver.poolUser(
-      "cognito-idp:AdminConfirmSignUp",
-      input,
-      options,
-    );
-
-    user.confirm();
-
-    await this.triggers.postConfirmation(
-      SimCognitoTriggerOccasion.confirmSignUp,
-      {
-        pool,
-        user,
-        clientMetadata: input.ClientMetadata,
-      },
-    );
-
-    return { $metadata: {} };
-  }
-
-  /**
-   * Resolve the user a client-side sign-up operation names.
-   *
-   * The `SECRET_HASH` covers the username, so it is checked as soon as the
-   * username is known and before anything looks the user up, which is the
-   * order the sign-in commands check it in too.
-   */
-  private signingUpUser(
-    pool: SimCognitoUserPool,
-    client: SimCognitoUserPoolClient,
-    input: SimCognitoSignUpCommandInput,
-  ): SimCognitoUser {
-    const username = requireSimCognitoUsername(input.Username);
-
-    requireSimCognitoSecretHash(username, client, input.SecretHash);
-
-    return pool.requireUser(username);
   }
 }

--- a/src/service/cognito/command/user/sim-cognito-user-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.ts
@@ -4,6 +4,10 @@ import { SimCognitoTriggerOccasion } from "../../user-pool/trigger/sim-cognito-t
 import type { SimCognitoUserPoolTriggers } from "../../user-pool/trigger/sim-cognito-user-pool-triggers.js";
 import type { SimCognitoUserFactory } from "../../user-pool/user/sim-cognito-user-factory.js";
 import { requireSimCognitoUsername } from "../../user-pool/user/sim-cognito-username.js";
+import { countedSimCognitoCompletion } from "../../metric/sim-cognito-counted-request.js";
+import { simCognitoAdminClientDimension } from "../../metric/sim-cognito-metrics.js";
+import type { SimCognitoPoolMetrics } from "../../metric/sim-cognito-pool-metrics.js";
+import type { SimCognitoUserPool } from "../../user-pool/sim-cognito-user-pool.js";
 import { SimCognitoUnsimulatedUserOptions } from "./sim-cognito-unsimulated-user-options.js";
 import type { SimCognitoRequestResolver } from "../sim-cognito-request-resolver.js";
 import { simCognitoValidationData } from "../sim-cognito-validation-data.js";
@@ -23,6 +27,7 @@ import type {
 } from "./user.command.js";
 
 interface SimCognitoUserCommandsProperties {
+  readonly poolMetrics: SimCognitoPoolMetrics;
   readonly resolver: SimCognitoRequestResolver;
   readonly tokenUser: SimCognitoTokenUser;
   readonly userFactory: SimCognitoUserFactory;
@@ -41,6 +46,7 @@ interface SimCognitoCommandOptions {
  * own.
  */
 export class SimCognitoUserCommands {
+  private readonly poolMetrics: SimCognitoPoolMetrics;
   private readonly resolver: SimCognitoRequestResolver;
   private readonly tokenUser: SimCognitoTokenUser;
   private readonly userFactory: SimCognitoUserFactory;
@@ -50,6 +56,7 @@ export class SimCognitoUserCommands {
   private readonly unsimulatedOptions = new SimCognitoUnsimulatedUserOptions();
 
   constructor(properties: SimCognitoUserCommandsProperties) {
+    this.poolMetrics = properties.poolMetrics;
     this.resolver = properties.resolver;
     this.tokenUser = properties.tokenUser;
     this.userFactory = properties.userFactory;
@@ -86,55 +93,20 @@ export class SimCognitoUserCommands {
     command: SimAdminCreateUserCommand,
     options?: SimCognitoCommandOptions,
   ): Promise<SimAdminCreateUserCommandOutput> {
-    const { input } = command;
     const pool = this.resolver.pool(
       "cognito-idp:AdminCreateUser",
-      input.UserPoolId,
+      command.input.UserPoolId,
       options,
     );
-    const requested = requireSimCognitoUsername(input.Username);
 
-    this.unsimulatedOptions.refuseInCreate(input);
-
-    // A pool signing users in by email or phone number stores a generated
-    // UUID as the username here too, so an admin-created user and one that
-    // signed itself up are identified the same way.
-    const identity = pool.settings.usernameAttributes.identify(
-      requested,
-      input.UserAttributes,
+    // A user an administrator registers reaches the pool through no app
+    // client, and real Cognito reports it under a fixed name in that place.
+    return await countedSimCognitoCompletion(
+      this.poolMetrics,
+      "SignUpSuccesses",
+      { pool, client: { id: simCognitoAdminClientDimension } },
+      async () => await this.created(command, pool),
     );
-
-    const user = this.userFactory.make({
-      username: identity.username,
-      attributes: identity.attributes,
-      schema: pool.settings.schema,
-      temporaryPassword: input.TemporaryPassword,
-      passwordPolicy: pool.settings.passwordPolicy,
-    });
-
-    await this.triggers.preSignUp(SimCognitoTriggerOccasion.adminCreateUser, {
-      pool,
-      user,
-      clientMetadata: input.ClientMetadata,
-      validationData: simCognitoValidationData(
-        input.ValidationData,
-        "AdminCreateUser",
-      ),
-    });
-
-    pool.addUser(user);
-
-    if (input.MessageAction !== "SUPPRESS") {
-      await this.messenger.send({
-        pool,
-        user,
-        occasion: "AdminCreateUser",
-        code: input.TemporaryPassword,
-        clientMetadata: input.ClientMetadata,
-      });
-    }
-
-    return { $metadata: {}, User: this.view.entry(user) };
   }
 
   /**
@@ -187,5 +159,55 @@ export class SimCognitoUserCommands {
     pool.removeUser(user);
 
     return { $metadata: {} };
+  }
+
+  private async created(
+    command: SimAdminCreateUserCommand,
+    pool: SimCognitoUserPool,
+  ): Promise<SimAdminCreateUserCommandOutput> {
+    const { input } = command;
+    const requested = requireSimCognitoUsername(input.Username);
+
+    this.unsimulatedOptions.refuseInCreate(input);
+
+    // A pool signing users in by email or phone number stores a generated
+    // UUID as the username here too, so an admin-created user and one that
+    // signed itself up are identified the same way.
+    const identity = pool.settings.usernameAttributes.identify(
+      requested,
+      input.UserAttributes,
+    );
+
+    const user = this.userFactory.make({
+      username: identity.username,
+      attributes: identity.attributes,
+      schema: pool.settings.schema,
+      temporaryPassword: input.TemporaryPassword,
+      passwordPolicy: pool.settings.passwordPolicy,
+    });
+
+    await this.triggers.preSignUp(SimCognitoTriggerOccasion.adminCreateUser, {
+      pool,
+      user,
+      clientMetadata: input.ClientMetadata,
+      validationData: simCognitoValidationData(
+        input.ValidationData,
+        "AdminCreateUser",
+      ),
+    });
+
+    pool.addUser(user);
+
+    if (input.MessageAction !== "SUPPRESS") {
+      await this.messenger.send({
+        pool,
+        user,
+        occasion: "AdminCreateUser",
+        code: input.TemporaryPassword,
+        clientMetadata: input.ClientMetadata,
+      });
+    }
+
+    return { $metadata: {}, User: this.view.entry(user) };
   }
 }

--- a/src/service/cognito/metric/sim-cognito-counted-request.ts
+++ b/src/service/cognito/metric/sim-cognito-counted-request.ts
@@ -1,0 +1,120 @@
+import type {
+  SimCognitoPoolMetrics,
+  SimCognitoRequestMetric,
+} from "./sim-cognito-pool-metrics.js";
+
+/**
+ * What an authentication request answers with, as the count reads it.
+ */
+interface SimCognitoAuthenticationOutcome {
+  readonly AuthenticationResult?: unknown;
+}
+
+/**
+ * The pool and app client a counted request ran against.
+ *
+ * The client id is a string rather than a client, because a request an
+ * administrator made reaches the pool through no app client and is reported
+ * under a fixed name instead.
+ */
+interface SimCognitoCountedScope {
+  readonly pool: { readonly id: string };
+  readonly client: { readonly id: string };
+}
+
+/**
+ * Run a request and count whether it issued tokens.
+ *
+ * A request the pool refused counts as a 0 rather than going uncounted, which
+ * is what makes `Average` over the metric a success rate. The failure itself
+ * still reaches the caller.
+ */
+async function countedSimCognitoRequest<T>(
+  metrics: SimCognitoPoolMetrics,
+  metricName: SimCognitoRequestMetric,
+  scope: SimCognitoCountedScope,
+  run: () => Promise<T>,
+  succeeded: (output: T) => boolean,
+): Promise<T> {
+  let counted = false;
+
+  try {
+    const output = await run();
+
+    counted = succeeded(output);
+
+    return output;
+  } finally {
+    metrics.count(metricName, scope.pool.id, scope.client.id, counted);
+  }
+}
+
+/**
+ * Run an authentication request and count whether it issued tokens.
+ *
+ * Real Cognito counts a sign-in successful once tokens have been issued, so a
+ * request answered with a challenge counts as a 0 and the response that
+ * finishes it counts as a 1.
+ */
+export async function countedSimCognitoAuth<
+  T extends SimCognitoAuthenticationOutcome,
+>(
+  metrics: SimCognitoPoolMetrics,
+  metricName: SimCognitoRequestMetric,
+  scope: SimCognitoCountedScope,
+  run: () => Promise<T>,
+): Promise<T> {
+  return await countedSimCognitoRequest(
+    metrics,
+    metricName,
+    scope,
+    run,
+    (output) => output.AuthenticationResult !== undefined,
+  );
+}
+
+/**
+ * Run a request that hands back no session and count whether it finished.
+ *
+ * A registration answers with a user rather than with tokens, so finishing is
+ * the whole of what makes one a success.
+ */
+export async function countedSimCognitoCompletion<T>(
+  metrics: SimCognitoPoolMetrics,
+  metricName: SimCognitoRequestMetric,
+  scope: SimCognitoCountedScope,
+  run: () => Promise<T>,
+): Promise<T> {
+  return await countedSimCognitoRequest(
+    metrics,
+    metricName,
+    scope,
+    run,
+    () => true,
+  );
+}
+
+/**
+ * Run a token grant and count it as a federation where it is one.
+ *
+ * A code from an identity provider becomes a `FederationSuccesses` at the
+ * tokens it is exchanged for. A code from the pool's own sign-in form is not a
+ * federation and counts nothing here.
+ */
+export async function countedSimCognitoFederation<T>(
+  metrics: SimCognitoPoolMetrics,
+  scope: SimCognitoCountedScope,
+  federated: boolean,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (!federated) {
+    return await run();
+  }
+
+  return await countedSimCognitoCompletion(
+    metrics,
+    "FederationSuccesses",
+    scope,
+    run,
+  );
+}

--- a/src/service/cognito/metric/sim-cognito-metrics.ts
+++ b/src/service/cognito/metric/sim-cognito-metrics.ts
@@ -1,0 +1,34 @@
+import type { SimCloudWatchDimensionInput } from "../../cloudwatch/metric/sim-cloudwatch-dimension.js";
+
+/**
+ * The namespace real Cognito publishes what it counts about a pool under.
+ */
+export const simCognitoMetricNamespace = "AWS/Cognito";
+
+/**
+ * The `UserPoolClient` real Cognito reports for a request an administrator
+ * made, which reaches the pool without going through an app client at all.
+ */
+export const simCognitoAdminClientDimension = "Admin";
+
+/**
+ * The `UserPoolClient` real Cognito reports for a request naming an app client
+ * the pool has none of. The id given is left out of the metric.
+ */
+export const simCognitoInvalidClientDimension = "Invalid";
+
+/**
+ * The dimensions every metric here carries.
+ *
+ * Real Cognito reports a pool's counts per app client as well as per pool, so
+ * one client's traffic can be watched on its own.
+ */
+export function simCognitoPoolDimensions(
+  poolId: string,
+  clientId: string,
+): readonly SimCloudWatchDimensionInput[] {
+  return [
+    { Name: "UserPool", Value: poolId },
+    { Name: "UserPoolClient", Value: clientId },
+  ];
+}

--- a/src/service/cognito/metric/sim-cognito-pool-metrics.ts
+++ b/src/service/cognito/metric/sim-cognito-pool-metrics.ts
@@ -1,0 +1,65 @@
+import type { SimCloudWatchServiceWriter } from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
+import {
+  simCognitoMetricNamespace,
+  simCognitoPoolDimensions,
+} from "./sim-cognito-metrics.js";
+
+/**
+ * The counts real Cognito keeps of what a pool was asked to do.
+ *
+ * Each is published on every request of its kind, as a 1 where the request
+ * issued tokens and a 0 where it did not. `Average` over one is therefore a
+ * success rate and `SampleCount` is the number of requests, which is how the
+ * AWS documentation says to read them.
+ */
+export type SimCognitoRequestMetric =
+  | "SignInSuccesses"
+  | "SignUpSuccesses"
+  | "TokenRefreshSuccesses"
+  | "FederationSuccesses";
+
+interface SimCognitoPoolMetricsProperties {
+  readonly metrics: SimCloudWatchServiceWriter | undefined;
+}
+
+/**
+ * What a simulated user pool publishes about the requests it handles.
+ *
+ * Real Cognito publishes these without being asked and without a caller
+ * needing any permission, so they go in through simulated CloudWatch's service
+ * writer rather than through `PutMetricData`, which refuses the `AWS/Cognito`
+ * namespace exactly as an account does.
+ *
+ * A pool built on its own, outside a `SimAws` instance, has no CloudWatch to
+ * publish into and counts nothing.
+ */
+export class SimCognitoPoolMetrics {
+  readonly #metrics: SimCloudWatchServiceWriter | undefined;
+
+  constructor(properties: SimCognitoPoolMetricsProperties) {
+    this.#metrics = properties.metrics;
+  }
+
+  /**
+   * Count one request against the pool and app client that made it.
+   *
+   * A request that was refused before the pool was known counts nothing,
+   * because there is no `UserPool` to report it under.
+   */
+  count(
+    metricName: SimCognitoRequestMetric,
+    poolId: string,
+    clientId: string,
+    issuedTokens: boolean,
+  ): void {
+    this.#metrics?.publish([
+      {
+        namespace: simCognitoMetricNamespace,
+        metricName,
+        dimensions: simCognitoPoolDimensions(poolId, clientId),
+        value: issuedTokens ? 1 : 0,
+        unit: "Count",
+      },
+    ]);
+  }
+}

--- a/src/service/cognito/metric/sim-cognito-sign-in-metrics.iso.test.ts
+++ b/src/service/cognito/metric/sim-cognito-sign-in-metrics.iso.test.ts
@@ -1,0 +1,205 @@
+import {
+  AdminInitiateAuthCommand,
+  InitiateAuthCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoForMetrics,
+  simCognitoMetricDatapoint,
+  simCognitoMetricPassword,
+  simCognitoMetricUser,
+} from "../../../../test/cognito/metric-fixture.js";
+
+function signIn(clientId: string, password: string): InitiateAuthCommand {
+  return new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: {
+      USERNAME: simCognitoMetricUser,
+      PASSWORD: password,
+    },
+  });
+}
+
+describe("AWS/Cognito sign-in metrics a simulated user pool publishes", () => {
+  it("counts a sign-in that issued tokens", async () => {
+    // Given a pool with a confirmed user.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics();
+
+    // When the user signs in.
+    await cognito.initiateAuth(signIn(clientId, simCognitoMetricPassword));
+
+    // Then the pool counted one successful authentication request, under the
+    // app client the request came through.
+    const reading = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInSuccesses",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(reading);
+    assertIdentical(reading.Sum, 1);
+    assertIdentical(reading.SampleCount, 1);
+  });
+
+  it("counts a refused sign-in as a request that succeeded none of the time", async () => {
+    // Given a pool with a confirmed user.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics();
+
+    // When one sign-in gives the wrong password and one gives the right one.
+    await assertThrowsErrorAsync(
+      async () =>
+        await cognito.initiateAuth(signIn(clientId, "Wr0ngPassword!")),
+    );
+    await cognito.initiateAuth(signIn(clientId, simCognitoMetricPassword));
+
+    // Then both were counted, and the average between them is the success
+    // rate, which is how the AWS documentation says to read the metric.
+    const reading = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInSuccesses",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(reading);
+    assertIdentical(reading.SampleCount, 2);
+    assertIdentical(reading.Sum, 1);
+    assertIdentical(reading.Average, 0.5);
+  });
+
+  it("counts an admin sign-in the same way", async () => {
+    // Given a pool whose app client allows the admin password flow.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics({
+        explicitAuthFlows: ["ALLOW_ADMIN_USER_PASSWORD_AUTH"],
+      });
+
+    // When an administrator signs the user in.
+    await cognito.adminInitiateAuth(
+      new AdminInitiateAuthCommand({
+        UserPoolId: userPoolId,
+        ClientId: clientId,
+        AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters: {
+          USERNAME: simCognitoMetricUser,
+          PASSWORD: simCognitoMetricPassword,
+        },
+      }),
+    );
+
+    // Then it counted under the app client the request named, because an
+    // admin sign-in still goes through one.
+    const reading = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInSuccesses",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(reading);
+    assertIdentical(reading.Sum, 1);
+  });
+
+  it("reports a client the pool has none of under a fixed name", async () => {
+    // Given a pool that knows nothing of the app client a request will name.
+    const { simAws, cognito, userPoolId } = await simCognitoForMetrics();
+
+    // When an admin request names an app client that is not there.
+    const unknownClient = new AdminInitiateAuthCommand({
+      UserPoolId: userPoolId,
+      ClientId: "1h57kf5cpq17m0eml12EXAMPLE",
+      AuthFlow: "ADMIN_USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: simCognitoMetricUser },
+    });
+
+    await assertThrowsErrorAsync(
+      async () => await cognito.adminInitiateAuth(unknownClient),
+    );
+
+    // Then the request was counted as a failure against `Invalid`, and the id
+    // it gave is left out of the metric.
+    const reading = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInSuccesses",
+      userPoolId,
+      "Invalid",
+    );
+
+    assertNonNullable(reading);
+    assertIdentical(reading.SampleCount, 1);
+    assertIdentical(reading.Sum, 0);
+  });
+
+  it("keeps a token refresh out of the sign-in count", async () => {
+    // Given a user signed in on a client that also allows refreshing.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics({
+        explicitAuthFlows: [
+          "ALLOW_USER_PASSWORD_AUTH",
+          "ALLOW_REFRESH_TOKEN_AUTH",
+        ],
+      });
+    const signedIn = await cognito.initiateAuth(
+      signIn(clientId, simCognitoMetricPassword),
+    );
+    const refreshToken = signedIn.AuthenticationResult?.RefreshToken;
+
+    assertNonNullable(refreshToken);
+
+    // When the session is renewed from its refresh token.
+    await cognito.initiateAuth(
+      new InitiateAuthCommand({
+        ClientId: clientId,
+        AuthFlow: "REFRESH_TOKEN_AUTH",
+        AuthParameters: { REFRESH_TOKEN: refreshToken },
+      }),
+    );
+
+    // Then the refresh landed in its own metric, and the sign-in count still
+    // reports the one sign-in, as real Cognito reports them.
+    const refreshes = await simCognitoMetricDatapoint(
+      simAws,
+      "TokenRefreshSuccesses",
+      userPoolId,
+      clientId,
+    );
+    const signIns = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInSuccesses",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(refreshes);
+    assertIdentical(refreshes.Sum, 1);
+    assertNonNullable(signIns);
+    assertIdentical(signIns.SampleCount, 1);
+  });
+
+  it("counts nothing for a pool nothing has asked to do anything", async () => {
+    // Given a pool with a client and a user, and no requests made to it.
+    const { simAws, userPoolId, clientId } = await simCognitoForMetrics();
+
+    // Then the sign-in metric holds nothing at all, in place of a rate that
+    // was never measured.
+    assertUndefined(
+      await simCognitoMetricDatapoint(
+        simAws,
+        "SignInSuccesses",
+        userPoolId,
+        clientId,
+      ),
+    );
+  });
+});

--- a/src/service/cognito/metric/sim-cognito-sign-up-metrics.iso.test.ts
+++ b/src/service/cognito/metric/sim-cognito-sign-up-metrics.iso.test.ts
@@ -1,0 +1,145 @@
+import {
+  AdminCreateUserCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoAuthorizationCode,
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+} from "../../../../test/cognito/federation-fixture.js";
+import {
+  simCognitoForMetrics,
+  simCognitoMetricDatapoint,
+  simCognitoMetricPassword,
+} from "../../../../test/cognito/metric-fixture.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+
+describe("AWS/Cognito sign-up and federation metrics", () => {
+  it("counts a user that signed itself up", async () => {
+    // Given a pool a user may sign itself up to.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics({ withUser: false });
+
+    // When the user registers through the app client.
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "bob",
+        Password: simCognitoMetricPassword,
+      }),
+    );
+
+    // Then the registration counted under the client it came through.
+    const reading = await simCognitoMetricDatapoint(
+      simAws,
+      "SignUpSuccesses",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(reading);
+    assertIdentical(reading.Sum, 1);
+    assertIdentical(reading.SampleCount, 1);
+  });
+
+  it("reports a user an administrator registered under a fixed name", async () => {
+    // Given a pool an administrator will add a user to.
+    const { simAws, cognito, userPoolId } = await simCognitoForMetrics({
+      withUser: false,
+    });
+
+    // When the administrator creates the user.
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({ UserPoolId: userPoolId, Username: "bob" }),
+    );
+
+    // Then it counted against `Admin`, because the request reached the pool
+    // through no app client at all.
+    const reading = await simCognitoMetricDatapoint(
+      simAws,
+      "SignUpSuccesses",
+      userPoolId,
+      "Admin",
+    );
+
+    assertNonNullable(reading);
+    assertIdentical(reading.Sum, 1);
+  });
+
+  it("counts a refused registration as a request that succeeded none of the time", async () => {
+    // Given a pool holding a user already.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics({ withUser: false });
+
+    await cognito.signUp(
+      new SignUpCommand({
+        ClientId: clientId,
+        Username: "bob",
+        Password: simCognitoMetricPassword,
+      }),
+    );
+
+    // When a second registration takes the name the first one has.
+    const taken = new SignUpCommand({
+      ClientId: clientId,
+      Username: "bob",
+      Password: simCognitoMetricPassword,
+    });
+
+    await assertThrowsErrorAsync(async () => await cognito.signUp(taken));
+
+    // Then both requests were counted, and only one of them succeeded.
+    const reading = await simCognitoMetricDatapoint(
+      simAws,
+      "SignUpSuccesses",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(reading);
+    assertIdentical(reading.SampleCount, 2);
+    assertIdentical(reading.Sum, 1);
+  });
+
+  it("counts a federated sign-in once it has issued tokens", async () => {
+    // Given a pool with a hosted domain and a Google provider.
+    const setUp = await simCognitoHosted();
+
+    await setUp.simAws.clock().setTo(new Date("2026-08-30T09:00:00.000Z"));
+
+    const code = await simCognitoAuthorizationCode(setUp);
+    const http = new SimAwsHttp({ simAws: setUp.simAws });
+
+    // When the application exchanges the provider's code for tokens.
+    await http.fetch(`https://${setUp.domainHost}/oauth2/token`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: setUp.clientId,
+        code,
+        redirect_uri: simCognitoCallbackUrl,
+      }).toString(),
+    });
+
+    // Then the federation counted at the tokens rather than at the code, the
+    // way real Cognito counts one.
+    const reading = await simCognitoMetricDatapoint(
+      setUp.simAws,
+      "FederationSuccesses",
+      setUp.userPoolId,
+      setUp.clientId,
+    );
+
+    assertNonNullable(reading);
+    assertIdentical(reading.Sum, 1);
+    assertIdentical(reading.SampleCount, 1);
+  });
+});

--- a/src/service/cognito/sim-cognito-identity-provider.ts
+++ b/src/service/cognito/sim-cognito-identity-provider.ts
@@ -4,6 +4,7 @@ import {
 } from "../../util/background/background.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimCloudWatchServiceWriter } from "../cloudwatch/write/sim-cloudwatch-service-writer.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimAwsMessageLog } from "../aws/message/sim-aws-message-log.js";
 import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
@@ -44,6 +45,13 @@ export type { SimCognitoIdentityProviderRequestOptions } from "./sim-cognito-use
 
 interface SimCognitoIdentityProviderProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
+
+  /**
+   * Where this pool's own `AWS/Cognito` metrics go. A provider built on its
+   * own has none, and counts nothing.
+   */
+  readonly metrics?: SimCloudWatchServiceWriter;
+
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
 
@@ -145,6 +153,7 @@ export class SimCognitoIdentityProvider extends SimCognitoUserPools {
         emailSenders,
         webAcls,
         messageLog,
+        metrics: properties.metrics,
       }),
       background,
     });

--- a/src/service/cognito/sim-cognito-user-directory.ts
+++ b/src/service/cognito/sim-cognito-user-directory.ts
@@ -57,7 +57,7 @@ export abstract class SimCognitoUserDirectory extends SimCognitoUserFactors {
     command: simCognitoCommands.SimConfirmSignUpCommand,
   ): Promise<simCognitoCommands.SimConfirmSignUpCommandOutput> {
     await this.background.sequence();
-    return this.commands.signUp.confirmSignUp(command);
+    return this.commands.confirmSignUp.confirmSignUp(command);
   }
 
   /**
@@ -67,7 +67,7 @@ export abstract class SimCognitoUserDirectory extends SimCognitoUserFactors {
     command: simCognitoCommands.SimResendConfirmationCodeCommand,
   ): Promise<simCognitoCommands.SimResendConfirmationCodeCommandOutput> {
     await this.background.sequence();
-    return this.commands.signUp.resendConfirmationCode(command);
+    return this.commands.confirmSignUp.resendConfirmationCode(command);
   }
 
   /**
@@ -78,7 +78,7 @@ export abstract class SimCognitoUserDirectory extends SimCognitoUserFactors {
     options?: SimCognitoIdentityProviderRequestOptions,
   ): Promise<simCognitoCommands.SimAdminConfirmSignUpCommandOutput> {
     await this.background.sequence();
-    return this.commands.signUp.adminConfirmSignUp(command, options);
+    return this.commands.confirmSignUp.adminConfirmSignUp(command, options);
   }
 
   /**

--- a/test/cognito/metric-fixture.ts
+++ b/test/cognito/metric-fixture.ts
@@ -1,0 +1,132 @@
+/**
+ * A pool whose `AWS/Cognito` counts a test can read back.
+ *
+ * The clock is stopped before anything is created, so every datapoint the pool
+ * publishes lands in the one window the readers below ask for.
+ */
+
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import {
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  CreateUserPoolClientCommand,
+  CreateUserPoolCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { ExplicitAuthFlowsType } from "@aws-sdk/client-cognito-identity-provider";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimCognitoIdentityProvider } from "../../src/service/cognito/sim-cognito-identity-provider.js";
+
+/** The instant every metric test starts from. */
+export const simCognitoMetricStart = new Date("2026-08-30T09:00:00.000Z");
+
+export const simCognitoMetricUser = "alice";
+export const simCognitoMetricPassword = "Sup3rSecret!";
+
+export interface SimCognitoMetricSetUp {
+  readonly simAws: SimAws;
+  readonly cognito: SimCognitoIdentityProvider;
+  readonly userPoolId: string;
+  readonly clientId: string;
+}
+
+interface SimCognitoMetricOptions {
+  readonly explicitAuthFlows?: ExplicitAuthFlowsType[];
+  readonly withUser?: boolean;
+}
+
+/**
+ * A pool with one app client, and a confirmed user unless asked otherwise.
+ */
+export async function simCognitoForMetrics(
+  options: SimCognitoMetricOptions = {},
+): Promise<SimCognitoMetricSetUp> {
+  const simAws = new SimAws();
+  const cognito = simAws.cognitoIdentityProvider();
+
+  await simAws.clock().setTo(simCognitoMetricStart);
+
+  const pool = await cognito.createUserPool(
+    new CreateUserPoolCommand({ PoolName: "myapp-users" }),
+  );
+
+  assertNonNullable(pool.UserPool?.Id);
+
+  const userPoolId = pool.UserPool.Id;
+  const client = await cognito.createUserPoolClient(
+    new CreateUserPoolClientCommand({
+      UserPoolId: userPoolId,
+      ClientName: "web",
+      ExplicitAuthFlows: options.explicitAuthFlows ?? [
+        "ALLOW_USER_PASSWORD_AUTH",
+      ],
+    }),
+  );
+
+  assertNonNullable(client.UserPoolClient?.ClientId);
+
+  if (options.withUser !== false) {
+    await cognito.adminCreateUser(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: simCognitoMetricUser,
+      }),
+    );
+    await cognito.adminSetUserPassword(
+      new AdminSetUserPasswordCommand({
+        UserPoolId: userPoolId,
+        Username: simCognitoMetricUser,
+        Password: simCognitoMetricPassword,
+        Permanent: true,
+      }),
+    );
+  }
+
+  return {
+    simAws,
+    cognito,
+    userPoolId,
+    clientId: client.UserPoolClient.ClientId,
+  };
+}
+
+/**
+ * What one of a pool's metrics reported over the window.
+ *
+ * `Sum` is how many of the requests succeeded, `SampleCount` how many were
+ * made, and `Average` the success rate between them.
+ */
+export interface SimCognitoMetricReading {
+  readonly Sum?: number | undefined;
+  readonly SampleCount?: number | undefined;
+  readonly Average?: number | undefined;
+}
+
+/**
+ * The one datapoint a pool's metric holds over the window, if it holds any.
+ */
+export async function simCognitoMetricDatapoint(
+  simAws: SimAws,
+  metricName: string,
+  userPoolId: string,
+  userPoolClient: string,
+): Promise<SimCognitoMetricReading | undefined> {
+  const statistics = new GetMetricStatisticsCommand({
+    Namespace: "AWS/Cognito",
+    MetricName: metricName,
+    Dimensions: [
+      { Name: "UserPool", Value: userPoolId },
+      { Name: "UserPoolClient", Value: userPoolClient },
+    ],
+    StartTime: simCognitoMetricStart,
+    EndTime: new Date(simCognitoMetricStart.getTime() + 300_000),
+    Period: 300,
+    Statistics: ["Sum", "SampleCount", "Average"],
+  });
+  const { Datapoints } = await simAws
+    .cloudWatch()
+    .getMetricStatistics(statistics);
+
+  return Datapoints?.at(0);
+}


### PR DESCRIPTION
A simulated user pool now publishes what real Cognito publishes about the requests it handles, under `AWS/Cognito` and dimensioned by `UserPool` and `UserPoolClient`. `SignInSuccesses` counts every authentication request, `SignUpSuccesses` every registration, `TokenRefreshSuccesses` every renewal from a refresh token, and `FederationSuccesses` every sign-in through an identity provider. Each is a 1 where the request issued tokens and a 0 where it did not, including one the pool refused outright, so `Average` over a metric is a success rate and `SampleCount` is the number of requests. That is how the AWS documentation says to read them, and it is what lets an alarm on a pool's sign-ins be driven to a state change by signing in.

Counting happens where a request is answered. The flow runner counts what `InitiateAuth` and `AdminInitiateAuth` ran, splitting a refresh out of the sign-in count the way real Cognito does. The two challenge-response commands count their own requests, so a sign-in challenged for a second factor counts as the two requests it is. `GetTokensFromRefreshToken` counts beside the refresh flow, and the hosted token endpoint counts a federation at the tokens it issues rather than at the authorization code the provider sent the browser back with.

Two `UserPoolClient` values are fixed names. `AdminCreateUser` reports `Admin`, because the request reaches the pool through no app client, and an admin authentication request naming a client the pool has none of reports `Invalid`.

Confirming a sign-up moved into `SimCognitoConfirmSignUpCommands`. Registration and confirmation share nothing but the pool, and the file was at the 300-line cap, so holding them apart is what left registration room for its count.

One gap is documented rather than closed. A client-side request naming an unknown app client counts nothing at all, because the app client id is what finds the pool and an unknown one reaches no pool to report against. The `*Throttles` metrics stay absent too, and #1181 covers what publishing those would take.

Resolves #1180
