### PR TITLE
feat: simulate AWS Backup resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm i -D @kensio/yulin
 - [API Gateway HTTP APIs](https://yulinsim.dev/services/apigatewayv2/ "Simulated API Gateway HTTP API docs")
 - [API Gateway REST APIs](https://yulinsim.dev/services/apigateway/ "Simulated API Gateway REST API docs")
 - [Athena](https://yulinsim.dev/services/athena/ "Simulated Amazon Athena docs")
+- [AWS Backup](https://yulinsim.dev/services/backup/ "Simulated AWS Backup docs")
 - [Bedrock](https://yulinsim.dev/services/bedrock/ "Simulated Amazon Bedrock docs")
 - [CloudFormation](https://yulinsim.dev/services/cloudformation/ "Simulated CloudFormation docs")
 - [CloudFront](https://yulinsim.dev/services/cloudfront/ "Simulated CloudFront docs")

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [API Gateway HTTP APIs](https://yulinsim.dev/services/apigatewayv2/ "Simulated API Gateway HTTP API usage docs")
 - [API Gateway REST APIs](https://yulinsim.dev/services/apigateway/ "Simulated API Gateway REST API usage docs")
 - [Athena](https://yulinsim.dev/services/athena/ "Simulated Amazon Athena usage docs")
+- [AWS Backup](https://yulinsim.dev/services/backup/ "Simulated AWS Backup usage docs")
 - [Bedrock](https://yulinsim.dev/services/bedrock/ "Simulated Amazon Bedrock usage docs")
 - [CloudFormation](https://yulinsim.dev/services/cloudformation/ "Simulated CloudFormation usage docs")
 - [CloudFront](https://yulinsim.dev/services/cloudfront/ "Simulated CloudFront usage docs")

--- a/docs/services/backup/README.md
+++ b/docs/services/backup/README.md
@@ -1,0 +1,414 @@
+# Simulated AWS Backup
+
+Yulin includes simulated AWS Backup vaults, plans and selections for tests and local development.
+The simulation stores backup configuration. Backup jobs and recovery points are outside it.
+AWS Backup types are imported from the `@kensio/yulin/backup` subpath.
+
+## Creating a vault, plan and selection
+
+`simAws.backup()` gives the AWS Backup service for the default account and Region. A plan rule names
+an existing vault. A selection belongs to one plan and records the resource ARNs assigned to it.
+
+```typescript sim-backup-create-plan-selection
+/**
+ * Creating a daily backup plan for one DynamoDB table.
+ */
+
+import {
+  CreateBackupPlanCommand,
+  CreateBackupSelectionCommand,
+  CreateBackupVaultCommand,
+  GetBackupPlanCommand,
+  GetBackupSelectionCommand,
+} from "@aws-sdk/client-backup";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const backup = simAws.backup();
+
+await backup.createBackupVault(
+  new CreateBackupVaultCommand({
+    BackupVaultName: "application-backups",
+  }),
+);
+
+const createdPlan = await backup.createBackupPlan(
+  new CreateBackupPlanCommand({
+    BackupPlan: {
+      BackupPlanName: "application-plan",
+      Rules: [
+        {
+          RuleName: "daily",
+          TargetBackupVaultName: "application-backups",
+          ScheduleExpression: "cron(0 1 ? * * *)",
+          Lifecycle: { DeleteAfterDays: 35 },
+        },
+      ],
+    },
+  }),
+);
+assertNonNullable(createdPlan.BackupPlanId);
+
+const createdSelection = await backup.createBackupSelection(
+  new CreateBackupSelectionCommand({
+    BackupPlanId: createdPlan.BackupPlanId,
+    BackupSelection: {
+      SelectionName: "orders",
+      IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+      Resources: ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"],
+    },
+  }),
+);
+assertNonNullable(createdSelection.SelectionId);
+
+const plan = await backup.getBackupPlan(
+  new GetBackupPlanCommand({ BackupPlanId: createdPlan.BackupPlanId }),
+);
+console.log(plan.BackupPlan?.Rules?.[0]?.ScheduleExpression);
+// "cron(0 1 ? * * *)"
+
+const selection = await backup.getBackupSelection(
+  new GetBackupSelectionCommand({
+    BackupPlanId: createdPlan.BackupPlanId,
+    SelectionId: createdSelection.SelectionId,
+  }),
+);
+console.log(selection.BackupSelection?.Resources);
+// ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"]
+```
+
+A plan needs at least one rule. Every rule needs a name and a target vault. An omitted schedule uses
+`cron(0 5 ? * * *)`, the AWS Backup default. Six-field AWS cron expressions and rate expressions
+are validated when the plan is created. A one-time `at(...)` expression is refused.
+
+`MoveToColdStorageAfterDays` can be combined with `DeleteAfterDays`. The deletion must be at least
+90 days after the move to cold storage. A shorter lifecycle raises
+`InvalidParameterValueException`. Set both values to `-1` to retain recovery points indefinitely.
+
+## Vault Lock
+
+`PutBackupVaultLockConfiguration` records minimum and maximum retention periods on a vault. Adding
+`ChangeableForDays` creates a compliance lock. The configuration stays changeable until the grace
+period ends, then becomes immutable.
+
+```typescript sim-backup-vault-lock
+/**
+ * Advancing a compliance lock through its grace period.
+ */
+
+import {
+  CreateBackupVaultCommand,
+  DescribeBackupVaultCommand,
+  PutBackupVaultLockConfigurationCommand,
+} from "@aws-sdk/client-backup";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-30T10:00:00.000Z")),
+});
+const backup = simAws.backup();
+
+await backup.createBackupVault(
+  new CreateBackupVaultCommand({ BackupVaultName: "compliance-backups" }),
+);
+
+await backup.putBackupVaultLockConfiguration(
+  new PutBackupVaultLockConfigurationCommand({
+    BackupVaultName: "compliance-backups",
+    ChangeableForDays: 3,
+    MinRetentionDays: 7,
+    MaxRetentionDays: 365,
+  }),
+);
+
+const changeable = await backup.describeBackupVault(
+  new DescribeBackupVaultCommand({
+    BackupVaultName: "compliance-backups",
+  }),
+);
+console.log(changeable.LockDate?.toISOString());
+// "2026-09-02T10:00:00.000Z"
+
+await simAws.clock().advanceBy({ days: 3 });
+
+try {
+  await backup.putBackupVaultLockConfiguration(
+    new PutBackupVaultLockConfigurationCommand({
+      BackupVaultName: "compliance-backups",
+      MinRetentionDays: 14,
+    }),
+  );
+} catch (error) {
+  console.log(error instanceof Error ? error.name : "unknown error");
+  // "InvalidParameterValueException"
+}
+```
+
+`ChangeableForDays` must be between 3 and 36,500. Retention periods are whole days. A minimum cannot
+exceed the maximum, and the maximum cannot exceed 36,500 days. A lock without
+`ChangeableForDays` remains changeable.
+
+## Deploying from CloudFormation
+
+Simulated CloudFormation deploys `AWS::Backup::BackupVault`, `AWS::Backup::BackupPlan` and
+`AWS::Backup::BackupSelection`. References between the resources resolve before AWS Backup creates
+them.
+
+```typescript sim-backup-cloudformation
+/**
+ * Deploying a vault, plan and selection from one template.
+ */
+
+import { GetBackupSelectionCommand } from "@aws-sdk/client-backup";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "backup-stack",
+  template: {
+    Resources: {
+      Vault: {
+        Type: "AWS::Backup::BackupVault",
+        Properties: {
+          BackupVaultName: "application-backups",
+          LockConfiguration: {
+            MinRetentionDays: 7,
+            MaxRetentionDays: 365,
+          },
+        },
+      },
+      Plan: {
+        Type: "AWS::Backup::BackupPlan",
+        Properties: {
+          BackupPlan: {
+            BackupPlanName: "application-plan",
+            BackupPlanRule: [
+              {
+                RuleName: "daily",
+                TargetBackupVault: { Ref: "Vault" },
+                ScheduleExpression: "cron(0 1 ? * * *)",
+                Lifecycle: { DeleteAfterDays: 35 },
+              },
+            ],
+          },
+        },
+      },
+      Selection: {
+        Type: "AWS::Backup::BackupSelection",
+        Properties: {
+          BackupPlanId: { Ref: "Plan" },
+          BackupSelection: {
+            SelectionName: "orders",
+            IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+            Resources: ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"],
+          },
+        },
+      },
+    },
+    Outputs: {
+      VaultArn: {
+        Value: { "Fn::GetAtt": ["Vault", "BackupVaultArn"] },
+      },
+      PlanId: { Value: { Ref: "Plan" } },
+      SelectionId: { Value: { Ref: "Selection" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const selection = await simAws.backup().getBackupSelection(
+  new GetBackupSelectionCommand({
+    BackupPlanId: stack.output("PlanId"),
+    SelectionId: stack.output("SelectionId"),
+  }),
+);
+
+console.log(stack.output("VaultArn"));
+// "arn:aws:backup:us-east-1:888888888888:backup-vault:application-backups"
+console.log(selection.BackupSelection?.SelectionName); // "orders"
+```
+
+`Ref` and `Fn::GetAtt` return these values:
+
+- `AWS::Backup::BackupVault` returns the vault name from `Ref`. `BackupVaultArn` and
+  `BackupVaultName` are available through `Fn::GetAtt`.
+- `AWS::Backup::BackupPlan` returns the plan ID from `Ref`. `BackupPlanArn`, `BackupPlanId` and
+  `VersionId` are available through `Fn::GetAtt`.
+- `AWS::Backup::BackupSelection` returns the selection ID from `Ref`. `Id`, `SelectionId` and
+  `BackupPlanId` are available through `Fn::GetAtt`.
+
+Stack teardown removes all three resource types from the simulation.
+
+## Permissions
+
+Every supported operation is authorized by simulated IAM. Vault operations use the vault ARN. Plan
+and selection operations use the plan ARN. `ListBackupVaults` has no resource in its request and is
+authorized against `*`.
+
+```typescript sim-backup-iam-policy
+/**
+ * A Role allowed to create one named backup vault.
+ */
+
+import { CreateBackupVaultCommand } from "@aws-sdk/client-backup";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "BackupAdministrator",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::888888888888:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "BackupAdministrator",
+    PolicyName: "CreateApplicationVault",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "backup:CreateBackupVault",
+        Resource:
+          "arn:aws:backup:us-east-1:888888888888:backup-vault:application-backups",
+      },
+    }),
+  }),
+);
+
+const created = await simAws.backup().createBackupVault(
+  new CreateBackupVaultCommand({
+    BackupVaultName: "application-backups",
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+console.log(created.BackupVaultName); // "application-backups"
+```
+
+Authorization runs before resource lookup. An unauthorized request for a missing vault or plan
+raises `AccessDeniedException`, without revealing whether the resource exists.
+
+## SDK interception
+
+`SimSdk` routes commands from an AWS `BackupClient` to the simulation. Intercept the client instance
+when a test owns it, or intercept the class when application code creates the client.
+
+```typescript sim-backup-sdk-interception
+/**
+ * Routing an AWS Backup client into the simulation.
+ */
+
+import {
+  BackupClient,
+  CreateBackupVaultCommand,
+  ListBackupVaultsCommand,
+} from "@aws-sdk/client-backup";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+const client = new BackupClient({ region: "us-east-1" });
+simSdk.intercept(client);
+
+await client.send(
+  new CreateBackupVaultCommand({ BackupVaultName: "application-backups" }),
+);
+
+const listed = await client.send(new ListBackupVaultsCommand({}));
+console.log(listed.BackupVaultList?.[0]?.BackupVaultName);
+// "application-backups"
+```
+
+The client's configured Region selects the simulated Region. Credentials select the account and
+caller when the intercepted client has them. See the [SDK interception docs](https://yulinsim.dev/sdk/)
+for class interception and credential handling.
+
+## Account and Region scoping
+
+AWS Backup state belongs to one account and Region. The same vault name can exist in another scope.
+
+```typescript sim-backup-account-region-scoping
+/**
+ * Keeping backup vaults inside their account and Region.
+ */
+
+import {
+  CreateBackupVaultCommand,
+  ListBackupVaultsCommand,
+} from "@aws-sdk/client-backup";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .backup()
+  .createBackupVault(
+    new CreateBackupVaultCommand({ BackupVaultName: "application-backups" }),
+  );
+
+const inLondon = await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .backup()
+  .listBackupVaults(new ListBackupVaultsCommand({}));
+
+const inVirginia = await simAws
+  .account("111111111111")
+  .region("us-east-1")
+  .backup()
+  .listBackupVaults(new ListBackupVaultsCommand({}));
+
+console.log(inLondon.BackupVaultList?.length); // 1
+console.log(inVirginia.BackupVaultList?.length); // 0
+```
+
+## Available functionality
+
+- `CreateBackupVault`, `DescribeBackupVault`, `DeleteBackupVault` and `ListBackupVaults`.
+- `PutBackupVaultLockConfiguration`, including compliance lock grace periods driven by simulated
+  time.
+- `CreateBackupPlan` and `GetBackupPlan`, with rule schedule and lifecycle validation.
+- `CreateBackupSelection`, `GetBackupSelection` and `ListBackupSelections`.
+- IAM authorization for every supported command.
+- SDK interception of `BackupClient`.
+- Account and Region scoped state, ARNs and timestamps.
+- `AWS::Backup::BackupVault`, `AWS::Backup::BackupPlan` and `AWS::Backup::BackupSelection` through
+  simulated CloudFormation.
+
+## Limitations
+
+- Backup jobs, recovery point copies, restores and expiry are outside the simulation.
+- A vault always reports `NumberOfRecoveryPoints` as zero. Vault deletion always sees an empty
+  vault.
+- A plan schedule is parsed and stored. Advancing simulated time leaves it unchanged.
+- A selection stores its `Resources`. `Conditions`, `ListOfTags` and wildcard resource matching are
+  outside the selection model.
+- The selection's `IamRoleArn` is stored. No backup job assumes it, and creating a selection does
+  no `iam:PassRole` check.
+- `EncryptionKeyArn` is stored on a vault. KMS calls and recovery point encryption are outside the
+  simulation.
+- Backup tags are accepted and discarded.
+- List operations return every item. `MaxResults` and `NextToken` do not paginate the result.
+- `GetBackupPlan` returns the one stored plan version. `VersionId` is accepted and ignored. Plan
+  updates are outside the simulation.
+- A compliance lock becomes immutable when its grace period ends. Deleting a lock configuration is
+  unsupported.

--- a/docs/services/backup/sim-backup-account-region-scoping.example.ts
+++ b/docs/services/backup/sim-backup-account-region-scoping.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Keeping backup vaults inside their account and Region.
+ */
+
+import {
+  CreateBackupVaultCommand,
+  ListBackupVaultsCommand,
+} from "@aws-sdk/client-backup";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .backup()
+  .createBackupVault(
+    new CreateBackupVaultCommand({ BackupVaultName: "application-backups" }),
+  );
+
+const inLondon = await simAws
+  .account("111111111111")
+  .region("eu-west-2")
+  .backup()
+  .listBackupVaults(new ListBackupVaultsCommand({}));
+
+const inVirginia = await simAws
+  .account("111111111111")
+  .region("us-east-1")
+  .backup()
+  .listBackupVaults(new ListBackupVaultsCommand({}));
+
+console.log(inLondon.BackupVaultList?.length); // 1
+console.log(inVirginia.BackupVaultList?.length); // 0

--- a/docs/services/backup/sim-backup-cloudformation.example.ts
+++ b/docs/services/backup/sim-backup-cloudformation.example.ts
@@ -1,0 +1,73 @@
+/**
+ * Deploying a vault, plan and selection from one template.
+ */
+
+import { GetBackupSelectionCommand } from "@aws-sdk/client-backup";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "backup-stack",
+  template: {
+    Resources: {
+      Vault: {
+        Type: "AWS::Backup::BackupVault",
+        Properties: {
+          BackupVaultName: "application-backups",
+          LockConfiguration: {
+            MinRetentionDays: 7,
+            MaxRetentionDays: 365,
+          },
+        },
+      },
+      Plan: {
+        Type: "AWS::Backup::BackupPlan",
+        Properties: {
+          BackupPlan: {
+            BackupPlanName: "application-plan",
+            BackupPlanRule: [
+              {
+                RuleName: "daily",
+                TargetBackupVault: { Ref: "Vault" },
+                ScheduleExpression: "cron(0 1 ? * * *)",
+                Lifecycle: { DeleteAfterDays: 35 },
+              },
+            ],
+          },
+        },
+      },
+      Selection: {
+        Type: "AWS::Backup::BackupSelection",
+        Properties: {
+          BackupPlanId: { Ref: "Plan" },
+          BackupSelection: {
+            SelectionName: "orders",
+            IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+            Resources: ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"],
+          },
+        },
+      },
+    },
+    Outputs: {
+      VaultArn: {
+        Value: { "Fn::GetAtt": ["Vault", "BackupVaultArn"] },
+      },
+      PlanId: { Value: { Ref: "Plan" } },
+      SelectionId: { Value: { Ref: "Selection" } },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+const selection = await simAws.backup().getBackupSelection(
+  new GetBackupSelectionCommand({
+    BackupPlanId: stack.output("PlanId"),
+    SelectionId: stack.output("SelectionId"),
+  }),
+);
+
+console.log(stack.output("VaultArn"));
+// "arn:aws:backup:us-east-1:888888888888:backup-vault:application-backups"
+console.log(selection.BackupSelection?.SelectionName); // "orders"

--- a/docs/services/backup/sim-backup-create-plan-selection.example.ts
+++ b/docs/services/backup/sim-backup-create-plan-selection.example.ts
@@ -1,0 +1,67 @@
+/**
+ * Creating a daily backup plan for one DynamoDB table.
+ */
+
+import {
+  CreateBackupPlanCommand,
+  CreateBackupSelectionCommand,
+  CreateBackupVaultCommand,
+  GetBackupPlanCommand,
+  GetBackupSelectionCommand,
+} from "@aws-sdk/client-backup";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const backup = simAws.backup();
+
+await backup.createBackupVault(
+  new CreateBackupVaultCommand({
+    BackupVaultName: "application-backups",
+  }),
+);
+
+const createdPlan = await backup.createBackupPlan(
+  new CreateBackupPlanCommand({
+    BackupPlan: {
+      BackupPlanName: "application-plan",
+      Rules: [
+        {
+          RuleName: "daily",
+          TargetBackupVaultName: "application-backups",
+          ScheduleExpression: "cron(0 1 ? * * *)",
+          Lifecycle: { DeleteAfterDays: 35 },
+        },
+      ],
+    },
+  }),
+);
+assertNonNullable(createdPlan.BackupPlanId);
+
+const createdSelection = await backup.createBackupSelection(
+  new CreateBackupSelectionCommand({
+    BackupPlanId: createdPlan.BackupPlanId,
+    BackupSelection: {
+      SelectionName: "orders",
+      IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+      Resources: ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"],
+    },
+  }),
+);
+assertNonNullable(createdSelection.SelectionId);
+
+const plan = await backup.getBackupPlan(
+  new GetBackupPlanCommand({ BackupPlanId: createdPlan.BackupPlanId }),
+);
+console.log(plan.BackupPlan?.Rules?.[0]?.ScheduleExpression);
+// "cron(0 1 ? * * *)"
+
+const selection = await backup.getBackupSelection(
+  new GetBackupSelectionCommand({
+    BackupPlanId: createdPlan.BackupPlanId,
+    SelectionId: createdSelection.SelectionId,
+  }),
+);
+console.log(selection.BackupSelection?.Resources);
+// ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"]

--- a/docs/services/backup/sim-backup-iam-policy.example.ts
+++ b/docs/services/backup/sim-backup-iam-policy.example.ts
@@ -1,0 +1,48 @@
+/**
+ * A Role allowed to create one named backup vault.
+ */
+
+import { CreateBackupVaultCommand } from "@aws-sdk/client-backup";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "BackupAdministrator",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: "arn:aws:iam::888888888888:root" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "BackupAdministrator",
+    PolicyName: "CreateApplicationVault",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "backup:CreateBackupVault",
+        Resource:
+          "arn:aws:backup:us-east-1:888888888888:backup-vault:application-backups",
+      },
+    }),
+  }),
+);
+
+const created = await simAws.backup().createBackupVault(
+  new CreateBackupVaultCommand({
+    BackupVaultName: "application-backups",
+  }),
+  { caller: { kind: "arn", arn: role.Role.Arn } },
+);
+
+console.log(created.BackupVaultName); // "application-backups"

--- a/docs/services/backup/sim-backup-sdk-interception.example.ts
+++ b/docs/services/backup/sim-backup-sdk-interception.example.ts
@@ -1,0 +1,23 @@
+/**
+ * Routing an AWS Backup client into the simulation.
+ */
+
+import {
+  BackupClient,
+  CreateBackupVaultCommand,
+  ListBackupVaultsCommand,
+} from "@aws-sdk/client-backup";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+const client = new BackupClient({ region: "us-east-1" });
+simSdk.intercept(client);
+
+await client.send(
+  new CreateBackupVaultCommand({ BackupVaultName: "application-backups" }),
+);
+
+const listed = await client.send(new ListBackupVaultsCommand({}));
+console.log(listed.BackupVaultList?.[0]?.BackupVaultName);
+// "application-backups"

--- a/docs/services/backup/sim-backup-vault-lock.example.ts
+++ b/docs/services/backup/sim-backup-vault-lock.example.ts
@@ -1,0 +1,51 @@
+/**
+ * Advancing a compliance lock through its grace period.
+ */
+
+import {
+  CreateBackupVaultCommand,
+  DescribeBackupVaultCommand,
+  PutBackupVaultLockConfigurationCommand,
+} from "@aws-sdk/client-backup";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-30T10:00:00.000Z")),
+});
+const backup = simAws.backup();
+
+await backup.createBackupVault(
+  new CreateBackupVaultCommand({ BackupVaultName: "compliance-backups" }),
+);
+
+await backup.putBackupVaultLockConfiguration(
+  new PutBackupVaultLockConfigurationCommand({
+    BackupVaultName: "compliance-backups",
+    ChangeableForDays: 3,
+    MinRetentionDays: 7,
+    MaxRetentionDays: 365,
+  }),
+);
+
+const changeable = await backup.describeBackupVault(
+  new DescribeBackupVaultCommand({
+    BackupVaultName: "compliance-backups",
+  }),
+);
+console.log(changeable.LockDate?.toISOString());
+// "2026-09-02T10:00:00.000Z"
+
+await simAws.clock().advanceBy({ days: 3 });
+
+try {
+  await backup.putBackupVaultLockConfiguration(
+    new PutBackupVaultLockConfigurationCommand({
+      BackupVaultName: "compliance-backups",
+      MinRetentionDays: 14,
+    }),
+  );
+} catch (error) {
+  console.log(error instanceof Error ? error.name : "unknown error");
+  // "InvalidParameterValueException"
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
       "import": "./dist/service/bedrock/index.js",
       "types": "./dist/service/bedrock/index.d.ts"
     },
+    "./backup": {
+      "import": "./dist/service/backup/index.js",
+      "types": "./dist/service/backup/index.d.ts"
+    },
     "./cloudformation": {
       "import": "./dist/service/cloudformation/index.js",
       "types": "./dist/service/cloudformation/index.d.ts"
@@ -231,6 +235,7 @@
     "@aws-sdk/client-api-gateway": "^3.1112.0",
     "@aws-sdk/client-apigatewayv2": "^3.1101.0",
     "@aws-sdk/client-athena": "^3.1115.0",
+    "@aws-sdk/client-backup": "^3.1121.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1115.0",
     "@aws-sdk/client-cloudformation": "^3.1101.0",
     "@aws-sdk/client-cloudfront": "^3.1101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@aws-sdk/client-athena':
         specifier: ^3.1115.0
         version: 3.1116.0
+      '@aws-sdk/client-backup':
+        specifier: ^3.1121.0
+        version: 3.1121.0
       '@aws-sdk/client-bedrock-runtime':
         specifier: ^3.1115.0
         version: 3.1115.0
@@ -324,6 +327,10 @@ packages:
 
   '@aws-sdk/client-athena@3.1116.0':
     resolution: {integrity: sha512-hrnQnc3HNNQM+tEeBku31Jf2WDwH6Gs8vuX/tpbaoBK64wcNJ7tjY/ubfJuNHuNRPyTT/H5ZISwxRtclfML0Jw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-backup@3.1121.0':
+    resolution: {integrity: sha512-0gqBtnQNz1vTTEtrggpY0OIcrql7WL4vmC8xQvJ1fQU3PhAOIIdkYqbzguXpwtvRS+cTaaR/d4LfOCJ/drN/SA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-bedrock-runtime@3.1115.0':
@@ -3721,6 +3728,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-athena@3.1116.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-backup@3.1121.0':
     dependencies:
       '@aws-sdk/core': 3.977.9
       '@aws-sdk/credential-provider-node': 3.972.81

--- a/src/sdk/router/resolve-sim-sdk-command-router.ts
+++ b/src/sdk/router/resolve-sim-sdk-command-router.ts
@@ -45,6 +45,10 @@ const scopedRouters: ReadonlyMap<string, SimSdkScopedRouter> = new Map<
     (scoped): SimSdkCommandRouter => scoped.bedrock().sdkCommandRouter(),
   ],
   [
+    "Backup",
+    (scoped): SimSdkCommandRouter => scoped.backup().sdkCommandRouter(),
+  ],
+  [
     "CloudFormation",
     (scoped): SimSdkCommandRouter => scoped.cloudFormation().sdkCommandRouter(),
   ],

--- a/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
+++ b/src/service/aws/factory/sim-aws-self-contained-service-builder.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionContainer } from "../sim-aws-account-region-scope.js";
 import { SimAthena } from "../../athena/index.js";
 import { SimBedrock } from "../../bedrock/index.js";
+import { SimBackup } from "../../backup/index.js";
 import { SimDynamoDb as SimDynamoDatabase } from "../../dynamodb/index.js";
 import { SimFirehose } from "../../firehose/index.js";
 import { SimGlue } from "../../glue/index.js";
@@ -62,6 +63,11 @@ export class SimAwsSelfContainedServiceBuilder {
    */
   createBedrock(scope: SimAwsAccountRegionContainer): SimBedrock {
     return new SimBedrock(this.scoped(scope));
+  }
+
+  /** Create simulated AWS Backup for an Account Region scope. */
+  createBackup(scope: SimAwsAccountRegionContainer): SimBackup {
+    return new SimBackup(this.scoped(scope));
   }
 
   /** Create simulated DynamoDB for an Account Region scope. */

--- a/src/service/aws/factory/sim-aws-service-factory.ts
+++ b/src/service/aws/factory/sim-aws-service-factory.ts
@@ -19,6 +19,7 @@ import type { SimEcr } from "../../ecr/index.js";
 import type { SimEcs } from "../../ecs/index.js";
 import type { SimAthena } from "../../athena/index.js";
 import type { SimBedrock } from "../../bedrock/index.js";
+import type { SimBackup } from "../../backup/index.js";
 import type { SimPersonalize } from "../../personalize/index.js";
 import type { SimRekognition } from "../../rekognition/index.js";
 import type { SimRoute53 } from "../../route53/index.js";
@@ -303,6 +304,11 @@ export class SimAwsServiceFactory {
   /** Create simulated Bedrock for an Account Region scope. */
   createBedrock(scope: SimAwsAccountRegionContainer): SimBedrock {
     return this.selfContainedServices.createBedrock(scope);
+  }
+
+  /** Create simulated AWS Backup for an Account Region scope. */
+  createBackup(scope: SimAwsAccountRegionContainer): SimBackup {
+    return this.selfContainedServices.createBackup(scope);
   }
 
   /** Create simulated Personalize for an Account Region scope. */

--- a/src/service/aws/sim-aws-account-region-scope.ts
+++ b/src/service/aws/sim-aws-account-region-scope.ts
@@ -5,6 +5,7 @@ import { isSimAwsClosing } from "./sim-aws-closing.js";
 import { SimAws } from "./sim-aws.js";
 import type { SimAthena } from "../athena/index.js";
 import type { SimBedrock } from "../bedrock/index.js";
+import type { SimBackup } from "../backup/index.js";
 import type { SimS3 } from "../s3/sim-s3.js";
 import type { SimScheduler } from "../scheduler/index.js";
 import type { SimCloudFront } from "../cloudfront/sim-cloudfront.js";
@@ -99,6 +100,13 @@ export class SimAwsAccountRegionContainer {
   bedrock(): SimBedrock {
     return this.memo.getOrCreate("bedrock", () =>
       this.factory.createBedrock(this),
+    );
+  }
+
+  /** Get simulated AWS Backup for this account and region. */
+  backup(): SimBackup {
+    return this.memo.getOrCreate("backup", () =>
+      this.factory.createBackup(this),
     );
   }
 

--- a/src/service/aws/sim-aws-account.ts
+++ b/src/service/aws/sim-aws-account.ts
@@ -20,6 +20,7 @@ import type { SimLambda } from "../lambda/index.js";
 import type { SimAwsPrincipal } from "./caller/sim-aws-caller.js";
 import { makeSimAwsAccountRootPrincipal } from "./caller/sim-aws-account-root-principal.js";
 import type { SimSts } from "../sts/sim-sts.js";
+import type { SimBackup } from "../backup/index.js";
 
 // An Account ID is its own small thing and is defined in its own module. It is
 // re-exported here because this is where the rest of the simulator already
@@ -80,6 +81,11 @@ export class SimAwsAccount {
    */
   acm(): SimAcm {
     return this.region().acm();
+  }
+
+  /** Get simulated AWS Backup for this Account's default Region. */
+  backup(): SimBackup {
+    return this.region().backup();
   }
 
   /**

--- a/src/service/aws/sim-aws-region.ts
+++ b/src/service/aws/sim-aws-region.ts
@@ -16,6 +16,7 @@ import type { SimKinesis } from "../kinesis/index.js";
 import type { SimKms } from "../kms/index.js";
 import type { SimLambda } from "../lambda/index.js";
 import type { SimRoute53 } from "../route53/index.js";
+import type { SimBackup } from "../backup/index.js";
 
 export const AWS_REGION_NAMES = [
   "us-east-1",
@@ -134,6 +135,11 @@ export class SimAwsRegion {
    */
   acm(): SimAcm {
     return this.account().acm();
+  }
+
+  /** Get simulated AWS Backup for this Region's default Account. */
+  backup(): SimBackup {
+    return this.account().backup();
   }
 
   /**

--- a/src/service/aws/sim-aws-service-accessors.ts
+++ b/src/service/aws/sim-aws-service-accessors.ts
@@ -2,6 +2,7 @@ import type { SimAwsAccountRegionContainer } from "./sim-aws-account-region-scop
 import type { SimAcm } from "../acm/sim-acm.js";
 import type { SimAthena } from "../athena/index.js";
 import type { SimBedrock } from "../bedrock/index.js";
+import type { SimBackup } from "../backup/index.js";
 import type { SimApiGateway } from "../apigateway/index.js";
 import type { SimApiGatewayV2 } from "../apigatewayv2/index.js";
 import type { SimCloudFormation } from "../cloudformation/index.js";
@@ -79,6 +80,11 @@ export abstract class SimAwsServiceAccessors {
   /** Get simulated Bedrock in the default Account Region scope. */
   bedrock(): SimBedrock {
     return this.defaultAccountRegionScope().bedrock();
+  }
+
+  /** Get simulated AWS Backup in the default Account Region scope. */
+  backup(): SimBackup {
+    return this.defaultAccountRegionScope().backup();
   }
 
   /** Get simulated CloudFormation in the default Account Region scope. */

--- a/src/service/backup/cfn/sim-backup-cfn-plan-creator.ts
+++ b/src/service/backup/cfn/sim-backup-cfn-plan-creator.ts
@@ -1,0 +1,35 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimBackupPlan } from "../plan/sim-backup-plan.js";
+import type { SimBackup } from "../sim-backup.js";
+import type { SimCfnBackupProperties } from "./sim-cfn-backup-properties.js";
+import {
+  backupPlanResourceType,
+  simCfnBackupResourceCreation,
+} from "./sim-cfn-backup-resource-error.js";
+
+/** Creates a simulated backup plan for CloudFormation. */
+export async function createSimBackupPlan(
+  backup: SimBackup,
+  resource: SimCfnResource,
+  properties: SimCfnBackupProperties,
+  context: SimCloudFormationResourceCreateContext,
+): Promise<SimBackupPlan> {
+  return await simCfnBackupResourceCreation(
+    backupPlanResourceType,
+    resource.logicalId,
+    async () => {
+      const created = await backup.createBackupPlan(
+        { input: { BackupPlan: properties.backupPlan() } },
+        simCfnResourceCallerOptions(context.caller),
+      );
+      const plan = backup.findBackupPlan(String(created.BackupPlanId));
+      assertDefined(plan, "sim Backup plan after CloudFormation creation");
+      return plan;
+    },
+  );
+}

--- a/src/service/backup/cfn/sim-backup-cfn-resource-deleter.ts
+++ b/src/service/backup/cfn/sim-backup-cfn-resource-deleter.ts
@@ -1,0 +1,46 @@
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimBackupPlan } from "../plan/sim-backup-plan.js";
+import type { SimBackupSelection } from "../selection/sim-backup-selection.js";
+import type { SimBackup } from "../sim-backup.js";
+import type { SimBackupVault } from "../vault/sim-backup-vault.js";
+
+/** Deletes AWS Backup resources during CloudFormation stack teardown. */
+export class SimBackupCfnResourceDeleter {
+  constructor(private readonly backup: SimBackup) {}
+
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    const simulated = resource.simResource;
+    if (resourceTypeName === "BackupVault" && this.isVault(simulated)) {
+      await this.backup.deleteBackupVault(
+        { input: { BackupVaultName: simulated.name } },
+        simCfnResourceCallerOptions(context.caller),
+      );
+      return;
+    }
+    if (resourceTypeName === "BackupPlan" && this.isPlan(simulated)) {
+      this.backup.removeBackupPlan(simulated.id);
+      return;
+    }
+    if (resourceTypeName === "BackupSelection" && this.isSelection(simulated)) {
+      this.backup.removeBackupSelection(simulated.id);
+    }
+  }
+
+  private isVault(value: object | undefined): value is SimBackupVault {
+    return value !== undefined && "name" in value && "configureLock" in value;
+  }
+
+  private isPlan(value: object | undefined): value is SimBackupPlan {
+    return value !== undefined && "versionId" in value && "rules" in value;
+  }
+
+  private isSelection(value: object | undefined): value is SimBackupSelection {
+    return value !== undefined && "planId" in value && "iamRoleArn" in value;
+  }
+}

--- a/src/service/backup/cfn/sim-backup-cfn-resource-factory.ts
+++ b/src/service/backup/cfn/sim-backup-cfn-resource-factory.ts
@@ -1,0 +1,82 @@
+import type { SimCfnServiceResourceFactory } from "../../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceDeleteContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimBackup } from "../sim-backup.js";
+import { createSimBackupPlan } from "./sim-backup-cfn-plan-creator.js";
+import { SimBackupCfnResourceDeleter } from "./sim-backup-cfn-resource-deleter.js";
+import { createSimBackupSelection } from "./sim-backup-cfn-selection-creator.js";
+import { createSimBackupVault } from "./sim-backup-cfn-vault-creator.js";
+import { SimCfnBackupProperties } from "./sim-cfn-backup-properties.js";
+import { simCfnBackupResourceError } from "./sim-cfn-backup-resource-error.js";
+
+/** Creates and deletes the AWS Backup resource types supported by the simulation. */
+export class SimBackupCfnResourceFactory implements SimCfnServiceResourceFactory {
+  private readonly deleter: SimBackupCfnResourceDeleter;
+
+  constructor(private readonly properties: { readonly backup: SimBackup }) {
+    this.deleter = new SimBackupCfnResourceDeleter(properties.backup);
+  }
+
+  async create(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceCreateContext,
+  ): Promise<object> {
+    const properties = this.read(
+      resource,
+      context.resolvedProperties ?? resource.properties,
+    );
+    switch (resourceTypeName) {
+      case "BackupVault": {
+        return await createSimBackupVault(
+          this.properties.backup,
+          resource,
+          properties,
+          context,
+        );
+      }
+      case "BackupPlan": {
+        return await createSimBackupPlan(
+          this.properties.backup,
+          resource,
+          properties,
+          context,
+        );
+      }
+      case "BackupSelection": {
+        return await createSimBackupSelection(
+          this.properties.backup,
+          resource,
+          properties,
+          context,
+        );
+      }
+      default: {
+        throw simCfnBackupResourceError(
+          `AWS::Backup::${resourceTypeName}`,
+          resource.logicalId,
+          "the Resource type is not simulated",
+        );
+      }
+    }
+  }
+
+  async delete(
+    resourceTypeName: string,
+    resource: SimCfnResource,
+    context: SimCloudFormationResourceDeleteContext,
+  ): Promise<void> {
+    await this.deleter.delete(resourceTypeName, resource, context);
+  }
+
+  private read(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnBackupProperties {
+    return new SimCfnBackupProperties(resource, properties);
+  }
+}

--- a/src/service/backup/cfn/sim-backup-cfn-selection-creator.ts
+++ b/src/service/backup/cfn/sim-backup-cfn-selection-creator.ts
@@ -1,0 +1,43 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimBackupSelection } from "../selection/sim-backup-selection.js";
+import type { SimBackup } from "../sim-backup.js";
+import type { SimCfnBackupProperties } from "./sim-cfn-backup-properties.js";
+import {
+  backupSelectionResourceType,
+  simCfnBackupResourceCreation,
+} from "./sim-cfn-backup-resource-error.js";
+
+/** Creates a simulated backup selection for CloudFormation. */
+export async function createSimBackupSelection(
+  backup: SimBackup,
+  resource: SimCfnResource,
+  properties: SimCfnBackupProperties,
+  context: SimCloudFormationResourceCreateContext,
+): Promise<SimBackupSelection> {
+  return await simCfnBackupResourceCreation(
+    backupSelectionResourceType,
+    resource.logicalId,
+    async () => {
+      const created = await backup.createBackupSelection(
+        {
+          input: {
+            BackupPlanId: properties.backupPlanId(),
+            BackupSelection: properties.backupSelection(),
+          },
+        },
+        simCfnResourceCallerOptions(context.caller),
+      );
+      const selection = backup.findBackupSelection(String(created.SelectionId));
+      assertDefined(
+        selection,
+        "sim Backup selection after CloudFormation creation",
+      );
+      return selection;
+    },
+  );
+}

--- a/src/service/backup/cfn/sim-backup-cfn-vault-creator.ts
+++ b/src/service/backup/cfn/sim-backup-cfn-vault-creator.ts
@@ -36,10 +36,15 @@ export async function createSimBackupVault(
       );
       const lock = properties.vaultLockConfiguration();
       if (lock !== undefined) {
-        await backup.putBackupVaultLockConfiguration(
-          { input: { BackupVaultName: name, ...lock } },
-          options,
-        );
+        try {
+          await backup.putBackupVaultLockConfiguration(
+            { input: { BackupVaultName: name, ...lock } },
+            options,
+          );
+        } catch (error) {
+          backup.removeBackupVault(name);
+          throw error;
+        }
       }
       const vault = backup.findBackupVault(name);
       assertDefined(

--- a/src/service/backup/cfn/sim-backup-cfn-vault-creator.ts
+++ b/src/service/backup/cfn/sim-backup-cfn-vault-creator.ts
@@ -1,0 +1,52 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimBackup } from "../sim-backup.js";
+import type { SimBackupVault } from "../vault/sim-backup-vault.js";
+import type { SimCfnBackupProperties } from "./sim-cfn-backup-properties.js";
+import {
+  backupVaultResourceType,
+  simCfnBackupResourceCreation,
+} from "./sim-cfn-backup-resource-error.js";
+
+/** Creates a simulated backup vault for CloudFormation. */
+export async function createSimBackupVault(
+  backup: SimBackup,
+  resource: SimCfnResource,
+  properties: SimCfnBackupProperties,
+  context: SimCloudFormationResourceCreateContext,
+): Promise<SimBackupVault> {
+  return await simCfnBackupResourceCreation(
+    backupVaultResourceType,
+    resource.logicalId,
+    async () => {
+      const name = properties.vaultName();
+      const options = simCfnResourceCallerOptions(context.caller);
+      await backup.createBackupVault(
+        {
+          input: {
+            BackupVaultName: name,
+            EncryptionKeyArn: properties.encryptionKeyArn(),
+          },
+        },
+        options,
+      );
+      const lock = properties.vaultLockConfiguration();
+      if (lock !== undefined) {
+        await backup.putBackupVaultLockConfiguration(
+          { input: { BackupVaultName: name, ...lock } },
+          options,
+        );
+      }
+      const vault = backup.findBackupVault(name);
+      assertDefined(
+        vault,
+        `sim Backup vault ${name} after CloudFormation creation`,
+      );
+      return vault;
+    },
+  );
+}

--- a/src/service/backup/cfn/sim-cfn-backup-plan-properties.ts
+++ b/src/service/backup/cfn/sim-cfn-backup-plan-properties.ts
@@ -1,0 +1,67 @@
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimBackupPlanInput,
+  SimBackupRuleInput,
+} from "../command/sim-backup-command.types.js";
+import { SimCfnBackupPropertyReader } from "./sim-cfn-backup-property-reader.js";
+
+/** Reads a backup plan and its nested rules from CloudFormation properties. */
+export class SimCfnBackupPlanProperties extends SimCfnBackupPropertyReader {
+  constructor(
+    resource: SimCfnResource,
+    private readonly plan: SimCfnTemplateValueRecord,
+  ) {
+    super(resource, plan);
+  }
+
+  read(): SimBackupPlanInput {
+    const rules = this.recordValue(this.plan, "BackupPlanRule");
+    if (!Array.isArray(rules)) {
+      throw this.error("BackupPlan.BackupPlanRule must be an array");
+    }
+    return {
+      BackupPlanName: this.requiredRecordString(this.plan, "BackupPlanName"),
+      Rules: rules.map((rule, index) => this.backupRule(rule, index)),
+    };
+  }
+
+  private backupRule(
+    value: SimCfnTemplateValue,
+    index: number,
+  ): SimBackupRuleInput {
+    const rule = this.record(value, `BackupPlanRule[${String(index)}]`);
+    const lifecycleValue = this.recordValue(rule, "Lifecycle");
+    const lifecycle =
+      lifecycleValue === undefined
+        ? undefined
+        : this.record(lifecycleValue, "Lifecycle");
+    return {
+      RuleName: this.requiredRecordString(rule, "RuleName"),
+      TargetBackupVaultName: this.requiredRecordString(
+        rule,
+        "TargetBackupVault",
+      ),
+      ScheduleExpression: this.optionalString(
+        this.recordValue(rule, "ScheduleExpression"),
+        "ScheduleExpression",
+      ),
+      Lifecycle:
+        lifecycle === undefined
+          ? undefined
+          : {
+              DeleteAfterDays: this.optionalNumber(
+                this.recordValue(lifecycle, "DeleteAfterDays"),
+                "DeleteAfterDays",
+              ),
+              MoveToColdStorageAfterDays: this.optionalNumber(
+                this.recordValue(lifecycle, "MoveToColdStorageAfterDays"),
+                "MoveToColdStorageAfterDays",
+              ),
+            },
+    };
+  }
+}

--- a/src/service/backup/cfn/sim-cfn-backup-properties.ts
+++ b/src/service/backup/cfn/sim-cfn-backup-properties.ts
@@ -1,0 +1,62 @@
+import type {
+  SimBackupPlanInput,
+  SimBackupSelectionInput,
+} from "../command/sim-backup-command.types.js";
+import type { SimBackupVaultLockConfiguration } from "../vault/sim-backup-vault.js";
+import { SimCfnBackupPlanProperties } from "./sim-cfn-backup-plan-properties.js";
+import { SimCfnBackupPropertyReader } from "./sim-cfn-backup-property-reader.js";
+
+/** Reads the CloudFormation properties supported by simulated AWS Backup. */
+export class SimCfnBackupProperties extends SimCfnBackupPropertyReader {
+  vaultName(): string {
+    return this.requiredString("BackupVaultName");
+  }
+
+  encryptionKeyArn(): string | undefined {
+    return this.string("EncryptionKeyArn");
+  }
+
+  vaultLockConfiguration(): SimBackupVaultLockConfiguration | undefined {
+    const value = this.values.get("LockConfiguration");
+    if (value === undefined) return undefined;
+    const lock = this.record(value, "LockConfiguration");
+    return {
+      MinRetentionDays: this.optionalNumber(
+        lock["MinRetentionDays"],
+        "MinRetentionDays",
+      ),
+      MaxRetentionDays: this.optionalNumber(
+        lock["MaxRetentionDays"],
+        "MaxRetentionDays",
+      ),
+      ChangeableForDays: this.optionalNumber(
+        lock["ChangeableForDays"],
+        "ChangeableForDays",
+      ),
+    };
+  }
+
+  backupPlan(): SimBackupPlanInput {
+    const plan = this.record(this.values.get("BackupPlan"), "BackupPlan");
+    return new SimCfnBackupPlanProperties(this.resource, plan).read();
+  }
+
+  backupPlanId(): string {
+    return this.requiredString("BackupPlanId");
+  }
+
+  backupSelection(): SimBackupSelectionInput {
+    const selection = this.record(
+      this.values.get("BackupSelection"),
+      "BackupSelection",
+    );
+    return {
+      SelectionName: this.requiredRecordString(selection, "SelectionName"),
+      IamRoleArn: this.requiredRecordString(selection, "IamRoleArn"),
+      Resources: this.stringArray(
+        this.recordValue(selection, "Resources"),
+        "Resources",
+      ),
+    };
+  }
+}

--- a/src/service/backup/cfn/sim-cfn-backup-property-reader.ts
+++ b/src/service/backup/cfn/sim-cfn-backup-property-reader.ts
@@ -1,0 +1,97 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnBackupResourceError } from "./sim-cfn-backup-resource-error.js";
+
+/** Provides typed access to AWS Backup CloudFormation properties. */
+export class SimCfnBackupPropertyReader {
+  protected readonly values: ReadonlyMap<string, SimCfnTemplateValue>;
+
+  constructor(
+    protected readonly resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ) {
+    this.values = new Map(Object.entries(properties));
+  }
+
+  protected requiredString(name: string): string {
+    const value = this.string(name);
+    if (value === undefined || value.length === 0) {
+      throw this.error(`${name} is required`);
+    }
+    return value;
+  }
+
+  protected string(name: string): string | undefined {
+    return this.optionalString(this.values.get(name), name);
+  }
+
+  protected optionalString(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): string | undefined {
+    if (value === undefined) return undefined;
+    if (typeof value !== "string") throw this.error(`${name} must be a string`);
+    return value;
+  }
+
+  protected requiredRecordString(
+    record: SimCfnTemplateValueRecord,
+    name: string,
+  ): string {
+    const value = this.optionalString(this.recordValue(record, name), name);
+    if (value === undefined || value.length === 0) {
+      throw this.error(`${name} is required`);
+    }
+    return value;
+  }
+
+  protected optionalNumber(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): number | undefined {
+    if (value === undefined) return undefined;
+    if (typeof value !== "number") throw this.error(`${name} must be a number`);
+    return value;
+  }
+
+  protected stringArray(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): readonly string[] | undefined {
+    if (value === undefined) return undefined;
+    if (
+      !Array.isArray(value) ||
+      !value.every((item): item is string => typeof item === "string")
+    ) {
+      throw this.error(`${name} must be an array of strings`);
+    }
+    return value;
+  }
+
+  protected record(
+    value: SimCfnTemplateValue | undefined,
+    name: string,
+  ): SimCfnTemplateValueRecord {
+    if (!isRecord(value)) throw this.error(`${name} must be an object`);
+    return value;
+  }
+
+  protected recordValue(
+    record: SimCfnTemplateValueRecord,
+    name: string,
+  ): SimCfnTemplateValue | undefined {
+    return new Map(Object.entries(record)).get(name);
+  }
+
+  protected error(reason: string): Error {
+    return simCfnBackupResourceError(
+      this.resource.type ?? "AWS::Backup::Unknown",
+      this.resource.logicalId,
+      reason,
+    );
+  }
+}

--- a/src/service/backup/cfn/sim-cfn-backup-resource-error.ts
+++ b/src/service/backup/cfn/sim-cfn-backup-resource-error.ts
@@ -1,0 +1,38 @@
+import { SimBackupError } from "../error/sim-backup.error.js";
+
+export const backupVaultResourceType = "AWS::Backup::BackupVault";
+export const backupPlanResourceType = "AWS::Backup::BackupPlan";
+export const backupSelectionResourceType = "AWS::Backup::BackupSelection";
+
+/** Creates an error for invalid AWS Backup CloudFormation resources. */
+export function simCfnBackupResourceError(
+  resourceType: string,
+  logicalId: string,
+  reason: string,
+  cause?: unknown,
+): Error {
+  return new Error(`Invalid ${resourceType} Resource ${logicalId}: ${reason}`, {
+    cause,
+  });
+}
+
+/** Rewrites AWS Backup command errors with CloudFormation resource context. */
+export async function simCfnBackupResourceCreation<T>(
+  resourceType: string,
+  logicalId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await create();
+  } catch (error) {
+    if (error instanceof SimBackupError) {
+      throw simCfnBackupResourceError(
+        resourceType,
+        logicalId,
+        error.message,
+        error,
+      );
+    }
+    throw error;
+  }
+}

--- a/src/service/backup/cfn/sim-cfn-backup-resources.iso.test.ts
+++ b/src/service/backup/cfn/sim-cfn-backup-resources.iso.test.ts
@@ -1,0 +1,170 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+
+describe("AWS Backup CloudFormation resources", () => {
+  it("deploys a vault, plan and selection into simulated AWS Backup", async () => {
+    // Given a template matching the resources emitted by the CDK constructs.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "backup-stack",
+      template: {
+        Resources: {
+          Vault: {
+            Type: "AWS::Backup::BackupVault",
+            Properties: {
+              BackupVaultName: "governed-backups",
+              EncryptionKeyArn:
+                "arn:aws:kms:us-east-1:888888888888:key/00000000-0000-0000-0000-000000000000",
+              LockConfiguration: {
+                MinRetentionDays: 7,
+                MaxRetentionDays: 365,
+              },
+            },
+          },
+          Plan: {
+            Type: "AWS::Backup::BackupPlan",
+            Properties: {
+              BackupPlan: {
+                BackupPlanName: "workload-backups",
+                BackupPlanRule: [
+                  {
+                    RuleName: "daily",
+                    TargetBackupVault: {
+                      "Fn::GetAtt": ["Vault", "BackupVaultName"],
+                    },
+                    ScheduleExpression: "cron(0 1 ? * * *)",
+                    Lifecycle: { DeleteAfterDays: 35 },
+                  },
+                  {
+                    RuleName: "monthly",
+                    TargetBackupVault: { Ref: "Vault" },
+                    ScheduleExpression: "cron(0 3 1 * ? *)",
+                    Lifecycle: {
+                      MoveToColdStorageAfterDays: 30,
+                      DeleteAfterDays: 120,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          Selection: {
+            Type: "AWS::Backup::BackupSelection",
+            Properties: {
+              BackupPlanId: { "Fn::GetAtt": ["Plan", "BackupPlanId"] },
+              BackupSelection: {
+                SelectionName: "orders",
+                IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+                Resources: [
+                  "arn:aws:dynamodb:us-east-1:888888888888:table/orders",
+                ],
+              },
+            },
+          },
+        },
+        Outputs: {
+          VaultName: { Value: { Ref: "Vault" } },
+          VaultArn: { Value: { "Fn::GetAtt": ["Vault", "BackupVaultArn"] } },
+          PlanId: { Value: { Ref: "Plan" } },
+          PlanArn: { Value: { "Fn::GetAtt": ["Plan", "BackupPlanArn"] } },
+          VersionId: { Value: { "Fn::GetAtt": ["Plan", "VersionId"] } },
+          SelectionId: { Value: { Ref: "Selection" } },
+          SelectionAlias: { Value: { "Fn::GetAtt": ["Selection", "Id"] } },
+          SelectionPlan: {
+            Value: { "Fn::GetAtt": ["Selection", "BackupPlanId"] },
+          },
+        },
+      },
+    });
+
+    // When deployment completes.
+    await stack.waitForDeployComplete();
+
+    // Then all three resources can be read from AWS Backup.
+    const vault = simAws.backup().findBackupVault("governed-backups");
+    assertNonNullable(vault);
+    assertTrue(vault.describe().Locked);
+
+    const planId = stack.output("PlanId");
+    const plan = simAws.backup().findBackupPlan(planId);
+    assertNonNullable(plan);
+    assertArrayLength(plan.rules, 2);
+    assertIdentical(plan.rules[1].Lifecycle?.MoveToColdStorageAfterDays, 30);
+
+    const selectionId = stack.output("SelectionId");
+    const selection = simAws.backup().findBackupSelection(selectionId);
+    assertNonNullable(selection);
+    assertIdentical(
+      selection.resources[0],
+      "arn:aws:dynamodb:us-east-1:888888888888:table/orders",
+    );
+    assertIdentical(stack.output("VaultName"), "governed-backups");
+    assertIdentical(stack.output("SelectionAlias"), selectionId);
+    assertIdentical(stack.output("SelectionPlan"), planId);
+    assertIdentical(stack.output("VersionId"), plan.versionId);
+  });
+
+  it("removes the Backup resources during stack teardown", async () => {
+    // Given a deployed vault, plan and selection.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "backup-stack",
+      template: {
+        Resources: {
+          Vault: {
+            Type: "AWS::Backup::BackupVault",
+            Properties: { BackupVaultName: "ephemeral-backups" },
+          },
+          Plan: {
+            Type: "AWS::Backup::BackupPlan",
+            Properties: {
+              BackupPlan: {
+                BackupPlanName: "ephemeral-plan",
+                BackupPlanRule: [
+                  {
+                    RuleName: "daily",
+                    TargetBackupVault: { Ref: "Vault" },
+                  },
+                ],
+              },
+            },
+          },
+          Selection: {
+            Type: "AWS::Backup::BackupSelection",
+            Properties: {
+              BackupPlanId: { Ref: "Plan" },
+              BackupSelection: {
+                SelectionName: "orders",
+                IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+              },
+            },
+          },
+        },
+        Outputs: {
+          PlanId: { Value: { Ref: "Plan" } },
+          SelectionId: { Value: { Ref: "Selection" } },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+    const planId = stack.output("PlanId");
+    const selectionId = stack.output("SelectionId");
+
+    // When the stack is torn down.
+    await stack.teardown();
+    await simAws.backgroundTasksComplete();
+
+    // Then none of the three resources remains.
+    assertUndefined(simAws.backup().findBackupVault("ephemeral-backups"));
+    assertUndefined(simAws.backup().findBackupPlan(planId));
+    assertUndefined(simAws.backup().findBackupSelection(selectionId));
+  });
+});

--- a/src/service/backup/cfn/sim-cfn-backup-resources.iso.test.ts
+++ b/src/service/backup/cfn/sim-cfn-backup-resources.iso.test.ts
@@ -2,6 +2,8 @@ import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
   assertTrue,
   assertUndefined,
 } from "@kensio/smartass";
@@ -166,5 +168,37 @@ describe("AWS Backup CloudFormation resources", () => {
     assertUndefined(simAws.backup().findBackupVault("ephemeral-backups"));
     assertUndefined(simAws.backup().findBackupPlan(planId));
     assertUndefined(simAws.backup().findBackupSelection(selectionId));
+  });
+
+  it("leaves no vault behind when its lock configuration fails", async () => {
+    // Given a vault Resource with a lock configuration AWS Backup refuses.
+    const simAws = new SimAws();
+
+    // When the template is deployed, then the deployment fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "invalid-backup-stack",
+        template: {
+          Resources: {
+            Vault: {
+              Type: "AWS::Backup::BackupVault",
+              Properties: {
+                BackupVaultName: "invalid-backups",
+                LockConfiguration: {
+                  MinRetentionDays: 30,
+                  MaxRetentionDays: 7,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the failed Resource leaves no vault to block another deployment.
+    assertStringIncludes(error.message, "MinRetentionDays must not exceed");
+    assertUndefined(simAws.backup().findBackupVault("invalid-backups"));
+
+    await simAws.backgroundTasksComplete();
   });
 });

--- a/src/service/backup/command/sim-backup-authorizer.ts
+++ b/src/service/backup/command/sim-backup-authorizer.ts
@@ -1,0 +1,34 @@
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamCallerIdentifier } from "../../iam/error/sim-iam-caller-identifier.js";
+import { SimBackupAccessDeniedException } from "../error/sim-backup.error.js";
+import type { SimBackupRequestOptions } from "./sim-backup-request-options.js";
+
+/**
+ *
+ */
+export class SimBackupAuthorizer {
+  private readonly callerIdentifier = new SimIamCallerIdentifier();
+
+  constructor(private readonly iam: SimIamInterServiceAuthZ) {}
+
+  authorize(
+    action: string,
+    resource: string,
+    options?: SimBackupRequestOptions,
+  ): void {
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller: options?.caller,
+    });
+
+    if (decision.isDenied) {
+      const caller = this.callerIdentifier.format(decision.caller.principal);
+
+      throw new SimBackupAccessDeniedException(
+        `User: ${caller} is not authorized to perform: ${action} on ` +
+          `resource: ${resource}`,
+      );
+    }
+  }
+}

--- a/src/service/backup/command/sim-backup-command.types.ts
+++ b/src/service/backup/command/sim-backup-command.types.ts
@@ -1,0 +1,170 @@
+export interface SimBackupLifecycle {
+  readonly MoveToColdStorageAfterDays?: number | undefined;
+  readonly DeleteAfterDays?: number | undefined;
+}
+
+export interface SimBackupRuleInput {
+  readonly RuleName?: string | undefined;
+  readonly TargetBackupVaultName?: string | undefined;
+  readonly ScheduleExpression?: string | undefined;
+  readonly Lifecycle?: SimBackupLifecycle | undefined;
+}
+
+export interface SimBackupRule extends SimBackupRuleInput {
+  readonly RuleId?: string | undefined;
+}
+
+export interface SimBackupPlanInput {
+  readonly BackupPlanName?: string | undefined;
+  readonly Rules?: readonly SimBackupRuleInput[] | undefined;
+}
+
+export interface SimBackupSelectionInput {
+  readonly SelectionName?: string | undefined;
+  readonly IamRoleArn?: string | undefined;
+  readonly Resources?: readonly string[] | undefined;
+}
+
+export interface SimBackupCommand<Input> {
+  readonly input: Input;
+}
+
+export type SimCreateBackupVaultCommand = SimBackupCommand<{
+  readonly BackupVaultName?: string | undefined;
+  readonly BackupVaultTags?: Readonly<Record<string, string>> | undefined;
+  readonly EncryptionKeyArn?: string | undefined;
+  readonly CreatorRequestId?: string | undefined;
+}>;
+
+export interface SimCreateBackupVaultCommandOutput {
+  readonly BackupVaultName?: string | undefined;
+  readonly BackupVaultArn?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+}
+
+export type SimDescribeBackupVaultCommand = SimBackupCommand<{
+  readonly BackupVaultName?: string | undefined;
+}>;
+
+export interface SimDescribeBackupVaultCommandOutput {
+  readonly BackupVaultName?: string | undefined;
+  readonly BackupVaultArn?: string | undefined;
+  readonly EncryptionKeyArn?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly CreatorRequestId?: string | undefined;
+  readonly NumberOfRecoveryPoints?: number | undefined;
+  readonly Locked?: boolean | undefined;
+  readonly MinRetentionDays?: number | undefined;
+  readonly MaxRetentionDays?: number | undefined;
+  readonly LockDate?: Date | undefined;
+}
+
+export type SimDeleteBackupVaultCommand = SimDescribeBackupVaultCommand;
+export type SimDeleteBackupVaultCommandOutput = object;
+
+export type SimListBackupVaultsCommand = SimBackupCommand<{
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}>;
+
+export interface SimBackupVaultListMember {
+  readonly BackupVaultName?: string | undefined;
+  readonly BackupVaultArn?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly EncryptionKeyArn?: string | undefined;
+  readonly CreatorRequestId?: string | undefined;
+  readonly NumberOfRecoveryPoints?: number | undefined;
+  readonly Locked?: boolean | undefined;
+  readonly MinRetentionDays?: number | undefined;
+  readonly MaxRetentionDays?: number | undefined;
+  readonly LockDate?: Date | undefined;
+}
+
+export interface SimListBackupVaultsCommandOutput {
+  readonly BackupVaultList?: readonly SimBackupVaultListMember[] | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export type SimPutBackupVaultLockConfigurationCommand = SimBackupCommand<{
+  readonly BackupVaultName?: string | undefined;
+  readonly MinRetentionDays?: number | undefined;
+  readonly MaxRetentionDays?: number | undefined;
+  readonly ChangeableForDays?: number | undefined;
+}>;
+export type SimPutBackupVaultLockConfigurationCommandOutput = object;
+
+export type SimCreateBackupPlanCommand = SimBackupCommand<{
+  readonly BackupPlan?: SimBackupPlanInput | undefined;
+  readonly CreatorRequestId?: string | undefined;
+}>;
+
+export interface SimCreateBackupPlanCommandOutput {
+  readonly BackupPlanId?: string | undefined;
+  readonly BackupPlanArn?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly VersionId?: string | undefined;
+}
+
+export type SimGetBackupPlanCommand = SimBackupCommand<{
+  readonly BackupPlanId?: string | undefined;
+  readonly VersionId?: string | undefined;
+}>;
+
+export interface SimGetBackupPlanCommandOutput {
+  readonly BackupPlan?: {
+    readonly BackupPlanName?: string | undefined;
+    readonly Rules?: readonly SimBackupRule[] | undefined;
+  };
+  readonly BackupPlanId?: string | undefined;
+  readonly BackupPlanArn?: string | undefined;
+  readonly VersionId?: string | undefined;
+  readonly CreatorRequestId?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+}
+
+export type SimCreateBackupSelectionCommand = SimBackupCommand<{
+  readonly BackupPlanId?: string | undefined;
+  readonly BackupSelection?: SimBackupSelectionInput | undefined;
+  readonly CreatorRequestId?: string | undefined;
+}>;
+
+export interface SimCreateBackupSelectionCommandOutput {
+  readonly SelectionId?: string | undefined;
+  readonly BackupPlanId?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+}
+
+export type SimGetBackupSelectionCommand = SimBackupCommand<{
+  readonly BackupPlanId?: string | undefined;
+  readonly SelectionId?: string | undefined;
+}>;
+
+export interface SimGetBackupSelectionCommandOutput {
+  readonly BackupSelection?: SimBackupSelectionInput | undefined;
+  readonly SelectionId?: string | undefined;
+  readonly BackupPlanId?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly CreatorRequestId?: string | undefined;
+}
+
+export type SimListBackupSelectionsCommand = SimBackupCommand<{
+  readonly BackupPlanId?: string | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}>;
+
+export interface SimBackupSelectionListMember {
+  readonly SelectionId?: string | undefined;
+  readonly SelectionName?: string | undefined;
+  readonly BackupPlanId?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly CreatorRequestId?: string | undefined;
+  readonly IamRoleArn?: string | undefined;
+}
+
+export interface SimListBackupSelectionsCommandOutput {
+  readonly BackupSelectionsList?:
+    | readonly SimBackupSelectionListMember[]
+    | undefined;
+  readonly NextToken?: string | undefined;
+}

--- a/src/service/backup/command/sim-backup-iam.iso.test.ts
+++ b/src/service/backup/command/sim-backup-iam.iso.test.ts
@@ -1,0 +1,111 @@
+import {
+  CreateBackupVaultCommand,
+  DescribeBackupVaultCommand,
+  ListBackupVaultsCommand,
+} from "@aws-sdk/client-backup";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimBackupAccessDeniedException } from "../error/sim-backup.error.js";
+
+async function simAwsWithRole(
+  statement: object,
+): Promise<{ readonly simAws: SimAws; readonly caller: SimAwsCaller }> {
+  const simAws = new SimAws();
+  const role = await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "BackupAdministrator",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "BackupAdministrator",
+      PolicyName: "ManageBackup",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: statement,
+      }),
+    }),
+  );
+  return { simAws, caller: { kind: "arn", arn: role.Role.Arn } };
+}
+
+describe("AWS Backup IAM authorization", () => {
+  it("authorizes a vault command against the vault ARN", async () => {
+    // Given a Role allowed to create one named vault.
+    const vaultName = "permitted-vault";
+    const vaultArn = `arn:aws:backup:us-east-1:888888888888:backup-vault:${vaultName}`;
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "backup:CreateBackupVault",
+      Resource: vaultArn,
+    });
+
+    // When it creates that vault.
+    const created = await simAws
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+        { caller },
+      );
+
+    // Then the command is allowed for the exact ARN.
+    assertIdentical(created.BackupVaultArn, vaultArn);
+  });
+
+  it("refuses an unauthorized read before looking up the vault", async () => {
+    // Given a Role with no permission to describe vaults.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "backup:CreateBackupVault",
+      Resource: "*",
+    });
+
+    // When it describes a vault that is absent.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .backup()
+        .describeBackupVault(
+          new DescribeBackupVaultCommand({ BackupVaultName: "missing" }),
+          { caller },
+        );
+    });
+
+    // Then authorization fails before resource lookup.
+    assertInstanceOf(error, SimBackupAccessDeniedException);
+  });
+
+  it("authorizes ListBackupVaults against every resource", async () => {
+    // Given a Role whose list permission names one vault ARN.
+    const { simAws, caller } = await simAwsWithRole({
+      Effect: "Allow",
+      Action: "backup:ListBackupVaults",
+      Resource: "arn:aws:backup:us-east-1:888888888888:backup-vault:one-vault",
+    });
+
+    // When it lists vaults.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.backup().listBackupVaults(new ListBackupVaultsCommand({}), {
+        caller,
+      });
+    });
+
+    // Then the resource-scoped permission does not match the list action.
+    assertInstanceOf(error, SimBackupAccessDeniedException);
+  });
+});

--- a/src/service/backup/command/sim-backup-request-options.ts
+++ b/src/service/backup/command/sim-backup-request-options.ts
@@ -1,0 +1,5 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+
+export interface SimBackupRequestOptions {
+  readonly caller?: SimAwsCaller | undefined;
+}

--- a/src/service/backup/command/sim-backup-required-string.ts
+++ b/src/service/backup/command/sim-backup-required-string.ts
@@ -1,0 +1,13 @@
+import { SimBackupMissingParameterValueException } from "../error/sim-backup.error.js";
+
+/** Reads a required non-empty string from an AWS Backup request. */
+export function requiredString(
+  value: string | undefined,
+  name: string,
+): string {
+  if (value === undefined || value.length === 0) {
+    throw new SimBackupMissingParameterValueException(`${name} is required`);
+  }
+
+  return value;
+}

--- a/src/service/backup/error/sim-backup.error.ts
+++ b/src/service/backup/error/sim-backup.error.ts
@@ -1,0 +1,70 @@
+export interface SimBackupErrorMetadata {
+  readonly httpStatusCode?: number | undefined;
+}
+
+/**
+ *
+ */
+export class SimBackupError extends Error {
+  constructor(
+    message: string,
+    public readonly $metadata: SimBackupErrorMetadata = {},
+  ) {
+    super(message);
+  }
+}
+
+/**
+ *
+ */
+export class SimBackupAccessDeniedException extends SimBackupError {
+  override readonly name = "AccessDeniedException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 403 });
+  }
+}
+
+/**
+ *
+ */
+export class SimBackupAlreadyExistsException extends SimBackupError {
+  override readonly name = "AlreadyExistsException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ *
+ */
+export class SimBackupInvalidParameterValueException extends SimBackupError {
+  override readonly name = "InvalidParameterValueException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ *
+ */
+export class SimBackupMissingParameterValueException extends SimBackupError {
+  override readonly name = "MissingParameterValueException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ *
+ */
+export class SimBackupResourceNotFoundException extends SimBackupError {
+  override readonly name = "ResourceNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/backup/index.ts
+++ b/src/service/backup/index.ts
@@ -1,0 +1,20 @@
+export { SimBackup } from "./sim-backup.js";
+export type { SimBackupRequestOptions } from "./command/sim-backup-request-options.js";
+export type {
+  SimBackupLifecycle,
+  SimBackupPlanInput,
+  SimBackupRule,
+  SimBackupRuleInput,
+  SimBackupSelectionInput,
+} from "./command/sim-backup-command.types.js";
+export { SimBackupPlan } from "./plan/sim-backup-plan.js";
+export { SimBackupSelection } from "./selection/sim-backup-selection.js";
+export { SimBackupVault } from "./vault/sim-backup-vault.js";
+export {
+  SimBackupAccessDeniedException,
+  SimBackupAlreadyExistsException,
+  SimBackupError,
+  SimBackupInvalidParameterValueException,
+  SimBackupMissingParameterValueException,
+  SimBackupResourceNotFoundException,
+} from "./error/sim-backup.error.js";

--- a/src/service/backup/plan/sim-backup-plan.ts
+++ b/src/service/backup/plan/sim-backup-plan.ts
@@ -1,0 +1,58 @@
+import type {
+  SimBackupPlanInput,
+  SimBackupRule,
+  SimGetBackupPlanCommandOutput,
+} from "../command/sim-backup-command.types.js";
+import { requiredString } from "../command/sim-backup-required-string.js";
+import { readBackupRules } from "./sim-backup-rule.js";
+
+interface SimBackupPlanProperties {
+  readonly id: string;
+  readonly arn: string;
+  readonly versionId: string;
+  readonly creationDate: Date;
+  readonly creatorRequestId?: string | undefined;
+  readonly plan: SimBackupPlanInput;
+}
+
+/** Stores one simulated AWS Backup plan. */
+export class SimBackupPlan {
+  public readonly id: string;
+  public readonly arn: string;
+  public readonly versionId: string;
+  public readonly creationDate: Date;
+  public readonly creatorRequestId?: string | undefined;
+  public readonly name: string;
+  public readonly rules: readonly SimBackupRule[];
+
+  constructor(properties: SimBackupPlanProperties) {
+    this.id = properties.id;
+    this.arn = properties.arn;
+    this.versionId = properties.versionId;
+    this.creationDate = new Date(properties.creationDate);
+    this.creatorRequestId = properties.creatorRequestId;
+    this.name = requiredString(
+      properties.plan.BackupPlanName,
+      "BackupPlanName",
+    );
+    this.rules = readBackupRules(properties.plan.Rules);
+  }
+
+  describe(): SimGetBackupPlanCommandOutput {
+    return {
+      BackupPlan: {
+        BackupPlanName: this.name,
+        Rules: this.rules.map((rule) => ({
+          ...rule,
+          Lifecycle:
+            rule.Lifecycle === undefined ? undefined : { ...rule.Lifecycle },
+        })),
+      },
+      BackupPlanId: this.id,
+      BackupPlanArn: this.arn,
+      VersionId: this.versionId,
+      CreatorRequestId: this.creatorRequestId,
+      CreationDate: new Date(this.creationDate),
+    };
+  }
+}

--- a/src/service/backup/plan/sim-backup-rule.ts
+++ b/src/service/backup/plan/sim-backup-rule.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from "node:crypto";
+
+import { awsCronFieldSpecs } from "../../../util/schedule/cron/sim-cron-field-spec.js";
+import { SimSchedule } from "../../../util/schedule/sim-schedule.js";
+import type { SimScheduleDialect } from "../../../util/schedule/sim-schedule-dialect.js";
+import { SimScheduleExpressionError } from "../../../util/schedule/sim-schedule.error.js";
+import type {
+  SimBackupRule,
+  SimBackupRuleInput,
+} from "../command/sim-backup-command.types.js";
+import { requiredString } from "../command/sim-backup-required-string.js";
+import {
+  SimBackupInvalidParameterValueException,
+  SimBackupMissingParameterValueException,
+} from "../error/sim-backup.error.js";
+
+export const defaultBackupScheduleExpression = "cron(0 5 ? * * *)";
+
+/** Defines the AWS Backup cron dialect used by plan rules. */
+export const backupScheduleDialect: SimScheduleDialect = {
+  cronFields: awsCronFieldSpecs,
+  requiresRateAgreement: true,
+  allowsOneTime: false,
+};
+
+/** Reads and validates the rules in a backup plan. */
+export function readBackupRules(
+  input: readonly SimBackupRuleInput[] | undefined,
+): readonly SimBackupRule[] {
+  if (input === undefined || input.length === 0) {
+    throw new SimBackupMissingParameterValueException(
+      "BackupPlan.Rules must contain at least one rule",
+    );
+  }
+
+  return input.map((rule) => readBackupRule(rule));
+}
+
+function readBackupRule(input: SimBackupRuleInput): SimBackupRule {
+  const schedule = input.ScheduleExpression ?? defaultBackupScheduleExpression;
+  validateSchedule(schedule);
+  validateLifecycle(input);
+
+  return {
+    RuleId: randomUUID(),
+    RuleName: requiredString(input.RuleName, "RuleName"),
+    TargetBackupVaultName: requiredString(
+      input.TargetBackupVaultName,
+      "TargetBackupVaultName",
+    ),
+    ScheduleExpression: schedule,
+    Lifecycle:
+      input.Lifecycle === undefined ? undefined : { ...input.Lifecycle },
+  };
+}
+
+function validateSchedule(schedule: string): void {
+  try {
+    SimSchedule.of(schedule, backupScheduleDialect);
+  } catch (error) {
+    if (error instanceof SimScheduleExpressionError) {
+      throw new SimBackupInvalidParameterValueException(error.message);
+    }
+    throw error;
+  }
+}
+
+function validateLifecycle(input: SimBackupRuleInput): void {
+  const coldAfter = input.Lifecycle?.MoveToColdStorageAfterDays;
+  const deleteAfter = input.Lifecycle?.DeleteAfterDays;
+  if (
+    coldAfter !== undefined &&
+    deleteAfter !== undefined &&
+    deleteAfter < coldAfter + 90
+  ) {
+    throw new SimBackupInvalidParameterValueException(
+      "DeleteAfterDays must be at least 90 days after MoveToColdStorageAfterDays",
+    );
+  }
+}

--- a/src/service/backup/plan/sim-backup-rule.ts
+++ b/src/service/backup/plan/sim-backup-rule.ts
@@ -36,6 +36,7 @@ export function readBackupRules(
   return input.map((rule) => readBackupRule(rule));
 }
 
+/** Validates and normalizes one backup plan rule for storage. */
 function readBackupRule(input: SimBackupRuleInput): SimBackupRule {
   const schedule = input.ScheduleExpression ?? defaultBackupScheduleExpression;
   validateSchedule(schedule);
@@ -54,6 +55,7 @@ function readBackupRule(input: SimBackupRuleInput): SimBackupRule {
   };
 }
 
+/** Rejects expressions outside the AWS Backup schedule dialect. */
 function validateSchedule(schedule: string): void {
   try {
     SimSchedule.of(schedule, backupScheduleDialect);
@@ -65,10 +67,13 @@ function validateSchedule(schedule: string): void {
   }
 }
 
+/** Enforces the relationship between cold storage and deletion. */
 function validateLifecycle(input: SimBackupRuleInput): void {
   const coldAfter = input.Lifecycle?.MoveToColdStorageAfterDays;
   const deleteAfter = input.Lifecycle?.DeleteAfterDays;
+  const retainedIndefinitely = coldAfter === -1 && deleteAfter === -1;
   if (
+    !retainedIndefinitely &&
     coldAfter !== undefined &&
     deleteAfter !== undefined &&
     deleteAfter < coldAfter + 90

--- a/src/service/backup/sdk/sim-backup-sdk-command-router.ts
+++ b/src/service/backup/sdk/sim-backup-sdk-command-router.ts
@@ -6,9 +6,7 @@ import {
 import type * as commands from "../command/sim-backup-command.types.js";
 import type { SimBackup } from "../sim-backup.js";
 
-/**
- *
- */
+/** Routes supported BackupClient commands to simulated AWS Backup. */
 export class SimBackupSdkCommandRouter implements SimSdkCommandRouter {
   private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
 
@@ -86,6 +84,7 @@ export class SimBackupSdkCommandRouter implements SimSdkCommandRouter {
   }
 }
 
+/** Builds one route with caller options from the interception context. */
 function route(
   name: string,
   handle: (

--- a/src/service/backup/sdk/sim-backup-sdk-command-router.ts
+++ b/src/service/backup/sdk/sim-backup-sdk-command-router.ts
@@ -1,0 +1,101 @@
+import {
+  simSdkCallerOptions,
+  type SimSdkCommandRoute,
+  type SimSdkCommandRouter,
+} from "../../../sdk/index.js";
+import type * as commands from "../command/sim-backup-command.types.js";
+import type { SimBackup } from "../sim-backup.js";
+
+/**
+ *
+ */
+export class SimBackupSdkCommandRouter implements SimSdkCommandRouter {
+  private readonly routes: ReadonlyMap<string, SimSdkCommandRoute>;
+
+  constructor(backup: SimBackup) {
+    this.routes = new Map([
+      route("CreateBackupVaultCommand", (command, options) =>
+        backup.createBackupVault(
+          command as commands.SimCreateBackupVaultCommand,
+          options,
+        ),
+      ),
+      route("DescribeBackupVaultCommand", (command, options) =>
+        backup.describeBackupVault(
+          command as commands.SimDescribeBackupVaultCommand,
+          options,
+        ),
+      ),
+      route("DeleteBackupVaultCommand", (command, options) =>
+        backup.deleteBackupVault(
+          command as commands.SimDeleteBackupVaultCommand,
+          options,
+        ),
+      ),
+      route("ListBackupVaultsCommand", (command, options) =>
+        backup.listBackupVaults(
+          command as commands.SimListBackupVaultsCommand,
+          options,
+        ),
+      ),
+      route("PutBackupVaultLockConfigurationCommand", (command, options) =>
+        backup.putBackupVaultLockConfiguration(
+          command as commands.SimPutBackupVaultLockConfigurationCommand,
+          options,
+        ),
+      ),
+      route("CreateBackupPlanCommand", (command, options) =>
+        backup.createBackupPlan(
+          command as commands.SimCreateBackupPlanCommand,
+          options,
+        ),
+      ),
+      route("GetBackupPlanCommand", (command, options) =>
+        backup.getBackupPlan(
+          command as commands.SimGetBackupPlanCommand,
+          options,
+        ),
+      ),
+      route("CreateBackupSelectionCommand", (command, options) =>
+        backup.createBackupSelection(
+          command as commands.SimCreateBackupSelectionCommand,
+          options,
+        ),
+      ),
+      route("GetBackupSelectionCommand", (command, options) =>
+        backup.getBackupSelection(
+          command as commands.SimGetBackupSelectionCommand,
+          options,
+        ),
+      ),
+      route("ListBackupSelectionsCommand", (command, options) =>
+        backup.listBackupSelections(
+          command as commands.SimListBackupSelectionsCommand,
+          options,
+        ),
+      ),
+    ]);
+  }
+
+  supportedCommandNames(): readonly string[] {
+    return this.routes.keys().toArray();
+  }
+
+  route(commandName: string): SimSdkCommandRoute | undefined {
+    return this.routes.get(commandName);
+  }
+}
+
+function route(
+  name: string,
+  handle: (
+    command: object,
+    options: ReturnType<typeof simSdkCallerOptions>,
+  ) => Promise<unknown>,
+): readonly [string, SimSdkCommandRoute] {
+  return [
+    name,
+    async (command, context): Promise<unknown> =>
+      await handle(command, simSdkCallerOptions(context)),
+  ];
+}

--- a/src/service/backup/selection/sim-backup-selection.ts
+++ b/src/service/backup/selection/sim-backup-selection.ts
@@ -1,0 +1,68 @@
+import type {
+  SimBackupSelectionInput,
+  SimBackupSelectionListMember,
+  SimGetBackupSelectionCommandOutput,
+} from "../command/sim-backup-command.types.js";
+import { requiredString } from "../command/sim-backup-required-string.js";
+
+interface SimBackupSelectionProperties {
+  readonly id: string;
+  readonly planId: string;
+  readonly creationDate: Date;
+  readonly creatorRequestId?: string | undefined;
+  readonly selection: SimBackupSelectionInput;
+}
+
+/**
+ *
+ */
+export class SimBackupSelection {
+  public readonly id: string;
+  public readonly planId: string;
+  public readonly creationDate: Date;
+  public readonly creatorRequestId?: string | undefined;
+  public readonly name: string;
+  public readonly iamRoleArn: string;
+  public readonly resources: readonly string[];
+
+  constructor(properties: SimBackupSelectionProperties) {
+    this.id = properties.id;
+    this.planId = properties.planId;
+    this.creationDate = new Date(properties.creationDate);
+    this.creatorRequestId = properties.creatorRequestId;
+    this.name = requiredString(
+      properties.selection.SelectionName,
+      "SelectionName",
+    );
+    this.iamRoleArn = requiredString(
+      properties.selection.IamRoleArn,
+      "IamRoleArn",
+    );
+    this.resources = [...(properties.selection.Resources ?? [])];
+  }
+
+  describe(): SimGetBackupSelectionCommandOutput {
+    return {
+      BackupSelection: {
+        SelectionName: this.name,
+        IamRoleArn: this.iamRoleArn,
+        Resources: [...this.resources],
+      },
+      SelectionId: this.id,
+      BackupPlanId: this.planId,
+      CreationDate: new Date(this.creationDate),
+      CreatorRequestId: this.creatorRequestId,
+    };
+  }
+
+  listMember(): SimBackupSelectionListMember {
+    return {
+      SelectionId: this.id,
+      SelectionName: this.name,
+      BackupPlanId: this.planId,
+      CreationDate: new Date(this.creationDate),
+      CreatorRequestId: this.creatorRequestId,
+      IamRoleArn: this.iamRoleArn,
+    };
+  }
+}

--- a/src/service/backup/selection/sim-backup-selection.ts
+++ b/src/service/backup/selection/sim-backup-selection.ts
@@ -13,9 +13,7 @@ interface SimBackupSelectionProperties {
   readonly selection: SimBackupSelectionInput;
 }
 
-/**
- *
- */
+/** Stored configuration for one selection in a backup plan. */
 export class SimBackupSelection {
   public readonly id: string;
   public readonly planId: string;

--- a/src/service/backup/sim-backup-arn.ts
+++ b/src/service/backup/sim-backup-arn.ts
@@ -1,0 +1,17 @@
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+
+/** Builds the ARN of a backup vault in the supplied scope. */
+export function backupVaultArn(
+  name: string,
+  scope: SimAwsAccountRegionScope,
+): string {
+  return `arn:aws:backup:${scope.regionName}:${scope.accountId}:backup-vault:${name}`;
+}
+
+/** Builds the ARN of a backup plan in the supplied scope. */
+export function backupPlanArn(
+  id: string,
+  scope: SimAwsAccountRegionScope,
+): string {
+  return `arn:aws:backup:${scope.regionName}:${scope.accountId}:backup-plan:${id}`;
+}

--- a/src/service/backup/sim-backup-commands.iso.test.ts
+++ b/src/service/backup/sim-backup-commands.iso.test.ts
@@ -197,4 +197,45 @@ describe("simulated AWS Backup commands", () => {
       .listBackupVaults(new ListBackupVaultsCommand({}));
     assertArrayLength(vaults.BackupVaultList ?? [], 0);
   });
+
+  it("stores an indefinite-retention lifecycle", async () => {
+    // Given a backup vault for an indefinite-retention plan.
+    const simAws = new SimAws();
+    const vaultName = `vault-${faker.string.uuid()}`;
+    await simAws
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+      );
+
+    // When a plan uses the paired AWS indefinite-retention values.
+    const created = await simAws.backup().createBackupPlan(
+      new CreateBackupPlanCommand({
+        BackupPlan: {
+          BackupPlanName: `plan-${faker.string.uuid()}`,
+          Rules: [
+            {
+              RuleName: "indefinite",
+              TargetBackupVaultName: vaultName,
+              Lifecycle: {
+                MoveToColdStorageAfterDays: -1,
+                DeleteAfterDays: -1,
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then the plan keeps both sentinel values.
+    const plan = await simAws
+      .backup()
+      .getBackupPlan(
+        new GetBackupPlanCommand({ BackupPlanId: created.BackupPlanId }),
+      );
+    const lifecycle = plan.BackupPlan?.Rules?.[0]?.Lifecycle;
+    assertNonNullable(lifecycle);
+    assertIdentical(lifecycle.MoveToColdStorageAfterDays, -1);
+    assertIdentical(lifecycle.DeleteAfterDays, -1);
+  });
 });

--- a/src/service/backup/sim-backup-commands.iso.test.ts
+++ b/src/service/backup/sim-backup-commands.iso.test.ts
@@ -1,0 +1,200 @@
+import { faker } from "@faker-js/faker";
+import {
+  BackupClient,
+  CreateBackupPlanCommand,
+  CreateBackupSelectionCommand,
+  CreateBackupVaultCommand,
+  DeleteBackupVaultCommand,
+  DescribeBackupVaultCommand,
+  GetBackupPlanCommand,
+  GetBackupSelectionCommand,
+  ListBackupSelectionsCommand,
+  ListBackupVaultsCommand,
+  PutBackupVaultLockConfigurationCommand,
+} from "@aws-sdk/client-backup";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTrue,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimSdk } from "../../sdk/sim-sdk.js";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+
+describe("simulated AWS Backup commands", () => {
+  it("stores a vault, a multi-rule plan and a resource selection", async () => {
+    // Given an SDK client intercepted by a simulation at a fixed time.
+    const now = new Date("2026-08-30T10:00:00.000Z");
+    const simAws = new SimAws({ clock: new SimFixedClock(now) });
+    using simSdk = new SimSdk({ simAws });
+    const client = new BackupClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+    const vaultName = `vault-${faker.string.uuid()}`;
+
+    await client.send(
+      new CreateBackupVaultCommand({
+        BackupVaultName: vaultName,
+        EncryptionKeyArn:
+          "arn:aws:kms:us-east-1:888888888888:key/00000000-0000-0000-0000-000000000000",
+      }),
+    );
+    await client.send(
+      new PutBackupVaultLockConfigurationCommand({
+        BackupVaultName: vaultName,
+        MinRetentionDays: 7,
+        MaxRetentionDays: 365,
+      }),
+    );
+
+    // When a daily, weekly and monthly plan selects one DynamoDB table.
+    const plan = await client.send(
+      new CreateBackupPlanCommand({
+        BackupPlan: {
+          BackupPlanName: `plan-${faker.string.uuid()}`,
+          Rules: [
+            {
+              RuleName: "daily",
+              TargetBackupVaultName: vaultName,
+              ScheduleExpression: "cron(0 1 ? * * *)",
+              Lifecycle: { DeleteAfterDays: 35 },
+            },
+            {
+              RuleName: "weekly",
+              TargetBackupVaultName: vaultName,
+              ScheduleExpression: "cron(0 2 ? * SUN *)",
+              Lifecycle: { DeleteAfterDays: 90 },
+            },
+            {
+              RuleName: "monthly",
+              TargetBackupVaultName: vaultName,
+              ScheduleExpression: "cron(0 3 1 * ? *)",
+              Lifecycle: {
+                MoveToColdStorageAfterDays: 30,
+                DeleteAfterDays: 120,
+              },
+            },
+          ],
+        },
+      }),
+    );
+    assertNonNullable(plan.BackupPlanId);
+    const selected = await client.send(
+      new CreateBackupSelectionCommand({
+        BackupPlanId: plan.BackupPlanId,
+        BackupSelection: {
+          SelectionName: `selection-${faker.string.uuid()}`,
+          IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+          Resources: ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"],
+        },
+      }),
+    );
+    assertNonNullable(selected.SelectionId);
+
+    // Then the SDK reads each stored resource back with its AWS-shaped values.
+    const vault = await client.send(
+      new DescribeBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    assertIdentical(vault.CreationDate?.toISOString(), now.toISOString());
+    assertTrue(vault.Locked);
+    assertIdentical(vault.MinRetentionDays, 7);
+    assertUndefined(vault.LockDate);
+    assertStringIncludes(
+      vault.BackupVaultArn ?? "",
+      `backup-vault:${vaultName}`,
+    );
+
+    const vaults = await client.send(new ListBackupVaultsCommand({}));
+    assertArrayLength(vaults.BackupVaultList ?? [], 1);
+
+    const describedPlan = await client.send(
+      new GetBackupPlanCommand({ BackupPlanId: plan.BackupPlanId }),
+    );
+    assertArrayLength(describedPlan.BackupPlan?.Rules ?? [], 3);
+    assertIdentical(
+      describedPlan.BackupPlan?.Rules?.[2]?.Lifecycle?.DeleteAfterDays,
+      120,
+    );
+
+    const selection = await client.send(
+      new GetBackupSelectionCommand({
+        BackupPlanId: plan.BackupPlanId,
+        SelectionId: selected.SelectionId,
+      }),
+    );
+    assertIdentical(
+      selection.BackupSelection?.Resources?.[0],
+      "arn:aws:dynamodb:us-east-1:888888888888:table/orders",
+    );
+    const selections = await client.send(
+      new ListBackupSelectionsCommand({ BackupPlanId: plan.BackupPlanId }),
+    );
+    assertArrayLength(selections.BackupSelectionsList ?? [], 1);
+  });
+
+  it("keeps Backup state inside its account and region", async () => {
+    // Given a vault in one account and Region.
+    const simAws = new SimAws();
+    const name = `vault-${faker.string.uuid()}`;
+    await simAws
+      .account("111111111111")
+      .region("eu-west-2")
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: name }),
+      );
+
+    // When the same service is reached from each scope.
+    const same = simAws.account("111111111111").region("eu-west-2").backup();
+    const anotherRegion = simAws
+      .account("111111111111")
+      .region("us-east-1")
+      .backup();
+    const anotherAccount = simAws
+      .account("222222222222")
+      .region("eu-west-2")
+      .backup();
+
+    // Then only the original scope holds the vault.
+    const sameVaults = await same.listBackupVaults(
+      new ListBackupVaultsCommand({}),
+    );
+    const otherRegionVaults = await anotherRegion.listBackupVaults(
+      new ListBackupVaultsCommand({}),
+    );
+    const otherAccountVaults = await anotherAccount.listBackupVaults(
+      new ListBackupVaultsCommand({}),
+    );
+    assertArrayLength(sameVaults.BackupVaultList ?? [], 1);
+    assertArrayLength(otherRegionVaults.BackupVaultList ?? [], 0);
+    assertArrayLength(otherAccountVaults.BackupVaultList ?? [], 0);
+  });
+
+  it("deletes a vault through its SDK command", async () => {
+    // Given a vault that exists.
+    const simAws = new SimAws();
+    const name = `vault-${faker.string.uuid()}`;
+    await simAws
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: name }),
+      );
+
+    // When it is deleted.
+    await simAws
+      .backup()
+      .deleteBackupVault(
+        new DeleteBackupVaultCommand({ BackupVaultName: name }),
+      );
+
+    // Then the vault listing is empty.
+    const vaults = await simAws
+      .backup()
+      .listBackupVaults(new ListBackupVaultsCommand({}));
+    assertArrayLength(vaults.BackupVaultList ?? [], 0);
+  });
+});

--- a/src/service/backup/sim-backup-properties.ts
+++ b/src/service/backup/sim-backup-properties.ts
@@ -1,0 +1,9 @@
+import type { BackgroundScheduler } from "../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimIamInterServiceAuthZ } from "../iam/authorize/sim-iam-inter-service-auth-z.js";
+
+export interface SimBackupProperties {
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}

--- a/src/service/backup/sim-backup-refusals.iso.test.ts
+++ b/src/service/backup/sim-backup-refusals.iso.test.ts
@@ -1,0 +1,218 @@
+import { faker } from "@faker-js/faker";
+import {
+  CreateBackupPlanCommand,
+  CreateBackupSelectionCommand,
+  CreateBackupVaultCommand,
+  DescribeBackupVaultCommand,
+  GetBackupSelectionCommand,
+  PutBackupVaultLockConfigurationCommand,
+} from "@aws-sdk/client-backup";
+import { assertInstanceOf, assertThrowsErrorAsync } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimBackupAlreadyExistsException,
+  SimBackupInvalidParameterValueException,
+  SimBackupResourceNotFoundException,
+} from "./error/sim-backup.error.js";
+
+describe("simulated AWS Backup refusals", () => {
+  it("makes a compliance lock immutable after its grace period", async () => {
+    // Given a compliance lock that is still inside its grace period.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-08-30T10:00:00.000Z")),
+    });
+    const name = `vault-${faker.string.uuid()}`;
+    await simAws
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: name }),
+      );
+    await simAws.backup().putBackupVaultLockConfiguration(
+      new PutBackupVaultLockConfigurationCommand({
+        BackupVaultName: name,
+        ChangeableForDays: 3,
+        MinRetentionDays: 7,
+      }),
+    );
+    await simAws.backup().putBackupVaultLockConfiguration(
+      new PutBackupVaultLockConfigurationCommand({
+        BackupVaultName: name,
+        ChangeableForDays: 4,
+        MinRetentionDays: 14,
+      }),
+    );
+
+    // When its revised grace period passes and another change is attempted.
+    await simAws.clock().advanceBy({ days: 4 });
+    const changing = simAws.backup().putBackupVaultLockConfiguration(
+      new PutBackupVaultLockConfigurationCommand({
+        BackupVaultName: name,
+        ChangeableForDays: 5,
+      }),
+    );
+
+    // Then the lock is immutable and its lock date remains visible.
+    await expect(changing).rejects.toBeInstanceOf(
+      SimBackupInvalidParameterValueException,
+    );
+    const vault = await simAws
+      .backup()
+      .describeBackupVault(
+        new DescribeBackupVaultCommand({ BackupVaultName: name }),
+      );
+    expect(vault.LockDate?.toISOString()).toBe("2026-09-03T10:00:00.000Z");
+  });
+
+  it.each([
+    { ChangeableForDays: 2 },
+    { ChangeableForDays: 36_501 },
+    { MinRetentionDays: 0 },
+    { MaxRetentionDays: 36_501 },
+    { MinRetentionDays: 10, MaxRetentionDays: 9 },
+  ])("refuses an invalid vault lock configuration", async (configuration) => {
+    // Given a vault and an invalid lock configuration.
+    const simAws = new SimAws();
+    const name = `vault-${faker.string.uuid()}`;
+    await simAws
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: name }),
+      );
+
+    // When the lock configuration is applied.
+    const locking = simAws.backup().putBackupVaultLockConfiguration(
+      new PutBackupVaultLockConfigurationCommand({
+        BackupVaultName: name,
+        ...configuration,
+      }),
+    );
+
+    // Then AWS Backup rejects it.
+    await expect(locking).rejects.toBeInstanceOf(
+      SimBackupInvalidParameterValueException,
+    );
+  });
+
+  it("refuses cold storage with less than 90 days remaining", async () => {
+    // Given a vault and a rule that deletes its cold backup too soon.
+    const simAws = new SimAws();
+    const name = `vault-${faker.string.uuid()}`;
+    await simAws
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: name }),
+      );
+
+    // When the plan is created.
+    const creating = simAws.backup().createBackupPlan(
+      new CreateBackupPlanCommand({
+        BackupPlan: {
+          BackupPlanName: `plan-${faker.string.uuid()}`,
+          Rules: [
+            {
+              RuleName: "monthly",
+              TargetBackupVaultName: name,
+              Lifecycle: {
+                MoveToColdStorageAfterDays: 30,
+                DeleteAfterDays: 119,
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then the lifecycle is rejected.
+    await expect(creating).rejects.toBeInstanceOf(
+      SimBackupInvalidParameterValueException,
+    );
+  });
+
+  it("refuses duplicate names and missing resources", async () => {
+    // Given one vault and one plan.
+    const simAws = new SimAws();
+    const name = `vault-${faker.string.uuid()}`;
+    await simAws
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: name }),
+      );
+
+    // When the vault is created twice and a plan names a missing vault.
+    const duplicate = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .backup()
+        .createBackupVault(
+          new CreateBackupVaultCommand({ BackupVaultName: name }),
+        );
+    });
+    const missing = await assertThrowsErrorAsync(async () => {
+      await simAws.backup().createBackupPlan(
+        new CreateBackupPlanCommand({
+          BackupPlan: {
+            BackupPlanName: `plan-${faker.string.uuid()}`,
+            Rules: [
+              {
+                RuleName: "daily",
+                TargetBackupVaultName: "missing-vault",
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    // Then each failure has the AWS service error type.
+    assertInstanceOf(duplicate, SimBackupAlreadyExistsException);
+    assertInstanceOf(missing, SimBackupResourceNotFoundException);
+  });
+
+  it("keeps selections inside the plan that owns them", async () => {
+    // Given two plans and a selection in the first.
+    const simAws = new SimAws();
+    const vault = `vault-${faker.string.uuid()}`;
+    await simAws
+      .backup()
+      .createBackupVault(
+        new CreateBackupVaultCommand({ BackupVaultName: vault }),
+      );
+    const makePlan = async (name: string): Promise<string> => {
+      const plan = await simAws.backup().createBackupPlan(
+        new CreateBackupPlanCommand({
+          BackupPlan: {
+            BackupPlanName: name,
+            Rules: [{ RuleName: "daily", TargetBackupVaultName: vault }],
+          },
+        }),
+      );
+      return String(plan.BackupPlanId);
+    };
+    const firstPlan = await makePlan(`plan-${faker.string.uuid()}`);
+    const secondPlan = await makePlan(`plan-${faker.string.uuid()}`);
+    const selection = await simAws.backup().createBackupSelection(
+      new CreateBackupSelectionCommand({
+        BackupPlanId: firstPlan,
+        BackupSelection: {
+          SelectionName: "orders",
+          IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+        },
+      }),
+    );
+
+    // When the second plan asks for the first plan's selection.
+    const getting = simAws.backup().getBackupSelection(
+      new GetBackupSelectionCommand({
+        BackupPlanId: secondPlan,
+        SelectionId: selection.SelectionId,
+      }),
+    );
+
+    // Then the selection is absent from that plan.
+    await expect(getting).rejects.toBeInstanceOf(
+      SimBackupResourceNotFoundException,
+    );
+  });
+});

--- a/src/service/backup/sim-backup-resource-resolver.ts
+++ b/src/service/backup/sim-backup-resource-resolver.ts
@@ -1,0 +1,84 @@
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import type { SimBackupRequestOptions } from "./command/sim-backup-request-options.js";
+import type { SimBackupAuthorizer } from "./command/sim-backup-authorizer.js";
+import { requiredString } from "./command/sim-backup-required-string.js";
+import { SimBackupResourceNotFoundException } from "./error/sim-backup.error.js";
+import type { SimBackupPlan } from "./plan/sim-backup-plan.js";
+import type { SimBackupSelection } from "./selection/sim-backup-selection.js";
+import { backupPlanArn, backupVaultArn } from "./sim-backup-arn.js";
+import type { SimBackupStore } from "./sim-backup-store.js";
+import type { SimBackupVault } from "./vault/sim-backup-vault.js";
+
+interface SimBackupResourceResolverProperties {
+  readonly scope: SimAwsAccountRegionScope;
+  readonly authorizer: SimBackupAuthorizer;
+  readonly store: SimBackupStore;
+}
+
+/** Resolves AWS Backup resources after validating the request and IAM policy. */
+export class SimBackupResourceResolver {
+  private readonly scope: SimAwsAccountRegionScope;
+  private readonly authorizer: SimBackupAuthorizer;
+  private readonly store: SimBackupStore;
+
+  constructor(properties: SimBackupResourceResolverProperties) {
+    this.scope = properties.scope;
+    this.authorizer = properties.authorizer;
+    this.store = properties.store;
+  }
+
+  authorizedVault(
+    action: string,
+    requestedName: string | undefined,
+    options?: SimBackupRequestOptions,
+  ): SimBackupVault {
+    const name = requiredString(requestedName, "BackupVaultName");
+    this.authorizer.authorize(
+      action,
+      backupVaultArn(name, this.scope),
+      options,
+    );
+    return this.requireVault(name);
+  }
+
+  authorizedPlan(
+    action: string,
+    requestedId: string | undefined,
+    options?: SimBackupRequestOptions,
+  ): SimBackupPlan {
+    const id = requiredString(requestedId, "BackupPlanId");
+    this.authorizer.authorize(action, backupPlanArn(id, this.scope), options);
+    const plan = this.store.plan(id);
+    if (plan === undefined) {
+      throw new SimBackupResourceNotFoundException(
+        `Backup plan ${id} does not exist`,
+      );
+    }
+    return plan;
+  }
+
+  requireVault(name: string | undefined): SimBackupVault {
+    const required = requiredString(name, "TargetBackupVaultName");
+    const vault = this.store.vault(required);
+    if (vault === undefined) {
+      throw new SimBackupResourceNotFoundException(
+        `Backup vault ${required} does not exist`,
+      );
+    }
+    return vault;
+  }
+
+  requireSelection(
+    planId: string,
+    requestedId: string | undefined,
+  ): SimBackupSelection {
+    const id = requiredString(requestedId, "SelectionId");
+    const selection = this.store.selection(id);
+    if (selection === undefined || selection.planId !== planId) {
+      throw new SimBackupResourceNotFoundException(
+        `Backup selection ${id} does not exist in plan ${planId}`,
+      );
+    }
+    return selection;
+  }
+}

--- a/src/service/backup/sim-backup-store.ts
+++ b/src/service/backup/sim-backup-store.ts
@@ -1,0 +1,88 @@
+import { SimBackupAlreadyExistsException } from "./error/sim-backup.error.js";
+import type { SimBackupPlan } from "./plan/sim-backup-plan.js";
+import type { SimBackupSelection } from "./selection/sim-backup-selection.js";
+import type { SimBackupVault } from "./vault/sim-backup-vault.js";
+
+/**
+ * Holds AWS Backup resources for one simulated account and Region.
+ */
+export class SimBackupStore {
+  private readonly vaults = new Map<string, SimBackupVault>();
+  private readonly plans = new Map<string, SimBackupPlan>();
+  private readonly selections = new Map<string, SimBackupSelection>();
+
+  addVault(vault: SimBackupVault): void {
+    if (this.vaults.has(vault.name)) {
+      throw new SimBackupAlreadyExistsException(
+        `A backup vault named ${vault.name} already exists`,
+      );
+    }
+    this.vaults.set(vault.name, vault);
+  }
+
+  vault(name: string): SimBackupVault | undefined {
+    return this.vaults.get(name);
+  }
+
+  allVaults(): MapIterator<SimBackupVault> {
+    return this.vaults.values();
+  }
+
+  removeVault(name: string): void {
+    this.vaults.delete(name);
+  }
+
+  addPlan(plan: SimBackupPlan): void {
+    if (this.plans.values().some((stored) => stored.name === plan.name)) {
+      throw new SimBackupAlreadyExistsException(
+        `A backup plan named ${plan.name} already exists`,
+      );
+    }
+    this.plans.set(plan.id, plan);
+  }
+
+  plan(id: string): SimBackupPlan | undefined {
+    return this.plans.get(id);
+  }
+
+  removePlan(id: string): void {
+    this.plans.delete(id);
+    const selectionIds = this.selections
+      .values()
+      .filter((selection) => selection.planId === id)
+      .map((selection) => selection.id)
+      .toArray();
+    for (const selectionId of selectionIds) this.selections.delete(selectionId);
+  }
+
+  addSelection(selection: SimBackupSelection): void {
+    if (
+      this.selections
+        .values()
+        .some(
+          (stored) =>
+            stored.planId === selection.planId &&
+            stored.name === selection.name,
+        )
+    ) {
+      throw new SimBackupAlreadyExistsException(
+        `A backup selection named ${selection.name} already exists`,
+      );
+    }
+    this.selections.set(selection.id, selection);
+  }
+
+  selection(id: string): SimBackupSelection | undefined {
+    return this.selections.get(id);
+  }
+
+  selectionsForPlan(planId: string): IteratorObject<SimBackupSelection> {
+    return this.selections
+      .values()
+      .filter((selection) => selection.planId === planId);
+  }
+
+  removeSelection(id: string): void {
+    this.selections.delete(id);
+  }
+}

--- a/src/service/backup/sim-backup.ts
+++ b/src/service/backup/sim-backup.ts
@@ -1,0 +1,264 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../util/background/background.js";
+import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
+import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
+import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
+import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
+import type * as commands from "./command/sim-backup-command.types.js";
+import { SimBackupAuthorizer } from "./command/sim-backup-authorizer.js";
+import type { SimBackupRequestOptions } from "./command/sim-backup-request-options.js";
+import { requiredString } from "./command/sim-backup-required-string.js";
+import { SimBackupPlan } from "./plan/sim-backup-plan.js";
+import { SimBackupSelection } from "./selection/sim-backup-selection.js";
+import { backupPlanArn, backupVaultArn } from "./sim-backup-arn.js";
+import type { SimBackupProperties } from "./sim-backup-properties.js";
+import { SimBackupResourceResolver } from "./sim-backup-resource-resolver.js";
+import { SimBackupStore } from "./sim-backup-store.js";
+import { SimBackupVault } from "./vault/sim-backup-vault.js";
+import { SimBackupSdkCommandRouter } from "./sdk/sim-backup-sdk-command-router.js";
+import { SimBackupCfnResourceFactory } from "./cfn/sim-backup-cfn-resource-factory.js";
+
+/** Simulates AWS Backup resources in one account and Region. */
+export class SimBackup {
+  private readonly store = new SimBackupStore();
+  private readonly scope: SimAwsAccountRegionScope;
+  private readonly background: BackgroundScheduler;
+  private readonly authorizer: SimBackupAuthorizer;
+  private readonly resolver: SimBackupResourceResolver;
+  private readonly sdkRouter = new SimBackupSdkCommandRouter(this);
+  private readonly cfnFactory = new SimBackupCfnResourceFactory({
+    backup: this,
+  });
+
+  constructor(properties: SimBackupProperties = {}) {
+    this.scope =
+      properties.accountRegionScope ?? simAwsAccountRegionScopeFactory.make();
+    this.background = properties.background ?? new BackgroundTasks();
+    this.authorizer = new SimBackupAuthorizer(
+      simIamInRegion(properties.iam, this.scope.regionName),
+    );
+    this.resolver = new SimBackupResourceResolver({
+      scope: this.scope,
+      authorizer: this.authorizer,
+      store: this.store,
+    });
+  }
+
+  async createBackupVault(
+    command: commands.SimCreateBackupVaultCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimCreateBackupVaultCommandOutput> {
+    await this.background.sequence();
+    const name = requiredString(
+      command.input.BackupVaultName,
+      "BackupVaultName",
+    );
+    const arn = backupVaultArn(name, this.scope);
+    this.authorizer.authorize("backup:CreateBackupVault", arn, options);
+
+    const vault = new SimBackupVault({
+      name,
+      arn,
+      creationDate: this.background.now(),
+      encryptionKeyArn: command.input.EncryptionKeyArn,
+      creatorRequestId: command.input.CreatorRequestId,
+    });
+    this.store.addVault(vault);
+
+    return {
+      BackupVaultName: vault.name,
+      BackupVaultArn: vault.arn,
+      CreationDate: new Date(vault.creationDate),
+    };
+  }
+
+  async describeBackupVault(
+    command: commands.SimDescribeBackupVaultCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimDescribeBackupVaultCommandOutput> {
+    await this.background.sequence();
+    const vault = this.resolver.authorizedVault(
+      "backup:DescribeBackupVault",
+      command.input.BackupVaultName,
+      options,
+    );
+    return vault.describe();
+  }
+
+  async deleteBackupVault(
+    command: commands.SimDeleteBackupVaultCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimDeleteBackupVaultCommandOutput> {
+    await this.background.sequence();
+    const vault = this.resolver.authorizedVault(
+      "backup:DeleteBackupVault",
+      command.input.BackupVaultName,
+      options,
+    );
+    this.store.removeVault(vault.name);
+    return {};
+  }
+
+  async listBackupVaults(
+    _command: commands.SimListBackupVaultsCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimListBackupVaultsCommandOutput> {
+    await this.background.sequence();
+    this.authorizer.authorize("backup:ListBackupVaults", "*", options);
+    return {
+      BackupVaultList: this.store
+        .allVaults()
+        .map((vault) => vault.listMember())
+        .toArray(),
+    };
+  }
+
+  async putBackupVaultLockConfiguration(
+    command: commands.SimPutBackupVaultLockConfigurationCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimPutBackupVaultLockConfigurationCommandOutput> {
+    await this.background.sequence();
+    const vault = this.resolver.authorizedVault(
+      "backup:PutBackupVaultLockConfiguration",
+      command.input.BackupVaultName,
+      options,
+    );
+    vault.configureLock(command.input, this.background.now());
+    return {};
+  }
+
+  async createBackupPlan(
+    command: commands.SimCreateBackupPlanCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimCreateBackupPlanCommandOutput> {
+    await this.background.sequence();
+    const id = randomUUID();
+    const arn = backupPlanArn(id, this.scope);
+    this.authorizer.authorize("backup:CreateBackupPlan", arn, options);
+    const plan = new SimBackupPlan({
+      id,
+      arn,
+      versionId: randomUUID(),
+      creationDate: this.background.now(),
+      creatorRequestId: command.input.CreatorRequestId,
+      plan: command.input.BackupPlan ?? {},
+    });
+
+    for (const rule of plan.rules) {
+      this.resolver.requireVault(rule.TargetBackupVaultName);
+    }
+    this.store.addPlan(plan);
+
+    return {
+      BackupPlanId: plan.id,
+      BackupPlanArn: plan.arn,
+      VersionId: plan.versionId,
+      CreationDate: new Date(plan.creationDate),
+    };
+  }
+
+  async getBackupPlan(
+    command: commands.SimGetBackupPlanCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimGetBackupPlanCommandOutput> {
+    await this.background.sequence();
+    const plan = this.resolver.authorizedPlan(
+      "backup:GetBackupPlan",
+      command.input.BackupPlanId,
+      options,
+    );
+    return plan.describe();
+  }
+
+  async createBackupSelection(
+    command: commands.SimCreateBackupSelectionCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimCreateBackupSelectionCommandOutput> {
+    await this.background.sequence();
+    const plan = this.resolver.authorizedPlan(
+      "backup:CreateBackupSelection",
+      command.input.BackupPlanId,
+      options,
+    );
+    const selection = new SimBackupSelection({
+      id: randomUUID(),
+      planId: plan.id,
+      creationDate: this.background.now(),
+      creatorRequestId: command.input.CreatorRequestId,
+      selection: command.input.BackupSelection ?? {},
+    });
+
+    this.store.addSelection(selection);
+
+    return {
+      SelectionId: selection.id,
+      BackupPlanId: plan.id,
+      CreationDate: new Date(selection.creationDate),
+    };
+  }
+
+  async getBackupSelection(
+    command: commands.SimGetBackupSelectionCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimGetBackupSelectionCommandOutput> {
+    await this.background.sequence();
+    const plan = this.resolver.authorizedPlan(
+      "backup:GetBackupSelection",
+      command.input.BackupPlanId,
+      options,
+    );
+    return this.resolver
+      .requireSelection(plan.id, command.input.SelectionId)
+      .describe();
+  }
+
+  async listBackupSelections(
+    command: commands.SimListBackupSelectionsCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimListBackupSelectionsCommandOutput> {
+    await this.background.sequence();
+    const plan = this.resolver.authorizedPlan(
+      "backup:ListBackupSelections",
+      command.input.BackupPlanId,
+      options,
+    );
+    return {
+      BackupSelectionsList: this.store
+        .selectionsForPlan(plan.id)
+        .map((selection) => selection.listMember())
+        .toArray(),
+    };
+  }
+
+  findBackupVault(name: string): SimBackupVault | undefined {
+    return this.store.vault(name);
+  }
+
+  findBackupPlan(id: string): SimBackupPlan | undefined {
+    return this.store.plan(id);
+  }
+
+  findBackupSelection(id: string): SimBackupSelection | undefined {
+    return this.store.selection(id);
+  }
+
+  removeBackupPlan(id: string): void {
+    this.store.removePlan(id);
+  }
+
+  removeBackupSelection(id: string): void {
+    this.store.removeSelection(id);
+  }
+
+  sdkCommandRouter(): SimSdkCommandRouter {
+    return this.sdkRouter;
+  }
+
+  cfnResourceFactory(): SimBackupCfnResourceFactory {
+    return this.cfnFactory;
+  }
+}

--- a/src/service/backup/sim-backup.ts
+++ b/src/service/backup/sim-backup.ts
@@ -246,6 +246,10 @@ export class SimBackup {
     return this.store.selection(id);
   }
 
+  removeBackupVault(name: string): void {
+    this.store.removeVault(name);
+  }
+
   removeBackupPlan(id: string): void {
     this.store.removePlan(id);
   }

--- a/src/service/backup/vault/sim-backup-vault.ts
+++ b/src/service/backup/vault/sim-backup-vault.ts
@@ -1,0 +1,135 @@
+import type {
+  SimBackupVaultListMember,
+  SimDescribeBackupVaultCommandOutput,
+} from "../command/sim-backup-command.types.js";
+import { SimBackupInvalidParameterValueException } from "../error/sim-backup.error.js";
+
+const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+export interface SimBackupVaultLockConfiguration {
+  readonly MinRetentionDays?: number | undefined;
+  readonly MaxRetentionDays?: number | undefined;
+  readonly ChangeableForDays?: number | undefined;
+}
+
+interface SimBackupVaultProperties {
+  readonly name: string;
+  readonly arn: string;
+  readonly creationDate: Date;
+  readonly encryptionKeyArn?: string | undefined;
+  readonly creatorRequestId?: string | undefined;
+}
+
+/** Stores one simulated AWS Backup vault. */
+export class SimBackupVault {
+  public readonly name: string;
+  public readonly arn: string;
+  public readonly creationDate: Date;
+  public readonly encryptionKeyArn?: string | undefined;
+  public readonly creatorRequestId?: string | undefined;
+
+  private lockConfiguration?: SimBackupVaultLockConfiguration | undefined;
+  private lockDate?: Date | undefined;
+
+  constructor(properties: SimBackupVaultProperties) {
+    this.name = properties.name;
+    this.arn = properties.arn;
+    this.creationDate = new Date(properties.creationDate);
+    this.encryptionKeyArn = properties.encryptionKeyArn;
+    this.creatorRequestId = properties.creatorRequestId;
+  }
+
+  configureLock(
+    configuration: SimBackupVaultLockConfiguration,
+    now: Date,
+  ): void {
+    if (this.isComplianceLocked(now)) {
+      throw new SimBackupInvalidParameterValueException(
+        `The lock configuration for backup vault ${this.name} is immutable`,
+      );
+    }
+
+    validateLockConfiguration(configuration);
+    this.lockConfiguration = { ...configuration };
+    this.lockDate = lockDate(configuration.ChangeableForDays, now);
+  }
+
+  describe(): SimDescribeBackupVaultCommandOutput {
+    const configuration = this.lockConfiguration;
+
+    return {
+      BackupVaultName: this.name,
+      BackupVaultArn: this.arn,
+      EncryptionKeyArn: this.encryptionKeyArn,
+      CreationDate: new Date(this.creationDate),
+      CreatorRequestId: this.creatorRequestId,
+      NumberOfRecoveryPoints: 0,
+      Locked: configuration !== undefined,
+      MinRetentionDays: configuration?.MinRetentionDays,
+      MaxRetentionDays: configuration?.MaxRetentionDays,
+      LockDate:
+        this.lockDate === undefined ? undefined : new Date(this.lockDate),
+    };
+  }
+
+  listMember(): SimBackupVaultListMember {
+    return this.describe();
+  }
+
+  private isComplianceLocked(now: Date): boolean {
+    return this.lockDate !== undefined && now >= this.lockDate;
+  }
+}
+
+function lockDate(
+  changeableForDays: number | undefined,
+  now: Date,
+): Date | undefined {
+  if (changeableForDays === undefined) {
+    return undefined;
+  }
+
+  return new Date(now.getTime() + changeableForDays * millisecondsPerDay);
+}
+
+function validateLockConfiguration(
+  configuration: SimBackupVaultLockConfiguration,
+): void {
+  const { MinRetentionDays: minimum, MaxRetentionDays: maximum } =
+    configuration;
+
+  if (
+    minimum !== undefined &&
+    (!Number.isSafeInteger(minimum) || minimum < 1)
+  ) {
+    throw new SimBackupInvalidParameterValueException(
+      "MinRetentionDays must be a positive whole number",
+    );
+  }
+
+  if (
+    maximum !== undefined &&
+    (!Number.isSafeInteger(maximum) || maximum < 1 || maximum > 36_500)
+  ) {
+    throw new SimBackupInvalidParameterValueException(
+      "MaxRetentionDays must be between 1 and 36500",
+    );
+  }
+
+  if (minimum !== undefined && maximum !== undefined && minimum > maximum) {
+    throw new SimBackupInvalidParameterValueException(
+      "MinRetentionDays must not exceed MaxRetentionDays",
+    );
+  }
+
+  const grace = configuration.ChangeableForDays;
+
+  if (
+    grace !== undefined &&
+    (!Number.isSafeInteger(grace) || grace < 3 || grace > 36_500)
+  ) {
+    throw new SimBackupInvalidParameterValueException(
+      "ChangeableForDays must be between 3 and 36500",
+    );
+  }
+}

--- a/src/service/cloudformation/resource/cfn/backup/sim-backup-cfn-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/backup/sim-backup-cfn-value-adapter.ts
@@ -1,0 +1,70 @@
+import { SimBackupPlan } from "../../../../backup/plan/sim-backup-plan.js";
+import { SimBackupSelection } from "../../../../backup/selection/sim-backup-selection.js";
+import { SimBackupVault } from "../../../../backup/vault/sim-backup-vault.js";
+import type { SimCfnTemplateValue } from "../../../template/value/sim-cfn-template-value.js";
+import type {
+  SimCfnResourceValueAdapter,
+  SimCfnResourceValueAdapterProperties,
+  SimCfnServiceValueAdapter,
+} from "../sim-cfn-resource-value-adapter.js";
+
+class SimBackupVaultCfn implements SimCfnResourceValueAdapter {
+  constructor(private readonly vault: SimBackupVault) {}
+
+  refValue(): SimCfnTemplateValue {
+    return this.vault.name;
+  }
+
+  attributeValue(name: string): SimCfnTemplateValue {
+    if (name === "BackupVaultArn") return this.vault.arn;
+    if (name === "BackupVaultName") return this.vault.name;
+    throw new Error(`Unsupported AWS::Backup::BackupVault attribute ${name}`);
+  }
+}
+
+class SimBackupPlanCfn implements SimCfnResourceValueAdapter {
+  constructor(private readonly plan: SimBackupPlan) {}
+
+  refValue(): SimCfnTemplateValue {
+    return this.plan.id;
+  }
+
+  attributeValue(name: string): SimCfnTemplateValue {
+    if (name === "BackupPlanArn") return this.plan.arn;
+    if (name === "BackupPlanId") return this.plan.id;
+    if (name === "VersionId") return this.plan.versionId;
+    throw new Error(`Unsupported AWS::Backup::BackupPlan attribute ${name}`);
+  }
+}
+
+class SimBackupSelectionCfn implements SimCfnResourceValueAdapter {
+  constructor(private readonly selection: SimBackupSelection) {}
+
+  refValue(): SimCfnTemplateValue {
+    return this.selection.id;
+  }
+
+  attributeValue(name: string): SimCfnTemplateValue {
+    if (name === "BackupPlanId") return this.selection.planId;
+    if (name === "Id" || name === "SelectionId") return this.selection.id;
+    throw new Error(
+      `Unsupported AWS::Backup::BackupSelection attribute ${name}`,
+    );
+  }
+}
+
+/** Returns the CloudFormation value adapter for an AWS Backup resource. */
+export function backupValueAdapter(
+  properties: SimCfnResourceValueAdapterProperties,
+): SimCfnServiceValueAdapter {
+  if (properties.simResource instanceof SimBackupVault) {
+    return new SimBackupVaultCfn(properties.simResource);
+  }
+  if (properties.simResource instanceof SimBackupPlan) {
+    return new SimBackupPlanCfn(properties.simResource);
+  }
+  if (properties.simResource instanceof SimBackupSelection) {
+    return new SimBackupSelectionCfn(properties.simResource);
+  }
+  return undefined;
+}

--- a/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-service-value-adapters.ts
@@ -2,6 +2,7 @@ import { acmValueAdapter } from "./acm/sim-acm-cfn-value-adapter.js";
 import { apiGatewayValueAdapter } from "./apigateway/sim-api-gateway-cfn-value-adapter.js";
 import { apiGatewayV2ValueAdapter } from "./apigatewayv2/sim-api-gateway-v2-cfn-value-adapter.js";
 import { athenaValueAdapter } from "./athena/sim-athena-cfn-value-adapter.js";
+import { backupValueAdapter } from "./backup/sim-backup-cfn-value-adapter.js";
 import { cdkCustomResourceValueAdapter } from "./cdk/sim-cdk-custom-resource-value-adapter.js";
 import { cloudFrontValueAdapter } from "./cloudfront/sim-cloudfront-cfn-value-adapter.js";
 import { cloudWatchValueAdapter } from "./cloudwatch/sim-cloudwatch-cfn-value-adapter.js";
@@ -52,6 +53,7 @@ export const simCfnServiceValueAdapters: readonly ((
   apiGatewayValueAdapter,
   apiGatewayV2ValueAdapter,
   athenaValueAdapter,
+  backupValueAdapter,
   cdkCustomResourceValueAdapter,
   cloudFrontValueAdapter,
   cloudWatchValueAdapter,

--- a/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
+++ b/src/service/cloudformation/resource/resolve/service/sim-cfn-service-factories.ts
@@ -42,6 +42,11 @@ export const simCfnServiceResourceFactories: ReadonlyMap<
       scopedAws.athena().cfnResourceFactory(),
   ],
   [
+    "Backup",
+    (scopedAws): SimCfnServiceResourceFactory =>
+      scopedAws.backup().cfnResourceFactory(),
+  ],
+  [
     "ApiGateway",
     (scopedAws): SimCfnServiceResourceFactory =>
       scopedAws.apiGateway().cfnResourceFactory(),

--- a/src/service/s3/bucket/lock/sim-s3-object-lock.iso.test.ts
+++ b/src/service/s3/bucket/lock/sim-s3-object-lock.iso.test.ts
@@ -19,6 +19,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
 import type { SimS3 } from "../../sim-s3.js";
 
 const bucketName = "reader-history";
@@ -299,9 +300,9 @@ describe("S3 Object Lock", () => {
 
   it("retains a version the Bucket's default retention covers", async () => {
     // Given a Bucket with a thirty day default retention.
-    const simAws = new SimAws();
+    const writtenAt = new Date("2026-08-30T09:00:00.000Z");
+    const simAws = new SimAws({ clock: new SimFixedClock(writtenAt) });
     const s3 = await lockedBucket(simAws, 30);
-    const writtenAt = simAws.clock().now();
 
     // When a version is written.
     const VersionId = await putEvent(s3);


### PR DESCRIPTION
## Summary

- add account- and region-scoped AWS Backup vaults, plans, and selections
- route supported Backup SDK commands through IAM authorization
- deploy AWS::Backup::BackupVault, AWS::Backup::BackupPlan, and AWS::Backup::BackupSelection through simulated CloudFormation
- model Vault Lock grace periods, Backup schedule expressions, lifecycle validation, and CloudFormation return values
- document direct use, CloudFormation, IAM, SDK interception, Vault Lock, and account and Region scoping
- roll back a CloudFormation vault when its lock configuration is rejected
- accept the paired -1 lifecycle values used for indefinite retention
- make the S3 Object Lock retention test deterministic with a fixed simulation clock

## Testing

- pnpm run check
- 1,944 test files passed
- 12,225 tests passed
- 99.13% statement coverage

Resolves https://github.com/KensioSoftware/yulin/issues/1195