### PR TITLE
fix(cloudfront): translate local viewer origins

### DIFF
--- a/src/service/cloudformation/watch/sim-cfn-template-file-watch.loc.test.ts
+++ b/src/service/cloudformation/watch/sim-cfn-template-file-watch.loc.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import { simWatchConfig } from "../../../watch/sim-watch.config.js";
 import { SimCfnTemplateFileWatch } from "./sim-cfn-template-file-watch.js";
 import {
   putSitePage,
@@ -85,8 +86,15 @@ describe("a deployed template file that changes", () => {
   });
 
   it("makes one update out of a burst of writes", async () => {
-    // Given a Stack deployed from a watched template file
-    const watched = await WatchedTemplate.of(siteTemplate());
+    // Given a Stack deployed from a watched template file, watched with the
+    // window a real save gets. The window has to outlast the gaps between the
+    // writes below, and those gaps belong to the machine. A single write takes
+    // tens of milliseconds on a loaded runner, long enough to step over the
+    // short window the rest of these tests run on. The burst is then applied in
+    // pieces, one update for each template it was written with.
+    const watched = await WatchedTemplate.of(siteTemplate(), {
+      settleMs: simWatchConfig.settleMs,
+    });
 
     try {
       // When it is written several times in a row, as one save does
@@ -94,8 +102,10 @@ describe("a deployed template file that changes", () => {
       await watched.write(siteTemplate({ description: "two" }));
       await watched.write(siteTemplate({ withUploads: true }));
 
+      // A second update would settle in one more window. Waiting that out is
+      // what makes a burst applied in pieces show up in the count below.
       await watched.updated();
-      await templatePause(200);
+      await templatePause(simWatchConfig.settleMs * 2);
 
       // Then the Stack is updated once, to the template that was left there
       assertIdentical(watched.updateCount(), 1);

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.iso.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.iso.test.ts
@@ -1,0 +1,113 @@
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimCfForwardedToOrigin } from "../../origin-request-policy/sim-cf-forwarded-to-origin.js";
+import { SimCfOriginRequestForwarding } from "../../origin-request-policy/sim-cf-origin-request-forwarding.js";
+import { simCfCustomOriginRequest } from "./sim-cf-custom-origin-request.js";
+
+describe("Building a CloudFront custom Origin request", () => {
+  const forwarded = new SimCfForwardedToOrigin({
+    forwarding: new SimCfOriginRequestForwarding({
+      headerBehavior: "allViewer",
+    }),
+  });
+
+  function forwardedOrigin(properties: {
+    readonly viewerUrl: string;
+    readonly origin: string;
+    readonly viewerProtocolPolicy:
+      | "allow-all"
+      | "redirect-to-https"
+      | "https-only";
+  }): string | null {
+    const request = simCfCustomOriginRequest({
+      domainName: "api123.execute-api.eu-west-2.amazonaws.com",
+      originPath: "",
+      request: new Request(properties.viewerUrl, {
+        headers: { origin: properties.origin },
+      }),
+      viewerProtocolPolicy: properties.viewerProtocolPolicy,
+      forwarded,
+    });
+
+    return request.headers.get("origin");
+  }
+
+  it("sends the HTTPS CloudFront origin for a local HTTPS-only viewer", () => {
+    // Given a browser request made to a local Distribution URL.
+    const localOrigin =
+      "http://distro123.cloudfront.net.sim-aws.localhost:5173";
+
+    // When CloudFront forwards its same-origin header to a custom Origin.
+    const origin = forwardedOrigin({
+      viewerUrl: `${localOrigin}/do/basket/add`,
+      origin: localOrigin,
+      viewerProtocolPolicy: "redirect-to-https",
+    });
+
+    // Then the custom Origin sees the AWS-facing HTTPS origin.
+    assertIdentical(origin, "https://distro123.cloudfront.net");
+  });
+
+  it("keeps HTTP for a local viewer allowed to use it", () => {
+    // Given a local Distribution request on a Behavior allowing HTTP.
+    const localOrigin =
+      "http://distro123.cloudfront.net.sim-aws.localhost:5173";
+
+    // When CloudFront forwards its same-origin header.
+    const origin = forwardedOrigin({
+      viewerUrl: `${localOrigin}/do/basket/add`,
+      origin: localOrigin,
+      viewerProtocolPolicy: "allow-all",
+    });
+
+    // Then the AWS-facing origin keeps the viewer protocol.
+    assertIdentical(origin, "http://distro123.cloudfront.net");
+  });
+
+  it("translates an alternate domain name", () => {
+    // Given a browser request made through a local alternate domain name.
+    const localOrigin = "http://shop.example.test.sim-aws.localhost:5173";
+
+    // When CloudFront forwards its same-origin header.
+    const origin = forwardedOrigin({
+      viewerUrl: `${localOrigin}/do/basket/add`,
+      origin: localOrigin,
+      viewerProtocolPolicy: "https-only",
+    });
+
+    // Then the custom Origin sees the AWS-facing alternate domain name.
+    assertIdentical(origin, "https://shop.example.test");
+  });
+
+  it("keeps a cross-origin local value", () => {
+    // Given a local Distribution request carrying another local site's Origin.
+    const crossOrigin = "http://admin.example.test.sim-aws.localhost:5173";
+
+    // When CloudFront forwards that cross-origin header.
+    const origin = forwardedOrigin({
+      viewerUrl:
+        "http://shop.example.test.sim-aws.localhost:5173/do/basket/add",
+      origin: crossOrigin,
+      viewerProtocolPolicy: "redirect-to-https",
+    });
+
+    // Then the unrelated value is unchanged.
+    assertIdentical(origin, crossOrigin);
+  });
+
+  it("keeps an AWS-facing value", () => {
+    // Given an in-process request carrying the AWS-facing Origin already.
+    const awsOrigin = "https://distro123.cloudfront.net";
+
+    // When CloudFront forwards the header.
+    const origin = forwardedOrigin({
+      viewerUrl: `${awsOrigin}/do/basket/add`,
+      origin: awsOrigin,
+      viewerProtocolPolicy: "redirect-to-https",
+    });
+
+    // Then the in-process value is unchanged.
+    assertIdentical(origin, awsOrigin);
+  });
+});

--- a/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
+++ b/src/service/cloudfront/origin/custom/sim-cf-custom-origin-request.ts
@@ -1,5 +1,10 @@
 import { SimAwsLocalUrl } from "../../../../serve/http/url/sim-aws-local-url.js";
+import {
+  isSimAwsLocalRequest,
+  simAwsRequestHostname,
+} from "../../../../serve/http/url/sim-aws-request-hostname.js";
 import { stripSimAwsControlHeaders } from "../../../iam/request/sim-aws-control-headers.js";
+import type { SimCloudFrontBehavior } from "../../behaviour/sim-cloud-front-behavior.js";
 import type { SimCfForwardedToOrigin } from "../../origin-request-policy/sim-cf-forwarded-to-origin.js";
 import {
   simCfForwardedOriginHeaders,
@@ -10,6 +15,9 @@ interface SimCfCustomOriginRequestProperties {
   readonly domainName: string;
   readonly originPath: string;
   readonly request: Request;
+  readonly viewerProtocolPolicy?:
+    | SimCloudFrontBehavior["viewerProtocolPolicy"]
+    | undefined;
   /**
    * What the Behavior's cache policy and origin request policy carry to the
    * Origin between them.
@@ -57,6 +65,7 @@ export function simCfCustomOriginRequest(
 
   const headers = simCfForwardedOriginHeaders(request.headers, forwarded);
 
+  applyAwsFacingViewerOrigin(headers, request, properties.viewerProtocolPolicy);
   headers.set("host", originUrl.host);
 
   // Who the Origin request is from is the Origin's business, not the viewer's,
@@ -91,6 +100,68 @@ export function simCfCustomOriginRequest(
     redirect: request.redirect,
     signal: request.signal,
   });
+}
+
+/**
+ * Replace the local same-origin value a browser sends with the origin the
+ * viewer would use against CloudFront.
+ *
+ * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html
+ */
+function applyAwsFacingViewerOrigin(
+  headers: Headers,
+  viewerRequest: Request,
+  viewerProtocolPolicy: SimCloudFrontBehavior["viewerProtocolPolicy"],
+): void {
+  const value = headers.get("origin");
+
+  if (value === null || !isSimAwsLocalRequest(viewerRequest)) {
+    return;
+  }
+
+  const origin = originUrl(value);
+  if (origin === undefined || origin.origin !== viewerOrigin(viewerRequest)) {
+    return;
+  }
+
+  origin.hostname = simAwsRequestHostname(viewerRequest);
+  origin.port = "";
+
+  if (
+    viewerProtocolPolicy === "redirect-to-https" ||
+    viewerProtocolPolicy === "https-only"
+  ) {
+    origin.protocol = "https:";
+  }
+
+  headers.set("origin", origin.origin);
+}
+
+/**
+ * The local origin the viewer used, including the Host header when it differs
+ * from the Request URL.
+ */
+function viewerOrigin(request: Request): string {
+  const url = new URL(request.url);
+  const host = request.headers.get("host");
+
+  if (host !== null) {
+    url.host = host;
+  }
+
+  return url.origin;
+}
+
+/**
+ * Read a serialized Origin without rejecting the request when it is `null` or
+ * malformed. CloudFront forwards those values unchanged.
+ */
+function originUrl(value: string): URL | undefined {
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.loc.test.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.loc.test.ts
@@ -14,10 +14,11 @@ import { describe, it } from "vitest";
 import { serveSimAws } from "../../../../serve/index.js";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../../lambda/function/code/lambda-zip-file-input.js";
+import { simCfManagedOriginRequestPolicyIds } from "../../origin-request-policy/sim-cf-managed-origin-request-policies.js";
 
 describe("Serving a sim CloudFront custom Origin on localhost", () => {
-  it("reaches the Origin in process for a real localhost request", async () => {
-    // Given a function behind a public Function URL.
+  it("presents the AWS-facing viewer Origin to a custom Origin", async () => {
+    // Given a function reporting the request it receives.
     const simAws = new SimAws();
     await simAws.lambda().createFunction(
       new CreateFunctionCommand({
@@ -25,10 +26,18 @@ describe("Serving a sim CloudFront custom Origin on localhost", () => {
         Role: "arn:aws:iam::111111111111:role/GreeterRole",
         Code: {
           ZipFile: makeLambdaZipFileInput(
-            (event: { rawPath?: string; body?: string }) => ({
+            (event: {
+              rawPath?: string;
+              body?: string;
+              headers?: Record<string, string>;
+            }) => ({
               statusCode: 200,
               headers: { "content-type": "text/plain" },
-              body: `${event.rawPath ?? ""} ${event.body ?? ""}`.trim(),
+              body: JSON.stringify({
+                path: event.rawPath,
+                body: event.body,
+                origin: event.headers?.["origin"],
+              }),
             }),
           ),
         },
@@ -67,7 +76,9 @@ describe("Serving a sim CloudFront custom Origin on localhost", () => {
           },
           DefaultCacheBehavior: {
             TargetOriginId: "function-origin",
-            ViewerProtocolPolicy: "allow-all",
+            ViewerProtocolPolicy: "redirect-to-https",
+            OriginRequestPolicyId:
+              simCfManagedOriginRequestPolicyIds.allViewerExceptHostHeader,
             AllowedMethods: {
               Quantity: 3,
               Items: ["GET", "HEAD", "POST"],
@@ -83,15 +94,24 @@ describe("Serving a sim CloudFront custom Origin on localhost", () => {
     const srv = await serveSimAws({ simAws });
 
     try {
-      // When the Distribution is requested over localhost.
-      const response = await fetch(
-        srv.localUrl(`http://${distroHostname}/greet`),
-        { method: "POST", body: "Yulin" },
-      );
+      // When a browser sends its local same-origin value through CloudFront.
+      const viewerUrl = srv.localUrl(`https://${distroHostname}/greet`);
+      const response = await fetch(viewerUrl, {
+        method: "POST",
+        headers: { origin: viewerUrl.origin },
+        body: "Yulin",
+      });
 
-      // Then the Origin served it, over the same request path and body.
+      // Then the custom Origin receives the production URL with the request.
       assertResponseStatus(response, 200, await describeResponse(response));
-      assertIdentical(await response.text(), "/greet Yulin");
+      assertIdentical(
+        await response.text(),
+        JSON.stringify({
+          path: "/greet",
+          body: "Yulin",
+          origin: `https://${distroHostname}`,
+        }),
+      );
     } finally {
       await srv.close();
     }

--- a/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
+++ b/src/service/cloudfront/origin/custom/sim-cloudfront-custom-origin.ts
@@ -98,6 +98,7 @@ export class SimCloudFrontCustomOrigin implements SimCloudFrontOrigin {
       domainName: this.domainName,
       originPath: this.originPath,
       request: request.req,
+      viewerProtocolPolicy: request.behavior.viewerProtocolPolicy,
       forwarded: simCfBehaviorForwardedToOrigin(
         request.behavior,
         this.policies,


### PR DESCRIPTION
Translate browser-generated localhost `Origin` headers to the AWS-facing viewer origin before CloudFront forwards them to a custom origin. The translation follows the viewer protocol policy, supports alternate domain names, and preserves cross-origin or already AWS-facing values.

Resolves https://github.com/KensioSoftware/yulin/issues/1228

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] Documentation is unchanged because this restores AWS parity without adding an API or option


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CloudFront custom-origin requests to correctly forward browser `Origin` headers.
  * Same-origin requests are translated to the appropriate AWS-facing hostname while preserving valid external, malformed, and `null` origins.
  * Origin protocols now respect HTTPS redirect and HTTPS-only policies.
  * Preserved request behavior across custom origins when host headers are excluded by the configured origin request policy.

* **Tests**
  * Added coverage for origin forwarding, protocol conversion, alternate domains, and cross-origin requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->