### PR TITLE
fix(lambda): authorize destinations with execution role

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -3306,11 +3306,45 @@ const stack = await simAws.cloudFormation().deployTemplate({
         Type: "AWS::SQS::Queue",
         Properties: { QueueName: "orders-dlq" },
       },
+      OrdersRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrdersRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "SendFailedOrders",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: "sqs:SendMessage",
+                    Resource: [
+                      { "Fn::GetAtt": ["OrderFailures", "Arn"] },
+                      { "Fn::GetAtt": ["OrderDeadLetters", "Arn"] },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
       OrdersFunction: {
         Type: "AWS::Lambda::Function",
         Properties: {
           FunctionName: "orders",
-          Role: "arn:aws:iam::111111111111:role/OrdersRole",
+          Role: { "Fn::GetAtt": ["OrdersRole", "Arn"] },
           Handler: "index.handler",
           Runtime: "nodejs22.x",
           Code: {

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -946,6 +946,19 @@ results go. An invocation that fails its last attempt is sent to the `OnFailure`
 one whose handler returns is sent to `OnSuccess`. A destination ARN can name a simulated SQS queue,
 SNS topic, EventBridge event bus or Lambda function.
 
+The source function's execution role must allow the operation that writes to the destination:
+
+| Destination           | Required action         |
+| --------------------- | ----------------------- |
+| SQS queue             | `sqs:SendMessage`       |
+| SNS topic             | `sns:Publish`           |
+| EventBridge event bus | `events:PutEvents`      |
+| Lambda function       | `lambda:InvokeFunction` |
+
+Simulated Lambda calls the destination service with that role as its caller. A denied delivery
+rejects the background task without changing the destination. A Lambda destination is invoked
+asynchronously, so the delivery succeeds once the target invocation has been accepted.
+
 ```typescript sim-lambda-async-destinations
 /**
  * Asynchronous invocation retries and an OnFailure destination.
@@ -956,6 +969,7 @@ import {
   InvokeCommand,
   PutFunctionEventInvokeConfigCommand,
 } from "@aws-sdk/client-lambda";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
 
 import { SimAws } from "@kensio/yulin";
@@ -964,19 +978,51 @@ import {
   type SimLambdaDestinationRecord,
 } from "@kensio/yulin/lambda";
 
-const simAws = new SimAws();
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const iam = simAws.iam();
 const lambda = simAws.lambda();
 const sqs = simAws.sqs();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:order-failures`;
 
 const created = await sqs.createQueue(
   new CreateQueueCommand({ QueueName: "order-failures" }),
+);
+
+const role = await iam.createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+const roleArn = role.Role.Arn;
+
+await iam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersRole",
+    PolicyName: "SendFailedOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+      },
+    }),
+  }),
 );
 
 const attempts: string[] = [];
 await lambda.createFunction(
   new CreateFunctionCommand({
     FunctionName: "orders",
-    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Role: roleArn,
     Code: {
       ZipFile: makeLambdaZipFileInput((event: { id: number }) => {
         attempts.push(`tried order ${event.id}`);
@@ -992,7 +1038,7 @@ await lambda.putFunctionEventInvokeConfig(
     MaximumRetryAttempts: 1,
     DestinationConfig: {
       OnFailure: {
-        Destination: "arn:aws:sqs:us-east-1:888888888888:order-failures",
+        Destination: queueArn,
       },
     },
   }),
@@ -1041,33 +1087,67 @@ a config of its own, and an invocation of a qualifier with no config of its own 
 `DeadLetterConfig` is the older way to keep a failed asynchronous invocation, and simulated Lambda
 takes it on `CreateFunction` and `UpdateFunctionConfiguration`. Its `TargetArn` names a simulated
 SQS queue or SNS topic, which receives the event as it was invoked rather than the destination
-record around it.
+record around it. The execution role needs `sqs:SendMessage` for a queue or `sns:Publish` for a
+topic. A denied delivery rejects the background task and leaves the target unchanged.
 
 ```typescript sim-lambda-dead-letter-queue
 /**
  * A simulated Lambda function with a dead-letter queue.
  */
 
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
 import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
 
 import { SimAws } from "@kensio/yulin";
 import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
 
-const simAws = new SimAws();
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const iam = simAws.iam();
 const lambda = simAws.lambda();
 const sqs = simAws.sqs();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders-dlq`;
 
 const created = await sqs.createQueue(
   new CreateQueueCommand({ QueueName: "orders-dlq" }),
 );
 
+const role = await iam.createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+const roleArn = role.Role.Arn;
+
+await iam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersRole",
+    PolicyName: "SendFailedOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
 await lambda.createFunction(
   new CreateFunctionCommand({
     FunctionName: "orders",
-    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Role: roleArn,
     DeadLetterConfig: {
-      TargetArn: "arn:aws:sqs:us-east-1:888888888888:orders-dlq",
+      TargetArn: queueArn,
     },
     Code: {
       ZipFile: makeLambdaZipFileInput(() => {
@@ -3531,7 +3611,8 @@ Sim Lambda currently supports:
 - `InvokeCommand`, with the `RequestResponse`, `Event` and `DryRun` invocation types
 - Asynchronous invocation retries on the simulated clock, and `OnSuccess`/`OnFailure` destinations
   written with `PutFunctionEventInvokeConfigCommand`, delivering the AWS destination record to a
-  simulated SQS queue, SNS topic, EventBridge event bus or Lambda function
+  simulated SQS queue, SNS topic, EventBridge event bus or Lambda function after authorizing the
+  target operation against the source function's execution role
 - `GetFunctionEventInvokeConfigCommand`, `UpdateFunctionEventInvokeConfigCommand`,
   `DeleteFunctionEventInvokeConfigCommand` and `ListFunctionEventInvokeConfigsCommand`, each taking
   a `Qualifier` for a version's or an alias's own config
@@ -3609,10 +3690,6 @@ Current documented limitations:
   settings simulated Lambda models, leaving out `Layers`, `VpcConfig`, `TracingConfig`, `KMSKeyArn`,
   `EphemeralStorage`, `SnapStart`, `LoggingConfig` and `RevisionId`. `ListFunctions` leaves out
   `Marker`/`MaxItems` paging and `MasterRegion`.
-- A destination is delivered to without checking that the function's execution role may write to it.
-  Real Lambda delivers under that role and drops the record where the role cannot, which would be
-  silent, so simulated Lambda delivers instead. Nothing else about the destination has to be set up,
-  since a destination needs no resource policy on real AWS either.
 - SAM's `EventInvokeConfig` and `DeadLetterQueue` on `AWS::Serverless::Function` are left out. A
   SAM application declaring either deploys a function with the default retries, no destinations and
   no dead-letter target. The `AWS::Lambda::EventInvokeConfig` Resource and the `DeadLetterConfig`

--- a/docs/services/lambda/sim-lambda-async-destinations.example.ts
+++ b/docs/services/lambda/sim-lambda-async-destinations.example.ts
@@ -7,6 +7,7 @@ import {
   InvokeCommand,
   PutFunctionEventInvokeConfigCommand,
 } from "@aws-sdk/client-lambda";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
 
 import { SimAws } from "@kensio/yulin";
@@ -15,19 +16,51 @@ import {
   type SimLambdaDestinationRecord,
 } from "@kensio/yulin/lambda";
 
-const simAws = new SimAws();
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const iam = simAws.iam();
 const lambda = simAws.lambda();
 const sqs = simAws.sqs();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:order-failures`;
 
 const created = await sqs.createQueue(
   new CreateQueueCommand({ QueueName: "order-failures" }),
+);
+
+const role = await iam.createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+const roleArn = role.Role.Arn;
+
+await iam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersRole",
+    PolicyName: "SendFailedOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+      },
+    }),
+  }),
 );
 
 const attempts: string[] = [];
 await lambda.createFunction(
   new CreateFunctionCommand({
     FunctionName: "orders",
-    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Role: roleArn,
     Code: {
       ZipFile: makeLambdaZipFileInput((event: { id: number }) => {
         attempts.push(`tried order ${event.id}`);
@@ -43,7 +76,7 @@ await lambda.putFunctionEventInvokeConfig(
     MaximumRetryAttempts: 1,
     DestinationConfig: {
       OnFailure: {
-        Destination: "arn:aws:sqs:us-east-1:888888888888:order-failures",
+        Destination: queueArn,
       },
     },
   }),

--- a/docs/services/lambda/sim-lambda-cloudformation-event-invoke-config.example.ts
+++ b/docs/services/lambda/sim-lambda-cloudformation-event-invoke-config.example.ts
@@ -23,11 +23,45 @@ const stack = await simAws.cloudFormation().deployTemplate({
         Type: "AWS::SQS::Queue",
         Properties: { QueueName: "orders-dlq" },
       },
+      OrdersRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "OrdersRole",
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: "SendFailedOrders",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: [
+                  {
+                    Effect: "Allow",
+                    Action: "sqs:SendMessage",
+                    Resource: [
+                      { "Fn::GetAtt": ["OrderFailures", "Arn"] },
+                      { "Fn::GetAtt": ["OrderDeadLetters", "Arn"] },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
       OrdersFunction: {
         Type: "AWS::Lambda::Function",
         Properties: {
           FunctionName: "orders",
-          Role: "arn:aws:iam::111111111111:role/OrdersRole",
+          Role: { "Fn::GetAtt": ["OrdersRole", "Arn"] },
           Handler: "index.handler",
           Runtime: "nodejs22.x",
           Code: {

--- a/docs/services/lambda/sim-lambda-dead-letter-queue.example.ts
+++ b/docs/services/lambda/sim-lambda-dead-letter-queue.example.ts
@@ -2,26 +2,59 @@
  * A simulated Lambda function with a dead-letter queue.
  */
 
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
 import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
 
 import { SimAws } from "@kensio/yulin";
 import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
 
-const simAws = new SimAws();
+const simAws = new SimAws({ defaultAccountId: "111111111111" });
+const iam = simAws.iam();
 const lambda = simAws.lambda();
 const sqs = simAws.sqs();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders-dlq`;
 
 const created = await sqs.createQueue(
   new CreateQueueCommand({ QueueName: "orders-dlq" }),
 );
 
+const role = await iam.createRole(
+  new CreateRoleCommand({
+    RoleName: "OrdersRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+const roleArn = role.Role.Arn;
+
+await iam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrdersRole",
+    PolicyName: "SendFailedOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "sqs:SendMessage",
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
 await lambda.createFunction(
   new CreateFunctionCommand({
     FunctionName: "orders",
-    Role: "arn:aws:iam::111111111111:role/OrdersRole",
+    Role: roleArn,
     DeadLetterConfig: {
-      TargetArn: "arn:aws:sqs:us-east-1:888888888888:orders-dlq",
+      TargetArn: queueArn,
     },
     Code: {
       ZipFile: makeLambdaZipFileInput(() => {

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -754,6 +754,13 @@ deploying.
 still there first, since deleting a function takes its configs with it and a Stack that reached the
 function first would otherwise fail a deletion over work it had already done.
 
+`destination/sim-aws-lambda-destinations.ts` sends each result through the ordinary simulated
+operation for the target service, with the source function's execution role as the caller. SQS
+checks `sqs:SendMessage`, SNS checks `sns:Publish`, EventBridge checks `events:PutEvents`, and Lambda
+checks `lambda:InvokeFunction`. The Lambda destination is invoked with `InvocationType: "Event"`,
+so delivery finishes once that invocation is accepted. A failed authorization rejects the
+background delivery before the target changes.
+
 ### Versions and aliases
 
 `cfn/version/` publishes `AWS::Lambda::Version` through `PublishVersion`, and `cfn/alias/` creates

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-dead-letter-config.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-dead-letter-config.iso.test.ts
@@ -54,6 +54,26 @@ async function deployOrders(
           Properties: {
             RoleName: "OrdersRole",
             AssumeRolePolicyDocument: assumeRolePolicyDocument,
+            Policies: [
+              {
+                PolicyName: "SendDeadLetters",
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [
+                    {
+                      Effect: "Allow",
+                      Action: "sqs:SendMessage",
+                      Resource: ordersQueueArn,
+                    },
+                    {
+                      Effect: "Allow",
+                      Action: "sns:Publish",
+                      Resource: ordersTopicArn,
+                    },
+                  ],
+                },
+              },
+            ],
           },
         },
         OrdersFunction: {

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-destinations.iso.test.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-destinations.iso.test.ts
@@ -8,6 +8,8 @@ import {
   assertIdentical,
   assertNonNullable,
   assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -74,7 +76,10 @@ async function ruleToQueue(
 describe("Lambda asynchronous invocation destinations", () => {
   it("sends a record to an OnFailure queue once the retries are exhausted", async () => {
     // Given a failing function sending its failures to a queue.
-    const { simAws } = await simAwsWithAsyncFunction();
+    const { simAws } = await simAwsWithAsyncFunction({
+      roleActions: ["sqs:SendMessage"],
+      roleResource: simLambdaQueueArn("failures"),
+    });
     const queueUrl = await makeQueue(simAws, "failures");
     await putEventInvokeConfig(simAws, {
       MaximumRetryAttempts: 1,
@@ -99,8 +104,11 @@ describe("Lambda asynchronous invocation destinations", () => {
 
   it("sends a record to an OnSuccess topic when the handler returns", async () => {
     // Given a function that works, publishing its successes to a topic.
+    const topicArn = "arn:aws:sns:us-east-1:888888888888:results";
     const { simAws } = await simAwsWithAsyncFunction({
       failuresBeforeSuccess: 0,
+      roleActions: ["sns:Publish"],
+      roleResource: topicArn,
     });
     const created = await simAws
       .sns()
@@ -127,7 +135,12 @@ describe("Lambda asynchronous invocation destinations", () => {
 
   it("invokes a function destination with the record", async () => {
     // Given a failing function sending its failures to another function.
-    const { simAws } = await simAwsWithAsyncFunction();
+    const destinationArn =
+      "arn:aws:lambda:us-east-1:888888888888:function:repairs";
+    const { simAws } = await simAwsWithAsyncFunction({
+      roleActions: ["lambda:InvokeFunction"],
+      roleResource: destinationArn,
+    });
     const handled: unknown[] = [];
     await simAws.lambda().createFunction(
       new CreateFunctionCommand({
@@ -143,7 +156,7 @@ describe("Lambda asynchronous invocation destinations", () => {
     );
     await putEventInvokeConfig(simAws, {
       MaximumRetryAttempts: 0,
-      OnFailure: "arn:aws:lambda:us-east-1:888888888888:function:repairs",
+      OnFailure: destinationArn,
     });
 
     // When the failing function is invoked asynchronously.
@@ -158,12 +171,16 @@ describe("Lambda asynchronous invocation destinations", () => {
   it("puts a record on an event bus destination", async () => {
     // Given a failing function sending its failures to the default bus, and a
     // rule carrying what lands there on to a queue.
-    const { simAws } = await simAwsWithAsyncFunction();
+    const busArn = "arn:aws:events:us-east-1:888888888888:event-bus/default";
+    const { simAws } = await simAwsWithAsyncFunction({
+      roleActions: ["events:PutEvents"],
+      roleResource: busArn,
+    });
     const queueUrl = await makeQueue(simAws, "results-queue");
     await ruleToQueue(simAws, queueUrl, "results-queue");
     await putEventInvokeConfig(simAws, {
       MaximumRetryAttempts: 0,
-      OnFailure: "arn:aws:events:us-east-1:888888888888:event-bus/default",
+      OnFailure: busArn,
     });
 
     // When the function is invoked asynchronously.
@@ -223,5 +240,123 @@ describe("Lambda asynchronous invocation destinations", () => {
     const record = await receivedRecord(simAws, queueUrl);
     assertIdentical(record.requestContext.condition, "EventAgeExceeded");
     assertUndefined(record.responseContext);
+  });
+
+  it("refuses a queue destination the execution role may not send to", async () => {
+    // Given a failing function whose execution Role cannot send to its queue
+    // destination.
+    const { simAws } = await simAwsWithAsyncFunction({
+      roleActions: ["lambda:GetFunction"],
+    });
+    const queueUrl = await makeQueue(simAws, "failures");
+    await putEventInvokeConfig(simAws, {
+      MaximumRetryAttempts: 0,
+      OnFailure: simLambdaQueueArn("failures"),
+    });
+
+    // When its failure record is delivered.
+    const error = await assertThrowsErrorAsync(async () => {
+      await invokeAsyncAndSettle(simAws);
+    });
+
+    // Then IAM refuses the execution Role and the queue remains empty.
+    assertStringIncludes(error.message, "role/OrdersRole");
+    assertStringIncludes(error.message, "sqs:SendMessage");
+    assertStringIncludes(error.message, simLambdaQueueArn("failures"));
+    assertArrayEmpty(await receivedBodies(simAws, queueUrl));
+  });
+
+  it("refuses a topic destination the execution role may not publish to", async () => {
+    // Given a successful function whose execution Role cannot publish to its
+    // topic destination.
+    const { simAws } = await simAwsWithAsyncFunction({
+      failuresBeforeSuccess: 0,
+      roleActions: ["lambda:GetFunction"],
+    });
+    const created = await simAws
+      .sns()
+      .createTopic(new CreateTopicCommand({ Name: "results" }));
+    assertNonNullable(created.TopicArn, "CreateTopic answered with an ARN");
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "results-queue",
+      created.TopicArn,
+    );
+    await putEventInvokeConfig(simAws, { OnSuccess: created.TopicArn });
+
+    // When its success record is delivered.
+    const error = await assertThrowsErrorAsync(async () => {
+      await invokeAsyncAndSettle(simAws);
+    });
+
+    // Then IAM refuses the execution Role and the subscriber receives nothing.
+    assertStringIncludes(error.message, "role/OrdersRole");
+    assertStringIncludes(error.message, "sns:Publish");
+    assertStringIncludes(error.message, created.TopicArn);
+    assertArrayEmpty(await receivedBodies(simAws, queueUrl));
+  });
+
+  it("refuses an event bus destination the execution role may not put to", async () => {
+    // Given a failing function whose execution Role cannot put events on its
+    // bus destination.
+    const { simAws } = await simAwsWithAsyncFunction({
+      roleActions: ["lambda:GetFunction"],
+    });
+    const queueUrl = await makeQueue(simAws, "results-queue");
+    await ruleToQueue(simAws, queueUrl, "results-queue");
+    const busArn = "arn:aws:events:us-east-1:888888888888:event-bus/default";
+    await putEventInvokeConfig(simAws, {
+      MaximumRetryAttempts: 0,
+      OnFailure: busArn,
+    });
+
+    // When its failure record is delivered.
+    const error = await assertThrowsErrorAsync(async () => {
+      await invokeAsyncAndSettle(simAws);
+    });
+
+    // Then IAM refuses the execution Role and no rule receives an event.
+    assertStringIncludes(error.message, "role/OrdersRole");
+    assertStringIncludes(error.message, "events:PutEvents");
+    assertStringIncludes(error.message, busArn);
+    assertArrayEmpty(await receivedBodies(simAws, queueUrl));
+  });
+
+  it("refuses a function destination the execution role may not invoke", async () => {
+    // Given a failing function whose execution Role cannot invoke its function
+    // destination.
+    const { simAws } = await simAwsWithAsyncFunction({
+      roleActions: ["lambda:GetFunction"],
+    });
+    const handled: unknown[] = [];
+    const destinationArn =
+      "arn:aws:lambda:us-east-1:888888888888:function:repairs";
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "repairs",
+        Role: "arn:aws:iam::888888888888:role/RepairsRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: unknown) => {
+            handled.push(event);
+            return null;
+          }),
+        },
+      }),
+    );
+    await putEventInvokeConfig(simAws, {
+      MaximumRetryAttempts: 0,
+      OnFailure: destinationArn,
+    });
+
+    // When its failure record is delivered.
+    const error = await assertThrowsErrorAsync(async () => {
+      await invokeAsyncAndSettle(simAws);
+    });
+
+    // Then IAM refuses the execution Role and the destination does not run.
+    assertStringIncludes(error.message, "role/OrdersRole");
+    assertStringIncludes(error.message, "lambda:InvokeFunction");
+    assertStringIncludes(error.message, destinationArn);
+    assertArrayEmpty(handled);
   });
 });

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-invocation.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-invocation.ts
@@ -11,6 +11,7 @@ import {
   SimLambdaAsyncOutcomeDelivery,
   simLambdaSuccessOutcome,
 } from "./sim-lambda-async-outcome.js";
+import { simLambdaHandlerAttempt } from "./sim-lambda-handler-attempt.js";
 
 interface SimLambdaAsyncInvocationProperties {
   readonly simFunction: SimLambdaFunction;
@@ -44,23 +45,24 @@ export class SimLambdaAsyncInvocation {
    * Accept the invocation and let it run behind the caller.
    */
   start(): void {
-    this.properties.background.schedule(async () => {
-      await this.attempt();
-    });
+    this.properties.background.schedule(() => this.attempt());
   }
 
   private async attempt(): Promise<void> {
     const { simFunction, event } = this.properties;
     this.attemptCount += 1;
 
-    try {
-      await this.outcomes.deliver(
-        simLambdaSuccessOutcome(await simFunction.invoke(event)),
-        this.attemptCount,
-      );
-    } catch (error) {
-      await this.failed(error);
+    const attempt = await simLambdaHandlerAttempt(simFunction, event);
+
+    if (!attempt.succeeded) {
+      await this.failed(attempt.error);
+      return;
     }
+
+    await this.outcomes.deliver(
+      simLambdaSuccessOutcome(attempt.result),
+      this.attemptCount,
+    );
   }
 
   /**
@@ -77,11 +79,10 @@ export class SimLambdaAsyncInvocation {
 
     background.scheduleAt(
       simLambdaRetryDueTime(background.now(), this.attemptCount),
-      async () => {
-        await (simLambdaEventTooOld(this.startedAt, background.now(), settings)
+      () =>
+        simLambdaEventTooOld(this.startedAt, background.now(), settings)
           ? this.abandon(error, "EventAgeExceeded")
-          : this.attempt());
-      },
+          : this.attempt(),
     );
   }
 

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-outcome.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-outcome.ts
@@ -104,6 +104,7 @@ export class SimLambdaAsyncOutcomeDelivery {
     await destinations.deliver({
       destinationArn: SimLambdaDestinationArn.of(destination),
       sourceFunctionArn: simFunction.arn,
+      sourceFunctionRoleArn: simFunction.roleArn,
       record: makeSimLambdaDestinationRecord({
         requestId: this.requestId,
         functionArn: simFunction.arn,
@@ -131,6 +132,7 @@ export class SimLambdaAsyncOutcomeDelivery {
       targetArn: SimLambdaDestinationArn.of(settings.deadLetterArn),
       payload: event,
       sourceFunctionArn: simFunction.arn,
+      sourceFunctionRoleArn: simFunction.roleArn,
     });
   }
 }

--- a/src/service/lambda/command/invoke/async/sim-lambda-dead-letter.iso.test.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-dead-letter.iso.test.ts
@@ -3,12 +3,14 @@ import {
   GetFunctionCommand,
   UpdateFunctionConfigurationCommand,
 } from "@aws-sdk/client-lambda";
+import { CreateTopicCommand } from "@aws-sdk/client-sns";
 import {
   assertArrayEmpty,
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
   assertObjectEquals,
+  assertStringIncludes,
   assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
@@ -24,14 +26,21 @@ import {
   simLambdaAsyncFunctionName,
   simLambdaQueueArn,
 } from "../../../../../../test/lambda/async-destination-fixture.js";
+import {
+  simSnsDeliveredMessage,
+  simSnsSubscribedQueue,
+} from "../../../../../../test/sns/subscription-fixture.js";
 import { SimAws } from "../../../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../../index.js";
 
 describe("Lambda dead-letter config", () => {
   it("sends the invoked event to a dead-letter queue when every attempt fails", async () => {
     // Given a failing function with a dead-letter queue.
+    const deadLetterArn = simLambdaQueueArn("orders-dlq");
     const { simAws } = await simAwsWithAsyncFunction({
       deadLetterTargetArn: simLambdaQueueArn("orders-dlq"),
+      roleActions: ["sqs:SendMessage"],
+      roleResource: deadLetterArn,
     });
     const queueUrl = await makeQueue(simAws, "orders-dlq");
     await putEventInvokeConfig(simAws, { MaximumRetryAttempts: 0 });
@@ -44,6 +53,89 @@ describe("Lambda dead-letter config", () => {
     const [body] = await receivedBodies(simAws, queueUrl);
     assertNonNullable(body, "the dead-letter queue received the event");
     assertObjectEquals(JSON.parse(body) as object, { id: 7 });
+  });
+
+  it("publishes the invoked event to an allowed dead-letter topic", async () => {
+    // Given a failing function whose execution Role may publish to its
+    // dead-letter topic.
+    const topicArn = "arn:aws:sns:us-east-1:888888888888:orders-failures";
+    const { simAws } = await simAwsWithAsyncFunction({
+      deadLetterTargetArn: topicArn,
+      roleActions: ["sns:Publish"],
+      roleResource: topicArn,
+    });
+    const created = await simAws
+      .sns()
+      .createTopic(new CreateTopicCommand({ Name: "orders-failures" }));
+    assertIdentical(created.TopicArn, topicArn);
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "dead-letter-subscriber",
+      topicArn,
+    );
+    await putEventInvokeConfig(simAws, { MaximumRetryAttempts: 0 });
+
+    // When every invocation attempt fails.
+    await invokeAsyncAndSettle(simAws);
+
+    // Then the topic publishes the original event to its subscriber.
+    const body = await simSnsDeliveredMessage(simAws, queueUrl);
+    assertNonNullable(body, "the topic delivered a message");
+    const envelope = JSON.parse(body) as { readonly Message: string };
+    assertObjectEquals(JSON.parse(envelope.Message) as object, { id: 7 });
+  });
+
+  it("refuses a dead-letter queue the execution role may not send to", async () => {
+    // Given a failing function whose execution Role cannot send to its
+    // dead-letter queue.
+    const deadLetterArn = simLambdaQueueArn("orders-dlq");
+    const { simAws } = await simAwsWithAsyncFunction({
+      deadLetterTargetArn: deadLetterArn,
+      roleActions: ["lambda:GetFunction"],
+    });
+    const queueUrl = await makeQueue(simAws, "orders-dlq");
+    await putEventInvokeConfig(simAws, { MaximumRetryAttempts: 0 });
+
+    // When every invocation attempt fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await invokeAsyncAndSettle(simAws);
+    });
+
+    // Then IAM refuses the execution Role and the queue remains empty.
+    assertStringIncludes(error.message, "role/OrdersRole");
+    assertStringIncludes(error.message, "sqs:SendMessage");
+    assertStringIncludes(error.message, deadLetterArn);
+    assertArrayEmpty(await receivedBodies(simAws, queueUrl));
+  });
+
+  it("refuses a dead-letter topic the execution role may not publish to", async () => {
+    // Given a failing function whose execution Role cannot publish to its
+    // dead-letter topic.
+    const topicArn = "arn:aws:sns:us-east-1:888888888888:orders-failures";
+    const { simAws } = await simAwsWithAsyncFunction({
+      deadLetterTargetArn: topicArn,
+      roleActions: ["lambda:GetFunction"],
+    });
+    await simAws
+      .sns()
+      .createTopic(new CreateTopicCommand({ Name: "orders-failures" }));
+    const { queueUrl } = await simSnsSubscribedQueue(
+      simAws,
+      "dead-letter-subscriber",
+      topicArn,
+    );
+    await putEventInvokeConfig(simAws, { MaximumRetryAttempts: 0 });
+
+    // When every invocation attempt fails.
+    const error = await assertThrowsErrorAsync(async () => {
+      await invokeAsyncAndSettle(simAws);
+    });
+
+    // Then IAM refuses the execution Role and the subscriber receives nothing.
+    assertStringIncludes(error.message, "role/OrdersRole");
+    assertStringIncludes(error.message, "sns:Publish");
+    assertStringIncludes(error.message, topicArn);
+    assertArrayEmpty(await receivedBodies(simAws, queueUrl));
   });
 
   it("leaves the dead-letter queue empty when a retry succeeds", async () => {

--- a/src/service/lambda/command/invoke/async/sim-lambda-handler-attempt.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-handler-attempt.ts
@@ -1,0 +1,20 @@
+import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js";
+
+export type SimLambdaHandlerAttempt =
+  | { readonly succeeded: true; readonly result: unknown }
+  | { readonly succeeded: false; readonly error: unknown };
+
+/**
+ * Invoke a function handler while keeping its error separate from later
+ * destination delivery errors.
+ */
+export async function simLambdaHandlerAttempt(
+  simFunction: SimLambdaFunction,
+  event: unknown,
+): Promise<SimLambdaHandlerAttempt> {
+  try {
+    return { succeeded: true, result: await simFunction.invoke(event) };
+  } catch (error) {
+    return { succeeded: false, error };
+  }
+}

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-bus.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-bus.ts
@@ -21,18 +21,21 @@ export class SimLambdaDestinationBus {
         ? "Success"
         : "Failure";
 
-    await scope.eventBridge().putEvents({
-      input: {
-        Entries: [
-          {
-            Source: "lambda",
-            DetailType: `Lambda Function Invocation Result - ${outcome}`,
-            Detail: JSON.stringify(request.record),
-            EventBusName: request.destinationArn.eventBusName,
-            Resources: [request.sourceFunctionArn],
-          },
-        ],
+    await scope.eventBridge().putEvents(
+      {
+        input: {
+          Entries: [
+            {
+              Source: "lambda",
+              DetailType: `Lambda Function Invocation Result - ${outcome}`,
+              Detail: JSON.stringify(request.record),
+              EventBusName: request.destinationArn.eventBusName,
+              Resources: [request.sourceFunctionArn],
+            },
+          ],
+        },
       },
-    });
+      { caller: { kind: "arn", arn: request.sourceFunctionRoleArn } },
+    );
   }
 }

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-function.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-function.ts
@@ -1,5 +1,4 @@
 import type { SimAwsAccountRegionContainer } from "../../../aws/sim-aws-account-region-scope.js";
-import { SimLambdaError } from "../../error/sim-lambda.error.js";
 import type { SimLambdaDestinationDeliveryRequest } from "../sim-lambda-destination-targets.js";
 
 /**
@@ -15,20 +14,17 @@ export class SimLambdaDestinationFunction {
     request: SimLambdaDestinationDeliveryRequest,
   ): Promise<void> {
     const { destinationArn: arn } = request;
-    const target = scope
-      .lambda()
-      .getSimFunctionTarget(arn.functionName, arn.functionQualifier);
 
-    if (target === undefined) {
-      throw new SimLambdaError(
-        `${arn.value} is not a simulated Lambda function.`,
-      );
-    }
-
-    // Invoked directly rather than through an Invoke command, because this is
-    // already inside the background task standing for the asynchronous
-    // invocation, and because a delivery failure has to reach the caller who
-    // advanced the clock rather than being swallowed a second time.
-    await target.simFunction.invoke(request.record);
+    await scope.lambda().invoke(
+      {
+        input: {
+          FunctionName: arn.functionName,
+          Qualifier: arn.functionQualifier,
+          InvocationType: "Event",
+          Payload: JSON.stringify(request.record),
+        },
+      },
+      { caller: { kind: "arn", arn: request.sourceFunctionRoleArn } },
+    );
   }
 }

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-queue.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-queue.ts
@@ -23,11 +23,12 @@ export class SimLambdaDestinationQueue {
 
     // Sent through the ordinary SendMessage path, so what arrives is the same
     // thing an SDK caller would have sent.
-    await send.scope
-      .sqs()
-      .sendMessage(
-        { input: { QueueUrl: queue.arn.url, MessageBody: send.body } },
-        { sourceArn: send.sourceFunctionArn },
-      );
+    await send.scope.sqs().sendMessage(
+      { input: { QueueUrl: queue.arn.url, MessageBody: send.body } },
+      {
+        caller: { kind: "arn", arn: send.sourceFunctionRoleArn },
+        sourceArn: send.sourceFunctionArn,
+      },
+    );
   }
 }

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-send.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-send.ts
@@ -13,4 +13,7 @@ export interface SimLambdaDestinationSend {
    * The function this came from, supplied to IAM as `aws:SourceArn`.
    */
   readonly sourceFunctionArn: string;
+
+  /** The execution Role Lambda uses to send the document. */
+  readonly sourceFunctionRoleArn: string;
 }

--- a/src/service/lambda/destination/deliver/sim-lambda-destination-topic.ts
+++ b/src/service/lambda/destination/deliver/sim-lambda-destination-topic.ts
@@ -21,11 +21,12 @@ export class SimLambdaDestinationTopic {
       );
     }
 
-    await send.scope
-      .sns()
-      .publish(
-        { input: { TopicArn: topic.arn.value, Message: send.body } },
-        { sourceArn: send.sourceFunctionArn },
-      );
+    await send.scope.sns().publish(
+      { input: { TopicArn: topic.arn.value, Message: send.body } },
+      {
+        caller: { kind: "arn", arn: send.sourceFunctionRoleArn },
+        sourceArn: send.sourceFunctionArn,
+      },
+    );
   }
 }

--- a/src/service/lambda/destination/sim-aws-lambda-destinations.ts
+++ b/src/service/lambda/destination/sim-aws-lambda-destinations.ts
@@ -24,12 +24,10 @@ interface SimAwsLambdaDestinationsProperties {
  * built: reaching another service while this one is being constructed is a
  * cycle with no bottom to it.
  *
- * Real Lambda delivers under the function's own execution role, and delivers
- * nothing when that role cannot write to the destination. The permission is
- * left unchecked here, so a delivery is made as the destination Account's own
- * root. A record that silently goes nowhere is the harder failure to find, and
- * a destination needs no resource policy on real AWS either, so nothing about
- * the destination itself has to be set up for a record to arrive.
+ * Every delivery uses the source function's execution Role as its caller. The
+ * destination service applies its ordinary IAM checks to that Role before it
+ * changes any state.
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/invocation-async-retain-records.html
  */
 export class SimAwsLambdaDestinations implements SimLambdaDestinationTargets {
   private readonly simAws: SimAws;
@@ -76,6 +74,7 @@ export class SimAwsLambdaDestinations implements SimLambdaDestinationTargets {
       arn: request.targetArn,
       body: JSON.stringify(request.payload),
       sourceFunctionArn: request.sourceFunctionArn,
+      sourceFunctionRoleArn: request.sourceFunctionRoleArn,
     };
 
     await (request.targetArn.service === "sqs"
@@ -91,6 +90,7 @@ export class SimAwsLambdaDestinations implements SimLambdaDestinationTargets {
       arn: request.destinationArn,
       body: JSON.stringify(request.record),
       sourceFunctionArn: request.sourceFunctionArn,
+      sourceFunctionRoleArn: request.sourceFunctionRoleArn,
     };
   }
 

--- a/src/service/lambda/destination/sim-lambda-destination-targets.ts
+++ b/src/service/lambda/destination/sim-lambda-destination-targets.ts
@@ -14,6 +14,9 @@ export interface SimLambdaDestinationDeliveryRequest {
    * delivery is attributed to.
    */
   readonly sourceFunctionArn: string;
+
+  /** The execution Role Lambda uses to deliver this record. */
+  readonly sourceFunctionRoleArn: string;
 }
 
 /**
@@ -27,6 +30,7 @@ export interface SimLambdaDeadLetterRequest {
   readonly targetArn: SimLambdaDestinationArn;
   readonly payload: unknown;
   readonly sourceFunctionArn: string;
+  readonly sourceFunctionRoleArn: string;
 }
 
 /**

--- a/src/service/scheduler/delivery/sim-scheduler-delivery.iso.test.ts
+++ b/src/service/scheduler/delivery/sim-scheduler-delivery.iso.test.ts
@@ -190,6 +190,37 @@ describe("Scheduler target invocation", () => {
         new CreateQueueCommand({ QueueName: "lambda-dead-letters" }),
       );
 
+    await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "ReconcileRole",
+        AssumeRolePolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Principal: { Service: "lambda.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ReconcileRole",
+        PolicyName: "SendFailures",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: {
+            Effect: "Allow",
+            Action: "sqs:SendMessage",
+            Resource: [
+              "arn:aws:sqs:us-east-1:888888888888:lambda-failures",
+              "arn:aws:sqs:us-east-1:888888888888:lambda-dead-letters",
+            ],
+          },
+        }),
+      }),
+    );
+
     await simAws.lambda().createFunction({
       input: {
         FunctionName: "reconcile",

--- a/test/lambda/async-destination-fixture.ts
+++ b/test/lambda/async-destination-fixture.ts
@@ -17,12 +17,20 @@ import { CreateQueueCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
 import { assertNonNullable } from "@kensio/smartass";
 
 import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../src/service/iam/role/sim-iam-role-with-policy.factory.js";
 import type { SimLambdaDestinationRecord } from "../../src/service/lambda/destination/sim-lambda-destination-record.js";
 import { makeLambdaZipFileInput } from "../../src/service/lambda/index.js";
 
 export const simLambdaAsyncFunctionName = "orders";
 export const simLambdaAsyncFunctionArn =
   "arn:aws:lambda:us-east-1:888888888888:function:orders";
+
+export const simLambdaDestinationActions = [
+  "sqs:SendMessage",
+  "sns:Publish",
+  "events:PutEvents",
+  "lambda:InvokeFunction",
+] as const;
 
 /**
  * The ARN of a queue of a name in the default Account and Region.
@@ -46,6 +54,8 @@ interface SimLambdaAsyncFunctionProperties {
    */
   readonly failuresBeforeSuccess?: number | undefined;
   readonly deadLetterTargetArn?: string | undefined;
+  readonly roleActions?: readonly string[] | undefined;
+  readonly roleResource?: string | undefined;
 }
 
 /**
@@ -57,11 +67,20 @@ export async function simAwsWithAsyncFunction(
   const { failuresBeforeSuccess = Infinity } = properties;
   const simAws = new SimAws();
   let attempts = 0;
+  const executionRole = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "OrdersRole",
+      policyName: "DestinationDelivery",
+      actions: properties.roleActions ?? simLambdaDestinationActions,
+      resource: properties.roleResource ?? "*",
+    },
+    simAws,
+  );
 
   await simAws.lambda().createFunction(
     new CreateFunctionCommand({
       FunctionName: simLambdaAsyncFunctionName,
-      Role: "arn:aws:iam::888888888888:role/OrdersRole",
+      Role: executionRole.Arn,
       DeadLetterConfig:
         properties.deadLetterTargetArn === undefined
           ? undefined

--- a/test/lambda/cfn-event-invoke-config-fixture.ts
+++ b/test/lambda/cfn-event-invoke-config-fixture.ts
@@ -53,6 +53,19 @@ export function ordersTemplate(
         Properties: {
           RoleName: "OrdersRole",
           AssumeRolePolicyDocument: assumeRolePolicyDocument,
+          Policies: [
+            {
+              PolicyName: "SendOrderFailures",
+              PolicyDocument: {
+                Version: "2012-10-17",
+                Statement: {
+                  Effect: "Allow",
+                  Action: "sqs:SendMessage",
+                  Resource: ordersFailuresQueueArn,
+                },
+              },
+            },
+          ],
         },
       },
       OrdersFunction: {


### PR DESCRIPTION
## Summary

- authorize asynchronous destinations and dead-letter queues with the source function execution role
- route SQS, SNS, EventBridge, and Lambda deliveries through their simulated service operations
- preserve destination configuration and surface authorization failures from background delivery tasks
- document the required IAM permissions with executable examples

Closes #1216.

## Testing

- `pnpm run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lambda asynchronous destinations and dead-letter queues now enforce execution-role authorization.
  * Supported delivery targets include SQS, SNS, EventBridge, and Lambda.
  * Authorized deliveries proceed normally; unauthorized deliveries fail with IAM errors without changing the destination.

* **Documentation**
  * Updated setup guidance and examples to configure required permissions and roles.
  * Clarified that destination delivery is subject to standard authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->