### PR TITLE
fix: invoke Scheduler Lambda targets asynchronously

### DIFF
--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -238,6 +238,12 @@ console.log(failure?.message);
 `JSON.stringify` on a failure carries the message alongside the schedule, the target, the role and
 the instant it names.
 
+A Lambda target has another boundary. Scheduler records a failure when it cannot assume the role,
+the role cannot invoke the function, the function is missing or Lambda refuses the request. Once
+Lambda accepts the asynchronous invocation, its event invoke config applies. Handler errors follow
+Lambda's retry, destination and function dead-letter queue settings and do not appear in
+`deliveryFailures`.
+
 ### One-time schedules and what happens after
 
 An `at(...)` schedule fires once and then stops. By default it stays in the Account afterwards, which
@@ -759,7 +765,7 @@ Resources of the same stack.
 - `at(...)`, `rate(...)` and six-field `cron(...)` expressions, fired by advancing the simulation's
   clock.
 - Lambda, SQS and SNS targets, with a target `Input`, invoked as the target's execution role and
-  authorized against that role's own policies.
+  authorized against that role's own policies. Lambda targets use asynchronous Event invocation.
 - ECS targets, running a simulated task as the execution role, with the task definition and
   `TaskCount` from `EcsParameters` and container overrides from the target's `Input`.
 - `ActionAfterCompletion`, and `deliveryFailures` for invocations that did not happen.
@@ -779,9 +785,10 @@ Resources of the same stack.
   of it, and a simulation left alone in real time never fires however long it is left.
 - Firing is exact and exactly once. Real Scheduler invokes within a minute of the due time, and its
   promise is at-least-once.
-- An invocation is attempted once. There is no retry and no dead letter queue. A target that throws
-  is recorded as a failure, and never redelivered. A failed invocation never rejects
-  `advanceBy(...)`, and is read from `deliveryFailures`.
+- Scheduler attempts each target delivery once. Target `RetryPolicy` and `DeadLetterConfig` are
+  unsupported. A failure before target acceptance is recorded in `deliveryFailures` and is never
+  redelivered. A Lambda handler failure uses Lambda's asynchronous retry, destination and function
+  dead-letter queue settings.
 - A schedule group carries no tags. `CreateScheduleGroup` refuses `Tags`, since the simulation
   stores them nowhere. A template's `Tags` are recorded as an ignored property and the group still
   deploys.

--- a/src/service/scheduler/README.md
+++ b/src/service/scheduler/README.md
@@ -141,6 +141,10 @@ The two failures are reported apart from each other, because they are fixed in d
 trust policy is on the role's `AssumeRolePolicyDocument`, and the permission is in a policy attached
 to it. Telling a reader which one it was saves the whole diagnosis.
 
+`SimSchedulerDeliveryFunction` asks Lambda for an asynchronous Event invocation after those checks.
+Scheduler has completed its delivery once Lambda accepts the event. Lambda then owns handler errors,
+event invoke retries, destinations and the function's dead-letter queue.
+
 `SimAwsSchedulerDeliveryTargets` assumes the role in the role's own Account and reaches the target in
 the target's, which need not be the same one. A `SimScheduler` built outside SimAws gets
 `SimSchedulerNoDeliveryTargets`, which records every invocation as a failure saying why there was

--- a/src/service/scheduler/delivery/sim-scheduler-delivery-function.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery-function.ts
@@ -59,10 +59,19 @@ export class SimSchedulerDeliveryFunction {
       );
     }
 
-    // Invoked directly rather than through an Invoke command, because the
-    // schedule is already inside the background task standing for the
-    // asynchronous invocation real Scheduler makes, and because a handler
-    // failure has to reach the delivery outcome rather than being swallowed.
-    await simFunction.invoke(simSchedulerDeliveryDocument(delivery.request));
+    // Scheduler waits for Lambda to accept the event. Lambda owns everything
+    // after acceptance, including handler errors, retries and destinations.
+    await this.scope.lambda().invoke(
+      {
+        input: {
+          FunctionName: targetArn.value,
+          InvocationType: "Event",
+          Payload: JSON.stringify(
+            simSchedulerDeliveryDocument(delivery.request),
+          ),
+        },
+      },
+      { caller: delivery.caller },
+    );
   }
 }

--- a/src/service/scheduler/delivery/sim-scheduler-delivery.iso.test.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery.iso.test.ts
@@ -1,4 +1,5 @@
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { PutFunctionEventInvokeConfigCommand } from "@aws-sdk/client-lambda";
 import { CreateScheduleCommand } from "@aws-sdk/client-scheduler";
 import { CreateTopicCommand, SubscribeCommand } from "@aws-sdk/client-sns";
 import {
@@ -10,6 +11,7 @@ import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertObjectEquals,
   assertStringIncludes,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -168,6 +170,90 @@ describe("Scheduler target invocation", () => {
       .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queue.QueueUrl }));
 
     assertArrayLength(received.Messages ?? [], 1);
+  });
+
+  it("leaves a failing handler to Lambda's asynchronous invocation", async () => {
+    // Given a failing function whose Lambda config sends the exhausted event
+    // and its failure record to separate queues.
+    const simAws = await simulationWithRole({
+      Effect: "Allow",
+      Action: "lambda:InvokeFunction",
+      Resource: functionArn,
+    });
+    const failures = await simAws
+      .sqs()
+      .createQueue(new CreateQueueCommand({ QueueName: "lambda-failures" }));
+    const deadLetters = await simAws
+      .sqs()
+      .createQueue(
+        new CreateQueueCommand({ QueueName: "lambda-dead-letters" }),
+      );
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "reconcile",
+        Role: "arn:aws:iam::888888888888:role/ReconcileRole",
+        DeadLetterConfig: {
+          TargetArn: "arn:aws:sqs:us-east-1:888888888888:lambda-dead-letters",
+        },
+        Code: {
+          ZipFile: makeLambdaZipFileInput(() => {
+            throw new Error("reconciliation failed");
+          }),
+        },
+      },
+    });
+    await simAws.lambda().putFunctionEventInvokeConfig(
+      new PutFunctionEventInvokeConfigCommand({
+        FunctionName: "reconcile",
+        MaximumRetryAttempts: 0,
+        DestinationConfig: {
+          OnFailure: {
+            Destination: "arn:aws:sqs:us-east-1:888888888888:lambda-failures",
+          },
+        },
+      }),
+    );
+
+    // When a schedule invokes it with an event.
+    await scheduleFor(simAws, {
+      Arn: functionArn,
+      RoleArn: roleArn,
+      Input: JSON.stringify({ report: "nightly" }),
+    });
+
+    // Then Scheduler records a successful delivery. Lambda sends its own
+    // failure record and dead-letter event after the handler throws.
+    assertArrayLength(simAws.scheduler().deliveryFailures, 0);
+
+    const failureMessages = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: failures.QueueUrl }),
+      );
+    const [failureMessage] = failureMessages.Messages ?? [];
+    assertNonNullable(failureMessage?.Body, "a Lambda failure record arrived");
+    const failureRecord = JSON.parse(failureMessage.Body) as {
+      readonly requestContext: {
+        readonly approximateInvokeCount: number;
+        readonly condition: string;
+      };
+      readonly requestPayload: object;
+    };
+    assertIdentical(failureRecord.requestContext.approximateInvokeCount, 1);
+    assertIdentical(failureRecord.requestContext.condition, "RetriesExhausted");
+    assertObjectEquals(failureRecord.requestPayload, { report: "nightly" });
+
+    const deadLetterMessages = await simAws
+      .sqs()
+      .receiveMessage(
+        new ReceiveMessageCommand({ QueueUrl: deadLetters.QueueUrl }),
+      );
+    assertArrayLength(deadLetterMessages.Messages ?? [], 1);
+    assertIdentical(
+      deadLetterMessages.Messages?.[0]?.Body,
+      '{"report":"nightly"}',
+    );
   });
 
   it("does not invoke when the role may not, and says why", async () => {


### PR DESCRIPTION
@coderabbitai ignore

Invoke Scheduler Lambda targets through Lambda's asynchronous Event path. Handler failures now use Lambda retry, destination and function dead-letter queue settings. Failures before acceptance remain Scheduler delivery failures.

Resolves https://github.com/KensioSoftware/yulin/issues/1200

Scheduler tests, isolated tests, TypeScript, lint, formatting, FTA and documentation checks passed. Sandbox policy blocked the localhost and IPC tests used by the full coverage run.

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [ ] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
