### PR TITLE
feat: turn a user pool request away and count the throttle

### DIFF
--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -3268,6 +3268,77 @@ Two `UserPoolClient` values are fixed names rather than ids. A user an administr
 
 A token refresh stays out of `SignInSuccesses` and lands in `TokenRefreshSuccesses`, whether it arrived as a `REFRESH_TOKEN_AUTH` flow or as `GetTokensFromRefreshToken`. A federated sign-in counts where its tokens are issued, at the token endpoint, rather than at the authorization code the provider sent the browser back with.
 
+### Turning requests away
+
+Real Cognito turns a request away when the account has gone over a rate limit, answering `TooManyRequestsException` and counting a `*Throttles` beside the `*Successes` it counts a 0 in. Those limits belong to the account and are mostly undocumented. Working one out here would be inventing a number, and a test asserting against an invented number proves little about a real pool. A test says how many requests a pool should turn away instead, and the pool turns away that many.
+
+```typescript sim-cognito-throttles
+/**
+ * An alarm on the sign-ins a pool is turning away.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { InitiateAuthCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+await simAws.cloudWatch().putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "SignInsThrottling",
+    Namespace: "AWS/Cognito",
+    MetricName: "SignInThrottles",
+    Dimensions: [
+      { Name: "UserPool", Value: userPoolId },
+      { Name: "UserPoolClient", Value: clientId },
+    ],
+    Statistic: "Sum",
+    Period: 300,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 1,
+    Threshold: 0,
+    ComparisonOperator: "GreaterThanThreshold",
+    TreatMissingData: "notBreaching",
+  }),
+);
+
+const cognito = simAws.cognitoIdentityProvider();
+
+cognito.userPool(userPoolId).auth.throttle.signIns(1);
+
+try {
+  await cognito.initiateAuth(
+    new InitiateAuthCommand({
+      ClientId: clientId,
+      AuthFlow: "USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+    }),
+  );
+} catch {
+  // TooManyRequestsException, counted in SignInThrottles.
+}
+
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(
+    new DescribeAlarmsCommand({ AlarmNames: ["SignInsThrottling"] }),
+  );
+
+// ALARM.
+console.log(MetricAlarms?.[0]?.StateValue);
+```
+
+`signUps`, `tokenRefreshes` and `federations` sit beside `signIns` on the same object, and each turns away only its own kind of request. A pool answers normally until a test asks it to turn requests away, and it goes back to answering normally once it has turned away the number it was given.
+
 ## Pool ARNs and IAM policies
 
 A pool ARN is the pool id after `userpool/`, and the region appears twice:
@@ -4812,11 +4883,10 @@ Sim Cognito currently supports:
 
 Current documented limitations:
 
-- `SignInSuccesses`, `SignUpSuccesses`, `TokenRefreshSuccesses` and `FederationSuccesses` are the
-  `AWS/Cognito` metrics a pool publishes. The `*Throttles` metrics beside them count what a rate
-  limit turned away, and this simulation applies none. A test that needs an alarm on one seeds the
-  datapoint through simulated CloudWatch's service writer. `CallCount` and `ThrottleCount` under
-  `AWS/Usage` are absent for the same reason. A client-side request naming an app client the pool
+- `SignInSuccesses`, `SignUpSuccesses`, `TokenRefreshSuccesses`, `FederationSuccesses` and the four
+  `*Throttles` beside them are the `AWS/Cognito` metrics a pool publishes. No rate limit works
+  itself out here. A pool turns a request away only where a test has told it to. `CallCount` and
+  `ThrottleCount` under `AWS/Usage` are absent. A client-side request naming an app client the pool
   has none of counts nothing at all, because the app client id is what finds the pool and an unknown
   one reaches no pool to report against.
 - Five authentication flows run: `ADMIN_USER_PASSWORD_AUTH` and `REFRESH_TOKEN_AUTH` through

--- a/docs/services/cognito/sim-cognito-throttles.example.ts
+++ b/docs/services/cognito/sim-cognito-throttles.example.ts
@@ -1,0 +1,62 @@
+/**
+ * An alarm on the sign-ins a pool is turning away.
+ */
+
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { InitiateAuthCommand } from "@aws-sdk/client-cognito-identity-provider";
+
+import type { SimAws } from "@kensio/yulin";
+
+declare const simAws: SimAws;
+declare const userPoolId: string;
+declare const clientId: string;
+
+await simAws.cloudWatch().putMetricAlarm(
+  new PutMetricAlarmCommand({
+    AlarmName: "SignInsThrottling",
+    Namespace: "AWS/Cognito",
+    MetricName: "SignInThrottles",
+    Dimensions: [
+      { Name: "UserPool", Value: userPoolId },
+      { Name: "UserPoolClient", Value: clientId },
+    ],
+    Statistic: "Sum",
+    Period: 300,
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 1,
+    Threshold: 0,
+    ComparisonOperator: "GreaterThanThreshold",
+    TreatMissingData: "notBreaching",
+  }),
+);
+
+const cognito = simAws.cognitoIdentityProvider();
+
+cognito.userPool(userPoolId).auth.throttle.signIns(1);
+
+try {
+  await cognito.initiateAuth(
+    new InitiateAuthCommand({
+      ClientId: clientId,
+      AuthFlow: "USER_PASSWORD_AUTH",
+      AuthParameters: { USERNAME: "alice", PASSWORD: "Sup3rSecret!" },
+    }),
+  );
+} catch {
+  // TooManyRequestsException, counted in SignInThrottles.
+}
+
+await simAws.backgroundTasksComplete();
+await simAws.clock().advanceBy({ minutes: 6 });
+
+const { MetricAlarms } = await simAws
+  .cloudWatch()
+  .describeAlarms(
+    new DescribeAlarmsCommand({ AlarmNames: ["SignInsThrottling"] }),
+  );
+
+// ALARM.
+console.log(MetricAlarms?.[0]?.StateValue);

--- a/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-admin-respond-to-challenge.ts
@@ -60,7 +60,7 @@ export class SimCognitoAdminRespondToChallenge {
     // counts its own.
     return await countedSimCognitoAuth(
       this.poolMetrics,
-      "SignInSuccesses",
+      "SignIn",
       { pool, client },
       async () =>
         await this.responses.handle(input.ChallengeName, {

--- a/src/service/cognito/command/auth/sim-cognito-auth-flow-runner.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-flow-runner.ts
@@ -56,7 +56,7 @@ export class SimCognitoAuthFlowRunner {
   ): Promise<SimCognitoAuthenticationOutput> {
     return await countedSimCognitoAuth(
       this.poolMetrics,
-      flow.exchangesRefreshToken ? "TokenRefreshSuccesses" : "SignInSuccesses",
+      flow.exchangesRefreshToken ? "TokenRefresh" : "SignIn",
       request,
       async () => await this.ran(flow, request),
     );

--- a/src/service/cognito/command/auth/sim-cognito-auth-resolver.ts
+++ b/src/service/cognito/command/auth/sim-cognito-auth-resolver.ts
@@ -76,7 +76,7 @@ export class SimCognitoAuthResolver {
       // of, reporting a fixed name in the client's place rather than the id
       // the request gave. The request still fails.
       this.poolMetrics.count(
-        "SignInSuccesses",
+        "SignIn",
         pool.id,
         simCognitoInvalidClientDimension,
         false,

--- a/src/service/cognito/command/auth/sim-cognito-get-tokens-from-refresh-token.ts
+++ b/src/service/cognito/command/auth/sim-cognito-get-tokens-from-refresh-token.ts
@@ -64,7 +64,7 @@ export class SimCognitoGetTokensFromRefreshToken {
 
     return await countedSimCognitoAuth(
       this.poolMetrics,
-      "TokenRefreshSuccesses",
+      "TokenRefresh",
       scope,
       async () => await this.renewed(command, scope),
     );

--- a/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.ts
+++ b/src/service/cognito/command/auth/sim-cognito-respond-to-challenge.ts
@@ -50,7 +50,7 @@ export class SimCognitoRespondToChallenge {
     // sign-in it belongs to started.
     return await countedSimCognitoAuth(
       this.poolMetrics,
-      "SignInSuccesses",
+      "SignIn",
       { pool, client },
       async () =>
         await this.responses.handle(input.ChallengeName, {

--- a/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-sign-up-commands.ts
@@ -81,7 +81,7 @@ export class SimCognitoSignUpCommands {
 
     return await countedSimCognitoCompletion(
       this.poolMetrics,
-      "SignUpSuccesses",
+      "SignUp",
       scope,
       async () => await this.registered(command, scope),
     );

--- a/src/service/cognito/command/user/sim-cognito-user-commands.ts
+++ b/src/service/cognito/command/user/sim-cognito-user-commands.ts
@@ -103,7 +103,7 @@ export class SimCognitoUserCommands {
     // client, and real Cognito reports it under a fixed name in that place.
     return await countedSimCognitoCompletion(
       this.poolMetrics,
-      "SignUpSuccesses",
+      "SignUp",
       { pool, client: { id: simCognitoAdminClientDimension } },
       async () => await this.created(command, pool),
     );

--- a/src/service/cognito/error/sim-cognito-throttle.error.ts
+++ b/src/service/cognito/error/sim-cognito-throttle.error.ts
@@ -1,0 +1,17 @@
+import { SimCognitoError } from "./sim-cognito.error.js";
+
+/**
+ * Simulated Cognito TooManyRequestsException error.
+ *
+ * Real Cognito answers this when a pool has turned a request away for rate
+ * limiting. Its own limits belong to the account and are mostly undocumented.
+ * Working one out here would be inventing a number, so a test says how many
+ * requests a pool should turn away and the pool turns away that many.
+ */
+export class SimCognitoTooManyRequestsException extends SimCognitoError {
+  public override readonly name = "TooManyRequestsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cognito/index.ts
+++ b/src/service/cognito/index.ts
@@ -192,6 +192,11 @@ export {
   SimCognitoWebAuthnOriginNotAllowedException,
   SimCognitoWebAuthnRelyingPartyMismatchException,
 } from "./error/sim-cognito-web-authn.error.js";
+export { SimCognitoTooManyRequestsException } from "./error/sim-cognito-throttle.error.js";
+export {
+  SimCognitoRequestThrottle,
+  type SimCognitoThrottledOperation,
+} from "./user-pool/auth/sim-cognito-request-throttle.js";
 export {
   isSimCognitoOAuthError,
   SimCognitoOAuthError,

--- a/src/service/cognito/metric/sim-cognito-counted-request.ts
+++ b/src/service/cognito/metric/sim-cognito-counted-request.ts
@@ -1,7 +1,9 @@
 import type {
-  SimCognitoPoolMetrics,
-  SimCognitoRequestMetric,
-} from "./sim-cognito-pool-metrics.js";
+  SimCognitoRequestThrottle,
+  SimCognitoThrottledOperation,
+} from "../user-pool/auth/sim-cognito-request-throttle.js";
+import type { SimCognitoPoolMetrics } from "./sim-cognito-pool-metrics.js";
+import { throttledSimCognitoRequest } from "./sim-cognito-throttled-request.js";
 
 /**
  * What an authentication request answers with, as the count reads it.
@@ -17,8 +19,11 @@ interface SimCognitoAuthenticationOutcome {
  * administrator made reaches the pool through no app client and is reported
  * under a fixed name instead.
  */
-interface SimCognitoCountedScope {
-  readonly pool: { readonly id: string };
+export interface SimCognitoCountedScope {
+  readonly pool: {
+    readonly id: string;
+    readonly auth: { readonly throttle: SimCognitoRequestThrottle };
+  };
   readonly client: { readonly id: string };
 }
 
@@ -31,7 +36,7 @@ interface SimCognitoCountedScope {
  */
 async function countedSimCognitoRequest<T>(
   metrics: SimCognitoPoolMetrics,
-  metricName: SimCognitoRequestMetric,
+  operation: SimCognitoThrottledOperation,
   scope: SimCognitoCountedScope,
   run: () => Promise<T>,
   succeeded: (output: T) => boolean,
@@ -39,13 +44,18 @@ async function countedSimCognitoRequest<T>(
   let counted = false;
 
   try {
-    const output = await run();
+    const output = await throttledSimCognitoRequest(
+      metrics,
+      operation,
+      scope,
+      run,
+    );
 
     counted = succeeded(output);
 
     return output;
   } finally {
-    metrics.count(metricName, scope.pool.id, scope.client.id, counted);
+    metrics.count(operation, scope.pool.id, scope.client.id, counted);
   }
 }
 
@@ -60,13 +70,13 @@ export async function countedSimCognitoAuth<
   T extends SimCognitoAuthenticationOutcome,
 >(
   metrics: SimCognitoPoolMetrics,
-  metricName: SimCognitoRequestMetric,
+  operation: SimCognitoThrottledOperation,
   scope: SimCognitoCountedScope,
   run: () => Promise<T>,
 ): Promise<T> {
   return await countedSimCognitoRequest(
     metrics,
-    metricName,
+    operation,
     scope,
     run,
     (output) => output.AuthenticationResult !== undefined,
@@ -81,13 +91,13 @@ export async function countedSimCognitoAuth<
  */
 export async function countedSimCognitoCompletion<T>(
   metrics: SimCognitoPoolMetrics,
-  metricName: SimCognitoRequestMetric,
+  operation: SimCognitoThrottledOperation,
   scope: SimCognitoCountedScope,
   run: () => Promise<T>,
 ): Promise<T> {
   return await countedSimCognitoRequest(
     metrics,
-    metricName,
+    operation,
     scope,
     run,
     () => true,
@@ -111,10 +121,5 @@ export async function countedSimCognitoFederation<T>(
     return await run();
   }
 
-  return await countedSimCognitoCompletion(
-    metrics,
-    "FederationSuccesses",
-    scope,
-    run,
-  );
+  return await countedSimCognitoCompletion(metrics, "Federation", scope, run);
 }

--- a/src/service/cognito/metric/sim-cognito-pool-metrics.ts
+++ b/src/service/cognito/metric/sim-cognito-pool-metrics.ts
@@ -1,22 +1,9 @@
 import type { SimCloudWatchServiceWriter } from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
+import type { SimCognitoThrottledOperation } from "../user-pool/auth/sim-cognito-request-throttle.js";
 import {
   simCognitoMetricNamespace,
   simCognitoPoolDimensions,
 } from "./sim-cognito-metrics.js";
-
-/**
- * The counts real Cognito keeps of what a pool was asked to do.
- *
- * Each is published on every request of its kind, as a 1 where the request
- * issued tokens and a 0 where it did not. `Average` over one is therefore a
- * success rate and `SampleCount` is the number of requests, which is how the
- * AWS documentation says to read them.
- */
-export type SimCognitoRequestMetric =
-  | "SignInSuccesses"
-  | "SignUpSuccesses"
-  | "TokenRefreshSuccesses"
-  | "FederationSuccesses";
 
 interface SimCognitoPoolMetricsProperties {
   readonly metrics: SimCloudWatchServiceWriter | undefined;
@@ -43,21 +30,53 @@ export class SimCognitoPoolMetrics {
   /**
    * Count one request against the pool and app client that made it.
    *
-   * A request that was refused before the pool was known counts nothing,
-   * because there is no `UserPool` to report it under.
+   * Real Cognito publishes a `*Successes` on every request of the kind, as a 1
+   * where it issued tokens and a 0 where it did not, so `Average` over one is
+   * a success rate and `SampleCount` is the number of requests. A request that
+   * was refused before the pool was known counts nothing, because there is no
+   * `UserPool` to report it under.
    */
   count(
-    metricName: SimCognitoRequestMetric,
+    operation: SimCognitoThrottledOperation,
     poolId: string,
     clientId: string,
     issuedTokens: boolean,
+  ): void {
+    this.publish(
+      `${operation}Successes`,
+      poolId,
+      clientId,
+      issuedTokens ? 1 : 0,
+    );
+  }
+
+  /**
+   * Count one request the pool turned away for rate limiting.
+   *
+   * Real Cognito counts a throttled request in both places. It is a 1 here and
+   * a 0 in the `*Successes` beside it, because a request that was turned away
+   * issued no tokens.
+   */
+  throttled(
+    operation: SimCognitoThrottledOperation,
+    poolId: string,
+    clientId: string,
+  ): void {
+    this.publish(`${operation}Throttles`, poolId, clientId, 1);
+  }
+
+  private publish(
+    metricName: string,
+    poolId: string,
+    clientId: string,
+    value: number,
   ): void {
     this.#metrics?.publish([
       {
         namespace: simCognitoMetricNamespace,
         metricName,
         dimensions: simCognitoPoolDimensions(poolId, clientId),
-        value: issuedTokens ? 1 : 0,
+        value,
         unit: "Count",
       },
     ]);

--- a/src/service/cognito/metric/sim-cognito-throttle-metrics.iso.test.ts
+++ b/src/service/cognito/metric/sim-cognito-throttle-metrics.iso.test.ts
@@ -1,0 +1,312 @@
+import {
+  DescribeAlarmsCommand,
+  PutMetricAlarmCommand,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  InitiateAuthCommand,
+  SignUpCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCognitoAuthorizationCode,
+  simCognitoCallbackUrl,
+  simCognitoHosted,
+} from "../../../../test/cognito/federation-fixture.js";
+import {
+  simCognitoForMetrics,
+  simCognitoMetricDatapoint,
+  simCognitoMetricPassword,
+  simCognitoMetricUser,
+} from "../../../../test/cognito/metric-fixture.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimCognitoTooManyRequestsException } from "../error/sim-cognito-throttle.error.js";
+
+function signIn(clientId: string): InitiateAuthCommand {
+  return new InitiateAuthCommand({
+    ClientId: clientId,
+    AuthFlow: "USER_PASSWORD_AUTH",
+    AuthParameters: {
+      USERNAME: simCognitoMetricUser,
+      PASSWORD: simCognitoMetricPassword,
+    },
+  });
+}
+
+describe("AWS/Cognito throttle metrics a simulated user pool publishes", () => {
+  it("turns a sign-in away once it has been told to", async () => {
+    // Given a pool told to turn the next sign-in away.
+    const { cognito, userPoolId, clientId } = await simCognitoForMetrics();
+
+    cognito.userPool(userPoolId).auth.throttle.signIns(1);
+
+    // When the user signs in with the right password.
+    const error = await assertThrowsErrorAsync(
+      async () => await cognito.initiateAuth(signIn(clientId)),
+    );
+
+    // Then the pool answered the way real Cognito answers a rate limit,
+    // rather than letting the sign-in through.
+    assertInstanceOf(error, SimCognitoTooManyRequestsException);
+    assertIdentical(error.name, "TooManyRequestsException");
+  });
+
+  it("counts a throttled sign-in in both places", async () => {
+    // Given a pool told to turn the next sign-in away.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics();
+
+    cognito.userPool(userPoolId).auth.throttle.signIns(1);
+
+    // When a sign-in is turned away.
+    await assertThrowsErrorAsync(
+      async () => await cognito.initiateAuth(signIn(clientId)),
+    );
+
+    // Then it counted as a throttle, and as an authentication request that
+    // issued no tokens, which is how real Cognito counts one.
+    const throttles = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInThrottles",
+      userPoolId,
+      clientId,
+    );
+    const successes = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInSuccesses",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(throttles);
+    assertIdentical(throttles.Sum, 1);
+    assertNonNullable(successes);
+    assertIdentical(successes.SampleCount, 1);
+    assertIdentical(successes.Sum, 0);
+  });
+
+  it("turns away only as many requests as it was told to", async () => {
+    // Given a pool told to turn the next two sign-ins away.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics();
+
+    cognito.userPool(userPoolId).auth.throttle.signIns(2);
+
+    // When three sign-ins are made.
+    await assertThrowsErrorAsync(
+      async () => await cognito.initiateAuth(signIn(clientId)),
+    );
+    await assertThrowsErrorAsync(
+      async () => await cognito.initiateAuth(signIn(clientId)),
+    );
+
+    const signedIn = await cognito.initiateAuth(signIn(clientId));
+
+    // Then the third one went through, and only the first two were counted as
+    // throttles.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+
+    const throttles = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInThrottles",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(throttles);
+    assertIdentical(throttles.Sum, 2);
+  });
+
+  it("counts a registration the pool turned away", async () => {
+    // Given a pool told to turn the next registration away.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics({ withUser: false });
+
+    cognito.userPool(userPoolId).auth.throttle.signUps(1);
+
+    // When a user tries to register.
+    await assertThrowsErrorAsync(
+      async () =>
+        await cognito.signUp(
+          new SignUpCommand({
+            ClientId: clientId,
+            Username: "bob",
+            Password: simCognitoMetricPassword,
+          }),
+        ),
+    );
+
+    // Then the registration counted under its own throttle metric.
+    const throttles = await simCognitoMetricDatapoint(
+      simAws,
+      "SignUpThrottles",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(throttles);
+    assertIdentical(throttles.Sum, 1);
+  });
+
+  it("counts a renewal the pool turned away", async () => {
+    // Given a signed-in user and a pool told to turn the next renewal away.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics({
+        explicitAuthFlows: [
+          "ALLOW_USER_PASSWORD_AUTH",
+          "ALLOW_REFRESH_TOKEN_AUTH",
+        ],
+      });
+    const signedIn = await cognito.initiateAuth(signIn(clientId));
+    const refreshToken = signedIn.AuthenticationResult?.RefreshToken;
+
+    assertNonNullable(refreshToken);
+
+    cognito.userPool(userPoolId).auth.throttle.tokenRefreshes(1);
+
+    // When the session is renewed.
+    await assertThrowsErrorAsync(
+      async () =>
+        await cognito.initiateAuth(
+          new InitiateAuthCommand({
+            ClientId: clientId,
+            AuthFlow: "REFRESH_TOKEN_AUTH",
+            AuthParameters: { REFRESH_TOKEN: refreshToken },
+          }),
+        ),
+    );
+
+    // Then the renewal counted as a token refresh throttle, and the sign-in
+    // that came before it is still the only sign-in counted.
+    const throttles = await simCognitoMetricDatapoint(
+      simAws,
+      "TokenRefreshThrottles",
+      userPoolId,
+      clientId,
+    );
+    const signIns = await simCognitoMetricDatapoint(
+      simAws,
+      "SignInSuccesses",
+      userPoolId,
+      clientId,
+    );
+
+    assertNonNullable(throttles);
+    assertIdentical(throttles.Sum, 1);
+    assertNonNullable(signIns);
+    assertIdentical(signIns.SampleCount, 1);
+  });
+
+  it("drives an alarm on a pool's throttling to ALARM", async () => {
+    // Given an alarm watching the sign-ins a pool turns away.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics();
+
+    await simAws.cloudWatch().putMetricAlarm(
+      new PutMetricAlarmCommand({
+        AlarmName: "SignInsThrottling",
+        Namespace: "AWS/Cognito",
+        MetricName: "SignInThrottles",
+        Dimensions: [
+          { Name: "UserPool", Value: userPoolId },
+          { Name: "UserPoolClient", Value: clientId },
+        ],
+        Statistic: "Sum",
+        Period: 300,
+        EvaluationPeriods: 3,
+        DatapointsToAlarm: 1,
+        Threshold: 0,
+        ComparisonOperator: "GreaterThanThreshold",
+        TreatMissingData: "notBreaching",
+      }),
+    );
+
+    // When the pool turns a sign-in away and the clock passes the period.
+    cognito.userPool(userPoolId).auth.throttle.signIns(1);
+    await assertThrowsErrorAsync(
+      async () => await cognito.initiateAuth(signIn(clientId)),
+    );
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ minutes: 6 });
+
+    // Then the alarm went off, driven by the pool rather than by a datapoint
+    // a test stood up on its behalf.
+    const described = new DescribeAlarmsCommand({
+      AlarmNames: ["SignInsThrottling"],
+    });
+    const { MetricAlarms } = await simAws
+      .cloudWatch()
+      .describeAlarms(described);
+
+    assertIdentical(MetricAlarms?.at(0)?.StateValue, "ALARM");
+  });
+
+  it("counts a federated sign-in the pool turned away", async () => {
+    // Given a hosted pool told to turn the next federation away.
+    const setUp = await simCognitoHosted();
+
+    await setUp.simAws.clock().setTo(new Date("2026-08-30T09:00:00.000Z"));
+
+    const code = await simCognitoAuthorizationCode(setUp);
+
+    setUp.cognito.userPool(setUp.userPoolId).auth.throttle.federations(1);
+
+    // When the application exchanges the provider's code for tokens.
+    const http = new SimAwsHttp({ simAws: setUp.simAws });
+    const exchange = await http.fetch(
+      `https://${setUp.domainHost}/oauth2/token`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          client_id: setUp.clientId,
+          code,
+          redirect_uri: simCognitoCallbackUrl,
+        }).toString(),
+      },
+    );
+
+    // Then the endpoint refused it and the pool counted the federation it
+    // turned away.
+    assertFalse(exchange.ok);
+
+    const throttles = await simCognitoMetricDatapoint(
+      setUp.simAws,
+      "FederationThrottles",
+      setUp.userPoolId,
+      setUp.clientId,
+    );
+
+    assertNonNullable(throttles);
+    assertIdentical(throttles.Sum, 1);
+  });
+
+  it("turns nothing away until a test asks it to", async () => {
+    // Given a pool nothing has told to turn anything away.
+    const { simAws, cognito, userPoolId, clientId } =
+      await simCognitoForMetrics();
+
+    // When the user signs in.
+    const signedIn = await cognito.initiateAuth(signIn(clientId));
+
+    // Then it went through, and the pool counted no throttle at all.
+    assertNonNullable(signedIn.AuthenticationResult?.AccessToken);
+    assertUndefined(
+      await simCognitoMetricDatapoint(
+        simAws,
+        "SignInThrottles",
+        userPoolId,
+        clientId,
+      ),
+    );
+  });
+});

--- a/src/service/cognito/metric/sim-cognito-throttled-request.ts
+++ b/src/service/cognito/metric/sim-cognito-throttled-request.ts
@@ -1,0 +1,28 @@
+import { SimCognitoTooManyRequestsException } from "../error/sim-cognito-throttle.error.js";
+import type { SimCognitoThrottledOperation } from "../user-pool/auth/sim-cognito-request-throttle.js";
+import type { SimCognitoCountedScope } from "./sim-cognito-counted-request.js";
+import type { SimCognitoPoolMetrics } from "./sim-cognito-pool-metrics.js";
+
+/**
+ * Turn a request away where the pool has been told to, and run it otherwise.
+ *
+ * The refusal is counted here, and the `*Successes` beside it is counted by
+ * the caller that wrapped this, because real Cognito counts a throttled
+ * request as an unsuccessful one as well as a throttled one.
+ */
+export async function throttledSimCognitoRequest<T>(
+  metrics: SimCognitoPoolMetrics,
+  operation: SimCognitoThrottledOperation,
+  scope: SimCognitoCountedScope,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (!scope.pool.auth.throttle.takesOne(operation)) {
+    return await run();
+  }
+
+  metrics.throttled(operation, scope.pool.id, scope.client.id);
+
+  throw new SimCognitoTooManyRequestsException(
+    `Rate exceeded for ${operation} on user pool ${scope.pool.id}.`,
+  );
+}

--- a/src/service/cognito/user-pool/auth/sim-cognito-pool-auth.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-pool-auth.ts
@@ -1,4 +1,5 @@
 import { SimCognitoNotAuthorizedException } from "../../error/sim-cognito.error.js";
+import { SimCognitoRequestThrottle } from "./sim-cognito-request-throttle.js";
 import { SimCognitoIdentityProviderStore } from "../idp/sim-cognito-identity-provider-store.js";
 import type { SimCognitoUserPoolDomain } from "../domain/sim-cognito-user-pool-domain.js";
 import type { SimCognitoAuthSession } from "./sim-cognito-auth-session.js";
@@ -35,6 +36,14 @@ export class SimCognitoPoolAuth {
    * The external identity providers this pool federates to.
    */
   public readonly identityProviders = new SimCognitoIdentityProviderStore();
+
+  /**
+   * How many requests of each kind this pool has been told to turn away.
+   *
+   * The simulator's own control rather than anything real Cognito exposes: a
+   * real pool's rate limits belong to the account and no API sets them.
+   */
+  public readonly throttle = new SimCognitoRequestThrottle();
 
   private readonly sessions = new SimCognitoAuthSessionStore();
   private readonly managedLogin = new SimCognitoManagedLoginSessionStore();

--- a/src/service/cognito/user-pool/auth/sim-cognito-request-throttle.ts
+++ b/src/service/cognito/user-pool/auth/sim-cognito-request-throttle.ts
@@ -1,0 +1,67 @@
+/**
+ * The kinds of request a pool counts, and can be told to turn away.
+ *
+ * These are the four real Cognito keeps a `*Successes` and a `*Throttles`
+ * metric for. The operation names the pair rather than either metric, because
+ * one request writes to both.
+ */
+export type SimCognitoThrottledOperation =
+  | "SignIn"
+  | "SignUp"
+  | "TokenRefresh"
+  | "Federation";
+
+/**
+ * How many requests of each kind a pool has been told to turn away.
+ *
+ * Real Cognito turns a request away when the account has gone over a rate
+ * limit, and those limits are per account and mostly undocumented. Working one
+ * out here would be inventing a number, and a test asserting against an
+ * invented number proves nothing about a real pool. So a test says how many
+ * requests to refuse instead, and the pool refuses that many and no more.
+ *
+ * A pool refuses nothing until a test asks it to.
+ */
+export class SimCognitoRequestThrottle {
+  readonly #queued = new Map<SimCognitoThrottledOperation, number>();
+
+  /** Turn away the next `count` sign-in requests. */
+  signIns(count: number): void {
+    this.queue("SignIn", count);
+  }
+
+  /** Turn away the next `count` registrations. */
+  signUps(count: number): void {
+    this.queue("SignUp", count);
+  }
+
+  /** Turn away the next `count` renewals from a refresh token. */
+  tokenRefreshes(count: number): void {
+    this.queue("TokenRefresh", count);
+  }
+
+  /** Turn away the next `count` sign-ins through an identity provider. */
+  federations(count: number): void {
+    this.queue("Federation", count);
+  }
+
+  /**
+   * Take one refusal for this operation, answering with whether there was one
+   * to take. A request that takes one is the request being turned away.
+   */
+  takesOne(operation: SimCognitoThrottledOperation): boolean {
+    const left = this.#queued.get(operation) ?? 0;
+
+    if (left < 1) {
+      return false;
+    }
+
+    this.#queued.set(operation, left - 1);
+
+    return true;
+  }
+
+  private queue(operation: SimCognitoThrottledOperation, count: number): void {
+    this.#queued.set(operation, (this.#queued.get(operation) ?? 0) + count);
+  }
+}


### PR DESCRIPTION
A test can now tell a pool how many requests to refuse, through `userPool(id).auth.throttle`, and the pool answers that many with `TooManyRequestsException` before going back to answering normally. `signIns`, `signUps`, `tokenRefreshes` and `federations` sit on that object and each turns away only its own kind of request. Every refusal counts a `SignInThrottles`, `SignUpThrottles`, `TokenRefreshThrottles` or `FederationThrottles` of 1, alongside a 0 in the `*Successes` beside it, because real Cognito counts a throttled request as an unsuccessful one as well as a throttled one. An alarm on a pool's throttling can therefore be driven to a state change by the pool itself. Seeding a datapoint on its behalf is no longer the only way.

The count of requests to refuse is what a test gives, rather than a rate. Real Cognito's limits belong to the account and are mostly undocumented, so working one out here would be inventing a number, and a test asserting against an invented number proves little about a real pool. This is the second of the two shapes the issue weighed, and the smaller one. Nothing here models a rate, and a test wanting to assert that some number of sign-ins a second gets throttled cannot be written.

Three things moved to make room. The four metric names are derived from the operation now rather than written out, so one name says which `*Successes` and which `*Throttles` a request belongs in. `TooManyRequestsException` went into `sim-cognito-throttle.error.ts` beside the four error files this service already splits by area, because the general catalogue was at the 300-line cap. The throttle check went into its own module for the same reason on the FTA gate.

Resolves #1181
