### PR TITLE
feat: bound the history a versioned Bucket keeps

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1026,10 +1026,11 @@ A delete on a versioned Bucket raises `s3:ObjectRemoved:DeleteMarkerCreated` rat
 "Disabled"` is taken, and any other value is refused with `InvalidArgument`.
 - A `versionId` in a `CopySource` is still refused with `NotImplemented`. A copy reads the current
   version.
-- `NoncurrentVersionExpiration`, `NoncurrentVersionTransitions` and `ExpiredObjectDeleteMarker` are
-  stored and unread, so a noncurrent version stays until something deletes it by id. An `Expiration`
-  rule expires the current version behind a delete marker, as real S3 does, and raises nothing. See
-  [Lifecycle configuration](#lifecycle-configuration).
+- `NoncurrentVersionTransitions` is stored and unread, because storage classes are left out. An
+  `Expiration` rule expires the current version behind a delete marker, as real S3 does, and raises
+  nothing. A `NoncurrentVersionExpiration` rule bounds the history, and `ExpiredObjectDeleteMarker`
+  removes a marker left bare. See
+  [Bounding the history a versioned Bucket keeps](#bounding-the-history-a-versioned-bucket-keeps).
 - The `?versioning` and `?versions` sub-resources are refused over the served S3 REST endpoint.
   Versioning is reachable through the SDK and through a template.
 - A Bucket mounted on a filesystem directory refuses the deletion a delete marker asks for, the way
@@ -2258,8 +2259,9 @@ them disabled in favour of policies.
 ## Lifecycle configuration
 
 Sim S3 stores a Bucket's lifecycle rules and acts on them. An `Expiration` rule removes the Objects
-it selects once simulated time passes the boundary, and an `AbortIncompleteMultipartUpload` rule
-discards uploads that were started and left unfinished.
+it selects once simulated time passes the boundary, a `NoncurrentVersionExpiration` rule bounds the
+history a versioned Bucket keeps, and an `AbortIncompleteMultipartUpload` rule discards uploads that
+were started and left unfinished.
 
 Retention is otherwise the one property of a log or a backup Bucket a test cannot demonstrate.
 Reading the rules back off a deployed Bucket says the rules arrived. Putting an Object, moving the
@@ -2324,6 +2326,100 @@ Expiry happens when the Bucket is read. What `ListObjectsV2`, `GetObject` and `H
 what the rules leave at that instant, and a Bucket carrying no rules costs one comparison. Moving
 the clock backwards afterwards leaves an expired Object gone, because the rule deleted it on the way
 past.
+
+### Bounding the history a versioned Bucket keeps
+
+A versioned Bucket gains a version on every write and keeps every one of them. A
+`NoncurrentVersionExpiration` rule bounds that. `NoncurrentDays` removes a version once simulated
+time passes it, counted from the moment that version stopped being current rather than from its
+write, which is how real S3 measures it. A version written a year ago and displaced yesterday has
+been noncurrent for a day.
+
+```typescript sim-s3-noncurrent-expiry
+/**
+ * Bounding a reader's history at ninety days of noncurrent versions.
+ */
+
+import {
+  ListObjectVersionsCommand,
+  PutBucketLifecycleConfigurationCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "history-stack",
+  template: {
+    Resources: {
+      HistoryBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "reader-history" },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+await simS3.putBucketVersioning(
+  new PutBucketVersioningCommand({
+    Bucket: "reader-history",
+    VersioningConfiguration: { Status: "Enabled" },
+  }),
+);
+
+await simS3.putBucketLifecycleConfiguration(
+  new PutBucketLifecycleConfigurationCommand({
+    Bucket: "reader-history",
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: "bound-history",
+          Status: "Enabled",
+          Filter: { Prefix: "snapshots/" },
+          NoncurrentVersionExpiration: { NoncurrentDays: 90 },
+        },
+      ],
+    },
+  }),
+);
+
+const snapshot = {
+  Bucket: "reader-history",
+  Key: "snapshots/reader-1.json",
+};
+
+await simS3.putObject(new PutObjectCommand({ ...snapshot, Body: "before" }));
+await simS3.putObject(new PutObjectCommand({ ...snapshot, Body: "after" }));
+
+await simAws.clock().advanceBy({ days: 91 });
+
+const listed = await simS3.listObjectVersions(
+  new ListObjectVersionsCommand({ Bucket: "reader-history" }),
+);
+
+// The version the second write displaced has gone, and the current one stays
+// however old it is.
+console.log(listed.Versions?.length); // 1
+```
+
+`NewerNoncurrentVersions` holds that many of the most recent noncurrent versions back from the rule,
+whatever their age, so a rule keeping two reaches the third and everything older. Real S3 requires
+`NoncurrentDays` alongside it, and a rule stating the count on its own names no period to measure and
+expires nothing.
+
+`ExpiredObjectDeleteMarker` under `Expiration` removes a delete marker left with no version under it,
+which takes the key out of `ListObjectVersions` altogether. A marker still hiding a version stays,
+since that marker is what a read of the key answers with. The two run in that order in one pass, so a
+marker whose last version expired in the same pass goes with it.
+
+A noncurrent version is removed from the Bucket's history, and a `GetObject` naming its `VersionId`
+answers `NoSuchVersion` afterwards. The current version is beyond every rule of this kind, however
+old it is.
 
 ### What a rule selects
 
@@ -2415,14 +2511,17 @@ all three, and a rule stored here that real S3 would have rejected reads back lo
 CloudFormation spells some rule fields differently from the request. `Id` becomes `ID`,
 `ExpirationInDays` and `ExpirationDate` are gathered under `Expiration`, and a transition's
 `TransitionInDays` becomes `Days`. The singular `Transition` a template may state alongside
-`Transitions` joins the list. Everything else, `Status`, `Prefix`, `AbortIncompleteMultipartUpload`,
-`TagFilters` and the object size bounds among them, is carried across as the template stated it.
+`Transitions` joins the list. `NoncurrentVersionExpirationInDays` becomes the `NoncurrentDays` of a
+`NoncurrentVersionExpiration`, which is what CDK's `noncurrentVersionExpiration` synthesises, and a
+template stating the nested object instead is taken as it stands. Everything else, `Status`,
+`Prefix`, `AbortIncompleteMultipartUpload`, `TagFilters` and the object size bounds among them, is
+carried across as the template stated it.
 
 `LifecycleConfiguration` is one of the properties simulated S3 acts on. It stays out of
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without).
-The two actions it enforces are `Expiration`, whether the template flattened it onto the rule or
-not, and `AbortIncompleteMultipartUpload`. A `Transitions` rule is stored and read back and goes no
-further. Which Objects an enforced action reaches is decided by the fields listed under
+The three actions it enforces are `Expiration`, whether the template flattened it onto the rule or
+not, `NoncurrentVersionExpiration`, in either of its two spellings, and
+`AbortIncompleteMultipartUpload`. A `Transitions` rule is stored and read back and goes no further. Which Objects an enforced action reaches is decided by the fields listed under
 [What a rule selects](#what-a-rule-selects).
 
 ### Limitations
@@ -2433,10 +2532,11 @@ No Object moves between storage classes. Storage classes are left out of the sim
 Real S3 raises `s3:LifecycleExpiration:Delete` when a rule removes an Object. That event family is
 among the ones sim S3 leaves out. An expiry here is silent.
 
-`NoncurrentVersionExpiration`, `NoncurrentVersionTransitions` and `ExpiredObjectDeleteMarker` are
-stored and unread, so nothing removes a noncurrent version. An `Expiration` rule on a versioned
-Bucket writes a delete marker over the current version and leaves the version itself where it is,
-which is what real S3 does. See [Object versioning](#object-versioning).
+`NoncurrentVersionTransitions` is stored and unread, alongside `Transitions`, because storage classes
+are left out. An `Expiration` rule on a versioned Bucket writes a delete marker over the current
+version and leaves the version itself where it is, which is what real S3 does, and a
+`NoncurrentVersionExpiration` rule is what then removes it. See
+[Object versioning](#object-versioning).
 
 A Bucket mounted on a filesystem directory refuses the deletion an expiry asks for, the way it
 refuses `DeleteObject`, and answers `NotImplemented`. Removing a real file off the mounted directory

--- a/docs/services/s3/sim-s3-noncurrent-expiry.example.ts
+++ b/docs/services/s3/sim-s3-noncurrent-expiry.example.ts
@@ -1,0 +1,69 @@
+/**
+ * Bounding a reader's history at ninety days of noncurrent versions.
+ */
+
+import {
+  ListObjectVersionsCommand,
+  PutBucketLifecycleConfigurationCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.s3();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "history-stack",
+  template: {
+    Resources: {
+      HistoryBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "reader-history" },
+      },
+    },
+  },
+});
+await stack.waitForDeployComplete();
+
+await simS3.putBucketVersioning(
+  new PutBucketVersioningCommand({
+    Bucket: "reader-history",
+    VersioningConfiguration: { Status: "Enabled" },
+  }),
+);
+
+await simS3.putBucketLifecycleConfiguration(
+  new PutBucketLifecycleConfigurationCommand({
+    Bucket: "reader-history",
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: "bound-history",
+          Status: "Enabled",
+          Filter: { Prefix: "snapshots/" },
+          NoncurrentVersionExpiration: { NoncurrentDays: 90 },
+        },
+      ],
+    },
+  }),
+);
+
+const snapshot = {
+  Bucket: "reader-history",
+  Key: "snapshots/reader-1.json",
+};
+
+await simS3.putObject(new PutObjectCommand({ ...snapshot, Body: "before" }));
+await simS3.putObject(new PutObjectCommand({ ...snapshot, Body: "after" }));
+
+await simAws.clock().advanceBy({ days: 91 });
+
+const listed = await simS3.listObjectVersions(
+  new ListObjectVersionsCommand({ Bucket: "reader-history" }),
+);
+
+// The version the second write displaced has gone, and the current one stays
+// however old it is.
+console.log(listed.Versions?.length); // 1

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -212,9 +212,12 @@ is a normalized form of what was applied rather than the original text.
 `SimS3BucketObjects` holds the storage implementation, the version history, the Object Lock, the
 multipart uploads in progress and the lifecycle configuration. The Bucket delegates to it rather than
 owning all five, because they are one concern: what is under the Bucket's keys, and what time does to
-it. Every read
-goes through it, and applying lifecycle rules on the way past is what keeps an untouched Bucket free
-of the cost of having them.
+it. Every read goes through it, and applying lifecycle rules on the way past is what keeps an
+untouched Bucket free of the cost of having them. There are two such passes.
+`SimS3LifecycleSweep` works on storage, which is where an `Expiration` reaches, and it has to be
+asynchronous because storage is. `SimS3NoncurrentSweep` works on the version history, which is where
+a `NoncurrentVersionExpiration` and an `ExpiredObjectDeleteMarker` reach, and it is synchronous
+because nothing it removes was ever in storage.
 
 ## Object versions
 
@@ -225,7 +228,10 @@ that has been versioned can be suspended but never taken back, because real S3 h
 
 `SimS3ObjectVersion` is one version of one key, which is either an Object or a delete marker.
 Modelling the marker as a version holding no Object keeps the ordering in one list, and that ordering
-is what decides which version is current.
+is what decides which version is current. A version also records when it stopped being current,
+which `SimS3ObjectVersions.add` writes onto whatever it displaces. A
+`NoncurrentVersionExpiration` counts from there rather than from the write, because a version
+written a year ago and displaced yesterday has been noncurrent for a day.
 
 `SimS3ObjectVersions` is the history, keyed by Object key with each key's versions newest first. That
 is the order `ListObjectVersions` reports them in.
@@ -235,6 +241,12 @@ maintains is that **storage holds the current, undeleted Object under each key a
 Writing a delete marker takes the Object out of storage while the history keeps it, and removing a
 version puts back whatever the removal left current. Every existing reader of a Bucket, the website
 endpoint and the REST endpoint among them, therefore needs no knowledge of versions at all.
+
+That invariant is what makes the noncurrent sweep cheap. A noncurrent version and a bare delete
+marker are both outside storage, so `removeExpired` takes them straight out of the history and
+leaves storage alone, where `deleteVersion` has to put back whatever the removal left current.
+`SimS3Bucket.getVersions()` runs that sweep before handing the history out, which is the one place
+every version read goes through.
 
 ## Object Lock
 

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
 import {
   simS3LifecycleReached,
+  simS3NoncurrentExpiryInstant,
   simS3ObjectExpiryInstant,
   simS3UploadAbortInstant,
 } from "./sim-s3-lifecycle-expiry.js";
@@ -20,6 +21,21 @@ export interface SimS3LifecycleObject {
   readonly key: string;
   readonly size: number;
   readonly lastModified: Date;
+}
+
+/**
+ * A noncurrent version as a lifecycle rule reads it.
+ *
+ * `newerVersionsAhead` is how many noncurrent versions of the same key are
+ * newer than this one, which is what `NewerNoncurrentVersions` counts. The
+ * current version is not one of them, since a rule for noncurrent versions
+ * never reaches it.
+ */
+export interface SimS3LifecycleNoncurrentVersion {
+  readonly key: string;
+  readonly size: number;
+  readonly noncurrentSince: Date | undefined;
+  readonly newerVersionsAhead: number;
 }
 
 /**
@@ -106,6 +122,50 @@ export class SimS3LifecycleConfiguration {
           simS3ObjectExpiryInstant(rule.Expiration, object.lastModified),
           now,
         ),
+    );
+  }
+
+  /**
+   * Whether an enabled rule has expired a noncurrent version by the given
+   * instant.
+   *
+   * `NewerNoncurrentVersions` holds that many of the most recent noncurrent
+   * versions back from the rule, whatever their age, so a rule keeping two
+   * reaches the third and everything older.
+   */
+  expiresNoncurrent(
+    version: SimS3LifecycleNoncurrentVersion,
+    now: Date,
+  ): boolean {
+    return this.enabledRules().some((rule) => {
+      const expiration = rule.NoncurrentVersionExpiration;
+
+      return (
+        expiration !== undefined &&
+        version.newerVersionsAhead >=
+          (expiration.NewerNoncurrentVersions ?? 0) &&
+        simS3LifecycleRuleSelects(rule, version) &&
+        simS3LifecycleReached(
+          simS3NoncurrentExpiryInstant(expiration, version.noncurrentSince),
+          now,
+        )
+      );
+    });
+  }
+
+  /**
+   * Whether an enabled rule removes a delete marker with nothing left under
+   * it.
+   *
+   * Real S3 calls that an expired object delete marker and takes it away on
+   * its next pass, with no period to wait out. The marker is what keeps the
+   * key in a listing once its last version has gone.
+   */
+  expiresDeleteMarker(key: string): boolean {
+    return this.enabledRules().some(
+      (rule) =>
+        rule.Expiration?.ExpiredObjectDeleteMarker === true &&
+        simS3LifecycleRuleSelects(rule, { key }),
     );
   }
 

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.ts
@@ -1,6 +1,7 @@
 import type {
   SimS3LifecycleAbortIncompleteMultipartUpload,
   SimS3LifecycleExpiration,
+  SimS3LifecycleNoncurrentVersionExpiration,
 } from "../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
 
 const millisecondsPerDay = 24 * 60 * 60 * 1000;
@@ -15,7 +16,8 @@ const millisecondsPerDay = 24 * 60 * 60 * 1000;
  *
  * `Days` wins over `Date` when a rule carries both, though real S3 refuses to
  * store such a rule. An `Expiration` carrying only `ExpiredObjectDeleteMarker`
- * has no boundary at all, since Object versions are left out.
+ * has no boundary at all, because it names a delete marker to remove rather
+ * than a period to wait out.
  */
 export function simS3ObjectExpiryInstant(
   expiration: SimS3LifecycleExpiration,
@@ -30,6 +32,29 @@ export function simS3ObjectExpiryInstant(
   }
 
   return undefined;
+}
+
+/**
+ * The instant a `NoncurrentVersionExpiration` puts a version past, counted
+ * from when that version stopped being the current one.
+ *
+ * A version that is still current has no such instant, and neither has one
+ * under a rule stating only `NewerNoncurrentVersions`. Real S3 requires
+ * `NoncurrentDays` alongside that count, and a rule without it names no period
+ * to measure.
+ */
+export function simS3NoncurrentExpiryInstant(
+  expiration: SimS3LifecycleNoncurrentVersionExpiration,
+  noncurrentSince: Date | undefined,
+): Date | undefined {
+  if (
+    noncurrentSince === undefined ||
+    expiration.NoncurrentDays === undefined
+  ) {
+    return undefined;
+  }
+
+  return afterDays(noncurrentSince, expiration.NoncurrentDays);
 }
 
 /**

--- a/src/service/s3/bucket/lifecycle/sim-s3-noncurrent-expiry.iso.test.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-noncurrent-expiry.iso.test.ts
@@ -1,0 +1,332 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  ListObjectVersionsCommand,
+  PutBucketLifecycleConfigurationCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import type { LifecycleRule } from "@aws-sdk/client-s3";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+import type { SimS3 } from "../../sim-s3.js";
+
+const bucketName = "reader-history";
+const key = "snapshots/reader-1.json";
+
+/** A versioned Bucket carrying the given rules. */
+async function versionedBucket(
+  simAws: SimAws,
+  rules: readonly LifecycleRule[],
+): Promise<SimS3> {
+  const s3 = simAws.s3();
+
+  await s3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+  await s3.putBucketVersioning(
+    new PutBucketVersioningCommand({
+      Bucket: bucketName,
+      VersioningConfiguration: { Status: "Enabled" },
+    }),
+  );
+  await s3.putBucketLifecycleConfiguration(
+    new PutBucketLifecycleConfigurationCommand({
+      Bucket: bucketName,
+      LifecycleConfiguration: { Rules: [...rules] },
+    }),
+  );
+
+  return s3;
+}
+
+/** A rule expiring noncurrent versions of the snapshot prefix. */
+function expiresNoncurrentAfter(
+  days: number,
+  newer?: number,
+): readonly LifecycleRule[] {
+  return [
+    {
+      ID: "expire-noncurrent",
+      Status: "Enabled",
+      Filter: { Prefix: "snapshots/" },
+      NoncurrentVersionExpiration: {
+        NoncurrentDays: days,
+        ...(newer !== undefined && { NewerNoncurrentVersions: newer }),
+      },
+    },
+  ];
+}
+
+/** Write one snapshot, answering the version it was given. */
+async function putSnapshot(s3: SimS3, body: string): Promise<string> {
+  const put = await s3.putObject(
+    new PutObjectCommand({ Bucket: bucketName, Key: key, Body: body }),
+  );
+
+  assertNonNullable(put.VersionId);
+
+  return put.VersionId;
+}
+
+/** The version ids a listing reports, newest first. */
+async function listedVersions(s3: SimS3): Promise<readonly string[]> {
+  const listed = await s3.listObjectVersions(
+    new ListObjectVersionsCommand({ Bucket: bucketName }),
+  );
+
+  return (listed.Versions ?? []).map((version) => version.VersionId);
+}
+
+describe("S3 NoncurrentVersionExpiration", () => {
+  it("expires a version older than NoncurrentDays and keeps the current one", async () => {
+    // Given a Bucket bounding its history at ninety days, holding two
+    // snapshots of one reader.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, expiresNoncurrentAfter(90));
+    const first = await putSnapshot(s3, "before");
+    const second = await putSnapshot(s3, "after");
+
+    // When simulated time passes the ninety days.
+    await simAws.clock().advanceBy({ days: 91 });
+
+    // Then the displaced version is gone from the listing and the current one
+    // stays, however old it is. The current version has no displacement to
+    // count from, which is what keeps every rule for noncurrent ones off it.
+    assertArrayEquals(await listedVersions(s3), [second]);
+    assertUndefined(
+      simAws.s3().getSimBucketByName(bucketName)?.getVersions().current(key)
+        ?.noncurrentSince,
+    );
+
+    // And reading it by its own id finds nothing.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await s3.getObject(
+        new GetObjectCommand({
+          Bucket: bucketName,
+          Key: key,
+          VersionId: first,
+        }),
+      );
+    });
+
+    assertIdentical(error.name, "NoSuchVersion");
+
+    // And the current version still reads.
+    const current = await s3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: key }),
+    );
+    assertNonNullable(current.Body);
+
+    const body = await simS3BodyToBuffer(current.Body);
+    assertIdentical(body.toString(), "after");
+  });
+
+  it("counts the period from the displacement rather than the write", async () => {
+    // Given a snapshot written and left as the current version for a year.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, expiresNoncurrentAfter(90));
+    const first = await putSnapshot(s3, "before");
+
+    await simAws.clock().advanceBy({ days: 365 });
+
+    // When a second write displaces it and a day passes.
+    const second = await putSnapshot(s3, "after");
+    await simAws.clock().advanceBy({ days: 1 });
+
+    // Then it is still there, having been noncurrent for a day rather than a
+    // year.
+    assertArrayEquals(await listedVersions(s3), [second, first]);
+
+    // And ninety days after the displacement it goes.
+    await simAws.clock().advanceBy({ days: 90 });
+
+    assertArrayEquals(await listedVersions(s3), [second]);
+  });
+
+  it("keeps the number of noncurrent versions NewerNoncurrentVersions names", async () => {
+    // Given a rule keeping the two most recent noncurrent versions.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, expiresNoncurrentAfter(30, 2));
+
+    await putSnapshot(s3, "one");
+    const second = await putSnapshot(s3, "two");
+    const third = await putSnapshot(s3, "three");
+    const current = await putSnapshot(s3, "four");
+
+    // When every one of them is older than thirty days.
+    await simAws.clock().advanceBy({ days: 31 });
+
+    // Then the current version and the two newest noncurrent ones stay, and
+    // the oldest goes.
+    assertArrayEquals(await listedVersions(s3), [current, third, second]);
+  });
+
+  it("leaves versions alone under a Disabled rule", async () => {
+    // Given the same rule turned off.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, [
+      {
+        ID: "expire-noncurrent",
+        Status: "Disabled",
+        Filter: { Prefix: "snapshots/" },
+        NoncurrentVersionExpiration: { NoncurrentDays: 90 },
+      },
+    ]);
+    await putSnapshot(s3, "before");
+    await putSnapshot(s3, "after");
+
+    // When a year passes, then both versions are still there.
+    await simAws.clock().advanceBy({ days: 365 });
+
+    assertArrayLength(await listedVersions(s3), 2);
+  });
+
+  it("reaches only the keys its prefix names", async () => {
+    // Given a rule scoped to the snapshot prefix.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, expiresNoncurrentAfter(90));
+
+    await putSnapshot(s3, "before");
+    await putSnapshot(s3, "after");
+
+    const other = { Bucket: bucketName, Key: "exports/reader-1.csv" };
+    await s3.putObject(new PutObjectCommand({ ...other, Body: "before" }));
+    await s3.putObject(new PutObjectCommand({ ...other, Body: "after" }));
+
+    // When a year passes.
+    await simAws.clock().advanceBy({ days: 365 });
+
+    // Then the snapshot lost its noncurrent version and the export kept both.
+    const listed = await s3.listObjectVersions(
+      new ListObjectVersionsCommand({ Bucket: bucketName }),
+    );
+    const byKey = (listed.Versions ?? []).filter(
+      (version) => version.Key === "exports/reader-1.csv",
+    );
+
+    assertArrayLength(listed.Versions ?? [], 3);
+    assertArrayLength(byKey, 2);
+  });
+
+  it("expires nothing under a rule naming no period to wait out", async () => {
+    // Given a rule keeping two noncurrent versions and stating no
+    // NoncurrentDays, which real S3 requires alongside that count.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, [
+      {
+        ID: "expire-noncurrent",
+        Status: "Enabled",
+        Filter: { Prefix: "snapshots/" },
+        NoncurrentVersionExpiration: { NewerNoncurrentVersions: 2 },
+      },
+    ]);
+
+    await putSnapshot(s3, "one");
+    await putSnapshot(s3, "two");
+    await putSnapshot(s3, "three");
+    await putSnapshot(s3, "four");
+
+    // When a year passes, then every version is still there. A count with no
+    // period behind it names nothing to measure.
+    await simAws.clock().advanceBy({ days: 365 });
+
+    assertArrayLength(await listedVersions(s3), 4);
+  });
+
+  it("expires a delete marker that has become noncurrent", async () => {
+    // Given a key written, deleted, and written again, which leaves the
+    // marker as a noncurrent version between the two writes.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, expiresNoncurrentAfter(90));
+
+    await putSnapshot(s3, "before");
+    await s3.deleteObject(
+      new DeleteObjectCommand({ Bucket: bucketName, Key: key }),
+    );
+    const current = await putSnapshot(s3, "after");
+
+    // When the ninety days pass.
+    await simAws.clock().advanceBy({ days: 91 });
+
+    // Then the marker goes with the version under it, since a noncurrent
+    // marker is a noncurrent version like any other.
+    const listed = await s3.listObjectVersions(
+      new ListObjectVersionsCommand({ Bucket: bucketName }),
+    );
+
+    assertArrayLength(listed.DeleteMarkers ?? [], 0);
+    assertArrayEquals(await listedVersions(s3), [current]);
+  });
+
+  it("removes a delete marker left with nothing under it", async () => {
+    // Given a rule expiring noncurrent versions and the delete markers left
+    // bare by them.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, [
+      {
+        ID: "expire-noncurrent",
+        Status: "Enabled",
+        Filter: { Prefix: "snapshots/" },
+        NoncurrentVersionExpiration: { NoncurrentDays: 90 },
+        Expiration: { ExpiredObjectDeleteMarker: true },
+      },
+    ]);
+
+    await putSnapshot(s3, "before");
+    await s3.deleteObject(
+      new DeleteObjectCommand({ Bucket: bucketName, Key: key }),
+    );
+
+    // When the version under the marker expires.
+    await simAws.clock().advanceBy({ days: 91 });
+
+    // Then the marker goes with it and the key leaves the listing entirely.
+    const listed = await s3.listObjectVersions(
+      new ListObjectVersionsCommand({ Bucket: bucketName }),
+    );
+
+    assertArrayLength(listed.Versions ?? [], 0);
+    assertArrayLength(listed.DeleteMarkers ?? [], 0);
+  });
+
+  it("keeps a delete marker with a version still under it", async () => {
+    // Given the same rule, and a key whose noncurrent version is too young to
+    // expire.
+    const simAws = new SimAws();
+    const s3 = await versionedBucket(simAws, [
+      {
+        ID: "expire-noncurrent",
+        Status: "Enabled",
+        Filter: { Prefix: "snapshots/" },
+        NoncurrentVersionExpiration: { NoncurrentDays: 90 },
+        Expiration: { ExpiredObjectDeleteMarker: true },
+      },
+    ]);
+
+    await putSnapshot(s3, "before");
+    await s3.deleteObject(
+      new DeleteObjectCommand({ Bucket: bucketName, Key: key }),
+    );
+
+    // When a day passes, then the marker stays, because the version beneath it
+    // is still there and the marker is what hides it.
+    await simAws.clock().advanceBy({ days: 1 });
+
+    const listed = await s3.listObjectVersions(
+      new ListObjectVersionsCommand({ Bucket: bucketName }),
+    );
+
+    assertArrayLength(listed.Versions ?? [], 1);
+    assertArrayLength(listed.DeleteMarkers ?? [], 1);
+  });
+});

--- a/src/service/s3/bucket/lifecycle/sim-s3-noncurrent-sweep.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-noncurrent-sweep.ts
@@ -1,0 +1,120 @@
+import type { SimS3BucketVersions } from "../versioning/sim-s3-bucket-versions.js";
+import type { SimS3ObjectVersion } from "../versioning/sim-s3-object-version.js";
+import type { SimS3LifecycleConfiguration } from "./sim-s3-lifecycle-configuration.js";
+
+/**
+ * One pass over what a Bucket's rules have expired in its version history.
+ *
+ * The Object sweep works on storage, which holds the current Object under each
+ * key and nothing else. Everything a `NoncurrentVersionExpiration` reaches is
+ * therefore invisible to it, and so is the delete marker an
+ * `ExpiredObjectDeleteMarker` removes. Both live in the history alone, which
+ * is why removing them touches no storage and this pass is synchronous where
+ * the Object sweep cannot be.
+ *
+ * A Bucket is swept when its versions are read, the way an Object is swept
+ * when it is. Nothing runs on a schedule.
+ */
+export class SimS3NoncurrentSweep {
+  private readonly lifecycle: SimS3LifecycleConfiguration;
+  private readonly now: Date;
+
+  constructor(lifecycle: SimS3LifecycleConfiguration, now: Date) {
+    this.lifecycle = lifecycle;
+    this.now = now;
+  }
+
+  /**
+   * Remove what the rules have expired from a Bucket's history.
+   */
+  sweep(versions: SimS3BucketVersions): void {
+    if (this.lifecycle.isEmpty || !versions.keepsVersions) {
+      return;
+    }
+
+    for (const held of byKey(versions.list()).values()) {
+      this.sweepKey(versions, held);
+    }
+  }
+
+  /**
+   * Remove what the rules have expired of one key.
+   *
+   * The noncurrent versions go first and a delete marker left bare goes
+   * second, so a marker whose last version went in this same pass goes with
+   * it. Real S3 orders the two the same way.
+   *
+   * The head of the list is the current version and no rule for noncurrent
+   * ones reaches it, however old it is. Everything after it is counted from
+   * the newest, which is the count `NewerNoncurrentVersions` holds back.
+   */
+  private sweepKey(
+    versions: SimS3BucketVersions,
+    held: readonly SimS3ObjectVersion[],
+  ): void {
+    const kept: SimS3ObjectVersion[] = [];
+
+    for (const [index, version] of held.entries()) {
+      if (index === 0 || !this.expires(version, index - 1)) {
+        kept.push(version);
+        continue;
+      }
+
+      versions.removeExpired(version.key, version.versionId);
+    }
+
+    this.sweepDeleteMarker(versions, kept);
+  }
+
+  /**
+   * Remove a delete marker the rules have expired, which is one left with no
+   * version under it at all.
+   *
+   * That takes the key out of `ListObjectVersions` altogether, since the
+   * marker was the only thing left holding the key there.
+   */
+  private sweepDeleteMarker(
+    versions: SimS3BucketVersions,
+    kept: readonly SimS3ObjectVersion[],
+  ): void {
+    const marker = kept[0];
+
+    if (
+      kept.length === 1 &&
+      marker?.isDeleteMarker === true &&
+      this.lifecycle.expiresDeleteMarker(marker.key)
+    ) {
+      versions.removeExpired(marker.key, marker.versionId);
+    }
+  }
+
+  private expires(version: SimS3ObjectVersion, ahead: number): boolean {
+    return this.lifecycle.expiresNoncurrent(
+      {
+        key: version.key,
+        size: version.isDeleteMarker ? 0 : version.object.body.length,
+        noncurrentSince: version.noncurrentSince,
+        newerVersionsAhead: ahead,
+      },
+      this.now,
+    );
+  }
+}
+
+/**
+ * The versions of one Bucket, gathered under the key each belongs to.
+ *
+ * A listing already holds each key's versions together and newest first, so
+ * this keeps that order and only groups them.
+ */
+function byKey(
+  listed: readonly SimS3ObjectVersion[],
+): ReadonlyMap<string, SimS3ObjectVersion[]> {
+  const grouped = new Map<string, SimS3ObjectVersion[]>();
+
+  for (const version of listed) {
+    grouped.set(version.key, [...(grouped.get(version.key) ?? []), version]);
+  }
+
+  return grouped;
+}

--- a/src/service/s3/bucket/sim-s3-bucket-objects.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-objects.ts
@@ -4,6 +4,7 @@ import type { SimS3BucketStorage } from "../storage/s3-bucket-storage.js";
 import { SimS3MultipartUploads } from "../upload/sim-s3-multipart-uploads.js";
 import { SimS3BucketObjectLock } from "./lock/sim-s3-bucket-object-lock.js";
 import { SimS3LifecycleConfiguration } from "./lifecycle/sim-s3-lifecycle-configuration.js";
+import { SimS3NoncurrentSweep } from "./lifecycle/sim-s3-noncurrent-sweep.js";
 import { SimS3LifecycleSweep } from "./lifecycle/sim-s3-lifecycle-sweep.js";
 import { SimS3ObjectDeletion } from "./sim-s3-object-deletion.js";
 import type { SimS3BucketVersioning } from "./versioning/sim-s3-bucket-versioning.js";
@@ -107,6 +108,7 @@ export class SimS3BucketObjects {
     versionId: string,
     bypassGovernance = false,
   ): Promise<SimS3ObjectVersion | undefined> {
+    this.sweptVersions();
     this.objectLock.assertDeletable(
       this.versions.find(key, versionId),
       this.clock.now(),
@@ -114,6 +116,22 @@ export class SimS3BucketObjects {
     );
 
     return await this.versions.deleteVersion(this.storage, key, versionId);
+  }
+
+  /**
+   * The versions this Bucket keeps, with whatever the rules have expired gone.
+   *
+   * Every read of the history goes through here, the way every read of an
+   * Object goes through the Object sweep. A noncurrent version and a bare
+   * delete marker are both invisible to storage, so this removes them without
+   * touching it.
+   */
+  sweptVersions(): SimS3BucketVersions {
+    new SimS3NoncurrentSweep(this.lifecycle, this.clock.now()).sweep(
+      this.versions,
+    );
+
+    return this.versions;
   }
 
   /**

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -133,7 +133,7 @@ export class SimS3Bucket {
 
   /** The versions this Bucket keeps, and whether it keeps any. */
   getVersions(): SimS3BucketVersions {
-    return this.objects.versions;
+    return this.objects.sweptVersions();
   }
 
   /** How this Bucket is locked, and what that does to a write and a delete. */

--- a/src/service/s3/bucket/versioning/sim-s3-bucket-versions.ts
+++ b/src/service/s3/bucket/versioning/sim-s3-bucket-versions.ts
@@ -157,6 +157,17 @@ export class SimS3BucketVersions {
   }
 
   /**
+   * Take a version a lifecycle rule expired out of the history.
+   *
+   * Storage is left alone, unlike `deleteVersion`. A rule for noncurrent
+   * versions never reaches the current one, and a delete marker holds no
+   * bytes, so nothing this removes was in storage to begin with.
+   */
+  removeExpired(key: string, versionId: string): void {
+    this.history.remove(key, versionId);
+  }
+
+  /**
    * Every version this Bucket holds, in the order a listing reports them.
    */
   list(prefix?: string): readonly SimS3ObjectVersion[] {

--- a/src/service/s3/bucket/versioning/sim-s3-object-version.ts
+++ b/src/service/s3/bucket/versioning/sim-s3-object-version.ts
@@ -36,6 +36,8 @@ export class SimS3ObjectVersion {
    */
   public readonly lock = new SimS3ObjectLock();
 
+  private displaced: Date | undefined;
+
   private readonly createdAt: Date;
   private readonly stored: SimS3Object | undefined;
 
@@ -92,5 +94,37 @@ export class SimS3ObjectVersion {
    */
   get lastModified(): Date {
     return new Date(this.createdAt);
+  }
+
+  /**
+   * When this version stopped being the current one, if it has.
+   *
+   * A `NoncurrentVersionExpiration` counts from here rather than from the
+   * write, because a version written a year ago and displaced yesterday has
+   * been noncurrent for a day. Real S3 measures it the same way.
+   */
+  get noncurrentSince(): Date | undefined {
+    const displaced = this.displaced;
+
+    return displaced === undefined ? undefined : new Date(displaced);
+  }
+
+  /**
+   * Record that a newer version has taken this one's place.
+   *
+   * Only the first displacement counts. Removing the version that displaced
+   * this one makes it current again, and a later write displaces it a second
+   * time, which real S3 measures from the later of the two.
+   */
+  displacedAt(instant: Date): void {
+    this.displaced = new Date(instant);
+  }
+
+  /**
+   * Record that this version is current again, which is what removing the
+   * version above it does.
+   */
+  restored(): void {
+    this.displaced = undefined;
   }
 }

--- a/src/service/s3/bucket/versioning/sim-s3-object-versions.ts
+++ b/src/service/s3/bucket/versioning/sim-s3-object-versions.ts
@@ -15,9 +15,14 @@ export class SimS3ObjectVersions {
 
   /**
    * Put a version at the head of its key, making it the current one.
+   *
+   * Whatever was at the head stops being current at that instant, and is told
+   * so, because a `NoncurrentVersionExpiration` counts from there.
    */
   add(version: SimS3ObjectVersion): void {
     const versions = this.byKey.get(version.key) ?? [];
+
+    versions[0]?.displacedAt(version.lastModified);
     this.byKey.set(version.key, [version, ...versions]);
   }
 
@@ -73,6 +78,12 @@ export class SimS3ObjectVersions {
     if (kept.length === 0) {
       this.byKey.delete(key);
     } else {
+      // Whatever the removal left at the head is current again, and stops
+      // counting towards a noncurrent expiry.
+      if (removed === versions[0]) {
+        kept[0]?.restored();
+      }
+
       this.byKey.set(key, kept);
     }
 

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-configuration.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-configuration.ts
@@ -10,7 +10,8 @@ import type {
 import { s3BucketResourceError } from "../error/sim-cfn-s3-bucket-error.js";
 import {
   simCfnS3CarriedRuleFields,
-  simCfnS3LifecycleDate,
+  simCfnS3RuleExpiration,
+  simCfnS3RuleNoncurrentExpiration,
   simCfnS3StatedFields,
 } from "./sim-cfn-s3-bucket-lifecycle-fields.js";
 import { readSimCfnS3LifecycleTransitions } from "./sim-cfn-s3-bucket-lifecycle-transitions.js";
@@ -71,7 +72,8 @@ export class SimCfnS3BucketLifecycleConfiguration {
       ...simCfnS3CarriedRuleFields(rule),
       ...simCfnS3StatedFields({
         ID: rule["Id"],
-        Expiration: this.expiration(rule),
+        Expiration: simCfnS3RuleExpiration(rule),
+        NoncurrentVersionExpiration: simCfnS3RuleNoncurrentExpiration(rule),
         Transitions: readSimCfnS3LifecycleTransitions({
           shape: this.shape,
           listed: rule["Transitions"],
@@ -80,21 +82,5 @@ export class SimCfnS3BucketLifecycleConfiguration {
         }),
       }),
     };
-  }
-
-  /**
-   * The three flattened expiry fields, gathered under the one the request
-   * carries. A rule stating none of them keeps no `Expiration` at all.
-   */
-  private expiration(
-    rule: SimCfnTemplateValueRecord,
-  ): SimCfnTemplateValue | undefined {
-    const expiration = {
-      Date: simCfnS3LifecycleDate(rule["ExpirationDate"]),
-      Days: rule["ExpirationInDays"],
-      ExpiredObjectDeleteMarker: rule["ExpiredObjectDeleteMarker"],
-    };
-
-    return simCfnS3StatedFields(expiration);
   }
 }

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-fields.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-bucket-lifecycle-fields.ts
@@ -7,7 +7,10 @@ import type {
  * The rule fields CloudFormation and the SDK spell differently.
  *
  * CloudFormation flattens an expiry onto the rule and names a transition's
- * timing after it, where the request nests both. Everything absent from here,
+ * timing after it, where the request nests both. It carries the noncurrent
+ * expiry both ways, as the nested object the request takes and as the older
+ * `NoncurrentVersionExpirationInDays` beside it, which is what CDK's
+ * `noncurrentVersionExpiration` synthesises. Everything absent from here,
  * `Status`, `Prefix`, `AbortIncompleteMultipartUpload`, `TagFilters` and the
  * object size bounds among them, is spelled the same way in both and goes
  * through untouched.
@@ -17,6 +20,8 @@ export const simCfnS3TranslatedLifecycleFields: ReadonlySet<string> = new Set([
   "ExpirationDate",
   "ExpirationInDays",
   "ExpiredObjectDeleteMarker",
+  "NoncurrentVersionExpiration",
+  "NoncurrentVersionExpirationInDays",
   "Transition",
   "Transitions",
 ]);
@@ -69,4 +74,40 @@ export function simCfnS3CarriedRuleFields(
       ([name]) => !simCfnS3TranslatedLifecycleFields.has(name),
     ),
   );
+}
+
+/**
+ * The three flattened expiry fields, gathered under the one the request
+ * carries. A rule stating none of them keeps no `Expiration` at all.
+ */
+export function simCfnS3RuleExpiration(
+  rule: SimCfnTemplateValueRecord,
+): SimCfnTemplateValue | undefined {
+  return simCfnS3StatedFields({
+    Date: simCfnS3LifecycleDate(rule["ExpirationDate"]),
+    Days: rule["ExpirationInDays"],
+    ExpiredObjectDeleteMarker: rule["ExpiredObjectDeleteMarker"],
+  });
+}
+
+/**
+ * The noncurrent expiry, from whichever of the two spellings the rule used.
+ *
+ * The nested object is the one the request takes and wins where a template
+ * states it. `NoncurrentVersionExpirationInDays` is the older flattened field
+ * beside it, and is what CDK synthesises, so a rule carrying only that one
+ * still reaches the versions it names.
+ */
+export function simCfnS3RuleNoncurrentExpiration(
+  rule: SimCfnTemplateValueRecord,
+): SimCfnTemplateValue | undefined {
+  const nested = rule["NoncurrentVersionExpiration"];
+
+  if (nested !== undefined) {
+    return nested;
+  }
+
+  return simCfnS3StatedFields({
+    NoncurrentDays: rule["NoncurrentVersionExpirationInDays"],
+  });
 }

--- a/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-noncurrent-expiry.iso.test.ts
+++ b/src/service/s3/cfn/bucket/lifecycle/sim-cfn-s3-noncurrent-expiry.iso.test.ts
@@ -1,0 +1,120 @@
+import {
+  ListObjectVersionsCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { assertArrayEquals, assertNonNullable } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimS3 } from "../../../sim-s3.js";
+
+const bucketName = "reader-history";
+const key = "snapshots/reader-1.json";
+
+/** Write one snapshot, answering the version it was given. */
+async function putSnapshot(s3: SimS3, body: string): Promise<string> {
+  const put = await s3.putObject(
+    new PutObjectCommand({ Bucket: bucketName, Key: key, Body: body }),
+  );
+
+  assertNonNullable(put.VersionId);
+
+  return put.VersionId;
+}
+
+/** The version ids a listing reports, newest first. */
+async function listedVersions(s3: SimS3): Promise<readonly string[]> {
+  const listed = await s3.listObjectVersions(
+    new ListObjectVersionsCommand({ Bucket: bucketName }),
+  );
+
+  return (listed.Versions ?? []).map((version) => version.VersionId);
+}
+
+describe("AWS::S3::Bucket NoncurrentVersionExpiration", () => {
+  it("expires a version a template's flattened rule names", async () => {
+    // Given a Bucket deployed from a template stating the older
+    // NoncurrentVersionExpirationInDays, which is what CDK synthesises for
+    // noncurrentVersionExpiration.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "history-stack",
+      template: {
+        Resources: {
+          HistoryBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: bucketName,
+              VersioningConfiguration: { Status: "Enabled" },
+              LifecycleConfiguration: {
+                Rules: [
+                  {
+                    Id: "expire-noncurrent",
+                    Status: "Enabled",
+                    Prefix: "snapshots/",
+                    NoncurrentVersionExpirationInDays: 90,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const s3 = simAws.s3();
+    await putSnapshot(s3, "before");
+    const second = await putSnapshot(s3, "after");
+
+    // When simulated time passes the ninety days.
+    await simAws.clock().advanceBy({ days: 91 });
+
+    // Then the displaced version is gone, the same as one a request named.
+    assertArrayEquals(await listedVersions(s3), [second]);
+  });
+  it("expires a version a template's nested rule names", async () => {
+    // Given a template stating the nested NoncurrentVersionExpiration the
+    // request itself takes, rather than the flattened field beside it.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "history-stack",
+      template: {
+        Resources: {
+          HistoryBucket: {
+            Type: "AWS::S3::Bucket",
+            Properties: {
+              BucketName: bucketName,
+              VersioningConfiguration: { Status: "Enabled" },
+              LifecycleConfiguration: {
+                Rules: [
+                  {
+                    Id: "expire-noncurrent",
+                    Status: "Enabled",
+                    Prefix: "snapshots/",
+                    NoncurrentVersionExpiration: {
+                      NoncurrentDays: 90,
+                      NewerNoncurrentVersions: 1,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    const s3 = simAws.s3();
+    await putSnapshot(s3, "one");
+    const second = await putSnapshot(s3, "two");
+    const current = await putSnapshot(s3, "three");
+
+    // When the ninety days pass.
+    await simAws.clock().advanceBy({ days: 91 });
+
+    // Then the count the nested rule carried is honoured too.
+    assertArrayEquals(await listedVersions(s3), [current, second]);
+  });
+});


### PR DESCRIPTION
A versioned Bucket gained a version on every write and kept every one of them, because `NoncurrentVersionExpiration` was stored and unread. `NoncurrentDays` now removes a version once simulated time passes it, counted from when that version stopped being current rather than from its write, which is how real S3 measures it. A version records that instant when the next write or delete marker displaces it, and gives it up again when the version above it goes. `NewerNoncurrentVersions` holds that many of the most recent noncurrent versions back from the rule whatever their age, and `ExpiredObjectDeleteMarker` removes a marker left with no version under it, taking the key out of `ListObjectVersions` altogether. The two run in one pass in that order, so a marker whose last version expired in the same pass goes with it.

`SimS3NoncurrentSweep` runs when a Bucket's versions are read, the way `SimS3LifecycleSweep` runs when an Object is read. It is synchronous where that one cannot be, because a noncurrent version and a bare delete marker both sit outside storage under the invariant `SimS3BucketVersions` already maintains, so removing them touches no storage. `SimS3Bucket.getVersions()` is the single place every version read goes through, which is where the sweep hangs.

One thing beyond the issue's list, found while checking the `cloudformation` label. CloudFormation carries the noncurrent expiry two ways, and only the nested object was passing through. `NoncurrentVersionExpirationInDays` is the older flattened field beside it and is what CDK's `noncurrentVersionExpiration` synthesises, so a CDK stack would have deployed a rule that silently expired nothing. It is translated now, with a test for each spelling.

Out of scope as the issue says: `NoncurrentVersionTransitions`, which stays stored and unenforced alongside `Transitions` while storage classes are left out, and the `s3:LifecycleExpiration:*` events, which stay unraised for an expiry of any kind.

Resolves #1185