### PR TITLE
fix: hand a template's RedrivePolicy to CreateQueue

### DIFF
--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -1049,8 +1049,39 @@ console.log(stack.output("OrdersQueueArn"));
 ```
 
 The properties applied to the queue are `VisibilityTimeout`, `DelaySeconds`,
-`MessageRetentionPeriod`, `MaximumMessageSize` and `ReceiveMessageWaitTimeSeconds`. Each is passed to
-`CreateQueue`, and a value outside the range real SQS accepts fails the resource.
+`MessageRetentionPeriod`, `MaximumMessageSize`, `ReceiveMessageWaitTimeSeconds` and
+`RedrivePolicy`. Each is passed to `CreateQueue`, and a value outside the range real SQS accepts
+fails the resource.
+
+`RedrivePolicy` is the same attribute [dead-letter queues](#dead-letter-queues) covers, and a
+template goes through the validation an SDK caller goes through. CloudFormation carries the policy
+as an object where SQS carries it as a JSON string, and both spellings arrive at `CreateQueue` the
+same way. The `deadLetterTargetArn` has to name a queue that already exists. Naming the dead-letter
+queue with `Fn::GetAtt` also puts the two queues in the order they have to be created in.
+
+```typescript
+{
+  OrdersDlq: {
+    Type: "AWS::SQS::Queue",
+    Properties: { QueueName: "orders-dlq" },
+  },
+  OrdersQueue: {
+    Type: "AWS::SQS::Queue",
+    Properties: {
+      QueueName: "orders",
+      RedrivePolicy: {
+        deadLetterTargetArn: { "Fn::GetAtt": ["OrdersDlq", "Arn"] },
+        maxReceiveCount: 3,
+      },
+    },
+  },
+}
+```
+
+A message the queue gives up on reaches `orders-dlq`, and `GetQueueAttributes` on `orders` reports
+the policy back. A policy real SQS would refuse fails the resource, in the words it refuses an SDK
+caller with. Terraform's `redrive_policy` and its `aws_sqs_queue_redrive_policy` resource both map
+onto this property. A plan carrying either deploys a working dead-letter queue.
 
 A queue with no `QueueName` is named from the stack name, the logical ID and a tail derived from
 both. The queue above with its name left out would be `orders-stack-OrdersQueue-` and twelve more
@@ -1065,10 +1096,10 @@ under the name the template gave it.
 The properties this simulation has no behaviour for are a different case. The queue is created without
 them and each one is recorded in
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without).
-A stack full of queues still deploys. Those properties are `RedrivePolicy`, `RedriveAllowPolicy`,
-`KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds`, `SqsManagedSseEnabled`,
-`ContentBasedDeduplication`, `DeduplicationScope`, `FifoThroughputLimit` and `Tags`. A property
-outside the `AWS::SQS::Queue` schema is recorded the same way.
+A stack full of queues still deploys. Those properties are `RedriveAllowPolicy`, `KmsMasterKeyId`,
+`KmsDataKeyReusePeriodSeconds`, `SqsManagedSseEnabled`, `ContentBasedDeduplication`,
+`DeduplicationScope`, `FifoThroughputLimit` and `Tags`. A property outside the `AWS::SQS::Queue`
+schema is recorded the same way.
 
 `AWS::SQS::QueuePolicy` deploys the policy it names onto each queue in its `Queues` list, through
 `SetQueueAttributes`. A policy declared in a template is therefore validated and enforced exactly as
@@ -1123,7 +1154,8 @@ Sim SQS currently supports:
 - Lambda event source mappings, delivering messages to a simulated function and deleting the batches
   it handles
 - `AWS::SQS::Queue` and `AWS::SQS::QueuePolicy` in a CloudFormation or CDK template, with `Ref`
-  giving the queue URL and `Fn::GetAtt` giving `Arn`, `QueueName` and `QueueUrl`
+  giving the queue URL and `Fn::GetAtt` giving `Arn`, `QueueName` and `QueueUrl`, and a
+  `RedrivePolicy` on a queue naming its dead-letter queue
 
 ## Limitations
 
@@ -1152,9 +1184,6 @@ Current documented limitations:
   reading of SQS, and AWS documents no answer either way. A receive count counts receives from one
   queue, and the moved message has not been received from the dead-letter queue yet. `SentTimestamp`
   being unchanged by the move is documented AWS behaviour, and is simulated as such.
-- The `RedrivePolicy` property on `AWS::SQS::Queue` is left out, and an SDK call is what configures a
-  dead-letter queue. The queue is created without the property and the omission is recorded in
-  `stack.ignoredProperties`.
 - A queue policy is set through the `Policy` attribute only. `AddPermission` and `RemovePermission`,
   shorthands for writing one statement of it, are absent.
 - `GetQueueAttributes` reports the `Policy` string that was set. Real SQS re-serialises the document

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -196,11 +196,12 @@ has no existence of its own in SQS: it is the `Policy` attribute of the queues i
 resource's simulated object is the first queue it named. `Ref` on an `AWS::SQS::Queue` gives its URL,
 which is what `Queues` carries and what `SetQueueAttributes` takes.
 
-The properties this simulation has no behaviour for fail the resource rather than being dropped,
-including `FifoQueue: true`. A queue deployed without its redrive policy would look to the template
-like a queue with a dead-letter queue and have none. The failures are worded as an invalid resource
-rather than an unsupported one, because sim CloudFormation skips a resource whose error reads as
-unsupported, and skipping is the wrong answer for a queue that cannot be created as asked.
+A property this simulation has no behaviour for is recorded against the Resource and the queue is
+created without it. `FifoQueue: true` fails the resource instead. A FIFO queue is named
+`<name>.fifo`, a name simulated SQS refuses, leaving no queue to create under the name the template
+gave it. The failures are worded as an invalid resource rather than an unsupported one, because sim
+CloudFormation skips a resource whose error reads as unsupported, and skipping is the wrong answer
+for a queue that cannot be created as asked.
 
 `SimCfnSqsQueueName` generates the name for a queue the template does not name, from the stack name
 and the logical ID. It applies the 80 characters a queue name allows through the shared
@@ -258,9 +259,8 @@ here, it does not make another Account's queues reachable through this one.
   The 60 second hold on a deleted queue's name is simulated.
 - A queue name ending in `.fifo` is refused, as are the FIFO-only request fields.
 - `SenderId` is not reported, because a simulated principal has no user or role id to report it as.
-- Tags, `RedriveAllowPolicy` and the encryption attributes are refused rather than ignored, whether a
-  request or a CloudFormation template asks for them. So is `RedrivePolicy` on a CloudFormation
-  resource, where it is not simulated, unlike the queue attribute of the same name.
+- Tags, `RedriveAllowPolicy` and the encryption attributes are refused rather than ignored when a
+  request sets them, and recorded against the Resource when a CloudFormation template declares them.
 - A queue policy is set through the `Policy` attribute only. `AddPermission` and `RemovePermission`,
   which are shorthands for writing one statement of it, are not implemented.
 - `GetQueueAttributes` reports the `Policy` string that was set. Real SQS re-serialises the document

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-properties.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-properties.ts
@@ -1,9 +1,12 @@
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimSqsQueueAttributeInput } from "../../queue/sim-sqs-queue-attributes.js";
+import { simSqsJsonQueueAttributeNames } from "../../queue/sim-sqs-queue-attribute-specs.js";
 import { SimCfnSqsQueueName } from "./sim-cfn-sqs-queue-name.js";
 import {
   SimCfnSqsQueuePropertyRules,
@@ -71,8 +74,42 @@ export class SimCfnSqsQueueProperties {
     return Object.fromEntries(
       Object.entries(this.properties)
         .filter(([name]) => this.rules.isAttributeProperty(name))
-        .map(([name, value]) => [name, this.numberValue(value, name)]),
+        .map(([name, value]) => [name, this.attributeValue(value, name)]),
     );
+  }
+
+  /**
+   * Read one property as the string the attribute of that name carries.
+   *
+   * Five of these properties are amounts and `RedrivePolicy` is a JSON
+   * document, so the two are read differently.
+   */
+  private attributeValue(value: SimCfnTemplateValue, name: string): string {
+    if (simSqsJsonQueueAttributeNames.has(name)) {
+      return this.documentValue(value, name);
+    }
+
+    return this.numberValue(value, name);
+  }
+
+  /**
+   * Read a JSON document property as the string an SQS attribute carries.
+   *
+   * CloudFormation carries the document as an object, and as a string when it
+   * came from a template Parameter or from a Terraform plan holding it as one.
+   * What the document has to say is left to SQS, which refuses a bad redrive
+   * policy in its own words.
+   */
+  private documentValue(value: SimCfnTemplateValue, name: string): string {
+    if (typeof value === "string") {
+      return value;
+    }
+
+    if (isRecord(value)) {
+      return jsonStringify(value);
+    }
+
+    throw this.propertyError(`${name} must be a JSON document`);
   }
 
   /**

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-names.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-names.ts
@@ -5,13 +5,17 @@ import type { SimCfnTemplateValue } from "../../../cloudformation/template/value
  *
  * CloudFormation names these exactly as the SQS API names the attributes, so
  * they are handed to CreateQueue rather than applied here. That leaves the
- * ranges and defaults in one place: the ones simulated SQS already validates.
+ * ranges and defaults in one place, the ones simulated SQS already validates.
+ *
+ * Five of them are amounts. `RedrivePolicy` is a JSON document, and
+ * CloudFormation carries it as an object where SQS carries it as a string.
  */
 export const attributePropertyNames: ReadonlySet<string> = new Set([
   "DelaySeconds",
   "MaximumMessageSize",
   "MessageRetentionPeriod",
   "ReceiveMessageWaitTimeSeconds",
+  "RedrivePolicy",
   "VisibilityTimeout",
 ]);
 
@@ -20,10 +24,8 @@ export const attributePropertyNames: ReadonlySet<string> = new Set([
  * each of them would have changed.
  *
  * The queue is created without them and each one is recorded against the
- * Resource. A queue deployed without its redrive policy looks like a queue with
- * a dead-letter queue to the template that wrote it and has none, so a test
- * expecting a failed message to end up somewhere needs to find out that it
- * never will.
+ * Resource. A test reads the record to find out what the queue it deployed
+ * behaves differently to AWS about.
  */
 export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
   ["ContentBasedDeduplication", "only standard queues are simulated"],
@@ -36,13 +38,8 @@ export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
   ["KmsMasterKeyId", "simulated SQS does not encrypt message bodies"],
   [
     "RedriveAllowPolicy",
-    "dead-letter queues are not simulated, so nothing enforces which queues " +
-      "may name this one as theirs",
-  ],
-  [
-    "RedrivePolicy",
-    "dead-letter queues are not simulated, so a message that is received " +
-      "past maxReceiveCount stays on this queue rather than moving",
+    "nothing enforces which queues may name this one as their dead-letter " +
+      "queue, and setting the attribute through the SQS API is refused",
   ],
   ["SqsManagedSseEnabled", "simulated SQS does not encrypt message bodies"],
   ["Tags", "no simulated service reads a queue tag"],

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-redrive.iso.test.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-redrive.iso.test.ts
@@ -1,0 +1,248 @@
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+  SendMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+
+const dlqArn = { "Fn::GetAtt": ["OrdersDlq", "Arn"] };
+
+/**
+ * A two-queue template, where the main queue redrives to the other one.
+ *
+ * The dead-letter queue is named through `Fn::GetAtt`, which is how CDK and a
+ * hand-written template both name it. That also puts the two queues in the
+ * order they have to be created in, since a redrive policy is only accepted
+ * once the queue it names exists.
+ */
+function ordersTemplate(policy: SimCfnTemplateValueRecord): {
+  Resources: SimCfnTemplateValueRecord;
+  Outputs: SimCfnTemplateValueRecord;
+} {
+  return {
+    Resources: {
+      OrdersDlq: {
+        Type: "AWS::SQS::Queue",
+        Properties: { QueueName: "orders-dlq" },
+      },
+      OrdersQueue: {
+        Type: "AWS::SQS::Queue",
+        Properties: {
+          QueueName: "orders",
+          VisibilityTimeout: 30,
+          RedrivePolicy: policy,
+        },
+      },
+    },
+    Outputs: {
+      QueueUrl: { Value: { Ref: "OrdersQueue" } },
+      DlqUrl: { Value: { Ref: "OrdersDlq" } },
+    },
+  };
+}
+
+async function deployOrders(
+  simAws: SimAws,
+  policy: SimCfnTemplateValueRecord,
+): Promise<SimCfnDeployedStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: ordersTemplate(policy),
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+describe("AWS::SQS::Queue RedrivePolicy", () => {
+  it("reports back the policy the template declared", async () => {
+    // Given a template declaring a queue that redrives to a dead-letter queue
+    // the same template creates.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await deployOrders(simAws, {
+      deadLetterTargetArn: dlqArn,
+      maxReceiveCount: 3,
+    });
+
+    // Then GetQueueAttributes answers with the policy, carrying the ARN
+    // Fn::GetAtt resolved to.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: stack.output("QueueUrl"),
+        AttributeNames: ["RedrivePolicy"],
+      }),
+    );
+
+    assertIdentical(
+      read.Attributes?.["RedrivePolicy"],
+      JSON.stringify({
+        deadLetterTargetArn: "arn:aws:sqs:us-east-1:888888888888:orders-dlq",
+        maxReceiveCount: 3,
+      }),
+    );
+
+    // And nothing is recorded against the Resource, since the queue was
+    // created with the property rather than around it.
+    assertUndefined(
+      stack.ignoredProperties.find(
+        (ignored) => ignored.path === "RedrivePolicy",
+      ),
+    );
+  });
+
+  it("moves a message past maxReceiveCount to the queue the template named", async () => {
+    // Given a deployed queue that gives up on a message after two receives.
+    const simAws = new SimAws();
+    const stack = await deployOrders(simAws, {
+      deadLetterTargetArn: dlqArn,
+      maxReceiveCount: 2,
+    });
+    const sqs = simAws.sqs();
+    const QueueUrl = stack.output("QueueUrl");
+
+    await sqs.sendMessage(
+      new SendMessageCommand({ QueueUrl, MessageBody: "order-1" }),
+    );
+
+    // When a consumer takes the message twice and deletes it neither time.
+    async function failToHandleMessage(): Promise<void> {
+      await sqs.receiveMessage(new ReceiveMessageCommand({ QueueUrl }));
+      await simAws.clock().advanceBy({ seconds: 31 });
+    }
+
+    await failToHandleMessage();
+    await failToHandleMessage();
+
+    // Then the source queue has given up on it.
+    const empty = await sqs.receiveMessage(
+      new ReceiveMessageCommand({ QueueUrl }),
+    );
+    assertUndefined(empty.Messages);
+
+    // And it is on the dead-letter queue the template named.
+    const dead = await sqs.receiveMessage(
+      new ReceiveMessageCommand({ QueueUrl: stack.output("DlqUrl") }),
+    );
+    assertIdentical(dead.Messages?.[0]?.Body, "order-1");
+  });
+
+  it("refuses a policy in the words an SDK caller is refused in", async () => {
+    // Given a receive count outside the range real SQS accepts.
+    const simAws = new SimAws();
+    const policy = {
+      deadLetterTargetArn: "arn:aws:sqs:us-east-1:888888888888:orders-dlq",
+      maxReceiveCount: 0,
+    };
+
+    await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "orders-dlq" }));
+
+    const throughSdk = await assertThrowsErrorAsync(async () => {
+      return await simAws.sqs().createQueue(
+        new CreateQueueCommand({
+          QueueName: "orders-sdk",
+          Attributes: { RedrivePolicy: JSON.stringify(policy) },
+        }),
+      );
+    });
+
+    // When a template declaring the same policy is deployed, then the
+    // deployment fails with what SQS told the SDK caller.
+    const throughTemplate = await assertThrowsErrorAsync(async () => {
+      return await deployOrders(new SimAws(), {
+        deadLetterTargetArn: dlqArn,
+        maxReceiveCount: 0,
+      });
+    });
+
+    assertStringIncludes(
+      throughSdk.message,
+      "Value 0 for maxReceiveCount is invalid. It must be an integer from 1 " +
+        "to 1000",
+    );
+    assertStringIncludes(throughTemplate.message, throughSdk.message);
+  });
+
+  it("refuses a dead-letter queue that is not there", async () => {
+    // Given a policy naming a queue no template created.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then it fails where a policy pointing at
+    // nothing would otherwise have looked like a working dead-letter queue.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployOrders(simAws, {
+        deadLetterTargetArn: "arn:aws:sqs:us-east-1:888888888888:missing",
+        maxReceiveCount: 3,
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Dead letter target arn:aws:sqs:us-east-1:888888888888:missing does " +
+        "not exist",
+    );
+    assertUndefined(simAws.sqs().findQueue("orders"));
+  });
+
+  it("takes a policy a template Parameter carries as a string", async () => {
+    // Given a template taking the whole policy from a Parameter, which
+    // resolves to the JSON string SQS carries the attribute as.
+    const simAws = new SimAws();
+    const policy = JSON.stringify({
+      deadLetterTargetArn: "arn:aws:sqs:us-east-1:888888888888:orders-dlq",
+      maxReceiveCount: 5,
+    });
+
+    // When the template is deployed with a value for it.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      parameters: { Redrive: policy },
+      template: {
+        Parameters: { Redrive: { Type: "String" } },
+        Resources: {
+          OrdersDlq: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: "orders-dlq" },
+          },
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            DependsOn: "OrdersDlq",
+            Properties: {
+              QueueName: "orders",
+              RedrivePolicy: { Ref: "Redrive" },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the queue reports the string the Parameter carried.
+    const queue = simAws.sqs().findQueue("orders");
+    assertNonNullable(queue);
+
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queue.url,
+        AttributeNames: ["RedrivePolicy"],
+      }),
+    );
+
+    assertIdentical(read.Attributes?.["RedrivePolicy"], policy);
+  });
+});

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-redrive.iso.test.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-redrive.iso.test.ts
@@ -199,6 +199,34 @@ describe("AWS::SQS::Queue RedrivePolicy", () => {
     assertUndefined(simAws.sqs().findQueue("orders"));
   });
 
+  it("refuses a policy that is neither an object nor a string", async () => {
+    // Given a RedrivePolicy carrying something no document could be read out
+    // of, which real CloudFormation refuses against its own schema.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then it is refused rather than handed to
+    // SQS as the text of a number.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws.cloudFormation().deployTemplate({
+        stackName: "orders-stack",
+        template: {
+          Resources: {
+            OrdersQueue: {
+              Type: "AWS::SQS::Queue",
+              Properties: { QueueName: "orders", RedrivePolicy: 3 },
+            },
+          },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::SQS::Queue Resource OrdersQueue: RedrivePolicy must be a " +
+        "JSON document",
+    );
+  });
+
   it("takes a policy a template Parameter carries as a string", async () => {
     // Given a template taking the whole policy from a Parameter, which
     // resolves to the JSON string SQS carries the attribute as.

--- a/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
+++ b/src/service/sqs/cfn/sim-cfn-sqs-queue-validation.iso.test.ts
@@ -143,16 +143,16 @@ describe("SQS CloudFormation Queue validation", () => {
     // simulated.
     // When each Resource is created, then each queue exists with the property
     // it behaves differently to AWS without recorded by name.
-    const redrive = await createdQueueResource({
+    const redriveAllow = await createdQueueResource({
       QueueName: "orders",
-      RedrivePolicy: { maxReceiveCount: 3 },
+      RedriveAllowPolicy: { redrivePermission: "allowAll" },
     });
     assertIdentical(
-      redrive[0]?.reason,
-      "RedrivePolicy is a real AWS::SQS::Queue property simulated SQS does " +
-        "not act on: dead-letter queues are not simulated, so a message that " +
-        "is received past maxReceiveCount stays on this queue rather than " +
-        "moving",
+      redriveAllow[0]?.reason,
+      "RedriveAllowPolicy is a real AWS::SQS::Queue property simulated SQS " +
+        "does not act on: nothing enforces which queues may name this one as " +
+        "their dead-letter queue, and setting the attribute through the SQS " +
+        "API is refused",
     );
 
     const encryption = await createdQueueResource({

--- a/src/terraform/map/sim-tf-map-sqs-redrive.ts
+++ b/src/terraform/map/sim-tf-map-sqs-redrive.ts
@@ -61,9 +61,10 @@ export function jsonDocument(
  *
  * Each names its queue in a `queue_url` attribute, which the queue resolves to
  * whether or not the URL itself was known at plan time. CloudFormation carries
- * both as properties of the `AWS::SQS::Queue`, and simulated SQS records each
- * one against the Resource: no message moves to a dead-letter queue here, and
- * nothing enforces which queues may name one as theirs.
+ * both as properties of the `AWS::SQS::Queue`. `RedrivePolicy` reaches
+ * CreateQueue from there and moves a message that has run out of receives.
+ * `RedriveAllowPolicy` is recorded against the Resource, since nothing
+ * enforces which queues may name this one as their dead-letter queue.
  */
 export const sqsRedriveFolds: ReadonlyMap<string, TerraformResourceFold> =
   new Map([

--- a/src/terraform/sim-tf-deploy.iso.test.ts
+++ b/src/terraform/sim-tf-deploy.iso.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "vitest";
 import { InvokeCommand } from "@aws-sdk/client-lambda";
+import { GetQueueAttributesCommand } from "@aws-sdk/client-sqs";
 import {
   assertArrayEquals,
   assertIdentical,
@@ -37,6 +38,54 @@ describe("deploying a Terraform plan into simulated AWS", () => {
     assertNonNullable(simAws.s3().getSimBucketByName("orders-uploads"));
     assertNonNullable(simAws.sqs().findQueue("orders-processing"));
     assertIdentical(stack.status, "CREATE_COMPLETE");
+  });
+
+  it("configures the dead-letter queue a redrive policy names", async () => {
+    // Given a plan declaring a queue that redrives to another queue the plan
+    // creates, with the policy resolved to the JSON string Terraform holds it
+    // in
+    const deadLetterTargetArn = "arn:aws:sqs:us-east-1:888888888888:orders-dlq";
+    const planPath = await planFile({
+      resources: [
+        terraformPlanResourceFactory.make({
+          name: "dlq",
+          values: { name: "orders-dlq" },
+        }),
+        terraformPlanResourceFactory.make({
+          values: {
+            name: "orders",
+            redrive_policy: JSON.stringify({
+              deadLetterTargetArn,
+              maxReceiveCount: 3,
+            }),
+          },
+          references: {
+            redrive_policy: ["aws_sqs_queue.dlq.arn", "aws_sqs_queue.dlq"],
+          },
+        }),
+      ],
+    });
+
+    // When the plan is deployed
+    const simAws = new SimAws();
+    await new TerraformAdapter(simAws).deployPlan(planPath);
+
+    // Then the queue reports the policy back, having reached CreateQueue
+    // through the AWS::SQS::Queue property the plan is mapped onto
+    const queue = simAws.sqs().findQueue("orders");
+    assertNonNullable(queue);
+
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: queue.url,
+        AttributeNames: ["RedrivePolicy"],
+      }),
+    );
+
+    assertIdentical(
+      read.Attributes?.["RedrivePolicy"],
+      JSON.stringify({ deadLetterTargetArn, maxReceiveCount: 3 }),
+    );
   });
 
   it("names the Stack after the plan file", async () => {


### PR DESCRIPTION
An `AWS::SQS::Queue` declaring a `RedrivePolicy` deployed without it, under a reason that went out of date when #249 landed dead-letter queues. The property joins the five attribute properties handed to `CreateQueue`, so a template reaches the validation an SDK caller reaches, a queue deployed with one answers `GetQueueAttributes` with it, and a message received past `maxReceiveCount` moves to the queue the policy names. CloudFormation carries the policy as an object where SQS carries it as a JSON string, and a template Parameter carries it as the string, so both are read. Terraform's `redrive_policy` maps onto the same property and now works too, which a deploy test confirms. `RedriveAllowPolicy` stays recorded and its reason is reworded, since nothing enforces which queues may name this one as their dead-letter queue.

Resolves #1191