### PR TITLE
feat: create and execute CloudFormation change sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
 
 .worktrees/
+.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,5 @@ test/terraform/**/builds/
 test/terraform/**/terraform.tfstate*
 test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
+
+.worktrees/

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -757,6 +757,18 @@
       }
     },
     {
+      // The CloudFormation service facade. As with the IAM one below, it
+      // carries one method per SDK command CloudFormation handles, each a doc
+      // comment and a line or two of delegation. The Stack commands and the
+      // change set commands together take it past 300 lines of that, and the
+      // work behind them sits in the handler classes and in
+      // SimCfnChangeSetCommands.
+      "files": ["src/service/cloudformation/sim-cloudformation.ts"],
+      "rules": {
+        "eslint/max-lines": ["error", 400]
+      }
+    },
+    {
       // The IAM service facade. It carries one method per SDK command IAM
       // handles, each a doc comment and a line of delegation, so its length
       // tracks the size of that command surface rather than the complexity of

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -431,8 +431,14 @@ The change set reports its own execution through `ExecutionStatus`. It reads `AV
 after. Every other executable change set against the same stack becomes `OBSOLETE`, because each was
 worked out against a stack the execution has moved on.
 
+A change set whose stack has moved on since it was created is refused as `OBSOLETE`, which is what
+CloudFormation calls a change set whose stack was already updated. An update sent directly, and
+another change set executed first, both leave it there. Executing it would apply a difference nobody
+has seen, because what it reports was worked out against the template the stack held then.
+
 `DeleteChangeSetCommand` takes a change set away without executing it, and a change set name that is
-not there is a success rather than an error. `ListChangeSetsCommand` reports the ones a stack still
+not there is a success rather than an error. Every other command naming one that is not there is
+refused with a `ChangeSetNotFoundException`. `ListChangeSetsCommand` reports the ones a stack still
 holds, in the order they were created.
 
 ## Deleting a stack

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -324,6 +324,117 @@ where the update got to. There is no rollback to the previous template.
 `StackStatusReason`. Dealing with the cause and sending `UpdateStackCommand` again applies the rest
 of the change.
 
+## Deploying through a change set
+
+A change set says what a template would do to a stack before anything happens to it. `cdk deploy`
+goes through one by default, and so does any deployment script that wants to see what an update will
+touch. Simulated CloudFormation serves `CreateChangeSetCommand`, `DescribeChangeSetCommand`,
+`ExecuteChangeSetCommand`, `DeleteChangeSetCommand` and `ListChangeSetsCommand`.
+
+```typescript sim-cloudformation-change-set
+/**
+ * Deploying a simulated CloudFormation Stack through a change set.
+ */
+
+import {
+  CreateChangeSetCommand,
+  DescribeChangeSetCommand,
+  ExecuteChangeSetCommand,
+} from "@aws-sdk/client-cloudformation";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+
+const templateBody = JSON.stringify({
+  Resources: {
+    ReportsBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "change-set-reports" },
+    },
+  },
+});
+
+// A CREATE change set brings the Stack into being in REVIEW_IN_PROGRESS,
+// holding no created Resources.
+await simCfn.createChangeSet(
+  new CreateChangeSetCommand({
+    StackName: "reports-stack",
+    ChangeSetName: "reports-create",
+    ChangeSetType: "CREATE",
+    TemplateBody: templateBody,
+  }),
+);
+
+// Describing it says what executing it would do. Nothing is deployed yet.
+const described = await simCfn.describeChangeSet(
+  new DescribeChangeSetCommand({
+    StackName: "reports-stack",
+    ChangeSetName: "reports-create",
+  }),
+);
+
+// [{ Action: "Add", LogicalResourceId: "ReportsBucket" }]
+console.log(
+  described.Changes?.map((change) => ({
+    Action: change.ResourceChange.Action,
+    LogicalResourceId: change.ResourceChange.LogicalResourceId,
+  })),
+);
+
+// Executing it deploys the template.
+await simCfn.executeChangeSet(
+  new ExecuteChangeSetCommand({
+    StackName: "reports-stack",
+    ChangeSetName: "reports-create",
+  }),
+);
+await simCfn.waitForStackDeployComplete("reports-stack");
+
+console.log(simAws.s3().getSimBucketByName("change-set-reports"));
+```
+
+`ChangeSetType: CREATE` creates the stack in `REVIEW_IN_PROGRESS` and creates none of its resources.
+`DescribeStacksCommand` reports the stack from that point on, and executing the change set is what
+deploys it. The default, `ChangeSetType: UPDATE`, works out the change against a stack that is
+already deployed and leaves it exactly as it is until the change set is executed.
+
+`CreateChangeSetCommand` returns the change set ARN as `Id`. Every command naming a change set takes
+either that ARN on its own or the change set name together with `StackName`, the way CloudFormation
+takes them.
+
+### What a change set reports
+
+`DescribeChangeSetCommand` answers with one `Changes` entry per resource, each carrying a
+`ResourceChange` with its `Action`, `LogicalResourceId`, `ResourceType` and `Replacement`. A resource
+only the new template has is an `Add`, one only the stack has is a `Remove`, and one both have whose
+template entry changed is a `Modify`.
+
+Every `Modify` carries `Replacement: "True"`. Simulated CloudFormation replaces a changed resource
+rather than updating it in place, and it replaces everything naming a replaced resource as well, so a
+change set reports each of those as a modification too. See
+[changed resources are replaced](#changed-resources-are-replaced) for what that costs.
+
+A change set describing a template the stack already holds is `FAILED`, carrying the reason
+CloudFormation gives, and refuses to execute. That is the same no-op rule an update follows, so a
+template that only moves an output still has something to execute.
+
+### Executing a change set
+
+`executeChangeSet(...)` returns once the stack operation has started, as `createStack(...)` and
+`updateStack(...)` do. Follow it with `waitForStackDeployComplete(...)` for a `CREATE` change set or
+`waitForStackUpdateComplete(...)` for an `UPDATE` one.
+
+The change set reports its own execution through `ExecutionStatus`. It reads `AVAILABLE` before,
+`EXECUTE_IN_PROGRESS` while the stack operation runs, and `EXECUTE_COMPLETE` or `EXECUTE_FAILED`
+after. Every other executable change set against the same stack becomes `OBSOLETE`, because each was
+worked out against a stack the execution has moved on.
+
+`DeleteChangeSetCommand` takes a change set away without executing it, and a change set name that is
+not there is a success rather than an error. `ListChangeSetsCommand` reports the ones a stack still
+holds, in the order they were created.
+
 ## Deleting a stack
 
 `DeleteStackCommand` deletes the resources a stack created, in the reverse of the order they were
@@ -3489,6 +3600,8 @@ Sim CloudFormation currently supports:
 
 - `CreateStackCommand`, `DescribeStacksCommand`, `UpdateStackCommand` and `DeleteStackCommand`,
   taking a `TemplateBody` written as JSON or as YAML with short-form intrinsic tags
+- `CreateChangeSetCommand`, `DescribeChangeSetCommand`, `ExecuteChangeSetCommand`,
+  `DeleteChangeSetCommand` and `ListChangeSetsCommand`, for both `CREATE` and `UPDATE` change sets
 - Waiting for simulated stack deployment, update and deletion completion
 - The resource `DeletionPolicy` attribute, for `Retain` and `RetainExceptOnCreate`
 - `deployTemplate(...)` for parsed template objects, optionally naming the synthesized template file
@@ -3589,9 +3702,10 @@ Each service's own docs describe what its resource types support.
   changed resource is still replaced and loses what it holds, the same as any other update.
 - Yulin never synthesizes a CDK app. It watches the synthesized output template. A change to the app
   itself reaches the stack once something has run `cdk synth` over it.
-- A stack update applies a whole template directly. Change sets are outside the simulation, so
-  `CreateChangeSetCommand` and `ExecuteChangeSetCommand` have nothing behind them, and neither does
-  drift detection.
+- A change set reports every `Modify` as `Replacement: True`, because a changed resource is replaced
+  rather than updated in place. `ChangeSetType: IMPORT` is refused, and so is a `CREATE` change set
+  naming a stack that is already there, where CloudFormation allows a second one against a stack
+  still in review. Drift detection is outside the simulation.
 - A failed stack update is not rolled back to the template the stack was deployed from. The stack is
   left in `UPDATE_FAILED` holding whatever the update managed.
 - `UpdateStackCommand` reads `StackName`, `TemplateBody` and `Parameters`. `UsePreviousTemplate` and

--- a/docs/services/cloudformation/sim-cloudformation-change-set.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-change-set.example.ts
@@ -1,0 +1,61 @@
+/**
+ * Deploying a simulated CloudFormation Stack through a change set.
+ */
+
+import {
+  CreateChangeSetCommand,
+  DescribeChangeSetCommand,
+  ExecuteChangeSetCommand,
+} from "@aws-sdk/client-cloudformation";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+
+const templateBody = JSON.stringify({
+  Resources: {
+    ReportsBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "change-set-reports" },
+    },
+  },
+});
+
+// A CREATE change set brings the Stack into being in REVIEW_IN_PROGRESS,
+// holding no created Resources.
+await simCfn.createChangeSet(
+  new CreateChangeSetCommand({
+    StackName: "reports-stack",
+    ChangeSetName: "reports-create",
+    ChangeSetType: "CREATE",
+    TemplateBody: templateBody,
+  }),
+);
+
+// Describing it says what executing it would do. Nothing is deployed yet.
+const described = await simCfn.describeChangeSet(
+  new DescribeChangeSetCommand({
+    StackName: "reports-stack",
+    ChangeSetName: "reports-create",
+  }),
+);
+
+// [{ Action: "Add", LogicalResourceId: "ReportsBucket" }]
+console.log(
+  described.Changes?.map((change) => ({
+    Action: change.ResourceChange.Action,
+    LogicalResourceId: change.ResourceChange.LogicalResourceId,
+  })),
+);
+
+// Executing it deploys the template.
+await simCfn.executeChangeSet(
+  new ExecuteChangeSetCommand({
+    StackName: "reports-stack",
+    ChangeSetName: "reports-create",
+  }),
+);
+await simCfn.waitForStackDeployComplete("reports-stack");
+
+console.log(simAws.s3().getSimBucketByName("change-set-reports"));

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -23,7 +23,9 @@ familiar CloudFormation/CDK outputs.
 - `sim-cloudformation.ts` is the main service object for one account/region scope.
 - `index.ts` exports the public CloudFormation simulator API.
 - `command/` contains AWS SDK-style command handlers such as `CreateStack`, `DescribeStacks`,
-  `UpdateStack` and `DeleteStack`.
+  `UpdateStack` and `DeleteStack`, and the five change set commands.
+- `changeset/` contains the change sets one `SimCloudFormation` holds, what executing one would do
+  to a Stack, and running it.
 - `deploy/` contains convenience helpers for deploying already-parsed templates or synthesized
   template files.
 - `template/` contains template body validation, template value parsing, intrinsic-function nodes,
@@ -517,6 +519,30 @@ resource holds, and it is recorded in the usage docs rather than hidden. Two thi
 - `UpdateReplacePolicy` is not read. Retaining the old resource would leave it holding the name its
   replacement needs, and CDK marks buckets and tables `Retain` as a matter of course, so honouring
   it would fail every such update.
+
+## Change sets
+
+A change set holds the difference an update would make. `SimCfnChangeSet` holds the template it was
+created from and the changes it reports, and `SimCfnChangeSets` is the registry one
+`SimCloudFormation` keeps them in. `SimCfnChangeSetCommands` assembles the five command handlers over
+that registry. That keeps them out of `SimCloudFormation` alongside the Stack commands, which had
+already reached its line limit.
+
+`simCfnChangeSetChanges` reports the comparison an update applies. It reads
+`simCfnStackReplacedLogicalIds`. A change set and the update it becomes therefore agree about what
+changed. Every `Modify` it reports carries `Replacement: True`, because a changed resource is
+replaced here.
+
+`simCfnChangeSetStack` decides which Stack the change set is held against. A `CREATE` change set
+constructs a `SimCfnStack` and leaves it undeployed, in the `REVIEW_IN_PROGRESS` status
+`SimCfnStackDeploymentLifecycle` starts in. A Stack in review therefore needs no state of its own.
+The lifecycle already models a Stack that has been described and left undeployed.
+
+`runSimCfnChangeSet` executes one. A `CREATE` change set deploys its Stack and an `UPDATE` change set
+applies its template, both through the machinery an SDK caller reaches. It then schedules a
+background task that waits for the Stack operation and records `EXECUTE_COMPLETE` or `EXECUTE_FAILED`
+on the change set. The failure itself stays on the Stack. That is where the error is held and where
+it is rethrown to whoever waits for the operation.
 
 ## Resource deployment loop
 

--- a/src/service/cloudformation/authorize/sim-cloudformation-authorization.ts
+++ b/src/service/cloudformation/authorize/sim-cloudformation-authorization.ts
@@ -53,6 +53,44 @@ export class SimCloudFormationAuthorization {
     this.authorize("cloudformation:DeleteStack", stackName, caller);
   }
 
+  /**
+   * Ensure the caller may create a change set against the named Stack.
+   */
+  createChangeSet(stackName: string | undefined, caller?: SimAwsCaller): void {
+    this.authorize("cloudformation:CreateChangeSet", stackName, caller);
+  }
+
+  /**
+   * Ensure the caller may describe a change set against the named Stack.
+   */
+  describeChangeSet(
+    stackName: string | undefined,
+    caller?: SimAwsCaller,
+  ): void {
+    this.authorize("cloudformation:DescribeChangeSet", stackName, caller);
+  }
+
+  /**
+   * Ensure the caller may execute a change set against the named Stack.
+   */
+  executeChangeSet(stackName: string | undefined, caller?: SimAwsCaller): void {
+    this.authorize("cloudformation:ExecuteChangeSet", stackName, caller);
+  }
+
+  /**
+   * Ensure the caller may delete a change set against the named Stack.
+   */
+  deleteChangeSet(stackName: string | undefined, caller?: SimAwsCaller): void {
+    this.authorize("cloudformation:DeleteChangeSet", stackName, caller);
+  }
+
+  /**
+   * Ensure the caller may list the change sets against the named Stack.
+   */
+  listChangeSets(stackName: string | undefined, caller?: SimAwsCaller): void {
+    this.authorize("cloudformation:ListChangeSets", stackName, caller);
+  }
+
   private authorize(
     action: string,
     stackName: string | undefined,

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-arn.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-arn.ts
@@ -1,0 +1,18 @@
+import { randomUUID } from "node:crypto";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+
+/**
+ * The ARN CloudFormation gives one change set.
+ *
+ * The unique part is a UUID, as it is for a Stack ID, so two change sets
+ * created under the same name against different Stacks are still told apart by
+ * their ARN alone.
+ */
+export function simCfnChangeSetArn(
+  scope: SimAwsAccountRegionScope,
+  changeSetName: string,
+): string {
+  const { regionName, accountId } = scope;
+
+  return `arn:aws:cloudformation:${regionName}:${accountId}:changeSet/${changeSetName}/${randomUUID()}`;
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-changes.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-changes.ts
@@ -1,0 +1,109 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import { makeSimCfnStackResourceMap } from "../stack/resource-map/sim-cfn-stack-resource-map.js";
+import { simCfnStackReplacedLogicalIds } from "../stack/update/sim-cfn-stack-replaced-resources.js";
+import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
+import type {
+  SimCfnChangeSetType,
+  SimCfnResourceChange,
+} from "./sim-cfn-change-set.type.js";
+
+interface SimCfnChangeSetPlanProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly background: BackgroundScheduler;
+  readonly stack: SimCfnStack;
+  readonly type: SimCfnChangeSetType;
+  readonly template: SimCfnTemplate;
+}
+
+/**
+ * What executing a change set would do to the Stack it is held against.
+ *
+ * A `CREATE` change set is compared against nothing, because the Stack it
+ * brought into being holds no created Resource yet.
+ */
+export function simCfnChangeSetPlan(
+  properties: SimCfnChangeSetPlanProperties,
+): readonly SimCfnResourceChange[] {
+  const { accountRegionScope, background, stack, type, template } = properties;
+
+  return simCfnChangeSetChanges({
+    current: type === "CREATE" ? new Map() : stack.resourceMap,
+    updated: makeSimCfnStackResourceMap({
+      accountRegionScope,
+      background,
+      template,
+    }),
+  });
+}
+
+interface SimCfnChangeSetChangesProperties {
+  /** The Resources the Stack holds now. Empty for a Stack in review. */
+  readonly current: ReadonlyMap<string, SimCfnResource>;
+
+  /** The Resources the change set's template describes. */
+  readonly updated: ReadonlyMap<string, SimCfnResource>;
+}
+
+/**
+ * What executing a change set would do to a Stack's Resources.
+ *
+ * The same comparison an update makes, reported rather than applied. A
+ * Resource only the new template has is an `Add`, one only the Stack has is a
+ * `Remove`, and one both have whose resolved template entry changed is a
+ * `Modify`. A Resource that would be replaced because it names a replaced one
+ * is a `Modify` too, which is how CloudFormation reports a dependent it has to
+ * hand a new physical name to.
+ *
+ * The order follows the templates. The new template's Resources come first, in
+ * the order it declares them, and the dropped ones after in the order the Stack
+ * holds them.
+ */
+export function simCfnChangeSetChanges(
+  properties: SimCfnChangeSetChangesProperties,
+): readonly SimCfnResourceChange[] {
+  const { current, updated } = properties;
+  const replaced = simCfnStackReplacedLogicalIds({ current, updated });
+
+  const changed = updated
+    .values()
+    .filter((resource) => !unchanged(resource, current, replaced))
+    .map((resource) => ({
+      action: current.has(resource.logicalId)
+        ? ("Modify" as const)
+        : ("Add" as const),
+      logicalResourceId: resource.logicalId,
+      resourceType: resource.type,
+      replacement: current.has(resource.logicalId)
+        ? ("True" as const)
+        : undefined,
+    }))
+    .toArray();
+
+  const removed = current
+    .values()
+    .filter((resource) => !updated.has(resource.logicalId))
+    .map((resource) => ({
+      action: "Remove" as const,
+      logicalResourceId: resource.logicalId,
+      resourceType: resource.type,
+      replacement: undefined,
+    }))
+    .toArray();
+
+  return [...changed, ...removed];
+}
+
+/**
+ * Whether the Stack already holds this Resource as the new template describes
+ * it, which is a Resource the change set leaves out.
+ */
+function unchanged(
+  resource: SimCfnResource,
+  current: ReadonlyMap<string, SimCfnResource>,
+  replaced: ReadonlySet<string>,
+): boolean {
+  return current.has(resource.logicalId) && !replaced.has(resource.logicalId);
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-commands.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-commands.ts
@@ -8,6 +8,7 @@ import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
 import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
+import type { SimCloudFormationAuthorization } from "../authorize/sim-cloudformation-authorization.js";
 import type {
   SimCreateChangeSetCommand,
   SimCreateChangeSetCommandOutput,
@@ -40,6 +41,7 @@ interface SimCfnChangeSetCommandsProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   readonly background: BackgroundScheduler & BackgroundCompleter;
+  readonly authorization: SimCloudFormationAuthorization;
   readonly exports?: SimCfnExports | undefined;
 }
 
@@ -50,8 +52,10 @@ interface SimCfnChangeSetCommandsProperties {
  * same Stack map every other command reads, so they are assembled once here
  * rather than in SimCloudFormation alongside the Stack commands.
  *
- * Authorization stays outside. SimCloudFormation decides whether the caller may
- * run the command before handing it here.
+ * Authorization happens here rather than in SimCloudFormation, because three of
+ * the five commands can name a change set by its ARN alone. The Stack such a
+ * request operates on is the one the change set belongs to, and only this
+ * registry knows which that is.
  */
 export class SimCfnChangeSetCommands {
   private readonly properties: SimCfnChangeSetCommandsProperties;
@@ -66,6 +70,11 @@ export class SimCfnChangeSetCommands {
     command: SimCreateChangeSetCommand,
     caller?: SimAwsCaller,
   ): Promise<SimCreateChangeSetCommandOutput> {
+    this.properties.authorization.createChangeSet(
+      command.input.StackName,
+      caller,
+    );
+
     return await new CreateChangeSetCommandHandler({
       ...this.properties,
       changeSets: this.changeSets,
@@ -76,7 +85,13 @@ export class SimCfnChangeSetCommands {
   /** Report what a held change set would do to its Stack. */
   async describe(
     command: SimDescribeChangeSetCommand,
+    caller?: SimAwsCaller,
   ): Promise<SimDescribeChangeSetCommandOutput> {
+    this.properties.authorization.describeChangeSet(
+      this.stackNameFor(command.input),
+      caller,
+    );
+
     return await new DescribeChangeSetCommandHandler({
       changeSets: this.changeSets,
       background: this.properties.background,
@@ -88,6 +103,11 @@ export class SimCfnChangeSetCommands {
     command: SimExecuteChangeSetCommand,
     caller?: SimAwsCaller,
   ): Promise<SimExecuteChangeSetCommandOutput> {
+    this.properties.authorization.executeChangeSet(
+      this.stackNameFor(command.input),
+      caller,
+    );
+
     return await new ExecuteChangeSetCommandHandler({
       stacks: this.properties.stacks,
       changeSets: this.changeSets,
@@ -99,7 +119,13 @@ export class SimCfnChangeSetCommands {
   /** Take a change set away without executing it. */
   async delete(
     command: SimDeleteChangeSetCommand,
+    caller?: SimAwsCaller,
   ): Promise<SimDeleteChangeSetCommandOutput> {
+    this.properties.authorization.deleteChangeSet(
+      this.stackNameFor(command.input),
+      caller,
+    );
+
     return await new DeleteChangeSetCommandHandler({
       changeSets: this.changeSets,
       background: this.properties.background,
@@ -109,10 +135,44 @@ export class SimCfnChangeSetCommands {
   /** List the change sets held against one Stack. */
   async list(
     command: SimListChangeSetsCommand,
+    caller?: SimAwsCaller,
   ): Promise<SimListChangeSetsCommandOutput> {
+    this.properties.authorization.listChangeSets(
+      command.input.StackName,
+      caller,
+    );
+
     return await new ListChangeSetsCommandHandler({
       changeSets: this.changeSets,
       background: this.properties.background,
     }).handle(command);
+  }
+
+  /**
+   * The Stack a request naming one change set operates on.
+   *
+   * A request carrying the change set ARN alone leaves out the Stack name, and
+   * the change set it names knows which Stack it belongs to. Authorizing on
+   * what the request said would ask about every Stack in the scope, so a
+   * caller allowed one Stack would be refused a change set against it.
+   *
+   * A change set the registry does not hold falls back to what the request
+   * said. The handler refuses it, and refusing an unauthorized caller first is
+   * what keeps that refusal from saying which change sets exist.
+   */
+  private stackNameFor(input: {
+    readonly ChangeSetName?: string | undefined;
+    readonly StackName?: string | undefined;
+  }): string | undefined {
+    if (input.ChangeSetName === undefined) {
+      return input.StackName;
+    }
+
+    return (
+      this.changeSets.find({
+        changeSetName: input.ChangeSetName,
+        stackName: input.StackName,
+      })?.stackName ?? input.StackName
+    );
   }
 }

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-commands.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-commands.ts
@@ -1,0 +1,118 @@
+import type {
+  BackgroundCompleter,
+  BackgroundScheduler,
+} from "../../../util/background/background.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
+import type { SimCfnExports } from "../export/sim-cfn-exports.js";
+import type {
+  SimCreateChangeSetCommand,
+  SimCreateChangeSetCommandOutput,
+} from "../command/create-change-set/create-change-set.command.js";
+import { CreateChangeSetCommandHandler } from "../command/create-change-set/create-change-set.handler.js";
+import type {
+  SimDescribeChangeSetCommand,
+  SimDescribeChangeSetCommandOutput,
+} from "../command/describe-change-set/describe-change-set.command.js";
+import { DescribeChangeSetCommandHandler } from "../command/describe-change-set/describe-change-set.handler.js";
+import type {
+  SimExecuteChangeSetCommand,
+  SimExecuteChangeSetCommandOutput,
+} from "../command/execute-change-set/execute-change-set.command.js";
+import { ExecuteChangeSetCommandHandler } from "../command/execute-change-set/execute-change-set.handler.js";
+import type {
+  SimDeleteChangeSetCommand,
+  SimDeleteChangeSetCommandOutput,
+} from "../command/delete-change-set/delete-change-set.command.js";
+import { DeleteChangeSetCommandHandler } from "../command/delete-change-set/delete-change-set.handler.js";
+import type {
+  SimListChangeSetsCommand,
+  SimListChangeSetsCommandOutput,
+} from "../command/list-change-sets/list-change-sets.command.js";
+import { ListChangeSetsCommandHandler } from "../command/list-change-sets/list-change-sets.handler.js";
+import { SimCfnChangeSets } from "./sim-cfn-change-sets.js";
+
+interface SimCfnChangeSetCommandsProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  readonly background: BackgroundScheduler & BackgroundCompleter;
+  readonly exports?: SimCfnExports | undefined;
+}
+
+/**
+ * The change set half of simulated CloudFormation's SDK surface.
+ *
+ * The five change set commands share one registry of held change sets and the
+ * same Stack map every other command reads, so they are assembled once here
+ * rather than in SimCloudFormation alongside the Stack commands.
+ *
+ * Authorization stays outside. SimCloudFormation decides whether the caller may
+ * run the command before handing it here.
+ */
+export class SimCfnChangeSetCommands {
+  private readonly properties: SimCfnChangeSetCommandsProperties;
+  private readonly changeSets = new SimCfnChangeSets();
+
+  constructor(properties: SimCfnChangeSetCommandsProperties) {
+    this.properties = properties;
+  }
+
+  /** Work out what a template would change about a Stack, and hold it. */
+  async create(
+    command: SimCreateChangeSetCommand,
+    caller?: SimAwsCaller,
+  ): Promise<SimCreateChangeSetCommandOutput> {
+    return await new CreateChangeSetCommandHandler({
+      ...this.properties,
+      changeSets: this.changeSets,
+      caller,
+    }).handle(command);
+  }
+
+  /** Report what a held change set would do to its Stack. */
+  async describe(
+    command: SimDescribeChangeSetCommand,
+  ): Promise<SimDescribeChangeSetCommandOutput> {
+    return await new DescribeChangeSetCommandHandler({
+      changeSets: this.changeSets,
+      background: this.properties.background,
+    }).handle(command);
+  }
+
+  /** Apply what a change set describes to its Stack. */
+  async execute(
+    command: SimExecuteChangeSetCommand,
+    caller?: SimAwsCaller,
+  ): Promise<SimExecuteChangeSetCommandOutput> {
+    return await new ExecuteChangeSetCommandHandler({
+      stacks: this.properties.stacks,
+      changeSets: this.changeSets,
+      background: this.properties.background,
+      caller,
+    }).handle(command);
+  }
+
+  /** Take a change set away without executing it. */
+  async delete(
+    command: SimDeleteChangeSetCommand,
+  ): Promise<SimDeleteChangeSetCommandOutput> {
+    return await new DeleteChangeSetCommandHandler({
+      changeSets: this.changeSets,
+      background: this.properties.background,
+    }).handle(command);
+  }
+
+  /** List the change sets held against one Stack. */
+  async list(
+    command: SimListChangeSetsCommand,
+  ): Promise<SimListChangeSetsCommandOutput> {
+    return await new ListChangeSetsCommandHandler({
+      changeSets: this.changeSets,
+      background: this.properties.background,
+    }).handle(command);
+  }
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-execution.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-execution.ts
@@ -1,0 +1,71 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCfnChangeSet } from "./sim-cfn-change-set.js";
+import type { SimCfnChangeSets } from "./sim-cfn-change-sets.js";
+
+interface SimCfnChangeSetExecutionProperties {
+  readonly changeSet: SimCfnChangeSet;
+  readonly stack: SimCfnStack;
+  readonly changeSets: SimCfnChangeSets;
+  readonly background: BackgroundScheduler;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * Start the Stack operation a change set describes.
+ *
+ * A `CREATE` change set deploys the Stack it brought into being, and an
+ * `UPDATE` change set applies its template to the Stack it was worked out
+ * against. Either way the work is scheduled in the background, so this returns
+ * once the operation has started.
+ *
+ * Every other executable change set against the Stack becomes obsolete, because
+ * each was worked out against a Stack this execution has moved on.
+ */
+export async function runSimCfnChangeSet(
+  properties: SimCfnChangeSetExecutionProperties,
+): Promise<void> {
+  const { changeSet, stack, changeSets, background, caller } = properties;
+
+  changeSet.executionStatus = "EXECUTE_IN_PROGRESS";
+
+  try {
+    await (changeSet.type === "CREATE"
+      ? stack.deploy()
+      : stack.update(changeSet.template, { caller }));
+  } catch (error) {
+    changeSet.executionStatus = "EXECUTE_FAILED";
+
+    throw error;
+  }
+
+  changeSets.markOthersObsolete(changeSet);
+  settleExecution(changeSet, stack, background);
+}
+
+/**
+ * Record how the Stack operation went, once it has finished in the background.
+ *
+ * The failure itself belongs to the Stack, which holds it as a failed status
+ * and rethrows it to whoever waits for the operation. This only reads which way
+ * it went, so a change set describes its own execution as well as the Stack
+ * describes the deployment or update behind it.
+ */
+function settleExecution(
+  changeSet: SimCfnChangeSet,
+  stack: SimCfnStack,
+  background: BackgroundScheduler,
+): void {
+  background.schedule(async () => {
+    try {
+      await (changeSet.type === "CREATE"
+        ? stack.waitForDeployComplete()
+        : stack.waitForUpdateComplete());
+
+      changeSet.executionStatus = "EXECUTE_COMPLETE";
+    } catch {
+      changeSet.executionStatus = "EXECUTE_FAILED";
+    }
+  });
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-execution.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-execution.ts
@@ -1,8 +1,12 @@
 import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import { simCfnStackTemplateChanged } from "../stack/update/sim-cfn-stack-template-changes.js";
 import type { SimCfnChangeSet } from "./sim-cfn-change-set.js";
-import type { SimCfnChangeSets } from "./sim-cfn-change-sets.js";
+import {
+  simCfnChangeSetNotExecutable,
+  type SimCfnChangeSets,
+} from "./sim-cfn-change-sets.js";
 
 interface SimCfnChangeSetExecutionProperties {
   readonly changeSet: SimCfnChangeSet;
@@ -20,13 +24,27 @@ interface SimCfnChangeSetExecutionProperties {
  * against. Either way the work is scheduled in the background, so this returns
  * once the operation has started.
  *
- * Every other executable change set against the Stack becomes obsolete, because
- * each was worked out against a Stack this execution has moved on.
+ * A Stack that has moved on since the change set was worked out leaves the
+ * change set obsolete, which is what CloudFormation calls a change set whose
+ * Stack was already updated. Executing it would apply a difference nobody has
+ * seen, because what it reports was worked out against the template the Stack
+ * held then.
+ *
+ * Every other executable change set against the Stack becomes obsolete for the
+ * same reason once this one has been applied.
  */
 export async function runSimCfnChangeSet(
   properties: SimCfnChangeSetExecutionProperties,
 ): Promise<void> {
   const { changeSet, stack, changeSets, background, caller } = properties;
+
+  if (
+    simCfnStackTemplateChanged(changeSet.plannedFrom, stack.currentTemplate)
+  ) {
+    changeSet.executionStatus = "OBSOLETE";
+
+    throw simCfnChangeSetNotExecutable(changeSet);
+  }
 
   changeSet.executionStatus = "EXECUTE_IN_PROGRESS";
 

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-failure.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-failure.ts
@@ -1,0 +1,35 @@
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import { simCfnStackTemplateChanged } from "../stack/update/sim-cfn-stack-template-changes.js";
+import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
+import { simCfnChangeSetNoChangesMessage } from "./sim-cfn-change-set-type.js";
+import type { SimCfnChangeSetType } from "./sim-cfn-change-set.type.js";
+
+interface SimCfnChangeSetFailureProperties {
+  readonly stack: SimCfnStack;
+  readonly type: SimCfnChangeSetType;
+  readonly template: SimCfnTemplate;
+  readonly changeCount: number;
+}
+
+/**
+ * Why a change set failed, for one that would change nothing.
+ *
+ * Everything else in the template counts as well as the Resources, the same way
+ * it does for an update, because a change set that only moves an Output still
+ * has something to execute.
+ *
+ * A `CREATE` change set never fails this way. The Stack it was made for holds
+ * no Resource, so there is always something for it to do.
+ */
+export function simCfnChangeSetFailure(
+  properties: SimCfnChangeSetFailureProperties,
+): string | undefined {
+  const { stack, type, template, changeCount } = properties;
+
+  const noChanges =
+    type === "UPDATE" &&
+    changeCount === 0 &&
+    !simCfnStackTemplateChanged(stack.currentTemplate, template);
+
+  return noChanges ? simCfnChangeSetNoChangesMessage : undefined;
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-input.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-input.ts
@@ -1,0 +1,39 @@
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
+import type { SimCreateChangeSetCommandInput } from "../command/create-change-set/create-change-set.command.js";
+import { simCfnChangeSetType } from "./sim-cfn-change-set-type.js";
+import type {
+  SimCfnChangeSetName,
+  SimCfnChangeSetType,
+} from "./sim-cfn-change-set.type.js";
+
+/**
+ * What a CreateChangeSet input says, once it has been read.
+ */
+export interface SimCfnChangeSetRequest {
+  readonly stackName: SimCloudFormationStackName;
+  readonly changeSetName: SimCfnChangeSetName;
+  readonly type: SimCfnChangeSetType;
+  readonly templateBody: string;
+}
+
+/**
+ * Read a CreateChangeSet input, refusing one that leaves out what a change set
+ * cannot be built without.
+ */
+export function simCfnChangeSetRequest(
+  input: SimCreateChangeSetCommandInput,
+): SimCfnChangeSetRequest {
+  const { StackName, ChangeSetName, TemplateBody } = input;
+
+  assertDefined(StackName, "CreateChangeSetCommand.input.StackName");
+  assertDefined(ChangeSetName, "CreateChangeSetCommand.input.ChangeSetName");
+  assertDefined(TemplateBody, "CreateChangeSetCommand.input.TemplateBody");
+
+  return {
+    stackName: StackName as SimCloudFormationStackName,
+    changeSetName: ChangeSetName as SimCfnChangeSetName,
+    type: simCfnChangeSetType(input.ChangeSetType),
+    templateBody: TemplateBody,
+  };
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-refusals.iso.test.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-refusals.iso.test.ts
@@ -1,0 +1,278 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEmpty,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import {
+  CreateChangeSetCommand,
+  CreateStackCommand,
+  DeleteChangeSetCommand,
+  DeleteStackCommand,
+  DescribeChangeSetCommand,
+  ExecuteChangeSetCommand,
+  ListChangeSetsCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import { SimAws } from "../../aws/sim-aws.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+const reportsBucket = {
+  Type: "AWS::S3::Bucket",
+  Properties: { BucketName: "reports" },
+};
+
+const archiveBucket = {
+  Type: "AWS::S3::Bucket",
+  Properties: { BucketName: "reports-archive" },
+};
+
+const template = { Resources: { ReportsBucket: reportsBucket } };
+
+const withArchive = {
+  Resources: { ReportsBucket: reportsBucket, ArchiveBucket: archiveBucket },
+};
+
+/**
+ * Deploy one Bucket as a Stack, ready for a change set against it.
+ */
+async function deployReportsStack(simAws: SimAws): Promise<void> {
+  const cloudFormation = simAws.cloudFormation();
+
+  await cloudFormation.createStack(
+    new CreateStackCommand({
+      StackName: "reports-stack",
+      TemplateBody: jsonStringify(template),
+    }),
+  );
+  await cloudFormation.waitForStackDeployComplete("reports-stack");
+}
+
+describe("Simulated CloudFormation change set refusals", () => {
+  it("refuses a ChangeSetType outside the simulation", async () => {
+    // Given a deployed Stack.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+
+    // When a change set asks to import Resources into it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().createChangeSet(
+        new CreateChangeSetCommand({
+          StackName: "reports-stack",
+          ChangeSetName: "reports-import",
+          ChangeSetType: "IMPORT",
+          TemplateBody: jsonStringify(withArchive),
+        }),
+      ),
+    );
+
+    // Then it is refused by name, because nothing here can adopt a Resource it
+    // did not create.
+    assertIdentical(error.name, "ValidationError");
+    assertStringIncludes(error.message, "IMPORT");
+  });
+
+  it("refuses a CREATE change set for a Stack that is already there", async () => {
+    // Given a deployed Stack.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+
+    // When a CREATE change set names it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().createChangeSet(
+        new CreateChangeSetCommand({
+          StackName: "reports-stack",
+          ChangeSetName: "reports-create",
+          ChangeSetType: "CREATE",
+          TemplateBody: jsonStringify(template),
+        }),
+      ),
+    );
+
+    // Then it is refused as an existing Stack.
+    assertIdentical(error.name, "AlreadyExistsException");
+  });
+
+  it("describes a change set by the ARN it was created with", async () => {
+    // Given a change set against a deployed Stack.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await deployReportsStack(simAws);
+
+    const created = await cloudFormation.createChangeSet(
+      new CreateChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+        TemplateBody: jsonStringify(withArchive),
+      }),
+    );
+
+    // When it is described by its ARN alone, with no Stack name.
+    const described = await cloudFormation.describeChangeSet(
+      new DescribeChangeSetCommand({ ChangeSetName: created.Id }),
+    );
+
+    // Then it is the change set that ARN names.
+    assertIdentical(described.ChangeSetName, "reports-change");
+    assertStringIncludes(created.Id ?? "", ":changeSet/reports-change/");
+  });
+
+  it("takes a change set name that is not there as nothing to delete", async () => {
+    // Given a deployed Stack holding no change set.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+
+    // When a change set that was never created is deleted.
+    await simAws.cloudFormation().deleteChangeSet(
+      new DeleteChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+      }),
+    );
+
+    // Then the call succeeded, because DeleteChangeSet says the change set
+    // should be gone and one that never existed satisfies that.
+    const listed = await simAws
+      .cloudFormation()
+      .listChangeSets(
+        new ListChangeSetsCommand({ StackName: "reports-stack" }),
+      );
+    assertArrayEmpty(listed.Summaries);
+  });
+
+  it("fails a change set whose Stack has gone since it was created", async () => {
+    // Given a change set against a Stack that is then deleted.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await deployReportsStack(simAws);
+    await cloudFormation.createChangeSet(
+      new CreateChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+        TemplateBody: jsonStringify(withArchive),
+      }),
+    );
+
+    await cloudFormation.deleteStack(
+      new DeleteStackCommand({ StackName: "reports-stack" }),
+    );
+    await cloudFormation.waitForStackDeleteComplete("reports-stack");
+
+    // When the change set is executed.
+    const error = await assertThrowsErrorAsync(async () =>
+      cloudFormation.executeChangeSet(
+        new ExecuteChangeSetCommand({
+          StackName: "reports-stack",
+          ChangeSetName: "reports-change",
+        }),
+      ),
+    );
+
+    // Then it is refused for the Stack it names.
+    assertIdentical(error.name, "ValidationError");
+    assertStringIncludes(error.message, "reports-stack");
+  });
+
+  it("fails a change set whose Stack has already been given the change", async () => {
+    // Given a change set adding a Bucket that an update then adds itself.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await deployReportsStack(simAws);
+    await cloudFormation.createChangeSet(
+      new CreateChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+        TemplateBody: jsonStringify(withArchive),
+      }),
+    );
+
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "reports-stack",
+        TemplateBody: jsonStringify(withArchive),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("reports-stack");
+
+    // When the change set is executed anyway.
+    const error = await assertThrowsErrorAsync(async () =>
+      cloudFormation.executeChangeSet(
+        new ExecuteChangeSetCommand({
+          StackName: "reports-stack",
+          ChangeSetName: "reports-change",
+        }),
+      ),
+    );
+
+    // Then it is refused as an update with nothing to do, and the change set
+    // records that its execution failed.
+    assertStringIncludes(error.message, "No updates are to be performed.");
+
+    const described = await cloudFormation.describeChangeSet(
+      new DescribeChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+      }),
+    );
+    assertIdentical(described.ExecutionStatus, "EXECUTE_FAILED");
+  });
+
+  it("records a failed execution on the change set", async () => {
+    // Given a CREATE change set whose template names a Role that is not there.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createChangeSet(
+      new CreateChangeSetCommand({
+        StackName: "policy-stack",
+        ChangeSetName: "policy-create",
+        ChangeSetType: "CREATE",
+        TemplateBody: jsonStringify({
+          Resources: {
+            ReportsPolicy: {
+              Type: "AWS::IAM::Policy",
+              Properties: {
+                PolicyName: "reports",
+                PolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [
+                    { Effect: "Allow", Action: "s3:*", Resource: "*" },
+                  ],
+                },
+                Roles: ["missing-role"],
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    // When it is executed and the deployment it starts fails.
+    await cloudFormation.executeChangeSet(
+      new ExecuteChangeSetCommand({
+        StackName: "policy-stack",
+        ChangeSetName: "policy-create",
+      }),
+    );
+    await assertThrowsErrorAsync(async () =>
+      cloudFormation.waitForStackDeployComplete("policy-stack"),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the change set records the failure alongside the Stack's own.
+    const described = await cloudFormation.describeChangeSet(
+      new DescribeChangeSetCommand({
+        StackName: "policy-stack",
+        ChangeSetName: "policy-create",
+      }),
+    );
+    assertIdentical(described.ExecutionStatus, "EXECUTE_FAILED");
+  });
+});

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-refusals.iso.test.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-refusals.iso.test.ts
@@ -2,8 +2,10 @@ import { describe, it } from "vitest";
 import {
   assertArrayEmpty,
   assertIdentical,
+  assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertUndefined,
 } from "@kensio/smartass";
 import {
   CreateChangeSetCommand,
@@ -15,6 +17,7 @@ import {
   ListChangeSetsCommand,
   UpdateStackCommand,
 } from "@aws-sdk/client-cloudformation";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { SimAws } from "../../aws/sim-aws.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
 
@@ -179,8 +182,8 @@ describe("Simulated CloudFormation change set refusals", () => {
     assertStringIncludes(error.message, "reports-stack");
   });
 
-  it("fails a change set whose Stack has already been given the change", async () => {
-    // Given a change set adding a Bucket that an update then adds itself.
+  it("gives up on a change set whose Stack has moved on", async () => {
+    // Given a change set that only adds a second Bucket.
     const simAws = new SimAws();
     const cloudFormation = simAws.cloudFormation();
 
@@ -193,15 +196,23 @@ describe("Simulated CloudFormation change set refusals", () => {
       }),
     );
 
+    // And an update that renames the Bucket the change set left alone.
     await cloudFormation.updateStack(
       new UpdateStackCommand({
         StackName: "reports-stack",
-        TemplateBody: jsonStringify(withArchive),
+        TemplateBody: jsonStringify({
+          Resources: {
+            ReportsBucket: {
+              Type: "AWS::S3::Bucket",
+              Properties: { BucketName: "reports-v2" },
+            },
+          },
+        }),
       }),
     );
     await cloudFormation.waitForStackUpdateComplete("reports-stack");
 
-    // When the change set is executed anyway.
+    // When the change set is executed.
     const error = await assertThrowsErrorAsync(async () =>
       cloudFormation.executeChangeSet(
         new ExecuteChangeSetCommand({
@@ -211,9 +222,13 @@ describe("Simulated CloudFormation change set refusals", () => {
       ),
     );
 
-    // Then it is refused as an update with nothing to do, and the change set
-    // records that its execution failed.
-    assertStringIncludes(error.message, "No updates are to be performed.");
+    // Then it is refused as obsolete, because what it reports was worked out
+    // against a template the Stack has moved on from. Executing it would put
+    // the renamed Bucket back, which its Changes never said it would.
+    assertIdentical(error.name, "InvalidChangeSetStatusException");
+    assertStringIncludes(error.message, "OBSOLETE");
+    assertNonNullable(simAws.s3().getSimBucketByName("reports-v2"));
+    assertUndefined(simAws.s3().getSimBucketByName("reports-archive"));
 
     const described = await cloudFormation.describeChangeSet(
       new DescribeChangeSetCommand({
@@ -221,7 +236,7 @@ describe("Simulated CloudFormation change set refusals", () => {
         ChangeSetName: "reports-change",
       }),
     );
-    assertIdentical(described.ExecutionStatus, "EXECUTE_FAILED");
+    assertIdentical(described.ExecutionStatus, "OBSOLETE");
   });
 
   it("records a failed execution on the change set", async () => {
@@ -274,5 +289,60 @@ describe("Simulated CloudFormation change set refusals", () => {
       }),
     );
     assertIdentical(described.ExecutionStatus, "EXECUTE_FAILED");
+  });
+
+  it("authorizes a change set named by ARN against the Stack it belongs to", async () => {
+    // Given a caller allowed change sets on one Stack only.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const roleArn = `arn:aws:iam::${simAws.defaultAccountId}:role/Deployer`;
+
+    await simAws.iam().createRole(
+      new CreateRoleCommand({
+        RoleName: "Deployer",
+        AssumeRolePolicyDocument: jsonStringify({
+          Version: "2012-10-17",
+          Statement: [],
+        }),
+      }),
+    );
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "Deployer",
+        PolicyName: "ReportsStackOnly",
+        PolicyDocument: jsonStringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: "cloudformation:*",
+              Resource: `arn:aws:cloudformation:${simAws.defaultRegionName}:${simAws.defaultAccountId}:stack/reports-stack/*`,
+            },
+          ],
+        }),
+      }),
+    );
+
+    await deployReportsStack(simAws);
+
+    const created = await cloudFormation.createChangeSet(
+      new CreateChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+        TemplateBody: jsonStringify(withArchive),
+      }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // When that caller describes it by ARN alone, with no Stack name.
+    const described = await cloudFormation.describeChangeSet(
+      new DescribeChangeSetCommand({ ChangeSetName: created.Id }),
+      { caller: { kind: "arn", arn: roleArn } },
+    );
+
+    // Then it is allowed, because the change set says which Stack it belongs
+    // to. Authorizing on what the request carried would have asked about every
+    // Stack in the Account and Region.
+    assertIdentical(described.ChangeSetName, "reports-change");
   });
 });

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-stack.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-stack.ts
@@ -1,0 +1,98 @@
+import type {
+  BackgroundCompleter,
+  BackgroundScheduler,
+} from "../../../util/background/background.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
+import type { SimCfnExports } from "../export/sim-cfn-exports.js";
+import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
+import {
+  SimCloudFormationAlreadyExistsException,
+  SimCloudFormationValidationError,
+} from "../error/sim-cloudformation.error.js";
+import type { SimCfnChangeSetType } from "./sim-cfn-change-set.type.js";
+
+interface SimCfnChangeSetStackProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  readonly background: BackgroundScheduler & BackgroundCompleter;
+  readonly stackName: SimCloudFormationStackName;
+  readonly type: SimCfnChangeSetType;
+  readonly template: SimCfnTemplate;
+  readonly caller?: SimAwsCaller | undefined;
+  readonly exports?: SimCfnExports | undefined;
+}
+
+/**
+ * The Stack a change set is held against.
+ *
+ * A `CREATE` change set brings the Stack into being in review, which is the
+ * status a Stack holds before anything has deployed it. Its Resources are
+ * worked out from the template and none of them is created, so executing the
+ * change set is what deploys them.
+ *
+ * An `UPDATE` change set needs a Stack that is already there, and leaves it
+ * exactly as it is.
+ */
+export function simCfnChangeSetStack(
+  properties: SimCfnChangeSetStackProperties,
+): SimCfnStack {
+  const { stacks, stackName, type } = properties;
+  const deployed = stacks.get(stackName);
+
+  if (type === "UPDATE") {
+    if (deployed === undefined) {
+      throw new SimCloudFormationValidationError(
+        `Stack [${stackName}] does not exist`,
+      );
+    }
+
+    return deployed;
+  }
+
+  if (deployed !== undefined) {
+    throw new SimCloudFormationAlreadyExistsException(
+      `Stack [${stackName}] already exists`,
+    );
+  }
+
+  const stack = new SimCfnStack({
+    simAws: properties.simAws,
+    accountRegionScope: properties.accountRegionScope,
+    background: properties.background,
+    stackName,
+    template: properties.template,
+    caller: properties.caller,
+    exports: properties.exports,
+  });
+
+  stacks.set(stack.stackName, stack);
+
+  return stack;
+}
+
+/**
+ * The Stack a change set was created against, for executing it.
+ *
+ * A Stack that has gone since the change set was created leaves the change set
+ * naming nothing, which CloudFormation refuses the way it refuses any command
+ * naming a Stack it cannot find.
+ */
+export function simCfnChangeSetDeployedStack(
+  stacks: ReadonlyMap<SimCloudFormationStackName, SimCfnStack>,
+  changeSet: { readonly stackName: SimCloudFormationStackName },
+): SimCfnStack {
+  const stack = stacks.get(changeSet.stackName);
+
+  if (stack === undefined) {
+    throw new SimCloudFormationValidationError(
+      `Stack [${changeSet.stackName}] does not exist`,
+    );
+  }
+
+  return stack;
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-type.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-type.ts
@@ -1,0 +1,31 @@
+import { SimCloudFormationValidationError } from "../error/sim-cloudformation.error.js";
+import type { SimCfnChangeSetType } from "./sim-cfn-change-set.type.js";
+
+/**
+ * What CloudFormation answers a change set that would change nothing.
+ */
+export const simCfnChangeSetNoChangesMessage =
+  "The submitted information didn't contain changes. " +
+  "Submit different information to create a change set.";
+
+/**
+ * Read the ChangeSetType a CreateChangeSet input asks for.
+ *
+ * CloudFormation defaults to `UPDATE`. `IMPORT` is outside the simulation,
+ * because nothing here can adopt a Resource it did not create.
+ */
+export function simCfnChangeSetType(
+  changeSetType: string | undefined,
+): SimCfnChangeSetType {
+  if (changeSetType === undefined || changeSetType === "UPDATE") {
+    return "UPDATE";
+  }
+
+  if (changeSetType === "CREATE") {
+    return "CREATE";
+  }
+
+  throw new SimCloudFormationValidationError(
+    `Sim CloudFormation ChangeSetType ${changeSetType} is not supported`,
+  );
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set.ts
@@ -17,6 +17,13 @@ interface SimCfnChangeSetProperties {
   readonly type: SimCfnChangeSetType;
   readonly template: SimCfnTemplate;
   readonly changes: readonly SimCfnResourceChange[];
+
+  /**
+   * The template the Stack was on when the changes were worked out. A Stack
+   * that has moved on from it leaves the change set obsolete.
+   */
+  readonly plannedFrom: SimCfnTemplate;
+
   readonly description?: string | undefined;
 
   /** Why the change set failed, for one the simulator refused to build. */
@@ -41,6 +48,7 @@ export class SimCfnChangeSet {
   public readonly type: SimCfnChangeSetType;
   public readonly template: SimCfnTemplate;
   public readonly changes: readonly SimCfnResourceChange[];
+  public readonly plannedFrom: SimCfnTemplate;
   public readonly description: string | undefined;
 
   /** How far the change set itself got. */
@@ -61,6 +69,7 @@ export class SimCfnChangeSet {
     this.type = properties.type;
     this.template = properties.template;
     this.changes = properties.changes;
+    this.plannedFrom = properties.plannedFrom;
     this.description = properties.description;
     this.changeSetId = simCfnChangeSetArn(
       properties.accountRegionScope,

--- a/src/service/cloudformation/changeset/sim-cfn-change-set.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set.ts
@@ -1,0 +1,79 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
+import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
+import { simCfnChangeSetArn } from "./sim-cfn-change-set-arn.js";
+import type {
+  SimCfnChangeSetExecutionStatus,
+  SimCfnChangeSetName,
+  SimCfnChangeSetStatus,
+  SimCfnChangeSetType,
+  SimCfnResourceChange,
+} from "./sim-cfn-change-set.type.js";
+
+interface SimCfnChangeSetProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly changeSetName: SimCfnChangeSetName;
+  readonly stackName: SimCloudFormationStackName;
+  readonly type: SimCfnChangeSetType;
+  readonly template: SimCfnTemplate;
+  readonly changes: readonly SimCfnResourceChange[];
+  readonly description?: string | undefined;
+
+  /** Why the change set failed, for one the simulator refused to build. */
+  readonly failureReason?: string | undefined;
+}
+
+/**
+ * One change set held against a simulated CloudFormation Stack.
+ *
+ * It holds the template it was created from and the Resource changes executing
+ * it would make. The changes are worked out when the change set is created and
+ * kept as they were, which is the point of a change set: what it reports is
+ * what was true of the Stack at the moment it was asked for.
+ *
+ * Executing it belongs to SimCloudFormation. This class only records how far
+ * that execution got.
+ */
+export class SimCfnChangeSet {
+  public readonly changeSetId: string;
+  public readonly changeSetName: SimCfnChangeSetName;
+  public readonly stackName: SimCloudFormationStackName;
+  public readonly type: SimCfnChangeSetType;
+  public readonly template: SimCfnTemplate;
+  public readonly changes: readonly SimCfnResourceChange[];
+  public readonly description: string | undefined;
+
+  /** How far the change set itself got. */
+  public status: SimCfnChangeSetStatus;
+
+  /** Why the change set is in the status it is in, where there is a reason. */
+  public readonly statusReason: string | undefined;
+
+  /** Whether the change set can be executed, and how execution went. */
+  public executionStatus: SimCfnChangeSetExecutionStatus;
+
+  constructor(properties: SimCfnChangeSetProperties) {
+    const { changeSetName, failureReason } = properties;
+    const built = failureReason === undefined;
+
+    this.changeSetName = changeSetName;
+    this.stackName = properties.stackName;
+    this.type = properties.type;
+    this.template = properties.template;
+    this.changes = properties.changes;
+    this.description = properties.description;
+    this.changeSetId = simCfnChangeSetArn(
+      properties.accountRegionScope,
+      changeSetName,
+    );
+
+    this.status = built ? "CREATE_COMPLETE" : "FAILED";
+    this.statusReason = failureReason;
+    this.executionStatus = built ? "AVAILABLE" : "UNAVAILABLE";
+  }
+
+  /** Whether ExecuteChangeSet will take this change set. */
+  public get executable(): boolean {
+    return this.executionStatus === "AVAILABLE";
+  }
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set.type.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set.type.ts
@@ -1,0 +1,51 @@
+import type { Brand } from "../../../util/brand.type.js";
+
+export type SimCfnChangeSetName = Brand<string, "SimCfnChangeSetName">;
+
+/**
+ * How far the change set itself has got.
+ *
+ * A change set the simulator refused to build lands in `FAILED` carrying the
+ * reason, which is what CloudFormation does with a change set describing no
+ * change at all.
+ */
+export type SimCfnChangeSetStatus =
+  | "CREATE_IN_PROGRESS"
+  | "CREATE_COMPLETE"
+  | "DELETE_COMPLETE"
+  | "FAILED";
+
+/**
+ * Whether the change set can be executed, and how the execution went.
+ *
+ * `OBSOLETE` is what a change set becomes once another one against the same
+ * Stack has been executed, because the plan it holds was worked out against a
+ * Stack that has moved on.
+ */
+export type SimCfnChangeSetExecutionStatus =
+  | "UNAVAILABLE"
+  | "AVAILABLE"
+  | "EXECUTE_IN_PROGRESS"
+  | "EXECUTE_COMPLETE"
+  | "EXECUTE_FAILED"
+  | "OBSOLETE";
+
+/**
+ * Whether executing the change set creates the Stack or updates it.
+ */
+export type SimCfnChangeSetType = "CREATE" | "UPDATE";
+
+export type SimCfnResourceChangeAction = "Add" | "Modify" | "Remove";
+
+/**
+ * One Resource a change set would create, replace or delete.
+ *
+ * `replacement` is `True` on every `Modify`. Simulated CloudFormation replaces
+ * a changed Resource, so a modification it reports is always a replacement.
+ */
+export interface SimCfnResourceChange {
+  readonly action: SimCfnResourceChangeAction;
+  readonly logicalResourceId: string;
+  readonly resourceType: string | undefined;
+  readonly replacement: "True" | undefined;
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-sets.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-sets.ts
@@ -1,0 +1,117 @@
+import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
+import {
+  SimCloudFormationInvalidChangeSetStatusException,
+  SimCloudFormationValidationError,
+} from "../error/sim-cloudformation.error.js";
+import type { SimCfnChangeSet } from "./sim-cfn-change-set.js";
+import type { SimCfnChangeSetName } from "./sim-cfn-change-set.type.js";
+
+interface SimCfnChangeSetLookup {
+  /** A change set name, or the change set ARN CreateChangeSet returned. */
+  readonly changeSetName: string;
+
+  /** The Stack the change set belongs to, needed alongside a plain name. */
+  readonly stackName?: string | undefined;
+}
+
+/**
+ * The change sets one simulated CloudFormation holds, in the order they were
+ * created.
+ *
+ * A change set is reached by its ARN on its own, or by its name together with
+ * the Stack it belongs to, which is how CloudFormation reaches one. Two change
+ * sets against different Stacks can carry the same name.
+ */
+export class SimCfnChangeSets {
+  private changeSets: readonly SimCfnChangeSet[] = [];
+
+  /** Hold a change set that has just been created. */
+  add(changeSet: SimCfnChangeSet): void {
+    this.changeSets = [...this.changeSets, changeSet];
+  }
+
+  /** Find a change set, or answer undefined where the lookup names none. */
+  find(lookup: SimCfnChangeSetLookup): SimCfnChangeSet | undefined {
+    const { changeSetName, stackName } = lookup;
+
+    return this.changeSets.find((changeSet) => {
+      if (changeSet.changeSetId === changeSetName) {
+        return true;
+      }
+
+      return (
+        changeSet.changeSetName === changeSetName &&
+        stackName !== undefined &&
+        changeSet.stackName === stackName
+      );
+    });
+  }
+
+  /**
+   * Find a change set, refusing a lookup that names none the way
+   * CloudFormation refuses it.
+   */
+  require(lookup: SimCfnChangeSetLookup): SimCfnChangeSet {
+    const changeSet = this.find(lookup);
+
+    if (changeSet === undefined) {
+      throw new SimCloudFormationValidationError(
+        `ChangeSet [${lookup.changeSetName}] does not exist`,
+      );
+    }
+
+    return changeSet;
+  }
+
+  /**
+   * Find a change set that can be executed, refusing one that cannot.
+   *
+   * A change set that failed to build, that has already been executed, or that
+   * another execution has made obsolete is refused for the status it is in,
+   * the way CloudFormation refuses it.
+   */
+  requireExecutable(lookup: SimCfnChangeSetLookup): SimCfnChangeSet {
+    const changeSet = this.require(lookup);
+
+    if (!changeSet.executable) {
+      throw new SimCloudFormationInvalidChangeSetStatusException(
+        `ChangeSet [${changeSet.changeSetId}] cannot be executed in its ` +
+          `current status of [${changeSet.executionStatus}]`,
+      );
+    }
+
+    return changeSet;
+  }
+
+  /** Whether this Stack already holds a change set under this name. */
+  has(
+    stackName: SimCloudFormationStackName,
+    name: SimCfnChangeSetName,
+  ): boolean {
+    return this.find({ changeSetName: name, stackName }) !== undefined;
+  }
+
+  /** The change sets held against one Stack, in the order they were created. */
+  forStack(stackName: SimCloudFormationStackName): readonly SimCfnChangeSet[] {
+    return this.changeSets.filter(
+      (changeSet) => changeSet.stackName === stackName,
+    );
+  }
+
+  /** Take a change set away, for DeleteChangeSet. */
+  remove(changeSet: SimCfnChangeSet): void {
+    this.changeSets = this.changeSets.filter((held) => held !== changeSet);
+  }
+
+  /**
+   * Give up on every other change set against this Stack, because the one
+   * given has been executed and the Stack has moved on from what they saw.
+   */
+  markOthersObsolete(executed: SimCfnChangeSet): void {
+    for (const changeSet of this.forStack(executed.stackName)) {
+      if (changeSet !== executed && changeSet.executable) {
+        changeSet.executionStatus = "OBSOLETE";
+      }
+    }
+  }
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-sets.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-sets.ts
@@ -1,10 +1,22 @@
 import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
 import {
+  SimCloudFormationChangeSetNotFoundException,
   SimCloudFormationInvalidChangeSetStatusException,
-  SimCloudFormationValidationError,
 } from "../error/sim-cloudformation.error.js";
 import type { SimCfnChangeSet } from "./sim-cfn-change-set.js";
 import type { SimCfnChangeSetName } from "./sim-cfn-change-set.type.js";
+
+/**
+ * How CloudFormation refuses a change set that cannot be executed.
+ */
+export function simCfnChangeSetNotExecutable(
+  changeSet: SimCfnChangeSet,
+): Error {
+  return new SimCloudFormationInvalidChangeSetStatusException(
+    `ChangeSet [${changeSet.changeSetId}] cannot be executed in its ` +
+      `current status of [${changeSet.executionStatus}]`,
+  );
+}
 
 interface SimCfnChangeSetLookup {
   /** A change set name, or the change set ARN CreateChangeSet returned. */
@@ -55,7 +67,7 @@ export class SimCfnChangeSets {
     const changeSet = this.find(lookup);
 
     if (changeSet === undefined) {
-      throw new SimCloudFormationValidationError(
+      throw new SimCloudFormationChangeSetNotFoundException(
         `ChangeSet [${lookup.changeSetName}] does not exist`,
       );
     }
@@ -74,10 +86,7 @@ export class SimCfnChangeSets {
     const changeSet = this.require(lookup);
 
     if (!changeSet.executable) {
-      throw new SimCloudFormationInvalidChangeSetStatusException(
-        `ChangeSet [${changeSet.changeSetId}] cannot be executed in its ` +
-          `current status of [${changeSet.executionStatus}]`,
-      );
+      throw simCfnChangeSetNotExecutable(changeSet);
     }
 
     return changeSet;

--- a/src/service/cloudformation/command/create-change-set/create-change-set.command.ts
+++ b/src/service/cloudformation/command/create-change-set/create-change-set.command.ts
@@ -1,0 +1,35 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimCreateStackParameter } from "../create-stack/create-stack.command.js";
+
+/**
+ * Minimal structural sim CloudFormation CreateChangeSet command.
+ */
+export interface SimCreateChangeSetCommand {
+  readonly input: SimCreateChangeSetCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFormation CreateChangeSet input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/CreateChangeSetCommand/
+ */
+export interface SimCreateChangeSetCommandInput {
+  readonly StackName?: string | undefined;
+  readonly ChangeSetName?: string | undefined;
+  readonly ChangeSetType?: string | undefined;
+  readonly TemplateBody?: string | undefined;
+  readonly Parameters?: readonly SimCreateStackParameter[] | undefined;
+  readonly Description?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFormation CreateChangeSet output.
+ *
+ * CloudFormation returns the change set ARN and the Stack ID. The changes it
+ * describes are only being worked out when the call returns.
+ */
+export interface SimCreateChangeSetCommandOutput {
+  readonly Id?: string;
+  readonly StackId?: string;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudformation/command/create-change-set/create-change-set.handler.ts
+++ b/src/service/cloudformation/command/create-change-set/create-change-set.handler.ts
@@ -1,0 +1,118 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import type {
+  BackgroundCompleter,
+  BackgroundScheduler,
+} from "../../../../util/background/background.js";
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnStack } from "../../stack/sim-cfn-stack.js";
+import type { SimCloudFormationStackName } from "../../stack/sim-cfn-stack.type.js";
+import { simCfnCommandTemplate } from "../../template/sim-cfn-command-template.js";
+import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
+import { SimCloudFormationAlreadyExistsException } from "../../error/sim-cloudformation.error.js";
+import { SimCfnChangeSet } from "../../changeset/sim-cfn-change-set.js";
+import type { SimCfnChangeSets } from "../../changeset/sim-cfn-change-sets.js";
+import type { SimCfnChangeSetName } from "../../changeset/sim-cfn-change-set.type.js";
+import { simCfnChangeSetPlan } from "../../changeset/sim-cfn-change-set-changes.js";
+import { simCfnChangeSetRequest } from "../../changeset/sim-cfn-change-set-input.js";
+import { simCfnChangeSetStack } from "../../changeset/sim-cfn-change-set-stack.js";
+import { simCfnChangeSetFailure } from "../../changeset/sim-cfn-change-set-failure.js";
+import type {
+  SimCreateChangeSetCommand,
+  SimCreateChangeSetCommandOutput,
+} from "./create-change-set.command.js";
+
+interface CreateChangeSetCommandHandlerProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  readonly changeSets: SimCfnChangeSets;
+  readonly background: BackgroundScheduler & BackgroundCompleter;
+  readonly caller?: SimAwsCaller | undefined;
+  readonly exports?: SimCfnExports | undefined;
+}
+
+/**
+ * Simulated CloudFormation CreateChangeSetCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/CreateChangeSetCommand/
+ */
+export class CreateChangeSetCommandHandler implements CommandHandler<
+  SimCreateChangeSetCommand,
+  SimCreateChangeSetCommandOutput
+> {
+  private readonly properties: CreateChangeSetCommandHandlerProperties;
+
+  constructor(properties: CreateChangeSetCommandHandlerProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Work out what a template would change about a Stack, and hold it.
+   *
+   * Nothing is created, deleted or replaced here. A `CREATE` change set puts
+   * the Stack itself in `REVIEW_IN_PROGRESS` holding no created Resources, and
+   * an `UPDATE` change set leaves the deployed Stack exactly as it is.
+   */
+  async handle(
+    command: SimCreateChangeSetCommand,
+  ): Promise<SimCreateChangeSetCommandOutput> {
+    const request = simCfnChangeSetRequest(command.input);
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.properties.background.sequence();
+
+    this.assertNameFree(request.stackName, request.changeSetName);
+
+    const template = simCfnCommandTemplate({
+      ...this.properties,
+      ...request,
+      input: command.input,
+    });
+    const stack = simCfnChangeSetStack({
+      ...this.properties,
+      ...request,
+      template,
+    });
+    const changes = simCfnChangeSetPlan({
+      ...this.properties,
+      ...request,
+      stack,
+      template,
+    });
+
+    const changeSet = new SimCfnChangeSet({
+      ...this.properties,
+      ...request,
+      template,
+      changes,
+      description: command.input.Description,
+      failureReason: simCfnChangeSetFailure({
+        ...request,
+        stack,
+        template,
+        changeCount: changes.length,
+      }),
+    });
+
+    this.properties.changeSets.add(changeSet);
+
+    return {
+      Id: changeSet.changeSetId,
+      StackId: stack.stackName,
+      $metadata: {},
+    };
+  }
+
+  private assertNameFree(
+    stackName: SimCloudFormationStackName,
+    changeSetName: SimCfnChangeSetName,
+  ): void {
+    if (this.properties.changeSets.has(stackName, changeSetName)) {
+      throw new SimCloudFormationAlreadyExistsException(
+        `ChangeSet [${changeSetName}] already exists`,
+      );
+    }
+  }
+}

--- a/src/service/cloudformation/command/create-change-set/create-change-set.handler.ts
+++ b/src/service/cloudformation/command/create-change-set/create-change-set.handler.ts
@@ -87,6 +87,7 @@ export class CreateChangeSetCommandHandler implements CommandHandler<
       ...request,
       template,
       changes,
+      plannedFrom: stack.currentTemplate,
       description: command.input.Description,
       failureReason: simCfnChangeSetFailure({
         ...request,

--- a/src/service/cloudformation/command/create-change-set/create-change-set.iso.test.ts
+++ b/src/service/cloudformation/command/create-change-set/create-change-set.iso.test.ts
@@ -1,0 +1,272 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import {
+  CreateChangeSetCommand,
+  CreateStackCommand,
+  DescribeChangeSetCommand,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+
+const reportsBucket = {
+  Type: "AWS::S3::Bucket",
+  Properties: { BucketName: "reports" },
+};
+
+const bucketNameParameter = {
+  Type: "AWS::SSM::Parameter",
+  Properties: {
+    Name: "/app/reports-bucket",
+    Type: "String",
+    Value: { Ref: "ReportsBucket" },
+  },
+};
+
+const template = {
+  Resources: {
+    ReportsBucket: reportsBucket,
+    BucketNameParameter: bucketNameParameter,
+  },
+};
+
+/**
+ * Deploy the Stack above, ready for a change set to be worked out against it.
+ */
+async function deployReportsStack(simAws: SimAws): Promise<void> {
+  const cloudFormation = simAws.cloudFormation();
+
+  await cloudFormation.createStack(
+    new CreateStackCommand({
+      StackName: "reports-stack",
+      TemplateBody: jsonStringify(template),
+    }),
+  );
+  await cloudFormation.waitForStackDeployComplete("reports-stack");
+}
+
+/**
+ * Create a change set against the deployed Stack and describe what it holds.
+ */
+async function describeChangeSetFor(
+  simAws: SimAws,
+  changed: CfnTemplateBodyRecord,
+  changeSetName = "reports-change",
+) {
+  const cloudFormation = simAws.cloudFormation();
+
+  await cloudFormation.createChangeSet(
+    new CreateChangeSetCommand({
+      StackName: "reports-stack",
+      ChangeSetName: changeSetName,
+      TemplateBody: jsonStringify(changed),
+    }),
+  );
+
+  return await cloudFormation.describeChangeSet(
+    new DescribeChangeSetCommand({
+      StackName: "reports-stack",
+      ChangeSetName: changeSetName,
+    }),
+  );
+}
+
+describe("CloudFormation CreateChangeSetCommand", () => {
+  it("reports a Resource the new template adds without creating it", async () => {
+    // Given a deployed Stack.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+
+    // When a change set is created from a template with a second Bucket.
+    const described = await describeChangeSetFor(simAws, {
+      Resources: {
+        ...template.Resources,
+        ArchiveBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "reports-archive" },
+        },
+      },
+    });
+
+    // Then the change set reports the added Bucket.
+    assertIdentical(described.Status, "CREATE_COMPLETE");
+    assertIdentical(described.ExecutionStatus, "AVAILABLE");
+    assertArrayLength(described.Changes, 1);
+    assertObjectMatches(described.Changes[0].ResourceChange, {
+      Action: "Add",
+      LogicalResourceId: "ArchiveBucket",
+      ResourceType: "AWS::S3::Bucket",
+    });
+
+    // And nothing has been created, because a change set only says what would
+    // happen.
+    assertUndefined(simAws.s3().getSimBucketByName("reports-archive"));
+  });
+
+  it("reports a changed Resource as a replacement", async () => {
+    // Given a deployed Stack whose Parameter holds a Ref to its Bucket.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+
+    // When a change set renames the Bucket.
+    const described = await describeChangeSetFor(simAws, {
+      Resources: {
+        ...template.Resources,
+        ReportsBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "reports-v2" },
+        },
+      },
+    });
+
+    // Then the Bucket and the Parameter naming it are both replacements, since
+    // simulated CloudFormation replaces a changed Resource and everything that
+    // names it.
+    assertArrayLength(described.Changes, 2);
+    assertObjectMatches(described.Changes[0].ResourceChange, {
+      Action: "Modify",
+      LogicalResourceId: "ReportsBucket",
+      Replacement: "True",
+    });
+    assertObjectMatches(described.Changes[1].ResourceChange, {
+      Action: "Modify",
+      LogicalResourceId: "BucketNameParameter",
+      Replacement: "True",
+    });
+
+    // And the deployed Bucket is still the one the Stack was created with.
+    assertNonNullable(simAws.s3().getSimBucketByName("reports"));
+  });
+
+  it("reports a Resource the new template drops", async () => {
+    // Given a deployed Stack.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+
+    // When a change set drops the Parameter.
+    const described = await describeChangeSetFor(simAws, {
+      Resources: { ReportsBucket: reportsBucket },
+    });
+
+    // Then the Parameter is reported as a removal.
+    assertArrayLength(described.Changes, 1);
+    assertObjectMatches(described.Changes[0].ResourceChange, {
+      Action: "Remove",
+      LogicalResourceId: "BucketNameParameter",
+    });
+  });
+
+  it("fails a change set that would change nothing", async () => {
+    // Given a deployed Stack.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+
+    // When a change set is created from the template the Stack already holds.
+    const described = await describeChangeSetFor(simAws, template);
+
+    // Then the change set failed, carrying the reason CloudFormation gives,
+    // and it cannot be executed.
+    assertIdentical(described.Status, "FAILED");
+    assertIdentical(described.ExecutionStatus, "UNAVAILABLE");
+    assertStringIncludes(
+      described.StatusReason ?? "",
+      "didn't contain changes",
+    );
+  });
+
+  it("creates a Stack in review for a CREATE change set", async () => {
+    // Given a simulation with no Stack of this name.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    // When a CREATE change set is created for it.
+    await cloudFormation.createChangeSet(
+      new CreateChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-create",
+        ChangeSetType: "CREATE",
+        TemplateBody: jsonStringify(template),
+      }),
+    );
+
+    // Then the Stack is there in review, holding no created Resources.
+    const stacks = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: "reports-stack" }),
+    );
+
+    assertArrayLength(stacks.Stacks, 1);
+    assertIdentical(stacks.Stacks[0].StackStatus, "REVIEW_IN_PROGRESS");
+    assertUndefined(simAws.s3().getSimBucketByName("reports"));
+
+    // And every Resource in the template is reported as an addition.
+    const described = await cloudFormation.describeChangeSet(
+      new DescribeChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-create",
+      }),
+    );
+
+    assertArrayLength(described.Changes, 2);
+    assertIdentical(described.Changes[0].ResourceChange.Action, "Add");
+    assertIdentical(described.Changes[1].ResourceChange.Action, "Add");
+  });
+
+  it("refuses an UPDATE change set against a Stack that is not there", async () => {
+    // Given a simulation with no Stack deployed.
+    const simAws = new SimAws();
+
+    // When an UPDATE change set names one anyway.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().createChangeSet(
+        new CreateChangeSetCommand({
+          StackName: "reports-stack",
+          ChangeSetName: "reports-change",
+          TemplateBody: jsonStringify(template),
+        }),
+      ),
+    );
+
+    // Then it is refused the way CloudFormation refuses it.
+    assertIdentical(error.name, "ValidationError");
+    assertStringIncludes(error.message, "does not exist");
+  });
+
+  it("refuses a second change set under the same name", async () => {
+    // Given a Stack holding a change set.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+    await describeChangeSetFor(simAws, {
+      Resources: { ReportsBucket: reportsBucket },
+    });
+
+    // When another change set is created under the same name.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().createChangeSet(
+        new CreateChangeSetCommand({
+          StackName: "reports-stack",
+          ChangeSetName: "reports-change",
+          TemplateBody: jsonStringify({
+            Resources: { ReportsBucket: reportsBucket },
+          }),
+        }),
+      ),
+    );
+
+    // Then it is refused as an existing change set.
+    assertIdentical(error.name, "AlreadyExistsException");
+  });
+});

--- a/src/service/cloudformation/command/create-change-set/create-change-set.iso.test.ts
+++ b/src/service/cloudformation/command/create-change-set/create-change-set.iso.test.ts
@@ -181,9 +181,10 @@ describe("CloudFormation CreateChangeSetCommand", () => {
     // and it cannot be executed.
     assertIdentical(described.Status, "FAILED");
     assertIdentical(described.ExecutionStatus, "UNAVAILABLE");
-    assertStringIncludes(
-      described.StatusReason ?? "",
-      "didn't contain changes",
+    assertIdentical(
+      described.StatusReason,
+      "The submitted information didn't contain changes. " +
+        "Submit different information to create a change set.",
     );
   });
 

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -16,9 +16,7 @@ import type {
   SimCreateStackCommand,
   SimCreateStackCommandOutput,
 } from "./create-stack.command.js";
-import { SimCfnTemplate } from "../../template/sim-cfn-template.js";
-import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
-import { makeSimCfnParameterStore } from "../../parameters/store/sim-cfn-parameter-store.js";
+import { simCfnCommandTemplate } from "../../template/sim-cfn-command-template.js";
 import type { SimCdkOutContext } from "../../cdk/sim-cdk-out-context.js";
 import type { SimCfnBinding } from "../../bind/sim-cfn-binding.js";
 import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
@@ -109,23 +107,14 @@ export class CreateStackCommandHandler implements CommandHandler<
       );
     }
 
-    const parameters = SimCfnParameters.fromInput(command.input, {
+    const template = simCfnCommandTemplate({
+      simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
       stackName,
-      parameterStore: makeSimCfnParameterStore({
-        simAws: this.simAws,
-        accountRegionScope: this.accountRegionScope,
-      }),
+      templateBody: command.input.TemplateBody,
+      input: command.input,
+      exports: this.exports,
     });
-
-    const template = SimCfnTemplate.fromTemplateBody(
-      command.input.TemplateBody,
-      {
-        stackName,
-        parameters,
-        accountRegionScope: this.accountRegionScope,
-        exports: this.exports,
-      },
-    );
 
     const stack = new SimCfnStack({
       simAws: this.simAws,

--- a/src/service/cloudformation/command/delete-change-set/delete-change-set.command.ts
+++ b/src/service/cloudformation/command/delete-change-set/delete-change-set.command.ts
@@ -1,0 +1,25 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudFormation DeleteChangeSet command.
+ */
+export interface SimDeleteChangeSetCommand {
+  readonly input: SimDeleteChangeSetCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFormation DeleteChangeSet input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/DeleteChangeSetCommand/
+ */
+export interface SimDeleteChangeSetCommandInput {
+  readonly ChangeSetName?: string | undefined;
+  readonly StackName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFormation DeleteChangeSet output.
+ */
+export interface SimDeleteChangeSetCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudformation/command/delete-change-set/delete-change-set.handler.ts
+++ b/src/service/cloudformation/command/delete-change-set/delete-change-set.handler.ts
@@ -1,0 +1,62 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimCfnChangeSets } from "../../changeset/sim-cfn-change-sets.js";
+import type {
+  SimDeleteChangeSetCommand,
+  SimDeleteChangeSetCommandOutput,
+} from "./delete-change-set.command.js";
+
+interface DeleteChangeSetCommandHandlerProperties {
+  readonly changeSets: SimCfnChangeSets;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Simulated CloudFormation DeleteChangeSetCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/DeleteChangeSetCommand/
+ */
+export class DeleteChangeSetCommandHandler implements CommandHandler<
+  SimDeleteChangeSetCommand,
+  SimDeleteChangeSetCommandOutput
+> {
+  private readonly changeSets: SimCfnChangeSets;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteChangeSetCommandHandlerProperties) {
+    this.changeSets = properties.changeSets;
+    this.background = properties.background;
+  }
+
+  /**
+   * Take a change set away without executing it.
+   *
+   * A change set name that is not there is a success, as it is in
+   * CloudFormation: DeleteChangeSet says the change set should be gone, and one
+   * that has already gone satisfies that.
+   */
+  async handle(
+    command: SimDeleteChangeSetCommand,
+  ): Promise<SimDeleteChangeSetCommandOutput> {
+    assertDefined(
+      command.input.ChangeSetName,
+      "DeleteChangeSetCommand.input.ChangeSetName",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const changeSet = this.changeSets.find({
+      changeSetName: command.input.ChangeSetName,
+      stackName: command.input.StackName,
+    });
+
+    if (changeSet !== undefined) {
+      changeSet.status = "DELETE_COMPLETE";
+      this.changeSets.remove(changeSet);
+    }
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/cloudformation/command/describe-change-set/describe-change-set.command.ts
+++ b/src/service/cloudformation/command/describe-change-set/describe-change-set.command.ts
@@ -1,0 +1,57 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimCfnChangeSetExecutionStatus,
+  SimCfnChangeSetStatus,
+  SimCfnResourceChangeAction,
+} from "../../changeset/sim-cfn-change-set.type.js";
+
+/**
+ * Minimal structural sim CloudFormation DescribeChangeSet command.
+ */
+export interface SimDescribeChangeSetCommand {
+  readonly input: SimDescribeChangeSetCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFormation DescribeChangeSet input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/DescribeChangeSetCommand/
+ */
+export interface SimDescribeChangeSetCommandInput {
+  readonly ChangeSetName?: string | undefined;
+  readonly StackName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFormation DescribeChangeSet output.
+ */
+export interface SimDescribeChangeSetCommandOutput {
+  readonly ChangeSetId?: string | undefined;
+  readonly ChangeSetName?: string | undefined;
+  readonly StackId?: string | undefined;
+  readonly StackName?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly Status?: SimCfnChangeSetStatus | undefined;
+  readonly StatusReason?: string | undefined;
+  readonly ExecutionStatus?: SimCfnChangeSetExecutionStatus | undefined;
+  readonly Changes?: SimCfnChangeDescription[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudFormation Change description.
+ */
+export interface SimCfnChangeDescription {
+  readonly Type: "Resource";
+  readonly ResourceChange: SimCfnResourceChangeDescription;
+}
+
+/**
+ * Minimal structural sim CloudFormation ResourceChange description.
+ */
+export interface SimCfnResourceChangeDescription {
+  readonly Action?: SimCfnResourceChangeAction | undefined;
+  readonly LogicalResourceId?: string | undefined;
+  readonly ResourceType?: string | undefined;
+  readonly Replacement?: string | undefined;
+}

--- a/src/service/cloudformation/command/describe-change-set/describe-change-set.handler.ts
+++ b/src/service/cloudformation/command/describe-change-set/describe-change-set.handler.ts
@@ -1,0 +1,83 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimCfnChangeSet } from "../../changeset/sim-cfn-change-set.js";
+import type { SimCfnChangeSets } from "../../changeset/sim-cfn-change-sets.js";
+import type {
+  SimCfnChangeDescription,
+  SimDescribeChangeSetCommand,
+  SimDescribeChangeSetCommandOutput,
+} from "./describe-change-set.command.js";
+
+interface DescribeChangeSetCommandHandlerProperties {
+  readonly changeSets: SimCfnChangeSets;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Simulated CloudFormation DescribeChangeSetCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/DescribeChangeSetCommand/
+ */
+export class DescribeChangeSetCommandHandler implements CommandHandler<
+  SimDescribeChangeSetCommand,
+  SimDescribeChangeSetCommandOutput
+> {
+  private readonly changeSets: SimCfnChangeSets;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DescribeChangeSetCommandHandlerProperties) {
+    this.changeSets = properties.changeSets;
+    this.background = properties.background;
+  }
+
+  /**
+   * Report what a change set would do to its Stack.
+   */
+  async handle(
+    command: SimDescribeChangeSetCommand,
+  ): Promise<SimDescribeChangeSetCommandOutput> {
+    assertDefined(
+      command.input.ChangeSetName,
+      "DescribeChangeSetCommand.input.ChangeSetName",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const changeSet = this.changeSets.require({
+      changeSetName: command.input.ChangeSetName,
+      stackName: command.input.StackName,
+    });
+
+    return {
+      ChangeSetId: changeSet.changeSetId,
+      ChangeSetName: changeSet.changeSetName,
+      StackId: changeSet.stackName,
+      StackName: changeSet.stackName,
+      Description: changeSet.description,
+      Status: changeSet.status,
+      StatusReason: changeSet.statusReason,
+      ExecutionStatus: changeSet.executionStatus,
+      Changes: describedChanges(changeSet),
+      $metadata: {},
+    };
+  }
+}
+
+/**
+ * The Resource changes in the shape DescribeChangeSet answers with.
+ */
+function describedChanges(
+  changeSet: SimCfnChangeSet,
+): SimCfnChangeDescription[] {
+  return changeSet.changes.map((change) => ({
+    Type: "Resource" as const,
+    ResourceChange: {
+      Action: change.action,
+      LogicalResourceId: change.logicalResourceId,
+      ResourceType: change.resourceType,
+      Replacement: change.replacement,
+    },
+  }));
+}

--- a/src/service/cloudformation/command/execute-change-set/execute-change-set.command.ts
+++ b/src/service/cloudformation/command/execute-change-set/execute-change-set.command.ts
@@ -1,0 +1,28 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim CloudFormation ExecuteChangeSet command.
+ */
+export interface SimExecuteChangeSetCommand {
+  readonly input: SimExecuteChangeSetCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFormation ExecuteChangeSet input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/ExecuteChangeSetCommand/
+ */
+export interface SimExecuteChangeSetCommandInput {
+  readonly ChangeSetName?: string | undefined;
+  readonly StackName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFormation ExecuteChangeSet output.
+ *
+ * CloudFormation returns nothing beyond response metadata. The Stack is only
+ * starting to change when the call returns.
+ */
+export interface SimExecuteChangeSetCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/cloudformation/command/execute-change-set/execute-change-set.handler.ts
+++ b/src/service/cloudformation/command/execute-change-set/execute-change-set.handler.ts
@@ -1,0 +1,69 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type {
+  BackgroundCompleter,
+  BackgroundScheduler,
+} from "../../../../util/background/background.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import type { SimCfnStack } from "../../stack/sim-cfn-stack.js";
+import type { SimCloudFormationStackName } from "../../stack/sim-cfn-stack.type.js";
+import type { SimCfnChangeSets } from "../../changeset/sim-cfn-change-sets.js";
+import { simCfnChangeSetDeployedStack } from "../../changeset/sim-cfn-change-set-stack.js";
+import { runSimCfnChangeSet } from "../../changeset/sim-cfn-change-set-execution.js";
+import type {
+  SimExecuteChangeSetCommand,
+  SimExecuteChangeSetCommandOutput,
+} from "./execute-change-set.command.js";
+
+interface ExecuteChangeSetCommandHandlerProperties {
+  readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  readonly changeSets: SimCfnChangeSets;
+  readonly background: BackgroundScheduler & BackgroundCompleter;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * Simulated CloudFormation ExecuteChangeSetCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/ExecuteChangeSetCommand/
+ */
+export class ExecuteChangeSetCommandHandler implements CommandHandler<
+  SimExecuteChangeSetCommand,
+  SimExecuteChangeSetCommandOutput
+> {
+  private readonly properties: ExecuteChangeSetCommandHandlerProperties;
+
+  constructor(properties: ExecuteChangeSetCommandHandlerProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Apply what a change set describes to its Stack.
+   *
+   * The call returns once the Stack operation has started, as CreateStack and
+   * UpdateStack do. A caller that needs the result should follow this with
+   * waitForStackDeployComplete(...) or waitForStackUpdateComplete(...).
+   */
+  async handle(
+    command: SimExecuteChangeSetCommand,
+  ): Promise<SimExecuteChangeSetCommandOutput> {
+    const { ChangeSetName, StackName } = command.input;
+    assertDefined(ChangeSetName, "ExecuteChangeSetCommand.input.ChangeSetName");
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.properties.background.sequence();
+
+    const changeSet = this.properties.changeSets.requireExecutable({
+      changeSetName: ChangeSetName,
+      stackName: StackName,
+    });
+
+    await runSimCfnChangeSet({
+      ...this.properties,
+      changeSet,
+      stack: simCfnChangeSetDeployedStack(this.properties.stacks, changeSet),
+    });
+
+    return { $metadata: {} };
+  }
+}

--- a/src/service/cloudformation/command/execute-change-set/execute-change-set.iso.test.ts
+++ b/src/service/cloudformation/command/execute-change-set/execute-change-set.iso.test.ts
@@ -1,0 +1,280 @@
+import { describe, it } from "vitest";
+import {
+  assertArrayEmpty,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import {
+  CreateChangeSetCommand,
+  CreateStackCommand,
+  DeleteChangeSetCommand,
+  DescribeChangeSetCommand,
+  DescribeStacksCommand,
+  ExecuteChangeSetCommand,
+  ListChangeSetsCommand,
+} from "@aws-sdk/client-cloudformation";
+import { GetParameterCommand } from "@aws-sdk/client-ssm";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import type { CfnTemplateBodyRecord } from "../../template/sim-cfn-template.js";
+
+const reportsBucket = {
+  Type: "AWS::S3::Bucket",
+  Properties: { BucketName: "reports" },
+};
+
+const bucketNameParameter = {
+  Type: "AWS::SSM::Parameter",
+  Properties: {
+    Name: "/app/reports-bucket",
+    Type: "String",
+    Value: { Ref: "ReportsBucket" },
+  },
+};
+
+const template = {
+  Resources: {
+    ReportsBucket: reportsBucket,
+    BucketNameParameter: bucketNameParameter,
+  },
+};
+
+/**
+ * Deploy the Stack above, ready for a change set against it.
+ */
+async function deployReportsStack(simAws: SimAws): Promise<void> {
+  const cloudFormation = simAws.cloudFormation();
+
+  await cloudFormation.createStack(
+    new CreateStackCommand({
+      StackName: "reports-stack",
+      TemplateBody: jsonStringify(template),
+    }),
+  );
+  await cloudFormation.waitForStackDeployComplete("reports-stack");
+}
+
+async function createChangeSet(
+  simAws: SimAws,
+  changeSetName: string,
+  changed: CfnTemplateBodyRecord,
+): Promise<void> {
+  await simAws.cloudFormation().createChangeSet(
+    new CreateChangeSetCommand({
+      StackName: "reports-stack",
+      ChangeSetName: changeSetName,
+      TemplateBody: jsonStringify(changed),
+    }),
+  );
+}
+
+async function describeChangeSet(simAws: SimAws, changeSetName: string) {
+  return await simAws.cloudFormation().describeChangeSet(
+    new DescribeChangeSetCommand({
+      StackName: "reports-stack",
+      ChangeSetName: changeSetName,
+    }),
+  );
+}
+
+const withArchiveBucket = {
+  Resources: {
+    ...template.Resources,
+    ArchiveBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "reports-archive" },
+    },
+  },
+};
+
+describe("CloudFormation ExecuteChangeSetCommand", () => {
+  it("applies what the change set describes", async () => {
+    // Given a deployed Stack with a change set adding a Bucket to it.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await deployReportsStack(simAws);
+    await createChangeSet(simAws, "reports-change", withArchiveBucket);
+
+    // When the change set is executed.
+    await cloudFormation.executeChangeSet(
+      new ExecuteChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("reports-stack");
+
+    // Then the Bucket the change set described is in simulated S3, and the
+    // Stack reports the update as complete.
+    assertNonNullable(simAws.s3().getSimBucketByName("reports-archive"));
+
+    const stacks = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: "reports-stack" }),
+    );
+    assertArrayLength(stacks.Stacks, 1);
+    assertIdentical(stacks.Stacks[0].StackStatus, "UPDATE_COMPLETE");
+
+    // And the change set records that it was executed.
+    await simAws.backgroundTasksComplete();
+
+    const described = await describeChangeSet(simAws, "reports-change");
+    assertIdentical(described.ExecutionStatus, "EXECUTE_COMPLETE");
+  });
+
+  it("creates the Stack a CREATE change set was made for", async () => {
+    // Given a Stack in review, brought into being by a CREATE change set.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createChangeSet(
+      new CreateChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-create",
+        ChangeSetType: "CREATE",
+        TemplateBody: jsonStringify(template),
+      }),
+    );
+
+    // When the change set is executed.
+    await cloudFormation.executeChangeSet(
+      new ExecuteChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-create",
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("reports-stack");
+
+    // Then the template's Resources are in simulated AWS.
+    assertNonNullable(simAws.s3().getSimBucketByName("reports"));
+
+    const parameter = await simAws
+      .ssm()
+      .getParameter(new GetParameterCommand({ Name: "/app/reports-bucket" }));
+    assertIdentical(parameter.Parameter?.Value, "reports");
+  });
+
+  it("refuses a change set that has already been executed", async () => {
+    // Given an executed change set.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await deployReportsStack(simAws);
+    await createChangeSet(simAws, "reports-change", withArchiveBucket);
+    await cloudFormation.executeChangeSet(
+      new ExecuteChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("reports-stack");
+
+    // When it is executed again.
+    const error = await assertThrowsErrorAsync(async () =>
+      cloudFormation.executeChangeSet(
+        new ExecuteChangeSetCommand({
+          StackName: "reports-stack",
+          ChangeSetName: "reports-change",
+        }),
+      ),
+    );
+
+    // Then it is refused for the status it is in.
+    assertIdentical(error.name, "InvalidChangeSetStatusException");
+    assertStringIncludes(error.message, "cannot be executed");
+  });
+
+  it("gives up on the other change sets against the Stack", async () => {
+    // Given a Stack holding two change sets.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await deployReportsStack(simAws);
+    await createChangeSet(simAws, "reports-change", withArchiveBucket);
+    await createChangeSet(simAws, "reports-other", {
+      Resources: { ReportsBucket: reportsBucket },
+    });
+
+    // When one of them is executed.
+    await cloudFormation.executeChangeSet(
+      new ExecuteChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("reports-stack");
+
+    // Then the other one is obsolete, because it was worked out against a
+    // Stack this execution has moved on.
+    const other = await describeChangeSet(simAws, "reports-other");
+    assertIdentical(other.ExecutionStatus, "OBSOLETE");
+
+    const error = await assertThrowsErrorAsync(async () =>
+      cloudFormation.executeChangeSet(
+        new ExecuteChangeSetCommand({
+          StackName: "reports-stack",
+          ChangeSetName: "reports-other",
+        }),
+      ),
+    );
+    assertIdentical(error.name, "InvalidChangeSetStatusException");
+  });
+
+  it("takes a change set away without executing it", async () => {
+    // Given a Stack holding a change set.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await deployReportsStack(simAws);
+    await createChangeSet(simAws, "reports-change", withArchiveBucket);
+
+    // When the change set is deleted.
+    await cloudFormation.deleteChangeSet(
+      new DeleteChangeSetCommand({
+        StackName: "reports-stack",
+        ChangeSetName: "reports-change",
+      }),
+    );
+
+    // Then the Stack holds none, and nothing the change set described happened.
+    const listed = await cloudFormation.listChangeSets(
+      new ListChangeSetsCommand({ StackName: "reports-stack" }),
+    );
+    assertArrayEmpty(listed.Summaries);
+    assertUndefined(simAws.s3().getSimBucketByName("reports-archive"));
+
+    // And describing it is refused, as CloudFormation refuses it.
+    const error = await assertThrowsErrorAsync(async () =>
+      describeChangeSet(simAws, "reports-change"),
+    );
+    assertIdentical(error.name, "ValidationError");
+  });
+
+  it("lists the change sets a Stack holds", async () => {
+    // Given a Stack holding two change sets.
+    const simAws = new SimAws();
+
+    await deployReportsStack(simAws);
+    await createChangeSet(simAws, "reports-change", withArchiveBucket);
+    await createChangeSet(simAws, "reports-other", {
+      Resources: { ReportsBucket: reportsBucket },
+    });
+
+    // When the Stack's change sets are listed.
+    const listed = await simAws
+      .cloudFormation()
+      .listChangeSets(
+        new ListChangeSetsCommand({ StackName: "reports-stack" }),
+      );
+
+    // Then both are there, in the order they were created.
+    assertArrayLength(listed.Summaries, 2);
+    assertIdentical(listed.Summaries[0].ChangeSetName, "reports-change");
+    assertIdentical(listed.Summaries[1].ChangeSetName, "reports-other");
+    assertIdentical(listed.Summaries[0].ExecutionStatus, "AVAILABLE");
+  });
+});

--- a/src/service/cloudformation/command/execute-change-set/execute-change-set.iso.test.ts
+++ b/src/service/cloudformation/command/execute-change-set/execute-change-set.iso.test.ts
@@ -251,7 +251,7 @@ describe("CloudFormation ExecuteChangeSetCommand", () => {
     const error = await assertThrowsErrorAsync(async () =>
       describeChangeSet(simAws, "reports-change"),
     );
-    assertIdentical(error.name, "ValidationError");
+    assertIdentical(error.name, "ChangeSetNotFoundException");
   });
 
   it("lists the change sets a Stack holds", async () => {

--- a/src/service/cloudformation/command/list-change-sets/list-change-sets.command.ts
+++ b/src/service/cloudformation/command/list-change-sets/list-change-sets.command.ts
@@ -34,6 +34,7 @@ export interface SimListChangeSetsCommandOutput {
 export interface SimCfnChangeSetSummary {
   readonly ChangeSetId?: string | undefined;
   readonly ChangeSetName?: string | undefined;
+  readonly StackId?: string | undefined;
   readonly StackName?: string | undefined;
   readonly Description?: string | undefined;
   readonly Status?: SimCfnChangeSetStatus | undefined;

--- a/src/service/cloudformation/command/list-change-sets/list-change-sets.command.ts
+++ b/src/service/cloudformation/command/list-change-sets/list-change-sets.command.ts
@@ -1,0 +1,42 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type {
+  SimCfnChangeSetExecutionStatus,
+  SimCfnChangeSetStatus,
+} from "../../changeset/sim-cfn-change-set.type.js";
+
+/**
+ * Minimal structural sim CloudFormation ListChangeSets command.
+ */
+export interface SimListChangeSetsCommand {
+  readonly input: SimListChangeSetsCommandInput;
+}
+
+/**
+ * Minimal structural sim CloudFormation ListChangeSets input.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/ListChangeSetsCommand/
+ */
+export interface SimListChangeSetsCommandInput {
+  readonly StackName?: string | undefined;
+}
+
+/**
+ * Minimal structural sim CloudFormation ListChangeSets output.
+ */
+export interface SimListChangeSetsCommandOutput {
+  readonly Summaries?: SimCfnChangeSetSummary[] | undefined;
+  readonly $metadata: SimResponseMetadata;
+}
+
+/**
+ * Minimal structural sim CloudFormation ChangeSetSummary.
+ */
+export interface SimCfnChangeSetSummary {
+  readonly ChangeSetId?: string | undefined;
+  readonly ChangeSetName?: string | undefined;
+  readonly StackName?: string | undefined;
+  readonly Description?: string | undefined;
+  readonly Status?: SimCfnChangeSetStatus | undefined;
+  readonly StatusReason?: string | undefined;
+  readonly ExecutionStatus?: SimCfnChangeSetExecutionStatus | undefined;
+}

--- a/src/service/cloudformation/command/list-change-sets/list-change-sets.handler.ts
+++ b/src/service/cloudformation/command/list-change-sets/list-change-sets.handler.ts
@@ -53,6 +53,7 @@ export class ListChangeSetsCommandHandler implements CommandHandler<
       Summaries: this.changeSets.forStack(stackName).map((changeSet) => ({
         ChangeSetId: changeSet.changeSetId,
         ChangeSetName: changeSet.changeSetName,
+        StackId: changeSet.stackName,
         StackName: changeSet.stackName,
         Description: changeSet.description,
         Status: changeSet.status,

--- a/src/service/cloudformation/command/list-change-sets/list-change-sets.handler.ts
+++ b/src/service/cloudformation/command/list-change-sets/list-change-sets.handler.ts
@@ -1,0 +1,65 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimCfnChangeSets } from "../../changeset/sim-cfn-change-sets.js";
+import type { SimCloudFormationStackName } from "../../stack/sim-cfn-stack.type.js";
+import type {
+  SimListChangeSetsCommand,
+  SimListChangeSetsCommandOutput,
+} from "./list-change-sets.command.js";
+
+interface ListChangeSetsCommandHandlerProperties {
+  readonly changeSets: SimCfnChangeSets;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Simulated CloudFormation ListChangeSetsCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/cloudformation/command/ListChangeSetsCommand/
+ */
+export class ListChangeSetsCommandHandler implements CommandHandler<
+  SimListChangeSetsCommand,
+  SimListChangeSetsCommandOutput
+> {
+  private readonly changeSets: SimCfnChangeSets;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: ListChangeSetsCommandHandlerProperties) {
+    this.changeSets = properties.changeSets;
+    this.background = properties.background;
+  }
+
+  /**
+   * List the change sets held against one Stack.
+   *
+   * A change set DeleteChangeSet has taken away is gone from here, as it is in
+   * CloudFormation.
+   */
+  async handle(
+    command: SimListChangeSetsCommand,
+  ): Promise<SimListChangeSetsCommandOutput> {
+    assertDefined(
+      command.input.StackName,
+      "ListChangeSetsCommand.input.StackName",
+    );
+
+    // Allow for potential non-deterministic sequencing of async events.
+    await this.background.sequence();
+
+    const stackName = command.input.StackName as SimCloudFormationStackName;
+
+    return {
+      Summaries: this.changeSets.forStack(stackName).map((changeSet) => ({
+        ChangeSetId: changeSet.changeSetId,
+        ChangeSetName: changeSet.changeSetName,
+        StackName: changeSet.stackName,
+        Description: changeSet.description,
+        Status: changeSet.status,
+        StatusReason: changeSet.statusReason,
+        ExecutionStatus: changeSet.executionStatus,
+      })),
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/cloudformation/command/update-stack/update-stack.handler.ts
+++ b/src/service/cloudformation/command/update-stack/update-stack.handler.ts
@@ -12,9 +12,7 @@ import type {
   SimCfnStack,
   SimCloudFormationStackName,
 } from "../../stack/sim-cfn-stack.js";
-import { SimCfnTemplate } from "../../template/sim-cfn-template.js";
-import { SimCfnParameters } from "../../parameters/sim-cfn-parameters.js";
-import { makeSimCfnParameterStore } from "../../parameters/store/sim-cfn-parameter-store.js";
+import { simCfnCommandTemplate } from "../../template/sim-cfn-command-template.js";
 import { SimCloudFormationValidationError } from "../../error/sim-cloudformation.error.js";
 import type { SimCfnExports } from "../../export/sim-cfn-exports.js";
 import type {
@@ -106,19 +104,13 @@ export class UpdateStackCommandHandler implements CommandHandler<
       );
     }
 
-    const parameters = SimCfnParameters.fromInput(command.input, {
-      stackName,
-      parameterStore: makeSimCfnParameterStore({
+    await stack.update(
+      simCfnCommandTemplate({
         simAws: this.simAws,
         accountRegionScope: this.accountRegionScope,
-      }),
-    });
-
-    await stack.update(
-      SimCfnTemplate.fromTemplateBody(command.input.TemplateBody, {
         stackName,
-        parameters,
-        accountRegionScope: this.accountRegionScope,
+        templateBody: command.input.TemplateBody,
+        input: command.input,
         exports: this.exports,
       }),
       { cdkOutContext: this.cdkOutContext, caller: this.caller },

--- a/src/service/cloudformation/error/sim-cloudformation.error.ts
+++ b/src/service/cloudformation/error/sim-cloudformation.error.ts
@@ -43,3 +43,18 @@ export class SimCloudFormationValidationError extends SimCloudFormationError {
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated CloudFormation InvalidChangeSetStatusException error.
+ *
+ * CloudFormation returns this for an ExecuteChangeSet naming a change set that
+ * cannot be executed, such as one that has already been executed or one another
+ * execution has made obsolete.
+ */
+export class SimCloudFormationInvalidChangeSetStatusException extends SimCloudFormationError {
+  public override readonly name = "InvalidChangeSetStatusException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/cloudformation/error/sim-cloudformation.error.ts
+++ b/src/service/cloudformation/error/sim-cloudformation.error.ts
@@ -58,3 +58,17 @@ export class SimCloudFormationInvalidChangeSetStatusException extends SimCloudFo
     super(message, { httpStatusCode: 400 });
   }
 }
+
+/**
+ * Simulated CloudFormation ChangeSetNotFoundException error.
+ *
+ * CloudFormation returns this for a command naming a change set it cannot
+ * find, which includes one DeleteChangeSet has taken away.
+ */
+export class SimCloudFormationChangeSetNotFoundException extends SimCloudFormationError {
+  public override readonly name = "ChangeSetNotFoundException";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}

--- a/src/service/cloudformation/sdk/sim-cloudformation-sdk-command-router.ts
+++ b/src/service/cloudformation/sdk/sim-cloudformation-sdk-command-router.ts
@@ -7,6 +7,11 @@ import type { SimCreateStackCommand } from "../command/create-stack/create-stack
 import type { SimDeleteStackCommand } from "../command/delete-stack/delete-stack.command.js";
 import type { SimDescribeStacksCommand } from "../command/describe-stacks/describe-stacks.command.js";
 import type { SimUpdateStackCommand } from "../command/update-stack/update-stack.command.js";
+import type { SimCreateChangeSetCommand } from "../command/create-change-set/create-change-set.command.js";
+import type { SimDescribeChangeSetCommand } from "../command/describe-change-set/describe-change-set.command.js";
+import type { SimExecuteChangeSetCommand } from "../command/execute-change-set/execute-change-set.command.js";
+import type { SimDeleteChangeSetCommand } from "../command/delete-change-set/delete-change-set.command.js";
+import type { SimListChangeSetsCommand } from "../command/list-change-sets/list-change-sets.command.js";
 import type { SimCloudFormation } from "../sim-cloudformation.js";
 
 /**
@@ -39,6 +44,46 @@ export class SimCloudFormationSdkCommandRouter implements SimSdkCommandRouter {
         async (command, context): Promise<unknown> =>
           await simCloudFormation.updateStack(
             command as SimUpdateStackCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "CreateChangeSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFormation.createChangeSet(
+            command as SimCreateChangeSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DescribeChangeSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFormation.describeChangeSet(
+            command as SimDescribeChangeSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ExecuteChangeSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFormation.executeChangeSet(
+            command as SimExecuteChangeSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "DeleteChangeSetCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFormation.deleteChangeSet(
+            command as SimDeleteChangeSetCommand,
+            simSdkCallerOptions(context),
+          ),
+      ],
+      [
+        "ListChangeSetsCommand",
+        async (command, context): Promise<unknown> =>
+          await simCloudFormation.listChangeSets(
+            command as SimListChangeSetsCommand,
             simSdkCallerOptions(context),
           ),
       ],

--- a/src/service/cloudformation/serve/sim-cfn-change-set-api.loc.test.ts
+++ b/src/service/cloudformation/serve/sim-cfn-change-set-api.loc.test.ts
@@ -1,0 +1,178 @@
+import {
+  CloudFormationClient,
+  CreateChangeSetCommand,
+  DeleteChangeSetCommand,
+  DescribeChangeSetCommand,
+  ExecuteChangeSetCommand,
+  ListChangeSetsCommand,
+} from "@aws-sdk/client-cloudformation";
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  assertArrayEmpty,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../serve/index.js";
+import { SimAws } from "../../aws/sim-aws.js";
+
+/**
+ * Simulated CloudFormation change sets reached over a port by a real client.
+ *
+ * A deployment tool creates a change set, reads what it would do, and executes
+ * it, so what these cover is whether all three survive a form-encoded request
+ * and an XML envelope on the way back.
+ */
+describe("Serving simulated CloudFormation change sets on an endpoint URL", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let client: CloudFormationClient;
+
+  /**
+   * A template holding one Bucket, named by a parameter.
+   */
+  function bucketTemplate(): string {
+    return JSON.stringify({
+      Parameters: { BucketName: { Type: "String" } },
+      Resources: {
+        SiteBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: { Ref: "BucketName" } },
+        },
+      },
+    });
+  }
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    const simIam = simAws.iam();
+    await simIam.createUser(new CreateUserCommand({ UserName: "Deployer" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Deployer",
+        PolicyName: "Everything",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Deployer" }),
+    );
+
+    client = new CloudFormationClient({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("creates, describes and executes a change set over the endpoint", async () => {
+    // Given a CREATE change set sent over the endpoint
+    const created = await client.send(
+      new CreateChangeSetCommand({
+        StackName: "site",
+        ChangeSetName: "site-create",
+        ChangeSetType: "CREATE",
+        Description: "The first deployment",
+        TemplateBody: bucketTemplate(),
+        Parameters: [
+          { ParameterKey: "BucketName", ParameterValue: "served-change-set" },
+        ],
+      }),
+    );
+    assertNonNullable(created.Id, "CreateChangeSet answered with an ARN");
+    assertIdentical(created.StackId, "site");
+
+    // When it is described over the same endpoint
+    const described = await client.send(
+      new DescribeChangeSetCommand({
+        StackName: "site",
+        ChangeSetName: "site-create",
+      }),
+    );
+
+    // Then the change it would make survived the XML envelope
+    assertIdentical(described.Status, "CREATE_COMPLETE");
+    assertIdentical(described.ExecutionStatus, "AVAILABLE");
+    assertIdentical(described.Description, "The first deployment");
+    assertArrayLength(described.Changes, 1);
+
+    const resourceChange = described.Changes[0].ResourceChange;
+    assertNonNullable(resourceChange, "the one Resource change");
+    assertIdentical(described.Changes[0].Type, "Resource");
+    assertIdentical(resourceChange.Action, "Add");
+    assertIdentical(resourceChange.LogicalResourceId, "SiteBucket");
+    assertIdentical(resourceChange.ResourceType, "AWS::S3::Bucket");
+
+    // And executing it deploys the Bucket the parameter named
+    await client.send(
+      new ExecuteChangeSetCommand({
+        StackName: "site",
+        ChangeSetName: "site-create",
+      }),
+    );
+    await simAws.cloudFormation().waitForStackDeployComplete("site");
+
+    assertNonNullable(simAws.s3().getSimBucketByName("served-change-set"));
+  });
+
+  it("lists and deletes a change set over the endpoint", async () => {
+    // Given a change set against the Stack the first test deployed
+    await client.send(
+      new CreateChangeSetCommand({
+        StackName: "site",
+        ChangeSetName: "site-rename",
+        TemplateBody: bucketTemplate(),
+        Parameters: [
+          { ParameterKey: "BucketName", ParameterValue: "served-renamed" },
+        ],
+      }),
+    );
+
+    // When the Stack's change sets are listed
+    const listed = await client.send(
+      new ListChangeSetsCommand({ StackName: "site" }),
+    );
+
+    // Then the executed one and the pending one are both there
+    assertArrayLength(listed.Summaries, 2);
+    assertIdentical(listed.Summaries[1].ChangeSetName, "site-rename");
+    assertIdentical(listed.Summaries[1].ExecutionStatus, "AVAILABLE");
+
+    // And deleting them leaves the Stack holding none
+    await client.send(
+      new DeleteChangeSetCommand({
+        StackName: "site",
+        ChangeSetName: "site-rename",
+      }),
+    );
+    await client.send(
+      new DeleteChangeSetCommand({
+        StackName: "site",
+        ChangeSetName: "site-create",
+      }),
+    );
+
+    const empty = await client.send(
+      new ListChangeSetsCommand({ StackName: "site" }),
+    );
+    assertArrayEmpty(empty.Summaries);
+  });
+});

--- a/src/service/cloudformation/serve/sim-cfn-change-set-api.loc.test.ts
+++ b/src/service/cloudformation/serve/sim-cfn-change-set-api.loc.test.ts
@@ -154,6 +154,8 @@ describe("Serving simulated CloudFormation change sets on an endpoint URL", () =
     // Then the executed one and the pending one are both there
     assertArrayLength(listed.Summaries, 2);
     assertIdentical(listed.Summaries[1].ChangeSetName, "site-rename");
+    assertIdentical(listed.Summaries[1].StackId, "site");
+    assertIdentical(listed.Summaries[1].StackName, "site");
     assertIdentical(listed.Summaries[1].ExecutionStatus, "AVAILABLE");
 
     // And deleting them leaves the Stack holding none

--- a/src/service/cloudformation/serve/sim-cloudformation-api.ts
+++ b/src/service/cloudformation/serve/sim-cloudformation-api.ts
@@ -6,6 +6,7 @@ import {
   queryMembers,
 } from "../../../serve/http/api/query/sim-query-result.js";
 import type { SimQueryFields } from "../../../serve/http/api/query/sim-query-request.js";
+import { simCfnChangeSetQueryOperations } from "./sim-cloudformation-change-set-api.js";
 
 /**
  * The XML namespace real CloudFormation stamps on every response it sends.
@@ -26,9 +27,10 @@ const stackOutputMembers = [
 /**
  * Serve the CloudFormation Query API to a client given an endpoint URL.
  *
- * The operations served are the four simulated CloudFormation implements:
- * `CreateStack`, `UpdateStack`, `DeleteStack` and `DescribeStacks`. Anything
- * else is refused as `NotImplemented`.
+ * The operations served are the Stack operations simulated CloudFormation
+ * implements, `CreateStack`, `UpdateStack`, `DeleteStack` and `DescribeStacks`,
+ * together with the five change set operations. Anything else is refused as
+ * `NotImplemented`.
  */
 export function simCloudFormationApiEndpoint(
   simAws: SimAws,
@@ -43,6 +45,7 @@ export function simCloudFormationApiEndpoint(
 
 function simCloudFormationQueryOperations(): SimQueryOperations {
   return new Map([
+    ...simCfnChangeSetQueryOperations(),
     [
       "CreateStack",
       {

--- a/src/service/cloudformation/serve/sim-cloudformation-change-set-api.ts
+++ b/src/service/cloudformation/serve/sim-cloudformation-change-set-api.ts
@@ -1,0 +1,117 @@
+import type { SimQueryOperations } from "../../../serve/http/api/query/sim-query-operation.js";
+import {
+  queryList,
+  queryMembers,
+  queryStructure,
+  type SimQueryOutput,
+} from "../../../serve/http/api/query/sim-query-result.js";
+import type { SimQueryFields } from "../../../serve/http/api/query/sim-query-request.js";
+
+/**
+ * The members CloudFormation describes one change set with.
+ */
+const changeSetMembers = [
+  "ChangeSetId",
+  "ChangeSetName",
+  "StackId",
+  "StackName",
+  "Description",
+  "Status",
+  "StatusReason",
+  "ExecutionStatus",
+];
+
+/**
+ * The members CloudFormation summarises one change set with in ListChangeSets.
+ */
+const changeSetSummaryMembers = [
+  "ChangeSetId",
+  "ChangeSetName",
+  "StackName",
+  "Description",
+  "Status",
+  "StatusReason",
+  "ExecutionStatus",
+];
+
+/**
+ * The members CloudFormation describes one Resource change with.
+ */
+const resourceChangeMembers = [
+  "Action",
+  "LogicalResourceId",
+  "ResourceType",
+  "Replacement",
+];
+
+/**
+ * The change set half of the CloudFormation Query API.
+ *
+ * Held apart from the Stack operations because the two halves share nothing
+ * but the service they belong to. Every operation here reaches the same Command
+ * an SDK caller sends, so a CLI deployment runs the code an in-process caller
+ * runs.
+ */
+export function simCfnChangeSetQueryOperations(): SimQueryOperations {
+  return new Map([
+    [
+      "CreateChangeSet",
+      {
+        input: (fields: SimQueryFields): Record<string, unknown> => ({
+          StackName: fields.text("StackName"),
+          ChangeSetName: fields.text("ChangeSetName"),
+          ChangeSetType: fields.text("ChangeSetType"),
+          Description: fields.text("Description"),
+          TemplateBody: fields.text("TemplateBody"),
+          Parameters: fields.list("Parameters", (parameter) => ({
+            ParameterKey: parameter.text("ParameterKey"),
+            ParameterValue: parameter.text("ParameterValue"),
+          })),
+        }),
+        result: (output: SimQueryOutput): string =>
+          queryMembers(output, ["Id", "StackId"]),
+      },
+    ],
+    [
+      "DescribeChangeSet",
+      {
+        input: changeSetInput,
+        result: (output: SimQueryOutput): string =>
+          queryMembers(output, changeSetMembers) +
+          queryList(
+            output,
+            "Changes",
+            (change) =>
+              queryMembers(change, ["Type"]) +
+              queryStructure(change, "ResourceChange", (resourceChange) =>
+                queryMembers(resourceChange, resourceChangeMembers),
+              ),
+          ),
+      },
+    ],
+    ["ExecuteChangeSet", { input: changeSetInput, result: (): string => "" }],
+    ["DeleteChangeSet", { input: changeSetInput, result: (): string => "" }],
+    [
+      "ListChangeSets",
+      {
+        input: (fields: SimQueryFields): Record<string, unknown> => ({
+          StackName: fields.text("StackName"),
+        }),
+        result: (output: SimQueryOutput): string =>
+          queryList(output, "Summaries", (summary) =>
+            queryMembers(summary, changeSetSummaryMembers),
+          ),
+      },
+    ],
+  ]);
+}
+
+/**
+ * The input every operation naming one change set sends.
+ */
+function changeSetInput(fields: SimQueryFields): Record<string, unknown> {
+  return {
+    StackName: fields.text("StackName"),
+    ChangeSetName: fields.text("ChangeSetName"),
+  };
+}

--- a/src/service/cloudformation/serve/sim-cloudformation-change-set-api.ts
+++ b/src/service/cloudformation/serve/sim-cloudformation-change-set-api.ts
@@ -27,6 +27,7 @@ const changeSetMembers = [
 const changeSetSummaryMembers = [
   "ChangeSetId",
   "ChangeSetName",
+  "StackId",
   "StackName",
   "Description",
   "Status",

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -116,6 +116,7 @@ export class SimCloudFormation {
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,
+      authorization: this.authorization,
       exports: this.exports,
     });
     this.templateDeployer = new SimCloudFormationTemplateDeployer({
@@ -202,6 +203,10 @@ export class SimCloudFormation {
 
   /**
    * Handle a Create Change Set Command from the SDK.
+   *
+   * The change set commands authorize themselves, unlike the Stack commands
+   * above. Three of them can name a change set by its ARN alone, and only the
+   * change set registry knows which Stack such a request operates on.
    */
   async createChangeSet(
     command: SimCreateChangeSetCommand,
@@ -222,12 +227,7 @@ export class SimCloudFormation {
     command: SimDescribeChangeSetCommand,
     options?: SimCloudFormationRequestOptions,
   ): Promise<SimDescribeChangeSetCommandOutput> {
-    this.authorization.describeChangeSet(
-      command.input.StackName,
-      options?.caller,
-    );
-
-    return await this.changeSetCommands.describe(command);
+    return await this.changeSetCommands.describe(command, options?.caller);
   }
 
   /**
@@ -237,11 +237,6 @@ export class SimCloudFormation {
     command: SimExecuteChangeSetCommand,
     options?: SimCloudFormationRequestOptions,
   ): Promise<SimExecuteChangeSetCommandOutput> {
-    this.authorization.executeChangeSet(
-      command.input.StackName,
-      options?.caller,
-    );
-
     return await this.changeSetCommands.execute(command, options?.caller);
   }
 
@@ -267,9 +262,7 @@ export class SimCloudFormation {
     command: SimListChangeSetsCommand,
     options?: SimCloudFormationRequestOptions,
   ): Promise<SimListChangeSetsCommandOutput> {
-    this.authorization.listChangeSets(command.input.StackName, options?.caller);
-
-    return await this.changeSetCommands.list(command);
+    return await this.changeSetCommands.list(command, options?.caller);
   }
 
   /**

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -30,6 +30,27 @@ import type {
   SimUpdateStackCommandOutput,
 } from "./command/update-stack/update-stack.command.js";
 import { UpdateStackCommandHandler } from "./command/update-stack/update-stack.handler.js";
+import type {
+  SimCreateChangeSetCommand,
+  SimCreateChangeSetCommandOutput,
+} from "./command/create-change-set/create-change-set.command.js";
+import type {
+  SimDescribeChangeSetCommand,
+  SimDescribeChangeSetCommandOutput,
+} from "./command/describe-change-set/describe-change-set.command.js";
+import type {
+  SimExecuteChangeSetCommand,
+  SimExecuteChangeSetCommandOutput,
+} from "./command/execute-change-set/execute-change-set.command.js";
+import type {
+  SimDeleteChangeSetCommand,
+  SimDeleteChangeSetCommandOutput,
+} from "./command/delete-change-set/delete-change-set.command.js";
+import type {
+  SimListChangeSetsCommand,
+  SimListChangeSetsCommandOutput,
+} from "./command/list-change-sets/list-change-sets.command.js";
+import { SimCfnChangeSetCommands } from "./changeset/sim-cfn-change-set-commands.js";
 import {
   type SimCloudFormationCreateStackProperties as SimCloudFormationCreateStackProperties,
   SimCloudFormationTemplateDeployer,
@@ -72,6 +93,7 @@ export class SimCloudFormation {
   private readonly templateDeployer: SimCloudFormationTemplateDeployer;
   private readonly sdkRouter = new SimCloudFormationSdkCommandRouter(this);
   private readonly authorization: SimCloudFormationAuthorization;
+  private readonly changeSetCommands: SimCfnChangeSetCommands;
 
   constructor(properties: SimCloudFormationProperties) {
     const {
@@ -88,6 +110,13 @@ export class SimCloudFormation {
     this.authorization = new SimCloudFormationAuthorization({
       iam,
       accountRegionScope: this.accountRegionScope,
+    });
+    this.changeSetCommands = new SimCfnChangeSetCommands({
+      simAws: this.simAws,
+      accountRegionScope: this.accountRegionScope,
+      stacks: this.stacks,
+      background: this.background,
+      exports: this.exports,
     });
     this.templateDeployer = new SimCloudFormationTemplateDeployer({
       simAws: this.simAws,
@@ -169,6 +198,78 @@ export class SimCloudFormation {
       background: this.background,
     });
     return await handler.handle(command);
+  }
+
+  /**
+   * Handle a Create Change Set Command from the SDK.
+   */
+  async createChangeSet(
+    command: SimCreateChangeSetCommand,
+    options?: SimCloudFormationRequestOptions,
+  ): Promise<SimCreateChangeSetCommandOutput> {
+    this.authorization.createChangeSet(
+      command.input.StackName,
+      options?.caller,
+    );
+
+    return await this.changeSetCommands.create(command, options?.caller);
+  }
+
+  /**
+   * Handle a Describe Change Set Command from the SDK.
+   */
+  async describeChangeSet(
+    command: SimDescribeChangeSetCommand,
+    options?: SimCloudFormationRequestOptions,
+  ): Promise<SimDescribeChangeSetCommandOutput> {
+    this.authorization.describeChangeSet(
+      command.input.StackName,
+      options?.caller,
+    );
+
+    return await this.changeSetCommands.describe(command);
+  }
+
+  /**
+   * Handle an Execute Change Set Command from the SDK.
+   */
+  async executeChangeSet(
+    command: SimExecuteChangeSetCommand,
+    options?: SimCloudFormationRequestOptions,
+  ): Promise<SimExecuteChangeSetCommandOutput> {
+    this.authorization.executeChangeSet(
+      command.input.StackName,
+      options?.caller,
+    );
+
+    return await this.changeSetCommands.execute(command, options?.caller);
+  }
+
+  /**
+   * Handle a Delete Change Set Command from the SDK.
+   */
+  async deleteChangeSet(
+    command: SimDeleteChangeSetCommand,
+    options?: SimCloudFormationRequestOptions,
+  ): Promise<SimDeleteChangeSetCommandOutput> {
+    this.authorization.deleteChangeSet(
+      command.input.StackName,
+      options?.caller,
+    );
+
+    return await this.changeSetCommands.delete(command);
+  }
+
+  /**
+   * Handle a List Change Sets Command from the SDK.
+   */
+  async listChangeSets(
+    command: SimListChangeSetsCommand,
+    options?: SimCloudFormationRequestOptions,
+  ): Promise<SimListChangeSetsCommandOutput> {
+    this.authorization.listChangeSets(command.input.StackName, options?.caller);
+
+    return await this.changeSetCommands.list(command);
   }
 
   /**

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -49,7 +49,6 @@ export class SimCfnStack implements SimCfnDeployedStack {
   public readonly deletion: SimCfnStackDeletionLifecycle;
   public readonly stackName: SimCloudFormationStackName;
   public readonly resourceMap: Map<string, SimCfnResource>;
-  public template: CfnTemplateBodyRecord;
   public outputs = new Map<string, SimCfnStackOutput>();
 
   private readonly background: BackgroundScheduler;
@@ -76,7 +75,6 @@ export class SimCfnStack implements SimCfnDeployedStack {
     this.stackName = stackName;
     this.stackOutputs = new SimCfnStackOutputs({ stackName, exports });
     this.cfnTemplate = template;
-    this.template = this.cfnTemplate.template;
     this.resourceMap = makeSimCfnStackResourceMap({
       accountRegionScope,
       background,
@@ -100,7 +98,8 @@ export class SimCfnStack implements SimCfnDeployedStack {
       background,
       stackName,
       runDeployment: async (): Promise<void> => {
-        await this.createResources();
+        await this.operations.createAll(this.resourceMap);
+        this.resolveOutputs();
       },
     });
     this.updating = new SimCfnStackUpdateLifecycle({ background, stackName });
@@ -122,21 +121,27 @@ export class SimCfnStack implements SimCfnDeployedStack {
     return this.operationStatus.status;
   }
 
+  /** The parsed template this Stack is deployed from. */
+  public get currentTemplate(): SimCfnTemplate {
+    return this.cfnTemplate;
+  }
+
+  /** The template body this Stack is deployed from. */
+  public get template(): CfnTemplateBodyRecord {
+    return this.cfnTemplate.template;
+  }
+
   /** The error the operation the status reports failed with, if it failed. */
   public get error(): Error | undefined {
     return this.operationStatus.error;
   }
 
-  /**
-   * Start deploying this simulated Stack into simulated AWS.
-   */
+  /** Start deploying this simulated Stack into simulated AWS. */
   async deploy(): Promise<void> {
     await this.lifecycle.deploy();
   }
 
-  /**
-   * Wait for the scheduled deployment task to finish.
-   */
+  /** Wait for the scheduled deployment task to finish. */
   async waitForDeployComplete(): Promise<void> {
     await this.lifecycle.waitForComplete();
   }
@@ -179,7 +184,6 @@ export class SimCfnStack implements SimCfnDeployedStack {
     this.operations.useUpdate(properties);
 
     this.cfnTemplate = template;
-    this.template = template.template;
 
     await this.updating.update(async (): Promise<void> => {
       await updater.apply();
@@ -187,9 +191,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
     });
   }
 
-  /**
-   * Wait for the scheduled Stack update to finish.
-   */
+  /** Wait for the scheduled Stack update to finish. */
   async waitForUpdateComplete(): Promise<void> {
     await this.updating.waitForComplete();
   }
@@ -206,9 +208,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
     await this.deletion.delete(properties);
   }
 
-  /**
-   * Wait for the scheduled Stack deletion to finish.
-   */
+  /** Wait for the scheduled Stack deletion to finish. */
   async waitForDeleteComplete(): Promise<void> {
     await this.deletion.waitForComplete();
   }
@@ -278,11 +278,6 @@ export class SimCfnStack implements SimCfnDeployedStack {
 
   private get report(): SimCfnStackResourceReport {
     return new SimCfnStackResourceReport(this.resourceMap, this.cfnTemplate);
-  }
-
-  private async createResources(): Promise<void> {
-    await this.operations.createAll(this.resourceMap);
-    this.resolveOutputs();
   }
 
   private resolveOutputs(): void {

--- a/src/service/cloudformation/template/sim-cfn-command-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-command-template.ts
@@ -1,0 +1,43 @@
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
+import type { SimCfnExports } from "../export/sim-cfn-exports.js";
+import { SimCfnParameters } from "../parameters/sim-cfn-parameters.js";
+import type { SimCloudFormationParameterInput } from "../parameters/sim-cfn-parameters.type.js";
+import { makeSimCfnParameterStore } from "../parameters/store/sim-cfn-parameter-store.js";
+import { SimCfnTemplate } from "./sim-cfn-template.js";
+
+interface SimCfnCommandTemplateProperties {
+  readonly simAws: SimAws;
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly stackName: SimCloudFormationStackName;
+  readonly templateBody: string;
+
+  /** The command input the template's Parameter values are read from. */
+  readonly input: SimCloudFormationParameterInput;
+
+  readonly exports?: SimCfnExports | undefined;
+}
+
+/**
+ * The template a Stack command was sent, parsed against its Parameter values.
+ *
+ * A Parameter of type `AWS::SSM::Parameter::Value` reads simulated Parameter
+ * Store, so parsing needs the simulation the command arrived at as well as the
+ * body it carried.
+ */
+export function simCfnCommandTemplate(
+  properties: SimCfnCommandTemplateProperties,
+): SimCfnTemplate {
+  const { simAws, accountRegionScope, stackName, exports } = properties;
+
+  return SimCfnTemplate.fromTemplateBody(properties.templateBody, {
+    stackName,
+    parameters: SimCfnParameters.fromInput(properties.input, {
+      stackName,
+      parameterStore: makeSimCfnParameterStore({ simAws, accountRegionScope }),
+    }),
+    accountRegionScope,
+    exports,
+  });
+}


### PR DESCRIPTION
Simulated CloudFormation serves `CreateChangeSet`, `DescribeChangeSet`, `ExecuteChangeSet`, `DeleteChangeSet` and `ListChangeSets`, over the SDK and over the served Query API. A change set holds the plan an update already worked out, so what it reports and what executing it does come from the same comparison. A `CREATE` change set brings its Stack into being in `REVIEW_IN_PROGRESS` and creates none of its Resources, and executing it deploys them. Every `Modify` carries `Replacement: True`, because a changed Resource is replaced here rather than updated in place. A change set describing a template the Stack already holds is `FAILED` and refuses to execute, and executing one makes every other change set against that Stack `OBSOLETE`.

Two things came out of the file gates rather than the feature. `SimCfnStack` was exactly at its 300-line limit, so `template` became a getter over the parsed template it was already holding, which removed the field that had to be reassigned in two places. `SimCloudFormation` gained a documented `max-lines` override at 400, the same one `sim-iam.ts` carries for the same reason: one method per SDK command, each a doc comment and a line of delegation.

`simCfnCommandTemplate` is the template parsing `CreateStack`, `UpdateStack` and `CreateChangeSet` now share.

Resolves #1221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated CloudFormation change-set support.
  * Create, describe, execute, delete, and list change sets.
  * Preview resource additions, modifications, removals, and replacements before deployment.
  * Track change-set and execution statuses, including failures and obsolete sets.
  * Support CREATE and UPDATE change sets with asynchronous execution.
  * Added endpoint coverage and an example workflow for creating and executing a change set.

* **Documentation**
  * Documented change-set workflows, supported behaviors, limitations, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->