### PR TITLE
feat: refuse a delete Object Lock is holding

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1037,9 +1037,11 @@ A delete on a versioned Bucket raises `s3:ObjectRemoved:DeleteMarkerCreated` rat
 
 ## Object Lock
 
-Object Lock stops anything deleting a version of an Object, the account root included. A version can
-be held by a retention period, by a legal hold or by both, and a delete naming a held version is
-answered with `AccessDenied`. Turn it on with `PutObjectLockConfigurationCommand`, or with
+Object Lock holds a version of an Object against a delete. A version can be held by a retention
+period, by a legal hold or by both, and a delete naming a held version is answered with
+`AccessDenied`. One way past exists and it is narrow. A `GOVERNANCE` retention period gives way to a
+request carrying `BypassGovernanceRetention` from a caller allowed to use it. A `COMPLIANCE` period
+and a legal hold hold against everyone, the account root included. Turn it on with `PutObjectLockConfigurationCommand`, or with
 `ObjectLockEnabled` on an `AWS::S3::Bucket` resource.
 
 Object Lock holds a version, and versioning has to be on underneath it. Turning it on over a Bucket
@@ -1148,8 +1150,10 @@ needed. Holding the permission and using it are separate. A delete that leaves t
 refused whatever the caller may do.
 
 A compliance period gives way to nobody, the account root included. `PutObjectRetentionCommand`
-follows the same split. A compliance period can be extended and never shortened, and a governance
-period can be shortened by a request that bypasses it.
+follows the same split. A compliance period can be extended in the same mode and that is all, since
+shortening one would end the guarantee early and turning one into a governance period would hand the
+version to the first caller holding the bypass permission. A governance period can be shortened, or
+turned into a compliance one, by a request that bypasses it.
 
 ### Legal holds
 
@@ -1162,7 +1166,8 @@ once, and either one on its own refuses the delete.
 
 A `DefaultRetention` under `Rule` retains every version written after it, counted from the write, so
 two versions of one key written a day apart are held until two different instants. It takes `Days` or
-`Years` and refuses both together, and a year is 365 days. A Bucket with Object Lock on and no
+`Years` and refuses both together, a year is 365 days, and the longest one real S3 takes is a hundred
+years. A Bucket with Object Lock on and no
 default leaves each version to whatever requests name it.
 
 ### From a CloudFormation template
@@ -1186,7 +1191,8 @@ Bucket created around the property would report a default retention it never app
 - The `?object-lock`, `?retention` and `?legal-hold` sub-resources are refused over the served S3
   REST endpoint. Object Lock is reachable through the SDK and through a template.
 - A Bucket policy setting minimum and maximum allowable retention periods is left out. The only
-  bound on a retention is the 1 to 1000 range real S3 puts on a `DefaultRetention` period.
+  bound applied is the hundred years real S3 caps a `DefaultRetention` at. A `RetainUntilDate` on a
+  single version is taken as given, however far ahead it names.
 - `S3 Batch Operations` applying retention across a manifest is left out.
 
 ## Event notifications

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1035,6 +1035,160 @@ A delete on a versioned Bucket raises `s3:ObjectRemoved:DeleteMarkerCreated` rat
 - A Bucket mounted on a filesystem directory refuses the deletion a delete marker asks for, the way
   it refuses `DeleteObject`. See [Filesystem-backed Bucket storage](#filesystem-backed-bucket-storage).
 
+## Object Lock
+
+Object Lock stops anything deleting a version of an Object, the account root included. A version can
+be held by a retention period, by a legal hold or by both, and a delete naming a held version is
+answered with `AccessDenied`. Turn it on with `PutObjectLockConfigurationCommand`, or with
+`ObjectLockEnabled` on an `AWS::S3::Bucket` resource.
+
+Object Lock holds a version, and versioning has to be on underneath it. Turning it on over a Bucket
+with versioning off is refused with `InvalidBucketState`, as real S3 refuses it, and a template
+declaring Object Lock without `VersioningConfiguration` fails the stack. See
+[Object versioning](#object-versioning) for what versioning itself changes.
+
+```typescript sim-s3-object-lock
+/**
+ * A reader's history in a Bucket nothing in the account can delete from.
+ */
+
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+// Versioning goes on underneath Object Lock. Every version written into this
+// Bucket is then retained for seven days from the write.
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "history-stack",
+  template: {
+    Resources: {
+      HistoryBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "reader-history",
+          VersioningConfiguration: { Status: "Enabled" },
+          ObjectLockEnabled: true,
+          ObjectLockConfiguration: {
+            ObjectLockEnabled: "Enabled",
+            Rule: { DefaultRetention: { Mode: "COMPLIANCE", Days: 7 } },
+          },
+        },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const written = await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "reader-history",
+    Key: "events/reader-1.json",
+    Body: JSON.stringify({ words: ["好"] }),
+  }),
+);
+
+const held = await simS3.headObject(
+  new HeadObjectCommand({
+    Bucket: "reader-history",
+    Key: "events/reader-1.json",
+    VersionId: written.VersionId,
+  }),
+);
+
+console.log(held.ObjectLockMode); // "COMPLIANCE"
+
+try {
+  await simS3.deleteObject(
+    new DeleteObjectCommand({
+      Bucket: "reader-history",
+      Key: "events/reader-1.json",
+      VersionId: written.VersionId,
+      BypassGovernanceRetention: true,
+    }),
+  );
+} catch (error) {
+  // AccessDenied. A compliance period gives way to nobody, and naming the
+  // bypass changes nothing.
+  console.log((error as Error).name);
+}
+
+// The period lapses because simulated time passed it.
+await simAws.clock().advanceBy({ days: 8 });
+
+await simS3.deleteObject(
+  new DeleteObjectCommand({
+    Bucket: "reader-history",
+    Key: "events/reader-1.json",
+    VersionId: written.VersionId,
+  }),
+);
+```
+
+The retention boundary is a pure function of simulated time, read off the clock every time a delete
+asks. Advancing the clock past `RetainUntilDate` is all a test does to watch a held version become
+deletable. See [Controlling time](https://yulinsim.dev/time/ "Controlling time").
+
+`GetObject` and `HeadObject` report `ObjectLockMode` and `ObjectLockRetainUntilDate` for a version
+under a retention period, and `ObjectLockLegalHoldStatus` for one under a hold. A version free of
+both leaves all three out.
+
+### Retention modes
+
+`GOVERNANCE` and `COMPLIANCE` differ over who can get out of them. A governance period gives way to a
+delete carrying `BypassGovernanceRetention` from a caller holding `s3:BypassGovernanceRetention`,
+which sim IAM authorizes as a decision of its own alongside the `s3:DeleteObject` the delete already
+needed. Holding the permission and using it are separate. A delete that leaves the flag off is
+refused whatever the caller may do.
+
+A compliance period gives way to nobody, the account root included. `PutObjectRetentionCommand`
+follows the same split. A compliance period can be extended and never shortened, and a governance
+period can be shortened by a request that bypasses it.
+
+### Legal holds
+
+`PutObjectLegalHoldCommand` turns the hold on a version on and off. A hold has no period to wait out.
+Only a `Status: "OFF"` takes one off, which is what makes a hold the thing to reach for when the end
+of the retention is unknowable in advance. A version can carry a hold and a retention period at
+once, and either one on its own refuses the delete.
+
+### Default retention
+
+A `DefaultRetention` under `Rule` retains every version written after it, counted from the write, so
+two versions of one key written a day apart are held until two different instants. It takes `Days` or
+`Years` and refuses both together, and a year is 365 days. A Bucket with Object Lock on and no
+default leaves each version to whatever requests name it.
+
+### From a CloudFormation template
+
+`ObjectLockEnabled` and `ObjectLockConfiguration` are applied through
+`PutObjectLockConfigurationCommand`, so a template and an SDK caller are validated identically. CDK's
+`objectLockEnabled` and `objectLockDefaultRetention` synthesise both. `ObjectLockConfiguration`
+without `ObjectLockEnabled: true` fails the resource, as real CloudFormation refuses it, because a
+Bucket created around the property would report a default retention it never applied.
+
+### Limitations
+
+- `GetObjectRetentionCommand` and `GetObjectLegalHoldCommand` are absent. A version reports both
+  through `GetObject` and `HeadObject`.
+- `PutObjectCommand` takes no `ObjectLockMode`, `ObjectLockRetainUntilDate` or
+  `ObjectLockLegalHoldStatus`. A version is held by the Bucket's default retention and by
+  `PutObjectRetentionCommand` and `PutObjectLegalHoldCommand` afterwards.
+- `CreateBucketCommand` takes no `ObjectLockEnabledForBucket`. Turn versioning on, then Object Lock.
+- `DeleteObjectsCommand` names keys and no versions, so a batch delete writes delete markers and
+  reaches no held version. See [Deleting Objects](#deleting-objects).
+- The `?object-lock`, `?retention` and `?legal-hold` sub-resources are refused over the served S3
+  REST endpoint. Object Lock is reachable through the SDK and through a template.
+- A Bucket policy setting minimum and maximum allowable retention periods is left out. The only
+  bound on a retention is the 1 to 1000 range real S3 puts on a `DefaultRetention` period.
+- `S3 Batch Operations` applying retention across a manifest is left out.
+
 ## Event notifications
 
 A simulated S3 Bucket can notify a simulated Lambda function, a simulated SQS queue or a simulated
@@ -1860,11 +2014,12 @@ writes fall outside it. Without that, the simulation stops after a thousand deli
 
 ## Buckets from CloudFormation
 
-An `AWS::S3::Bucket` resource carries six properties simulated S3 acts on. Those are `BucketName`,
-`LifecycleConfiguration`, `NotificationConfiguration`, `PublicAccessBlockConfiguration`,
-`VersioningConfiguration` and `WebsiteConfiguration`. See
-[Lifecycle configuration](#lifecycle-configuration) for the parts of a rule that are read, and
-[Object versioning](#object-versioning) for what versioning a Bucket changes.
+An `AWS::S3::Bucket` resource carries eight properties simulated S3 acts on. Those are `BucketName`,
+`LifecycleConfiguration`, `NotificationConfiguration`, `ObjectLockConfiguration`,
+`ObjectLockEnabled`, `PublicAccessBlockConfiguration`, `VersioningConfiguration` and
+`WebsiteConfiguration`. See [Lifecycle configuration](#lifecycle-configuration) for the parts of a
+rule that are read, [Object versioning](#object-versioning) for what versioning a Bucket changes, and
+[Object Lock](#object-lock) for what holds a version once it is written.
 
 A Bucket with no `BucketName` is named from the stack name, the logical ID and a tail derived from
 both, lower cased as a bucket name has to be. A `SiteBucket` in `orders-stack` becomes
@@ -1875,12 +2030,12 @@ cover how the stack name and the logical ID share what is left.
 Any other property is left out and recorded in
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without),
 and the Bucket is created and the stack carries on. That matters because a Bucket deployed without
-the Object Lock, replication or CORS configuration its template asked for looks configured and
+the replication or CORS configuration its template asked for looks configured and
 behaves as though it were bare, and the failure that causes turns up somewhere else entirely. The
 record is where a test checks which of those it is standing on. A property name `AWS::S3::Bucket`
 never had is recorded the same way, and a typo leaves the stack standing.
 
-One of the six given in the wrong shape still fails the stack, and so does a `BucketName` that is
+One of the eight given in the wrong shape still fails the stack, and so does a `BucketName` that is
 something other than a string. There is no Bucket to create under a name nothing else in the
 template refers to.
 
@@ -3196,8 +3351,6 @@ needs them to model the requested behaviour.
 
 These apply across the page. The sections above each list what is specific to them.
 
-- Object Lock is left out. A Bucket declaring it deploys without it, and an Object inside a
-  retention period can still be deleted.
 - A listing reports `StorageClass` as `STANDARD` for every Object. Storage classes themselves are
   left out, and every Object is in that one.
 - `EncodingType` is ignored on a listing, and keys come back unencoded.

--- a/docs/services/s3/sim-s3-object-lock.example.ts
+++ b/docs/services/s3/sim-s3-object-lock.example.ts
@@ -1,0 +1,81 @@
+/**
+ * A reader's history in a Bucket nothing in the account can delete from.
+ */
+
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+// Versioning goes on underneath Object Lock. Every version written into this
+// Bucket is then retained for seven days from the write.
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "history-stack",
+  template: {
+    Resources: {
+      HistoryBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "reader-history",
+          VersioningConfiguration: { Status: "Enabled" },
+          ObjectLockEnabled: true,
+          ObjectLockConfiguration: {
+            ObjectLockEnabled: "Enabled",
+            Rule: { DefaultRetention: { Mode: "COMPLIANCE", Days: 7 } },
+          },
+        },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+const written = await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "reader-history",
+    Key: "events/reader-1.json",
+    Body: JSON.stringify({ words: ["好"] }),
+  }),
+);
+
+const held = await simS3.headObject(
+  new HeadObjectCommand({
+    Bucket: "reader-history",
+    Key: "events/reader-1.json",
+    VersionId: written.VersionId,
+  }),
+);
+
+console.log(held.ObjectLockMode); // "COMPLIANCE"
+
+try {
+  await simS3.deleteObject(
+    new DeleteObjectCommand({
+      Bucket: "reader-history",
+      Key: "events/reader-1.json",
+      VersionId: written.VersionId,
+      BypassGovernanceRetention: true,
+    }),
+  );
+} catch (error) {
+  // AccessDenied. A compliance period gives way to nobody, and naming the
+  // bypass changes nothing.
+  console.log((error as Error).name);
+}
+
+// The period lapses because simulated time passed it.
+await simAws.clock().advanceBy({ days: 8 });
+
+await simS3.deleteObject(
+  new DeleteObjectCommand({
+    Bucket: "reader-history",
+    Key: "events/reader-1.json",
+    VersionId: written.VersionId,
+  }),
+);

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -23,6 +23,8 @@ familiar AWS SDK command shapes, CloudFormation resources, and local HTTP reques
   static website configuration, and the event notification configuration.
 - `bucket/versioning/` contains the version history a Bucket keeps, and the configuration deciding
   whether it keeps one.
+- `bucket/lock/` contains Object Lock, the retention periods and legal holds that hold a version
+  against a delete, and the Bucket configuration putting a default on every new one.
 - `notification/` contains event notification delivery: the event, its `Records` serialisation, and
   the destinations S3 pushes to.
 - `object/` contains the simulated S3 Object model.
@@ -93,6 +95,10 @@ Supported command areas currently include:
 - `put-bucket-versioning/`
 - `get-bucket-versioning/`
 - `list-object-versions/`
+- `put-object-lock-configuration/`
+- `get-object-lock-configuration/`
+- `put-object-retention/`
+- `put-object-legal-hold/`
 
 `SimS3Commands` owns the wiring: every handler is built from the same Bucket map, IAM and background
 scheduler, so that construction lives in one place rather than being repeated once per command on
@@ -104,6 +110,7 @@ the service facade. It groups the commands into areas, each a small class under 
 - `SimS3ObjectCommands` in `command/object/`
 - `SimS3NotificationCommands` in `command/notification/`
 - `SimS3VersioningCommands` in `command/versioning/`
+- `SimS3ObjectLockCommands` in `command/object-lock/`
 
 An area holds the shared `SimS3BucketCommandState` and hands it to the handler it runs, so adding a
 command means adding one method to the area it belongs to. `requireSimS3Bucket` is the shared Bucket lookup
@@ -202,9 +209,10 @@ is a normalized form of what was applied rather than the original text.
 
 ## What a Bucket stores
 
-`SimS3BucketObjects` holds the storage implementation, the version history, the multipart uploads in
-progress and the lifecycle configuration. The Bucket delegates to it rather than owning all four,
-because they are one concern: what is under the Bucket's keys, and what time does to it. Every read
+`SimS3BucketObjects` holds the storage implementation, the version history, the Object Lock, the
+multipart uploads in progress and the lifecycle configuration. The Bucket delegates to it rather than
+owning all five, because they are one concern: what is under the Bucket's keys, and what time does to
+it. Every read
 goes through it, and applying lifecycle rules on the way past is what keeps an untouched Bucket free
 of the cost of having them.
 
@@ -227,6 +235,34 @@ maintains is that **storage holds the current, undeleted Object under each key a
 Writing a delete marker takes the Object out of storage while the history keeps it, and removing a
 version puts back whatever the removal left current. Every existing reader of a Bucket, the website
 endpoint and the REST endpoint among them, therefore needs no knowledge of versions at all.
+
+## Object Lock
+
+`bucket/lock/` holds the Object Lock model, which sits on top of the version model and is meaningless
+without it. There are four pieces.
+
+`SimS3ObjectRetention` is a mode and an instant. It answers whether it still holds at an instant of
+simulated time and whether it runs at least as long as another one, which is the comparison that
+decides whether a `PutObjectRetention` is extending a period or shortening it.
+
+`SimS3ObjectLock` is what one version carries. Every `SimS3ObjectVersion` holds one, empty until
+something is put on it, which lets the delete path ask the same question of a locked Bucket and an
+unlocked one. It is mutable where the version around it is fixed, because real S3 changes a retention
+and a hold through requests of their own against a version that is already there.
+
+`SimS3ObjectLockConfiguration` is the Bucket configuration. Its one job beyond reporting itself back
+is `retentionAt(instant)`, which turns a `DefaultRetention` of so many days into the instant a
+version written now is held until.
+
+`SimS3BucketObjectLock` is what the Bucket holds. It applies the default to a new version and refuses
+a delete of a held one, which are the two places `SimS3BucketObjects` reaches it from. Both take the
+instant from the Bucket's clock. That keeps the boundary a pure function of simulated time, crossed
+by the clock moving and by nothing else, the same approach lifecycle expiry takes.
+
+`s3:BypassGovernanceRetention` is authorized as a decision of its own in
+`SimS3ObjectLockAuthorizer`, alongside the `s3:DeleteObject` the delete already needed, because real
+S3 evaluates the two separately. A request that leaves the flag off skips the decision entirely, so
+lacking the permission costs a caller who never wanted it nothing.
 
 ## Block Public Access
 
@@ -857,11 +893,18 @@ Bucket resource creation flow:
 1. apply website configuration through the normal simulated `putBucketWebsite` command path
 1. return the simulated Bucket as the CloudFormation-backed resource
 
+`SimCfnS3BucketDeclaredConfigurations` reads the other declared properties and applies each through
+the command an SDK caller would reach. Order matters twice over. Versioning goes before Object Lock
+and before the lifecycle rules, because both describe a Bucket that keeps versions and
+`PutObjectLockConfiguration` refuses a Bucket without them. Notifications go last, because S3 checks
+every destination the configuration names and the Resources behind them have to exist by then.
+
 Unsupported S3 CloudFormation resource types throw a diagnostic error.
 
 ## Error model
 
-S3-specific errors live in `error/sim-s3.error.ts`.
+S3-specific errors live in `error/sim-s3.error.ts`, apart from the Object Lock ones, which are in
+`error/sim-s3-object-lock.error.ts` alongside them.
 
 Handlers throw AWS-like errors for supported failure cases, including:
 
@@ -877,6 +920,9 @@ Handlers throw AWS-like errors for supported failure cases, including:
 - malformed XML, for a `DeleteObjects` request naming no Objects or more than 1000 of them
 - not implemented, for something the simulator refuses rather than approximates, such as deleting an
   Object out of filesystem-backed storage
+- invalid Bucket state, for turning Object Lock on over a Bucket that keeps no versions
+- Object Lock configuration not found, for reading the Object Lock of a Bucket that has never had
+  one
 
 These errors carry AWS-style names and HTTP status metadata where implemented. Tests should assert
 the specific simulator error when behaviour depends on AWS-compatible failure semantics.

--- a/src/service/s3/bucket/lock/sim-s3-bucket-object-lock.ts
+++ b/src/service/s3/bucket/lock/sim-s3-bucket-object-lock.ts
@@ -1,0 +1,79 @@
+import { SimS3AccessDenied } from "../../error/sim-s3.error.js";
+import type { SimS3ObjectVersion } from "../versioning/sim-s3-object-version.js";
+import type { SimS3ObjectLockConfiguration } from "./sim-s3-object-lock-configuration.js";
+
+/**
+ * The Object Lock of one simulated S3 Bucket.
+ *
+ * It holds the configuration and applies it, which is two jobs a Bucket needs
+ * doing in two different places. A write asks it what retention the new
+ * version starts with, and a delete asks it whether the version may go.
+ */
+export class SimS3BucketObjectLock {
+  private locking: SimS3ObjectLockConfiguration | undefined;
+
+  /** How this Bucket is locked, or nothing where it has never been. */
+  get configuration(): SimS3ObjectLockConfiguration | undefined {
+    return this.locking;
+  }
+
+  /** Whether Object Lock is on. */
+  get isEnabled(): boolean {
+    return this.locking !== undefined;
+  }
+
+  /**
+   * Turn Object Lock on, or replace the default retention it carries.
+   *
+   * Real S3 has no request that turns it off, so this only ever arrives at a
+   * configuration with it on.
+   */
+  configure(configuration: SimS3ObjectLockConfiguration): void {
+    this.locking = configuration;
+  }
+
+  /**
+   * Give a newly written version the Bucket's default retention, if it has
+   * one, and hand the version back.
+   *
+   * The period is counted from the write, so two versions of one key written a
+   * day apart are retained until two different instants. A Bucket keeping no
+   * versions wrote none, and gets nothing back.
+   */
+  withDefaultRetention(
+    version: SimS3ObjectVersion | undefined,
+    writtenAt: Date,
+  ): SimS3ObjectVersion | undefined {
+    const retention = this.locking?.retentionAt(writtenAt);
+
+    if (version !== undefined && retention !== undefined) {
+      version.lock.setDefaultRetention(retention);
+    }
+
+    return version;
+  }
+
+  /**
+   * Refuse a delete Object Lock is holding a version against.
+   *
+   * Real S3 answers this with `AccessDenied`, the same code it answers a
+   * caller with no permission with. The reason says which of the two things
+   * holding the version is doing it, since a legal hold and a retention period
+   * are got past in different ways. A version that is not there is held
+   * against nothing, and the delete goes on to report it missing.
+   */
+  assertDeletable(
+    version: SimS3ObjectVersion | undefined,
+    instant: Date,
+    bypassed: boolean,
+  ): void {
+    const refusal = version?.lock.refusesDeleteAt(instant, bypassed);
+
+    if (version !== undefined && refusal !== undefined) {
+      throw new SimS3AccessDenied(
+        `Version ${version.versionId} of S3 Object ${version.key} cannot be ` +
+          `deleted because ${refusal}`,
+      );
+    }
+  }
+}

--- a/src/service/s3/bucket/lock/sim-s3-default-retention.ts
+++ b/src/service/s3/bucket/lock/sim-s3-default-retention.ts
@@ -1,0 +1,23 @@
+import { SimS3InvalidRequest } from "../../error/sim-s3.error.js";
+import {
+  simS3ComplianceMode,
+  simS3GovernanceMode,
+  simS3RetentionModeNames,
+} from "./sim-s3-object-retention.js";
+
+/**
+ * Read the mode of a default retention, refusing one real S3 refuses.
+ *
+ * The same two modes a per-version retention takes. They are read here rather
+ * than through `SimS3ObjectRetention.parse`, because a default carries a
+ * length where a retention carries an instant.
+ */
+export function simS3RetentionMode(mode: string | undefined): string {
+  if (mode === simS3GovernanceMode || mode === simS3ComplianceMode) {
+    return mode;
+  }
+
+  throw new SimS3InvalidRequest(
+    `Object Lock DefaultRetention Mode has to be ${simS3RetentionModeNames}`,
+  );
+}

--- a/src/service/s3/bucket/lock/sim-s3-object-lock-bypass.iso.test.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock-bypass.iso.test.ts
@@ -1,0 +1,221 @@
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+  PutObjectLockConfigurationCommand,
+  PutObjectRetentionCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { ObjectLockRetentionMode } from "@aws-sdk/client-s3";
+
+import { makeSimAwsAccountId } from "../../../aws/sim-aws-account.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimS3 } from "../../sim-s3.js";
+
+const bucketName = "reader-history";
+const key = "events/reader-1.json";
+const bucketArn = `arn:aws:s3:::${bucketName}`;
+
+const assumedByAccountRoot = (accountId: string): string =>
+  JSON.stringify({
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+      Action: "sts:AssumeRole",
+    },
+  });
+
+/**
+ * A Role allowed to do everything the tests below ask for, apart from what
+ * each test leaves out of `actions`.
+ */
+async function roleAllowing(
+  simAws: SimAws,
+  accountId: string,
+  actions: readonly string[],
+): Promise<string> {
+  const simIam = simAws.account(accountId).iam();
+  const created = await simIam.createRole(
+    new CreateRoleCommand({
+      RoleName: "HistoryKeeper",
+      AssumeRolePolicyDocument: assumedByAccountRoot(accountId),
+    }),
+  );
+
+  await simIam.putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "HistoryKeeper",
+      PolicyName: "KeepHistory",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: actions,
+          Resource: [bucketArn, `${bucketArn}/*`],
+        },
+      }),
+    }),
+  );
+
+  return created.Role.Arn;
+}
+
+/**
+ * A locked Bucket holding one retained version, and the id of that version.
+ */
+async function retainedVersion(
+  s3: SimS3,
+  simAws: SimAws,
+  mode: ObjectLockRetentionMode,
+): Promise<string> {
+  await s3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+  await s3.putBucketVersioning(
+    new PutBucketVersioningCommand({
+      Bucket: bucketName,
+      VersioningConfiguration: { Status: "Enabled" },
+    }),
+  );
+  await s3.putObjectLockConfiguration(
+    new PutObjectLockConfigurationCommand({
+      Bucket: bucketName,
+      ObjectLockConfiguration: { ObjectLockEnabled: "Enabled" },
+    }),
+  );
+
+  const put = await s3.putObject(
+    new PutObjectCommand({ Bucket: bucketName, Key: key, Body: "one" }),
+  );
+  assertNonNullable(put.VersionId);
+
+  const retainUntil = new Date(simAws.clock().now().getTime() + 3_600_000);
+
+  await s3.putObjectRetention(
+    new PutObjectRetentionCommand({
+      Bucket: bucketName,
+      Key: key,
+      VersionId: put.VersionId,
+      Retention: { Mode: mode, RetainUntilDate: retainUntil },
+    }),
+  );
+
+  return put.VersionId;
+}
+
+describe("S3 Object Lock governance bypass", () => {
+  it("lets a caller holding the bypass permission through", async () => {
+    // Given a version under a governance retention, and a Role allowed to
+    // delete it and to bypass governance.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const s3 = simAws.account(accountId).region("eu-west-2").s3();
+    const VersionId = await retainedVersion(s3, simAws, "GOVERNANCE");
+    const roleArn = await roleAllowing(simAws, accountId, [
+      "s3:DeleteObject",
+      "s3:BypassGovernanceRetention",
+    ]);
+
+    // When it deletes the version, naming the bypass.
+    const deleted = await s3.deleteObject(
+      new DeleteObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId,
+        BypassGovernanceRetention: true,
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then the version is gone, inside its retention period.
+    assertIdentical(deleted.VersionId, VersionId);
+  });
+
+  it("refuses the same caller a compliance retention", async () => {
+    // Given the same Role and the same permissions, over a version under a
+    // compliance retention rather than a governance one.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const s3 = simAws.account(accountId).region("eu-west-2").s3();
+    const VersionId = await retainedVersion(s3, simAws, "COMPLIANCE");
+    const roleArn = await roleAllowing(simAws, accountId, [
+      "s3:DeleteObject",
+      "s3:BypassGovernanceRetention",
+    ]);
+
+    // When it deletes the version, naming the bypass, then it is refused.
+    // Compliance is the mode nobody can get out of, which is what makes it
+    // worth having.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.deleteObject(
+        new DeleteObjectCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId,
+          BypassGovernanceRetention: true,
+        }),
+        { caller: { kind: "arn", arn: roleArn } },
+      );
+    });
+
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "COMPLIANCE retention period");
+  });
+
+  it("refuses a caller that may delete but may not bypass", async () => {
+    // Given a Role allowed to delete Objects and nothing more.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const s3 = simAws.account(accountId).region("eu-west-2").s3();
+    const VersionId = await retainedVersion(s3, simAws, "GOVERNANCE");
+    const roleArn = await roleAllowing(simAws, accountId, ["s3:DeleteObject"]);
+
+    // When it names the bypass, then IAM refuses it, because bypassing is a
+    // permission of its own alongside the delete.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.deleteObject(
+        new DeleteObjectCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId,
+          BypassGovernanceRetention: true,
+        }),
+        { caller: { kind: "arn", arn: roleArn } },
+      );
+    });
+
+    assertStringIncludes(error.message, "s3:BypassGovernanceRetention");
+  });
+
+  it("refuses a governance retention the request does not bypass", async () => {
+    // Given the same Role, holding both permissions.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws();
+    const s3 = simAws.account(accountId).region("eu-west-2").s3();
+    const VersionId = await retainedVersion(s3, simAws, "GOVERNANCE");
+    const roleArn = await roleAllowing(simAws, accountId, [
+      "s3:DeleteObject",
+      "s3:BypassGovernanceRetention",
+    ]);
+
+    // When it deletes the version without naming the bypass, then the
+    // retention holds. Holding the permission is not the same as using it.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.deleteObject(
+        new DeleteObjectCommand({ Bucket: bucketName, Key: key, VersionId }),
+        { caller: { kind: "arn", arn: roleArn } },
+      );
+    });
+
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "GOVERNANCE retention period");
+  });
+});

--- a/src/service/s3/bucket/lock/sim-s3-object-lock-configuration.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock-configuration.ts
@@ -3,6 +3,16 @@ import { SimS3ObjectRetention } from "./sim-s3-object-retention.js";
 import { simS3RetentionMode } from "./sim-s3-default-retention.js";
 
 const millisecondsPerDay = 86_400_000;
+const daysPerYear = 365;
+
+/**
+ * The longest default retention real S3 takes, which is a hundred years.
+ *
+ * An unbounded one would compute a `RetainUntilDate` past the range a
+ * JavaScript Date holds, and a version retained until an instant that reads
+ * back as `NaN` is a version nothing is holding at all.
+ */
+const maximumRetentionDays = 100 * daysPerYear;
 
 /** The one value `ObjectLockEnabled` takes. Real S3 has no way to turn it off. */
 export const simS3ObjectLockEnabled = "Enabled";
@@ -141,5 +151,14 @@ function simS3DefaultRetentionDays(declared: {
     );
   }
 
-  return Days === undefined ? period * 365 : period;
+  const days = Days === undefined ? period * daysPerYear : period;
+
+  if (days > maximumRetentionDays) {
+    throw new SimS3InvalidRequest(
+      `Object Lock DefaultRetention period ${String(period)} is longer than ` +
+        `the hundred years real S3 retains a version for`,
+    );
+  }
+
+  return days;
 }

--- a/src/service/s3/bucket/lock/sim-s3-object-lock-configuration.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock-configuration.ts
@@ -1,0 +1,145 @@
+import { SimS3InvalidRequest } from "../../error/sim-s3.error.js";
+import { SimS3ObjectRetention } from "./sim-s3-object-retention.js";
+import { simS3RetentionMode } from "./sim-s3-default-retention.js";
+
+const millisecondsPerDay = 86_400_000;
+
+/** The one value `ObjectLockEnabled` takes. Real S3 has no way to turn it off. */
+export const simS3ObjectLockEnabled = "Enabled";
+
+/**
+ * Structural shape of an S3 ObjectLockConfiguration.
+ *
+ * Matches the AWS SDK and CloudFormation property shape, so the same object
+ * can come from either.
+ */
+export interface SimS3ObjectLockConfigurationInput {
+  readonly ObjectLockEnabled?: string | undefined;
+  readonly Rule?:
+    | {
+        readonly DefaultRetention?:
+          | {
+              readonly Mode?: string | undefined;
+              readonly Days?: number | undefined;
+              readonly Years?: number | undefined;
+            }
+          | undefined;
+      }
+    | undefined;
+}
+
+interface SimS3ObjectLockConfigurationProperties {
+  readonly mode: string;
+  readonly days: number;
+}
+
+/**
+ * How one simulated S3 Bucket is locked, and for how long by default.
+ *
+ * A Bucket either has Object Lock turned on or has never had it. Real S3 has
+ * no request that turns it off again, which is what lets a reader's history be
+ * promised rather than merely configured.
+ *
+ * The default retention is optional. A Bucket with Object Lock on and no
+ * default locks nothing on its own, and every version it holds is retained
+ * only by the requests that name it. A Bucket with one retains every version
+ * written after it, counted from the write.
+ */
+export class SimS3ObjectLockConfiguration {
+  private readonly defaults: SimS3ObjectLockConfigurationProperties | undefined;
+
+  private constructor(defaults?: SimS3ObjectLockConfigurationProperties) {
+    this.defaults = defaults;
+  }
+
+  /**
+   * Read a configuration a request is setting, refusing one real S3 refuses.
+   */
+  static parse(
+    input: SimS3ObjectLockConfigurationInput,
+  ): SimS3ObjectLockConfiguration {
+    if (input.ObjectLockEnabled !== simS3ObjectLockEnabled) {
+      throw new SimS3InvalidRequest(
+        `ObjectLockEnabled has to be ${simS3ObjectLockEnabled}`,
+      );
+    }
+
+    const declared = input.Rule?.DefaultRetention;
+
+    if (declared === undefined) {
+      return new SimS3ObjectLockConfiguration();
+    }
+
+    return new SimS3ObjectLockConfiguration({
+      mode: simS3RetentionMode(declared.Mode),
+      days: simS3DefaultRetentionDays(declared),
+    });
+  }
+
+  /**
+   * The retention a version written at an instant is given.
+   *
+   * Real S3 counts a default retention from the write rather than from the
+   * configuration, so two versions of one key written a day apart are retained
+   * until two different instants.
+   */
+  retentionAt(instant: Date): SimS3ObjectRetention | undefined {
+    const defaults = this.defaults;
+
+    if (defaults === undefined) {
+      return undefined;
+    }
+
+    return new SimS3ObjectRetention({
+      mode: defaults.mode,
+      retainUntil: new Date(
+        instant.getTime() + defaults.days * millisecondsPerDay,
+      ),
+    });
+  }
+
+  /** What GetObjectLockConfiguration answers with. */
+  get reported(): SimS3ObjectLockConfigurationInput {
+    const defaults = this.defaults;
+
+    return {
+      ObjectLockEnabled: simS3ObjectLockEnabled,
+      ...(defaults !== undefined && {
+        Rule: {
+          DefaultRetention: { Mode: defaults.mode, Days: defaults.days },
+        },
+      }),
+    };
+  }
+}
+
+/**
+ * The length of a default retention, in days.
+ *
+ * Real S3 takes it as either `Days` or `Years` and refuses both together. A
+ * year is 365 days here, which is what S3 documents its own arithmetic as.
+ */
+function simS3DefaultRetentionDays(declared: {
+  readonly Days?: number | undefined;
+  readonly Years?: number | undefined;
+}): number {
+  const { Days, Years } = declared;
+
+  if ((Days === undefined) === (Years === undefined)) {
+    throw new SimS3InvalidRequest(
+      "Object Lock DefaultRetention requires either Days or Years, and " +
+        "refuses both together",
+    );
+  }
+
+  const period = Days ?? Years;
+
+  if (period === undefined || period < 1 || !Number.isSafeInteger(period)) {
+    throw new SimS3InvalidRequest(
+      `Object Lock DefaultRetention period ${String(period)} has to be a ` +
+        `whole number of at least 1`,
+    );
+  }
+
+  return Days === undefined ? period * 365 : period;
+}

--- a/src/service/s3/bucket/lock/sim-s3-object-lock-output.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock-output.ts
@@ -1,0 +1,14 @@
+/**
+ * What a read of an Object says about the Object Lock holding it.
+ *
+ * `GetObject` and `HeadObject` both report these, and a version nothing is
+ * holding leaves all three out rather than reporting them empty.
+ */
+export interface SimS3ObjectLockOutput {
+  /** The mode of the retention period on the version, if it has one. */
+  readonly ObjectLockMode?: string;
+  /** When that period lapses. */
+  readonly ObjectLockRetainUntilDate?: Date;
+  /** `ON` while a legal hold is on the version, and absent otherwise. */
+  readonly ObjectLockLegalHoldStatus?: string;
+}

--- a/src/service/s3/bucket/lock/sim-s3-object-lock-retention-changes.iso.test.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock-retention-changes.iso.test.ts
@@ -1,0 +1,162 @@
+import {
+  CreateBucketCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+  PutObjectLockConfigurationCommand,
+  PutObjectRetentionCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimS3 } from "../../sim-s3.js";
+
+const bucketName = "reader-history";
+const key = "events/reader-1.json";
+const anHour = 3_600_000;
+
+/** A locked Bucket holding one version, which is what a retention goes on. */
+async function bucketHoldingOneVersion(
+  simAws: SimAws,
+): Promise<{ s3: SimS3; versionId: string }> {
+  const s3 = simAws.s3();
+
+  await s3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+  await s3.putBucketVersioning(
+    new PutBucketVersioningCommand({
+      Bucket: bucketName,
+      VersioningConfiguration: { Status: "Enabled" },
+    }),
+  );
+  await s3.putObjectLockConfiguration(
+    new PutObjectLockConfigurationCommand({
+      Bucket: bucketName,
+      ObjectLockConfiguration: { ObjectLockEnabled: "Enabled" },
+    }),
+  );
+
+  const put = await s3.putObject(
+    new PutObjectCommand({ Bucket: bucketName, Key: key, Body: "one" }),
+  );
+  assertNonNullable(put.VersionId);
+
+  return { s3, versionId: put.VersionId };
+}
+
+describe("changing an S3 Object Lock retention period", () => {
+  it("extends a compliance retention and refuses to shorten one", async () => {
+    // Given a version retained for two hours in compliance mode.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws);
+    const now = simAws.clock().now().getTime();
+
+    async function retainFor(hours: number): Promise<void> {
+      await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          Retention: {
+            Mode: "COMPLIANCE",
+            RetainUntilDate: new Date(now + hours * anHour),
+          },
+          BypassGovernanceRetention: true,
+        }),
+      );
+    }
+
+    await retainFor(2);
+
+    // When it is extended, that is allowed.
+    await retainFor(3);
+
+    // And when it is shortened, that is refused, whoever asks and whatever
+    // they bypass.
+    const error = await assertThrowsErrorAsync(async () => {
+      await retainFor(1);
+    });
+
+    assertStringIncludes(
+      error.message,
+      "COMPLIANCE retention period can only be extended in the same mode",
+    );
+  });
+  it("refuses to turn a compliance retention into a governance one", async () => {
+    // Given a version retained for two hours in compliance mode.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws);
+    const now = simAws.clock().now().getTime();
+
+    await s3.putObjectRetention(
+      new PutObjectRetentionCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId: versionId,
+        Retention: {
+          Mode: "COMPLIANCE",
+          RetainUntilDate: new Date(now + 2 * anHour),
+        },
+      }),
+    );
+
+    // When a longer governance retention is put over it, then it is refused.
+    // Taking the mode down to governance would hand the version to the first
+    // caller holding the bypass permission, which is the guarantee gone.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          Retention: {
+            Mode: "GOVERNANCE",
+            RetainUntilDate: new Date(now + 3 * anHour),
+          },
+          BypassGovernanceRetention: true,
+        }),
+      );
+    });
+
+    assertStringIncludes(
+      error.message,
+      "never shortened or turned into a GOVERNANCE one",
+    );
+  });
+  it("shortens a governance retention only for a request that bypasses", async () => {
+    // Given a version retained for two hours in governance mode.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws);
+    const now = simAws.clock().now().getTime();
+
+    async function retainFor(hours: number, bypass = false): Promise<void> {
+      await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          Retention: {
+            Mode: "GOVERNANCE",
+            RetainUntilDate: new Date(now + hours * anHour),
+          },
+          BypassGovernanceRetention: bypass,
+        }),
+      );
+    }
+
+    await retainFor(2);
+
+    // When it is shortened without a bypass, then it is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      await retainFor(1);
+    });
+
+    assertStringIncludes(error.message, "requires BypassGovernanceRetention");
+
+    // And with one, it goes through.
+    await retainFor(1, true);
+  });
+});

--- a/src/service/s3/bucket/lock/sim-s3-object-lock-validation.iso.test.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock-validation.iso.test.ts
@@ -1,0 +1,333 @@
+import {
+  CreateBucketCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+  PutObjectLegalHoldCommand,
+  PutObjectLockConfigurationCommand,
+  PutObjectRetentionCommand,
+} from "@aws-sdk/client-s3";
+import type { ObjectLockConfiguration } from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimS3 } from "../../sim-s3.js";
+
+const bucketName = "reader-history";
+const key = "events/reader-1.json";
+const anHour = 3_600_000;
+
+/** A versioned Bucket, locked or not, holding one version of one key. */
+async function bucketHoldingOneVersion(
+  simAws: SimAws,
+  locked: boolean,
+): Promise<{ s3: SimS3; versionId: string }> {
+  const s3 = simAws.s3();
+
+  await s3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+  await s3.putBucketVersioning(
+    new PutBucketVersioningCommand({
+      Bucket: bucketName,
+      VersioningConfiguration: { Status: "Enabled" },
+    }),
+  );
+
+  if (locked) {
+    await s3.putObjectLockConfiguration(
+      new PutObjectLockConfigurationCommand({
+        Bucket: bucketName,
+        ObjectLockConfiguration: { ObjectLockEnabled: "Enabled" },
+      }),
+    );
+  }
+
+  const put = await s3.putObject(
+    new PutObjectCommand({ Bucket: bucketName, Key: key, Body: "one" }),
+  );
+  assertNonNullable(put.VersionId);
+
+  return { s3, versionId: put.VersionId };
+}
+
+/** Whatever locking a Bucket with this configuration is refused with. */
+async function lockRefusal(
+  configuration: ObjectLockConfiguration,
+): Promise<Error> {
+  const simAws = new SimAws();
+  const s3 = simAws.s3();
+
+  await s3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+  await s3.putBucketVersioning(
+    new PutBucketVersioningCommand({
+      Bucket: bucketName,
+      VersioningConfiguration: { Status: "Enabled" },
+    }),
+  );
+
+  return await assertThrowsErrorAsync(async () => {
+    return await s3.putObjectLockConfiguration(
+      new PutObjectLockConfigurationCommand({
+        Bucket: bucketName,
+        ObjectLockConfiguration: configuration,
+      }),
+    );
+  });
+}
+
+describe("S3 Object Lock validation", () => {
+  it("refuses a configuration that is not enabled", async () => {
+    // Given a configuration saying Object Lock is off, which real S3 has no
+    // request for. When it is applied, then it is refused.
+    const error = await lockRefusal({
+      ObjectLockEnabled: "Disabled" as "Enabled",
+    });
+
+    assertIdentical(error.name, "InvalidRequest");
+    assertStringIncludes(error.message, "ObjectLockEnabled has to be Enabled");
+  });
+
+  it("refuses a default retention with both Days and Years", async () => {
+    // Given a default retention measured two ways at once.
+    // When it is applied, then it is refused, since the two disagree about
+    // how long a version is held.
+    const error = await lockRefusal({
+      ObjectLockEnabled: "Enabled",
+      Rule: { DefaultRetention: { Mode: "GOVERNANCE", Days: 1, Years: 1 } },
+    });
+
+    assertStringIncludes(error.message, "requires either Days or Years");
+  });
+
+  it("refuses a default retention measured neither way", async () => {
+    // Given a default retention with a mode and no period.
+    const error = await lockRefusal({
+      ObjectLockEnabled: "Enabled",
+      Rule: { DefaultRetention: { Mode: "GOVERNANCE" } },
+    });
+
+    assertStringIncludes(error.message, "requires either Days or Years");
+  });
+
+  it("refuses a default retention period that is not a whole number", async () => {
+    // Given half a day, which real S3 measures nothing in.
+    const error = await lockRefusal({
+      ObjectLockEnabled: "Enabled",
+      Rule: { DefaultRetention: { Mode: "GOVERNANCE", Days: 0.5 } },
+    });
+
+    assertStringIncludes(
+      error.message,
+      "has to be a whole number of at least 1",
+    );
+  });
+
+  it("refuses a default retention in a mode real S3 has no name for", async () => {
+    // Given a mode that is neither of the two.
+    const error = await lockRefusal({
+      ObjectLockEnabled: "Enabled",
+      Rule: { DefaultRetention: { Mode: "STRICT" as "GOVERNANCE", Days: 1 } },
+    });
+
+    assertStringIncludes(
+      error.message,
+      "DefaultRetention Mode has to be GOVERNANCE or COMPLIANCE",
+    );
+  });
+
+  it("refuses a retention on a Bucket nobody locked", async () => {
+    // Given a versioned Bucket with Object Lock off.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws, false);
+    const retainUntil = new Date(simAws.clock().now().getTime() + anHour);
+
+    // When a version is retained, then it is refused. A retention that
+    // appeared to apply would report a guarantee nothing was enforcing.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          Retention: {
+            Mode: "COMPLIANCE",
+            RetainUntilDate: retainUntil,
+          },
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "does not have Object Lock enabled");
+  });
+
+  it("refuses a retention naming a version the Bucket never issued", async () => {
+    // Given a locked Bucket holding one version.
+    const simAws = new SimAws();
+    const { s3 } = await bucketHoldingOneVersion(simAws, true);
+    const retainUntil = new Date(simAws.clock().now().getTime() + anHour);
+
+    // When another version is retained, then it is refused as missing.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: "never-issued",
+          Retention: {
+            Mode: "COMPLIANCE",
+            RetainUntilDate: retainUntil,
+          },
+        }),
+      );
+    });
+
+    assertIdentical(error.name, "NoSuchVersion");
+  });
+
+  it("refuses a retention in a mode real S3 has no name for", async () => {
+    // Given a locked Bucket holding one version.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws, true);
+    const retainUntil = new Date(simAws.clock().now().getTime() + anHour);
+
+    // When it is retained in some third mode, then it is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          Retention: {
+            Mode: "STRICT" as "GOVERNANCE",
+            RetainUntilDate: retainUntil,
+          },
+        }),
+      );
+    });
+
+    assertStringIncludes(
+      error.message,
+      "retention Mode has to be GOVERNANCE or COMPLIANCE",
+    );
+  });
+
+  it("refuses a retention with no instant to run until", async () => {
+    // Given a locked Bucket holding one version.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws, true);
+
+    // When it is retained with no RetainUntilDate, then it is refused rather
+    // than held until an instant nobody named.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          Retention: { Mode: "GOVERNANCE" },
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "requires a RetainUntilDate");
+  });
+
+  it("refuses a legal hold that is neither on nor off", async () => {
+    // Given a locked Bucket holding one version.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws, true);
+
+    // When the hold is set to something else, then it is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectLegalHold(
+        new PutObjectLegalHoldCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          LegalHold: { Status: "MAYBE" as "ON" },
+        }),
+      );
+    });
+
+    assertStringIncludes(
+      error.message,
+      "legal hold Status has to be ON or OFF",
+    );
+  });
+
+  it("extends a compliance retention and refuses to shorten one", async () => {
+    // Given a version retained for two hours in compliance mode.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws, true);
+    const now = simAws.clock().now().getTime();
+
+    async function retainFor(hours: number): Promise<void> {
+      await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          Retention: {
+            Mode: "COMPLIANCE",
+            RetainUntilDate: new Date(now + hours * anHour),
+          },
+          BypassGovernanceRetention: true,
+        }),
+      );
+    }
+
+    await retainFor(2);
+
+    // When it is extended, that is allowed.
+    await retainFor(3);
+
+    // And when it is shortened, that is refused, whoever asks and whatever
+    // they bypass.
+    const error = await assertThrowsErrorAsync(async () => {
+      await retainFor(1);
+    });
+
+    assertStringIncludes(
+      error.message,
+      "COMPLIANCE retention period can be extended and never shortened",
+    );
+  });
+
+  it("shortens a governance retention only for a request that bypasses", async () => {
+    // Given a version retained for two hours in governance mode.
+    const simAws = new SimAws();
+    const { s3, versionId } = await bucketHoldingOneVersion(simAws, true);
+    const now = simAws.clock().now().getTime();
+
+    async function retainFor(hours: number, bypass = false): Promise<void> {
+      await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: versionId,
+          Retention: {
+            Mode: "GOVERNANCE",
+            RetainUntilDate: new Date(now + hours * anHour),
+          },
+          BypassGovernanceRetention: bypass,
+        }),
+      );
+    }
+
+    await retainFor(2);
+
+    // When it is shortened without a bypass, then it is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      await retainFor(1);
+    });
+
+    assertStringIncludes(error.message, "requires BypassGovernanceRetention");
+
+    // And with one, it goes through.
+    await retainFor(1, true);
+  });
+});

--- a/src/service/s3/bucket/lock/sim-s3-object-lock-validation.iso.test.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock-validation.iso.test.ts
@@ -259,75 +259,57 @@ describe("S3 Object Lock validation", () => {
     );
   });
 
-  it("extends a compliance retention and refuses to shorten one", async () => {
-    // Given a version retained for two hours in compliance mode.
-    const simAws = new SimAws();
-    const { s3, versionId } = await bucketHoldingOneVersion(simAws, true);
-    const now = simAws.clock().now().getTime();
-
-    async function retainFor(hours: number): Promise<void> {
-      await s3.putObjectRetention(
-        new PutObjectRetentionCommand({
-          Bucket: bucketName,
-          Key: key,
-          VersionId: versionId,
-          Retention: {
-            Mode: "COMPLIANCE",
-            RetainUntilDate: new Date(now + hours * anHour),
-          },
-          BypassGovernanceRetention: true,
-        }),
-      );
-    }
-
-    await retainFor(2);
-
-    // When it is extended, that is allowed.
-    await retainFor(3);
-
-    // And when it is shortened, that is refused, whoever asks and whatever
-    // they bypass.
-    const error = await assertThrowsErrorAsync(async () => {
-      await retainFor(1);
+  it("refuses a default retention longer than real S3 keeps one", async () => {
+    // Given a default retention of a thousand years, which would compute a
+    // RetainUntilDate past the range a Date holds.
+    const error = await lockRefusal({
+      ObjectLockEnabled: "Enabled",
+      Rule: { DefaultRetention: { Mode: "COMPLIANCE", Years: 1000 } },
     });
 
     assertStringIncludes(
       error.message,
-      "COMPLIANCE retention period can be extended and never shortened",
+      "longer than the hundred years real S3 retains a version for",
     );
   });
 
-  it("shortens a governance retention only for a request that bypasses", async () => {
-    // Given a version retained for two hours in governance mode.
+  it("takes the hundred years real S3 keeps a version for", async () => {
+    // Given the longest default retention real S3 accepts.
     const simAws = new SimAws();
-    const { s3, versionId } = await bucketHoldingOneVersion(simAws, true);
-    const now = simAws.clock().now().getTime();
+    const s3 = simAws.s3();
 
-    async function retainFor(hours: number, bypass = false): Promise<void> {
-      await s3.putObjectRetention(
-        new PutObjectRetentionCommand({
+    await s3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await s3.putBucketVersioning(
+      new PutBucketVersioningCommand({
+        Bucket: bucketName,
+        VersioningConfiguration: { Status: "Enabled" },
+      }),
+    );
+
+    // When it is applied, then it is taken, and the day either side of the
+    // boundary is what the refusal is measured against.
+    await s3.putObjectLockConfiguration(
+      new PutObjectLockConfigurationCommand({
+        Bucket: bucketName,
+        ObjectLockConfiguration: {
+          ObjectLockEnabled: "Enabled",
+          Rule: { DefaultRetention: { Mode: "COMPLIANCE", Days: 36_500 } },
+        },
+      }),
+    );
+
+    const tooLong = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectLockConfiguration(
+        new PutObjectLockConfigurationCommand({
           Bucket: bucketName,
-          Key: key,
-          VersionId: versionId,
-          Retention: {
-            Mode: "GOVERNANCE",
-            RetainUntilDate: new Date(now + hours * anHour),
+          ObjectLockConfiguration: {
+            ObjectLockEnabled: "Enabled",
+            Rule: { DefaultRetention: { Mode: "COMPLIANCE", Days: 36_501 } },
           },
-          BypassGovernanceRetention: bypass,
         }),
       );
-    }
-
-    await retainFor(2);
-
-    // When it is shortened without a bypass, then it is refused.
-    const error = await assertThrowsErrorAsync(async () => {
-      await retainFor(1);
     });
 
-    assertStringIncludes(error.message, "requires BypassGovernanceRetention");
-
-    // And with one, it goes through.
-    await retainFor(1, true);
+    assertStringIncludes(tooLong.message, "longer than the hundred years");
   });
 });

--- a/src/service/s3/bucket/lock/sim-s3-object-lock.iso.test.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock.iso.test.ts
@@ -1,0 +1,320 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetObjectLockConfigurationCommand,
+  HeadObjectCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+  PutObjectLegalHoldCommand,
+  PutObjectLockConfigurationCommand,
+  PutObjectRetentionCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimS3 } from "../../sim-s3.js";
+
+const bucketName = "reader-history";
+const key = "events/reader-1/2026-08-30.json";
+
+/**
+ * A versioned Bucket with Object Lock on, and no default retention.
+ *
+ * Object Lock holds a version, so every test needs versioning underneath it.
+ */
+async function lockedBucket(simAws: SimAws, days?: number): Promise<SimS3> {
+  const s3 = simAws.s3();
+
+  await s3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+  await s3.putBucketVersioning(
+    new PutBucketVersioningCommand({
+      Bucket: bucketName,
+      VersioningConfiguration: { Status: "Enabled" },
+    }),
+  );
+  await s3.putObjectLockConfiguration(
+    new PutObjectLockConfigurationCommand({
+      Bucket: bucketName,
+      ObjectLockConfiguration: {
+        ObjectLockEnabled: "Enabled",
+        ...(days !== undefined && {
+          Rule: { DefaultRetention: { Mode: "GOVERNANCE", Days: days } },
+        }),
+      },
+    }),
+  );
+
+  return s3;
+}
+
+/** Write one version of the reader's history, answering its version id. */
+async function putEvent(s3: SimS3, body = "one"): Promise<string> {
+  const put = await s3.putObject(
+    new PutObjectCommand({ Bucket: bucketName, Key: key, Body: body }),
+  );
+
+  assertNonNullable(put.VersionId);
+
+  return put.VersionId;
+}
+
+describe("S3 Object Lock", () => {
+  it("reports the configuration a Bucket was locked with", async () => {
+    // Given a Bucket locked with a default retention.
+    const simAws = new SimAws();
+    const s3 = await lockedBucket(simAws, 30);
+
+    // When the configuration is read back.
+    const read = await s3.getObjectLockConfiguration(
+      new GetObjectLockConfigurationCommand({ Bucket: bucketName }),
+    );
+
+    // Then it answers with what was set.
+    assertIdentical(read.ObjectLockConfiguration.ObjectLockEnabled, "Enabled");
+
+    const defaults = read.ObjectLockConfiguration.Rule?.DefaultRetention;
+    assertNonNullable(defaults);
+    assertIdentical(defaults.Mode, "GOVERNANCE");
+    assertIdentical(defaults.Days, 30);
+  });
+
+  it("refuses Object Lock on a Bucket that keeps no versions", async () => {
+    // Given a Bucket nobody turned versioning on for.
+    const simAws = new SimAws();
+    const s3 = simAws.s3();
+    await s3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    // When Object Lock is turned on, then it is refused, because Object Lock
+    // holds a version and this Bucket holds none.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectLockConfiguration(
+        new PutObjectLockConfigurationCommand({
+          Bucket: bucketName,
+          ObjectLockConfiguration: { ObjectLockEnabled: "Enabled" },
+        }),
+      );
+    });
+
+    assertIdentical(error.name, "InvalidBucketState");
+    assertStringIncludes(error.message, "does not have versioning enabled");
+  });
+
+  it("retains a version until the clock passes the retention", async () => {
+    // Given a version under a compliance retention of one hour.
+    const simAws = new SimAws();
+    const s3 = await lockedBucket(simAws);
+    const VersionId = await putEvent(s3);
+    const retainUntil = new Date(simAws.clock().now().getTime() + 3_600_000);
+
+    await s3.putObjectRetention(
+      new PutObjectRetentionCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId,
+        Retention: { Mode: "COMPLIANCE", RetainUntilDate: retainUntil },
+      }),
+    );
+
+    // When the version is deleted, then it is refused.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.deleteObject(
+        new DeleteObjectCommand({ Bucket: bucketName, Key: key, VersionId }),
+      );
+    });
+
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "COMPLIANCE retention period");
+
+    // And once simulated time passes the retention, the delete goes through.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    await s3.deleteObject(
+      new DeleteObjectCommand({ Bucket: bucketName, Key: key, VersionId }),
+    );
+
+    assertUndefined(
+      simAws
+        .s3()
+        .getSimBucketByName(bucketName)
+        ?.getVersions()
+        .find(key, VersionId),
+    );
+  });
+
+  it("reports the retention a read of the version finds", async () => {
+    // Given a version under a governance retention.
+    const simAws = new SimAws();
+    const s3 = await lockedBucket(simAws);
+    const VersionId = await putEvent(s3);
+    const retainUntil = new Date(simAws.clock().now().getTime() + 3_600_000);
+
+    await s3.putObjectRetention(
+      new PutObjectRetentionCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId,
+        Retention: { Mode: "GOVERNANCE", RetainUntilDate: retainUntil },
+      }),
+    );
+
+    // When the version is described.
+    const head = await s3.headObject(
+      new HeadObjectCommand({ Bucket: bucketName, Key: key, VersionId }),
+    );
+
+    // Then the lock is reported alongside everything else about it.
+    assertIdentical(head.ObjectLockMode, "GOVERNANCE");
+    assertIdentical(
+      head.ObjectLockRetainUntilDate?.toISOString(),
+      retainUntil.toISOString(),
+    );
+    assertUndefined(head.ObjectLockLegalHoldStatus);
+  });
+
+  it("holds a version for as long as its legal hold is on", async () => {
+    // Given a version under a legal hold and no retention period.
+    const simAws = new SimAws();
+    const s3 = await lockedBucket(simAws);
+    const VersionId = await putEvent(s3);
+
+    await s3.putObjectLegalHold(
+      new PutObjectLegalHoldCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId,
+        LegalHold: { Status: "ON" },
+      }),
+    );
+
+    // When the version is deleted a year later, then it is still refused,
+    // because a hold has no period to wait out.
+    await simAws.clock().advanceBy({ days: 365 });
+
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.deleteObject(
+        new DeleteObjectCommand({ Bucket: bucketName, Key: key, VersionId }),
+      );
+    });
+
+    assertIdentical(error.name, "AccessDenied");
+    assertStringIncludes(error.message, "legal hold");
+
+    // And a read of the version says the hold is what is on it.
+    const held = await s3.headObject(
+      new HeadObjectCommand({ Bucket: bucketName, Key: key, VersionId }),
+    );
+    assertIdentical(held.ObjectLockLegalHoldStatus, "ON");
+    assertUndefined(held.ObjectLockMode);
+
+    // And taking the hold off is what lets the version go.
+    await s3.putObjectLegalHold(
+      new PutObjectLegalHoldCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId,
+        LegalHold: { Status: "OFF" },
+      }),
+    );
+
+    await s3.deleteObject(
+      new DeleteObjectCommand({ Bucket: bucketName, Key: key, VersionId }),
+    );
+  });
+
+  it("refuses a retention that runs until no instant in particular", async () => {
+    // Given a locked Bucket holding one version.
+    const simAws = new SimAws();
+    const s3 = await lockedBucket(simAws);
+    const VersionId = await putEvent(s3);
+
+    // When it is retained until something that is not a date, then it is
+    // refused rather than held until an instant nobody can work out.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId,
+          Retention: {
+            Mode: "GOVERNANCE",
+            RetainUntilDate: new Date("the end of time"),
+          },
+        }),
+      );
+    });
+
+    assertStringIncludes(error.message, "is not a date");
+  });
+
+  it("refuses a retention on a key holding nothing", async () => {
+    // Given a locked Bucket that has never been written to.
+    const simAws = new SimAws();
+    const s3 = await lockedBucket(simAws);
+    const retainUntil = new Date(simAws.clock().now().getTime() + 3_600_000);
+
+    // When its current version is retained, then there is none to retain.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectRetention(
+        new PutObjectRetentionCommand({
+          Bucket: bucketName,
+          Key: key,
+          Retention: { Mode: "GOVERNANCE", RetainUntilDate: retainUntil },
+        }),
+      );
+    });
+
+    assertIdentical(error.name, "NoSuchKey");
+  });
+
+  it("refuses a legal hold on a delete marker", async () => {
+    // Given a locked Bucket whose current version is a delete marker.
+    const simAws = new SimAws();
+    const s3 = await lockedBucket(simAws);
+    await putEvent(s3);
+    await s3.deleteObject(
+      new DeleteObjectCommand({ Bucket: bucketName, Key: key }),
+    );
+
+    // When a hold is put on the current version, then it is refused. A marker
+    // holds no bytes, so there is nothing for a hold to keep.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.putObjectLegalHold(
+        new PutObjectLegalHoldCommand({
+          Bucket: bucketName,
+          Key: key,
+          LegalHold: { Status: "ON" },
+        }),
+      );
+    });
+
+    assertIdentical(error.name, "MethodNotAllowed");
+  });
+
+  it("retains a version the Bucket's default retention covers", async () => {
+    // Given a Bucket with a thirty day default retention.
+    const simAws = new SimAws();
+    const s3 = await lockedBucket(simAws, 30);
+    const writtenAt = simAws.clock().now();
+
+    // When a version is written.
+    const VersionId = await putEvent(s3);
+
+    // Then it is retained for thirty days counted from the write.
+    const head = await s3.headObject(
+      new HeadObjectCommand({ Bucket: bucketName, Key: key, VersionId }),
+    );
+
+    assertIdentical(head.ObjectLockMode, "GOVERNANCE");
+    assertIdentical(
+      head.ObjectLockRetainUntilDate?.getTime(),
+      writtenAt.getTime() + 30 * 86_400_000,
+    );
+  });
+});

--- a/src/service/s3/bucket/lock/sim-s3-object-lock.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock.ts
@@ -1,0 +1,126 @@
+import { SimS3InvalidRequest } from "../../error/sim-s3.error.js";
+import {
+  simS3ComplianceMode,
+  simS3GovernanceMode,
+  type SimS3ObjectRetention,
+} from "./sim-s3-object-retention.js";
+
+/** The two values `LegalHold.Status` takes. */
+export const simS3LegalHoldOn = "ON";
+export const simS3LegalHoldOff = "OFF";
+
+/** The two statuses, as a refusal names them. */
+const legalHoldStatuses = `${simS3LegalHoldOn} or ${simS3LegalHoldOff}`;
+
+/**
+ * Structural shape of an S3 ObjectLockLegalHold.
+ */
+export interface SimS3LegalHoldInput {
+  readonly Status?: string | undefined;
+}
+
+/**
+ * What Object Lock holds against one version of one Object.
+ *
+ * A retention period and a legal hold are configured independently and either
+ * one on its own refuses a delete. The difference is that a retention lapses
+ * when simulated time passes it and a legal hold has no expiry to wait out, so
+ * the only way past one is to take it off.
+ *
+ * This is mutable, unlike the version holding it. Real S3 changes both through
+ * requests of their own against a version that is already there, and a version
+ * whose retention could not change would have no PutObjectRetention.
+ */
+export class SimS3ObjectLock {
+  private retention: SimS3ObjectRetention | undefined;
+  private legalHold = false;
+
+  /**
+   * Put a retention on this version, refusing one real S3 refuses.
+   *
+   * Object Lock is a guarantee rather than a setting, so the ways out of one
+   * are the point. A compliance retention can be extended and never shortened,
+   * by anyone, including the account root. A governance retention can be
+   * shortened or dropped by a caller who names `BypassGovernanceRetention`,
+   * and the caller's permission to do that is checked before this is reached.
+   */
+  applyRetention(retention: SimS3ObjectRetention, bypassed: boolean): void {
+    const held = this.retention;
+
+    if (held === undefined || retention.isAtLeast(held)) {
+      this.retention = retention;
+      return;
+    }
+
+    if (bypassed && held.mode === simS3GovernanceMode) {
+      this.retention = retention;
+      return;
+    }
+
+    throw new SimS3InvalidRequest(
+      held.mode === simS3ComplianceMode
+        ? "A COMPLIANCE retention period can be extended and never shortened"
+        : "Shortening a GOVERNANCE retention period requires " +
+            "BypassGovernanceRetention",
+    );
+  }
+
+  /**
+   * Turn the legal hold on this version on or off.
+   */
+  applyLegalHold(input: SimS3LegalHoldInput): void {
+    if (
+      input.Status !== simS3LegalHoldOn &&
+      input.Status !== simS3LegalHoldOff
+    ) {
+      throw new SimS3InvalidRequest(
+        `Object Lock legal hold Status has to be ${legalHoldStatuses}`,
+      );
+    }
+
+    this.legalHold = input.Status === simS3LegalHoldOn;
+  }
+
+  /**
+   * Set the retention a Bucket's default puts on a new version.
+   *
+   * Nothing is checked, because a version this is reached for has just been
+   * written and carries no retention to be shortening.
+   */
+  setDefaultRetention(retention: SimS3ObjectRetention): void {
+    this.retention = retention;
+  }
+
+  /**
+   * Whether Object Lock refuses to let this version be deleted.
+   *
+   * A legal hold refuses whatever the caller says, since there is no bypass
+   * for one. A retention that has lapsed refuses nothing, which is what makes
+   * advancing the clock the way past a governance or a compliance period.
+   */
+  refusesDeleteAt(instant: Date, bypassed: boolean): string | undefined {
+    if (this.legalHold) {
+      return "it is under a legal hold";
+    }
+
+    const retention = this.retention;
+
+    if (retention === undefined || !retention.isActiveAt(instant)) {
+      return undefined;
+    }
+
+    if (bypassed && retention.mode === simS3GovernanceMode) {
+      return undefined;
+    }
+
+    return `it is under a ${retention.mode} retention period until ${retention.retainUntilDate.toISOString()}`;
+  }
+
+  /** What GetObject and HeadObject report about the version. */
+  get reported(): Record<string, string | Date> {
+    return {
+      ...this.retention?.reported,
+      ...(this.legalHold && { ObjectLockLegalHoldStatus: simS3LegalHoldOn }),
+    };
+  }
+}

--- a/src/service/s3/bucket/lock/sim-s3-object-lock.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock.ts
@@ -39,29 +39,37 @@ export class SimS3ObjectLock {
    * Put a retention on this version, refusing one real S3 refuses.
    *
    * Object Lock is a guarantee rather than a setting, so the ways out of one
-   * are the point. A compliance retention can be extended and never shortened,
-   * by anyone, including the account root. A governance retention can be
-   * shortened or dropped by a caller who names `BypassGovernanceRetention`,
-   * and the caller's permission to do that is checked before this is reached.
+   * are the point. A compliance period can be extended in the same mode, by
+   * anyone, and that is all that can be done to it. Shortening one would end
+   * the guarantee early, and turning one into a governance period would hand
+   * it to the first caller holding the bypass permission, so both are refused
+   * whoever asks and whatever they bypass.
+   *
+   * A governance period can be shortened, or turned into a compliance one, by
+   * a caller who names `BypassGovernanceRetention`, and the caller's
+   * permission to do that is checked before this is reached.
    */
   applyRetention(retention: SimS3ObjectRetention, bypassed: boolean): void {
     const held = this.retention;
 
-    if (held === undefined || retention.isAtLeast(held)) {
+    if (held === undefined) {
       this.retention = retention;
       return;
     }
 
-    if (bypassed && held.mode === simS3GovernanceMode) {
+    const extending = retention.mode === held.mode && retention.isAtLeast(held);
+
+    if (extending || (bypassed && held.mode === simS3GovernanceMode)) {
       this.retention = retention;
       return;
     }
 
     throw new SimS3InvalidRequest(
       held.mode === simS3ComplianceMode
-        ? "A COMPLIANCE retention period can be extended and never shortened"
-        : "Shortening a GOVERNANCE retention period requires " +
-            "BypassGovernanceRetention",
+        ? "A COMPLIANCE retention period can only be extended in the same " +
+            "mode, and never shortened or turned into a GOVERNANCE one"
+        : "Shortening a GOVERNANCE retention period, or changing its mode, " +
+            "requires BypassGovernanceRetention",
     );
   }
 

--- a/src/service/s3/bucket/lock/sim-s3-object-retention.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-retention.ts
@@ -1,0 +1,121 @@
+import { SimS3InvalidRequest } from "../../error/sim-s3.error.js";
+
+/**
+ * The two modes a retention period can be in.
+ *
+ * Governance is the one an account can get out of, by naming
+ * `BypassGovernanceRetention` while holding `s3:BypassGovernanceRetention`.
+ * Compliance is the one nobody can, including the account root, which is what
+ * makes it worth having.
+ */
+export const simS3GovernanceMode = "GOVERNANCE";
+export const simS3ComplianceMode = "COMPLIANCE";
+
+const retentionModes: ReadonlySet<string> = new Set([
+  simS3GovernanceMode,
+  simS3ComplianceMode,
+]);
+
+/** The two modes, as a refusal names them. */
+export const simS3RetentionModeNames = `${simS3GovernanceMode} or ${simS3ComplianceMode}`;
+
+/**
+ * Structural shape of an S3 ObjectLockRetention.
+ *
+ * Matches the AWS SDK and CloudFormation property shape, so the same object
+ * can come from either.
+ */
+export interface SimS3RetentionInput {
+  readonly Mode?: string | undefined;
+  readonly RetainUntilDate?: Date | string | undefined;
+}
+
+interface SimS3ObjectRetentionProperties {
+  readonly mode: string;
+  readonly retainUntil: Date;
+}
+
+/**
+ * How long one version of one Object cannot be deleted for.
+ *
+ * A retention is a mode and an instant, and the instant is compared against
+ * simulated time on every delete. Nothing schedules its expiry: the period
+ * lapses because the clock moved past it, which is how a test watches a
+ * retained version become deletable.
+ */
+export class SimS3ObjectRetention {
+  public readonly mode: string;
+
+  private readonly retainUntil: Date;
+
+  constructor(properties: SimS3ObjectRetentionProperties) {
+    this.mode = properties.mode;
+    this.retainUntil = new Date(properties.retainUntil);
+  }
+
+  /**
+   * Read a retention a request is setting, refusing one real S3 refuses.
+   */
+  static parse(input: SimS3RetentionInput): SimS3ObjectRetention {
+    const mode = input.Mode;
+
+    if (mode === undefined || !retentionModes.has(mode)) {
+      throw new SimS3InvalidRequest(
+        `Object Lock retention Mode has to be ${simS3RetentionModeNames}`,
+      );
+    }
+
+    return new SimS3ObjectRetention({
+      mode,
+      retainUntil: retainUntilDate(input.RetainUntilDate),
+    });
+  }
+
+  /** When the period lapses. A copy, because a Date is mutable. */
+  get retainUntilDate(): Date {
+    return new Date(this.retainUntil);
+  }
+
+  /** Whether this retention still holds at an instant of simulated time. */
+  isActiveAt(instant: Date): boolean {
+    return instant.getTime() < this.retainUntil.getTime();
+  }
+
+  /** Whether this retention runs at least as long as another. */
+  isAtLeast(other: SimS3ObjectRetention): boolean {
+    return this.retainUntil.getTime() >= other.retainUntil.getTime();
+  }
+
+  /** What GetObject and HeadObject report about the version. */
+  get reported(): { ObjectLockMode: string; ObjectLockRetainUntilDate: Date } {
+    return {
+      ObjectLockMode: this.mode,
+      ObjectLockRetainUntilDate: this.retainUntilDate,
+    };
+  }
+}
+
+/**
+ * Read the instant a retention runs until.
+ *
+ * The SDK sends a Date and CloudFormation sends the string it was written as,
+ * so both are read. A value that is not a date at all leaves a version looking
+ * retained until an unknowable instant, so it is refused instead.
+ */
+function retainUntilDate(value: Date | string | undefined): Date {
+  if (value === undefined) {
+    throw new SimS3InvalidRequest(
+      "Object Lock retention requires a RetainUntilDate",
+    );
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new SimS3InvalidRequest(
+      `Object Lock retention RetainUntilDate ${String(value)} is not a date`,
+    );
+  }
+
+  return parsed;
+}

--- a/src/service/s3/bucket/sim-s3-bucket-objects.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-objects.ts
@@ -2,6 +2,7 @@ import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimS3Object } from "../object/s3-object.js";
 import type { SimS3BucketStorage } from "../storage/s3-bucket-storage.js";
 import { SimS3MultipartUploads } from "../upload/sim-s3-multipart-uploads.js";
+import { SimS3BucketObjectLock } from "./lock/sim-s3-bucket-object-lock.js";
 import { SimS3LifecycleConfiguration } from "./lifecycle/sim-s3-lifecycle-configuration.js";
 import { SimS3LifecycleSweep } from "./lifecycle/sim-s3-lifecycle-sweep.js";
 import { SimS3ObjectDeletion } from "./sim-s3-object-deletion.js";
@@ -25,6 +26,7 @@ interface SimS3BucketObjectsProperties {
  */
 export class SimS3BucketObjects {
   public readonly versions = new SimS3BucketVersions();
+  public readonly objectLock = new SimS3BucketObjectLock();
 
   private readonly clock: SimClock;
   private readonly uploads = new SimS3MultipartUploads();
@@ -41,12 +43,16 @@ export class SimS3BucketObjects {
    * Put an Object into storage, answering the version it was given.
    *
    * A Bucket that keeps no versions answers with nothing, which is what tells
-   * a caller there is no `VersionId` to report.
+   * a caller there is no `VersionId` to report. A version the Bucket did keep
+   * starts under whatever default retention Object Lock puts on it.
    */
   async put(object: SimS3Object): Promise<SimS3ObjectVersion | undefined> {
     await this.storage.putObject(object);
 
-    return this.versions.recordPut(object);
+    return this.objectLock.withDefaultRetention(
+      this.versions.recordPut(object),
+      this.clock.now(),
+    );
   }
 
   /**
@@ -93,12 +99,20 @@ export class SimS3BucketObjects {
    * Remove one version permanently, answering the version that went.
    *
    * Whatever the removal leaves at the head of the key becomes current, so
-   * deleting a delete marker brings the Object under it back.
+   * deleting a delete marker brings the Object under it back. A version Object
+   * Lock is holding never gets that far.
    */
   async deleteVersion(
     key: string,
     versionId: string,
+    bypassGovernance = false,
   ): Promise<SimS3ObjectVersion | undefined> {
+    this.objectLock.assertDeletable(
+      this.versions.find(key, versionId),
+      this.clock.now(),
+      bypassGovernance,
+    );
+
     return await this.versions.deleteVersion(this.storage, key, versionId);
   }
 

--- a/src/service/s3/bucket/sim-s3-bucket-objects.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-objects.ts
@@ -51,7 +51,7 @@ export class SimS3BucketObjects {
 
     return this.objectLock.withDefaultRetention(
       this.versions.recordPut(object),
-      this.clock.now(),
+      object.lastModified,
     );
   }
 

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -5,6 +5,7 @@ import type { SimS3Object } from "../object/s3-object.js";
 import { MemoryS3BucketStorage } from "../storage/s3-memory-storage.js";
 import { SimS3BucketObjects } from "./sim-s3-bucket-objects.js";
 import type { SimS3ObjectDeletion } from "./sim-s3-object-deletion.js";
+import type { SimS3BucketObjectLock } from "./lock/sim-s3-bucket-object-lock.js";
 import type { SimS3BucketVersioning } from "./versioning/sim-s3-bucket-versioning.js";
 import type { SimS3BucketVersions } from "./versioning/sim-s3-bucket-versions.js";
 import type { SimS3ObjectVersion } from "./versioning/sim-s3-object-version.js";
@@ -119,20 +120,25 @@ export class SimS3Bucket {
    * Remove one version of a key permanently, answering the version that went.
    *
    * Whatever the removal leaves at the head of the key becomes current, so
-   * deleting a delete marker brings the Object under it back.
+   * deleting a delete marker brings the Object under it back. Object Lock
+   * refuses the removal of a version it is holding.
    */
   async deleteObjectVersion(
     key: string,
     versionId: string,
+    bypassGovernance = false,
   ): Promise<SimS3ObjectVersion | undefined> {
-    return await this.objects.deleteVersion(key, versionId);
+    return await this.objects.deleteVersion(key, versionId, bypassGovernance);
   }
 
-  /**
-   * The versions this Bucket keeps, and whether it keeps any.
-   */
+  /** The versions this Bucket keeps, and whether it keeps any. */
   getVersions(): SimS3BucketVersions {
     return this.objects.versions;
+  }
+
+  /** How this Bucket is locked, and what that does to a write and a delete. */
+  getObjectLock(): SimS3BucketObjectLock {
+    return this.objects.objectLock;
   }
 
   /**

--- a/src/service/s3/bucket/versioning/sim-s3-object-version.ts
+++ b/src/service/s3/bucket/versioning/sim-s3-object-version.ts
@@ -1,4 +1,5 @@
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimS3ObjectLock } from "../lock/sim-s3-object-lock.js";
 import type { SimS3Object } from "../../object/s3-object.js";
 import { simS3NullVersionId } from "./sim-s3-bucket-versioning.js";
 
@@ -25,6 +26,15 @@ interface SimS3ObjectVersionProperties {
 export class SimS3ObjectVersion {
   public readonly versionId: string;
   public readonly key: string;
+
+  /**
+   * What Object Lock holds against this version.
+   *
+   * Every version carries one, empty until something is put on it. A Bucket
+   * without Object Lock leaves every one of them empty, and an empty lock
+   * refuses nothing, so the delete path asks the same question either way.
+   */
+  public readonly lock = new SimS3ObjectLock();
 
   private readonly createdAt: Date;
   private readonly stored: SimS3Object | undefined;

--- a/src/service/s3/bucket/versioning/sim-s3-versioning-configuration.iso.test.ts
+++ b/src/service/s3/bucket/versioning/sim-s3-versioning-configuration.iso.test.ts
@@ -3,6 +3,7 @@ import {
   DeleteObjectCommand,
   GetBucketVersioningCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   ListObjectVersionsCommand,
   PutBucketVersioningCommand,
@@ -212,6 +213,44 @@ describe("Configuring versioning on a simulated S3 Bucket", () => {
     // gives it, and any other id names a version that was never there.
     assertArrayLength(emptied.Contents ?? [], 0);
     assertArrayLength(kept.Contents ?? [], 1);
+  });
+
+  it("reads the null version of an Object in an unversioned Bucket", async () => {
+    // Given a Bucket nobody turned versioning on for
+    const simAws = new SimAws();
+    const s3 = simAws.s3();
+    await s3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await s3.putObject(
+      new PutObjectCommand({ Bucket: "uploads", Key: "a.txt", Body: "a" }),
+    );
+
+    // When the Object is read by the null version id
+    const read = await s3.headObject(
+      new HeadObjectCommand({
+        Bucket: "uploads",
+        Key: "a.txt",
+        VersionId: "null",
+      }),
+    );
+
+    // Then it answers with the Object, since that is the id real S3 gives
+    // every Object in such a Bucket, and reports no version of its own
+    assertIdentical(read.ContentLength, 1);
+    assertUndefined(read.VersionId);
+
+    // And the same read of a key holding nothing finds nothing, rather than
+    // an empty Object under the id every Object there answers to
+    const missing = await assertThrowsErrorAsync(async () =>
+      s3.headObject(
+        new HeadObjectCommand({
+          Bucket: "uploads",
+          Key: "b.txt",
+          VersionId: "null",
+        }),
+      ),
+    );
+
+    assertIdentical(missing.name, "NotFound");
   });
 
   it("refuses a versioning status S3 does not take", async () => {

--- a/src/service/s3/cfn/bucket/lock/sim-cfn-s3-bucket-object-lock-configuration.ts
+++ b/src/service/s3/cfn/bucket/lock/sim-cfn-s3-bucket-object-lock-configuration.ts
@@ -1,0 +1,102 @@
+import type { SimCfnTemplateValueRecord } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnValueShape } from "../../../../cloudformation/template/value/sim-cfn-value-shape.js";
+import type { SimS3ObjectLockConfigurationInput } from "../../../bucket/lock/sim-s3-object-lock-configuration.js";
+import { simS3ObjectLockEnabled } from "../../../bucket/lock/sim-s3-object-lock-configuration.js";
+import { s3BucketResourceError } from "../error/sim-cfn-s3-bucket-error.js";
+
+/**
+ * The AWS::S3::Bucket values that turn Object Lock on. CloudFormation carries
+ * a boolean property as either, depending on where the value came from.
+ */
+const objectLockEnabledValues: ReadonlySet<unknown> = new Set([true, "true"]);
+const objectLockDisabledValues: ReadonlySet<unknown> = new Set([
+  false,
+  "false",
+]);
+
+/**
+ * Reads the Object Lock properties of an AWS::S3::Bucket Resource.
+ *
+ * A Bucket declares Object Lock across two properties. `ObjectLockEnabled`
+ * turns it on and `ObjectLockConfiguration` carries the default retention,
+ * and real CloudFormation requires the first before it will read the second.
+ * CDK's `objectLockEnabled` and `objectLockDefaultRetention` synthesise both.
+ *
+ * The configuration is handed to PutObjectLockConfiguration rather than
+ * translated here, so a template and an SDK caller are validated identically,
+ * including the versioning a locked Bucket has to have underneath it.
+ */
+export class SimCfnS3BucketObjectLockConfiguration {
+  private readonly logicalId: string;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly shape: SimCfnValueShape;
+
+  constructor(logicalId: string, properties: SimCfnTemplateValueRecord) {
+    this.logicalId = logicalId;
+    this.properties = properties;
+    this.shape = new SimCfnValueShape((reason) =>
+      s3BucketResourceError(logicalId, reason),
+    );
+  }
+
+  /**
+   * The configuration to apply, or nothing where the Resource declares none.
+   *
+   * A Bucket declaring `ObjectLockEnabled` and no configuration is locked with
+   * no default retention, which is a real thing to declare: every version it
+   * holds is then retained only by the requests that name one.
+   */
+  read(): SimS3ObjectLockConfigurationInput | undefined {
+    if (!this.isEnabled()) {
+      return undefined;
+    }
+
+    const declared = this.properties["ObjectLockConfiguration"];
+
+    if (declared === undefined) {
+      return { ObjectLockEnabled: simS3ObjectLockEnabled };
+    }
+
+    return {
+      ...this.shape.record(declared, "ObjectLockConfiguration"),
+      ObjectLockEnabled: simS3ObjectLockEnabled,
+    };
+  }
+
+  /**
+   * Whether the Resource asks for Object Lock.
+   *
+   * Real CloudFormation refuses an `ObjectLockConfiguration` on a Bucket that
+   * does not also declare `ObjectLockEnabled`, and so does this: a Bucket
+   * created around the property would report a default retention it was not
+   * applying to anything.
+   */
+  private isEnabled(): boolean {
+    const enabled = this.properties["ObjectLockEnabled"];
+
+    if (objectLockEnabledValues.has(enabled)) {
+      return true;
+    }
+
+    if (
+      this.properties["ObjectLockConfiguration"] !== undefined &&
+      (enabled === undefined || objectLockDisabledValues.has(enabled))
+    ) {
+      throw s3BucketResourceError(
+        this.logicalId,
+        "ObjectLockConfiguration requires ObjectLockEnabled to be true, " +
+          "because Object Lock holds a version and a Bucket without it holds " +
+          "none",
+      );
+    }
+
+    if (enabled !== undefined && !objectLockDisabledValues.has(enabled)) {
+      throw s3BucketResourceError(
+        this.logicalId,
+        "ObjectLockEnabled must be true or false",
+      );
+    }
+
+    return false;
+  }
+}

--- a/src/service/s3/cfn/bucket/lock/sim-cfn-s3-bucket-object-lock.iso.test.ts
+++ b/src/service/s3/cfn/bucket/lock/sim-cfn-s3-bucket-object-lock.iso.test.ts
@@ -1,0 +1,250 @@
+import {
+  DeleteObjectCommand,
+  GetObjectLockConfigurationCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimCfnDeployedStack } from "../../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { SimCfnTemplateValueRecord } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const bucketName = "reader-history";
+const key = "events/reader-1.json";
+
+/**
+ * Deploy a history Bucket declaring the given Object Lock properties.
+ */
+async function deployBucket(
+  simAws: SimAws,
+  properties: SimCfnTemplateValueRecord,
+): Promise<SimCfnDeployedStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "history-stack",
+    template: {
+      Resources: {
+        HistoryBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: bucketName, ...properties },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+const versionedAndLocked: SimCfnTemplateValueRecord = {
+  VersioningConfiguration: { Status: "Enabled" },
+  ObjectLockEnabled: true,
+};
+
+describe("AWS::S3::Bucket Object Lock", () => {
+  it("answers with the configuration the template declared", async () => {
+    // Given a template declaring a locked Bucket with a default retention,
+    // which is what CDK synthesises for objectLockDefaultRetention.
+    const simAws = new SimAws();
+    const stack = await deployBucket(simAws, {
+      ...versionedAndLocked,
+      ObjectLockConfiguration: {
+        ObjectLockEnabled: "Enabled",
+        Rule: { DefaultRetention: { Mode: "COMPLIANCE", Days: 7 } },
+      },
+    });
+
+    // When the Bucket is read back through the SDK.
+    const read = await simAws
+      .s3()
+      .getObjectLockConfiguration(
+        new GetObjectLockConfigurationCommand({ Bucket: bucketName }),
+      );
+
+    // Then it answers with what the template declared.
+    assertIdentical(read.ObjectLockConfiguration.ObjectLockEnabled, "Enabled");
+
+    const defaults = read.ObjectLockConfiguration.Rule?.DefaultRetention;
+    assertNonNullable(defaults);
+    assertIdentical(defaults.Mode, "COMPLIANCE");
+    assertIdentical(defaults.Days, 7);
+
+    // And neither property is recorded as one the Bucket was created without.
+    assertUndefined(
+      stack.ignoredProperties.find((ignored) =>
+        ignored.path.startsWith("ObjectLock"),
+      ),
+    );
+  });
+
+  it("locks a Bucket declaring ObjectLockEnabled and no configuration", async () => {
+    // Given a template turning Object Lock on and declaring no default
+    // retention, which locks nothing on its own.
+    const simAws = new SimAws();
+    await deployBucket(simAws, versionedAndLocked);
+
+    // When the configuration is read back.
+    const read = await simAws
+      .s3()
+      .getObjectLockConfiguration(
+        new GetObjectLockConfigurationCommand({ Bucket: bucketName }),
+      );
+
+    // Then Object Lock is on, with no rule under it.
+    assertIdentical(read.ObjectLockConfiguration.ObjectLockEnabled, "Enabled");
+    assertUndefined(read.ObjectLockConfiguration.Rule);
+  });
+
+  it("refuses a locked Bucket the template leaves unversioned", async () => {
+    // Given a template turning Object Lock on and no versioning under it.
+    // When it is deployed, then the Resource fails, in the words an SDK caller
+    // is refused in. A Bucket created around the property would report a
+    // retention nothing was enforcing.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployBucket(new SimAws(), { ObjectLockEnabled: true });
+    });
+
+    assertStringIncludes(error.message, "does not have versioning enabled");
+  });
+
+  it("refuses a configuration the template does not enable", async () => {
+    // Given a template declaring a default retention without turning Object
+    // Lock on, which real CloudFormation refuses too.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployBucket(new SimAws(), {
+        VersioningConfiguration: { Status: "Enabled" },
+        ObjectLockConfiguration: {
+          ObjectLockEnabled: "Enabled",
+          Rule: { DefaultRetention: { Mode: "GOVERNANCE", Days: 1 } },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "ObjectLockConfiguration requires ObjectLockEnabled to be true",
+    );
+  });
+
+  it("retains a version written into a Bucket the template locked", async () => {
+    // Given a deployed Bucket retaining every version for a year.
+    const simAws = new SimAws();
+    await deployBucket(simAws, {
+      ...versionedAndLocked,
+      ObjectLockConfiguration: {
+        ObjectLockEnabled: "Enabled",
+        Rule: { DefaultRetention: { Mode: "COMPLIANCE", Years: 1 } },
+      },
+    });
+    const s3 = simAws.s3();
+
+    // When a reader's history is appended to.
+    const put = await s3.putObject(
+      new PutObjectCommand({ Bucket: bucketName, Key: key, Body: "one" }),
+    );
+    assertNonNullable(put.VersionId);
+
+    // Then the version reports the retention, counted from the write.
+    const head = await s3.headObject(
+      new HeadObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId: put.VersionId,
+      }),
+    );
+    assertIdentical(head.ObjectLockMode, "COMPLIANCE");
+
+    // And nothing in the account can delete it.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.deleteObject(
+        new DeleteObjectCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: put.VersionId,
+          BypassGovernanceRetention: true,
+        }),
+      );
+    });
+
+    assertIdentical(error.name, "AccessDenied");
+  });
+
+  it("refuses an ObjectLockEnabled that is neither true nor false", async () => {
+    // Given a template carrying something else as ObjectLockEnabled, which
+    // real CloudFormation refuses as well.
+    // When it is deployed, then it is refused rather than read as false,
+    // because the Bucket it asked for is not knowable.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployBucket(new SimAws(), { ObjectLockEnabled: "yes" });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "ObjectLockEnabled must be true or false",
+    );
+  });
+
+  it("refuses an ObjectLockConfiguration that is not an object", async () => {
+    // Given a configuration declared as a string.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployBucket(new SimAws(), {
+        ...versionedAndLocked,
+        ObjectLockConfiguration: "COMPLIANCE",
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "ObjectLockConfiguration must be an object",
+    );
+  });
+
+  it("refuses a configuration on a Bucket that says Object Lock is off", async () => {
+    // Given a template carrying a default retention and ObjectLockEnabled
+    // false, which is the two properties disagreeing about the same thing.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployBucket(new SimAws(), {
+        VersioningConfiguration: { Status: "Enabled" },
+        ObjectLockEnabled: false,
+        ObjectLockConfiguration: {
+          ObjectLockEnabled: "Enabled",
+          Rule: { DefaultRetention: { Mode: "GOVERNANCE", Days: 1 } },
+        },
+      });
+    });
+
+    assertStringIncludes(
+      error.message,
+      "ObjectLockConfiguration requires ObjectLockEnabled to be true",
+    );
+  });
+
+  it("leaves a Bucket declaring ObjectLockEnabled false unlocked", async () => {
+    // Given a template saying Object Lock is off, which is what CDK
+    // synthesises for a Bucket that never asked for it.
+    const simAws = new SimAws();
+    await deployBucket(simAws, {
+      VersioningConfiguration: { Status: "Enabled" },
+      ObjectLockEnabled: false,
+    });
+
+    // When the configuration is read, then there is none, as real S3 answers
+    // a Bucket that has never had one.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await simAws
+        .s3()
+        .getObjectLockConfiguration(
+          new GetObjectLockConfigurationCommand({ Bucket: bucketName }),
+        );
+    });
+
+    assertIdentical(error.name, "ObjectLockConfigurationNotFoundError");
+  });
+});

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-configurator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-configurator.ts
@@ -46,15 +46,17 @@ export class SimCfnS3BucketConfigurator {
   /**
    * Apply every configuration the Resource declares.
    *
-   * Versioning goes before the lifecycle rules, because a rule acting on
-   * noncurrent versions describes a Bucket that keeps them. Notifications go
-   * last, because S3 checks every destination the configuration names, and the
-   * Resources those destinations live on have to exist by then.
+   * Versioning goes before Object Lock and before the lifecycle rules,
+   * because both describe a Bucket that keeps versions and Object Lock refuses
+   * one that does not. Notifications go last, because S3 checks every
+   * destination the configuration names, and the Resources those destinations
+   * live on have to exist by then.
    */
   async configure(): Promise<void> {
     await this.declared.applyWebsite();
     await this.declared.applyPublicAccess();
     await this.declared.applyVersioning();
+    await this.declared.applyObjectLock();
     await this.declared.applyLifecycle();
     await this.configureNotifications();
   }

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-declared-configurations.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-declared-configurations.ts
@@ -2,6 +2,7 @@ import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resour
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimS3 } from "../../sim-s3.js";
 import { SimCfnS3BucketLifecycleConfiguration } from "./lifecycle/sim-cfn-s3-bucket-lifecycle-configuration.js";
+import { SimCfnS3BucketObjectLockConfiguration } from "./lock/sim-cfn-s3-bucket-object-lock-configuration.js";
 import { SimCfnS3BucketPublicAccessConfiguration } from "./public-access/sim-cfn-s3-bucket-public-access-configuration.js";
 import { SimCfnS3BucketVersioningConfiguration } from "./versioning/sim-cfn-s3-bucket-versioning-configuration.js";
 import { SimCfnS3BucketWebsiteConfiguration } from "./website/sim-cfn-s3-bucket-website-configuration.js";
@@ -18,7 +19,7 @@ interface SimCfnS3BucketDeclaredConfigurationsProperties {
  * The AWS::S3::Bucket properties that are read straight off the Resource and
  * handed to a command.
  *
- * Four properties with one shape between them. Each is read from the Resource,
+ * Five properties with one shape between them. Each is read from the Resource,
  * left alone where the Resource omitted it, and otherwise applied through the
  * command an SDK caller would reach, so a template and an SDK caller are
  * validated identically. The event notification configuration is the one that
@@ -81,6 +82,27 @@ export class SimCfnS3BucketDeclaredConfigurations {
     if (VersioningConfiguration !== undefined) {
       await this.simS3.putBucketVersioning(
         { input: { Bucket: this.bucketName, VersioningConfiguration } },
+        this.options,
+      );
+    }
+  }
+
+  /**
+   * Apply the Object Lock configuration the Resource declares.
+   *
+   * This goes after versioning, because Object Lock holds a version and
+   * PutObjectLockConfiguration refuses a Bucket that keeps none. A template
+   * declaring Object Lock without versioning therefore fails the Resource, in
+   * the words an SDK caller is refused in.
+   */
+  async applyObjectLock(): Promise<void> {
+    const ObjectLockConfiguration = this.read(
+      SimCfnS3BucketObjectLockConfiguration,
+    );
+
+    if (ObjectLockConfiguration !== undefined) {
+      await this.simS3.putObjectLockConfiguration(
+        { input: { Bucket: this.bucketName, ObjectLockConfiguration } },
         this.options,
       );
     }

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
@@ -4,6 +4,8 @@
 export const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "BucketName",
   "LifecycleConfiguration",
+  "ObjectLockConfiguration",
+  "ObjectLockEnabled",
   "NotificationConfiguration",
   "PublicAccessBlockConfiguration",
   "VersioningConfiguration",
@@ -29,9 +31,9 @@ export const inertPropertyNames: ReadonlySet<string> = new Set([
  * each of them would have changed.
  *
  * The Bucket is created without them and each one is recorded against the
- * Resource. A Bucket with Object Lock, for instance, refuses a delete inside
- * an Object's retention period, where this simulator carries it out, so a test
- * written against Object Lock needs to find out that it was never configured.
+ * Resource. A Bucket declaring replication, for instance, copies nothing to
+ * the Bucket it names, so a test expecting an Object to arrive there needs to
+ * find out that nothing was ever going to send it.
  */
 export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
   ["AbacStatus", "attribute-based access control is not simulated"],
@@ -57,14 +59,6 @@ export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
   ["MetadataConfiguration", "Bucket metadata tables are not simulated"],
   ["MetadataTableConfiguration", "Bucket metadata tables are not simulated"],
   ["MetricsConfigurations", "CloudWatch request metrics are not simulated"],
-  [
-    "ObjectLockConfiguration",
-    "Object Lock is not simulated, so a retained Object can still be deleted",
-  ],
-  [
-    "ObjectLockEnabled",
-    "Object Lock is not simulated, so a retained Object can still be deleted",
-  ],
   ["OwnershipControls", "Object ownership and ACLs are not simulated"],
   ["ReplicationConfiguration", "Bucket replication is not simulated"],
 ]);

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.iso.test.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.iso.test.ts
@@ -114,12 +114,12 @@ describe("AWS::S3::Bucket property rules", () => {
   });
 
   it("records every unsimulated property, not only the first", async () => {
-    // Given a template asking for object locking as well as acceleration.
+    // Given a template asking for access logging as well as acceleration.
     const simAws = new SimAws();
 
     // When the template is deployed.
     const stack = await deployBucket(simAws, {
-      ObjectLockEnabled: true,
+      LoggingConfiguration: { LogFilePrefix: "access/" },
       AccelerateConfiguration: { AccelerationStatus: "Enabled" },
     });
 
@@ -128,7 +128,7 @@ describe("AWS::S3::Bucket property rules", () => {
     assertArrayLength(stack.ignoredProperties, 2);
     assertIdentical(
       stack.ignoredProperties.map((entry) => entry.path).join(", "),
-      "ObjectLockEnabled, AccelerateConfiguration",
+      "LoggingConfiguration, AccelerateConfiguration",
     );
   });
 

--- a/src/service/s3/command/authorize/sim-s3-authorize-action.ts
+++ b/src/service/s3/command/authorize/sim-s3-authorize-action.ts
@@ -1,0 +1,48 @@
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "./sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "./sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+/** One S3 request, as the decision to allow it is asked for. */
+export interface SimS3AuthorizedAction {
+  readonly iam: SimIamInterServiceAuthZ;
+  /** The real IAM action, such as `s3:PutObjectRetention`. */
+  readonly action: string;
+  /** The Bucket ARN or the Object ARN, whichever the action is granted on. */
+  readonly resource: string;
+  /** The Bucket whose own policy is part of the decision. */
+  readonly bucket: SimS3Bucket;
+  readonly options: SimS3RequestOptions | undefined;
+}
+
+/**
+ * Ensure one caller may take one action on one S3 resource.
+ *
+ * The Bucket's own policy is part of every decision, alongside whatever the
+ * caller's identity policies say, and the request's source ARN and Account are
+ * supplied as the condition keys a Bucket policy is usually written against.
+ * An omitted caller is passed through to sim IAM, so Account root fallback
+ * stays owned by IAM.
+ */
+export function simS3AuthorizeAction(request: SimS3AuthorizedAction): void {
+  const { iam, action, resource, bucket, options } = request;
+
+  const decision = iam.authorize({
+    action,
+    resource,
+    caller: options?.caller,
+    conditionContext: simS3ConditionContext(options),
+    resourcePolicies: simS3BucketResourcePolicies(bucket),
+  });
+
+  if (decision.isDenied) {
+    throw new SimIamAccessDenied({
+      principal: decision.caller.principal,
+      reason: decision.denialReason,
+      action,
+      resource,
+    });
+  }
+}

--- a/src/service/s3/command/delete-object/delete-object-version-removal.ts
+++ b/src/service/s3/command/delete-object/delete-object-version-removal.ts
@@ -1,10 +1,26 @@
 import type { SimAwsResolvedCaller } from "../../../aws/caller/sim-aws-caller-resolver.js";
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import type { SimS3ObjectNotifier } from "../../notification/sim-s3-object-notifier.js";
+import { SimS3ObjectLockAuthorizer } from "../object-lock/sim-s3-object-lock-authorizer.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import type { SimDeleteObjectCommandOutput } from "./delete-object.command.js";
 
 interface DeleteObjectVersionRemovalProperties {
   readonly notifications: SimS3ObjectNotifier;
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * One request to remove one named version.
+ */
+export interface SimS3VersionRemoval {
+  readonly bucket: SimS3Bucket;
+  readonly key: string;
+  readonly versionId: string;
+  readonly caller: SimAwsResolvedCaller;
+  readonly bypassGovernance: boolean | undefined;
+  readonly options: SimS3RequestOptions | undefined;
 }
 
 /**
@@ -13,13 +29,16 @@ interface DeleteObjectVersionRemovalProperties {
  * Separate from the request-level delete because the two answer differently.
  * A delete without a version id writes a marker over the current version and
  * leaves the bytes where they are. This one takes a version away, and only
- * this one can leave a key with nothing under it on a versioned Bucket.
+ * this one can leave a key with nothing under it on a versioned Bucket. It is
+ * also the only one Object Lock has anything to say about.
  */
 export class DeleteObjectVersionRemoval {
   private readonly notifications: SimS3ObjectNotifier;
+  private readonly objectLock: SimS3ObjectLockAuthorizer;
 
   constructor(properties: DeleteObjectVersionRemovalProperties) {
     this.notifications = properties.notifications;
+    this.objectLock = new SimS3ObjectLockAuthorizer({ iam: properties.iam });
   }
 
   /**
@@ -29,14 +48,25 @@ export class DeleteObjectVersionRemoval {
    * it removed, so a version id nothing matches is reported back rather than
    * raised. Removing a delete marker is reported as such, which is how a
    * caller undoing a delete knows the marker was what went.
+   *
+   * A version Object Lock is holding is refused with `AccessDenied` before
+   * anything is removed. Naming `BypassGovernanceRetention` gets past a
+   * governance period, and needs `s3:BypassGovernanceRetention` as well as the
+   * `s3:DeleteObject` the request already needed.
    */
   async remove(
-    bucket: SimS3Bucket,
-    key: string,
-    versionId: string,
-    caller: SimAwsResolvedCaller,
+    request: SimS3VersionRemoval,
   ): Promise<SimDeleteObjectCommandOutput> {
-    const removed = await bucket.deleteObjectVersion(key, versionId);
+    const { bucket, key, versionId, caller } = request;
+
+    const bypassed = this.objectLock.authorizeBypass(
+      bucket,
+      key,
+      request.bypassGovernance,
+      request.options,
+    );
+
+    const removed = await bucket.deleteObjectVersion(key, versionId, bypassed);
 
     if (removed !== undefined && !removed.isDeleteMarker) {
       this.notifications.objectRemoved({

--- a/src/service/s3/command/delete-object/delete-object.command.ts
+++ b/src/service/s3/command/delete-object/delete-object.command.ts
@@ -20,6 +20,14 @@ export interface SimDeleteObjectCommandInput {
    * Bucket answers by writing a delete marker rather than removing anything.
    */
   readonly VersionId?: string | undefined;
+  /**
+   * Whether to get past a governance retention period holding the named
+   * version, which the caller also needs `s3:BypassGovernanceRetention` for.
+   *
+   * A compliance period and a legal hold have no bypass, so this changes
+   * nothing for either.
+   */
+  readonly BypassGovernanceRetention?: boolean | undefined;
 }
 
 /**

--- a/src/service/s3/command/delete-object/delete-object.handler.ts
+++ b/src/service/s3/command/delete-object/delete-object.handler.ts
@@ -56,7 +56,10 @@ export class DeleteObjectCommandHandler implements CommandHandler<
     this.authorizer = new DeleteObjectAuthorizer({ iam });
     this.background = background;
     this.notifications = properties.notifications;
-    this.versionRemoval = new DeleteObjectVersionRemoval(properties);
+    this.versionRemoval = new DeleteObjectVersionRemoval({
+      notifications: properties.notifications,
+      iam,
+    });
   }
 
   /**
@@ -68,13 +71,14 @@ export class DeleteObjectCommandHandler implements CommandHandler<
    *
    * A `VersionId` asks for that one version and removes it for good. A request
    * without one asks for the current version, which a versioned Bucket answers
-   * by writing a delete marker over it.
+   * by writing a delete marker over it. Object Lock holds a named version and
+   * never the marker, since a marker hides an Object without losing it.
    */
   async handle(
     command: SimDeleteObjectCommand,
     options?: SimS3RequestOptions,
   ): Promise<SimDeleteObjectCommandOutput> {
-    const { Bucket, Key, VersionId } = command.input;
+    const { Bucket, Key, VersionId, BypassGovernanceRetention } = command.input;
     assertDefined(Bucket, "DeleteObjectCommand.input.Bucket");
     assertDefined(Key, "DeleteObjectCommand.input.Key");
 
@@ -85,7 +89,14 @@ export class DeleteObjectCommandHandler implements CommandHandler<
     const caller = this.authorizer.authorize(bucket, Key, options);
 
     if (VersionId !== undefined) {
-      return await this.versionRemoval.remove(bucket, Key, VersionId, caller);
+      return await this.versionRemoval.remove({
+        bucket,
+        key: Key,
+        versionId: VersionId,
+        caller,
+        bypassGovernance: BypassGovernanceRetention,
+        options,
+      });
     }
 
     const deletion = await bucket.deleteObject(Key);

--- a/src/service/s3/command/get-object-lock-configuration/get-object-lock-configuration.command.ts
+++ b/src/service/s3/command/get-object-lock-configuration/get-object-lock-configuration.command.ts
@@ -1,0 +1,28 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3ObjectLockConfigurationInput } from "../../bucket/lock/sim-s3-object-lock-configuration.js";
+
+/**
+ * Minimal structural sim S3 GetObjectLockConfiguration command.
+ */
+export interface SimGetObjectLockConfigurationCommand {
+  readonly input: SimGetObjectLockConfigurationCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 GetObjectLockConfiguration input.
+ */
+export interface SimGetObjectLockConfigurationCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 GetObjectLockConfiguration output.
+ *
+ * A Bucket that has never had Object Lock answers with
+ * `ObjectLockConfigurationNotFoundError` rather than an empty configuration,
+ * so this always carries one.
+ */
+export interface SimGetObjectLockConfigurationCommandOutput {
+  readonly ObjectLockConfiguration: SimS3ObjectLockConfigurationInput;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/get-object-lock-configuration/get-object-lock-configuration.handler.ts
+++ b/src/service/s3/command/get-object-lock-configuration/get-object-lock-configuration.handler.ts
@@ -1,0 +1,85 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3ObjectLockConfigurationNotFound } from "../../error/sim-s3-object-lock.error.js";
+import { SimS3ObjectLockAuthorizer } from "../object-lock/sim-s3-object-lock-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimGetObjectLockConfigurationCommand,
+  SimGetObjectLockConfigurationCommandOutput,
+} from "./get-object-lock-configuration.command.js";
+
+interface GetObjectLockConfigurationHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 GetObjectLockConfigurationCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/GetObjectLockConfigurationCommand/
+ */
+export class GetObjectLockConfigurationCommandHandler implements CommandHandler<
+  SimGetObjectLockConfigurationCommand,
+  SimGetObjectLockConfigurationCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3ObjectLockAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: GetObjectLockConfigurationHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3ObjectLockAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Report how a Bucket is locked.
+   *
+   * A Bucket that has never had Object Lock is answered with
+   * `ObjectLockConfigurationNotFoundError`, as real S3 answers one, rather
+   * than with a configuration saying it is off.
+   */
+  async handle(
+    command: SimGetObjectLockConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimGetObjectLockConfigurationCommandOutput> {
+    const { Bucket } = command.input;
+    assertDefined(Bucket, "GetObjectLockConfigurationCommand.input.Bucket");
+
+    const bucket = requireSimS3Bucket(this.buckets, Bucket as SimS3BucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeReadConfiguration(bucket, options);
+
+    const configuration = bucket.getObjectLock().configuration;
+
+    if (configuration === undefined) {
+      throw new SimS3ObjectLockConfigurationNotFound(
+        `S3 Bucket ${Bucket} does not have an Object Lock configuration`,
+      );
+    }
+
+    return { ObjectLockConfiguration: configuration.reported, $metadata: {} };
+  }
+}

--- a/src/service/s3/command/get-object/get-object-loader.ts
+++ b/src/service/s3/command/get-object/get-object-loader.ts
@@ -66,6 +66,7 @@ export class GetObjectLoader {
       LastModified: object.lastModified,
       ContentLength: body.length,
       ...(read.versionId !== undefined && { VersionId: read.versionId }),
+      ...read.lock?.reported,
       ...(range !== undefined && {
         ContentRange: simS3ContentRange(range, size),
       }),

--- a/src/service/s3/command/get-object/get-object.command.ts
+++ b/src/service/s3/command/get-object/get-object.command.ts
@@ -1,5 +1,6 @@
 import type { Readable } from "node:stream";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3ObjectLockOutput } from "../../bucket/lock/sim-s3-object-lock-output.js";
 import type { SimS3SystemMetadataOutput } from "../../object/s3-system-metadata-read.js";
 
 /**
@@ -43,7 +44,8 @@ export interface SimGetObjectCommandInput {
  * when it was written. `Metadata` is what the caller attached to it, and holds
  * nothing else.
  */
-export interface SimGetObjectCommandOutput extends SimS3SystemMetadataOutput {
+export interface SimGetObjectCommandOutput
+  extends SimS3SystemMetadataOutput, SimS3ObjectLockOutput {
   readonly Body?: Readable;
   readonly Metadata?: Record<string, string>;
   readonly ETag?: string;

--- a/src/service/s3/command/head-object/head-object-loader.ts
+++ b/src/service/s3/command/head-object/head-object-loader.ts
@@ -35,6 +35,7 @@ export class HeadObjectLoader {
       ETag: simS3QuotedETag(object.etag),
       LastModified: object.lastModified,
       ...(read.versionId !== undefined && { VersionId: read.versionId }),
+      ...read.lock?.reported,
       $metadata: {},
     };
   }

--- a/src/service/s3/command/head-object/head-object.command.ts
+++ b/src/service/s3/command/head-object/head-object.command.ts
@@ -1,4 +1,5 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3ObjectLockOutput } from "../../bucket/lock/sim-s3-object-lock-output.js";
 import type { SimS3SystemMetadataOutput } from "../../object/s3-system-metadata-read.js";
 
 /**
@@ -28,7 +29,8 @@ export interface SimHeadObjectCommandInput {
  * the Object itself, so this is a GetObject output without its body and with
  * the length that body would have had.
  */
-export interface SimHeadObjectCommandOutput extends SimS3SystemMetadataOutput {
+export interface SimHeadObjectCommandOutput
+  extends SimS3SystemMetadataOutput, SimS3ObjectLockOutput {
   readonly ContentLength?: number;
   readonly Metadata?: Record<string, string>;
   readonly ETag?: string;

--- a/src/service/s3/command/object-lock/sim-s3-locked-version.ts
+++ b/src/service/s3/command/object-lock/sim-s3-locked-version.ts
@@ -1,0 +1,48 @@
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type { SimS3ObjectVersion } from "../../bucket/versioning/sim-s3-object-version.js";
+import {
+  SimS3InvalidRequest,
+  SimS3MethodNotAllowed,
+  SimS3NoSuchKey,
+  SimS3NoSuchVersion,
+} from "../../error/sim-s3.error.js";
+
+/**
+ * The version a retention or a legal hold is being put on.
+ *
+ * A request naming no version acts on the current one, which is what real S3
+ * does. A Bucket without Object Lock has no version to put either on, and
+ * refusing there is what stops a test believing a retention it set is holding
+ * anything.
+ */
+export function simS3LockedVersion(
+  bucket: SimS3Bucket,
+  key: string,
+  versionId: string | undefined,
+): SimS3ObjectVersion {
+  if (!bucket.getObjectLock().isEnabled) {
+    throw new SimS3InvalidRequest(
+      `Bucket ${bucket.bucketName} does not have Object Lock enabled`,
+    );
+  }
+
+  const versions = bucket.getVersions();
+  const version =
+    versionId === undefined
+      ? versions.current(key)
+      : versions.find(key, versionId);
+
+  if (version === undefined) {
+    throw versionId === undefined
+      ? new SimS3NoSuchKey(`No S3 Object named ${key}`)
+      : new SimS3NoSuchVersion(`No version ${versionId} of S3 Object ${key}`);
+  }
+
+  if (version.isDeleteMarker) {
+    throw new SimS3MethodNotAllowed(
+      `Version ${version.versionId} of S3 Object ${key} is a delete marker`,
+    );
+  }
+
+  return version;
+}

--- a/src/service/s3/command/object-lock/sim-s3-object-lock-authorizer.ts
+++ b/src/service/s3/command/object-lock/sim-s3-object-lock-authorizer.ts
@@ -1,0 +1,111 @@
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3AuthorizeAction } from "../authorize/sim-s3-authorize-action.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+/** The IAM action a caller needs to get past a governance retention period. */
+export const simS3BypassGovernanceAction = "s3:BypassGovernanceRetention";
+
+const readConfiguration = "s3:GetBucketObjectLockConfiguration";
+const writeConfiguration = "s3:PutBucketObjectLockConfiguration";
+const putRetention = "s3:PutObjectRetention";
+const putLegalHold = "s3:PutObjectLegalHold";
+
+interface SimS3ObjectLockAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to the S3 Object Lock commands.
+ *
+ * The two Bucket configuration actions are authorized against the Bucket ARN
+ * and the two version actions against the Object ARN, which is how real S3
+ * splits them: a policy can let a caller retain the Objects under one prefix
+ * without letting it configure the Bucket they are in.
+ *
+ * `s3:BypassGovernanceRetention` is authorized separately from the request it
+ * accompanies. A caller deleting a retained version needs both that and
+ * `s3:DeleteObject`, and real S3 checks them as two decisions.
+ */
+export class SimS3ObjectLockAuthorizer {
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimS3ObjectLockAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /** Ensure the caller may read how the Bucket is locked. */
+  authorizeReadConfiguration(
+    bucket: SimS3Bucket,
+    options?: SimS3RequestOptions,
+  ): void {
+    this.authorize(readConfiguration, bucketArn(bucket), bucket, options);
+  }
+
+  /** Ensure the caller may change how the Bucket is locked. */
+  authorizeWriteConfiguration(
+    bucket: SimS3Bucket,
+    options?: SimS3RequestOptions,
+  ): void {
+    this.authorize(writeConfiguration, bucketArn(bucket), bucket, options);
+  }
+
+  /** Ensure the caller may put a retention period on a version. */
+  authorizeRetention(
+    bucket: SimS3Bucket,
+    key: string,
+    options?: SimS3RequestOptions,
+  ): void {
+    this.authorize(putRetention, objectArn(bucket, key), bucket, options);
+  }
+
+  /** Ensure the caller may put a legal hold on a version. */
+  authorizeLegalHold(
+    bucket: SimS3Bucket,
+    key: string,
+    options?: SimS3RequestOptions,
+  ): void {
+    this.authorize(putLegalHold, objectArn(bucket, key), bucket, options);
+  }
+
+  /**
+   * Ensure the caller may get past a governance retention period, where the
+   * request asked to.
+   *
+   * A request that asked for nothing is answered without a decision, so a
+   * caller who never needed the permission is never refused for lacking it.
+   */
+  authorizeBypass(
+    bucket: SimS3Bucket,
+    key: string,
+    asked: boolean | undefined,
+    options?: SimS3RequestOptions,
+  ): boolean {
+    if (asked !== true) {
+      return false;
+    }
+
+    const action = simS3BypassGovernanceAction;
+    this.authorize(action, objectArn(bucket, key), bucket, options);
+
+    return true;
+  }
+
+  private authorize(
+    action: string,
+    resource: string,
+    bucket: SimS3Bucket,
+    options?: SimS3RequestOptions,
+  ): void {
+    simS3AuthorizeAction({ iam: this.iam, action, resource, bucket, options });
+  }
+}
+
+function bucketArn(bucket: SimS3Bucket): string {
+  return simS3BucketArn(bucket.bucketName);
+}
+
+function objectArn(bucket: SimS3Bucket, key: string): string {
+  return `${bucketArn(bucket)}/${key}`;
+}

--- a/src/service/s3/command/object-lock/sim-s3-object-lock-commands.ts
+++ b/src/service/s3/command/object-lock/sim-s3-object-lock-commands.ts
@@ -1,0 +1,72 @@
+import { GetObjectLockConfigurationCommandHandler } from "../get-object-lock-configuration/get-object-lock-configuration.handler.js";
+import { PutObjectLegalHoldCommandHandler } from "../put-object-legal-hold/put-object-legal-hold.handler.js";
+import { PutObjectLockConfigurationCommandHandler } from "../put-object-lock-configuration/put-object-lock-configuration.handler.js";
+import { PutObjectRetentionCommandHandler } from "../put-object-retention/put-object-retention.handler.js";
+import type { SimS3BucketCommandState } from "../sim-s3-bucket-command-state.js";
+import type * as simS3Commands from "../sim-s3-command.types.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+/**
+ * The Object Lock commands of one simulated S3 scope.
+ *
+ * Two of them configure a Bucket and two of them hold one version of one
+ * Object, and they are kept together because a version can only be held on a
+ * Bucket the first two turned Object Lock on for.
+ */
+export class SimS3ObjectLockCommands {
+  private readonly state: SimS3BucketCommandState;
+
+  constructor(state: SimS3BucketCommandState) {
+    this.state = state;
+  }
+
+  /**
+   * Turn Object Lock on for a Bucket, with the default retention it carries.
+   */
+  async putConfiguration(
+    command: simS3Commands.SimPutObjectLockConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutObjectLockConfigurationCommandOutput> {
+    return await new PutObjectLockConfigurationCommandHandler(
+      this.state,
+    ).handle(command, options);
+  }
+
+  /**
+   * Read how a Bucket is locked.
+   */
+  async getConfiguration(
+    command: simS3Commands.SimGetObjectLockConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetObjectLockConfigurationCommandOutput> {
+    return await new GetObjectLockConfigurationCommandHandler(
+      this.state,
+    ).handle(command, options);
+  }
+
+  /**
+   * Put a retention period on one version.
+   */
+  async putRetention(
+    command: simS3Commands.SimPutObjectRetentionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutObjectRetentionCommandOutput> {
+    return await new PutObjectRetentionCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Turn the legal hold on one version on or off.
+   */
+  async putLegalHold(
+    command: simS3Commands.SimPutObjectLegalHoldCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutObjectLegalHoldCommandOutput> {
+    return await new PutObjectLegalHoldCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+}

--- a/src/service/s3/command/object/sim-s3-read-object-version.ts
+++ b/src/service/s3/command/object/sim-s3-read-object-version.ts
@@ -4,6 +4,7 @@ import {
   SimS3MethodNotAllowed,
   SimS3NoSuchVersion,
 } from "../../error/sim-s3.error.js";
+import type { SimS3ObjectLock } from "../../bucket/lock/sim-s3-object-lock.js";
 import type { SimS3Object } from "../../object/s3-object.js";
 
 /**
@@ -15,6 +16,13 @@ import type { SimS3Object } from "../../object/s3-object.js";
 export interface SimS3ReadObjectVersion {
   readonly object: SimS3Object;
   readonly versionId: string | undefined;
+  /**
+   * What Object Lock holds against the version read.
+   *
+   * A Bucket keeping no versions has none, and a Bucket that keeps them but
+   * has never been locked has an empty one. Both report nothing.
+   */
+  readonly lock: SimS3ObjectLock | undefined;
 }
 
 /**
@@ -40,9 +48,13 @@ export async function simS3ReadObjectVersion(
   if (versionId === undefined) {
     const object = await bucket.getObject(key);
 
-    return object === undefined
-      ? undefined
-      : { object, versionId: versions.current(key)?.versionId };
+    if (object === undefined) {
+      return undefined;
+    }
+
+    const current = versions.current(key);
+
+    return { object, versionId: current?.versionId, lock: current?.lock };
   }
 
   if (!versions.keepsVersions) {
@@ -61,7 +73,7 @@ export async function simS3ReadObjectVersion(
     );
   }
 
-  return { object: version.object, versionId };
+  return { object: version.object, versionId, lock: version.lock };
 }
 
 /**
@@ -81,5 +93,7 @@ async function simS3ReadUnversioned(
 
   const object = await bucket.getObject(key);
 
-  return object === undefined ? undefined : { object, versionId: undefined };
+  return object === undefined
+    ? undefined
+    : { object, versionId: undefined, lock: undefined };
 }

--- a/src/service/s3/command/put-object-legal-hold/put-object-legal-hold.command.ts
+++ b/src/service/s3/command/put-object-legal-hold/put-object-legal-hold.command.ts
@@ -1,0 +1,27 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3LegalHoldInput } from "../../bucket/lock/sim-s3-object-lock.js";
+
+/**
+ * Minimal structural sim S3 PutObjectLegalHold command.
+ */
+export interface SimPutObjectLegalHoldCommand {
+  readonly input: SimPutObjectLegalHoldCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 PutObjectLegalHold input.
+ */
+export interface SimPutObjectLegalHoldCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  /** The version to hold. A request naming none holds the current one. */
+  readonly VersionId?: string | undefined;
+  readonly LegalHold?: SimS3LegalHoldInput | undefined;
+}
+
+/**
+ * Minimal structural sim S3 PutObjectLegalHold output.
+ */
+export interface SimPutObjectLegalHoldCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/put-object-legal-hold/put-object-legal-hold.handler.ts
+++ b/src/service/s3/command/put-object-legal-hold/put-object-legal-hold.handler.ts
@@ -1,0 +1,82 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3ObjectLockAuthorizer } from "../object-lock/sim-s3-object-lock-authorizer.js";
+import { simS3LockedVersion } from "../object-lock/sim-s3-locked-version.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimPutObjectLegalHoldCommand,
+  SimPutObjectLegalHoldCommandOutput,
+} from "./put-object-legal-hold.command.js";
+
+interface PutObjectLegalHoldHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 PutObjectLegalHoldCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutObjectLegalHoldCommand/
+ */
+export class PutObjectLegalHoldCommandHandler implements CommandHandler<
+  SimPutObjectLegalHoldCommand,
+  SimPutObjectLegalHoldCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3ObjectLockAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: PutObjectLegalHoldHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3ObjectLockAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and turn the legal hold on one version on or off.
+   *
+   * A hold goes on and comes off through the same request and the same
+   * permission. There is no bypass and no period to wait out, which is what
+   * makes a hold the thing to reach for when the end of the retention is not
+   * knowable in advance.
+   */
+  async handle(
+    command: SimPutObjectLegalHoldCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutObjectLegalHoldCommandOutput> {
+    const { Bucket, Key, VersionId, LegalHold } = command.input;
+    assertDefined(Bucket, "PutObjectLegalHoldCommand.input.Bucket");
+    assertDefined(Key, "PutObjectLegalHoldCommand.input.Key");
+    assertDefined(LegalHold, "PutObjectLegalHoldCommand.input.LegalHold");
+
+    const bucket = requireSimS3Bucket(this.buckets, Bucket as SimS3BucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeLegalHold(bucket, Key, options);
+
+    simS3LockedVersion(bucket, Key, VersionId).lock.applyLegalHold(LegalHold);
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/s3/command/put-object-lock-configuration/put-object-lock-configuration.command.ts
+++ b/src/service/s3/command/put-object-lock-configuration/put-object-lock-configuration.command.ts
@@ -1,0 +1,26 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3ObjectLockConfigurationInput } from "../../bucket/lock/sim-s3-object-lock-configuration.js";
+
+/**
+ * Minimal structural sim S3 PutObjectLockConfiguration command.
+ */
+export interface SimPutObjectLockConfigurationCommand {
+  readonly input: SimPutObjectLockConfigurationCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 PutObjectLockConfiguration input.
+ */
+export interface SimPutObjectLockConfigurationCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly ObjectLockConfiguration?:
+    | SimS3ObjectLockConfigurationInput
+    | undefined;
+}
+
+/**
+ * Minimal structural sim S3 PutObjectLockConfiguration output.
+ */
+export interface SimPutObjectLockConfigurationCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/put-object-lock-configuration/put-object-lock-configuration.handler.ts
+++ b/src/service/s3/command/put-object-lock-configuration/put-object-lock-configuration.handler.ts
@@ -1,0 +1,94 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3ObjectLockConfiguration } from "../../bucket/lock/sim-s3-object-lock-configuration.js";
+import { SimS3InvalidBucketState } from "../../error/sim-s3-object-lock.error.js";
+import { SimS3ObjectLockAuthorizer } from "../object-lock/sim-s3-object-lock-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimPutObjectLockConfigurationCommand,
+  SimPutObjectLockConfigurationCommandOutput,
+} from "./put-object-lock-configuration.command.js";
+
+interface PutObjectLockConfigurationHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 PutObjectLockConfigurationCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutObjectLockConfigurationCommand/
+ */
+export class PutObjectLockConfigurationCommandHandler implements CommandHandler<
+  SimPutObjectLockConfigurationCommand,
+  SimPutObjectLockConfigurationCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3ObjectLockAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: PutObjectLockConfigurationHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3ObjectLockAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and apply a Bucket's Object Lock configuration.
+   *
+   * Object Lock protects a version and has no meaning without one, so a Bucket
+   * that keeps none is refused. Real S3 requires versioning underneath it for
+   * the same reason, and a Bucket that appeared to accept the configuration
+   * would report a retention nothing was enforcing.
+   */
+  async handle(
+    command: SimPutObjectLockConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutObjectLockConfigurationCommandOutput> {
+    const { Bucket, ObjectLockConfiguration } = command.input;
+    assertDefined(Bucket, "PutObjectLockConfigurationCommand.input.Bucket");
+    assertDefined(
+      ObjectLockConfiguration,
+      "PutObjectLockConfigurationCommand.input.ObjectLockConfiguration",
+    );
+
+    const bucket = requireSimS3Bucket(this.buckets, Bucket as SimS3BucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeWriteConfiguration(bucket, options);
+
+    if (!bucket.getVersions().configuration.isEnabled) {
+      throw new SimS3InvalidBucketState(
+        `Object Lock cannot be enabled on Bucket ${Bucket}, which does not ` +
+          `have versioning enabled`,
+      );
+    }
+
+    bucket
+      .getObjectLock()
+      .configure(SimS3ObjectLockConfiguration.parse(ObjectLockConfiguration));
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/s3/command/put-object-retention/put-object-retention.command.ts
+++ b/src/service/s3/command/put-object-retention/put-object-retention.command.ts
@@ -1,0 +1,32 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3RetentionInput } from "../../bucket/lock/sim-s3-object-retention.js";
+
+/**
+ * Minimal structural sim S3 PutObjectRetention command.
+ */
+export interface SimPutObjectRetentionCommand {
+  readonly input: SimPutObjectRetentionCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 PutObjectRetention input.
+ */
+export interface SimPutObjectRetentionCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly Key?: string | undefined;
+  /** The version to retain. A request naming none retains the current one. */
+  readonly VersionId?: string | undefined;
+  readonly Retention?: SimS3RetentionInput | undefined;
+  /**
+   * Whether to shorten a governance retention period already on the version,
+   * which the caller also needs `s3:BypassGovernanceRetention` for.
+   */
+  readonly BypassGovernanceRetention?: boolean | undefined;
+}
+
+/**
+ * Minimal structural sim S3 PutObjectRetention output.
+ */
+export interface SimPutObjectRetentionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/put-object-retention/put-object-retention.handler.ts
+++ b/src/service/s3/command/put-object-retention/put-object-retention.handler.ts
@@ -1,0 +1,92 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3ObjectRetention } from "../../bucket/lock/sim-s3-object-retention.js";
+import { SimS3ObjectLockAuthorizer } from "../object-lock/sim-s3-object-lock-authorizer.js";
+import { simS3LockedVersion } from "../object-lock/sim-s3-locked-version.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimPutObjectRetentionCommand,
+  SimPutObjectRetentionCommandOutput,
+} from "./put-object-retention.command.js";
+
+interface PutObjectRetentionHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 PutObjectRetentionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutObjectRetentionCommand/
+ */
+export class PutObjectRetentionCommandHandler implements CommandHandler<
+  SimPutObjectRetentionCommand,
+  SimPutObjectRetentionCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3ObjectLockAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: PutObjectRetentionHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3ObjectLockAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and put a retention period on one version.
+   *
+   * Lengthening a period is always allowed. Shortening one is what the modes
+   * differ over, and the version itself is what refuses it, so a template and
+   * an SDK caller are held to the same rule.
+   */
+  async handle(
+    command: SimPutObjectRetentionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutObjectRetentionCommandOutput> {
+    const { Bucket, Key, VersionId, Retention, BypassGovernanceRetention } =
+      command.input;
+    assertDefined(Bucket, "PutObjectRetentionCommand.input.Bucket");
+    assertDefined(Key, "PutObjectRetentionCommand.input.Key");
+    assertDefined(Retention, "PutObjectRetentionCommand.input.Retention");
+
+    const bucket = requireSimS3Bucket(this.buckets, Bucket as SimS3BucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeRetention(bucket, Key, options);
+    const bypassed = this.authorizer.authorizeBypass(
+      bucket,
+      Key,
+      BypassGovernanceRetention,
+      options,
+    );
+
+    simS3LockedVersion(bucket, Key, VersionId).lock.applyRetention(
+      SimS3ObjectRetention.parse(Retention),
+      bypassed,
+    );
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -149,3 +149,23 @@ export type {
   SimUploadPartCommand,
   SimUploadPartCommandOutput,
 } from "./upload-part/upload-part.command.js";
+export type {
+  SimPutObjectLockConfigurationCommand,
+  SimPutObjectLockConfigurationCommandInput,
+  SimPutObjectLockConfigurationCommandOutput,
+} from "./put-object-lock-configuration/put-object-lock-configuration.command.js";
+export type {
+  SimGetObjectLockConfigurationCommand,
+  SimGetObjectLockConfigurationCommandInput,
+  SimGetObjectLockConfigurationCommandOutput,
+} from "./get-object-lock-configuration/get-object-lock-configuration.command.js";
+export type {
+  SimPutObjectRetentionCommand,
+  SimPutObjectRetentionCommandInput,
+  SimPutObjectRetentionCommandOutput,
+} from "./put-object-retention/put-object-retention.command.js";
+export type {
+  SimPutObjectLegalHoldCommand,
+  SimPutObjectLegalHoldCommandInput,
+  SimPutObjectLegalHoldCommandOutput,
+} from "./put-object-legal-hold/put-object-legal-hold.command.js";

--- a/src/service/s3/error/sim-s3-object-lock.error.ts
+++ b/src/service/s3/error/sim-s3-object-lock.error.ts
@@ -1,0 +1,30 @@
+import { SimS3Error } from "./sim-s3.error.js";
+
+/**
+ * Simulated S3 InvalidBucketState error.
+ *
+ * A request real S3 refuses because of how the Bucket is configured rather
+ * than because of anything in the request. Turning Object Lock on over a
+ * Bucket that keeps no versions is the one sim S3 raises it for.
+ */
+export class SimS3InvalidBucketState extends SimS3Error {
+  public override readonly name = "InvalidBucketState";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 409 });
+  }
+}
+
+/**
+ * Simulated S3 ObjectLockConfigurationNotFoundError.
+ *
+ * What real S3 answers a read of the Object Lock configuration of a Bucket
+ * that has never had one, rather than answering with an empty configuration.
+ */
+export class SimS3ObjectLockConfigurationNotFound extends SimS3Error {
+  public override readonly name = "ObjectLockConfigurationNotFoundError";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -312,11 +312,15 @@ describe("simulated S3 SDK Command routing", () => {
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 33);
+    assertArrayLength(supported, 37);
     assertArrayIncludes(supported, "CopyObjectCommand");
     assertArrayIncludes(supported, "PutBucketVersioningCommand");
     assertArrayIncludes(supported, "GetBucketVersioningCommand");
     assertArrayIncludes(supported, "ListObjectVersionsCommand");
+    assertArrayIncludes(supported, "PutObjectLockConfigurationCommand");
+    assertArrayIncludes(supported, "GetObjectLockConfigurationCommand");
+    assertArrayIncludes(supported, "PutObjectRetentionCommand");
+    assertArrayIncludes(supported, "PutObjectLegalHoldCommand");
     assertArrayIncludes(supported, "GetObjectCommand");
     assertArrayIncludes(supported, "ListObjectsV2Command");
     assertArrayIncludes(supported, "DeleteBucketCommand");

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../sdk/index.js";
 import type { SimS3 } from "../sim-s3.js";
 import { simS3SdkBucketRoutes } from "./sim-s3-sdk-bucket-routes.js";
+import { simS3SdkObjectLockRoutes } from "./sim-s3-sdk-object-lock-routes.js";
 import { simS3SdkObjectRoutes } from "./sim-s3-sdk-object-routes.js";
 
 /**
@@ -16,6 +17,7 @@ export class SimS3SdkCommandRouter implements SimSdkCommandRouter {
     this.routes = new Map<string, SimSdkCommandRoute>([
       ...simS3SdkBucketRoutes(simS3),
       ...simS3SdkObjectRoutes(simS3),
+      ...simS3SdkObjectLockRoutes(simS3),
     ]);
   }
 

--- a/src/service/s3/sdk/sim-s3-sdk-object-lock-routes.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-object-lock-routes.iso.test.ts
@@ -1,0 +1,105 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetObjectLockConfigurationCommand,
+  HeadObjectCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+  PutObjectLegalHoldCommand,
+  PutObjectLockConfigurationCommand,
+  PutObjectRetentionCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../../sdk/index.js";
+
+const bucketName = "reader-history";
+const key = "events/reader-1.json";
+
+describe("simulated S3 Object Lock SDK Command routing", () => {
+  it("locks, retains and holds through an intercepted client", async () => {
+    // Given an intercepted S3 client and a versioned Bucket.
+    using simSdk = new SimSdk();
+    const client = new S3Client({ region: "us-east-1" });
+    simSdk.intercept(client);
+
+    await client.send(new CreateBucketCommand({ Bucket: bucketName }));
+    await client.send(
+      new PutBucketVersioningCommand({
+        Bucket: bucketName,
+        VersioningConfiguration: { Status: "Enabled" },
+      }),
+    );
+
+    // When every Object Lock command is sent through it.
+    await client.send(
+      new PutObjectLockConfigurationCommand({
+        Bucket: bucketName,
+        ObjectLockConfiguration: { ObjectLockEnabled: "Enabled" },
+      }),
+    );
+
+    const locking = await client.send(
+      new GetObjectLockConfigurationCommand({ Bucket: bucketName }),
+    );
+    assertIdentical(
+      locking.ObjectLockConfiguration?.ObjectLockEnabled,
+      "Enabled",
+    );
+
+    const put = await client.send(
+      new PutObjectCommand({ Bucket: bucketName, Key: key, Body: "one" }),
+    );
+    assertNonNullable(put.VersionId);
+
+    const retainUntil = new Date(Date.now() + 3_600_000);
+    await client.send(
+      new PutObjectRetentionCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId: put.VersionId,
+        Retention: { Mode: "GOVERNANCE", RetainUntilDate: retainUntil },
+      }),
+    );
+
+    await client.send(
+      new PutObjectLegalHoldCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId: put.VersionId,
+        LegalHold: { Status: "ON" },
+      }),
+    );
+
+    // Then the version reports both, and nothing can delete it.
+    const head = await client.send(
+      new HeadObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+        VersionId: put.VersionId,
+      }),
+    );
+
+    assertIdentical(head.ObjectLockMode, "GOVERNANCE");
+    assertIdentical(head.ObjectLockLegalHoldStatus, "ON");
+
+    const error = await assertThrowsErrorAsync(async () => {
+      return await client.send(
+        new DeleteObjectCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: put.VersionId,
+          BypassGovernanceRetention: true,
+        }),
+      );
+    });
+
+    assertIdentical(error.name, "AccessDenied");
+  });
+});

--- a/src/service/s3/sdk/sim-s3-sdk-object-lock-routes.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-object-lock-routes.ts
@@ -1,0 +1,50 @@
+import type { SimSdkCommandRoute } from "../../../sdk/index.js";
+import { simSdkCallerOptions } from "../../../sdk/index.js";
+import type * as simS3Commands from "../command/sim-s3-command.types.js";
+import type { SimS3 } from "../sim-s3.js";
+
+/**
+ * The SDK Commands that lock a Bucket and hold the versions in it.
+ *
+ * Two configure the Bucket and two hold one version each, and they route
+ * together because a version can only be held on a Bucket the first two turned
+ * Object Lock on for.
+ */
+export function simS3SdkObjectLockRoutes(
+  simS3: SimS3,
+): readonly (readonly [string, SimSdkCommandRoute])[] {
+  return [
+    [
+      "PutObjectLockConfigurationCommand",
+      async (command, context): Promise<unknown> =>
+        await simS3.putObjectLockConfiguration(
+          command as simS3Commands.SimPutObjectLockConfigurationCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "GetObjectLockConfigurationCommand",
+      async (command, context): Promise<unknown> =>
+        await simS3.getObjectLockConfiguration(
+          command as simS3Commands.SimGetObjectLockConfigurationCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "PutObjectRetentionCommand",
+      async (command, context): Promise<unknown> =>
+        await simS3.putObjectRetention(
+          command as simS3Commands.SimPutObjectRetentionCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "PutObjectLegalHoldCommand",
+      async (command, context): Promise<unknown> =>
+        await simS3.putObjectLegalHold(
+          command as simS3Commands.SimPutObjectLegalHoldCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+  ];
+}

--- a/src/service/s3/sim-s3-commands.ts
+++ b/src/service/s3/sim-s3-commands.ts
@@ -12,6 +12,7 @@ import { SimS3LifecycleCommands } from "./command/lifecycle/sim-s3-lifecycle-com
 import { SimS3MultipartCommands } from "./command/multipart/sim-s3-multipart-commands.js";
 import { SimS3NotificationCommands } from "./command/notification/sim-s3-notification-commands.js";
 import { SimS3ObjectCommands } from "./command/object/sim-s3-object-commands.js";
+import { SimS3ObjectLockCommands } from "./command/object-lock/sim-s3-object-lock-commands.js";
 import { SimS3PublicAccessBlockCommands } from "./command/public-access-block/sim-s3-public-access-block-commands.js";
 import { SimS3VersioningCommands } from "./command/versioning/sim-s3-versioning-commands.js";
 import type { SimS3BucketCommandState } from "./command/sim-s3-bucket-command-state.js";
@@ -64,6 +65,7 @@ export class SimS3Commands {
   public readonly notifications: SimS3NotificationCommands;
   public readonly lifecycles: SimS3LifecycleCommands;
   public readonly versioning: SimS3VersioningCommands;
+  public readonly objectLock: SimS3ObjectLockCommands;
   public readonly objects: SimS3ObjectCommands;
   public readonly multipartUploads: SimS3MultipartCommands;
   public readonly objectNotifier: SimS3ObjectNotifier;
@@ -103,6 +105,7 @@ export class SimS3Commands {
     this.notifications = new SimS3NotificationCommands(state);
     this.lifecycles = new SimS3LifecycleCommands(state);
     this.versioning = new SimS3VersioningCommands(state);
+    this.objectLock = new SimS3ObjectLockCommands(state);
     this.objects = new SimS3ObjectCommands(state);
     this.multipartUploads = new SimS3MultipartCommands(state);
   }

--- a/src/service/s3/sim-s3-operations.ts
+++ b/src/service/s3/sim-s3-operations.ts
@@ -1,17 +1,17 @@
 import type * as simS3Commands from "./command/sim-s3-command.types.js";
 import type { SimS3RequestOptions } from "./command/sim-s3-request-options.js";
-import type { SimS3Commands } from "./sim-s3-commands.js";
+import { SimS3VersionOperations } from "./sim-s3-version-operations.js";
 
 /**
  * The AWS operations simulated S3 answers. One delegation per SDK Command,
  * onto the handler in `SimS3Commands` that runs it.
  *
  * `SimS3` extends this. A caller reaches every operation on the one service
- * object, alongside the simulator-only controls `SimS3` holds itself.
+ * object, alongside the simulator-only controls `SimS3` holds itself. The
+ * operations that make a Bucket keep what it held are on
+ * `SimS3VersionOperations`, which this extends.
  */
-export abstract class SimS3Operations {
-  protected constructor(protected readonly commands: SimS3Commands) {}
-
+export abstract class SimS3Operations extends SimS3VersionOperations {
   /** Handle a Create Bucket Command from the SDK. */
   async createBucket(
     command: simS3Commands.SimCreateBucketCommand,
@@ -138,30 +138,6 @@ export abstract class SimS3Operations {
     options?: SimS3RequestOptions,
   ): Promise<simS3Commands.SimGetBucketLifecycleConfigurationCommandOutput> {
     return await this.commands.lifecycles.get(command, options);
-  }
-
-  /** Handle a Put Bucket Versioning Command from the SDK. */
-  async putBucketVersioning(
-    command: simS3Commands.SimPutBucketVersioningCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimPutBucketVersioningCommandOutput> {
-    return await this.commands.versioning.put(command, options);
-  }
-
-  /** Handle a Get Bucket Versioning Command from the SDK. */
-  async getBucketVersioning(
-    command: simS3Commands.SimGetBucketVersioningCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimGetBucketVersioningCommandOutput> {
-    return await this.commands.versioning.get(command, options);
-  }
-
-  /** Handle a List Object Versions Command from the SDK. */
-  async listObjectVersions(
-    command: simS3Commands.SimListObjectVersionsCommand,
-    options?: SimS3RequestOptions,
-  ): Promise<simS3Commands.SimListObjectVersionsCommandOutput> {
-    return await this.commands.versioning.list(command, options);
   }
 
   /** Handle a Delete Bucket Lifecycle Command from the SDK. */

--- a/src/service/s3/sim-s3-version-operations.ts
+++ b/src/service/s3/sim-s3-version-operations.ts
@@ -1,0 +1,74 @@
+import type * as simS3Commands from "./command/sim-s3-command.types.js";
+import type { SimS3RequestOptions } from "./command/sim-s3-request-options.js";
+import type { SimS3Commands } from "./sim-s3-commands.js";
+
+/**
+ * The AWS operations that make a Bucket keep what it held.
+ *
+ * Versioning is what a Bucket keeps its history in, and Object Lock is what
+ * stops anything taking that history away. Object Lock refuses a Bucket
+ * without versioning underneath it, so the two are one subject and sit
+ * together.
+ *
+ * `SimS3Operations` extends this, and `SimS3` extends that, so a caller
+ * reaches all of them on the one service object.
+ */
+export abstract class SimS3VersionOperations {
+  protected constructor(protected readonly commands: SimS3Commands) {}
+
+  /** Handle a Put Bucket Versioning Command from the SDK. */
+  async putBucketVersioning(
+    command: simS3Commands.SimPutBucketVersioningCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketVersioningCommandOutput> {
+    return await this.commands.versioning.put(command, options);
+  }
+
+  /** Handle a Get Bucket Versioning Command from the SDK. */
+  async getBucketVersioning(
+    command: simS3Commands.SimGetBucketVersioningCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketVersioningCommandOutput> {
+    return await this.commands.versioning.get(command, options);
+  }
+
+  /** Handle a List Object Versions Command from the SDK. */
+  async listObjectVersions(
+    command: simS3Commands.SimListObjectVersionsCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimListObjectVersionsCommandOutput> {
+    return await this.commands.versioning.list(command, options);
+  }
+
+  /** Handle a Put Object Lock Configuration Command from the SDK. */
+  async putObjectLockConfiguration(
+    command: simS3Commands.SimPutObjectLockConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutObjectLockConfigurationCommandOutput> {
+    return await this.commands.objectLock.putConfiguration(command, options);
+  }
+
+  /** Handle a Get Object Lock Configuration Command from the SDK. */
+  async getObjectLockConfiguration(
+    command: simS3Commands.SimGetObjectLockConfigurationCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetObjectLockConfigurationCommandOutput> {
+    return await this.commands.objectLock.getConfiguration(command, options);
+  }
+
+  /** Handle a Put Object Retention Command from the SDK. */
+  async putObjectRetention(
+    command: simS3Commands.SimPutObjectRetentionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutObjectRetentionCommandOutput> {
+    return await this.commands.objectLock.putRetention(command, options);
+  }
+
+  /** Handle a Put Object Legal Hold Command from the SDK. */
+  async putObjectLegalHold(
+    command: simS3Commands.SimPutObjectLegalHoldCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutObjectLegalHoldCommandOutput> {
+    return await this.commands.objectLock.putLegalHold(command, options);
+  }
+}


### PR DESCRIPTION
Object Lock turns "nothing in the account can delete a reader's history" from an intention into a guarantee, and a test asserting that failed here because the simulator carried the delete out. `PutObjectLockConfiguration` and `GetObjectLockConfiguration` configure a Bucket, `PutObjectRetention` and `PutObjectLegalHold` hold one version, and `GetObject` and `HeadObject` report both back. A delete naming a held version is refused with `AccessDenied`. Governance mode gives way to `BypassGovernanceRetention` from a caller holding `s3:BypassGovernanceRetention`, authorized as a decision of its own alongside the `s3:DeleteObject` the delete already needed, and compliance mode gives way to nobody. The retention boundary is read off the simulation's clock on every delete, so advancing the clock past `RetainUntilDate` is what lets a held version go. `ObjectLockConfiguration` and `ObjectLockEnabled` on an `AWS::S3::Bucket` reach the same put and leave `stack.ignoredProperties`, and Object Lock over a Bucket that keeps no versions is refused the way real S3 refuses it.

Two files went over the 300 line limit and one over the FTA threshold on the way. `SimS3VersionOperations` takes the versioning and Object Lock operations off `SimS3Operations`, the Object Lock errors move to `error/sim-s3-object-lock.error.ts`, and `simS3AuthorizeAction` in `command/authorize/` is the IAM decision every S3 authorizer was already writing out by hand.

Out of scope as the issue says: Object Lock over the served REST endpoint, a Bucket policy bounding allowable retention periods, and S3 Batch Operations. `GetObjectRetention`, `GetObjectLegalHold`, per-put lock parameters and `ObjectLockEnabledForBucket` on `CreateBucket` are absent too, and the docs say so.

Resolves #1184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated S3 Object Lock support for versioned buckets.
  * Supports governance and compliance retention, default retention, legal holds, and simulated-time expiration.
  * Added commands for configuring Object Lock, retrieving configuration, managing retention, and applying legal holds.
  * Object Lock metadata is now included in object reads and headers.
  * Added CloudFormation support for Object Lock bucket properties.
  * Governance-retention deletion bypass now requires appropriate authorization.

* **Documentation**
  * Added Object Lock usage guidance, limitations, configuration details, and an end-to-end example.

* **Tests**
  * Added comprehensive coverage for retention, legal holds, authorization, CloudFormation, routing, and deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->