### PR TITLE
feat(ses): record suppression feedback

### DIFF
--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -357,8 +357,9 @@ sending switch, the delivery options and the reputation switch are all declared 
 SES holds a set as state. A test can then assert what a stack declared, with no AWS account to read
 it back from.
 
-A set is attached to an identity, or named on a send. `SendingEnabled` is the one option a send acts
-on. The rest are held for a test to read back.
+A set is attached to an identity, or named on a send. `SendingEnabled` acts during acceptance.
+Suppression options decide whether explicit bounce or complaint feedback adds the recipient to the
+account suppression list. The rest are held for a test to read back.
 
 ```typescript sim-ses-configuration-sets
 /**
@@ -404,8 +405,13 @@ console.log(ses.allConfigurationSets().map((set) => set.configurationSetName));
 ```
 
 A set declaring only its name gets the defaults real SES applies. Sending is on, TLS is optional,
-reputation metrics are off and no reason is suppressed. `GetConfigurationSet` reports those defaults
-back rather than leaving the groups out of the answer.
+reputation metrics are off and suppression falls back to the account reasons.
+`GetConfigurationSet` reports the sending, delivery and reputation defaults. It leaves suppression
+options absent where the set has no override.
+
+An explicit empty override is different. `SuppressionOptions: { SuppressedReasons: [] }` disables
+suppression for feedback on messages sent through that set. Simulated SES retains the empty list so
+it does not fall back to the account reasons.
 
 `findConfigurationSet` reaches one set by name and `allConfigurationSets` hands over every set in
 the scope, oldest first.
@@ -490,9 +496,9 @@ set at a time.
 domain and the events that report a click. The Virtual Deliverability Manager reports on engagement,
 which this simulation never measures.
 
-A set's suppression reasons are held and read back, and that is all they do. On real SES they decide
-what a bounce or a complaint would add to the account suppression list. Both are absent here. The
-list itself is a separate thing, filled by hand.
+A set's suppression reasons override the account reasons when `recordFeedback` records a hard bounce
+or complaint for a message sent through it. A set with no suppression options falls back to the
+account reasons. The feedback entry goes onto the account suppression list.
 
 `TlsPolicy` accepts `REQUIRE` and `OPTIONAL` and refuses anything else, and a `SuppressedReasons`
 entry that is neither `BOUNCE` nor `COMPLAINT` is refused too. `MaxDeliverySeconds` takes whole
@@ -698,9 +704,9 @@ review is beyond what a test can assert on anyway.
 ## The suppression list
 
 Real SES holds an account-level suppression list and fills it from hard bounces and complaints.
-Nothing bounces here, so every address on this one was put there by a caller. That is what makes it
-worth having in a test. The support tool that lists suppressed addresses, the form that removes one
-and the script that seeds the list all have somewhere to run.
+Tests supply that feedback explicitly with `recordFeedback`. Suppression commands manage the same
+list. The support tool that lists suppressed addresses, the form that removes one and the script
+that seeds the list all have somewhere to run.
 
 `PutSuppressedDestination`, `GetSuppressedDestination`, `ListSuppressedDestinations` and
 `DeleteSuppressedDestination` manage it.
@@ -758,6 +764,70 @@ recipient, and counts it toward the daily sending quota. The send succeeds here 
 carries the answer. `suppressedRecipients` names who was held back and why,
 and `isFullySuppressed` is the narrower question of whether the message reached nobody. A message to
 two recipients with one of them suppressed went to the other.
+
+### Recording a hard bounce or complaint
+
+`recordFeedback` takes the message id of an accepted message, one of its recipient addresses and a
+`BOUNCE` or `COMPLAINT` reason. Active feedback adds or updates the account suppression entry at the
+current simulated time. The existing suppression commands and `suppressedDestinations()` read the
+result.
+
+```typescript sim-ses-feedback-suppression
+/**
+ * Recording a hard bounce and observing the next send being suppressed.
+ */
+
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-31T09:00:00.000Z")),
+});
+const ses = simAws.sesV2();
+
+ses.verifyIdentity("hello@example.com");
+ses.verifyIdentity("someone@example.org");
+
+const message = new SendEmailCommand({
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+});
+
+const accepted = await ses.sendEmail(message);
+
+ses.recordFeedback({
+  messageId: accepted.MessageId!,
+  emailAddress: "someone@example.org",
+  reason: "BOUNCE",
+});
+
+await ses.sendEmail(message);
+
+const suppressed = ses.suppressedDestinations()[0];
+const later = ses.sentEmails()[1];
+
+// "BOUNCE" "2026-08-31T09:00:00.000Z" true
+console.log(
+  suppressed?.reason,
+  suppressed?.lastUpdateTime.toISOString(),
+  later?.isFullySuppressed,
+);
+```
+
+The operation refuses a message id this SES scope did not issue and an address that was not a
+recipient of that message. Recipient matching ignores case and a display name, while the suppression
+entry keeps the address spelling from the accepted message.
+
+Without a configuration-set override, the account's `SuppressedReasons` decide whether feedback is
+active. A configuration set with suppression options replaces those reasons for messages sent
+through it. An empty override leaves the suppression list unchanged.
 
 `ListSuppressedDestinations` pages with `PageSize` and `NextToken`, and narrows with `Reasons`,
 `StartDate` and `EndDate`. Removing an address that was never on the list succeeds, so a form that
@@ -1005,7 +1075,7 @@ time forward past the window sees the count fall the way an account's would.
 | `ListEmailTemplates`              | Names and creation times only, paged.                                                                       |
 | `DeleteEmailTemplate`             |                                                                                                             |
 | `CreateConfigurationSet`          | `TrackingOptions`, `VdmOptions` and `Tags` are refused.                                                     |
-| `GetConfigurationSet`             | Reports the defaults it applied as well as what was declared.                                               |
+| `GetConfigurationSet`             | Reports applied defaults and preserves whether suppression options were absent.                             |
 | `ListConfigurationSets`           | Names only, paged with `PageSize` and `NextToken`.                                                          |
 | `DeleteConfigurationSet`          |                                                                                                             |
 | `GetAccount`                      | Reports `SuppressionAttributes` alongside the quota.                                                        |
@@ -1032,19 +1102,18 @@ Anything else refuses on send with `SimSdkUnsupportedCommandError`.
   the template. Template data holding an object where the template wants a value is refused too,
   where real Handlebars would render `[object Object]`.
 - **`SendBulkEmail` is absent**, along with its per-recipient replacement data.
-- **Nothing is delivered, and nothing bounces.** There are no bounce or complaint events and no
-  event destinations.
+- **Nothing is delivered.** A test supplies a hard bounce or complaint through `recordFeedback`.
+  Feedback is never generated automatically, and there are no event destinations.
 - **A configuration set acts on one send.** `SendingEnabled` refuses a send made through the set.
-  The suppression reasons, delivery options and reputation switch are held and read back, and
-  nothing acts on those.
+  Suppression reasons act on explicit feedback. Delivery options and the reputation switch are held
+  and read back.
 - **A set name nothing created is still accepted.** Real SES refuses one on an identity and on a
   send. Both stand here and the name is recorded, because a test failing over a set missing from a
   local setup fails for a reason unrelated to what it asserts.
 - **A configuration set holds what it was created with.** The `Put` commands that change one group
   of options are absent. A set cannot be changed once it exists.
-- **The suppression list fills only by hand.** Every address on it was put there by a caller,
-  because no message here ever bounces. A configuration set's `SuppressedReasons` name what a bounce
-  or a complaint would suppress for, and both are absent.
+- **Feedback is explicit.** Hard bounces and complaints update the suppression list only when a test
+  calls `recordFeedback`. Soft bounces are absent.
 - **Tenant-level suppression lists are left out.** A suppression command carrying `TenantName` is
   refused rather than answered from the account-level list.
 - **`PutSuppressedDestination` works in the sandbox.** Real SES refuses it until an account has

--- a/docs/services/ses/sim-ses-feedback-suppression.example.ts
+++ b/docs/services/ses/sim-ses-feedback-suppression.example.ts
@@ -1,0 +1,46 @@
+/**
+ * Recording a hard bounce and observing the next send being suppressed.
+ */
+
+import { SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  clock: new SimFixedClock(new Date("2026-08-31T09:00:00.000Z")),
+});
+const ses = simAws.sesV2();
+
+ses.verifyIdentity("hello@example.com");
+ses.verifyIdentity("someone@example.org");
+
+const message = new SendEmailCommand({
+  FromEmailAddress: "hello@example.com",
+  Destination: { ToAddresses: ["someone@example.org"] },
+  Content: {
+    Simple: {
+      Subject: { Data: "Welcome" },
+      Body: { Text: { Data: "Hi there" } },
+    },
+  },
+});
+
+const accepted = await ses.sendEmail(message);
+
+ses.recordFeedback({
+  messageId: accepted.MessageId!,
+  emailAddress: "someone@example.org",
+  reason: "BOUNCE",
+});
+
+await ses.sendEmail(message);
+
+const suppressed = ses.suppressedDestinations()[0];
+const later = ses.sentEmails()[1];
+
+// "BOUNCE" "2026-08-31T09:00:00.000Z" true
+console.log(
+  suppressed?.reason,
+  suppressed?.lastUpdateTime.toISOString(),
+  later?.isFullySuppressed,
+);

--- a/src/service/ses/README.md
+++ b/src/service/ses/README.md
@@ -86,9 +86,13 @@ Configuration set state lives under `configuration-set/`, and the send-side reso
 `command/send/sim-ses-configuration-set-check.ts`.
 
 `SimSesConfigurationSet` holds the suppression reasons, the sending switch, the delivery options and
-the reputation options a set was created with. The sending switch is the only one of them a send
-acts on. The others have nothing here to act on, because no message is delivered and no bounce is
-recorded.
+the reputation options a set was created with. The sending switch acts when a message is accepted.
+Suppression reasons act when a test records bounce or complaint feedback. Delivery and reputation
+options are held for a test to read.
+
+An absent `SuppressionOptions` group leaves `suppressedReasons` undefined. Feedback for a message
+sent through that set falls back to the account reasons. A present group with no reasons stores an
+empty list and disables suppression for that feedback.
 
 `SimSesConfigurationSetCheck` answers two questions about a send. Which set it goes through, and
 whether that set will carry it. The set is the one the send names, or the one the sending identity
@@ -180,3 +184,18 @@ messages started failing for a reason unrelated to what it asserts, and simulati
 rate would mean tests that take real time to run. The numbers `GetAccount` reports are the real
 sandbox and production ones, and `SentLast24Hours` counts what was actually sent, on the simulated
 clock, so moving time forward past the window drops the count the way an account's would.
+
+## Suppression and feedback
+
+Suppression list state lives under `suppression/`. `SimSesSuppressionList` stores account entries
+and applies the case rules of the SES API. Suppression commands manage addresses by exact case, while
+sending matches a listed address without regard to case.
+
+Feedback handling lives under `feedback/`. `SimSesFeedbackRecorder` finds an accepted message by id
+and checks that the supplied address was one of its recipients. It then resolves the active reasons
+from the message's configuration set. A set with no override falls back to
+`SimSesAccount.suppressedReasons`. Active feedback puts the recipient on the account list with the
+simulated clock's current time. Inactive feedback leaves the list unchanged.
+
+This operation models hard bounces and complaints only. It does not deliver mail, create automatic
+feedback, or publish to an SES event destination.

--- a/src/service/ses/cfn/sim-cfn-ses-configuration-set.iso.test.ts
+++ b/src/service/ses/cfn/sim-cfn-ses-configuration-set.iso.test.ts
@@ -84,6 +84,7 @@ describe("AWS::SES::ConfigurationSet", () => {
 
     assertArrayEmpty(stack.skippedResources);
     assertNonNullable(configurationSet);
+    assertNonNullable(configurationSet.suppressedReasons);
     assertArrayEquals(configurationSet.suppressedReasons, [
       "BOUNCE",
       "COMPLAINT",
@@ -241,13 +242,14 @@ describe("AWS::SES::ConfigurationSet property types", () => {
       DeliveryOptions: {},
     });
 
-    // Then the set reads as one declaring no group at all, with the defaults
-    // real SES applies.
+    // Then the empty suppression group remains an explicit override, while
+    // the empty delivery group uses the real SES defaults.
     const configurationSet = simAws
       .sesV2()
       .findConfigurationSet("transactional");
 
     assertNonNullable(configurationSet);
+    assertNonNullable(configurationSet.suppressedReasons);
     assertArrayEmpty(configurationSet.suppressedReasons);
     assertIdentical(configurationSet.deliveryOptions.tlsPolicy, "OPTIONAL");
     assertUndefined(configurationSet.deliveryOptions.maxDeliverySeconds);

--- a/src/service/ses/command/configuration-set/sim-ses-configuration-set-commands.ts
+++ b/src/service/ses/command/configuration-set/sim-ses-configuration-set-commands.ts
@@ -156,17 +156,15 @@ export class SimSesConfigurationSetCommands {
 /**
  * What GetConfigurationSet answers with.
  *
- * Every group is reported, including the ones the set never declared, because
- * real SES answers with the defaults it applied rather than leaving them out.
+ * Sending, delivery and reputation options report their applied defaults.
+ * Suppression options stay absent unless the set declared an override.
  */
 function reported(
   configurationSet: SimSesConfigurationSet,
 ): Omit<SimGetConfigurationSetCommandOutput, "$metadata"> {
   return {
     ConfigurationSetName: configurationSet.configurationSetName,
-    SuppressionOptions: {
-      SuppressedReasons: configurationSet.suppressedReasons,
-    },
+    ...reportedSuppressionOptions(configurationSet),
     SendingOptions: { SendingEnabled: configurationSet.sendingEnabled },
     DeliveryOptions: {
       TlsPolicy: configurationSet.deliveryOptions.tlsPolicy,
@@ -176,6 +174,20 @@ function reported(
     ReputationOptions: {
       ReputationMetricsEnabled:
         configurationSet.reputationOptions.reputationMetricsEnabled,
+    },
+  };
+}
+
+function reportedSuppressionOptions(
+  configurationSet: SimSesConfigurationSet,
+): Pick<SimGetConfigurationSetCommandOutput, "SuppressionOptions"> {
+  if (configurationSet.suppressedReasons === undefined) {
+    return {};
+  }
+
+  return {
+    SuppressionOptions: {
+      SuppressedReasons: configurationSet.suppressedReasons,
     },
   };
 }

--- a/src/service/ses/command/configuration-set/sim-ses-configuration-set-options.ts
+++ b/src/service/ses/command/configuration-set/sim-ses-configuration-set-options.ts
@@ -8,6 +8,7 @@ import { SimSesBadRequestException } from "../../error/sim-ses.error.js";
 import type {
   SimCreateConfigurationSetCommandInput,
   SimSesDeliveryOptions,
+  SimSesSuppressionOptions,
 } from "./configuration-set.command.js";
 
 /** What real SES uses where a set declares no TLS policy. */
@@ -25,15 +26,13 @@ const tlsPolicies = new Set(["REQUIRE", "OPTIONAL"]);
  * refuses.
  *
  * A set declaring none of these gets the defaults real SES applies: sending
- * on, no suppression reasons, optional TLS and no reputation metrics.
+ * on, account-level suppression, optional TLS and no reputation metrics.
  */
 export function readSimSesConfigurationSetOptions(
   input: SimCreateConfigurationSetCommandInput,
 ): SimSesConfigurationSetOptions {
   return {
-    suppressedReasons: readSuppressedReasons(
-      input.SuppressionOptions?.SuppressedReasons,
-    ),
+    suppressedReasons: readSuppressedReasons(input.SuppressionOptions),
     sendingEnabled: input.SendingOptions?.SendingEnabled ?? true,
     deliveryOptions: readDeliveryOptions(input.DeliveryOptions),
     reputationOptions: {
@@ -46,18 +45,18 @@ export function readSimSesConfigurationSetOptions(
 /**
  * The suppression reasons a set names, refusing one SES has no meaning for.
  *
- * An absent `SuppressionOptions` leaves this empty. Real SES falls back to the
- * account-level setting there, and this simulation has no account suppression
- * list to fall back to.
+ * An absent `SuppressionOptions` returns undefined, which preserves the
+ * account-level fallback. A present group with no reasons returns an empty
+ * override and disables suppression for messages sent through the set.
  */
 function readSuppressedReasons(
-  reasons: readonly string[] | undefined,
-): readonly SimSesSuppressedReason[] {
-  if (reasons === undefined) {
-    return [];
+  options: SimSesSuppressionOptions | undefined,
+): readonly SimSesSuppressedReason[] | undefined {
+  if (options === undefined) {
+    return undefined;
   }
 
-  return reasons.map((reason) => {
+  return (options.SuppressedReasons ?? []).map((reason) => {
     if (!isSuppressedReason(reason)) {
       throw new SimSesBadRequestException(
         `1 validation error detected: Value '${reason}' at ` +

--- a/src/service/ses/command/suppression/suppression.command.ts
+++ b/src/service/ses/command/suppression/suppression.command.ts
@@ -3,8 +3,9 @@ import type { SimResponseMetadata } from "../../../aws/metadata/response-metadat
 /**
  * What a suppression list entry says, in the shape the SES v2 API reports it.
  *
- * `Attributes` is left out. It describes the bounce or complaint SES put the
- * address on the list for, and nothing bounces here.
+ * `Attributes` is left out. Real SES uses it for details of the feedback event
+ * that put the address on the list. Explicit simulator feedback records the
+ * reason and time only.
  */
 export interface SimSesSuppressedDestinationDetail {
   readonly EmailAddress: string;

--- a/src/service/ses/configuration-set/sim-ses-configuration-set.ts
+++ b/src/service/ses/configuration-set/sim-ses-configuration-set.ts
@@ -73,7 +73,8 @@ export class SimSesConfigurationSet {
    *
    * Undefined where the set declares no `SuppressionOptions`, which makes a
    * send fall back to the account setting. An empty list is an explicit
-   * override that disables suppression for a send through this set.
+   * override that disables suppression for feedback recorded for a message
+   * sent through this set.
    */
   public readonly suppressedReasons:
     | readonly SimSesSuppressedReason[]

--- a/src/service/ses/configuration-set/sim-ses-configuration-set.ts
+++ b/src/service/ses/configuration-set/sim-ses-configuration-set.ts
@@ -41,7 +41,7 @@ export interface SimSesConfigurationSetReputationOptions {
  * Everything a configuration set holds apart from its name.
  */
 export interface SimSesConfigurationSetOptions {
-  readonly suppressedReasons: readonly SimSesSuppressedReason[];
+  readonly suppressedReasons: readonly SimSesSuppressedReason[] | undefined;
   readonly sendingEnabled: boolean;
   readonly deliveryOptions: SimSesConfigurationSetDeliveryOptions;
   readonly reputationOptions: SimSesConfigurationSetReputationOptions;
@@ -59,11 +59,9 @@ interface SimSesConfigurationSetProperties {
  * A configuration set is a named group of settings a send can be made under,
  * covering suppression, whether sending is on, how the message is handed on
  * and whether reputation metrics are published. None of it changes what a
- * message says, which is why this is state to read back rather than behaviour
- * to reproduce.
- *
- * Sending is the exception, and it is left to the work that attaches a set to
- * a send. Here the switch is recorded and acted on by nothing.
+ * message says. The sending switch controls acceptance, and the suppression
+ * reasons control feedback. Delivery and reputation options remain state for
+ * a test to read back.
  */
 export class SimSesConfigurationSet {
   public readonly configurationSetName: string;
@@ -73,11 +71,13 @@ export class SimSesConfigurationSet {
   /**
    * The reasons that would put a recipient on the account suppression list.
    *
-   * Empty where the set declares no `SuppressionOptions`. Real SES falls back
-   * to the account setting there, and this simulation has no account
-   * suppression list to fall back to.
+   * Undefined where the set declares no `SuppressionOptions`, which makes a
+   * send fall back to the account setting. An empty list is an explicit
+   * override that disables suppression for a send through this set.
    */
-  public readonly suppressedReasons: readonly SimSesSuppressedReason[];
+  public readonly suppressedReasons:
+    | readonly SimSesSuppressedReason[]
+    | undefined;
 
   /** Whether SES would accept a send made through this set. */
   public readonly sendingEnabled: boolean;

--- a/src/service/ses/email/sim-ses-sent-email-store.ts
+++ b/src/service/ses/email/sim-ses-sent-email-store.ts
@@ -1,4 +1,5 @@
 import { SimAwsMessageLog } from "../../aws/message/sim-aws-message-log.js";
+import { SimSesFeedbackError } from "../error/sim-ses.error.js";
 import type { SimSesSentEmail } from "./sim-ses-sent-email.js";
 
 const hoursInADay = 24;
@@ -37,6 +38,28 @@ export class SimSesSentEmailStore {
    */
   get all(): readonly SimSesSentEmail[] {
     return [...this.#sent];
+  }
+
+  /**
+   * Find an accepted message by the id SES returned for it.
+   */
+  find(messageId: string): SimSesSentEmail | undefined {
+    return this.#sent.find((email) => email.messageId === messageId);
+  }
+
+  /**
+   * Get an accepted message by id, refusing an id this scope never issued.
+   */
+  require(messageId: string): SimSesSentEmail {
+    const email = this.find(messageId);
+
+    if (email === undefined) {
+      throw new SimSesFeedbackError(
+        `No accepted sim SES message has id ${messageId}.`,
+      );
+    }
+
+    return email;
   }
 
   /**

--- a/src/service/ses/error/sim-ses.error.ts
+++ b/src/service/ses/error/sim-ses.error.ts
@@ -108,3 +108,14 @@ export class SimSesSendingPausedException extends SimSesError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * A feedback event that cannot belong to the recorded message it names.
+ *
+ * This is a simulator diagnostic rather than an AWS error. A test supplies
+ * feedback through `recordFeedback`, and the error is raised at that call so
+ * an unrelated message or recipient cannot alter the suppression list.
+ */
+export class SimSesFeedbackError extends SimSesError {
+  public override readonly name = "SimSesFeedbackError";
+}

--- a/src/service/ses/feedback/sim-ses-feedback-recorder.ts
+++ b/src/service/ses/feedback/sim-ses-feedback-recorder.ts
@@ -1,0 +1,97 @@
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimSesAccount } from "../account/sim-ses-account.js";
+import type { SimSesConfigurationSetStore } from "../configuration-set/sim-ses-configuration-set-store.js";
+import { simSesBareAddress } from "../email/sim-ses-address.js";
+import type { SimSesSentEmail } from "../email/sim-ses-sent-email.js";
+import type { SimSesSentEmailStore } from "../email/sim-ses-sent-email-store.js";
+import { SimSesFeedbackError } from "../error/sim-ses.error.js";
+import { requiredSimSesSuppressionAddress } from "../suppression/sim-ses-suppression-address.js";
+import type { SimSesSuppressionList } from "../suppression/sim-ses-suppression-list.js";
+import {
+  requiredSimSesSuppressionReason,
+  type SimSesSuppressionReason,
+} from "../suppression/sim-ses-suppression-reason.js";
+import type { SimSesSuppressedDestination } from "../suppression/sim-ses-suppressed-destination.js";
+
+/** A hard bounce or complaint reported for one accepted message recipient. */
+export interface SimSesFeedback {
+  readonly messageId: string;
+  readonly emailAddress: string;
+  readonly reason: SimSesSuppressionReason;
+}
+
+interface SimSesFeedbackRecorderProperties {
+  readonly sent: SimSesSentEmailStore;
+  readonly configurationSets: SimSesConfigurationSetStore;
+  readonly account: SimSesAccount;
+  readonly suppression: SimSesSuppressionList;
+  readonly clock: SimClock;
+}
+
+/** Applies explicit delivery feedback to the account suppression list. */
+export class SimSesFeedbackRecorder {
+  readonly #sent: SimSesSentEmailStore;
+  readonly #configurationSets: SimSesConfigurationSetStore;
+  readonly #account: SimSesAccount;
+  readonly #suppression: SimSesSuppressionList;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimSesFeedbackRecorderProperties) {
+    this.#sent = properties.sent;
+    this.#configurationSets = properties.configurationSets;
+    this.#account = properties.account;
+    this.#suppression = properties.suppression;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Record a hard bounce or complaint for one recipient of an accepted
+   * message.
+   *
+   * The returned entry is undefined when suppression for the feedback reason
+   * was inactive for this send.
+   */
+  record(feedback: SimSesFeedback): SimSesSuppressedDestination | undefined {
+    const email = this.#sent.require(feedback.messageId);
+    const emailAddress = requiredSimSesSuppressionAddress(
+      feedback.emailAddress,
+    );
+    const reason = requiredSimSesSuppressionReason(feedback.reason);
+    const recipient = this.#recipient(email, emailAddress);
+
+    if (!this.#isActive(email, reason)) {
+      return undefined;
+    }
+
+    return this.#suppression.put(recipient, reason, this.#clock.now());
+  }
+
+  #recipient(email: SimSesSentEmail, emailAddress: string): string {
+    const wanted = emailAddress.toLowerCase();
+    const recipient = email.recipients
+      .map((address) => simSesBareAddress(address))
+      .find((address) => address.toLowerCase() === wanted);
+
+    if (recipient === undefined) {
+      throw new SimSesFeedbackError(
+        `${emailAddress} is not a recipient of sim SES message ${email.messageId}.`,
+      );
+    }
+
+    return recipient;
+  }
+
+  #isActive(email: SimSesSentEmail, reason: SimSesSuppressionReason): boolean {
+    if (email.configurationSetName !== undefined) {
+      const configurationSet = this.#configurationSets.find(
+        email.configurationSetName,
+      );
+
+      if (configurationSet?.suppressedReasons !== undefined) {
+        return configurationSet.suppressedReasons.includes(reason);
+      }
+    }
+
+    return this.#account.isSuppressedFor(reason);
+  }
+}

--- a/src/service/ses/index.ts
+++ b/src/service/ses/index.ts
@@ -49,6 +49,10 @@ export {
 } from "./email/sim-ses-sent-email.js";
 export { SimSesSentEmailStore } from "./email/sim-ses-sent-email-store.js";
 export {
+  type SimSesFeedback,
+  SimSesFeedbackRecorder,
+} from "./feedback/sim-ses-feedback-recorder.js";
+export {
   requiredSimSesFromAddress,
   simSesBareAddress,
 } from "./email/sim-ses-address.js";
@@ -67,6 +71,7 @@ export {
   SimSesAlreadyExistsException,
   SimSesBadRequestException,
   SimSesError,
+  SimSesFeedbackError,
   type SimSesErrorMetadata,
   SimSesMessageRejected,
   SimSesNotFoundException,

--- a/src/service/ses/sim-ses-commands.ts
+++ b/src/service/ses/sim-ses-commands.ts
@@ -21,6 +21,7 @@ import { SimSesVerifiedIdentityCheck } from "./command/send/sim-ses-verified-ide
 import { SimSesSuppressionCommands } from "./command/suppression/sim-ses-suppression-commands.js";
 import { SimSesSuppressionList } from "./suppression/sim-ses-suppression-list.js";
 import { SimSesSentEmailStore } from "./email/sim-ses-sent-email-store.js";
+import { SimSesFeedbackRecorder } from "./feedback/sim-ses-feedback-recorder.js";
 import { SimSesConfigurationSetStore } from "./configuration-set/sim-ses-configuration-set-store.js";
 import { SimSesIdentityStore } from "./identity/sim-ses-identity-store.js";
 import { SimSesTemplateCommands } from "./command/template/sim-ses-template-commands.js";
@@ -56,6 +57,7 @@ export class SimSesCommands {
   readonly templateCommands: SimSesTemplateCommands;
   readonly configurationSetCommands: SimSesConfigurationSetCommands;
   readonly sendEmail: SimSesSendEmail;
+  readonly feedback: SimSesFeedbackRecorder;
 
   /**
    * The way another simulated service reaches this SES, which is the send
@@ -131,6 +133,13 @@ export class SimSesCommands {
       configurationSetCheck,
       suppressionCheck,
       authorizer,
+      clock: background,
+    });
+    this.feedback = new SimSesFeedbackRecorder({
+      sent,
+      configurationSets,
+      account,
+      suppression,
       clock: background,
     });
     this.serviceSend = new SimSesServiceSend({

--- a/src/service/ses/sim-ses-configuration-sets.iso.test.ts
+++ b/src/service/ses/sim-ses-configuration-sets.iso.test.ts
@@ -46,6 +46,7 @@ describe("simulated SES configuration sets", () => {
     // Then each group is there to assert on, which is the whole point of
     // holding a set that nothing here routes an event to.
     assertNonNullable(configurationSet);
+    assertNonNullable(configurationSet.suppressedReasons);
     assertArrayEquals(configurationSet.suppressedReasons, [
       "BOUNCE",
       "COMPLAINT",
@@ -64,16 +65,37 @@ describe("simulated SES configuration sets", () => {
       new CreateConfigurationSetCommand({ ConfigurationSetName: "bare" }),
     );
 
-    // Then sending is on, TLS is optional, reputation metrics are off and no
-    // reason is suppressed, which is what a real set defaults to.
+    // Then sending is on, TLS is optional, reputation metrics are off and
+    // suppression falls back to the account, as a real set defaults to.
     const configurationSet = ses.findConfigurationSet("bare");
 
     assertNonNullable(configurationSet);
     assertTrue(configurationSet.sendingEnabled);
     assertIdentical(configurationSet.deliveryOptions.tlsPolicy, "OPTIONAL");
     assertFalse(configurationSet.reputationOptions.reputationMetricsEnabled);
-    assertArrayEmpty(configurationSet.suppressedReasons);
+    assertUndefined(configurationSet.suppressedReasons);
     assertUndefined(configurationSet.deliveryOptions.sendingPoolName);
+  });
+
+  it("keeps an explicit empty suppression override", async () => {
+    // Given a set with suppression options present and no active reasons.
+    const ses = new SimAws().sesV2();
+
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({
+        ConfigurationSetName: "no-feedback-suppression",
+        SuppressionOptions: { SuppressedReasons: [] },
+      }),
+    );
+
+    // Then the empty override stays distinct from an absent option group.
+    const configurationSet = ses.findConfigurationSet(
+      "no-feedback-suppression",
+    );
+
+    assertNonNullable(configurationSet);
+    assertNonNullable(configurationSet.suppressedReasons);
+    assertArrayEmpty(configurationSet.suppressedReasons);
   });
 
   it("reports every option group back from GetConfigurationSet", async () => {
@@ -95,7 +117,7 @@ describe("simulated SES configuration sets", () => {
     assertTrue(read.ReputationOptions?.ReputationMetricsEnabled);
   });
 
-  it("answers the defaults it applied rather than leaving them out", async () => {
+  it("reports applied defaults and keeps absent suppression options out", async () => {
     // Given a set declaring nothing but its name.
     const ses = new SimAws().sesV2();
 
@@ -108,10 +130,11 @@ describe("simulated SES configuration sets", () => {
       new GetConfigurationSetCommand({ ConfigurationSetName: "bare" }),
     );
 
-    // Then the groups the set never declared are still reported, as real SES
-    // reports them.
+    // Then applied defaults are reported, while the absent suppression group
+    // remains absent so feedback can fall back to the account reasons.
     assertTrue(read.SendingOptions?.SendingEnabled);
     assertIdentical(read.DeliveryOptions?.TlsPolicy, "OPTIONAL");
+    assertUndefined(read.SuppressionOptions);
   });
 
   it("lists the sets by name, in the order they were made", async () => {

--- a/src/service/ses/sim-ses-configuration-sets.ts
+++ b/src/service/ses/sim-ses-configuration-sets.ts
@@ -11,10 +11,10 @@ import { SimSesSuppression } from "./sim-ses-suppression.js";
  * separate classes because one class holding every SES operation grows by a
  * method with each one added.
  *
- * A configuration set here is state and no behaviour. Its suppression reasons,
- * sending switch, delivery options and reputation switch are all held and read
- * back, and nothing acts on any of them. A send naming a set keeps the name on
- * its record and goes no further.
+ * A configuration set holds suppression reasons, the sending switch, delivery
+ * options and the reputation switch. The sending switch acts on acceptance.
+ * Suppression reasons act when feedback is recorded for an accepted message.
+ * The remaining options are held for a test to read back.
  */
 export abstract class SimSesConfigurationSets extends SimSesSuppression {
   /**

--- a/src/service/ses/sim-ses-feedback-suppression.iso.test.ts
+++ b/src/service/ses/sim-ses-feedback-suppression.iso.test.ts
@@ -1,0 +1,351 @@
+import {
+  CreateConfigurationSetCommand,
+  PutAccountSuppressionAttributesCommand,
+  SendEmailCommand,
+  type SendEmailCommandInput,
+} from "@aws-sdk/client-sesv2";
+import {
+  assertArrayEmpty,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsError,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../util/clock/sim-clock.js";
+import { SimAws } from "../aws/sim-aws.js";
+import {
+  SimSesBadRequestException,
+  SimSesFeedbackError,
+} from "./error/sim-ses.error.js";
+import type { SimSesSentEmail } from "./email/sim-ses-sent-email.js";
+import type { SimSesV2 } from "./sim-ses-v2.js";
+
+describe("SimSesV2 recording delivery feedback", () => {
+  const startedAt = new Date("2026-08-31T09:00:00.000Z");
+
+  function sendingSes(): { readonly simAws: SimAws; readonly ses: SimSesV2 } {
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("hello@example.com");
+    ses.verifyIdentity("example.org");
+
+    return { simAws, ses };
+  }
+
+  async function acceptedEmail(
+    ses: SimSesV2,
+    input: Partial<SendEmailCommandInput> = {},
+  ): Promise<SimSesSentEmail> {
+    await ses.sendEmail(
+      new SendEmailCommand({
+        FromEmailAddress: "hello@example.com",
+        Destination: { ToAddresses: ["someone@example.org"] },
+        Content: {
+          Simple: {
+            Subject: { Data: "Welcome" },
+            Body: { Text: { Data: "Hi there" } },
+          },
+        },
+        ...input,
+      }),
+    );
+
+    const email = ses.sentEmails().at(-1);
+    assertNonNullable(email);
+    return email;
+  }
+
+  it("records a hard bounce at simulated time and withholds a later send", async () => {
+    // Given an accepted message on an account suppressing hard bounces.
+    const { ses } = sendingSes();
+    const email = await acceptedEmail(ses);
+
+    // When its recipient reports a hard bounce.
+    const feedback = ses.recordFeedback({
+      messageId: email.messageId,
+      emailAddress: "someone@example.org",
+      reason: "BOUNCE",
+    });
+
+    // Then the account list records it at simulated time, and a later send is
+    // accepted but held back from that recipient.
+    assertNonNullable(feedback);
+    assertIdentical(feedback.emailAddress, "someone@example.org");
+    assertIdentical(feedback.reason, "BOUNCE");
+    assertIdentical(
+      feedback.lastUpdateTime.toISOString(),
+      startedAt.toISOString(),
+    );
+
+    const later = await acceptedEmail(ses);
+    assertArrayLength(later.suppressedRecipients, 1);
+    assertIdentical(
+      later.suppressedRecipients[0].emailAddress,
+      "someone@example.org",
+    );
+  });
+
+  it("updates an existing entry with complaint feedback and the newer time", async () => {
+    // Given two accepted messages to the same recipient.
+    const { simAws, ses } = sendingSes();
+    const bounced = await acceptedEmail(ses);
+    const complained = await acceptedEmail(ses);
+
+    ses.recordFeedback({
+      messageId: bounced.messageId,
+      emailAddress: "someone@example.org",
+      reason: "BOUNCE",
+    });
+    await simAws.clock().advanceBy({ hours: 2 });
+
+    // When the newer message receives complaint feedback.
+    ses.recordFeedback({
+      messageId: complained.messageId,
+      emailAddress: "someone@example.org",
+      reason: "COMPLAINT",
+    });
+
+    // Then the one account entry carries the new reason and time.
+    const [suppressed] = ses.suppressedDestinations();
+    assertArrayLength(ses.suppressedDestinations(), 1);
+    assertNonNullable(suppressed);
+    assertIdentical(suppressed.reason, "COMPLAINT");
+    assertIdentical(
+      suppressed.lastUpdateTime.toISOString(),
+      "2026-08-31T11:00:00.000Z",
+    );
+  });
+
+  it("leaves the list unchanged for an inactive account reason", async () => {
+    // Given an account suppressing bounces only and an accepted message.
+    const { ses } = sendingSes();
+    await ses.putAccountSuppressionAttributes(
+      new PutAccountSuppressionAttributesCommand({
+        SuppressedReasons: ["BOUNCE"],
+      }),
+    );
+    const email = await acceptedEmail(ses);
+
+    // When that recipient complains.
+    const feedback = ses.recordFeedback({
+      messageId: email.messageId,
+      emailAddress: "someone@example.org",
+      reason: "COMPLAINT",
+    });
+
+    // Then complaint feedback is inactive and the list stays empty.
+    assertUndefined(feedback);
+    assertArrayEmpty(ses.suppressedDestinations());
+  });
+
+  it("uses an active configuration-set reason instead of the account reasons", async () => {
+    // Given an account suppressing complaints and a set suppressing bounces.
+    const { ses } = sendingSes();
+    await ses.putAccountSuppressionAttributes(
+      new PutAccountSuppressionAttributesCommand({
+        SuppressedReasons: ["COMPLAINT"],
+      }),
+    );
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({
+        ConfigurationSetName: "bounce-feedback",
+        SuppressionOptions: { SuppressedReasons: ["BOUNCE"] },
+      }),
+    );
+    const email = await acceptedEmail(ses, {
+      ConfigurationSetName: "bounce-feedback",
+    });
+
+    // When its recipient hard bounces.
+    ses.recordFeedback({
+      messageId: email.messageId,
+      emailAddress: "someone@example.org",
+      reason: "BOUNCE",
+    });
+
+    // Then the configuration-set override puts the recipient on the account
+    // list despite the account reason being inactive.
+    assertIdentical(ses.suppressedDestinations()[0]?.reason, "BOUNCE");
+  });
+
+  it("ignores a reason excluded by the configuration-set override", async () => {
+    // Given an account suppressing complaints and a set suppressing bounces.
+    const { ses } = sendingSes();
+    await ses.putAccountSuppressionAttributes(
+      new PutAccountSuppressionAttributesCommand({
+        SuppressedReasons: ["COMPLAINT"],
+      }),
+    );
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({
+        ConfigurationSetName: "bounce-feedback",
+        SuppressionOptions: { SuppressedReasons: ["BOUNCE"] },
+      }),
+    );
+    const email = await acceptedEmail(ses, {
+      ConfigurationSetName: "bounce-feedback",
+    });
+
+    // When its recipient complains.
+    const feedback = ses.recordFeedback({
+      messageId: email.messageId,
+      emailAddress: "someone@example.org",
+      reason: "COMPLAINT",
+    });
+
+    // Then the set overrides the active account reason and nothing is added.
+    assertUndefined(feedback);
+    assertArrayEmpty(ses.suppressedDestinations());
+  });
+
+  it("distinguishes an absent override from an explicit empty override", async () => {
+    // Given one set falling back to active account reasons and one explicitly
+    // disabling suppression.
+    const { ses } = sendingSes();
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({
+        ConfigurationSetName: "account-defaults",
+      }),
+    );
+    await ses.createConfigurationSet(
+      new CreateConfigurationSetCommand({
+        ConfigurationSetName: "suppression-disabled",
+        SuppressionOptions: { SuppressedReasons: [] },
+      }),
+    );
+    const fallback = await acceptedEmail(ses, {
+      ConfigurationSetName: "account-defaults",
+    });
+    const disabled = await acceptedEmail(ses, {
+      ConfigurationSetName: "suppression-disabled",
+      Destination: { ToAddresses: ["other@example.org"] },
+    });
+
+    // When both recipients hard bounce.
+    ses.recordFeedback({
+      messageId: fallback.messageId,
+      emailAddress: "someone@example.org",
+      reason: "BOUNCE",
+    });
+    const ignored = ses.recordFeedback({
+      messageId: disabled.messageId,
+      emailAddress: "other@example.org",
+      reason: "BOUNCE",
+    });
+
+    // Then only the send with no override falls back to the account reasons.
+    assertUndefined(ignored);
+    assertArrayLength(ses.suppressedDestinations(), 1);
+    assertIdentical(
+      ses.suppressedDestinations()[0]?.emailAddress,
+      "someone@example.org",
+    );
+  });
+
+  it("records feedback for one matching recipient of a multi-recipient send", async () => {
+    // Given an accepted message addressed to two recipients.
+    const { ses } = sendingSes();
+    const email = await acceptedEmail(ses, {
+      Destination: {
+        ToAddresses: ["someone@example.org"],
+        CcAddresses: ["Someone Else <SOMEONE.ELSE@example.org>"],
+      },
+    });
+
+    // When feedback names the cc recipient without its display name and in a
+    // different case.
+    ses.recordFeedback({
+      messageId: email.messageId,
+      emailAddress: "someone.else@example.org",
+      reason: "COMPLAINT",
+    });
+
+    // Then that recipient alone is added, using the address from the message.
+    const [suppressed] = ses.suppressedDestinations();
+    assertArrayLength(ses.suppressedDestinations(), 1);
+    assertIdentical(suppressed?.emailAddress, "SOMEONE.ELSE@example.org");
+  });
+
+  it("refuses feedback for a message this scope did not accept", () => {
+    // Given a simulated SES with no accepted message under the supplied id.
+    const { ses } = sendingSes();
+
+    // When feedback names that id.
+    const error = assertThrowsError(() => {
+      ses.recordFeedback({
+        messageId: "missing-message",
+        emailAddress: "someone@example.org",
+        reason: "BOUNCE",
+      });
+    });
+
+    // Then the invalid relationship is reported and the list stays empty.
+    assertInstanceOf(error, SimSesFeedbackError);
+    assertStringIncludes(error.message, "missing-message");
+    assertArrayEmpty(ses.suppressedDestinations());
+  });
+
+  it("refuses feedback for an address outside the message", async () => {
+    // Given an accepted message to someone else.
+    const { ses } = sendingSes();
+    const email = await acceptedEmail(ses);
+
+    // When feedback names an address that was not a recipient.
+    const error = assertThrowsError(() => {
+      ses.recordFeedback({
+        messageId: email.messageId,
+        emailAddress: "other@example.org",
+        reason: "BOUNCE",
+      });
+    });
+
+    // Then the mismatch is refused without changing the list.
+    assertInstanceOf(error, SimSesFeedbackError);
+    assertStringIncludes(error.message, "other@example.org");
+    assertArrayEmpty(ses.suppressedDestinations());
+  });
+
+  it("refuses a feedback recipient that is not an email address", async () => {
+    // Given an accepted message.
+    const { ses } = sendingSes();
+    const email = await acceptedEmail(ses);
+
+    // When feedback names a domain instead of an address.
+    const error = assertThrowsError(() => {
+      ses.recordFeedback({
+        messageId: email.messageId,
+        emailAddress: "example.org",
+        reason: "BOUNCE",
+      });
+    });
+
+    // Then the input is refused without changing the list.
+    assertInstanceOf(error, SimSesBadRequestException);
+    assertArrayEmpty(ses.suppressedDestinations());
+  });
+
+  it("refuses a feedback reason SES does not have", async () => {
+    // Given an accepted message.
+    const { ses } = sendingSes();
+    const email = await acceptedEmail(ses);
+
+    // When feedback names another reason at runtime.
+    const error = assertThrowsError(() => {
+      ses.recordFeedback({
+        messageId: email.messageId,
+        emailAddress: "someone@example.org",
+        reason: "SOFT_BOUNCE" as "BOUNCE",
+      });
+    });
+
+    // Then the input is refused without changing the list.
+    assertInstanceOf(error, SimSesBadRequestException);
+    assertArrayEmpty(ses.suppressedDestinations());
+  });
+});

--- a/src/service/ses/sim-ses-suppression.ts
+++ b/src/service/ses/sim-ses-suppression.ts
@@ -15,8 +15,9 @@ interface SimSesSuppressionProperties {
  * SES operation grows by a method with each one added, and the suppression
  * commands are the part of the API a reader can take in on their own.
  *
- * Real SES fills this list from hard bounces and complaints. Nothing bounces
- * here, so every address on it was put there by a caller.
+ * Real SES fills this list from hard bounces and complaints. A test supplies
+ * that feedback explicitly, and callers may also manage entries through the
+ * suppression commands.
  */
 export abstract class SimSesSuppression {
   protected readonly commands: SimSesCommands;

--- a/src/service/ses/sim-ses-v2.ts
+++ b/src/service/ses/sim-ses-v2.ts
@@ -3,6 +3,8 @@ import type * as simSesCommands from "./command/sim-ses-command.types.js";
 import type { SimSesRequestOptions } from "./command/sim-ses-request-options.js";
 import type * as simSesServiceSend from "./command/send/sim-ses-service-send.js";
 import type { SimSesSentEmail } from "./email/sim-ses-sent-email.js";
+import type { SimSesFeedback } from "./feedback/sim-ses-feedback-recorder.js";
+import type { SimSesSuppressedDestination } from "./suppression/sim-ses-suppressed-destination.js";
 import type { SimSesIdentity } from "./identity/sim-ses-identity.js";
 import type { SimSesTemplate } from "./template/sim-ses-template.js";
 import { SimSesCfnResourceFactory } from "./cfn/sim-ses-cfn-resource-factory.js";
@@ -47,6 +49,22 @@ export class SimSesV2 extends SimSesConfigurationSets {
    */
   sentEmails(): readonly SimSesSentEmail[] {
     return this.commands.sent.all;
+  }
+
+  /**
+   * Record a hard bounce or complaint for one recipient of an accepted
+   * message.
+   *
+   * Real feedback happens after SES hands a message to a mail system. A test
+   * process cannot observe that exchange, so this simulator-side operation
+   * supplies the feedback explicitly. Active feedback adds or updates the
+   * account suppression entry at the current simulated time. Inactive
+   * feedback returns undefined and leaves the list unchanged.
+   */
+  recordFeedback(
+    feedback: SimSesFeedback,
+  ): SimSesSuppressedDestination | undefined {
+    return this.commands.feedback.record(feedback);
   }
 
   /**

--- a/src/service/ses/suppression/sim-ses-suppressed-destination.ts
+++ b/src/service/ses/suppression/sim-ses-suppressed-destination.ts
@@ -9,10 +9,9 @@ interface SimSesSuppressedDestinationProperties {
 /**
  * One address on an account's suppression list.
  *
- * Real SES also reports a `MessageId` and a `FeedbackId` on the address it put
- * there itself, describing the bounce or complaint that did it. Nothing
- * bounces here, so every address on this list was put there by hand and there
- * is no feedback event to point at.
+ * Real SES also reports a `MessageId` and a `FeedbackId` on an address added by
+ * delivery feedback. This simulation records the reason and time only. It
+ * does not publish or retain a feedback event.
  */
 export class SimSesSuppressedDestination {
   /** The address as it was given, case and all. */

--- a/src/service/ses/suppression/sim-ses-suppression-list.ts
+++ b/src/service/ses/suppression/sim-ses-suppression-list.ts
@@ -5,10 +5,10 @@ import type { SimSesSuppressionReason } from "./sim-ses-suppression-reason.js";
 /**
  * The account-level suppression list of one simulated SES scope.
  *
- * Real SES fills this from hard bounces and complaints. Nothing bounces here,
- * so every address on it was put there by a caller, which is the point: an
- * application's own support tooling and operations scripts have somewhere to
- * run.
+ * Real SES fills this from hard bounces and complaints. A test supplies those
+ * events through the simulator's feedback operation. The ordinary suppression
+ * commands also manage the same entries, giving application support tooling
+ * and operations scripts somewhere to run.
  *
  * The list is region scoped, as identities and sends are. An address
  * suppressed in one region says nothing about another.


### PR DESCRIPTION
## Summary

- add explicit hard-bounce and complaint feedback for accepted SES messages
- apply account or configuration-set suppression reasons, including empty overrides
- document the operation and cover validation and later-send suppression

## Testing

- `pnpm run check`

Resolves #1208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SES feedback recording for bounce and complaint events.
  * Feedback can now update suppression entries with the reason and timestamp.
  * Added validation for message IDs, recipients, addresses, and supported feedback reasons.
  * Configuration sets now distinguish account-level suppression defaults from explicitly disabled suppression.
  * Added an example demonstrating feedback-driven suppression behavior.

* **Documentation**
  * Expanded SES documentation covering feedback recording, suppression configuration, validation, and lookup behavior.

* **Tests**
  * Added coverage for feedback suppression, configuration precedence, timestamps, recipient matching, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->