### PR TITLE
fix: reject invalid DynamoDB GSI stack updates

### DIFF
--- a/src/service/cloudformation/resource/factory/sim-cfn-resource-factory.type.ts
+++ b/src/service/cloudformation/resource/factory/sim-cfn-resource-factory.type.ts
@@ -3,6 +3,7 @@ import type {
   SimCloudFormationResourceCreateContext,
   SimCloudFormationResourceDeleteContext,
 } from "../sim-cfn-resource.js";
+import type { SimCloudFormationResourceUpdateContext } from "../sim-cfn-resource.type.js";
 
 export interface SimCfnServiceResourceFactory {
   create(
@@ -29,6 +30,20 @@ export interface SimCfnServiceResourceFactory {
     resource: SimCfnResource,
     context: SimCloudFormationResourceDeleteContext,
   ): Promise<void>;
+
+  /**
+   * Refuse an invalid replacement before CloudFormation deletes anything.
+   *
+   * Most simulated Resource types have no update-specific validation. A
+   * service can implement this hook when an update carries constraints that a
+   * create request cannot check.
+   */
+  assertUpdateAllowed?(
+    resourceTypeName: string,
+    current: SimCfnResource,
+    updated: SimCfnResource,
+    context: SimCloudFormationResourceUpdateContext,
+  ): Promise<void> | void;
 }
 
 export interface SimCloudFormationParsedResourceType {

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -103,3 +103,15 @@ export interface SimCloudFormationResourceDeleteContext {
   /** The principal the teardown runs as, as creation carries it. */
   readonly caller?: SimAwsCaller | undefined;
 }
+
+/**
+ * The two resolved Resource definitions available to update validation.
+ */
+export interface SimCloudFormationResourceUpdateContext {
+  readonly simAws: SimAws;
+  readonly currentResources: ReadonlyMap<string, SimCfnResource>;
+  readonly updatedResources: ReadonlyMap<string, SimCfnResource>;
+  readonly currentResolvedProperties: SimCfnTemplateValueRecord;
+  readonly updatedResolvedProperties: SimCfnTemplateValueRecord;
+  readonly caller?: SimAwsCaller | undefined;
+}

--- a/src/service/cloudformation/resource/update/sim-cfn-resource-update-validator.ts
+++ b/src/service/cloudformation/resource/update/sim-cfn-resource-update-validator.ts
@@ -1,8 +1,10 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
 import type { SimCfnResource } from "../sim-cfn-resource.js";
 import { parseSimCloudFormationResourceType } from "../parser/sim-cfn-resource-parser.js";
 import { resolveSimCloudFormationServiceResourceFactory } from "../resolve/service/sim-cfn-service-resolver.js";
+import { isSimCfnUnsupportedResourceError } from "../unsupported/sim-cfn-unsupported-resource.js";
 
 interface SimCfnResourceUpdateValidatorProperties {
   readonly current: SimCfnResource;
@@ -43,11 +45,21 @@ export class SimCfnResourceUpdateValidator {
     }
 
     const resourceType = parseSimCloudFormationResourceType(type);
-    const factory = resolveSimCloudFormationServiceResourceFactory(
-      simAws,
-      updated.accountRegionScope,
-      resourceType,
-    );
+    let factory: SimCfnServiceResourceFactory;
+
+    try {
+      factory = resolveSimCloudFormationServiceResourceFactory(
+        simAws,
+        updated.accountRegionScope,
+        resourceType,
+      );
+    } catch (error) {
+      if (isSimCfnUnsupportedResourceError(error)) {
+        return;
+      }
+
+      throw error;
+    }
 
     if (factory.assertUpdateAllowed === undefined) {
       return;

--- a/src/service/cloudformation/resource/update/sim-cfn-resource-update-validator.ts
+++ b/src/service/cloudformation/resource/update/sim-cfn-resource-update-validator.ts
@@ -1,0 +1,78 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfnResource } from "../sim-cfn-resource.js";
+import { parseSimCloudFormationResourceType } from "../parser/sim-cfn-resource-parser.js";
+import { resolveSimCloudFormationServiceResourceFactory } from "../resolve/service/sim-cfn-service-resolver.js";
+
+interface SimCfnResourceUpdateValidatorProperties {
+  readonly current: SimCfnResource;
+  readonly updated: SimCfnResource;
+}
+
+interface AssertSimCfnResourceUpdateAllowedProperties {
+  readonly simAws: SimAws;
+  readonly currentResources: ReadonlyMap<string, SimCfnResource>;
+  readonly updatedResources: ReadonlyMap<string, SimCfnResource>;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * Runs service-specific validation for one Resource replacement.
+ */
+export class SimCfnResourceUpdateValidator {
+  private readonly current: SimCfnResource;
+  private readonly updated: SimCfnResource;
+
+  constructor(properties: SimCfnResourceUpdateValidatorProperties) {
+    this.current = properties.current;
+    this.updated = properties.updated;
+  }
+
+  /**
+   * Refuse an invalid update before its current Resource is deleted.
+   */
+  async assertAllowed(
+    properties: AssertSimCfnResourceUpdateAllowedProperties,
+  ): Promise<void> {
+    const { current, updated } = this;
+    const { simAws, currentResources, updatedResources, caller } = properties;
+    const { type } = updated;
+
+    if (type === undefined || current.type !== type) {
+      return;
+    }
+
+    const resourceType = parseSimCloudFormationResourceType(type);
+    const factory = resolveSimCloudFormationServiceResourceFactory(
+      simAws,
+      updated.accountRegionScope,
+      resourceType,
+    );
+
+    if (factory.assertUpdateAllowed === undefined) {
+      return;
+    }
+
+    await factory.assertUpdateAllowed(
+      resourceType.resourceTypeName,
+      current,
+      updated,
+      {
+        simAws,
+        currentResources,
+        updatedResources,
+        currentResolvedProperties: await current.resolvedProperties({
+          simAws,
+          resources: currentResources,
+          caller,
+        }),
+        updatedResolvedProperties: await updated.resolvedProperties({
+          simAws,
+          resources: updatedResources,
+          caller,
+        }),
+        caller,
+      },
+    );
+  }
+}

--- a/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
@@ -11,6 +11,8 @@ import { SimCfnStackResourceCreator } from "./deploy/sim-cfn-stack-resource-crea
 import type { SimCfnResourceOrder } from "./deploy/sim-cfn-resource-order.js";
 import { SimCfnStackResourceDeleter } from "./teardown/sim-cfn-stack-resource-deleter.js";
 import { SimCfnStackUpdater } from "./update/sim-cfn-stack-updater.js";
+import type { SimCfnStackResourceReplacement } from "./update/sim-cfn-stack-update-plan.js";
+import { SimCfnResourceUpdateValidator } from "../resource/update/sim-cfn-resource-update-validator.js";
 import type { SimCloudFormationStackName } from "./sim-cfn-stack.js";
 
 interface SimCfnStackUpdateProperties {
@@ -141,6 +143,29 @@ export class SimCfnStackResourceOperations {
     deleting: readonly SimCfnResource[],
   ): Promise<void> {
     await this.deleter(resources).delete(deleting);
+  }
+
+  /**
+   * Validate every Resource replacement before the update changes the Stack.
+   */
+  async assertUpdatesAllowed(
+    currentResources: ReadonlyMap<string, SimCfnResource>,
+    updatedResources: ReadonlyMap<string, SimCfnResource>,
+    replacements: readonly SimCfnStackResourceReplacement[],
+  ): Promise<void> {
+    await Promise.all(
+      replacements.map(async ({ current, updated }) => {
+        await new SimCfnResourceUpdateValidator({
+          current,
+          updated,
+        }).assertAllowed({
+          simAws: this.simAws,
+          currentResources,
+          updatedResources,
+          caller: this.caller,
+        });
+      }),
+    );
   }
 
   /**

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-update-plan.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-update-plan.ts
@@ -6,6 +6,11 @@ interface SimCfnStackUpdatePlanProperties {
   readonly updated: ReadonlyMap<string, SimCfnResource>;
 }
 
+export interface SimCfnStackResourceReplacement {
+  readonly current: SimCfnResource;
+  readonly updated: SimCfnResource;
+}
+
 /**
  * What an update has to do to a Stack's Resources, worked out before any of it
  * happens.
@@ -20,6 +25,9 @@ interface SimCfnStackUpdatePlanProperties {
  * simCfnStackReplacedLogicalIds decides what changed.
  */
 export class SimCfnStackUpdatePlan {
+  /** The current and updated halves of each Resource replacement. */
+  public readonly replacements: readonly SimCfnStackResourceReplacement[];
+
   /**
    * The deployed Resources to delete: the ones the new template drops, and the
    * deployed halves of the ones it replaces.
@@ -32,13 +40,28 @@ export class SimCfnStackUpdatePlan {
    */
   public readonly creations: readonly SimCfnResource[];
 
-  private readonly updated: ReadonlyMap<string, SimCfnResource>;
+  public readonly updated: ReadonlyMap<string, SimCfnResource>;
 
   constructor(properties: SimCfnStackUpdatePlanProperties) {
     const { current, updated } = properties;
     const replaced = simCfnStackReplacedLogicalIds({ current, updated });
 
     this.updated = updated;
+    this.replacements = replaced
+      .values()
+      .map((logicalId) => {
+        const currentResource = current.get(logicalId);
+        const updatedResource = updated.get(logicalId);
+
+        if (currentResource === undefined || updatedResource === undefined) {
+          throw new Error(
+            `CloudFormation replacement ${logicalId} is missing one of its Resource definitions`,
+          );
+        }
+
+        return { current: currentResource, updated: updatedResource };
+      })
+      .toArray();
 
     // Both lists are worked out now rather than on demand, because the Stack's
     // Resource map is the current one and applying the plan changes it.

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-update.iso.test.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-update.iso.test.ts
@@ -4,6 +4,7 @@ import {
   assertInstanceOf,
   assertNonNullable,
   assertThrowsErrorAsync,
+  assertTrue,
   assertUndefined,
 } from "@kensio/smartass";
 import {
@@ -34,6 +35,56 @@ const parameterisedTemplate = {
 };
 
 describe("simulated CloudFormation Stack update", () => {
+  it("updates a skipped unsupported Resource", async () => {
+    // Given a Stack with a Resource the simulator skips.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "instance-stack",
+        TemplateBody: jsonStringify({
+          Resources: {
+            TestInstance: {
+              Type: "AWS::EC2::Instance",
+              Properties: { InstanceType: "t3.micro" },
+            },
+          },
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("instance-stack");
+
+    // When the unsupported Resource changes.
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "instance-stack",
+        TemplateBody: jsonStringify({
+          Resources: {
+            TestInstance: {
+              Type: "AWS::EC2::Instance",
+              Properties: { InstanceType: "t3.small" },
+            },
+          },
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("instance-stack");
+
+    // Then validation skips the Resource as creation does.
+    const stack = cloudFormation.getStackByName("instance-stack");
+    assertNonNullable(stack);
+    assertIdentical(stack.status, "UPDATE_COMPLETE");
+
+    const resource = stack.getResource("TestInstance");
+    assertNonNullable(resource);
+    assertTrue(resource.skipped);
+    assertIdentical(
+      resource.skippedReason,
+      "Unsupported sim CloudFormation Resource service EC2",
+    );
+  });
+
   it("leaves a Resource the new template does not change alone", async () => {
     // Given a deployed Stack of two Buckets.
     const simAws = new SimAws();

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-updater.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-updater.ts
@@ -81,6 +81,12 @@ export class SimCfnStackUpdater {
     const { resources, operations } = this.properties;
     const { plan } = this;
 
+    await operations.assertUpdatesAllowed(
+      resources,
+      plan.updated,
+      plan.replacements,
+    );
+
     await operations.delete(resources, plan.deletions);
 
     plan.applyTo(resources);

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-resource-factory.ts
@@ -4,11 +4,13 @@ import type {
   SimCloudFormationResourceCreateContext,
   SimCloudFormationResourceDeleteContext,
 } from "../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCloudFormationResourceUpdateContext } from "../../cloudformation/resource/sim-cfn-resource.type.js";
 import { simCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimDynamoDb } from "../sim-dynamodb.js";
 import { SimCfnDynamoDbGlobalTableCreator } from "./global-table/sim-cfn-dynamodb-global-table-creator.js";
 import { SimCfnDynamoDbTableCreator } from "./table/sim-cfn-dynamodb-table-creator.js";
 import { SimCfnDynamoDbResourceDeleter } from "./sim-cfn-dynamodb-resource-deleter.js";
+import { SimCfnDynamoDbTableUpdateValidator } from "./table/sim-cfn-dynamodb-table-update-validator.js";
 
 interface SimDynamoDbCfnResourceFactoryProperties {
   readonly dynamoDb: SimDynamoDb;
@@ -83,5 +85,26 @@ export class SimDynamoDbCfnResourceFactory implements SimCfnServiceResourceFacto
       resource,
       simCfnResourceCallerOptions(context.caller),
     );
+  }
+
+  /**
+   * Validate a DynamoDB Resource replacement before its table is deleted.
+   */
+  assertUpdateAllowed(
+    resourceTypeName: string,
+    current: SimCfnResource,
+    updated: SimCfnResource,
+    context: SimCloudFormationResourceUpdateContext,
+  ): void {
+    if (resourceTypeName !== "Table") {
+      return;
+    }
+
+    new SimCfnDynamoDbTableUpdateValidator({
+      currentResource: current,
+      updatedResource: updated,
+      currentProperties: context.currentResolvedProperties,
+      updatedProperties: context.updatedResolvedProperties,
+    }).assertAllowed();
   }
 }

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-indexes.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-indexes.iso.test.ts
@@ -1,17 +1,26 @@
 import {
   DescribeTableCommand,
+  GetItemCommand,
   PutItemCommand,
   QueryCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
+  DescribeStacksCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
   assertArrayLength,
   assertIdentical,
+  assertInstanceOf,
   assertNonNullable,
+  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { jsonStringify } from "../../../util/type-guard/json.js";
 import { SimAws } from "../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
 import { simCfnDynamoDbIndexedTableResourceFactory } from "./table/sim-cfn-dynamodb-indexed-table-resource.factory.js";
 import { simCfnDynamoDbTableResourceFactory } from "./table/sim-cfn-dynamodb-table-resource.factory.js";
 
@@ -56,6 +65,121 @@ async function deployIndexedOrders(simAws: SimAws): Promise<void> {
 }
 
 describe("DynamoDB CloudFormation Table secondary indexes", () => {
+  it("refuses an update that creates two global secondary indexes", async () => {
+    // Given a deployed table with one index and an item stored in it.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const initialTable = simCfnDynamoDbTableResourceFactory.make({
+      tableName: "orders",
+      partitionKeyName: "orderId",
+      properties: {
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+          { AttributeName: "first", AttributeType: "S" },
+        ],
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byFirst",
+            KeySchema: [{ AttributeName: "first", KeyType: "HASH" }],
+            Projection: { ProjectionType: "ALL" },
+          },
+        ],
+      },
+    });
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "orders-stack",
+      template: { Resources: { OrdersTable: initialTable } },
+    });
+    await stack.waitForDeployComplete();
+    await simAws.backgroundTasksComplete();
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: "orders",
+        Item: {
+          orderId: { S: "order-1" },
+          first: { S: "one" },
+          second: { S: "two" },
+          third: { S: "three" },
+        },
+      }),
+    );
+    const tableBeforeUpdate = simAws.dynamoDb().findTable("orders");
+
+    // When one CloudFormation update adds two indexes.
+    const updatedTable = simCfnDynamoDbTableResourceFactory.make({
+      tableName: "orders",
+      partitionKeyName: "orderId",
+      properties: {
+        AttributeDefinitions: [
+          { AttributeName: "orderId", AttributeType: "S" },
+          { AttributeName: "first", AttributeType: "S" },
+          { AttributeName: "second", AttributeType: "S" },
+          { AttributeName: "third", AttributeType: "S" },
+        ],
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: "byFirst",
+            KeySchema: [{ AttributeName: "first", KeyType: "HASH" }],
+            Projection: { ProjectionType: "ALL" },
+          },
+          {
+            IndexName: "bySecond",
+            KeySchema: [{ AttributeName: "second", KeyType: "HASH" }],
+            Projection: { ProjectionType: "ALL" },
+          },
+          {
+            IndexName: "byThird",
+            KeySchema: [{ AttributeName: "third", KeyType: "HASH" }],
+            Projection: { ProjectionType: "ALL" },
+          },
+        ],
+      },
+    });
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "orders-stack",
+        TemplateBody: jsonStringify({
+          Resources: { OrdersTable: updatedTable },
+        }),
+      }),
+    );
+    const error = await assertThrowsErrorAsync(async () => {
+      await cloudFormation.waitForStackUpdateComplete("orders-stack");
+    });
+
+    // Then DynamoDB refuses the update before the table changes.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertIdentical(error.name, "ValidationException");
+    assertIdentical(error.$metadata.httpStatusCode, 400);
+    assertIdentical(
+      error.message,
+      "Cannot perform more than one GSI creation or deletion in a single update",
+    );
+    assertIdentical(simAws.dynamoDb().findTable("orders"), tableBeforeUpdate);
+
+    const describedTable = await simAws
+      .dynamoDb()
+      .describeTable(new DescribeTableCommand({ TableName: "orders" }));
+    assertArrayLength(describedTable.Table?.GlobalSecondaryIndexes, 1);
+    assertIdentical(
+      describedTable.Table.GlobalSecondaryIndexes[0].IndexName,
+      "byFirst",
+    );
+
+    const stored = await simAws.dynamoDb().getItem(
+      new GetItemCommand({
+        TableName: "orders",
+        Key: { orderId: { S: "order-1" } },
+      }),
+    );
+    assertIdentical(stored.Item?.["third"]?.S, "three");
+
+    const describedStack = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: "orders-stack" }),
+    );
+    assertIdentical(describedStack.Stacks?.[0]?.StackStatus, "UPDATE_FAILED");
+  });
+
   it("describes the indexes a template declares", async () => {
     // Given a template declaring a global and a local secondary index.
     const simAws = new SimAws();

--- a/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-indexes.iso.test.ts
+++ b/src/service/dynamodb/cfn/sim-cfn-dynamodb-table-indexes.iso.test.ts
@@ -160,11 +160,10 @@ describe("DynamoDB CloudFormation Table secondary indexes", () => {
     const describedTable = await simAws
       .dynamoDb()
       .describeTable(new DescribeTableCommand({ TableName: "orders" }));
-    assertArrayLength(describedTable.Table?.GlobalSecondaryIndexes, 1);
-    assertIdentical(
-      describedTable.Table.GlobalSecondaryIndexes[0].IndexName,
-      "byFirst",
-    );
+    const indexes = describedTable.Table?.GlobalSecondaryIndexes;
+
+    assertArrayLength(indexes, 1);
+    assertIdentical(indexes[0].IndexName, "byFirst");
 
     const stored = await simAws.dynamoDb().getItem(
       new GetItemCommand({

--- a/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-update-validator.ts
+++ b/src/service/dynamodb/cfn/table/sim-cfn-dynamodb-table-update-validator.ts
@@ -1,0 +1,80 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type {
+  SimDynamoDbGlobalSecondaryIndexUpdateInput,
+  SimDynamoDbSecondaryIndexInput,
+} from "../../command/table/table.types.js";
+import { readSimDynamoDbIndexName } from "../../secondary-index/sim-dynamodb-index-name.js";
+import { SimDynamoDbIndexUpdate } from "../../table/sim-dynamodb-index-update.js";
+import { SimCfnDynamoDbTableProperties } from "./sim-cfn-dynamodb-table-properties.js";
+
+interface SimCfnDynamoDbTableUpdateValidatorProperties {
+  readonly currentResource: SimCfnResource;
+  readonly updatedResource: SimCfnResource;
+  readonly currentProperties: SimCfnTemplateValueRecord;
+  readonly updatedProperties: SimCfnTemplateValueRecord;
+}
+
+/**
+ * Validates constraints that apply when CloudFormation updates a table.
+ */
+export class SimCfnDynamoDbTableUpdateValidator {
+  private readonly properties: SimCfnDynamoDbTableUpdateValidatorProperties;
+
+  constructor(properties: SimCfnDynamoDbTableUpdateValidatorProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Refuse a template diff that asks DynamoDB for too many index operations.
+   *
+   * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+   */
+  assertAllowed(): void {
+    const { currentResource, updatedResource } = this.properties;
+    const current = this.tableProperties(
+      currentResource,
+      this.properties.currentProperties,
+    ).globalSecondaryIndexes();
+    const updated = this.tableProperties(
+      updatedResource,
+      this.properties.updatedProperties,
+    ).globalSecondaryIndexes();
+
+    SimDynamoDbIndexUpdate.fromInput(this.indexUpdates(current, updated));
+  }
+
+  private tableProperties(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+  ): SimCfnDynamoDbTableProperties {
+    return new SimCfnDynamoDbTableProperties({ resource, properties });
+  }
+
+  private indexUpdates(
+    current: readonly SimDynamoDbSecondaryIndexInput[],
+    updated: readonly SimDynamoDbSecondaryIndexInput[],
+  ): readonly SimDynamoDbGlobalSecondaryIndexUpdateInput[] {
+    const currentNames = new Set(
+      current.map((index) => readSimDynamoDbIndexName(index.IndexName)),
+    );
+    const updatedNames = new Set(
+      updated.map((index) => readSimDynamoDbIndexName(index.IndexName)),
+    );
+
+    return [
+      ...updated
+        .filter(
+          (index) =>
+            !currentNames.has(readSimDynamoDbIndexName(index.IndexName)),
+        )
+        .map((index) => ({ Create: index })),
+      ...current
+        .filter(
+          (index) =>
+            !updatedNames.has(readSimDynamoDbIndexName(index.IndexName)),
+        )
+        .map((index) => ({ Delete: { IndexName: index.IndexName } })),
+    ];
+  }
+}

--- a/src/service/dynamodb/command/table/sim-dynamodb-update-table-validation.iso.test.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-update-table-validation.iso.test.ts
@@ -96,10 +96,9 @@ describe("DynamoDB UpdateTableCommand validation", () => {
     });
 
     assertInstanceOf(error, SimDynamoDbValidationException);
-    assertStringIncludes(
+    assertIdentical(
       error.message,
-      "You can create or delete only one global secondary index per " +
-        "UpdateTable operation",
+      "Cannot perform more than one GSI creation or deletion in a single update",
     );
   });
 

--- a/src/service/dynamodb/table/sim-dynamodb-index-update.ts
+++ b/src/service/dynamodb/table/sim-dynamodb-index-update.ts
@@ -112,8 +112,7 @@ export class SimDynamoDbIndexUpdate {
 
     if (created.length + deleted.length > 1) {
       throw new SimDynamoDbValidationException(
-        "You can create or delete only one global secondary index per " +
-          "UpdateTable operation",
+        "Cannot perform more than one GSI creation or deletion in a single update",
       );
     }
 


### PR DESCRIPTION
## Change

CloudFormation now validates resource replacements before it deletes the current resource. DynamoDB table replacements reject updates that create or delete more than one global secondary index.

The regression test checks the `ValidationException` response, the `UPDATE_FAILED` stack status, and the unchanged table data and index definition.

## Checks

- `pnpm check`

Closes #1213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pre-update validation for CloudFormation resource replacements.
  - DynamoDB table updates now validate global secondary index changes before making modifications.
  - Invalid updates are rejected before existing resources or data are altered.

- **Bug Fixes**
  - Improved error reporting for requests that create or delete multiple global secondary indexes.
  - Preserved existing tables and data when an update fails validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->