### PR TITLE
feat(ses): record simple-message attachments

### DIFF
--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -14,7 +14,7 @@ SES specific types are imported from the `@kensio/yulin/ses` subpath.
 ## Asserting on a message that was sent
 
 `sentEmails()` hands over the record. Each message carries who it was from, the three recipient
-lists, the subject, the body and the message id SES answered with.
+lists, the subject, the body, its attachments and the message id SES answered with.
 
 ```typescript sim-ses-send-and-assert
 /**
@@ -58,6 +58,60 @@ read. The three recipient lists stay apart, leaving a test free to assert that a
 
 `body` keeps `text` and `html` apart too. A message sent with only an HTML body reports `undefined`
 for its text, and never the markup.
+
+### Asserting on an attachment
+
+A simple message may carry structured attachments. The record keeps them in request order.
+`rawContent` contains a copy of the bytes from the request, and the other fields contain the supplied
+SES attachment metadata.
+
+```typescript sim-ses-attachments
+/**
+ * Sending a generated CSV and reading it from the simulated SES record.
+ */
+
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ses = simAws.sesV2();
+
+ses.verifyIdentity("hello@example.com");
+ses.verifyIdentity("someone@example.org");
+
+const csv = new TextEncoder().encode("word,meaning\n你好,hello\n");
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Your vocabulary backup" },
+        Body: { Text: { Data: "Your backup is attached." } },
+        Attachments: [
+          {
+            RawContent: csv,
+            FileName: "vocabulary.csv",
+            ContentType: "text/csv; charset=utf-8",
+            ContentDisposition: "ATTACHMENT",
+          },
+        ],
+      },
+    },
+  }),
+);
+
+const [email] = ses.sentEmails();
+const [attachment] = email?.attachments ?? [];
+
+// vocabulary.csv "word,meaning\n你好,hello\n"
+console.log(
+  attachment?.fileName,
+  new TextDecoder().decode(attachment?.rawContent),
+);
+```
 
 ## Verifying identities
 
@@ -938,29 +992,29 @@ time forward past the window sees the count fall the way an account's would.
 
 ## Simulated commands
 
-| Command                           | Notes                                                                                                     |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `SendEmail`                       | `Content.Simple` and `Content.Template`. Recorded rather than delivered.                                  |
-| `CreateEmailIdentity`             | Starts unverified. `Tags`, `DkimSigningAttributes` and `ConfigurationSetName` are held and reported back. |
-| `GetEmailIdentity`                | Reports the DKIM, MAIL FROM, feedback, configuration set and tag settings the identity holds.             |
-| `ListEmailIdentities`             | Paged with `PageSize` and `NextToken`.                                                                    |
-| `DeleteEmailIdentity`             |                                                                                                           |
-| `CreateEmailTemplate`             | Substitution only. `Tags` are refused.                                                                    |
-| `GetEmailTemplate`                | Reports the wording with its placeholders unrendered.                                                     |
-| `UpdateEmailTemplate`             | Replaces the wording outright, keeping the creation time.                                                 |
-| `ListEmailTemplates`              | Names and creation times only, paged.                                                                     |
-| `DeleteEmailTemplate`             |                                                                                                           |
-| `CreateConfigurationSet`          | `TrackingOptions`, `VdmOptions` and `Tags` are refused.                                                   |
-| `GetConfigurationSet`             | Reports the defaults it applied as well as what was declared.                                             |
-| `ListConfigurationSets`           | Names only, paged with `PageSize` and `NextToken`.                                                        |
-| `DeleteConfigurationSet`          |                                                                                                           |
-| `GetAccount`                      | Reports `SuppressionAttributes` alongside the quota.                                                      |
-| `PutAccountDetails`               | `MailType` and `WebsiteURL` are required, as on real SES.                                                 |
-| `PutAccountSuppressionAttributes` | No reasons at all turns the suppression list off.                                                         |
-| `PutSuppressedDestination`        | Accepted in the sandbox, which real SES refuses.                                                          |
-| `GetSuppressedDestination`        |                                                                                                           |
-| `ListSuppressedDestinations`      | Paged, and narrowed by `Reasons`, `StartDate` and `EndDate`.                                              |
-| `DeleteSuppressedDestination`     | Removing an address that is not on the list succeeds.                                                     |
+| Command                           | Notes                                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `SendEmail`                       | `Content.Simple`, including structured attachments, and `Content.Template`. Recorded rather than delivered. |
+| `CreateEmailIdentity`             | Starts unverified. `Tags`, `DkimSigningAttributes` and `ConfigurationSetName` are held and reported back.   |
+| `GetEmailIdentity`                | Reports the DKIM, MAIL FROM, feedback, configuration set and tag settings the identity holds.               |
+| `ListEmailIdentities`             | Paged with `PageSize` and `NextToken`.                                                                      |
+| `DeleteEmailIdentity`             |                                                                                                             |
+| `CreateEmailTemplate`             | Substitution only. `Tags` are refused.                                                                      |
+| `GetEmailTemplate`                | Reports the wording with its placeholders unrendered.                                                       |
+| `UpdateEmailTemplate`             | Replaces the wording outright, keeping the creation time.                                                   |
+| `ListEmailTemplates`              | Names and creation times only, paged.                                                                       |
+| `DeleteEmailTemplate`             |                                                                                                             |
+| `CreateConfigurationSet`          | `TrackingOptions`, `VdmOptions` and `Tags` are refused.                                                     |
+| `GetConfigurationSet`             | Reports the defaults it applied as well as what was declared.                                               |
+| `ListConfigurationSets`           | Names only, paged with `PageSize` and `NextToken`.                                                          |
+| `DeleteConfigurationSet`          |                                                                                                             |
+| `GetAccount`                      | Reports `SuppressionAttributes` alongside the quota.                                                        |
+| `PutAccountDetails`               | `MailType` and `WebsiteURL` are required, as on real SES.                                                   |
+| `PutAccountSuppressionAttributes` | No reasons at all turns the suppression list off.                                                           |
+| `PutSuppressedDestination`        | Accepted in the sandbox, which real SES refuses.                                                            |
+| `GetSuppressedDestination`        |                                                                                                             |
+| `ListSuppressedDestinations`      | Paged, and narrowed by `Reasons`, `StartDate` and `EndDate`.                                                |
+| `DeleteSuppressedDestination`     | Removing an address that is not on the list succeeds.                                                       |
 
 Anything else refuses on send with `SimSdkUnsupportedCommandError`.
 

--- a/docs/services/ses/sim-ses-attachments.example.ts
+++ b/docs/services/ses/sim-ses-attachments.example.ts
@@ -1,0 +1,45 @@
+/**
+ * Sending a generated CSV and reading it from the simulated SES record.
+ */
+
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const ses = simAws.sesV2();
+
+ses.verifyIdentity("hello@example.com");
+ses.verifyIdentity("someone@example.org");
+
+const csv = new TextEncoder().encode("word,meaning\n你好,hello\n");
+
+await ses.sendEmail(
+  new SendEmailCommand({
+    FromEmailAddress: "hello@example.com",
+    Destination: { ToAddresses: ["someone@example.org"] },
+    Content: {
+      Simple: {
+        Subject: { Data: "Your vocabulary backup" },
+        Body: { Text: { Data: "Your backup is attached." } },
+        Attachments: [
+          {
+            RawContent: csv,
+            FileName: "vocabulary.csv",
+            ContentType: "text/csv; charset=utf-8",
+            ContentDisposition: "ATTACHMENT",
+          },
+        ],
+      },
+    },
+  }),
+);
+
+const [email] = ses.sentEmails();
+const [attachment] = email?.attachments ?? [];
+
+// vocabulary.csv "word,meaning\n你好,hello\n"
+console.log(
+  attachment?.fileName,
+  new TextDecoder().decode(attachment?.rawContent),
+);

--- a/src/service/ses/README.md
+++ b/src/service/ses/README.md
@@ -71,6 +71,10 @@ reported one at a time, because real SES names every identity that failed in a s
 asserting a bcc was a bcc still can, and the body keeps text and HTML apart so a test asserting on
 the text of an HTML-only message finds nothing rather than the markup.
 
+Attachments on a simple message stay structured on the record in request order. The record copies
+their raw bytes and keeps the supplied metadata. SES would use those values to assemble MIME content
+after accepting the request.
+
 `SimSesContentReader` dispatches the three kinds of content. `Simple` and `Template` are both read;
 `Raw` is refused by name, since a raw MIME message would have to be parsed to say anything about its
 subject or body and a recorded message with nothing in it would make a test pass for a reason

--- a/src/service/ses/command/send/send.command.ts
+++ b/src/service/ses/command/send/send.command.ts
@@ -14,11 +14,25 @@ export interface SimSesBody {
   readonly Html?: SimSesContent | undefined;
 }
 
+export interface SimSesAttachment {
+  readonly RawContent: Uint8Array | undefined;
+  readonly ContentDisposition?: "ATTACHMENT" | "INLINE" | undefined;
+  readonly FileName: string | undefined;
+  readonly ContentDescription?: string | undefined;
+  readonly ContentId?: string | undefined;
+  readonly ContentTransferEncoding?:
+    | "BASE64"
+    | "QUOTED_PRINTABLE"
+    | "SEVEN_BIT"
+    | undefined;
+  readonly ContentType?: string | undefined;
+}
+
 export interface SimSesMessage {
   readonly Subject?: SimSesContent | undefined;
   readonly Body?: SimSesBody | undefined;
   readonly Headers?: readonly unknown[] | undefined;
-  readonly Attachments?: readonly unknown[] | undefined;
+  readonly Attachments?: readonly SimSesAttachment[] | undefined;
 }
 
 export interface SimSesRawMessage {

--- a/src/service/ses/command/send/send.command.ts
+++ b/src/service/ses/command/send/send.command.ts
@@ -15,9 +15,9 @@ export interface SimSesBody {
 }
 
 export interface SimSesAttachment {
-  readonly RawContent: Uint8Array | undefined;
+  readonly RawContent?: Uint8Array | undefined;
   readonly ContentDisposition?: "ATTACHMENT" | "INLINE" | undefined;
-  readonly FileName: string | undefined;
+  readonly FileName?: string | undefined;
   readonly ContentDescription?: string | undefined;
   readonly ContentId?: string | undefined;
   readonly ContentTransferEncoding?:

--- a/src/service/ses/command/send/sim-ses-read-content.ts
+++ b/src/service/ses/command/send/sim-ses-read-content.ts
@@ -1,4 +1,7 @@
-import type { SimSesSentEmailBody } from "../../email/sim-ses-sent-email.js";
+import type {
+  SimSesSentEmailAttachment,
+  SimSesSentEmailBody,
+} from "../../email/sim-ses-sent-email.js";
 
 /**
  * What a message says, read out of the content of a send.
@@ -12,6 +15,7 @@ import type { SimSesSentEmailBody } from "../../email/sim-ses-sent-email.js";
 export interface SimSesReadContent {
   readonly subject: string;
   readonly body: SimSesSentEmailBody;
+  readonly attachments: readonly SimSesSentEmailAttachment[];
 
   /** The template this was rendered from, if it was rendered from a stored one. */
   readonly templateName: string | undefined;

--- a/src/service/ses/command/send/sim-ses-send-email.ts
+++ b/src/service/ses/command/send/sim-ses-send-email.ts
@@ -118,6 +118,7 @@ export class SimSesSendEmail {
         replyToAddresses: [...(input.ReplyToAddresses ?? [])],
         subject: content.subject,
         body: content.body,
+        attachments: content.attachments,
         templateName: content.templateName,
         templateData: content.templateData,
         configurationSetName,

--- a/src/service/ses/command/send/sim-ses-service-send.ts
+++ b/src/service/ses/command/send/sim-ses-service-send.ts
@@ -115,6 +115,7 @@ export class SimSesServiceSend {
         replyToAddresses: [...request.replyToAddresses],
         subject: request.subject,
         body: { text: request.body, html: undefined },
+        attachments: [],
         templateName: undefined,
         templateData: undefined,
         configurationSetName,

--- a/src/service/ses/command/send/sim-ses-simple-content.ts
+++ b/src/service/ses/command/send/sim-ses-simple-content.ts
@@ -44,6 +44,7 @@ export function readSimSesSimpleMessage(
   };
 }
 
+/** Read and validate one attachment from a simple message. */
 function readAttachment(
   attachment: SimSesAttachment,
   index: number,
@@ -67,6 +68,7 @@ function readAttachment(
   };
 }
 
+/** Build the SES validation error for a missing attachment member. */
 function missingAttachmentMember(
   index: number,
   member: "fileName" | "rawContent",

--- a/src/service/ses/command/send/sim-ses-simple-content.ts
+++ b/src/service/ses/command/send/sim-ses-simple-content.ts
@@ -1,9 +1,7 @@
-import {
-  SimSesBadRequestException,
-  SimSesUnsupportedOperationException,
-} from "../../error/sim-ses.error.js";
+import { SimSesBadRequestException } from "../../error/sim-ses.error.js";
+import type { SimSesSentEmailAttachment } from "../../email/sim-ses-sent-email.js";
 import type { SimSesReadContent } from "./sim-ses-read-content.js";
-import type { SimSesMessage } from "./send.command.js";
+import type { SimSesAttachment, SimSesMessage } from "./send.command.js";
 
 /**
  * Read a message a send wrote out in full, refusing what real SES refuses and
@@ -16,13 +14,6 @@ import type { SimSesMessage } from "./send.command.js";
 export function readSimSesSimpleMessage(
   message: SimSesMessage,
 ): SimSesReadContent {
-  if (message.Attachments !== undefined) {
-    throw new SimSesUnsupportedOperationException(
-      "Attachments are not simulated, so SendEmail refuses them rather than " +
-        "recording a message without them",
-    );
-  }
-
   const subject = message.Subject?.Data;
 
   if (subject === undefined) {
@@ -45,7 +36,44 @@ export function readSimSesSimpleMessage(
   return {
     subject,
     body: { text, html },
+    attachments: (message.Attachments ?? []).map((attachment, index) =>
+      readAttachment(attachment, index),
+    ),
     templateName: undefined,
     templateData: undefined,
   };
+}
+
+function readAttachment(
+  attachment: SimSesAttachment,
+  index: number,
+): SimSesSentEmailAttachment {
+  if (attachment.RawContent === undefined) {
+    throw missingAttachmentMember(index, "rawContent");
+  }
+
+  if (attachment.FileName === undefined) {
+    throw missingAttachmentMember(index, "fileName");
+  }
+
+  return {
+    rawContent: Uint8Array.from(attachment.RawContent),
+    fileName: attachment.FileName,
+    contentType: attachment.ContentType,
+    contentDisposition: attachment.ContentDisposition,
+    contentDescription: attachment.ContentDescription,
+    contentId: attachment.ContentId,
+    contentTransferEncoding: attachment.ContentTransferEncoding,
+  };
+}
+
+function missingAttachmentMember(
+  index: number,
+  member: "fileName" | "rawContent",
+): SimSesBadRequestException {
+  return new SimSesBadRequestException(
+    "1 validation error detected: Value at " +
+      `'content.simple.attachments.${String(index)}.${member}' failed to ` +
+      "satisfy constraint: Member must not be null",
+  );
 }

--- a/src/service/ses/command/send/sim-ses-template-send.ts
+++ b/src/service/ses/command/send/sim-ses-template-send.ts
@@ -56,6 +56,7 @@ export class SimSesTemplateSendReader {
         text: renderOptional(content.text, data),
         html: renderOptional(content.html, data),
       },
+      attachments: [],
       templateName: template.TemplateName,
       templateData: data,
     };

--- a/src/service/ses/email/sim-ses-sent-email.ts
+++ b/src/service/ses/email/sim-ses-sent-email.ts
@@ -22,6 +22,26 @@ export interface SimSesSentEmailBody {
 }
 
 /**
+ * One structured attachment on a simple message.
+ *
+ * The bytes and metadata use the values from the SendEmail request. SES would
+ * use them to assemble MIME content after accepting the request.
+ */
+export interface SimSesSentEmailAttachment {
+  readonly rawContent: Uint8Array;
+  readonly fileName: string;
+  readonly contentType: string | undefined;
+  readonly contentDisposition: "ATTACHMENT" | "INLINE" | undefined;
+  readonly contentDescription: string | undefined;
+  readonly contentId: string | undefined;
+  readonly contentTransferEncoding:
+    | "BASE64"
+    | "QUOTED_PRINTABLE"
+    | "SEVEN_BIT"
+    | undefined;
+}
+
+/**
  * A recipient the account's suppression list held back.
  *
  * The address is kept as the message wrote it, which is what a test asserting
@@ -40,6 +60,7 @@ interface SimSesSentEmailProperties {
   readonly replyToAddresses: readonly string[];
   readonly subject: string;
   readonly body: SimSesSentEmailBody;
+  readonly attachments: readonly SimSesSentEmailAttachment[];
   readonly templateName: string | undefined;
   readonly templateData: Readonly<Record<string, unknown>> | undefined;
   readonly configurationSetName: string | undefined;
@@ -73,6 +94,9 @@ export class SimSesSentEmail {
   public readonly subject: string;
 
   public readonly body: SimSesSentEmailBody;
+
+  /** Structured attachments in request order. */
+  public readonly attachments: readonly SimSesSentEmailAttachment[];
 
   /**
    * The template this message was rendered from, if it was rendered from a
@@ -111,6 +135,7 @@ export class SimSesSentEmail {
     this.replyToAddresses = properties.replyToAddresses;
     this.subject = properties.subject;
     this.body = properties.body;
+    this.attachments = properties.attachments;
     this.templateName = properties.templateName;
     this.templateData = properties.templateData;
     this.configurationSetName = properties.configurationSetName;

--- a/src/service/ses/index.ts
+++ b/src/service/ses/index.ts
@@ -42,6 +42,7 @@ export {
 export { SimSesConfigurationSetStore } from "./configuration-set/sim-ses-configuration-set-store.js";
 export {
   SimSesSentEmail,
+  type SimSesSentEmailAttachment,
   type SimSesSentEmailBody,
   type SimSesSentEmailDestination,
   type SimSesSuppressedRecipient,

--- a/src/service/ses/sim-ses-send-email.iso.test.ts
+++ b/src/service/ses/sim-ses-send-email.iso.test.ts
@@ -7,6 +7,7 @@ import {
   assertArrayEmpty,
   assertArrayEquals,
   assertArrayLength,
+  assertBufferEqual,
   assertFalse,
   assertIdentical,
   assertNonNullable,
@@ -64,7 +65,73 @@ describe("SimSesV2 SendEmail", () => {
     assertArrayEquals(email.destination.toAddresses, ["someone@example.org"]);
     assertIdentical(email.subject, "Welcome");
     assertIdentical(email.body.text, "Hi there");
+    assertArrayEmpty(email.attachments);
     assertIdentical(email.sentDate.getTime(), sentAt.getTime());
+  });
+
+  it("records simple-message attachments in request order", async () => {
+    // Given a simulated SES out of the sandbox and a generated CSV.
+    const ses = sendingSes();
+    const csv = new TextEncoder().encode("word,meaning\n你好,hello\n");
+    const notes = new TextEncoder().encode("Generated on request\n");
+
+    await leaveTheSandbox(ses);
+
+    // When a simple message sends the CSV and a second attachment.
+    const sent = await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        Content: {
+          Simple: {
+            Subject: { Data: "Your vocabulary backup" },
+            Body: { Text: { Data: "Your backup is attached." } },
+            Attachments: [
+              {
+                RawContent: csv,
+                FileName: "vocabulary.csv",
+                ContentType: "text/csv; charset=utf-8",
+                ContentDisposition: "ATTACHMENT",
+                ContentDescription: "Vocabulary backup",
+                ContentId: "vocabulary-backup",
+                ContentTransferEncoding: "BASE64",
+              },
+              { RawContent: notes, FileName: "notes.txt" },
+            ],
+          },
+        },
+      }),
+    );
+
+    // Then the send succeeds and the record keeps the bytes and metadata.
+    const [email] = ses.sentEmails();
+
+    assertNonNullable(sent.MessageId);
+    assertNonNullable(email);
+    assertIdentical(email.messageId, sent.MessageId);
+    assertArrayLength(email.attachments, 2);
+
+    const [csvAttachment, notesAttachment] = email.attachments;
+
+    assertNonNullable(csvAttachment);
+    assertNonNullable(notesAttachment);
+    assertIdentical(csvAttachment.fileName, "vocabulary.csv");
+    assertBufferEqual(csvAttachment.rawContent, csv);
+    assertIdentical(
+      new TextDecoder().decode(csvAttachment.rawContent),
+      "word,meaning\n你好,hello\n",
+    );
+    assertIdentical(csvAttachment.contentType, "text/csv; charset=utf-8");
+    assertIdentical(csvAttachment.contentDisposition, "ATTACHMENT");
+    assertIdentical(csvAttachment.contentDescription, "Vocabulary backup");
+    assertIdentical(csvAttachment.contentId, "vocabulary-backup");
+    assertIdentical(csvAttachment.contentTransferEncoding, "BASE64");
+    assertIdentical(notesAttachment.fileName, "notes.txt");
+    assertBufferEqual(notesAttachment.rawContent, notes);
+    assertUndefined(notesAttachment.contentType);
+    assertUndefined(notesAttachment.contentDisposition);
+    assertUndefined(notesAttachment.contentDescription);
+    assertUndefined(notesAttachment.contentId);
+    assertUndefined(notesAttachment.contentTransferEncoding);
   });
 
   it("keeps the to, cc and bcc lists apart", async () => {

--- a/src/service/ses/sim-ses-send-refusals.iso.test.ts
+++ b/src/service/ses/sim-ses-send-refusals.iso.test.ts
@@ -143,11 +143,35 @@ describe("SimSesV2 SendEmail refusals", () => {
     assertStringIncludes(error.message, "Content.Raw");
   });
 
-  it("refuses a message with attachments", async () => {
+  it("refuses an attachment with no raw content", async () => {
     // Given a simulated SES that would otherwise accept the message.
     const ses = await sendingSes();
 
-    // When a message carries an attachment.
+    // When a message carries an attachment with no bytes.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(
+        new SendEmailCommand({
+          ...welcome,
+          Content: {
+            Simple: {
+              Subject: { Data: "Welcome" },
+              Body: { Text: { Data: "Hi there" } },
+              Attachments: [{ FileName: "terms.pdf", RawContent: undefined }],
+            },
+          },
+        }),
+      );
+    });
+
+    assertInstanceOf(error, SimSesBadRequestException);
+    assertStringIncludes(error.message, "rawContent");
+  });
+
+  it("refuses an attachment with no file name", async () => {
+    // Given a simulated SES that would otherwise accept the message.
+    const ses = await sendingSes();
+
+    // When a message carries attachment bytes with no file name.
     const error = await assertThrowsErrorAsync(async () => {
       await ses.sendEmail(
         new SendEmailCommand({
@@ -157,7 +181,7 @@ describe("SimSesV2 SendEmail refusals", () => {
               Subject: { Data: "Welcome" },
               Body: { Text: { Data: "Hi there" } },
               Attachments: [
-                { FileName: "terms.pdf", RawContent: new Uint8Array([1]) },
+                { FileName: undefined, RawContent: new Uint8Array([1]) },
               ],
             },
           },
@@ -165,7 +189,8 @@ describe("SimSesV2 SendEmail refusals", () => {
       );
     });
 
-    assertInstanceOf(error, SimSesUnsupportedOperationException);
+    assertInstanceOf(error, SimSesBadRequestException);
+    assertStringIncludes(error.message, "fileName");
   });
 
   it("refuses message tags, which are not simulated", async () => {


### PR DESCRIPTION
Record SES v2 simple-message attachments on simulated sends.

`sentEmails()` now exposes attachments in request order. Each attachment contains a copy of
`RawContent` and the supplied metadata. Sends without attachments expose an empty attachment list.
Missing required attachment members return SES-style validation errors.

The SES guide includes an example that sends and reads a generated CSV attachment.

Resolves #1207

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SES simulations now support attachments in simple email messages.
  * Sent emails preserve attachment order, raw content, filenames, and MIME metadata for later retrieval.
  * Added validation for required attachment content and filenames.
  * Added an example demonstrating sending and reading a CSV attachment.

* **Documentation**
  * Updated SES documentation and command references with attachment usage and recorded-message behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->