### PR TITLE
fix(cognito): pre-fill mapped claims by schema type

### DIFF
--- a/src/service/cognito/serve/page/sim-cognito-provider-page.iso.test.ts
+++ b/src/service/cognito/serve/page/sim-cognito-provider-page.iso.test.ts
@@ -62,6 +62,22 @@ function usernamesIn(setUp: SimCognitoHostedSetUp): readonly string[] {
     .users.map((user) => String(user.username));
 }
 
+/**
+ * The values a browser posts when nobody edits the page's inputs.
+ */
+function formFields(page: string): Record<string, string> {
+  return Object.fromEntries(
+    page
+      .matchAll(/<input [^>]*name="([^"]+)"[^>]*value="([^"]*)"[^>]*>/gu)
+      .map(([, name, value]) => {
+        assertNonNullable(name);
+        assertNonNullable(value);
+
+        return [name, value] as const;
+      }),
+  );
+}
+
 describe("The page a sim Cognito domain stands in for an identity provider with", () => {
   it("answers an authorize request naming a provider nobody is signed in at", async () => {
     // Given a pool whose Google provider has nobody signed in at it.
@@ -137,6 +153,40 @@ describe("The page a sim Cognito domain stands in for an identity provider with"
       .requireUser("Google_simulated-google-subject" as never);
     assertIdentical(user.attributeValues.get("email"), "someone@example.com");
     assertIdentical(user.status.value, "EXTERNAL_PROVIDER");
+  });
+
+  it("signs in with pre-filled claims mapped onto every schema type", async () => {
+    // Given a Google provider mapping claims onto each kind of pool attribute.
+    const setUp = await simCognitoHosted({
+      schema: [
+        { Name: "score", AttributeDataType: "Number", Mutable: true },
+        { Name: "joined_at", AttributeDataType: "DateTime", Mutable: true },
+      ],
+      attributeMapping: {
+        email: "email",
+        email_verified: "email_verified",
+        "custom:score": "score",
+        "custom:joined_at": "joined_at",
+      },
+    });
+    const page = await providerPage(setUp);
+    const fields = formFields(page);
+
+    // When the page is posted without editing its pre-filled claims.
+    const posted = await simCognitoPostForm(setUp, "/oauth2/authorize", fields);
+
+    // Then the values satisfy the mapped attributes and the sign-in finishes.
+    assertResponseStatus(posted, 302, await describeResponse(posted));
+    const user = setUp.cognito
+      .userPool(setUp.userPoolId)
+      .requireUser("Google_simulated-google-subject" as never);
+    assertIdentical(user.attributeValues.get("email"), "someone@example.com");
+    assertIdentical(user.attributeValues.get("email_verified"), "true");
+    assertIdentical(user.attributeValues.get("custom:score"), "0");
+    assertIdentical(
+      user.attributeValues.get("custom:joined_at"),
+      "1970-01-01T00:00:00.000Z",
+    );
   });
 
   it("takes an edited address, beside a local user already holding it", async () => {

--- a/src/service/cognito/serve/page/sim-cognito-provider-page.ts
+++ b/src/service/cognito/serve/page/sim-cognito-provider-page.ts
@@ -79,7 +79,7 @@ export class SimCognitoProviderPage {
           `${simCognitoClaimFieldPrefix}${claimName}`,
           `${claimName} claim`,
           "text",
-          simCognitoDefaultClaim(claimName),
+          simCognitoDefaultClaim(provider, claimName),
         ),
       )
       .join("");

--- a/src/service/cognito/user-pool/idp/sim-cognito-attribute-mapping.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-attribute-mapping.ts
@@ -1,4 +1,5 @@
 import { SimCognitoInvalidParameterException } from "../../error/sim-cognito.error.js";
+import type { SimCognitoAttributeDataTypeValue } from "../schema/sim-cognito-attribute-data-type.js";
 import type { SimCognitoUserPoolSchema } from "../schema/sim-cognito-user-pool-schema.js";
 import type { SimCognitoAttributeType } from "../user/sim-cognito-user-attributes.js";
 import type { SimCognitoExternalUser } from "./sim-cognito-external-user.js";
@@ -38,6 +39,30 @@ export class SimCognitoAttributeMapping {
    */
   toOutput(): SimCognitoAttributeMappingType {
     return { ...this.mapping };
+  }
+
+  /**
+   * The pool attribute types one provider claim is mapped onto.
+   */
+  dataTypesForClaim(
+    claimName: string,
+  ): readonly SimCognitoAttributeDataTypeValue[] {
+    return Object.entries(this.mapping).flatMap(
+      ([attributeName, mappedClaimName]) => {
+        if (mappedClaimName !== claimName) {
+          return [];
+        }
+
+        const attribute = this.schema.find(attributeName);
+
+        return attribute === undefined
+          ? []
+          : [
+              attribute.toOutput()
+                .AttributeDataType as SimCognitoAttributeDataTypeValue,
+            ];
+      },
+    );
   }
 
   /**

--- a/src/service/cognito/user-pool/idp/sim-cognito-presented-external-user.ts
+++ b/src/service/cognito/user-pool/idp/sim-cognito-presented-external-user.ts
@@ -37,16 +37,37 @@ export function simCognitoMappedClaimNames(
 }
 
 /**
- * What one claim field is pre-filled with, so that the page signs a user in
- * when nobody edits it.
+ * What one claim field is pre-filled with, so the page signs a user in when
+ * nobody edits it.
  *
- * An address has to look like one, because a pool that verifies or aliases by
- * email holds it to that. Everything else is a name as far as this knows.
+ * The pool attribute type decides the shape. A string claim whose name refers
+ * to an email address uses the reserved address.
  */
-export function simCognitoDefaultClaim(claimName: string): string {
-  return claimName.toLowerCase().includes("email")
-    ? defaultAddress
-    : defaultClaimValue;
+export function simCognitoDefaultClaim(
+  provider: SimCognitoUserPoolIdentityProvider,
+  claimName: string,
+): string {
+  const dataType =
+    provider.attributeMapping
+      .dataTypesForClaim(claimName)
+      .find((mappedType) => mappedType !== "String") ?? "String";
+
+  switch (dataType) {
+    case "Boolean": {
+      return "true";
+    }
+    case "DateTime": {
+      return "1970-01-01T00:00:00.000Z";
+    }
+    case "Number": {
+      return "0";
+    }
+    case "String": {
+      return claimName.toLowerCase().includes("email")
+        ? defaultAddress
+        : defaultClaimValue;
+    }
+  }
 }
 
 /**

--- a/test/cognito/federation-fixture.ts
+++ b/test/cognito/federation-fixture.ts
@@ -96,6 +96,9 @@ export interface SimCognitoHostedSetUpOptions {
   /** The pool's `Schema`, which is the standard attributes by default. */
   readonly schema?: SchemaAttributeType[];
 
+  /** How the Google provider's claims map onto pool attributes. */
+  readonly attributeMapping?: Record<string, string>;
+
   /**
    * The attributes the pool verifies automatically, none by default. A pool
    * with none has nowhere to send a password reset code.
@@ -178,7 +181,10 @@ export async function simCognitoHosted(
         client_secret: "google-client-secret",
         authorize_scopes: "openid email",
       },
-      AttributeMapping: { email: "email", given_name: "given_name" },
+      AttributeMapping: options.attributeMapping ?? {
+        email: "email",
+        given_name: "given_name",
+      },
     }),
   );
 


### PR DESCRIPTION
The simulated provider page now chooses each claim's default from the mapped
user-pool attribute type. Google `email_verified` starts as `true`. Number and
DateTime mappings also receive valid values.

An isolated managed-login test submits the page without edits and covers
String, Boolean, Number and DateTime mappings.

Resolves https://github.com/KensioSoftware/yulin/issues/1233

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

See https://www.conventionalcommits.org/en/v1.0.0/
