### PR TITLE
feat: check a skipped CloudFormation property

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -3404,9 +3404,13 @@ Three things are still refused outright, and fail the Resource:
 - A value real AWS answers with a 400, on a property that is skipped. Nothing acts on the property
   either way, and what it says is read far enough to catch a template CloudFormation will reject. A
   value that passes is recorded like any other skipped property. One that fails takes the Resource
-  with it, before anything is recorded against it. An `AWS::S3::Bucket` `ReplicationConfiguration`
-  is the one that does this today. See
-  [Buckets from CloudFormation](https://yulinsim.dev/services/s3/#buckets-from-cloudformation "Buckets from CloudFormation").
+  with it, before anything is recorded against it. Two properties do this today. An
+  `AWS::S3::Bucket` `ReplicationConfiguration` is checked against the constraints the S3 API
+  documents, covered under
+  [Buckets from CloudFormation](https://yulinsim.dev/services/s3/#buckets-from-cloudformation "Buckets from CloudFormation"),
+  and an `AWS::SQS::Queue` `KmsDataKeyReusePeriodSeconds` against the minute to a day real SQS
+  accepts, covered under
+  [Deploying a queue from CloudFormation](https://yulinsim.dev/services/sqs/#deploying-a-queue-from-cloudformation "Deploying a queue from CloudFormation").
 
 Properties nothing simulated could tell apart are left off the list. There is no simulated KMS and
 Object bytes are stored as they arrive. An `AWS::S3::Bucket` carrying `BucketEncryption` and `Tags`,

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -1101,6 +1101,12 @@ A stack full of queues still deploys. Those properties are `RedriveAllowPolicy`,
 `DeduplicationScope`, `FifoThroughputLimit` and `Tags`. A property outside the `AWS::SQS::Queue`
 schema is recorded the same way.
 
+`KmsDataKeyReusePeriodSeconds` is read for one thing before being recorded. Real SQS takes a period
+between 60 seconds and 86,400, and answers anything else with `InvalidAttributeValue`, which fails
+the stack at `CreateQueue`. Nothing here encrypts a message either way, and a queue that deployed
+with a period outside that range would report a template CloudFormation rejects as working. A period
+inside it is recorded like any other skipped property.
+
 `AWS::SQS::QueuePolicy` deploys the policy it names onto each queue in its `Queues` list, through
 `SetQueueAttributes`. A policy declared in a template is therefore validated and enforced exactly as
 one set through the SDK, and a document SQS would refuse fails the resource. `Queues` carries queue
@@ -1194,6 +1200,8 @@ Current documented limitations:
 - Encryption is left out. `KmsMasterKeyId`, `KmsDataKeyReusePeriodSeconds` and
   `SqsManagedSseEnabled` are recorded on an `AWS::SQS::Queue` and applied to nothing, and message
   bodies are held in process memory as they were sent. Anything sharing the process can read them.
+  The one thing read off them is the range on `KmsDataKeyReusePeriodSeconds`, so a template real
+  SQS refuses does not deploy here.
 - Tags are left out. `TagQueue`, `UntagQueue` and `ListQueueTags` are absent, and `CreateQueue`
   refuses a `tags` parameter rather than dropping it.
 - `SenderId` is left out, because a simulated caller has no user or role id to report it as.

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -594,6 +594,38 @@ shared provider's `Layers`, which is why a Layer is recognised on being a Layer 
 Keeping the two lists apart is the whole point. `stack.skippedResources` is what a test would find
 missing; running the deliberate omissions in with the gaps is how the gaps stop being findable.
 
+## Properties a Resource was created without
+
+`resource/ignore/` holds the level below a skipped Resource. A service that cannot act on one
+property of a Resource it otherwise creates records the omission through `SimCfnPropertyIgnorer`,
+and `SimCfnIgnoredProperties` collects them for the Resource and the stack. The Resource still
+deploys, because a Bucket without its access logging is a usable Bucket, and the record is what
+lets a test find out that the setting was never applied.
+
+`SimCfnSkippedProperties` is the seam a service reaches that through. It is built from the map a
+service already keeps of the properties it skips, the Resource's declared properties, and the error
+builder that service refuses its own Resources with. Two things come off it. `reasonFor(name)` is
+the lookup the recording loop already did, and `assertConstraints()` is the part worth adding.
+
+A skipped property can carry a value real AWS answers with a 400 as readily as a simulated one can.
+Deploying it here reports a template AWS refuses as working, which is the one failure a local deploy
+of a real template exists to catch. So a service states what such a value has to satisfy beside the
+reason it skips it. That entry becomes a `SimCfnSkippedPropertyRule`, and the constraint on it runs
+wherever the property is recorded. Both shapes live in the one map, so a service with nothing to
+check keeps its plain strings.
+
+A constraint reads the whole Resource rather than its own value alone, because the constraints AWS
+enforces on a property it is not acting on are usually about a second one. It refuses through the
+`refuse` handed to it, which keeps the wording the service's. That matters here more than it looks.
+Sim CloudFormation downgrades a failure reading as an unsupported Resource type into a skip, and a
+skipped Resource would deploy the very template the constraint exists to refuse.
+
+Every constraint runs before anything is recorded, so a Resource failing one leaves no half-written
+list of what it was created without.
+
+`AWS::S3::Bucket` `ReplicationConfiguration` and `AWS::SQS::Queue` `KmsDataKeyReusePeriodSeconds`
+are the two through the seam today.
+
 ## Resource teardown loop
 
 `SimCfnStackResourceDeleter` owns the reverse-dependency-ordered deletion loop, and mirrors

--- a/src/service/cloudformation/resource/ignore/sim-cfn-skipped-properties.iso.test.ts
+++ b/src/service/cloudformation/resource/ignore/sim-cfn-skipped-properties.iso.test.ts
@@ -1,0 +1,149 @@
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { SimCfnSkippedProperties } from "./sim-cfn-skipped-properties.js";
+import type {
+  SimCfnSkippedPropertyRule,
+  SimCfnSkippedPropertyValue,
+} from "./sim-cfn-skipped-property.type.js";
+
+/** The error one made-up service refuses its own Resources with. */
+const refusal = (reason: string): Error =>
+  new Error(`Invalid Test::Service::Thing Resource Thing: ${reason}`);
+
+function skipped(
+  properties: SimCfnTemplateValueRecord,
+  rules: ReadonlyMap<string, SimCfnSkippedPropertyRule | string>,
+): SimCfnSkippedProperties {
+  return new SimCfnSkippedProperties({ rules, properties, error: refusal });
+}
+
+describe("constraints on a skipped CloudFormation property", () => {
+  it("reads the reason off either shape a rule takes", () => {
+    // Given one property naming a reason alone and one naming a constraint
+    // beside it.
+    const rules = new Map<string, SimCfnSkippedPropertyRule | string>([
+      ["Plain", "nothing here acts on it"],
+      [
+        "Checked",
+        {
+          reason: "nothing here acts on it either",
+          constraint: (declared) => void declared,
+        },
+      ],
+    ]);
+
+    // When each reason is read.
+    const properties = skipped({}, rules);
+
+    // Then both answer, and a property this service has no entry for answers
+    // with nothing.
+    assertIdentical(properties.reasonFor("Plain"), "nothing here acts on it");
+    assertIdentical(
+      properties.reasonFor("Checked"),
+      "nothing here acts on it either",
+    );
+    assertUndefined(properties.reasonFor("Unknown"));
+  });
+
+  it("refuses the Resource in the service's own words", () => {
+    // Given a constraint that refuses whatever it is handed.
+    const rules = new Map<string, SimCfnSkippedPropertyRule | string>([
+      [
+        "Checked",
+        {
+          reason: "nothing here acts on it",
+          constraint: (declared) => declared.refuse("Checked has to be a name"),
+        },
+      ],
+    ]);
+
+    // When a Resource declaring it is checked, then the refusal carries the
+    // wording the service builds its own errors with. Sim CloudFormation
+    // reads that wording to decide whether to skip the Resource or fail the
+    // stack, so the constraint never words its own.
+    const error = assertThrowsError(() => {
+      skipped({ Checked: 1 }, rules).assertConstraints();
+    });
+
+    assertIdentical(
+      error.message,
+      "Invalid Test::Service::Thing Resource Thing: Checked has to be a name",
+    );
+  });
+
+  it("hands a constraint the value and the Resource around it", () => {
+    // Given a constraint reading a second property beside its own, which is
+    // the shape most of these constraints take.
+    const seen: SimCfnSkippedPropertyValue[] = [];
+    const rules = new Map<string, SimCfnSkippedPropertyRule | string>([
+      [
+        "Checked",
+        {
+          reason: "nothing here acts on it",
+          constraint: (declared) => {
+            seen.push(declared);
+          },
+        },
+      ],
+    ]);
+
+    // When a Resource declaring it is checked.
+    skipped({ Checked: "here", Sibling: "there" }, rules).assertConstraints();
+
+    // Then the constraint saw its own value and everything else the Resource
+    // declared.
+    assertArrayLength(seen, 1);
+    assertNonNullable(seen[0]);
+    assertIdentical(seen[0].value, "here");
+    assertIdentical(seen[0].properties["Sibling"], "there");
+  });
+
+  it("leaves a constraint alone for a property the Resource never declared", () => {
+    // Given a constraint that would refuse anything.
+    let ran = false;
+    const rules = new Map<string, SimCfnSkippedPropertyRule | string>([
+      [
+        "Checked",
+        {
+          reason: "nothing here acts on it",
+          constraint: (declared) => {
+            ran = true;
+            declared.refuse("never reached");
+          },
+        },
+      ],
+    ]);
+
+    // When a Resource that states something else entirely is checked, then
+    // nothing runs. A constraint says what a declared value has to satisfy,
+    // and says nothing about a template leaving the property out.
+    skipped({ Other: 1 }, rules).assertConstraints();
+
+    assertFalse(ran);
+  });
+
+  it("leaves a property carrying a reason alone", () => {
+    // Given the common case, a reason with no constraint behind it.
+    const rules = new Map<string, SimCfnSkippedPropertyRule | string>([
+      ["Plain", "nothing here acts on it"],
+    ]);
+
+    // When a Resource declaring it is checked, then it passes. Most skipped
+    // properties are a single flag with nothing to check.
+    skipped({ Plain: true }, rules).assertConstraints();
+
+    assertIdentical(
+      skipped({ Plain: true }, rules).reasonFor("Plain"),
+      "nothing here acts on it",
+    );
+  });
+});

--- a/src/service/cloudformation/resource/ignore/sim-cfn-skipped-properties.iso.test.ts
+++ b/src/service/cloudformation/resource/ignore/sim-cfn-skipped-properties.iso.test.ts
@@ -19,6 +19,7 @@ import type {
 const refusal = (reason: string): Error =>
   new Error(`Invalid Test::Service::Thing Resource Thing: ${reason}`);
 
+/** The seam, built the way a service builds one for its own Resource. */
 function skipped(
   properties: SimCfnTemplateValueRecord,
   rules: ReadonlyMap<string, SimCfnSkippedPropertyRule | string>,

--- a/src/service/cloudformation/resource/ignore/sim-cfn-skipped-properties.ts
+++ b/src/service/cloudformation/resource/ignore/sim-cfn-skipped-properties.ts
@@ -1,0 +1,75 @@
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import type {
+  SimCfnSkippedPropertyConstraint,
+  SimCfnSkippedPropertyRules,
+} from "./sim-cfn-skipped-property.type.js";
+
+interface SimCfnSkippedPropertiesProperties {
+  readonly rules: SimCfnSkippedPropertyRules;
+  readonly properties: SimCfnTemplateValueRecord;
+  readonly error: (reason: string) => Error;
+}
+
+/**
+ * What one Resource's skipped properties say, and what they still have to
+ * satisfy.
+ *
+ * Simulated CloudFormation deploys what it can, so a property a service cannot
+ * act on is recorded against the Resource rather than taking it down. That
+ * leaves a gap. A skipped property can carry a value real AWS answers with a
+ * 400 as readily as a simulated one can, and deploying it here reports a
+ * template AWS refuses as working, which is the one failure a local deploy of
+ * a real template exists to catch.
+ *
+ * This is where a service closes that gap. The constraint sits beside the
+ * reason in the same map, and every service reaches it the same way, so the
+ * next one to need it has nothing to build.
+ */
+export class SimCfnSkippedProperties {
+  private readonly rules: SimCfnSkippedPropertyRules;
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly error: (reason: string) => Error;
+
+  constructor(properties: SimCfnSkippedPropertiesProperties) {
+    this.rules = properties.rules;
+    this.properties = properties.properties;
+    this.error = properties.error;
+  }
+
+  /**
+   * Refuse the Resource where a skipped value is one real AWS would answer
+   * with a 400.
+   *
+   * Every constraint runs before anything is recorded, so a Resource that
+   * fails one leaves no half-written list of what it was created without.
+   */
+  assertConstraints(): void {
+    for (const [name, value] of Object.entries(this.properties)) {
+      this.constraintOn(name)?.({
+        value,
+        properties: this.properties,
+        refuse: (reason) => {
+          throw this.error(reason);
+        },
+      });
+    }
+  }
+
+  /**
+   * Why a property is skipped, or nothing where this service has no entry for
+   * it.
+   */
+  reasonFor(name: string): string | undefined {
+    const rule = this.rules.get(name);
+
+    return typeof rule === "string" ? rule : rule?.reason;
+  }
+
+  private constraintOn(
+    name: string,
+  ): SimCfnSkippedPropertyConstraint | undefined {
+    const rule = this.rules.get(name);
+
+    return typeof rule === "string" ? undefined : rule?.constraint;
+  }
+}

--- a/src/service/cloudformation/resource/ignore/sim-cfn-skipped-properties.ts
+++ b/src/service/cloudformation/resource/ignore/sim-cfn-skipped-properties.ts
@@ -65,6 +65,12 @@ export class SimCfnSkippedProperties {
     return typeof rule === "string" ? rule : rule?.reason;
   }
 
+  /**
+   * What a property's value has to satisfy, where the service stated it.
+   *
+   * A rule that is a bare reason states nothing, which is the common case and
+   * the reason both shapes share one map.
+   */
   private constraintOn(
     name: string,
   ): SimCfnSkippedPropertyConstraint | undefined {

--- a/src/service/cloudformation/resource/ignore/sim-cfn-skipped-property.type.ts
+++ b/src/service/cloudformation/resource/ignore/sim-cfn-skipped-property.type.ts
@@ -1,0 +1,65 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../template/value/sim-cfn-template-value.js";
+
+/**
+ * One skipped property, as a constraint on it reads the Resource.
+ *
+ * The whole Resource comes with it, because the constraints AWS enforces on a
+ * property it is not acting on are usually about a second one. Replication on
+ * an S3 Bucket needs versioning turned on beside it, and neither property is
+ * simulated.
+ */
+export interface SimCfnSkippedPropertyValue {
+  /** What the template declared for the skipped property. */
+  readonly value: SimCfnTemplateValue;
+
+  /** Everything else the Resource declared. */
+  readonly properties: SimCfnTemplateValueRecord;
+
+  /**
+   * Refuse the Resource, in the service's own words.
+   *
+   * The wording matters. Sim CloudFormation downgrades a failure that reads as
+   * an unsupported Resource type into a skip, and a skipped Resource here
+   * would deploy the very template this exists to refuse, so each service
+   * passes the error builder it already refuses its own Resources with.
+   */
+  refuse(reason: string): never;
+}
+
+/**
+ * What a skipped value has to satisfy even though nothing acts on it.
+ *
+ * A value that passes is recorded against the Resource as any skipped value
+ * is. One that fails takes the Resource with it, before anything is recorded.
+ */
+export type SimCfnSkippedPropertyConstraint = (
+  declared: SimCfnSkippedPropertyValue,
+) => void;
+
+/**
+ * What a service says about a property its Resource is created without acting
+ * on.
+ *
+ * A reason on its own is the common case and stays a bare string. A property
+ * carrying a value real AWS answers with a 400 states the constraint here too,
+ * beside the reason, rather than in a check of its own somewhere up the call
+ * path.
+ */
+export interface SimCfnSkippedPropertyRule {
+  readonly reason: string;
+  readonly constraint: SimCfnSkippedPropertyConstraint;
+}
+
+/**
+ * The properties one Resource type is created without acting on, by name.
+ *
+ * Most name a reason and nothing more. The rest state what the value has to
+ * satisfy alongside it.
+ */
+export type SimCfnSkippedPropertyRules = ReadonlyMap<
+  string,
+  SimCfnSkippedPropertyRule | string
+>;

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -884,6 +884,12 @@ as the Resource's simulated object, because a Bucket policy has no existence of 
 A `Bucket` naming a Bucket that does not exist fails the Stack with `SimS3NoSuchBucket` rather than
 being skipped.
 
+`ReplicationConfiguration` is read on the way to being recorded, unlike the other skipped
+properties. `validateSimCfnS3BucketReplication` states the constraints the S3 API documents and the
+CloudFormation Resource schema leaves out, and hangs off the property in
+`unsimulatedPropertyReasons` through the shared `SimCfnSkippedProperties` seam rather than off a
+call site of its own. See the CloudFormation service README for what the seam is for.
+
 Bucket resource creation flow:
 
 1. determine the Bucket name

--- a/src/service/s3/cfn/bucket/replication/sim-cfn-s3-bucket-replication-rules.ts
+++ b/src/service/s3/cfn/bucket/replication/sim-cfn-s3-bucket-replication-rules.ts
@@ -1,9 +1,6 @@
 import { isRecord } from "../../../../../util/type-guard/record.js";
-import type {
-  SimCfnTemplateValue,
-  SimCfnTemplateValueRecord,
-} from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
-import { s3BucketResourceError } from "../error/sim-cfn-s3-bucket-error.js";
+import type { SimCfnSkippedPropertyValue } from "../../../../cloudformation/resource/ignore/sim-cfn-skipped-property.type.js";
+import type { SimCfnTemplateValue } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 /**
  * The AWS::S3::Bucket ReplicationConfiguration constraints real S3 enforces.
@@ -18,27 +15,30 @@ import { s3BucketResourceError } from "../error/sim-cfn-s3-bucket-error.js";
  * These are the constraints the S3 API documents and the CloudFormation
  * Resource schema leaves out, so cfn-lint passes a template failing any of
  * them.
+ *
+ * Attached to the property in `unsimulatedPropertyReasons`, so it runs
+ * wherever a skipped AWS::S3::Bucket property is recorded rather than from a
+ * call site of its own.
  */
 export function validateSimCfnS3BucketReplication(
-  logicalId: string,
-  properties: SimCfnTemplateValueRecord,
+  declared: SimCfnSkippedPropertyValue,
 ): void {
-  const declared = properties["ReplicationConfiguration"];
+  const configuration = declared.value;
 
-  if (!isRecord(declared)) {
+  if (!isRecord(configuration)) {
     return;
   }
 
-  refuseUnversionedSource(logicalId, properties);
+  refuseUnversionedSource(declared);
 
-  const rules = declared["Rules"];
+  const rules = configuration["Rules"];
 
   if (!Array.isArray(rules)) {
     return;
   }
 
   rules.forEach((rule, index) => {
-    validateRule(logicalId, rule, `ReplicationConfiguration Rules[${index}]`);
+    validateRule(declared, rule, `ReplicationConfiguration Rules[${index}]`);
   });
 }
 
@@ -52,34 +52,30 @@ export function validateSimCfnS3BucketReplication(
  * Bucket ARN that may belong to another Stack or another Account, so there is
  * nothing here to read it from at all.
  */
-function refuseUnversionedSource(
-  logicalId: string,
-  properties: SimCfnTemplateValueRecord,
-): void {
-  const versioning = properties["VersioningConfiguration"];
+function refuseUnversionedSource(declared: SimCfnSkippedPropertyValue): void {
+  const versioning = declared.properties["VersioningConfiguration"];
 
   if (isRecord(versioning) && versioning["Status"] === "Enabled") {
     return;
   }
 
-  throw s3BucketResourceError(
-    logicalId,
+  declared.refuse(
     "Versioning must be Enabled on the Bucket to apply a " +
       "ReplicationConfiguration",
   );
 }
 
 function validateRule(
-  logicalId: string,
-  declared: SimCfnTemplateValue,
+  declared: SimCfnSkippedPropertyValue,
+  rule: SimCfnTemplateValue,
   path: string,
 ): void {
-  if (!isRecord(declared)) {
+  if (!isRecord(rule)) {
     return;
   }
 
-  refuseEventThresholdWithoutReplicationTime(logicalId, declared, path);
-  refuseFilterWithoutItsCompanions(logicalId, declared, path);
+  refuseEventThresholdWithoutReplicationTime(declared, rule, path);
+  refuseFilterWithoutItsCompanions(declared, rule, path);
 }
 
 /**
@@ -93,8 +89,8 @@ function validateRule(
  * an ordinary L2 call.
  */
 function refuseEventThresholdWithoutReplicationTime(
-  logicalId: string,
-  rule: SimCfnTemplateValueRecord,
+  declared: SimCfnSkippedPropertyValue,
+  rule: Readonly<Record<string, SimCfnTemplateValue>>,
   path: string,
 ): void {
   const destination = rule["Destination"];
@@ -115,8 +111,7 @@ function refuseEventThresholdWithoutReplicationTime(
     return;
   }
 
-  throw s3BucketResourceError(
-    logicalId,
+  declared.refuse(
     `${path} Destination Metrics cannot contain an event threshold when ` +
       "ReplicationTime is not specified or Disabled",
   );
@@ -130,8 +125,8 @@ function refuseEventThresholdWithoutReplicationTime(
  * none of them, so the check is on `Filter` rather than on the rule.
  */
 function refuseFilterWithoutItsCompanions(
-  logicalId: string,
-  rule: SimCfnTemplateValueRecord,
+  declared: SimCfnSkippedPropertyValue,
+  rule: Readonly<Record<string, SimCfnTemplateValue>>,
   path: string,
 ): void {
   if (rule["Filter"] === undefined) {
@@ -150,8 +145,7 @@ function refuseFilterWithoutItsCompanions(
     return;
   }
 
-  throw s3BucketResourceError(
-    logicalId,
+  declared.refuse(
     `${path} states a Filter, which requires ${missing.join(", ")} as well`,
   );
 }

--- a/src/service/s3/cfn/bucket/replication/sim-cfn-s3-bucket-replication.iso.test.ts
+++ b/src/service/s3/cfn/bucket/replication/sim-cfn-s3-bucket-replication.iso.test.ts
@@ -248,6 +248,32 @@ describe("AWS::S3::Bucket ReplicationConfiguration rules", () => {
     assertStringIncludes(error.message, "Versioning must be Enabled");
   });
 
+  it("deploys a Bucket whose replication is misshapen further down", async () => {
+    // Given configurations misshapen at each level below the property itself,
+    // which are template errors these rules have no opinion about.
+    const misshapen: readonly SimCfnTemplateValueRecord[] = [
+      { Role: replicationRole, Rules: "every-object" },
+      { Role: replicationRole, Rules: ["replicate-everything"] },
+      {
+        Role: replicationRole,
+        Rules: [replicationRule({ Destination: "the-other-bucket" })],
+      },
+    ];
+
+    // When each is deployed, then the Bucket is still created and the
+    // property recorded. Reading further than the shape allows would refuse a
+    // template over the reading rather than over what it said.
+    const stacks = await Promise.all(
+      misshapen.map(async (configuration) =>
+        deployBucket(bucketProperties(configuration)),
+      ),
+    );
+
+    for (const stack of stacks) {
+      assertArrayLength(stack.ignoredProperties, 1);
+    }
+  });
+
   it("deploys a Bucket whose ReplicationConfiguration is not an object", async () => {
     // Given a misshapen configuration, which is a template error this rule has
     // no opinion about.

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
@@ -26,6 +26,12 @@ export const inertPropertyNames: ReadonlySet<string> = new Set([
   "Tags",
 ]);
 
+import type {
+  SimCfnSkippedPropertyRule,
+  SimCfnSkippedPropertyRules,
+} from "../../../cloudformation/resource/ignore/sim-cfn-skipped-property.type.js";
+import { validateSimCfnS3BucketReplication } from "./replication/sim-cfn-s3-bucket-replication-rules.js";
+
 /**
  * Real AWS::S3::Bucket properties this simulation does not model, with what
  * each of them would have changed.
@@ -34,8 +40,15 @@ export const inertPropertyNames: ReadonlySet<string> = new Set([
  * Resource. A Bucket declaring replication, for instance, copies nothing to
  * the Bucket it names, so a test expecting an Object to arrive there needs to
  * find out that nothing was ever going to send it.
+ *
+ * A property whose value real S3 answers with a 400 states what it has to
+ * satisfy here as well. Nothing acts on the value either way, and reading it
+ * this far is what keeps a template AWS refuses from deploying.
  */
-export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+export const unsimulatedPropertyReasons: SimCfnSkippedPropertyRules = new Map<
+  string,
+  SimCfnSkippedPropertyRule | string
+>([
   ["AbacStatus", "attribute-based access control is not simulated"],
   ["AccelerateConfiguration", "transfer acceleration is not simulated"],
   [
@@ -60,5 +73,11 @@ export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
   ["MetadataTableConfiguration", "Bucket metadata tables are not simulated"],
   ["MetricsConfigurations", "CloudWatch request metrics are not simulated"],
   ["OwnershipControls", "Object ownership and ACLs are not simulated"],
-  ["ReplicationConfiguration", "Bucket replication is not simulated"],
+  [
+    "ReplicationConfiguration",
+    {
+      reason: "Bucket replication is not simulated",
+      constraint: validateSimCfnS3BucketReplication,
+    },
+  ],
 ]);

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-rules.ts
@@ -1,7 +1,7 @@
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import { SimCfnSkippedProperties } from "../../../cloudformation/resource/ignore/sim-cfn-skipped-properties.js";
 import { s3BucketResourceError } from "./error/sim-cfn-s3-bucket-error.js";
-import { validateSimCfnS3BucketReplication } from "./replication/sim-cfn-s3-bucket-replication-rules.js";
 import {
   inertPropertyNames,
   simulatedPropertyNames,
@@ -35,11 +35,17 @@ export class SimCfnS3BucketPropertyRules {
   private readonly logicalId: string;
   private readonly properties: SimCfnTemplateValueRecord;
   private readonly ignorer: SimCfnPropertyIgnorer;
+  private readonly skipped: SimCfnSkippedProperties;
 
   constructor(properties: SimCfnS3BucketPropertyRulesProperties) {
     this.logicalId = properties.logicalId;
     this.properties = properties.properties;
     this.ignorer = properties.ignorer;
+    this.skipped = new SimCfnSkippedProperties({
+      rules: unsimulatedPropertyReasons,
+      properties: this.properties,
+      error: (reason): Error => s3BucketResourceError(this.logicalId, reason),
+    });
   }
 
   /**
@@ -48,7 +54,7 @@ export class SimCfnS3BucketPropertyRules {
    */
   apply(): void {
     this.refuseUnusableBucketName();
-    validateSimCfnS3BucketReplication(this.logicalId, this.properties);
+    this.skipped.assertConstraints();
 
     for (const name of Object.keys(this.properties)) {
       this.applyToProperty(name);
@@ -81,7 +87,7 @@ export class SimCfnS3BucketPropertyRules {
       return;
     }
 
-    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+    const unsimulatedReason = this.skipped.reasonFor(name);
 
     if (unsimulatedReason !== undefined) {
       this.ignorer.ignoreProperty(

--- a/src/service/sqs/README.md
+++ b/src/service/sqs/README.md
@@ -197,7 +197,14 @@ resource's simulated object is the first queue it named. `Ref` on an `AWS::SQS::
 which is what `Queues` carries and what `SetQueueAttributes` takes.
 
 A property this simulation has no behaviour for is recorded against the Resource and the queue is
-created without it. `FifoQueue: true` fails the resource instead. A FIFO queue is named
+created without it. `KmsDataKeyReusePeriodSeconds` is read on the way past all the same.
+`validateSimCfnSqsKmsDataKeyReusePeriod` holds it to the minute-to-a-day range real SQS accepts, and
+hangs off the property in `unsimulatedPropertyReasons` through the shared
+`SimCfnSkippedProperties` seam rather than off a call site of its own. Nothing here encrypts a
+message either way, and a period outside that range fails the stack at `CreateQueue` on real AWS.
+See the CloudFormation service README for what the seam is for.
+
+`FifoQueue: true` fails the resource instead. A FIFO queue is named
 `<name>.fifo`, a name simulated SQS refuses, leaving no queue to create under the name the template
 gave it. The failures are worded as an invalid resource rather than an unsupported one, because sim
 CloudFormation skips a resource whose error reads as unsupported, and skipping is the wrong answer

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-encryption-rules.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-encryption-rules.ts
@@ -1,0 +1,47 @@
+import type { SimCfnSkippedPropertyValue } from "../../../cloudformation/resource/ignore/sim-cfn-skipped-property.type.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+const minimumReuseSeconds = 60;
+const maximumReuseSeconds = 86_400;
+
+/**
+ * The range real SQS accepts for `KmsDataKeyReusePeriodSeconds`.
+ *
+ * Encryption itself is not simulated. The property is recorded against the
+ * Resource and the queue is created without it, and no key is ever asked for.
+ * How long the value says to reuse one is still read, because a period outside
+ * this range is one real SQS answers with `InvalidAttributeValue`, and
+ * CloudFormation fails the stack on it at CreateQueue. A queue that deployed
+ * here would report a template AWS refuses as working.
+ *
+ * The bound is the one the SQS API documents, a minute at the short end and a
+ * day at the long one.
+ */
+export function validateSimCfnSqsKmsDataKeyReusePeriod(
+  declared: SimCfnSkippedPropertyValue,
+): void {
+  const stated = declared.value;
+  const seconds =
+    typeof stated === "number" || typeof stated === "string"
+      ? Number(stated)
+      : NaN;
+
+  if (
+    Number.isSafeInteger(seconds) &&
+    seconds >= minimumReuseSeconds &&
+    seconds <= maximumReuseSeconds
+  ) {
+    return;
+  }
+
+  declared.refuse(
+    `KmsDataKeyReusePeriodSeconds ${stringified(stated)} is outside the ` +
+      `${String(minimumReuseSeconds)} to ${String(maximumReuseSeconds)} ` +
+      `seconds real SQS accepts`,
+  );
+}
+
+/** The value as a refusal names it, whatever shape the template gave it. */
+function stringified(value: SimCfnTemplateValue): string {
+  return typeof value === "object" ? JSON.stringify(value) : String(value);
+}

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-encryption.iso.test.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-encryption.iso.test.ts
@@ -1,0 +1,155 @@
+import { GetQueueAttributesCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimCfnDeployedStack } from "../../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+
+/** Deploy an encrypted queue reusing its data key for the given period. */
+async function deployQueue(
+  simAws: SimAws,
+  reusePeriod: SimCfnTemplateValue,
+): Promise<SimCfnDeployedStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders-stack",
+    template: {
+      Resources: {
+        OrdersQueue: {
+          Type: "AWS::SQS::Queue",
+          Properties: {
+            QueueName: "orders",
+            KmsMasterKeyId: "alias/aws/sqs",
+            KmsDataKeyReusePeriodSeconds: reusePeriod,
+          },
+        },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+describe("AWS::SQS::Queue KmsDataKeyReusePeriodSeconds", () => {
+  it("records a period real SQS accepts and creates the queue without it", async () => {
+    // Given a template reusing its data key for five minutes, which is the
+    // default real SQS applies.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await deployQueue(simAws, 300);
+
+    // Then the queue exists, since encryption changes nothing a test here can
+    // observe, and both encryption properties are recorded against it.
+    assertNonNullable(simAws.sqs().findQueue("orders"));
+
+    const recorded = stack.ignoredProperties.map((entry) => entry.path);
+    assertArrayLength(recorded, 2);
+    assertStringIncludes(recorded.join(", "), "KmsDataKeyReusePeriodSeconds");
+
+    // And nothing acts on it, so the queue reports no such attribute.
+    const read = await simAws.sqs().getQueueAttributes(
+      new GetQueueAttributesCommand({
+        QueueUrl: "https://sqs.us-east-1.amazonaws.com/888888888888/orders",
+        AttributeNames: ["All"],
+      }),
+    );
+    assertUndefined(read.Attributes?.["KmsDataKeyReusePeriodSeconds"]);
+  });
+
+  it("refuses a period shorter than the minute real SQS takes", async () => {
+    // Given a template reusing its data key for thirty seconds.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the Resource fails. Nothing here
+    // encrypts anything, and a stack that deployed would report a template
+    // CloudFormation fails at CreateQueue as working.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployQueue(simAws, 30);
+    });
+
+    assertStringIncludes(
+      error.message,
+      "KmsDataKeyReusePeriodSeconds 30 is outside the 60 to 86400 seconds " +
+        "real SQS accepts",
+    );
+
+    // And nothing was recorded against a Resource that never existed.
+    const stack = simAws.cloudFormation().getStackByName("orders-stack");
+    assertNonNullable(stack);
+    assertArrayLength(stack.ignoredProperties, 0);
+    assertIdentical(stack.getResource("OrdersQueue")?.status, "CREATE_FAILED");
+    assertUndefined(simAws.sqs().findQueue("orders"));
+  });
+
+  it("refuses a period longer than the day real SQS takes", async () => {
+    // Given a template reusing its data key for a week.
+    // When it is deployed, then the far end of the range is refused too.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployQueue(new SimAws(), 604_800);
+    });
+
+    assertStringIncludes(error.message, "is outside the 60 to 86400 seconds");
+  });
+
+  it("refuses a period that is not a whole number of seconds", async () => {
+    // Given a template stating something no period could be read out of.
+    // When it is deployed, then it is refused rather than read as zero.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployQueue(new SimAws(), "five minutes");
+    });
+
+    assertStringIncludes(
+      error.message,
+      "KmsDataKeyReusePeriodSeconds five minutes is outside",
+    );
+  });
+
+  it("refuses a period stated as something no number could come from", async () => {
+    // Given a template stating an object where a number belongs.
+    // When it is deployed, then it is refused, naming what the template said
+    // rather than the reading of it.
+    const error = await assertThrowsErrorAsync(async () => {
+      return await deployQueue(new SimAws(), { Minutes: 5 });
+    });
+
+    assertStringIncludes(
+      error.message,
+      'KmsDataKeyReusePeriodSeconds {"Minutes":5} is outside',
+    );
+  });
+
+  it("takes a period a template Parameter carries as a string", async () => {
+    // Given a template taking the period from a Parameter, which resolves to
+    // a string where a literal property carries a number.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      parameters: { ReusePeriod: "600" },
+      template: {
+        Parameters: { ReusePeriod: { Type: "Number" } },
+        Resources: {
+          OrdersQueue: {
+            Type: "AWS::SQS::Queue",
+            Properties: {
+              QueueName: "orders",
+              KmsDataKeyReusePeriodSeconds: { Ref: "ReusePeriod" },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the queue exists, because the string holds a period in range.
+    assertNonNullable(simAws.sqs().findQueue("orders"));
+  });
+});

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-names.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-names.ts
@@ -1,4 +1,9 @@
+import type {
+  SimCfnSkippedPropertyRule,
+  SimCfnSkippedPropertyRules,
+} from "../../../cloudformation/resource/ignore/sim-cfn-skipped-property.type.js";
 import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { validateSimCfnSqsKmsDataKeyReusePeriod } from "./sim-cfn-sqs-queue-encryption-rules.js";
 
 /**
  * The AWS::SQS::Queue properties carrying a queue attribute of the same name.
@@ -26,14 +31,24 @@ export const attributePropertyNames: ReadonlySet<string> = new Set([
  * The queue is created without them and each one is recorded against the
  * Resource. A test reads the record to find out what the queue it deployed
  * behaves differently to AWS about.
+ *
+ * A property whose value real SQS answers with a 400 states what it has to
+ * satisfy here as well. Nothing acts on the value either way, and reading it
+ * this far is what keeps a template AWS refuses from deploying.
  */
-export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+export const unsimulatedPropertyReasons: SimCfnSkippedPropertyRules = new Map<
+  string,
+  SimCfnSkippedPropertyRule | string
+>([
   ["ContentBasedDeduplication", "only standard queues are simulated"],
   ["DeduplicationScope", "only standard queues are simulated"],
   ["FifoThroughputLimit", "only standard queues are simulated"],
   [
     "KmsDataKeyReusePeriodSeconds",
-    "simulated SQS does not encrypt message bodies",
+    {
+      reason: "simulated SQS does not encrypt message bodies",
+      constraint: validateSimCfnSqsKmsDataKeyReusePeriod,
+    },
   ],
   ["KmsMasterKeyId", "simulated SQS does not encrypt message bodies"],
   [

--- a/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-rules.ts
+++ b/src/service/sqs/cfn/queue/sim-cfn-sqs-queue-property-rules.ts
@@ -1,5 +1,6 @@
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCfnPropertyIgnorer } from "../../../cloudformation/resource/ignore/sim-cfn-ignored-property.type.js";
+import { SimCfnSkippedProperties } from "../../../cloudformation/resource/ignore/sim-cfn-skipped-properties.js";
 import {
   attributePropertyNames,
   fifoQueueValues,
@@ -41,11 +42,17 @@ export class SimCfnSqsQueuePropertyRules {
   private readonly logicalId: string;
   private readonly properties: SimCfnTemplateValueRecord;
   private readonly ignorer: SimCfnPropertyIgnorer;
+  private readonly skipped: SimCfnSkippedProperties;
 
   constructor(properties: SimCfnSqsQueuePropertyRulesProperties) {
     this.logicalId = properties.logicalId;
     this.properties = properties.properties;
     this.ignorer = properties.ignorer;
+    this.skipped = new SimCfnSkippedProperties({
+      rules: unsimulatedPropertyReasons,
+      properties: this.properties,
+      error: (reason): Error => sqsQueuePropertyError(this.logicalId, reason),
+    });
   }
 
   /**
@@ -60,6 +67,7 @@ export class SimCfnSqsQueuePropertyRules {
    */
   apply(): void {
     this.applyToFifoQueue();
+    this.skipped.assertConstraints();
 
     for (const name of Object.keys(this.properties)) {
       this.applyToProperty(name);
@@ -104,7 +112,7 @@ export class SimCfnSqsQueuePropertyRules {
   }
 
   private applyToProperty(name: string): void {
-    const unsimulatedReason = unsimulatedPropertyReasons.get(name);
+    const unsimulatedReason = this.skipped.reasonFor(name);
 
     if (unsimulatedReason !== undefined) {
       this.ignorer.ignoreProperty(


### PR DESCRIPTION
A property a service cannot act on is recorded and the Resource still deploys, which leaves a gap. A skipped property carries a value real AWS answers with a 400 as readily as a simulated one, and deploying it reports a template AWS refuses as working. #1187 closed one such case inside simulated S3, and it generalised to nothing.

`SimCfnSkippedProperties` in `resource/ignore/` is the seam. A service's existing skip map gains an entry shape carrying a constraint beside the reason, and the runner does two things: `reasonFor(name)` is the lookup each recording loop already did, and `assertConstraints()` is the part worth adding. Both entry shapes live in the one map, so the forty-odd services with nothing to check keep their plain strings and are untouched.

Two decisions in there worth flagging. A constraint reads the whole Resource rather than its own value, because what AWS enforces on a property it is not acting on is usually about a second one — S3 replication needs versioning beside it, and neither property is simulated. And a constraint refuses through a `refuse` handed to it rather than throwing its own error, which keeps the wording the service's. That matters more than it looks: sim CloudFormation downgrades a failure reading as an unsupported Resource type into a skip, and a skipped Resource would deploy the very template the constraint exists to refuse. Every constraint runs before anything is recorded, so a Resource that fails one leaves no half-written list of what it was created without.

Simulated S3 moves onto the seam and behaves as it did. Its replication module and its call site in `SimCfnS3BucketPropertyRules.apply()` are gone, replaced by the constraint hanging off the property in `unsimulatedPropertyReasons`. The #1187 tests pass unchanged — that file's diff is 26 insertions and no deletions.

The issue asked for the second caller to be chosen deliberately rather than assumed, so I audited the skip lists across every service. Most are single flags with nothing to check, as the issue said. `AWS::SQS::Queue` `KmsDataKeyReusePeriodSeconds` is the one I settled on: encryption is not simulated so the property is skipped, real SQS documents a 60 to 86,400 second range and answers anything else with `InvalidAttributeValue`, and CloudFormation fails the stack on it at `CreateQueue`. Nothing here encrypts a message either way, which is exactly the shape the seam is for.

Resolves #1192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for SQS KMS data-key reuse periods, accepting values from 60 to 86,400 seconds.
  * Added validation for unsupported S3 replication configurations.
  * Unsupported properties are now consistently recorded with service-specific reasons and constraints.

* **Bug Fixes**
  * Invalid SQS encryption settings now fail resource creation instead of being silently accepted.
  * Malformed S3 replication configurations can deploy while remaining properly recorded as ignored properties.

* **Documentation**
  * Expanded CloudFormation, S3, and SQS documentation to explain ignored-property behavior and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->