### PR TITLE
feat(backup): create scheduled recovery points

### DIFF
--- a/docs/services/backup/README.md
+++ b/docs/services/backup/README.md
@@ -1,8 +1,7 @@
 # Simulated AWS Backup
 
-Yulin includes simulated AWS Backup vaults, plans and selections for tests and local development.
-The simulation stores backup configuration. Backup jobs and recovery points are outside it.
-AWS Backup types are imported from the `@kensio/yulin/backup` subpath.
+Yulin includes simulated AWS Backup vaults, plans, selections, backup jobs and recovery points for
+tests and local development. AWS Backup types are imported from the `@kensio/yulin/backup` subpath.
 
 ## Creating a vault, plan and selection
 
@@ -86,6 +85,137 @@ are validated when the plan is created. A one-time `at(...)` expression is refus
 `MoveToColdStorageAfterDays` can be combined with `DeleteAfterDays`. The deletion must be at least
 90 days after the move to cold storage. A shorter lifecycle raises
 `InvalidParameterValueException`. Set both values to `-1` to retain recovery points indefinitely.
+
+## Running scheduled backups
+
+Each plan rule runs on the simulated clock. A due rule creates one recovery point for each distinct
+resource ARN in the plan's selections. The recovery point records the rule, resource ARN, lifecycle
+and creation time. The simulation completes backup jobs at the scheduled instant.
+
+```typescript sim-backup-run-schedule
+/**
+ * Advancing a plan through its next scheduled backup.
+ */
+
+import {
+  CreateBackupPlanCommand,
+  CreateBackupSelectionCommand,
+  CreateBackupVaultCommand,
+  ListBackupJobsCommand,
+  ListRecoveryPointsByBackupVaultCommand,
+} from "@aws-sdk/client-backup";
+import { assertArrayLength, assertNonNullable } from "@kensio/smartass";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-31T09:30:00.000Z")),
+});
+const backup = simAws.backup();
+
+await backup.createBackupVault(
+  new CreateBackupVaultCommand({ BackupVaultName: "application-backups" }),
+);
+const createdPlan = await backup.createBackupPlan(
+  new CreateBackupPlanCommand({
+    BackupPlan: {
+      BackupPlanName: "application-plan",
+      Rules: [
+        {
+          RuleName: "hourly",
+          TargetBackupVaultName: "application-backups",
+          ScheduleExpression: "rate(1 hour)",
+          Lifecycle: { DeleteAfterDays: 35 },
+        },
+      ],
+    },
+  }),
+);
+assertNonNullable(createdPlan.BackupPlanId);
+await backup.createBackupSelection(
+  new CreateBackupSelectionCommand({
+    BackupPlanId: createdPlan.BackupPlanId,
+    BackupSelection: {
+      SelectionName: "orders",
+      IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+      Resources: ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"],
+    },
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 1 });
+
+const stored = backup.vault("application-backups").recoveryPoints();
+assertArrayLength(stored, 1);
+console.log(stored[0].creationDate.toISOString());
+// "2026-08-31T10:30:00.000Z"
+
+const points = await backup.listRecoveryPointsByBackupVault(
+  new ListRecoveryPointsByBackupVaultCommand({
+    BackupVaultName: "application-backups",
+  }),
+);
+const jobs = await backup.listBackupJobs(new ListBackupJobsCommand({}));
+console.log(points.RecoveryPoints?.[0]?.ResourceArn);
+// "arn:aws:dynamodb:us-east-1:888888888888:table/orders"
+console.log(jobs.BackupJobs?.[0]?.State); // "COMPLETED"
+```
+
+`DeleteAfterDays` removes a recovery point when the clock reaches its deletion time. Vault reads,
+`ListRecoveryPointsByBackupVault` and `DescribeRecoveryPoint` apply the expiry before returning.
+Repeated schedules keep every unexpired recovery point.
+
+Vault Lock bounds apply when a backup starts. A lifecycle shorter than `MinRetentionDays`, longer
+than `MaxRetentionDays` or indefinite under a finite maximum produces a `FAILED` backup job. The
+vault receives no recovery point for that job. Use `ListBackupJobs` or `DescribeBackupJob` to read
+the failure and its `StatusMessage`.
+
+## Starting an on-demand backup
+
+`StartBackupJob` completes an on-demand job at the current simulated time. It applies the same
+lifecycle validation and Vault Lock bounds as a scheduled rule.
+
+```typescript sim-backup-start-job
+/**
+ * Creating an on-demand recovery point.
+ */
+
+import {
+  CreateBackupVaultCommand,
+  DescribeRecoveryPointCommand,
+  StartBackupJobCommand,
+} from "@aws-sdk/client-backup";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-31T12:00:00.000Z")),
+});
+const backup = simAws.backup();
+await backup.createBackupVault(
+  new CreateBackupVaultCommand({ BackupVaultName: "manual-backups" }),
+);
+
+const started = await backup.startBackupJob(
+  new StartBackupJobCommand({
+    BackupVaultName: "manual-backups",
+    ResourceArn: "arn:aws:s3:::application-files",
+    IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+    Lifecycle: { DeleteAfterDays: 14 },
+  }),
+);
+assertNonNullable(started.RecoveryPointArn);
+
+const point = await backup.describeRecoveryPoint(
+  new DescribeRecoveryPointCommand({
+    BackupVaultName: "manual-backups",
+    RecoveryPointArn: started.RecoveryPointArn,
+  }),
+);
+console.log(point.CreationDate?.toISOString());
+// "2026-08-31T12:00:00.000Z"
+```
 
 ## Vault Lock
 
@@ -248,7 +378,8 @@ Stack teardown removes all three resource types from the simulation.
 
 Every supported operation is authorized by simulated IAM. Vault operations use the vault ARN. Plan
 and selection operations use the plan ARN. `ListBackupVaults` has no resource in its request and is
-authorized against `*`.
+authorized against `*`. `StartBackupJob` and `ListRecoveryPointsByBackupVault` use the vault ARN.
+`DescribeRecoveryPoint` uses the recovery point ARN. Backup job reads use `*`.
 
 ```typescript sim-backup-iam-policy
 /**
@@ -388,6 +519,11 @@ console.log(inVirginia.BackupVaultList?.length); // 0
   time.
 - `CreateBackupPlan` and `GetBackupPlan`, with rule schedule and lifecycle validation.
 - `CreateBackupSelection`, `GetBackupSelection` and `ListBackupSelections`.
+- Scheduled backup jobs driven by `simAws.clock()` and the plan rule schedule.
+- `StartBackupJob`, `ListBackupJobs` and `DescribeBackupJob`.
+- `ListRecoveryPointsByBackupVault`, `DescribeRecoveryPoint` and
+  `simAws.backup().vault(name).recoveryPoints()`.
+- Recovery point expiry from `DeleteAfterDays` and Vault Lock retention checks.
 - IAM authorization for every supported command.
 - SDK interception of `BackupClient`.
 - Account and Region scoped state, ARNs and timestamps.
@@ -396,10 +532,13 @@ console.log(inVirginia.BackupVaultList?.length); // 0
 
 ## Limitations
 
-- Backup jobs, recovery point copies, restores and expiry are outside the simulation.
-- A vault always reports `NumberOfRecoveryPoints` as zero. Vault deletion always sees an empty
-  vault.
-- A plan schedule is parsed and stored. Advancing simulated time leaves it unchanged.
+- Recovery point copies and restores are outside the simulation.
+- Backup jobs complete immediately at their scheduled or requested simulated instant. Start and
+  completion windows are accepted by the SDK types and ignored by the simulation.
+- Cold-storage lifecycle values are recorded. Recovery points stay in one storage state.
+- Overlapping plan rules are evaluated independently. AWS Backup's overlapping-window optimisation
+  is outside the simulation.
+- Vault deletion removes the vault and its recovery points.
 - A selection stores its `Resources`. `Conditions`, `ListOfTags` and wildcard resource matching are
   outside the selection model.
 - The selection's `IamRoleArn` is stored. No backup job assumes it, and creating a selection does

--- a/docs/services/backup/sim-backup-run-schedule.example.ts
+++ b/docs/services/backup/sim-backup-run-schedule.example.ts
@@ -1,0 +1,66 @@
+/**
+ * Advancing a plan through its next scheduled backup.
+ */
+
+import {
+  CreateBackupPlanCommand,
+  CreateBackupSelectionCommand,
+  CreateBackupVaultCommand,
+  ListBackupJobsCommand,
+  ListRecoveryPointsByBackupVaultCommand,
+} from "@aws-sdk/client-backup";
+import { assertArrayLength, assertNonNullable } from "@kensio/smartass";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-31T09:30:00.000Z")),
+});
+const backup = simAws.backup();
+
+await backup.createBackupVault(
+  new CreateBackupVaultCommand({ BackupVaultName: "application-backups" }),
+);
+const createdPlan = await backup.createBackupPlan(
+  new CreateBackupPlanCommand({
+    BackupPlan: {
+      BackupPlanName: "application-plan",
+      Rules: [
+        {
+          RuleName: "hourly",
+          TargetBackupVaultName: "application-backups",
+          ScheduleExpression: "rate(1 hour)",
+          Lifecycle: { DeleteAfterDays: 35 },
+        },
+      ],
+    },
+  }),
+);
+assertNonNullable(createdPlan.BackupPlanId);
+await backup.createBackupSelection(
+  new CreateBackupSelectionCommand({
+    BackupPlanId: createdPlan.BackupPlanId,
+    BackupSelection: {
+      SelectionName: "orders",
+      IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+      Resources: ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"],
+    },
+  }),
+);
+
+await simAws.clock().advanceBy({ hours: 1 });
+
+const stored = backup.vault("application-backups").recoveryPoints();
+assertArrayLength(stored, 1);
+console.log(stored[0].creationDate.toISOString());
+// "2026-08-31T10:30:00.000Z"
+
+const points = await backup.listRecoveryPointsByBackupVault(
+  new ListRecoveryPointsByBackupVaultCommand({
+    BackupVaultName: "application-backups",
+  }),
+);
+const jobs = await backup.listBackupJobs(new ListBackupJobsCommand({}));
+console.log(points.RecoveryPoints?.[0]?.ResourceArn);
+// "arn:aws:dynamodb:us-east-1:888888888888:table/orders"
+console.log(jobs.BackupJobs?.[0]?.State); // "COMPLETED"

--- a/docs/services/backup/sim-backup-start-job.example.ts
+++ b/docs/services/backup/sim-backup-start-job.example.ts
@@ -1,0 +1,39 @@
+/**
+ * Creating an on-demand recovery point.
+ */
+
+import {
+  CreateBackupVaultCommand,
+  DescribeRecoveryPointCommand,
+  StartBackupJobCommand,
+} from "@aws-sdk/client-backup";
+import { assertNonNullable } from "@kensio/smartass";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-31T12:00:00.000Z")),
+});
+const backup = simAws.backup();
+await backup.createBackupVault(
+  new CreateBackupVaultCommand({ BackupVaultName: "manual-backups" }),
+);
+
+const started = await backup.startBackupJob(
+  new StartBackupJobCommand({
+    BackupVaultName: "manual-backups",
+    ResourceArn: "arn:aws:s3:::application-files",
+    IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+    Lifecycle: { DeleteAfterDays: 14 },
+  }),
+);
+assertNonNullable(started.RecoveryPointArn);
+
+const point = await backup.describeRecoveryPoint(
+  new DescribeRecoveryPointCommand({
+    BackupVaultName: "manual-backups",
+    RecoveryPointArn: started.RecoveryPointArn,
+  }),
+);
+console.log(point.CreationDate?.toISOString());
+// "2026-08-31T12:00:00.000Z"

--- a/src/service/backup/cfn/sim-cfn-backup-resources.iso.test.ts
+++ b/src/service/backup/cfn/sim-cfn-backup-resources.iso.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { SimFixedClock } from "../../../util/clock/sim-clock.js";
 import { SimAws } from "../../aws/sim-aws.js";
 
 describe("AWS Backup CloudFormation resources", () => {
@@ -168,6 +169,65 @@ describe("AWS Backup CloudFormation resources", () => {
     assertUndefined(simAws.backup().findBackupVault("ephemeral-backups"));
     assertUndefined(simAws.backup().findBackupPlan(planId));
     assertUndefined(simAws.backup().findBackupSelection(selectionId));
+  });
+
+  it("runs a backup rule deployed through CloudFormation", async () => {
+    // Given a deployed vault, hourly plan and resource selection.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-08-31T09:30:00.000Z")),
+    });
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "scheduled-backup-stack",
+      template: {
+        Resources: {
+          Vault: {
+            Type: "AWS::Backup::BackupVault",
+            Properties: { BackupVaultName: "scheduled-backups" },
+          },
+          Plan: {
+            Type: "AWS::Backup::BackupPlan",
+            Properties: {
+              BackupPlan: {
+                BackupPlanName: "scheduled-plan",
+                BackupPlanRule: [
+                  {
+                    RuleName: "hourly",
+                    TargetBackupVault: { Ref: "Vault" },
+                    ScheduleExpression: "rate(1 hour)",
+                    Lifecycle: { DeleteAfterDays: 30 },
+                  },
+                ],
+              },
+            },
+          },
+          Selection: {
+            Type: "AWS::Backup::BackupSelection",
+            Properties: {
+              BackupPlanId: { Ref: "Plan" },
+              BackupSelection: {
+                SelectionName: "orders",
+                IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+                Resources: [
+                  "arn:aws:dynamodb:us-east-1:888888888888:table/orders",
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+    await stack.waitForDeployComplete();
+
+    // When the simulated clock reaches the rule's first occurrence.
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the deployed configuration creates a recovery point.
+    const points = simAws.backup().vault("scheduled-backups").recoveryPoints();
+    assertArrayLength(points, 1);
+    assertIdentical(
+      points[0].resourceArn,
+      "arn:aws:dynamodb:us-east-1:888888888888:table/orders",
+    );
   });
 
   it("leaves no vault behind when its lock configuration fails", async () => {

--- a/src/service/backup/command/sim-backup-command.types.ts
+++ b/src/service/backup/command/sim-backup-command.types.ts
@@ -11,7 +11,24 @@ export interface SimBackupRuleInput {
 }
 
 export interface SimBackupRule extends SimBackupRuleInput {
-  readonly RuleId?: string | undefined;
+  readonly RuleId: string;
+  readonly RuleName: string;
+  readonly TargetBackupVaultName: string;
+  readonly ScheduleExpression: string;
+}
+
+export interface SimRecoveryPointCreator {
+  readonly BackupPlanId?: string | undefined;
+  readonly BackupPlanArn?: string | undefined;
+  readonly BackupPlanName?: string | undefined;
+  readonly BackupPlanVersion?: string | undefined;
+  readonly BackupRuleId?: string | undefined;
+  readonly BackupRuleName?: string | undefined;
+}
+
+export interface SimCalculatedLifecycle {
+  readonly MoveToColdStorageAt?: Date | undefined;
+  readonly DeleteAt?: Date | undefined;
 }
 
 export interface SimBackupPlanInput {
@@ -168,3 +185,95 @@ export interface SimListBackupSelectionsCommandOutput {
     | undefined;
   readonly NextToken?: string | undefined;
 }
+
+export type SimStartBackupJobCommand = SimBackupCommand<{
+  readonly BackupVaultName?: string | undefined;
+  readonly ResourceArn?: string | undefined;
+  readonly IamRoleArn?: string | undefined;
+  readonly IdempotencyToken?: string | undefined;
+  readonly Lifecycle?: SimBackupLifecycle | undefined;
+}>;
+
+export interface SimStartBackupJobCommandOutput {
+  readonly BackupJobId?: string | undefined;
+  readonly RecoveryPointArn?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly IsParent?: boolean | undefined;
+}
+
+export type SimDescribeBackupJobCommand = SimBackupCommand<{
+  readonly BackupJobId?: string | undefined;
+}>;
+
+export interface SimBackupJobOutput {
+  readonly AccountId?: string | undefined;
+  readonly BackupJobId?: string | undefined;
+  readonly BackupVaultName?: string | undefined;
+  readonly BackupVaultArn?: string | undefined;
+  readonly RecoveryPointArn?: string | undefined;
+  readonly ResourceArn?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly InitiationDate?: Date | undefined;
+  readonly CompletionDate?: Date | undefined;
+  readonly State?: string | undefined;
+  readonly StatusMessage?: string | undefined;
+  readonly PercentDone?: string | undefined;
+  readonly IamRoleArn?: string | undefined;
+  readonly CreatedBy?: SimRecoveryPointCreator | undefined;
+  readonly RecoveryPointLifecycle?: SimBackupLifecycle | undefined;
+  readonly IsParent?: boolean | undefined;
+  readonly MessageCategory?: string | undefined;
+}
+
+export type SimDescribeBackupJobCommandOutput = SimBackupJobOutput;
+
+export type SimListBackupJobsCommand = SimBackupCommand<{
+  readonly ByResourceArn?: string | undefined;
+  readonly ByState?: string | undefined;
+  readonly ByBackupVaultName?: string | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}>;
+
+export interface SimListBackupJobsCommandOutput {
+  readonly BackupJobs?: readonly SimBackupJobOutput[] | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export interface SimRecoveryPointOutput {
+  readonly RecoveryPointArn?: string | undefined;
+  readonly BackupVaultName?: string | undefined;
+  readonly BackupVaultArn?: string | undefined;
+  readonly ResourceArn?: string | undefined;
+  readonly CreatedBy?: SimRecoveryPointCreator | undefined;
+  readonly IamRoleArn?: string | undefined;
+  readonly Status?: string | undefined;
+  readonly CreationDate?: Date | undefined;
+  readonly InitiationDate?: Date | undefined;
+  readonly CompletionDate?: Date | undefined;
+  readonly CalculatedLifecycle?: SimCalculatedLifecycle | undefined;
+  readonly Lifecycle?: SimBackupLifecycle | undefined;
+  readonly EncryptionKeyArn?: string | undefined;
+  readonly IsEncrypted?: boolean | undefined;
+  readonly VaultType?: string | undefined;
+}
+
+export type SimListRecoveryPointsByBackupVaultCommand = SimBackupCommand<{
+  readonly BackupVaultName?: string | undefined;
+  readonly ByResourceArn?: string | undefined;
+  readonly ByBackupPlanId?: string | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}>;
+
+export interface SimListRecoveryPointsByBackupVaultCommandOutput {
+  readonly RecoveryPoints?: readonly SimRecoveryPointOutput[] | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+export type SimDescribeRecoveryPointCommand = SimBackupCommand<{
+  readonly BackupVaultName?: string | undefined;
+  readonly RecoveryPointArn?: string | undefined;
+}>;
+
+export type SimDescribeRecoveryPointCommandOutput = SimRecoveryPointOutput;

--- a/src/service/backup/command/sim-backup-configuration-commands.ts
+++ b/src/service/backup/command/sim-backup-configuration-commands.ts
@@ -83,6 +83,7 @@ export class SimBackupConfigurationCommands {
       command.input.BackupVaultName,
       options,
     );
+    vault.assertEmpty();
     store.removeVault(vault.name);
     return {};
   }

--- a/src/service/backup/command/sim-backup-configuration-commands.ts
+++ b/src/service/backup/command/sim-backup-configuration-commands.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from "node:crypto";
+
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimBackupPlan } from "../plan/sim-backup-plan.js";
+import type { SimBackupPlanSchedules } from "../plan/sim-backup-plan-schedules.js";
+import { SimBackupSelection } from "../selection/sim-backup-selection.js";
+import { backupPlanArn, backupVaultArn } from "../sim-backup-arn.js";
+import type { SimBackupResourceResolver } from "../sim-backup-resource-resolver.js";
+import type { SimBackupStore } from "../sim-backup-store.js";
+import { SimBackupVault } from "../vault/sim-backup-vault.js";
+import type { SimBackupAuthorizer } from "./sim-backup-authorizer.js";
+import type * as commands from "./sim-backup-command.types.js";
+import type { SimBackupRequestOptions } from "./sim-backup-request-options.js";
+import { requiredString } from "./sim-backup-required-string.js";
+
+interface SimBackupConfigurationCommandsProperties {
+  readonly scope: SimAwsAccountRegionScope;
+  readonly background: BackgroundScheduler;
+  readonly authorizer: SimBackupAuthorizer;
+  readonly resolver: SimBackupResourceResolver;
+  readonly store: SimBackupStore;
+  readonly schedules: SimBackupPlanSchedules;
+}
+
+/** Handles backup vault, plan and selection commands. */
+export class SimBackupConfigurationCommands {
+  constructor(
+    private readonly properties: SimBackupConfigurationCommandsProperties,
+  ) {}
+
+  async createBackupVault(
+    command: commands.SimCreateBackupVaultCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimCreateBackupVaultCommandOutput> {
+    const { background, scope, authorizer, store } = this.properties;
+    await background.sequence();
+    const name = requiredString(
+      command.input.BackupVaultName,
+      "BackupVaultName",
+    );
+    const arn = backupVaultArn(name, scope);
+    authorizer.authorize("backup:CreateBackupVault", arn, options);
+    const vault = new SimBackupVault({
+      name,
+      arn,
+      creationDate: background.now(),
+      encryptionKeyArn: command.input.EncryptionKeyArn,
+      creatorRequestId: command.input.CreatorRequestId,
+      background,
+    });
+    store.addVault(vault);
+    return {
+      BackupVaultName: vault.name,
+      BackupVaultArn: vault.arn,
+      CreationDate: new Date(vault.creationDate),
+    };
+  }
+
+  async describeBackupVault(
+    command: commands.SimDescribeBackupVaultCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimDescribeBackupVaultCommandOutput> {
+    const { background, resolver } = this.properties;
+    await background.sequence();
+    return resolver
+      .authorizedVault(
+        "backup:DescribeBackupVault",
+        command.input.BackupVaultName,
+        options,
+      )
+      .describe();
+  }
+
+  async deleteBackupVault(
+    command: commands.SimDeleteBackupVaultCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimDeleteBackupVaultCommandOutput> {
+    const { background, resolver, store } = this.properties;
+    await background.sequence();
+    const vault = resolver.authorizedVault(
+      "backup:DeleteBackupVault",
+      command.input.BackupVaultName,
+      options,
+    );
+    store.removeVault(vault.name);
+    return {};
+  }
+
+  async listBackupVaults(
+    _command: commands.SimListBackupVaultsCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimListBackupVaultsCommandOutput> {
+    const { background, authorizer, store } = this.properties;
+    await background.sequence();
+    authorizer.authorize("backup:ListBackupVaults", "*", options);
+    return {
+      BackupVaultList: store
+        .allVaults()
+        .map((vault) => vault.listMember())
+        .toArray(),
+    };
+  }
+
+  async putBackupVaultLockConfiguration(
+    command: commands.SimPutBackupVaultLockConfigurationCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimPutBackupVaultLockConfigurationCommandOutput> {
+    const { background, resolver } = this.properties;
+    await background.sequence();
+    resolver
+      .authorizedVault(
+        "backup:PutBackupVaultLockConfiguration",
+        command.input.BackupVaultName,
+        options,
+      )
+      .configureLock(command.input, background.now());
+    return {};
+  }
+
+  async createBackupPlan(
+    command: commands.SimCreateBackupPlanCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimCreateBackupPlanCommandOutput> {
+    const { background, scope, authorizer, resolver, store, schedules } =
+      this.properties;
+    await background.sequence();
+    const id = randomUUID();
+    const arn = backupPlanArn(id, scope);
+    authorizer.authorize("backup:CreateBackupPlan", arn, options);
+    const plan = new SimBackupPlan({
+      id,
+      arn,
+      versionId: randomUUID(),
+      creationDate: background.now(),
+      creatorRequestId: command.input.CreatorRequestId,
+      plan: command.input.BackupPlan ?? {},
+    });
+    for (const rule of plan.rules) {
+      resolver.requireVault(rule.TargetBackupVaultName);
+    }
+    store.addPlan(plan);
+    schedules.arm(plan);
+    return {
+      BackupPlanId: plan.id,
+      BackupPlanArn: plan.arn,
+      VersionId: plan.versionId,
+      CreationDate: new Date(plan.creationDate),
+    };
+  }
+
+  async getBackupPlan(
+    command: commands.SimGetBackupPlanCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimGetBackupPlanCommandOutput> {
+    const { background, resolver } = this.properties;
+    await background.sequence();
+    return resolver
+      .authorizedPlan(
+        "backup:GetBackupPlan",
+        command.input.BackupPlanId,
+        options,
+      )
+      .describe();
+  }
+
+  async createBackupSelection(
+    command: commands.SimCreateBackupSelectionCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimCreateBackupSelectionCommandOutput> {
+    const { background, resolver, store } = this.properties;
+    await background.sequence();
+    const plan = resolver.authorizedPlan(
+      "backup:CreateBackupSelection",
+      command.input.BackupPlanId,
+      options,
+    );
+    const selection = new SimBackupSelection({
+      id: randomUUID(),
+      planId: plan.id,
+      creationDate: background.now(),
+      creatorRequestId: command.input.CreatorRequestId,
+      selection: command.input.BackupSelection ?? {},
+    });
+    store.addSelection(selection);
+    return {
+      SelectionId: selection.id,
+      BackupPlanId: plan.id,
+      CreationDate: new Date(selection.creationDate),
+    };
+  }
+
+  async getBackupSelection(
+    command: commands.SimGetBackupSelectionCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimGetBackupSelectionCommandOutput> {
+    const { background, resolver } = this.properties;
+    await background.sequence();
+    const plan = resolver.authorizedPlan(
+      "backup:GetBackupSelection",
+      command.input.BackupPlanId,
+      options,
+    );
+    return resolver
+      .requireSelection(plan.id, command.input.SelectionId)
+      .describe();
+  }
+
+  async listBackupSelections(
+    command: commands.SimListBackupSelectionsCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimListBackupSelectionsCommandOutput> {
+    const { background, resolver, store } = this.properties;
+    await background.sequence();
+    const plan = resolver.authorizedPlan(
+      "backup:ListBackupSelections",
+      command.input.BackupPlanId,
+      options,
+    );
+    return {
+      BackupSelectionsList: store
+        .selectionsForPlan(plan.id)
+        .map((selection) => selection.listMember())
+        .toArray(),
+    };
+  }
+}

--- a/src/service/backup/command/sim-backup-job-commands.iso.test.ts
+++ b/src/service/backup/command/sim-backup-job-commands.iso.test.ts
@@ -1,0 +1,135 @@
+import { faker } from "@faker-js/faker";
+import {
+  CreateBackupVaultCommand,
+  ListBackupJobsCommand,
+  StartBackupJobCommand,
+} from "@aws-sdk/client-backup";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimBackupInvalidParameterValueException } from "../error/sim-backup.error.js";
+
+describe("simulated AWS Backup job commands", () => {
+  it("reuses an on-demand job for the same idempotency token", async () => {
+    // Given an on-demand backup request with a customer token.
+    const simAws = new SimAws();
+    const backup = simAws.backup();
+    const vaultName = `vault-${faker.string.uuid()}`;
+    await backup.createBackupVault(
+      new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    const command = new StartBackupJobCommand({
+      BackupVaultName: vaultName,
+      ResourceArn: `arn:aws:s3:::${faker.string.uuid()}`,
+      IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+      IdempotencyToken: faker.string.uuid(),
+    });
+
+    // When the successful request is retried with the same token.
+    const first = await backup.startBackupJob(command);
+    const retried = await backup.startBackupJob(command);
+
+    // Then AWS Backup returns the original job without another recovery point.
+    assertNonNullable(first.BackupJobId);
+    assertIdentical(retried.BackupJobId, first.BackupJobId);
+    assertIdentical(retried.RecoveryPointArn, first.RecoveryPointArn);
+    assertArrayLength(backup.vault(vaultName).recoveryPoints(), 1);
+    const jobs = await backup.listBackupJobs(new ListBackupJobsCommand({}));
+    assertArrayLength(jobs.BackupJobs ?? [], 1);
+  });
+
+  it("paginates jobs after applying the request filters", async () => {
+    // Given two jobs in one vault with a job from another vault between them.
+    const simAws = new SimAws();
+    const backup = simAws.backup();
+    const vaultName = `vault-${faker.string.uuid()}`;
+    const otherVaultName = `vault-${faker.string.uuid()}`;
+    await backup.createBackupVault(
+      new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    await backup.createBackupVault(
+      new CreateBackupVaultCommand({ BackupVaultName: otherVaultName }),
+    );
+    const firstResourceArn = `arn:aws:s3:::${faker.string.uuid()}`;
+    const secondResourceArn = `arn:aws:s3:::${faker.string.uuid()}`;
+    const roleArn = "arn:aws:iam::888888888888:role/BackupRole";
+    await backup.startBackupJob(
+      new StartBackupJobCommand({
+        BackupVaultName: vaultName,
+        ResourceArn: firstResourceArn,
+        IamRoleArn: roleArn,
+      }),
+    );
+    await backup.startBackupJob(
+      new StartBackupJobCommand({
+        BackupVaultName: otherVaultName,
+        ResourceArn: `arn:aws:s3:::${faker.string.uuid()}`,
+        IamRoleArn: roleArn,
+      }),
+    );
+    await backup.startBackupJob(
+      new StartBackupJobCommand({
+        BackupVaultName: vaultName,
+        ResourceArn: secondResourceArn,
+        IamRoleArn: roleArn,
+      }),
+    );
+
+    // When the matching jobs are read one at a time.
+    const first = await backup.listBackupJobs(
+      new ListBackupJobsCommand({
+        ByBackupVaultName: vaultName,
+        MaxResults: 1,
+      }),
+    );
+    assertNonNullable(first.NextToken);
+    const second = await backup.listBackupJobs(
+      new ListBackupJobsCommand({
+        ByBackupVaultName: vaultName,
+        MaxResults: 1,
+        NextToken: first.NextToken,
+      }),
+    );
+
+    // Then each page contains the next filtered job and the last has no token.
+    assertArrayLength(first.BackupJobs ?? [], 1);
+    assertIdentical(first.BackupJobs?.[0]?.ResourceArn, firstResourceArn);
+    assertArrayLength(second.BackupJobs ?? [], 1);
+    assertIdentical(second.BackupJobs?.[0]?.ResourceArn, secondResourceArn);
+    assertUndefined(second.NextToken);
+  });
+
+  it("refuses invalid backup job pagination", async () => {
+    // Given a stored backup job.
+    const simAws = new SimAws();
+    const backup = simAws.backup();
+    const vaultName = `vault-${faker.string.uuid()}`;
+    await backup.createBackupVault(
+      new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    await backup.startBackupJob(
+      new StartBackupJobCommand({
+        BackupVaultName: vaultName,
+        ResourceArn: `arn:aws:s3:::${faker.string.uuid()}`,
+        IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+      }),
+    );
+
+    // When a page size or continuation token falls outside the API contract.
+    // Then AWS Backup refuses each listing.
+    await expect(
+      backup.listBackupJobs(new ListBackupJobsCommand({ MaxResults: 0 })),
+    ).rejects.toBeInstanceOf(SimBackupInvalidParameterValueException);
+    await expect(
+      backup.listBackupJobs(
+        new ListBackupJobsCommand({ NextToken: "not-a-token" }),
+      ),
+    ).rejects.toBeInstanceOf(SimBackupInvalidParameterValueException);
+  });
+});

--- a/src/service/backup/command/sim-backup-job-commands.ts
+++ b/src/service/backup/command/sim-backup-job-commands.ts
@@ -1,0 +1,100 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import { SimBackupResourceNotFoundException } from "../error/sim-backup.error.js";
+import type { SimBackupJobs } from "../job/sim-backup-jobs.js";
+import { readBackupLifecycle } from "../plan/sim-backup-rule.js";
+import type { SimBackupResourceResolver } from "../sim-backup-resource-resolver.js";
+import type { SimBackupStore } from "../sim-backup-store.js";
+import type { SimBackupAuthorizer } from "./sim-backup-authorizer.js";
+import type * as commands from "./sim-backup-command.types.js";
+import type { SimBackupRequestOptions } from "./sim-backup-request-options.js";
+import { requiredString } from "./sim-backup-required-string.js";
+
+interface SimBackupJobCommandsProperties {
+  readonly background: BackgroundScheduler;
+  readonly authorizer: SimBackupAuthorizer;
+  readonly resolver: SimBackupResourceResolver;
+  readonly store: SimBackupStore;
+  readonly jobs: SimBackupJobs;
+}
+
+/** Handles backup job commands. */
+export class SimBackupJobCommands {
+  constructor(private readonly properties: SimBackupJobCommandsProperties) {}
+
+  async start(
+    command: commands.SimStartBackupJobCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimStartBackupJobCommandOutput> {
+    const { background, resolver, jobs } = this.properties;
+    await background.sequence();
+    const vault = resolver.authorizedVault(
+      "backup:StartBackupJob",
+      command.input.BackupVaultName,
+      options,
+    );
+    const job = jobs.start({
+      vault,
+      resourceArn: requiredString(command.input.ResourceArn, "ResourceArn"),
+      iamRoleArn: requiredString(command.input.IamRoleArn, "IamRoleArn"),
+      at: background.now(),
+      lifecycle: readBackupLifecycle(command.input.Lifecycle),
+    });
+    const output = job.describe();
+    return {
+      BackupJobId: job.id,
+      RecoveryPointArn: output.RecoveryPointArn,
+      CreationDate: output.CreationDate,
+      IsParent: false,
+    };
+  }
+
+  async describe(
+    command: commands.SimDescribeBackupJobCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimDescribeBackupJobCommandOutput> {
+    const { background, authorizer, store } = this.properties;
+    await background.sequence();
+    const id = requiredString(command.input.BackupJobId, "BackupJobId");
+    authorizer.authorize("backup:DescribeBackupJob", "*", options);
+    const job = store.job(id);
+    if (job === undefined) {
+      throw new SimBackupResourceNotFoundException(
+        `Backup job ${id} does not exist`,
+      );
+    }
+    return job.describe();
+  }
+
+  async list(
+    command: commands.SimListBackupJobsCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimListBackupJobsCommandOutput> {
+    const { background, authorizer, store } = this.properties;
+    await background.sequence();
+    authorizer.authorize("backup:ListBackupJobs", "*", options);
+    return {
+      BackupJobs: store
+        .allJobs()
+        .filter((job) => matchesJob(job, command.input))
+        .map((job) => job.describe())
+        .toArray(),
+    };
+  }
+}
+
+function matchesJob(
+  job: {
+    readonly resourceArn: string;
+    readonly state: string;
+    readonly vaultName: string;
+  },
+  filter: commands.SimListBackupJobsCommand["input"],
+): boolean {
+  return (
+    (filter.ByResourceArn === undefined ||
+      job.resourceArn === filter.ByResourceArn) &&
+    (filter.ByState === undefined || job.state === filter.ByState) &&
+    (filter.ByBackupVaultName === undefined ||
+      job.vaultName === filter.ByBackupVaultName)
+  );
+}

--- a/src/service/backup/command/sim-backup-job-commands.ts
+++ b/src/service/backup/command/sim-backup-job-commands.ts
@@ -1,6 +1,7 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import { SimBackupResourceNotFoundException } from "../error/sim-backup.error.js";
 import type { SimBackupJobs } from "../job/sim-backup-jobs.js";
+import { SimBackupJobPage } from "../job/sim-backup-job-page.js";
 import { readBackupLifecycle } from "../plan/sim-backup-rule.js";
 import type { SimBackupResourceResolver } from "../sim-backup-resource-resolver.js";
 import type { SimBackupStore } from "../sim-backup-store.js";
@@ -37,6 +38,7 @@ export class SimBackupJobCommands {
       resourceArn: requiredString(command.input.ResourceArn, "ResourceArn"),
       iamRoleArn: requiredString(command.input.IamRoleArn, "IamRoleArn"),
       at: background.now(),
+      idempotencyToken: command.input.IdempotencyToken,
       lifecycle: readBackupLifecycle(command.input.Lifecycle),
     });
     const output = job.describe();
@@ -72,29 +74,10 @@ export class SimBackupJobCommands {
     const { background, authorizer, store } = this.properties;
     await background.sequence();
     authorizer.authorize("backup:ListBackupJobs", "*", options);
+    const page = new SimBackupJobPage(store.allJobs().toArray(), command.input);
     return {
-      BackupJobs: store
-        .allJobs()
-        .filter((job) => matchesJob(job, command.input))
-        .map((job) => job.describe())
-        .toArray(),
+      BackupJobs: page.jobs.map((job) => job.describe()),
+      NextToken: page.nextToken,
     };
   }
-}
-
-function matchesJob(
-  job: {
-    readonly resourceArn: string;
-    readonly state: string;
-    readonly vaultName: string;
-  },
-  filter: commands.SimListBackupJobsCommand["input"],
-): boolean {
-  return (
-    (filter.ByResourceArn === undefined ||
-      job.resourceArn === filter.ByResourceArn) &&
-    (filter.ByState === undefined || job.state === filter.ByState) &&
-    (filter.ByBackupVaultName === undefined ||
-      job.vaultName === filter.ByBackupVaultName)
-  );
 }

--- a/src/service/backup/command/sim-backup-recovery-point-commands.ts
+++ b/src/service/backup/command/sim-backup-recovery-point-commands.ts
@@ -1,0 +1,77 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import { SimBackupResourceNotFoundException } from "../error/sim-backup.error.js";
+import type { SimBackupResourceResolver } from "../sim-backup-resource-resolver.js";
+import type { SimBackupAuthorizer } from "./sim-backup-authorizer.js";
+import type * as commands from "./sim-backup-command.types.js";
+import type { SimBackupRequestOptions } from "./sim-backup-request-options.js";
+import { requiredString } from "./sim-backup-required-string.js";
+
+interface SimBackupRecoveryPointCommandsProperties {
+  readonly background: BackgroundScheduler;
+  readonly authorizer: SimBackupAuthorizer;
+  readonly resolver: SimBackupResourceResolver;
+}
+
+/** Handles recovery point read commands. */
+export class SimBackupRecoveryPointCommands {
+  constructor(
+    private readonly properties: SimBackupRecoveryPointCommandsProperties,
+  ) {}
+
+  async list(
+    command: commands.SimListRecoveryPointsByBackupVaultCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimListRecoveryPointsByBackupVaultCommandOutput> {
+    const { background, resolver } = this.properties;
+    await background.sequence();
+    const vault = resolver.authorizedVault(
+      "backup:ListRecoveryPointsByBackupVault",
+      command.input.BackupVaultName,
+      options,
+    );
+    return {
+      RecoveryPoints: vault
+        .recoveryPoints()
+        .filter((point) => matchesPoint(point, command.input))
+        .map((point) => point.describe()),
+    };
+  }
+
+  async describe(
+    command: commands.SimDescribeRecoveryPointCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimDescribeRecoveryPointCommandOutput> {
+    const { background, authorizer, resolver } = this.properties;
+    await background.sequence();
+    const arn = requiredString(
+      command.input.RecoveryPointArn,
+      "RecoveryPointArn",
+    );
+    authorizer.authorize("backup:DescribeRecoveryPoint", arn, options);
+    const vault = resolver.requireVault(command.input.BackupVaultName);
+    const point = vault.recoveryPoint(arn);
+    if (point === undefined) {
+      throw new SimBackupResourceNotFoundException(
+        `Recovery point ${arn} does not exist in backup vault ${vault.name}`,
+      );
+    }
+    return point.describe();
+  }
+}
+
+function matchesPoint(
+  point: {
+    readonly resourceArn: string;
+    readonly createdBy?:
+      | { readonly BackupPlanId?: string | undefined }
+      | undefined;
+  },
+  filter: commands.SimListRecoveryPointsByBackupVaultCommand["input"],
+): boolean {
+  return (
+    (filter.ByResourceArn === undefined ||
+      point.resourceArn === filter.ByResourceArn) &&
+    (filter.ByBackupPlanId === undefined ||
+      point.createdBy?.BackupPlanId === filter.ByBackupPlanId)
+  );
+}

--- a/src/service/backup/error/sim-backup.error.ts
+++ b/src/service/backup/error/sim-backup.error.ts
@@ -2,9 +2,7 @@ export interface SimBackupErrorMetadata {
   readonly httpStatusCode?: number | undefined;
 }
 
-/**
- *
- */
+/** Base class for AWS Backup service errors. */
 export class SimBackupError extends Error {
   constructor(
     message: string,
@@ -14,9 +12,7 @@ export class SimBackupError extends Error {
   }
 }
 
-/**
- *
- */
+/** AWS Backup refused the caller's permissions. */
 export class SimBackupAccessDeniedException extends SimBackupError {
   override readonly name = "AccessDeniedException";
 
@@ -25,9 +21,7 @@ export class SimBackupAccessDeniedException extends SimBackupError {
   }
 }
 
-/**
- *
- */
+/** AWS Backup found a resource with the requested identity. */
 export class SimBackupAlreadyExistsException extends SimBackupError {
   override readonly name = "AlreadyExistsException";
 
@@ -36,9 +30,7 @@ export class SimBackupAlreadyExistsException extends SimBackupError {
   }
 }
 
-/**
- *
- */
+/** AWS Backup refused a parameter value. */
 export class SimBackupInvalidParameterValueException extends SimBackupError {
   override readonly name = "InvalidParameterValueException";
 
@@ -47,9 +39,16 @@ export class SimBackupInvalidParameterValueException extends SimBackupError {
   }
 }
 
-/**
- *
- */
+/** AWS Backup refused a request that is invalid for the resource state. */
+export class SimBackupInvalidRequestException extends SimBackupError {
+  override readonly name = "InvalidRequestException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/** AWS Backup found a required parameter missing. */
 export class SimBackupMissingParameterValueException extends SimBackupError {
   override readonly name = "MissingParameterValueException";
 
@@ -58,9 +57,7 @@ export class SimBackupMissingParameterValueException extends SimBackupError {
   }
 }
 
-/**
- *
- */
+/** AWS Backup could not find the requested resource. */
 export class SimBackupResourceNotFoundException extends SimBackupError {
   override readonly name = "ResourceNotFoundException";
 

--- a/src/service/backup/index.ts
+++ b/src/service/backup/index.ts
@@ -17,6 +17,7 @@ export {
   SimBackupAlreadyExistsException,
   SimBackupError,
   SimBackupInvalidParameterValueException,
+  SimBackupInvalidRequestException,
   SimBackupMissingParameterValueException,
   SimBackupResourceNotFoundException,
 } from "./error/sim-backup.error.js";

--- a/src/service/backup/index.ts
+++ b/src/service/backup/index.ts
@@ -8,6 +8,8 @@ export type {
   SimBackupSelectionInput,
 } from "./command/sim-backup-command.types.js";
 export { SimBackupPlan } from "./plan/sim-backup-plan.js";
+export { SimBackupJob } from "./job/sim-backup-job.js";
+export { SimBackupRecoveryPoint } from "./recovery-point/sim-backup-recovery-point.js";
 export { SimBackupSelection } from "./selection/sim-backup-selection.js";
 export { SimBackupVault } from "./vault/sim-backup-vault.js";
 export {

--- a/src/service/backup/job/sim-backup-job-input.ts
+++ b/src/service/backup/job/sim-backup-job-input.ts
@@ -9,6 +9,7 @@ export interface StartSimBackupJob {
   readonly resourceArn: string;
   readonly iamRoleArn: string;
   readonly at: Date;
+  readonly idempotencyToken?: string | undefined;
   readonly lifecycle?: SimBackupLifecycle | undefined;
   readonly createdBy?: SimRecoveryPointCreator | undefined;
 }

--- a/src/service/backup/job/sim-backup-job-input.ts
+++ b/src/service/backup/job/sim-backup-job-input.ts
@@ -1,0 +1,14 @@
+import type {
+  SimBackupLifecycle,
+  SimRecoveryPointCreator,
+} from "../command/sim-backup-command.types.js";
+import type { SimBackupVault } from "../vault/sim-backup-vault.js";
+
+export interface StartSimBackupJob {
+  readonly vault: SimBackupVault;
+  readonly resourceArn: string;
+  readonly iamRoleArn: string;
+  readonly at: Date;
+  readonly lifecycle?: SimBackupLifecycle | undefined;
+  readonly createdBy?: SimRecoveryPointCreator | undefined;
+}

--- a/src/service/backup/job/sim-backup-job-page.ts
+++ b/src/service/backup/job/sim-backup-job-page.ts
@@ -1,0 +1,96 @@
+import { SimBackupInvalidParameterValueException } from "../error/sim-backup.error.js";
+import type { SimBackupJob } from "./sim-backup-job.js";
+
+const defaultMaxResults = 1000;
+const maximumMaxResults = 1000;
+
+export interface SimBackupJobPageInput {
+  readonly ByResourceArn?: string | undefined;
+  readonly ByState?: string | undefined;
+  readonly ByBackupVaultName?: string | undefined;
+  readonly MaxResults?: number | undefined;
+  readonly NextToken?: string | undefined;
+}
+
+/** One page of backup jobs and the token for the next page. */
+export class SimBackupJobPage {
+  public readonly jobs: readonly SimBackupJob[];
+  public readonly nextToken: string | undefined;
+
+  constructor(listed: readonly SimBackupJob[], input: SimBackupJobPageInput) {
+    const matching = listed.filter((job) =>
+      SimBackupJobPage.matches(job, input),
+    );
+    const startIndex = SimBackupJobPage.startIndex(
+      input.NextToken,
+      matching.length,
+    );
+    const nextIndex = startIndex + SimBackupJobPage.pageSize(input.MaxResults);
+    this.jobs = matching.slice(startIndex, nextIndex);
+    this.nextToken = SimBackupJobPage.tokenFor(nextIndex, matching.length);
+  }
+
+  /** Return whether a stored job satisfies all requested filters. */
+  private static matches(
+    job: SimBackupJob,
+    input: SimBackupJobPageInput,
+  ): boolean {
+    return (
+      (input.ByResourceArn === undefined ||
+        job.resourceArn === input.ByResourceArn) &&
+      (input.ByState === undefined || job.state === input.ByState) &&
+      (input.ByBackupVaultName === undefined ||
+        job.vaultName === input.ByBackupVaultName)
+    );
+  }
+
+  /** Read and validate the requested page size. */
+  private static pageSize(requested: number | undefined): number {
+    const maxResults = requested ?? defaultMaxResults;
+    if (
+      !Number.isSafeInteger(maxResults) ||
+      maxResults < 1 ||
+      maxResults > maximumMaxResults
+    ) {
+      throw new SimBackupInvalidParameterValueException(
+        `MaxResults ${String(requested)} is outside the range 1 to ${String(
+          maximumMaxResults,
+        )}`,
+      );
+    }
+    return maxResults;
+  }
+
+  /** Read a continuation token as an offset into the filtered jobs. */
+  private static startIndex(
+    nextToken: string | undefined,
+    listedCount: number,
+  ): number {
+    if (nextToken === undefined) {
+      return 0;
+    }
+    const startIndex = Number(nextToken);
+    if (
+      !Number.isSafeInteger(startIndex) ||
+      startIndex <= 0 ||
+      startIndex >= listedCount ||
+      String(startIndex) !== nextToken
+    ) {
+      throw new SimBackupInvalidParameterValueException(
+        "NextToken is not a token this simulation issued",
+      );
+    }
+    return startIndex;
+  }
+
+  /** Issue a continuation token when more jobs remain. */
+  private static tokenFor(
+    nextIndex: number,
+    listedCount: number,
+  ): string | undefined {
+    if (nextIndex >= listedCount) {
+      return undefined;
+    }
+    return String(nextIndex);
+  }
+}

--- a/src/service/backup/job/sim-backup-job.factory.ts
+++ b/src/service/backup/job/sim-backup-job.factory.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimBackupRecoveryPoint } from "../recovery-point/sim-backup-recovery-point.js";
+import { SimBackupJob } from "./sim-backup-job.js";
+import type { StartSimBackupJob } from "./sim-backup-job-input.js";
+
+/** Creates the stored record for a completed backup attempt. */
+export class SimBackupJobFactory {
+  constructor(private readonly scope: SimAwsAccountRegionScope) {}
+
+  make(
+    input: StartSimBackupJob,
+    recoveryPoint: SimBackupRecoveryPoint | undefined,
+    failure: string | undefined,
+  ): SimBackupJob {
+    return new SimBackupJob({
+      accountId: this.scope.accountId,
+      id: randomUUID(),
+      vaultName: input.vault.name,
+      vaultArn: input.vault.arn,
+      resourceArn: input.resourceArn,
+      iamRoleArn: input.iamRoleArn,
+      creationDate: input.at,
+      lifecycle: input.lifecycle,
+      createdBy: input.createdBy,
+      recoveryPointArn: recoveryPoint?.arn,
+      failure,
+    });
+  }
+}

--- a/src/service/backup/job/sim-backup-job.ts
+++ b/src/service/backup/job/sim-backup-job.ts
@@ -1,0 +1,83 @@
+import type {
+  SimBackupJobOutput,
+  SimBackupLifecycle,
+  SimRecoveryPointCreator,
+} from "../command/sim-backup-command.types.js";
+
+interface SimBackupJobProperties {
+  readonly accountId: string;
+  readonly id: string;
+  readonly vaultName: string;
+  readonly vaultArn: string;
+  readonly resourceArn: string;
+  readonly iamRoleArn: string;
+  readonly creationDate: Date;
+  readonly lifecycle?: SimBackupLifecycle | undefined;
+  readonly createdBy?: SimRecoveryPointCreator | undefined;
+  readonly recoveryPointArn?: string | undefined;
+  readonly failure?: string | undefined;
+}
+
+/** The completed result of one simulated backup attempt. */
+export class SimBackupJob {
+  public readonly id: string;
+  public readonly vaultName: string;
+  public readonly resourceArn: string;
+  public readonly state: "COMPLETED" | "FAILED";
+
+  private readonly output: SimBackupJobOutput;
+
+  constructor(properties: SimBackupJobProperties) {
+    this.id = properties.id;
+    this.vaultName = properties.vaultName;
+    this.resourceArn = properties.resourceArn;
+    this.state = properties.failure === undefined ? "COMPLETED" : "FAILED";
+    this.output = {
+      AccountId: properties.accountId,
+      BackupJobId: properties.id,
+      BackupVaultName: properties.vaultName,
+      BackupVaultArn: properties.vaultArn,
+      RecoveryPointArn: properties.recoveryPointArn,
+      ResourceArn: properties.resourceArn,
+      CreationDate: new Date(properties.creationDate),
+      InitiationDate: new Date(properties.creationDate),
+      CompletionDate: new Date(properties.creationDate),
+      State: this.state,
+      StatusMessage: properties.failure,
+      PercentDone: this.state === "COMPLETED" ? "100.0" : "0.0",
+      IamRoleArn: properties.iamRoleArn,
+      CreatedBy:
+        properties.createdBy === undefined
+          ? undefined
+          : { ...properties.createdBy },
+      RecoveryPointLifecycle:
+        properties.lifecycle === undefined
+          ? undefined
+          : { ...properties.lifecycle },
+      IsParent: false,
+      MessageCategory:
+        this.state === "COMPLETED" ? "SUCCESS" : "InvalidParameters",
+    };
+  }
+
+  describe(): SimBackupJobOutput {
+    return {
+      ...this.output,
+      CreationDate: cloneDate(this.output.CreationDate),
+      InitiationDate: cloneDate(this.output.InitiationDate),
+      CompletionDate: cloneDate(this.output.CompletionDate),
+      CreatedBy:
+        this.output.CreatedBy === undefined
+          ? undefined
+          : { ...this.output.CreatedBy },
+      RecoveryPointLifecycle:
+        this.output.RecoveryPointLifecycle === undefined
+          ? undefined
+          : { ...this.output.RecoveryPointLifecycle },
+    };
+  }
+}
+
+function cloneDate(date: Date | undefined): Date | undefined {
+  return date === undefined ? undefined : new Date(date);
+}

--- a/src/service/backup/job/sim-backup-jobs.ts
+++ b/src/service/backup/job/sim-backup-jobs.ts
@@ -23,6 +23,11 @@ export class SimBackupJobs {
   }
 
   start(input: StartSimBackupJob): SimBackupJob {
+    const previous = this.previous(input.idempotencyToken);
+    if (previous !== undefined) {
+      return previous;
+    }
+
     const failure = input.vault.lifecycleRefusal(input.lifecycle);
     const recoveryPoint =
       failure === undefined ? this.pointFactory.make(input) : undefined;
@@ -32,7 +37,16 @@ export class SimBackupJobs {
     }
 
     const job = this.jobFactory.make(input, recoveryPoint, failure);
-    this.store.addJob(job);
+    this.store.addJob(job, input.idempotencyToken);
     return job;
+  }
+
+  private previous(
+    idempotencyKey: string | undefined,
+  ): SimBackupJob | undefined {
+    if (idempotencyKey === undefined) {
+      return undefined;
+    }
+    return this.store.jobByIdempotencyToken(idempotencyKey);
   }
 }

--- a/src/service/backup/job/sim-backup-jobs.ts
+++ b/src/service/backup/job/sim-backup-jobs.ts
@@ -1,0 +1,38 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimBackupRecoveryPointFactory } from "../recovery-point/sim-backup-recovery-point.factory.js";
+import type { SimBackupStore } from "../sim-backup-store.js";
+import type { SimBackupJob } from "./sim-backup-job.js";
+import { SimBackupJobFactory } from "./sim-backup-job.factory.js";
+import type { StartSimBackupJob } from "./sim-backup-job-input.js";
+
+interface SimBackupJobsProperties {
+  readonly scope: SimAwsAccountRegionScope;
+  readonly store: SimBackupStore;
+}
+
+/** Completes backup attempts and records their jobs and recovery points. */
+export class SimBackupJobs {
+  private readonly store: SimBackupStore;
+  private readonly pointFactory: SimBackupRecoveryPointFactory;
+  private readonly jobFactory: SimBackupJobFactory;
+
+  constructor(properties: SimBackupJobsProperties) {
+    this.store = properties.store;
+    this.pointFactory = new SimBackupRecoveryPointFactory(properties.scope);
+    this.jobFactory = new SimBackupJobFactory(properties.scope);
+  }
+
+  start(input: StartSimBackupJob): SimBackupJob {
+    const failure = input.vault.lifecycleRefusal(input.lifecycle);
+    const recoveryPoint =
+      failure === undefined ? this.pointFactory.make(input) : undefined;
+
+    if (recoveryPoint !== undefined) {
+      input.vault.addRecoveryPoint(recoveryPoint);
+    }
+
+    const job = this.jobFactory.make(input, recoveryPoint, failure);
+    this.store.addJob(job);
+    return job;
+  }
+}

--- a/src/service/backup/plan/sim-backup-plan-schedules.ts
+++ b/src/service/backup/plan/sim-backup-plan-schedules.ts
@@ -1,0 +1,99 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import { SimSchedule } from "../../../util/schedule/sim-schedule.js";
+import type { SimBackupRule } from "../command/sim-backup-command.types.js";
+import type { SimBackupJobs } from "../job/sim-backup-jobs.js";
+import type { SimBackupStore } from "../sim-backup-store.js";
+import type { SimBackupPlan } from "./sim-backup-plan.js";
+import { backupScheduleDialect } from "./sim-backup-rule.js";
+
+interface SimBackupPlanSchedulesProperties {
+  readonly store: SimBackupStore;
+  readonly jobs: SimBackupJobs;
+  readonly background: BackgroundScheduler;
+}
+
+/** Runs backup plan rules when simulated time reaches their schedules. */
+export class SimBackupPlanSchedules {
+  private readonly store: SimBackupStore;
+  private readonly jobs: SimBackupJobs;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: SimBackupPlanSchedulesProperties) {
+    this.store = properties.store;
+    this.jobs = properties.jobs;
+    this.background = properties.background;
+  }
+
+  arm(plan: SimBackupPlan): void {
+    for (const rule of plan.rules) {
+      const schedule = SimSchedule.of(
+        rule.ScheduleExpression,
+        backupScheduleDialect,
+      );
+      this.armAfter(plan, rule, schedule, this.background.now());
+    }
+  }
+
+  private armAfter(
+    plan: SimBackupPlan,
+    rule: SimBackupRule,
+    schedule: SimSchedule,
+    after: Date,
+  ): void {
+    const due = schedule.nextAfter(after);
+    if (due === undefined) {
+      return;
+    }
+
+    this.background.scheduleAt(due, () => {
+      this.fire(plan, rule, schedule, due);
+      return Promise.resolve();
+    });
+  }
+
+  private fire(
+    plan: SimBackupPlan,
+    rule: SimBackupRule,
+    schedule: SimSchedule,
+    due: Date,
+  ): void {
+    if (this.store.plan(plan.id) !== plan) {
+      return;
+    }
+
+    const vault = this.store.vault(rule.TargetBackupVaultName);
+    if (vault !== undefined) {
+      for (const [resourceArn, iamRoleArn] of this.selectedResources(plan)) {
+        this.jobs.start({
+          vault,
+          resourceArn,
+          iamRoleArn,
+          at: due,
+          lifecycle: rule.Lifecycle,
+          createdBy: {
+            BackupPlanId: plan.id,
+            BackupPlanArn: plan.arn,
+            BackupPlanName: plan.name,
+            BackupPlanVersion: plan.versionId,
+            BackupRuleId: rule.RuleId,
+            BackupRuleName: rule.RuleName,
+          },
+        });
+      }
+    }
+
+    this.armAfter(plan, rule, schedule, due);
+  }
+
+  private selectedResources(plan: SimBackupPlan): ReadonlyMap<string, string> {
+    const selected = new Map<string, string>();
+    for (const selection of this.store.selectionsForPlan(plan.id)) {
+      for (const resourceArn of selection.resources) {
+        if (!selected.has(resourceArn)) {
+          selected.set(resourceArn, selection.iamRoleArn);
+        }
+      }
+    }
+    return selected;
+  }
+}

--- a/src/service/backup/plan/sim-backup-rule.ts
+++ b/src/service/backup/plan/sim-backup-rule.ts
@@ -40,7 +40,7 @@ export function readBackupRules(
 function readBackupRule(input: SimBackupRuleInput): SimBackupRule {
   const schedule = input.ScheduleExpression ?? defaultBackupScheduleExpression;
   validateSchedule(schedule);
-  validateLifecycle(input);
+  const lifecycle = readBackupLifecycle(input.Lifecycle);
 
   return {
     RuleId: randomUUID(),
@@ -50,8 +50,7 @@ function readBackupRule(input: SimBackupRuleInput): SimBackupRule {
       "TargetBackupVaultName",
     ),
     ScheduleExpression: schedule,
-    Lifecycle:
-      input.Lifecycle === undefined ? undefined : { ...input.Lifecycle },
+    Lifecycle: lifecycle,
   };
 }
 
@@ -68,10 +67,34 @@ function validateSchedule(schedule: string): void {
 }
 
 /** Enforces the relationship between cold storage and deletion. */
-function validateLifecycle(input: SimBackupRuleInput): void {
-  const coldAfter = input.Lifecycle?.MoveToColdStorageAfterDays;
-  const deleteAfter = input.Lifecycle?.DeleteAfterDays;
+export function readBackupLifecycle(
+  lifecycle: SimBackupRuleInput["Lifecycle"],
+): SimBackupRuleInput["Lifecycle"] {
+  const coldAfter = lifecycle?.MoveToColdStorageAfterDays;
+  const deleteAfter = lifecycle?.DeleteAfterDays;
   const retainedIndefinitely = coldAfter === -1 && deleteAfter === -1;
+
+  for (const [name, days] of [
+    ["MoveToColdStorageAfterDays", coldAfter],
+    ["DeleteAfterDays", deleteAfter],
+  ] as const) {
+    if (
+      days !== undefined &&
+      days !== -1 &&
+      (!Number.isSafeInteger(days) || days < 1 || days > 36_500)
+    ) {
+      throw new SimBackupInvalidParameterValueException(
+        `${name} must be between 1 and 36500`,
+      );
+    }
+  }
+
+  if (!retainedIndefinitely && (coldAfter === -1 || deleteAfter === -1)) {
+    throw new SimBackupInvalidParameterValueException(
+      "MoveToColdStorageAfterDays and DeleteAfterDays must both be -1",
+    );
+  }
+
   if (
     !retainedIndefinitely &&
     coldAfter !== undefined &&
@@ -82,4 +105,6 @@ function validateLifecycle(input: SimBackupRuleInput): void {
       "DeleteAfterDays must be at least 90 days after MoveToColdStorageAfterDays",
     );
   }
+
+  return lifecycle === undefined ? undefined : { ...lifecycle };
 }

--- a/src/service/backup/recovery-point/sim-backup-recovery-point.factory.ts
+++ b/src/service/backup/recovery-point/sim-backup-recovery-point.factory.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from "node:crypto";
+
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { StartSimBackupJob } from "../job/sim-backup-job-input.js";
+import { recoveryPointArn } from "../sim-backup-arn.js";
+import { SimBackupRecoveryPoint } from "./sim-backup-recovery-point.js";
+
+/** Creates a recovery point from a successful backup attempt. */
+export class SimBackupRecoveryPointFactory {
+  constructor(private readonly scope: SimAwsAccountRegionScope) {}
+
+  make(input: StartSimBackupJob): SimBackupRecoveryPoint {
+    return new SimBackupRecoveryPoint({
+      arn: recoveryPointArn(randomUUID(), this.scope),
+      vaultName: input.vault.name,
+      vaultArn: input.vault.arn,
+      resourceArn: input.resourceArn,
+      iamRoleArn: input.iamRoleArn,
+      creationDate: input.at,
+      lifecycle: input.lifecycle,
+      createdBy: input.createdBy,
+      encryptionKeyArn: input.vault.encryptionKeyArn,
+    });
+  }
+}

--- a/src/service/backup/recovery-point/sim-backup-recovery-point.ts
+++ b/src/service/backup/recovery-point/sim-backup-recovery-point.ts
@@ -1,0 +1,99 @@
+import type {
+  SimBackupLifecycle,
+  SimRecoveryPointCreator,
+  SimRecoveryPointOutput,
+} from "../command/sim-backup-command.types.js";
+
+const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+interface SimBackupRecoveryPointProperties {
+  readonly arn: string;
+  readonly vaultName: string;
+  readonly vaultArn: string;
+  readonly resourceArn: string;
+  readonly iamRoleArn: string;
+  readonly creationDate: Date;
+  readonly lifecycle?: SimBackupLifecycle | undefined;
+  readonly createdBy?: SimRecoveryPointCreator | undefined;
+  readonly encryptionKeyArn?: string | undefined;
+}
+
+/** A completed recovery point stored in a simulated backup vault. */
+export class SimBackupRecoveryPoint {
+  public readonly arn: string;
+  public readonly vaultName: string;
+  public readonly vaultArn: string;
+  public readonly resourceArn: string;
+  public readonly iamRoleArn: string;
+  public readonly creationDate: Date;
+  public readonly lifecycle?: SimBackupLifecycle | undefined;
+  public readonly createdBy?: SimRecoveryPointCreator | undefined;
+  public readonly encryptionKeyArn?: string | undefined;
+
+  constructor(properties: SimBackupRecoveryPointProperties) {
+    this.arn = properties.arn;
+    this.vaultName = properties.vaultName;
+    this.vaultArn = properties.vaultArn;
+    this.resourceArn = properties.resourceArn;
+    this.iamRoleArn = properties.iamRoleArn;
+    this.creationDate = new Date(properties.creationDate);
+    this.lifecycle =
+      properties.lifecycle === undefined
+        ? undefined
+        : { ...properties.lifecycle };
+    this.createdBy =
+      properties.createdBy === undefined
+        ? undefined
+        : { ...properties.createdBy };
+    this.encryptionKeyArn = properties.encryptionKeyArn;
+  }
+
+  isExpired(now: Date): boolean {
+    const deleteAt = lifecycleDate(
+      this.creationDate,
+      this.lifecycle?.DeleteAfterDays,
+    );
+    return deleteAt !== undefined && now >= deleteAt;
+  }
+
+  describe(): SimRecoveryPointOutput {
+    return {
+      RecoveryPointArn: this.arn,
+      BackupVaultName: this.vaultName,
+      BackupVaultArn: this.vaultArn,
+      ResourceArn: this.resourceArn,
+      CreatedBy:
+        this.createdBy === undefined ? undefined : { ...this.createdBy },
+      IamRoleArn: this.iamRoleArn,
+      Status: "COMPLETED",
+      CreationDate: new Date(this.creationDate),
+      InitiationDate: new Date(this.creationDate),
+      CompletionDate: new Date(this.creationDate),
+      CalculatedLifecycle: {
+        MoveToColdStorageAt: lifecycleDate(
+          this.creationDate,
+          this.lifecycle?.MoveToColdStorageAfterDays,
+        ),
+        DeleteAt: lifecycleDate(
+          this.creationDate,
+          this.lifecycle?.DeleteAfterDays,
+        ),
+      },
+      Lifecycle:
+        this.lifecycle === undefined ? undefined : { ...this.lifecycle },
+      EncryptionKeyArn: this.encryptionKeyArn,
+      IsEncrypted: true,
+      VaultType: "BACKUP_VAULT",
+    };
+  }
+}
+
+function lifecycleDate(
+  createdAt: Date,
+  days: number | undefined,
+): Date | undefined {
+  if (days === undefined || days === -1) {
+    return undefined;
+  }
+  return new Date(createdAt.getTime() + days * millisecondsPerDay);
+}

--- a/src/service/backup/sdk/sim-backup-sdk-command-router.ts
+++ b/src/service/backup/sdk/sim-backup-sdk-command-router.ts
@@ -72,6 +72,36 @@ export class SimBackupSdkCommandRouter implements SimSdkCommandRouter {
           options,
         ),
       ),
+      route("StartBackupJobCommand", (command, options) =>
+        backup.startBackupJob(
+          command as commands.SimStartBackupJobCommand,
+          options,
+        ),
+      ),
+      route("DescribeBackupJobCommand", (command, options) =>
+        backup.describeBackupJob(
+          command as commands.SimDescribeBackupJobCommand,
+          options,
+        ),
+      ),
+      route("ListBackupJobsCommand", (command, options) =>
+        backup.listBackupJobs(
+          command as commands.SimListBackupJobsCommand,
+          options,
+        ),
+      ),
+      route("ListRecoveryPointsByBackupVaultCommand", (command, options) =>
+        backup.listRecoveryPointsByBackupVault(
+          command as commands.SimListRecoveryPointsByBackupVaultCommand,
+          options,
+        ),
+      ),
+      route("DescribeRecoveryPointCommand", (command, options) =>
+        backup.describeRecoveryPoint(
+          command as commands.SimDescribeRecoveryPointCommand,
+          options,
+        ),
+      ),
     ]);
   }
 

--- a/src/service/backup/sim-backup-arn.ts
+++ b/src/service/backup/sim-backup-arn.ts
@@ -15,3 +15,11 @@ export function backupPlanArn(
 ): string {
   return `arn:aws:backup:${scope.regionName}:${scope.accountId}:backup-plan:${id}`;
 }
+
+/** Builds the ARN of a recovery point in the supplied scope. */
+export function recoveryPointArn(
+  id: string,
+  scope: SimAwsAccountRegionScope,
+): string {
+  return `arn:aws:backup:${scope.regionName}:${scope.accountId}:recovery-point:${id}`;
+}

--- a/src/service/backup/sim-backup-commands.iso.test.ts
+++ b/src/service/backup/sim-backup-commands.iso.test.ts
@@ -11,6 +11,7 @@ import {
   ListBackupSelectionsCommand,
   ListBackupVaultsCommand,
   PutBackupVaultLockConfigurationCommand,
+  StartBackupJobCommand,
 } from "@aws-sdk/client-backup";
 import {
   assertArrayLength,
@@ -20,11 +21,12 @@ import {
   assertTrue,
   assertUndefined,
 } from "@kensio/smartass";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { SimSdk } from "../../sdk/sim-sdk.js";
 import { SimFixedClock } from "../../util/clock/sim-clock.js";
 import { SimAws } from "../aws/sim-aws.js";
+import { SimBackupInvalidRequestException } from "./error/sim-backup.error.js";
 
 describe("simulated AWS Backup commands", () => {
   it("stores a vault, a multi-rule plan and a resource selection", async () => {
@@ -195,6 +197,42 @@ describe("simulated AWS Backup commands", () => {
     const vaults = await simAws
       .backup()
       .listBackupVaults(new ListBackupVaultsCommand({}));
+    assertArrayLength(vaults.BackupVaultList ?? [], 0);
+  });
+
+  it("deletes a vault only after its recovery points expire", async () => {
+    // Given a vault containing a recovery point with one day of retention.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-08-31T10:00:00.000Z")),
+    });
+    const backup = simAws.backup();
+    const vaultName = `vault-${faker.string.uuid()}`;
+    await backup.createBackupVault(
+      new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    await backup.startBackupJob(
+      new StartBackupJobCommand({
+        BackupVaultName: vaultName,
+        ResourceArn: `arn:aws:s3:::${faker.string.uuid()}`,
+        IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+        Lifecycle: { DeleteAfterDays: 1 },
+      }),
+    );
+
+    // When deletion is requested before and after the expiry instant.
+    // Then the live point prevents deletion, while the expired point does not.
+    await expect(
+      backup.deleteBackupVault(
+        new DeleteBackupVaultCommand({ BackupVaultName: vaultName }),
+      ),
+    ).rejects.toBeInstanceOf(SimBackupInvalidRequestException);
+    await simAws.clock().advanceBy({ days: 1 });
+    await backup.deleteBackupVault(
+      new DeleteBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    const vaults = await backup.listBackupVaults(
+      new ListBackupVaultsCommand({}),
+    );
     assertArrayLength(vaults.BackupVaultList ?? [], 0);
   });
 

--- a/src/service/backup/sim-backup-recovery-points.iso.test.ts
+++ b/src/service/backup/sim-backup-recovery-points.iso.test.ts
@@ -1,0 +1,275 @@
+import { faker } from "@faker-js/faker";
+import {
+  BackupClient,
+  CreateBackupPlanCommand,
+  CreateBackupSelectionCommand,
+  CreateBackupVaultCommand,
+  DescribeBackupJobCommand,
+  DescribeBackupVaultCommand,
+  DescribeRecoveryPointCommand,
+  ListBackupJobsCommand,
+  ListRecoveryPointsByBackupVaultCommand,
+  PutBackupVaultLockConfigurationCommand,
+  StartBackupJobCommand,
+} from "@aws-sdk/client-backup";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { SimSdk } from "../../sdk/sim-sdk.js";
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+import { SimBackupResourceNotFoundException } from "./error/sim-backup.error.js";
+
+describe("simulated AWS Backup recovery points", () => {
+  it("creates one recovery point for each selected resource on schedule", async () => {
+    // Given an hourly plan with two distinct selected resources.
+    const createdAt = new Date("2026-08-31T09:30:00.000Z");
+    const simAws = new SimAws({ clock: new SimFixedClock(createdAt) });
+    const backup = simAws.backup();
+    const vaultName = `vault-${faker.string.uuid()}`;
+    const tableArn = `arn:aws:dynamodb:us-east-1:888888888888:table/${faker.string.uuid()}`;
+    const bucketArn = `arn:aws:s3:::${faker.string.uuid()}`;
+    await backup.createBackupVault(
+      new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    const plan = await backup.createBackupPlan(
+      new CreateBackupPlanCommand({
+        BackupPlan: {
+          BackupPlanName: `plan-${faker.string.uuid()}`,
+          Rules: [
+            {
+              RuleName: "hourly",
+              TargetBackupVaultName: vaultName,
+              ScheduleExpression: "rate(1 hour)",
+              Lifecycle: { DeleteAfterDays: 30 },
+            },
+          ],
+        },
+      }),
+    );
+    assertNonNullable(plan.BackupPlanId);
+    await backup.createBackupSelection(
+      new CreateBackupSelectionCommand({
+        BackupPlanId: plan.BackupPlanId,
+        BackupSelection: {
+          SelectionName: `selection-${faker.string.uuid()}`,
+          IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+          Resources: [tableArn, bucketArn, tableArn],
+        },
+      }),
+    );
+
+    // When the simulated clock reaches two hourly occurrences.
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    // Then each occurrence creates one point per distinct resource.
+    const points = backup.vault(vaultName).recoveryPoints();
+    assertArrayLength(points, 4);
+    assertIdentical(
+      points[0].creationDate.toISOString(),
+      "2026-08-31T10:30:00.000Z",
+    );
+    assertIdentical(
+      points[2].creationDate.toISOString(),
+      "2026-08-31T11:30:00.000Z",
+    );
+    const jobs = await backup.listBackupJobs(new ListBackupJobsCommand({}));
+    const backupJobs = jobs.BackupJobs ?? [];
+    assertArrayLength(backupJobs, 4);
+    assertIdentical(backupJobs[0].State, "COMPLETED");
+    assertIdentical(backupJobs[0].CreatedBy?.BackupPlanId, plan.BackupPlanId);
+  });
+
+  it("expires a recovery point after its retention period", async () => {
+    // Given a rule with one finite occurrence and a two-day lifecycle.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-08-31T23:59:00.000Z")),
+    });
+    const backup = simAws.backup();
+    const vaultName = `vault-${faker.string.uuid()}`;
+    await backup.createBackupVault(
+      new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    const plan = await backup.createBackupPlan(
+      new CreateBackupPlanCommand({
+        BackupPlan: {
+          BackupPlanName: `plan-${faker.string.uuid()}`,
+          Rules: [
+            {
+              RuleName: "once",
+              TargetBackupVaultName: vaultName,
+              ScheduleExpression: "cron(0 1 1 9 ? 2026)",
+              Lifecycle: { DeleteAfterDays: 2 },
+            },
+          ],
+        },
+      }),
+    );
+    await backup.createBackupSelection(
+      new CreateBackupSelectionCommand({
+        BackupPlanId: plan.BackupPlanId,
+        BackupSelection: {
+          SelectionName: `selection-${faker.string.uuid()}`,
+          IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+          Resources: [`arn:aws:s3:::${faker.string.uuid()}`],
+        },
+      }),
+    );
+    await simAws.clock().advanceBy({ hours: 1, minutes: 1 });
+    const [point] = backup.vault(vaultName).recoveryPoints();
+    assertNonNullable(point);
+
+    // When its deletion instant passes.
+    await simAws.clock().advanceBy({ days: 2 });
+
+    // Then vault reads sweep the expired point from both access paths.
+    assertArrayLength(backup.vault(vaultName).recoveryPoints(), 0);
+    const listed = await backup.listRecoveryPointsByBackupVault(
+      new ListRecoveryPointsByBackupVaultCommand({
+        BackupVaultName: vaultName,
+      }),
+    );
+    assertArrayLength(listed.RecoveryPoints ?? [], 0);
+    await expect(
+      backup.describeRecoveryPoint(
+        new DescribeRecoveryPointCommand({
+          BackupVaultName: vaultName,
+          RecoveryPointArn: point.arn,
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SimBackupResourceNotFoundException);
+  });
+
+  it("records a failed job when Vault Lock rejects rule retention", async () => {
+    // Given a vault whose minimum retention exceeds the rule lifecycle.
+    const simAws = new SimAws({
+      clock: new SimFixedClock(new Date("2026-08-31T09:30:00.000Z")),
+    });
+    const backup = simAws.backup();
+    const vaultName = `vault-${faker.string.uuid()}`;
+    await backup.createBackupVault(
+      new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    await backup.putBackupVaultLockConfiguration(
+      new PutBackupVaultLockConfigurationCommand({
+        BackupVaultName: vaultName,
+        MinRetentionDays: 7,
+      }),
+    );
+    const plan = await backup.createBackupPlan(
+      new CreateBackupPlanCommand({
+        BackupPlan: {
+          BackupPlanName: `plan-${faker.string.uuid()}`,
+          Rules: [
+            {
+              RuleName: "hourly",
+              TargetBackupVaultName: vaultName,
+              ScheduleExpression: "rate(1 hour)",
+              Lifecycle: { DeleteAfterDays: 3 },
+            },
+          ],
+        },
+      }),
+    );
+    await backup.createBackupSelection(
+      new CreateBackupSelectionCommand({
+        BackupPlanId: plan.BackupPlanId,
+        BackupSelection: {
+          SelectionName: `selection-${faker.string.uuid()}`,
+          IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+          Resources: [`arn:aws:s3:::${faker.string.uuid()}`],
+        },
+      }),
+    );
+
+    // When the rule falls due.
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then it leaves a readable failed job and no recovery point.
+    assertArrayLength(backup.vault(vaultName).recoveryPoints(), 0);
+    const listed = await backup.listBackupJobs(new ListBackupJobsCommand({}));
+    assertArrayLength(listed.BackupJobs ?? [], 1);
+    const jobId = listed.BackupJobs?.[0]?.BackupJobId;
+    assertNonNullable(jobId);
+    const job = await backup.describeBackupJob(
+      new DescribeBackupJobCommand({ BackupJobId: jobId }),
+    );
+    assertIdentical(job.State, "FAILED");
+    assertStringIncludes(job.StatusMessage ?? "", "below the vault minimum");
+  });
+
+  it("creates on-demand points and exposes them through SDK commands", async () => {
+    // Given an intercepted Backup client and a vault with bounded retention.
+    const now = new Date("2026-08-31T12:00:00.000Z");
+    const simAws = new SimAws({ clock: new SimFixedClock(now) });
+    using simSdk = new SimSdk({ simAws });
+    const client = new BackupClient({ region: "us-east-1" });
+    simSdk.intercept(client);
+    const vaultName = `vault-${faker.string.uuid()}`;
+    const resourceArn = `arn:aws:s3:::${faker.string.uuid()}`;
+    await client.send(
+      new CreateBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    await client.send(
+      new PutBackupVaultLockConfigurationCommand({
+        BackupVaultName: vaultName,
+        MinRetentionDays: 7,
+        MaxRetentionDays: 30,
+      }),
+    );
+
+    // When an on-demand job uses retention inside the bounds.
+    const started = await client.send(
+      new StartBackupJobCommand({
+        BackupVaultName: vaultName,
+        ResourceArn: resourceArn,
+        IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+        Lifecycle: { DeleteAfterDays: 14 },
+      }),
+    );
+    assertNonNullable(started.BackupJobId);
+    assertNonNullable(started.RecoveryPointArn);
+
+    // Then the job, point and vault count are immediately readable.
+    const job = await client.send(
+      new DescribeBackupJobCommand({ BackupJobId: started.BackupJobId }),
+    );
+    assertIdentical(job.State, "COMPLETED");
+    const point = await client.send(
+      new DescribeRecoveryPointCommand({
+        BackupVaultName: vaultName,
+        RecoveryPointArn: started.RecoveryPointArn,
+      }),
+    );
+    assertIdentical(point.ResourceArn, resourceArn);
+    assertIdentical(point.CreationDate?.toISOString(), now.toISOString());
+    assertIdentical(
+      point.CalculatedLifecycle?.DeleteAt?.toISOString(),
+      "2026-09-14T12:00:00.000Z",
+    );
+    const vault = await client.send(
+      new DescribeBackupVaultCommand({ BackupVaultName: vaultName }),
+    );
+    assertIdentical(vault.NumberOfRecoveryPoints, 1);
+
+    const refused = await client.send(
+      new StartBackupJobCommand({
+        BackupVaultName: vaultName,
+        ResourceArn: `arn:aws:s3:::${faker.string.uuid()}`,
+        IamRoleArn: "arn:aws:iam::888888888888:role/BackupRole",
+        Lifecycle: { DeleteAfterDays: 31 },
+      }),
+    );
+    assertNonNullable(refused.BackupJobId);
+    const failed = await client.send(
+      new DescribeBackupJobCommand({ BackupJobId: refused.BackupJobId }),
+    );
+    assertIdentical(failed.State, "FAILED");
+    assertArrayLength(simAws.backup().vault(vaultName).recoveryPoints(), 1);
+  });
+});

--- a/src/service/backup/sim-backup-store.ts
+++ b/src/service/backup/sim-backup-store.ts
@@ -12,6 +12,7 @@ export class SimBackupStore {
   private readonly plans = new Map<string, SimBackupPlan>();
   private readonly selections = new Map<string, SimBackupSelection>();
   private readonly jobs = new Map<string, SimBackupJob>();
+  private readonly jobsByIdempotencyToken = new Map<string, SimBackupJob>();
 
   addVault(vault: SimBackupVault): void {
     if (this.vaults.has(vault.name)) {
@@ -88,12 +89,19 @@ export class SimBackupStore {
     this.selections.delete(id);
   }
 
-  addJob(job: SimBackupJob): void {
+  addJob(job: SimBackupJob, idempotencyToken?: string): void {
     this.jobs.set(job.id, job);
+    if (idempotencyToken !== undefined) {
+      this.jobsByIdempotencyToken.set(idempotencyToken, job);
+    }
   }
 
   job(id: string): SimBackupJob | undefined {
     return this.jobs.get(id);
+  }
+
+  jobByIdempotencyToken(token: string): SimBackupJob | undefined {
+    return this.jobsByIdempotencyToken.get(token);
   }
 
   allJobs(): MapIterator<SimBackupJob> {

--- a/src/service/backup/sim-backup-store.ts
+++ b/src/service/backup/sim-backup-store.ts
@@ -1,4 +1,5 @@
 import { SimBackupAlreadyExistsException } from "./error/sim-backup.error.js";
+import type { SimBackupJob } from "./job/sim-backup-job.js";
 import type { SimBackupPlan } from "./plan/sim-backup-plan.js";
 import type { SimBackupSelection } from "./selection/sim-backup-selection.js";
 import type { SimBackupVault } from "./vault/sim-backup-vault.js";
@@ -10,6 +11,7 @@ export class SimBackupStore {
   private readonly vaults = new Map<string, SimBackupVault>();
   private readonly plans = new Map<string, SimBackupPlan>();
   private readonly selections = new Map<string, SimBackupSelection>();
+  private readonly jobs = new Map<string, SimBackupJob>();
 
   addVault(vault: SimBackupVault): void {
     if (this.vaults.has(vault.name)) {
@@ -84,5 +86,17 @@ export class SimBackupStore {
 
   removeSelection(id: string): void {
     this.selections.delete(id);
+  }
+
+  addJob(job: SimBackupJob): void {
+    this.jobs.set(job.id, job);
+  }
+
+  job(id: string): SimBackupJob | undefined {
+    return this.jobs.get(id);
+  }
+
+  allJobs(): MapIterator<SimBackupJob> {
+    return this.jobs.values();
   }
 }

--- a/src/service/backup/sim-backup.ts
+++ b/src/service/backup/sim-backup.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-
 import {
   type BackgroundScheduler,
   BackgroundTasks,
@@ -8,17 +6,20 @@ import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-route
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
+import { SimBackupConfigurationCommands } from "./command/sim-backup-configuration-commands.js";
 import type * as commands from "./command/sim-backup-command.types.js";
 import { SimBackupAuthorizer } from "./command/sim-backup-authorizer.js";
+import { SimBackupJobCommands } from "./command/sim-backup-job-commands.js";
+import { SimBackupRecoveryPointCommands } from "./command/sim-backup-recovery-point-commands.js";
 import type { SimBackupRequestOptions } from "./command/sim-backup-request-options.js";
-import { requiredString } from "./command/sim-backup-required-string.js";
-import { SimBackupPlan } from "./plan/sim-backup-plan.js";
-import { SimBackupSelection } from "./selection/sim-backup-selection.js";
-import { backupPlanArn, backupVaultArn } from "./sim-backup-arn.js";
+import type { SimBackupPlan } from "./plan/sim-backup-plan.js";
+import { SimBackupPlanSchedules } from "./plan/sim-backup-plan-schedules.js";
+import type { SimBackupSelection } from "./selection/sim-backup-selection.js";
 import type { SimBackupProperties } from "./sim-backup-properties.js";
 import { SimBackupResourceResolver } from "./sim-backup-resource-resolver.js";
 import { SimBackupStore } from "./sim-backup-store.js";
-import { SimBackupVault } from "./vault/sim-backup-vault.js";
+import type { SimBackupVault } from "./vault/sim-backup-vault.js";
+import { SimBackupJobs } from "./job/sim-backup-jobs.js";
 import { SimBackupSdkCommandRouter } from "./sdk/sim-backup-sdk-command-router.js";
 import { SimBackupCfnResourceFactory } from "./cfn/sim-backup-cfn-resource-factory.js";
 
@@ -29,6 +30,11 @@ export class SimBackup {
   private readonly background: BackgroundScheduler;
   private readonly authorizer: SimBackupAuthorizer;
   private readonly resolver: SimBackupResourceResolver;
+  private readonly jobs: SimBackupJobs;
+  private readonly schedules: SimBackupPlanSchedules;
+  private readonly jobCommands: SimBackupJobCommands;
+  private readonly recoveryPointCommands: SimBackupRecoveryPointCommands;
+  private readonly configurationCommands: SimBackupConfigurationCommands;
   private readonly sdkRouter = new SimBackupSdkCommandRouter(this);
   private readonly cfnFactory = new SimBackupCfnResourceFactory({
     backup: this,
@@ -46,192 +52,156 @@ export class SimBackup {
       authorizer: this.authorizer,
       store: this.store,
     });
+    this.jobs = new SimBackupJobs({ scope: this.scope, store: this.store });
+    this.schedules = new SimBackupPlanSchedules({
+      store: this.store,
+      jobs: this.jobs,
+      background: this.background,
+    });
+    this.jobCommands = new SimBackupJobCommands({
+      background: this.background,
+      authorizer: this.authorizer,
+      resolver: this.resolver,
+      store: this.store,
+      jobs: this.jobs,
+    });
+    this.recoveryPointCommands = new SimBackupRecoveryPointCommands({
+      background: this.background,
+      authorizer: this.authorizer,
+      resolver: this.resolver,
+    });
+    this.configurationCommands = new SimBackupConfigurationCommands({
+      scope: this.scope,
+      background: this.background,
+      authorizer: this.authorizer,
+      resolver: this.resolver,
+      store: this.store,
+      schedules: this.schedules,
+    });
   }
 
   async createBackupVault(
     command: commands.SimCreateBackupVaultCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimCreateBackupVaultCommandOutput> {
-    await this.background.sequence();
-    const name = requiredString(
-      command.input.BackupVaultName,
-      "BackupVaultName",
-    );
-    const arn = backupVaultArn(name, this.scope);
-    this.authorizer.authorize("backup:CreateBackupVault", arn, options);
-
-    const vault = new SimBackupVault({
-      name,
-      arn,
-      creationDate: this.background.now(),
-      encryptionKeyArn: command.input.EncryptionKeyArn,
-      creatorRequestId: command.input.CreatorRequestId,
-    });
-    this.store.addVault(vault);
-
-    return {
-      BackupVaultName: vault.name,
-      BackupVaultArn: vault.arn,
-      CreationDate: new Date(vault.creationDate),
-    };
+    return await this.configurationCommands.createBackupVault(command, options);
   }
 
   async describeBackupVault(
     command: commands.SimDescribeBackupVaultCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimDescribeBackupVaultCommandOutput> {
-    await this.background.sequence();
-    const vault = this.resolver.authorizedVault(
-      "backup:DescribeBackupVault",
-      command.input.BackupVaultName,
+    return await this.configurationCommands.describeBackupVault(
+      command,
       options,
     );
-    return vault.describe();
   }
 
   async deleteBackupVault(
     command: commands.SimDeleteBackupVaultCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimDeleteBackupVaultCommandOutput> {
-    await this.background.sequence();
-    const vault = this.resolver.authorizedVault(
-      "backup:DeleteBackupVault",
-      command.input.BackupVaultName,
-      options,
-    );
-    this.store.removeVault(vault.name);
-    return {};
+    return await this.configurationCommands.deleteBackupVault(command, options);
   }
 
   async listBackupVaults(
     _command: commands.SimListBackupVaultsCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimListBackupVaultsCommandOutput> {
-    await this.background.sequence();
-    this.authorizer.authorize("backup:ListBackupVaults", "*", options);
-    return {
-      BackupVaultList: this.store
-        .allVaults()
-        .map((vault) => vault.listMember())
-        .toArray(),
-    };
+    return await this.configurationCommands.listBackupVaults(_command, options);
   }
 
   async putBackupVaultLockConfiguration(
     command: commands.SimPutBackupVaultLockConfigurationCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimPutBackupVaultLockConfigurationCommandOutput> {
-    await this.background.sequence();
-    const vault = this.resolver.authorizedVault(
-      "backup:PutBackupVaultLockConfiguration",
-      command.input.BackupVaultName,
+    return await this.configurationCommands.putBackupVaultLockConfiguration(
+      command,
       options,
     );
-    vault.configureLock(command.input, this.background.now());
-    return {};
   }
 
   async createBackupPlan(
     command: commands.SimCreateBackupPlanCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimCreateBackupPlanCommandOutput> {
-    await this.background.sequence();
-    const id = randomUUID();
-    const arn = backupPlanArn(id, this.scope);
-    this.authorizer.authorize("backup:CreateBackupPlan", arn, options);
-    const plan = new SimBackupPlan({
-      id,
-      arn,
-      versionId: randomUUID(),
-      creationDate: this.background.now(),
-      creatorRequestId: command.input.CreatorRequestId,
-      plan: command.input.BackupPlan ?? {},
-    });
-
-    for (const rule of plan.rules) {
-      this.resolver.requireVault(rule.TargetBackupVaultName);
-    }
-    this.store.addPlan(plan);
-
-    return {
-      BackupPlanId: plan.id,
-      BackupPlanArn: plan.arn,
-      VersionId: plan.versionId,
-      CreationDate: new Date(plan.creationDate),
-    };
+    return await this.configurationCommands.createBackupPlan(command, options);
   }
 
   async getBackupPlan(
     command: commands.SimGetBackupPlanCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimGetBackupPlanCommandOutput> {
-    await this.background.sequence();
-    const plan = this.resolver.authorizedPlan(
-      "backup:GetBackupPlan",
-      command.input.BackupPlanId,
-      options,
-    );
-    return plan.describe();
+    return await this.configurationCommands.getBackupPlan(command, options);
   }
 
   async createBackupSelection(
     command: commands.SimCreateBackupSelectionCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimCreateBackupSelectionCommandOutput> {
-    await this.background.sequence();
-    const plan = this.resolver.authorizedPlan(
-      "backup:CreateBackupSelection",
-      command.input.BackupPlanId,
+    return await this.configurationCommands.createBackupSelection(
+      command,
       options,
     );
-    const selection = new SimBackupSelection({
-      id: randomUUID(),
-      planId: plan.id,
-      creationDate: this.background.now(),
-      creatorRequestId: command.input.CreatorRequestId,
-      selection: command.input.BackupSelection ?? {},
-    });
-
-    this.store.addSelection(selection);
-
-    return {
-      SelectionId: selection.id,
-      BackupPlanId: plan.id,
-      CreationDate: new Date(selection.creationDate),
-    };
   }
 
   async getBackupSelection(
     command: commands.SimGetBackupSelectionCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimGetBackupSelectionCommandOutput> {
-    await this.background.sequence();
-    const plan = this.resolver.authorizedPlan(
-      "backup:GetBackupSelection",
-      command.input.BackupPlanId,
+    return await this.configurationCommands.getBackupSelection(
+      command,
       options,
     );
-    return this.resolver
-      .requireSelection(plan.id, command.input.SelectionId)
-      .describe();
   }
 
   async listBackupSelections(
     command: commands.SimListBackupSelectionsCommand,
     options?: SimBackupRequestOptions,
   ): Promise<commands.SimListBackupSelectionsCommandOutput> {
-    await this.background.sequence();
-    const plan = this.resolver.authorizedPlan(
-      "backup:ListBackupSelections",
-      command.input.BackupPlanId,
+    return await this.configurationCommands.listBackupSelections(
+      command,
       options,
     );
-    return {
-      BackupSelectionsList: this.store
-        .selectionsForPlan(plan.id)
-        .map((selection) => selection.listMember())
-        .toArray(),
-    };
+  }
+
+  async startBackupJob(
+    command: commands.SimStartBackupJobCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimStartBackupJobCommandOutput> {
+    return await this.jobCommands.start(command, options);
+  }
+
+  async describeBackupJob(
+    command: commands.SimDescribeBackupJobCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimDescribeBackupJobCommandOutput> {
+    return await this.jobCommands.describe(command, options);
+  }
+
+  async listBackupJobs(
+    command: commands.SimListBackupJobsCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimListBackupJobsCommandOutput> {
+    return await this.jobCommands.list(command, options);
+  }
+
+  async listRecoveryPointsByBackupVault(
+    command: commands.SimListRecoveryPointsByBackupVaultCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimListRecoveryPointsByBackupVaultCommandOutput> {
+    return await this.recoveryPointCommands.list(command, options);
+  }
+
+  async describeRecoveryPoint(
+    command: commands.SimDescribeRecoveryPointCommand,
+    options?: SimBackupRequestOptions,
+  ): Promise<commands.SimDescribeRecoveryPointCommandOutput> {
+    return await this.recoveryPointCommands.describe(command, options);
+  }
+
+  vault(name: string): SimBackupVault {
+    return this.resolver.requireVault(name);
   }
 
   findBackupVault(name: string): SimBackupVault | undefined {

--- a/src/service/backup/vault/sim-backup-vault-description.ts
+++ b/src/service/backup/vault/sim-backup-vault-description.ts
@@ -1,0 +1,31 @@
+import type { SimDescribeBackupVaultCommandOutput } from "../command/sim-backup-command.types.js";
+import type { SimBackupVaultLockConfiguration } from "./sim-backup-vault-lock.js";
+
+interface SimBackupVaultDescriptionSource {
+  readonly name: string;
+  readonly arn: string;
+  readonly creationDate: Date;
+  readonly encryptionKeyArn?: string | undefined;
+  readonly creatorRequestId?: string | undefined;
+}
+
+/** Builds the SDK description of one backup vault. */
+export function describeBackupVault(
+  vault: SimBackupVaultDescriptionSource,
+  lock: SimBackupVaultLockConfiguration | undefined,
+  lockDate: Date | undefined,
+  recoveryPointCount: number,
+): SimDescribeBackupVaultCommandOutput {
+  return {
+    BackupVaultName: vault.name,
+    BackupVaultArn: vault.arn,
+    EncryptionKeyArn: vault.encryptionKeyArn,
+    CreationDate: new Date(vault.creationDate),
+    CreatorRequestId: vault.creatorRequestId,
+    NumberOfRecoveryPoints: recoveryPointCount,
+    Locked: lock !== undefined,
+    MinRetentionDays: lock?.MinRetentionDays,
+    MaxRetentionDays: lock?.MaxRetentionDays,
+    LockDate: lockDate === undefined ? undefined : new Date(lockDate),
+  };
+}

--- a/src/service/backup/vault/sim-backup-vault-lock-configuration.ts
+++ b/src/service/backup/vault/sim-backup-vault-lock-configuration.ts
@@ -1,0 +1,56 @@
+import { SimBackupInvalidParameterValueException } from "../error/sim-backup.error.js";
+import type { SimBackupVaultLockConfiguration } from "./sim-backup-vault-lock.js";
+
+const millisecondsPerDay = 24 * 60 * 60 * 1000;
+
+/** Calculates when a Vault Lock grace period ends. */
+export function backupVaultLockDate(
+  changeableForDays: number | undefined,
+  now: Date,
+): Date | undefined {
+  if (changeableForDays === undefined) {
+    return undefined;
+  }
+  return new Date(now.getTime() + changeableForDays * millisecondsPerDay);
+}
+
+/** Validates a Vault Lock configuration before storage. */
+export function validateBackupVaultLockConfiguration(
+  configuration: SimBackupVaultLockConfiguration,
+): void {
+  const { MinRetentionDays: minimum, MaxRetentionDays: maximum } =
+    configuration;
+  if (
+    minimum !== undefined &&
+    (!Number.isSafeInteger(minimum) || minimum < 1)
+  ) {
+    throw new SimBackupInvalidParameterValueException(
+      "MinRetentionDays must be a positive whole number",
+    );
+  }
+  if (
+    maximum !== undefined &&
+    (!Number.isSafeInteger(maximum) || maximum < 1 || maximum > 36_500)
+  ) {
+    throw new SimBackupInvalidParameterValueException(
+      "MaxRetentionDays must be between 1 and 36500",
+    );
+  }
+  if (minimum !== undefined && maximum !== undefined && minimum > maximum) {
+    throw new SimBackupInvalidParameterValueException(
+      "MinRetentionDays must not exceed MaxRetentionDays",
+    );
+  }
+  validateGracePeriod(configuration.ChangeableForDays);
+}
+
+function validateGracePeriod(grace: number | undefined): void {
+  if (
+    grace !== undefined &&
+    (!Number.isSafeInteger(grace) || grace < 3 || grace > 36_500)
+  ) {
+    throw new SimBackupInvalidParameterValueException(
+      "ChangeableForDays must be between 3 and 36500",
+    );
+  }
+}

--- a/src/service/backup/vault/sim-backup-vault-lock.ts
+++ b/src/service/backup/vault/sim-backup-vault-lock.ts
@@ -1,0 +1,38 @@
+import type { SimBackupLifecycle } from "../command/sim-backup-command.types.js";
+import { SimBackupInvalidParameterValueException } from "../error/sim-backup.error.js";
+import {
+  backupVaultLockDate,
+  validateBackupVaultLockConfiguration,
+} from "./sim-backup-vault-lock-configuration.js";
+import { backupLifecycleRefusal } from "./sim-backup-vault-retention.js";
+
+export interface SimBackupVaultLockConfiguration {
+  readonly MinRetentionDays?: number | undefined;
+  readonly MaxRetentionDays?: number | undefined;
+  readonly ChangeableForDays?: number | undefined;
+}
+
+/** Holds the Vault Lock state for one backup vault. */
+export class SimBackupVaultLock {
+  public configuration?: SimBackupVaultLockConfiguration | undefined;
+  public lockDate?: Date | undefined;
+
+  constructor(private readonly vaultName: string) {}
+
+  configure(configuration: SimBackupVaultLockConfiguration, now: Date): void {
+    if (this.lockDate !== undefined && now >= this.lockDate) {
+      throw new SimBackupInvalidParameterValueException(
+        `The lock configuration for backup vault ${this.vaultName} is immutable`,
+      );
+    }
+    validateBackupVaultLockConfiguration(configuration);
+    this.configuration = { ...configuration };
+    this.lockDate = backupVaultLockDate(configuration.ChangeableForDays, now);
+  }
+
+  lifecycleRefusal(
+    lifecycle: SimBackupLifecycle | undefined,
+  ): string | undefined {
+    return backupLifecycleRefusal(lifecycle, this.configuration);
+  }
+}

--- a/src/service/backup/vault/sim-backup-vault-recovery-points.ts
+++ b/src/service/backup/vault/sim-backup-vault-recovery-points.ts
@@ -1,0 +1,35 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimBackupRecoveryPoint } from "../recovery-point/sim-backup-recovery-point.js";
+
+/** Holds the unexpired recovery points in one backup vault. */
+export class SimBackupVaultRecoveryPoints {
+  private readonly stored = new Map<string, SimBackupRecoveryPoint>();
+
+  constructor(private readonly background: BackgroundScheduler) {}
+
+  add(recoveryPoint: SimBackupRecoveryPoint): void {
+    this.stored.set(recoveryPoint.arn, recoveryPoint);
+  }
+
+  all(): readonly SimBackupRecoveryPoint[] {
+    this.expire();
+    return this.stored.values().toArray();
+  }
+
+  find(arn: string): SimBackupRecoveryPoint | undefined {
+    this.expire();
+    return this.stored.get(arn);
+  }
+
+  private expire(): void {
+    const now = this.background.now();
+    const expired = this.stored
+      .values()
+      .filter((point) => point.isExpired(now))
+      .map((point) => point.arn)
+      .toArray();
+    for (const arn of expired) {
+      this.stored.delete(arn);
+    }
+  }
+}

--- a/src/service/backup/vault/sim-backup-vault-retention.ts
+++ b/src/service/backup/vault/sim-backup-vault-retention.ts
@@ -1,0 +1,32 @@
+import type { SimBackupLifecycle } from "../command/sim-backup-command.types.js";
+import type { SimBackupVaultLockConfiguration } from "./sim-backup-vault-lock.js";
+
+/** Returns the Vault Lock reason that rejects a recovery point lifecycle. */
+export function backupLifecycleRefusal(
+  lifecycle: SimBackupLifecycle | undefined,
+  lock: SimBackupVaultLockConfiguration | undefined,
+): string | undefined {
+  const retention = lifecycle?.DeleteAfterDays;
+  const minimum = lock?.MinRetentionDays;
+  if (
+    minimum !== undefined &&
+    retention !== undefined &&
+    retention !== -1 &&
+    retention < minimum
+  ) {
+    return `Lifecycle retention of ${retention} days is below the vault minimum of ${minimum} days`;
+  }
+
+  const maximum = lock?.MaxRetentionDays;
+  if (
+    maximum === undefined ||
+    (retention !== undefined && retention !== -1 && retention <= maximum)
+  ) {
+    return undefined;
+  }
+  const requested =
+    retention === undefined || retention === -1
+      ? "indefinite"
+      : `${retention} days`;
+  return `Lifecycle retention of ${requested} exceeds the vault maximum of ${maximum} days`;
+}

--- a/src/service/backup/vault/sim-backup-vault.ts
+++ b/src/service/backup/vault/sim-backup-vault.ts
@@ -2,15 +2,17 @@ import type {
   SimBackupVaultListMember,
   SimDescribeBackupVaultCommandOutput,
 } from "../command/sim-backup-command.types.js";
-import { SimBackupInvalidParameterValueException } from "../error/sim-backup.error.js";
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimBackupLifecycle } from "../command/sim-backup-command.types.js";
+import type { SimBackupRecoveryPoint } from "../recovery-point/sim-backup-recovery-point.js";
+import { describeBackupVault } from "./sim-backup-vault-description.js";
+import {
+  SimBackupVaultLock,
+  type SimBackupVaultLockConfiguration,
+} from "./sim-backup-vault-lock.js";
+import { SimBackupVaultRecoveryPoints } from "./sim-backup-vault-recovery-points.js";
 
-const millisecondsPerDay = 24 * 60 * 60 * 1000;
-
-export interface SimBackupVaultLockConfiguration {
-  readonly MinRetentionDays?: number | undefined;
-  readonly MaxRetentionDays?: number | undefined;
-  readonly ChangeableForDays?: number | undefined;
-}
+export type { SimBackupVaultLockConfiguration } from "./sim-backup-vault-lock.js";
 
 interface SimBackupVaultProperties {
   readonly name: string;
@@ -18,6 +20,7 @@ interface SimBackupVaultProperties {
   readonly creationDate: Date;
   readonly encryptionKeyArn?: string | undefined;
   readonly creatorRequestId?: string | undefined;
+  readonly background: BackgroundScheduler;
 }
 
 /** Stores one simulated AWS Backup vault. */
@@ -28,8 +31,8 @@ export class SimBackupVault {
   public readonly encryptionKeyArn?: string | undefined;
   public readonly creatorRequestId?: string | undefined;
 
-  private lockConfiguration?: SimBackupVaultLockConfiguration | undefined;
-  private lockDate?: Date | undefined;
+  private readonly lock: SimBackupVaultLock;
+  private readonly points: SimBackupVaultRecoveryPoints;
 
   constructor(properties: SimBackupVaultProperties) {
     this.name = properties.name;
@@ -37,99 +40,45 @@ export class SimBackupVault {
     this.creationDate = new Date(properties.creationDate);
     this.encryptionKeyArn = properties.encryptionKeyArn;
     this.creatorRequestId = properties.creatorRequestId;
+    this.lock = new SimBackupVaultLock(this.name);
+    this.points = new SimBackupVaultRecoveryPoints(properties.background);
   }
 
   configureLock(
     configuration: SimBackupVaultLockConfiguration,
     now: Date,
   ): void {
-    if (this.isComplianceLocked(now)) {
-      throw new SimBackupInvalidParameterValueException(
-        `The lock configuration for backup vault ${this.name} is immutable`,
-      );
-    }
-
-    validateLockConfiguration(configuration);
-    this.lockConfiguration = { ...configuration };
-    this.lockDate = lockDate(configuration.ChangeableForDays, now);
+    this.lock.configure(configuration, now);
   }
 
   describe(): SimDescribeBackupVaultCommandOutput {
-    const configuration = this.lockConfiguration;
-
-    return {
-      BackupVaultName: this.name,
-      BackupVaultArn: this.arn,
-      EncryptionKeyArn: this.encryptionKeyArn,
-      CreationDate: new Date(this.creationDate),
-      CreatorRequestId: this.creatorRequestId,
-      NumberOfRecoveryPoints: 0,
-      Locked: configuration !== undefined,
-      MinRetentionDays: configuration?.MinRetentionDays,
-      MaxRetentionDays: configuration?.MaxRetentionDays,
-      LockDate:
-        this.lockDate === undefined ? undefined : new Date(this.lockDate),
-    };
+    return describeBackupVault(
+      this,
+      this.lock.configuration,
+      this.lock.lockDate,
+      this.recoveryPoints().length,
+    );
   }
 
   listMember(): SimBackupVaultListMember {
     return this.describe();
   }
 
-  private isComplianceLocked(now: Date): boolean {
-    return this.lockDate !== undefined && now >= this.lockDate;
-  }
-}
-
-function lockDate(
-  changeableForDays: number | undefined,
-  now: Date,
-): Date | undefined {
-  if (changeableForDays === undefined) {
-    return undefined;
+  addRecoveryPoint(recoveryPoint: SimBackupRecoveryPoint): void {
+    this.points.add(recoveryPoint);
   }
 
-  return new Date(now.getTime() + changeableForDays * millisecondsPerDay);
-}
-
-function validateLockConfiguration(
-  configuration: SimBackupVaultLockConfiguration,
-): void {
-  const { MinRetentionDays: minimum, MaxRetentionDays: maximum } =
-    configuration;
-
-  if (
-    minimum !== undefined &&
-    (!Number.isSafeInteger(minimum) || minimum < 1)
-  ) {
-    throw new SimBackupInvalidParameterValueException(
-      "MinRetentionDays must be a positive whole number",
-    );
+  recoveryPoints(): readonly SimBackupRecoveryPoint[] {
+    return this.points.all();
   }
 
-  if (
-    maximum !== undefined &&
-    (!Number.isSafeInteger(maximum) || maximum < 1 || maximum > 36_500)
-  ) {
-    throw new SimBackupInvalidParameterValueException(
-      "MaxRetentionDays must be between 1 and 36500",
-    );
+  recoveryPoint(arn: string): SimBackupRecoveryPoint | undefined {
+    return this.points.find(arn);
   }
 
-  if (minimum !== undefined && maximum !== undefined && minimum > maximum) {
-    throw new SimBackupInvalidParameterValueException(
-      "MinRetentionDays must not exceed MaxRetentionDays",
-    );
-  }
-
-  const grace = configuration.ChangeableForDays;
-
-  if (
-    grace !== undefined &&
-    (!Number.isSafeInteger(grace) || grace < 3 || grace > 36_500)
-  ) {
-    throw new SimBackupInvalidParameterValueException(
-      "ChangeableForDays must be between 3 and 36500",
-    );
+  lifecycleRefusal(
+    lifecycle: SimBackupLifecycle | undefined,
+  ): string | undefined {
+    return this.lock.lifecycleRefusal(lifecycle);
   }
 }

--- a/src/service/backup/vault/sim-backup-vault.ts
+++ b/src/service/backup/vault/sim-backup-vault.ts
@@ -4,6 +4,7 @@ import type {
 } from "../command/sim-backup-command.types.js";
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimBackupLifecycle } from "../command/sim-backup-command.types.js";
+import { SimBackupInvalidRequestException } from "../error/sim-backup.error.js";
 import type { SimBackupRecoveryPoint } from "../recovery-point/sim-backup-recovery-point.js";
 import { describeBackupVault } from "./sim-backup-vault-description.js";
 import {
@@ -74,6 +75,14 @@ export class SimBackupVault {
 
   recoveryPoint(arn: string): SimBackupRecoveryPoint | undefined {
     return this.points.find(arn);
+  }
+
+  assertEmpty(): void {
+    if (this.recoveryPoints().length > 0) {
+      throw new SimBackupInvalidRequestException(
+        `Backup vault ${this.name} cannot be deleted while it contains recovery points`,
+      );
+    }
   }
 
   lifecycleRefusal(


### PR DESCRIPTION
Run backup plan rules when the simulated clock reaches their schedules. Each selected resource produces a recovery point and completed job. Vault Lock lifecycle refusals produce failed jobs, and DeleteAfterDays expires stored points. The Backup SDK routes now support starting and reading jobs and listing and describing recovery points.

Resolves https://github.com/KensioSoftware/yulin/issues/1196

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like feat/concise-description
- [x] Full check with pnpm run check passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in docs/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated AWS Backup support for scheduled and on-demand backup jobs.
  * Added recovery-point creation, listing, description, lifecycle expiration, and filtering.
  * Added backup vault, plan, selection, and Vault Lock operations.
  * Added IAM authorization guidance and support for backup-related operations.

* **Documentation**
  * Added examples for scheduled backups and on-demand backup jobs using a simulated clock.
  * Documented current capabilities, limitations, retention behavior, and supported APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->