### PR TITLE
feat: simulate S3 storage classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
 
 .worktrees/
+.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,5 @@ test/terraform/**/builds/
 test/terraform/**/terraform.tfstate*
 test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
+
+.worktrees/

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -2256,12 +2256,149 @@ Bucket ACLs and Object ownership settings are left out, and stay that way by cho
 defaults to Bucket owner enforced on new Buckets, which disables ACLs, and AWS recommends keeping
 them disabled in favour of policies.
 
+## Storage classes
+
+Every Object is in a storage class. A write names one and the Object stays there until a lifecycle
+rule moves it. `PutObject`, `CopyObject` and `CreateMultipartUpload` all take a `StorageClass`, and
+both list operations, `GetObject` and `HeadObject` report where the Object ended up.
+
+```typescript sim-s3-storage-class
+/**
+ * Writing a simulated S3 Object into an archival storage class.
+ */
+
+import {
+  CreateBucketCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "archive" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "archive",
+    Key: "ledgers/2026.csv",
+    Body: "a,b",
+    StorageClass: "GLACIER",
+  }),
+);
+
+const listing = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "archive" }),
+);
+const head = await simS3.headObject(
+  new HeadObjectCommand({ Bucket: "archive", Key: "ledgers/2026.csv" }),
+);
+
+// GLACIER, from the listing and from the Object itself.
+console.log(listing.Contents?.[0]?.StorageClass, head.StorageClass);
+```
+
+A write naming a class S3 has no such class for is refused with `InvalidStorageClass`, before
+anything is stored. The classes taken are `STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`,
+`ONEZONE_IA`, `INTELLIGENT_TIERING`, `GLACIER_IR`, `GLACIER`, `DEEP_ARCHIVE`, `EXPRESS_ONEZONE`,
+`OUTPOSTS` and `SNOW`.
+
+A listing always reports a class, and a read reports one only for an Object outside `STANDARD`. That
+is how real S3 answers, and it is why `GetObject.StorageClass` is undefined for most Objects. A copy
+is stored in the class the copy names rather than the source's, and an upload in parts takes its
+class at `CreateMultipartUpload` rather than at the completion.
+
+Where the Object is changes nothing about reading it. Real S3 refuses a read of an archived Object
+until `RestoreObject` has brought it back, and sim S3 serves every Object whatever class it is in.
+See [Limitations](#limitations).
+
+## Default encryption
+
+Every Bucket is encrypted, and every Object written into one reports the algorithm it was stored
+under. Nothing is actually encrypted here. The bytes are stored as they arrive and the ETag stays
+the MD5 of them, which is what real S3 reports for an SSE-S3 Object too. What this gives a test is
+the answer S3 gives about an Object, so code that reads `ServerSideEncryption` or the
+`x-amz-server-side-encryption` header has something to read.
+
+```typescript sim-s3-bucket-encryption
+/**
+ * Configuring a simulated S3 Bucket's default encryption.
+ */
+
+import {
+  CreateBucketCommand,
+  GetBucketEncryptionCommand,
+  GetObjectCommand,
+  PutBucketEncryptionCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "documents" }));
+
+await simS3.putBucketEncryption(
+  new PutBucketEncryptionCommand({
+    Bucket: "documents",
+    ServerSideEncryptionConfiguration: {
+      Rules: [
+        { ApplyServerSideEncryptionByDefault: { SSEAlgorithm: "aws:kms" } },
+      ],
+    },
+  }),
+);
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "documents",
+    Key: "contracts/one.pdf",
+    Body: "one",
+  }),
+);
+
+const configured = await simS3.getBucketEncryption(
+  new GetBucketEncryptionCommand({ Bucket: "documents" }),
+);
+const read = await simS3.getObject(
+  new GetObjectCommand({ Bucket: "documents", Key: "contracts/one.pdf" }),
+);
+
+// aws:kms, from the Bucket's configuration and from the Object it stamped.
+console.log(
+  configured.ServerSideEncryptionConfiguration?.Rules?.[0]
+    ?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm,
+  read.ServerSideEncryption,
+);
+```
+
+A write names its own algorithm, the Bucket's configuration answers for a write that names none, and
+a Bucket nobody has configured is `AES256`. Real S3 has encrypted every new Object that way since
+January 2023, and `GetBucketEncryption` answers for an unconfigured Bucket with the same `AES256`
+rule rather than an error. `DeleteBucketEncryption` puts a Bucket back to that rule, since there is
+no such thing as an unencrypted Bucket.
+
+`AES256`, `aws:kms` and `aws:kms:dsse` are taken, and anything else is refused with
+`InvalidArgument`. The Objects already in a Bucket keep what they were written with when its
+configuration changes.
+
+An Object that reached a Bucket without a write reports no encryption at all. That covers the files
+a mounted directory serves and the ones a CDK `BucketDeployment` publishes, since neither went
+through `PutObject` to be stamped by one.
+
+An `AWS::S3::Bucket` `BucketEncryption` property is applied as the request is. CloudFormation states
+the rule under `ServerSideEncryptionByDefault` where the request states
+`ApplyServerSideEncryptionByDefault`, and the Resource translates that one name.
+
 ## Lifecycle configuration
 
 Sim S3 stores a Bucket's lifecycle rules and acts on them. An `Expiration` rule removes the Objects
-it selects once simulated time passes the boundary, a `NoncurrentVersionExpiration` rule bounds the
-history a versioned Bucket keeps, and an `AbortIncompleteMultipartUpload` rule discards uploads that
-were started and left unfinished.
+it selects once simulated time passes the boundary, a `Transitions` rule moves them between storage
+classes, a `NoncurrentVersionExpiration` rule bounds the history a versioned Bucket keeps, and an
+`AbortIncompleteMultipartUpload` rule discards uploads that were started and left unfinished.
 
 Retention is otherwise the one property of a log or a backup Bucket a test cannot demonstrate.
 Reading the rules back off a deployed Bucket says the rules arrived. Putting an Object, moving the
@@ -2421,6 +2558,77 @@ A noncurrent version is removed from the Bucket's history, and a `GetObject` nam
 answers `NoSuchVersion` afterwards. The current version is beyond every rule of this kind, however
 old it is.
 
+### Transitioning between storage classes
+
+A `Transitions` rule moves the Objects it selects into another storage class as the clock passes the
+days it names. A rule listing several walks an Object down them, and the last transition reached is
+where the Object is. `NoncurrentVersionTransitions` does the same for the versions a write has
+displaced, counted from the moment each stopped being current.
+
+```typescript sim-s3-lifecycle-transition
+/**
+ * Moving simulated S3 Objects between storage classes on a lifecycle rule.
+ */
+
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutBucketLifecycleConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+await simS3.putBucketLifecycleConfiguration(
+  new PutBucketLifecycleConfigurationCommand({
+    Bucket: "logs",
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: "cool-then-freeze",
+          Status: "Enabled",
+          Filter: { Prefix: "raw/" },
+          Transitions: [
+            { Days: 30, StorageClass: "STANDARD_IA" },
+            { Days: 90, StorageClass: "GLACIER" },
+          ],
+        },
+      ],
+    },
+  }),
+);
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "logs",
+    Key: "raw/2026-08-24.gz",
+    Body: "one raw log line",
+  }),
+);
+
+await simAws.clock().advanceBy({ days: 90 });
+
+const listing = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "logs", Prefix: "raw/" }),
+);
+
+// GLACIER, the last transition the clock reached.
+console.log(listing.Contents?.[0]?.StorageClass);
+```
+
+A transition is worked out when the Bucket is read, as an expiry is, so what a listing or a read
+reports is where the rules put the Object at that instant. The bytes stay where they are. Moving the
+clock back afterwards moves the Object back, and an expiry that has already happened stays done. The
+expiry deleted something on the way past, and a transition changed only what S3 says about the
+Object.
+
+A rule naming a class S3 has no such class for is refused with `InvalidStorageClass` where the
+configuration is stored, before it reaches any Object. An `Expiration` on the same rule still expires
+at its own age, whatever the transitions have done in the meantime.
+
 ### What a rule selects
 
 A rule selects Objects by its `Filter`, or by the older top-level `Prefix`. A rule with no scope at
@@ -2519,22 +2727,23 @@ carried across as the template stated it.
 
 `LifecycleConfiguration` is one of the properties simulated S3 acts on. It stays out of
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without).
-The three actions it enforces are `Expiration`, whether the template flattened it onto the rule or
-not, `NoncurrentVersionExpiration`, in either of its two spellings, and
-`AbortIncompleteMultipartUpload`. A `Transitions` rule is stored and read back and goes no further. Which Objects an enforced action reaches is decided by the fields listed under
-[What a rule selects](#what-a-rule-selects).
+The actions it enforces are `Expiration`, whether the template flattened it onto the rule or not,
+`Transitions` and `NoncurrentVersionTransitions`, `NoncurrentVersionExpiration`, in either of its
+two spellings, and `AbortIncompleteMultipartUpload`. Which Objects an enforced action reaches is
+decided by the fields listed under [What a rule selects](#what-a-rule-selects).
 
 ### Limitations
 
-No Object moves between storage classes. Storage classes are left out of the simulator entirely. A
-`Transitions` rule is stored and read back and goes no further.
+Real S3 raises `s3:LifecycleExpiration:Delete` when a rule removes an Object, and
+`s3:LifecycleTransition` when one moves an Object. Both event families are among the ones sim S3
+leaves out. An expiry and a transition here are silent.
 
-Real S3 raises `s3:LifecycleExpiration:Delete` when a rule removes an Object. That event family is
-among the ones sim S3 leaves out. An expiry here is silent.
+A transition changes the class an Object reads back in and nothing else. Real S3 also takes an
+Object in an archival class out of reach until `RestoreObject` has brought it back, and sim S3
+serves every Object whatever class a rule has moved it to.
 
-`NoncurrentVersionTransitions` is stored and unread, alongside `Transitions`, because storage classes
-are left out. An `Expiration` rule on a versioned Bucket writes a delete marker over the current
-version and leaves the version itself where it is, which is what real S3 does, and a
+An `Expiration` rule on a versioned Bucket writes a delete marker over the current version and
+leaves the version itself where it is, which is what real S3 does, and a
 `NoncurrentVersionExpiration` rule is what then removes it. See
 [Object versioning](#object-versioning).
 
@@ -3427,8 +3636,8 @@ Sim S3 currently supports:
   removable on its own
 - `PutBucketWebsiteCommand`, for static website hosting
 - `PutBucketLifecycleConfigurationCommand`, `GetBucketLifecycleConfigurationCommand` and
-  `DeleteBucketLifecycleCommand`, storing a Bucket's lifecycle rules and handing them back without
-  expiring or transitioning any Object against them
+  `DeleteBucketLifecycleCommand`, storing a Bucket's lifecycle rules and expiring, transitioning and
+  abandoning against them in simulated time
 - `PutBucketPolicyCommand`, `GetBucketPolicyCommand` and `DeleteBucketPolicyCommand`, evaluated by
   sim IAM alongside identity policies
 - The `AWS::S3::Bucket` and `AWS::S3::BucketPolicy` CloudFormation resources
@@ -3440,6 +3649,11 @@ Sim S3 currently supports:
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
 - Object system metadata set by a `PutObjectCommand` and returned on a read, over every endpoint
   that serves an Object
+- Object storage classes, named on a write and moved by a lifecycle rule, reported on a listing and
+  on a read
+- `PutBucketEncryptionCommand`, `GetBucketEncryptionCommand` and `DeleteBucketEncryptionCommand`,
+  and the `BucketEncryption` property of an `AWS::S3::Bucket`, deciding the algorithm an Object
+  reports
 - Bucket website index documents, error documents, trailing-slash redirects, redirect-all
   configuration, and routing-rule redirects
 - Bucket-global uniqueness within a `SimAws` instance across simulated Accounts and Regions
@@ -3457,12 +3671,13 @@ needs them to model the requested behaviour.
 
 These apply across the page. The sections above each list what is specific to them.
 
-- A listing reports `StorageClass` as `STANDARD` for every Object. Storage classes themselves are
-  left out, and every Object is in that one.
+- A storage class says where S3 keeps an Object and nothing else. Every Object is readable whatever
+  class it is in, `RestoreObject` is left out, and nothing costs or takes longer in one class than
+  another. See [Storage classes](#storage-classes).
 - `EncodingType` is ignored on a listing, and keys come back unencoded.
-- Object tags, ACLs, replication and server-side encryption are left out. A lifecycle rule expires
-  Objects and abandons uploads, and transitions nothing between storage classes. See
-  [Lifecycle configuration](#lifecycle-configuration).
+- Object tags, ACLs and replication are left out. Server-side encryption is reported and never
+  applied, and an `aws:kms` Object names no key, because there is no simulated KMS behind it. See
+  [Default encryption](#default-encryption).
 - A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
   notifications, because it swaps the whole storage backend in place of putting Objects.
 - An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, leaving

--- a/docs/services/s3/sim-s3-bucket-encryption.example.ts
+++ b/docs/services/s3/sim-s3-bucket-encryption.example.ts
@@ -1,0 +1,50 @@
+/**
+ * Configuring a simulated S3 Bucket's default encryption.
+ */
+
+import {
+  CreateBucketCommand,
+  GetBucketEncryptionCommand,
+  GetObjectCommand,
+  PutBucketEncryptionCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "documents" }));
+
+await simS3.putBucketEncryption(
+  new PutBucketEncryptionCommand({
+    Bucket: "documents",
+    ServerSideEncryptionConfiguration: {
+      Rules: [
+        { ApplyServerSideEncryptionByDefault: { SSEAlgorithm: "aws:kms" } },
+      ],
+    },
+  }),
+);
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "documents",
+    Key: "contracts/one.pdf",
+    Body: "one",
+  }),
+);
+
+const configured = await simS3.getBucketEncryption(
+  new GetBucketEncryptionCommand({ Bucket: "documents" }),
+);
+const read = await simS3.getObject(
+  new GetObjectCommand({ Bucket: "documents", Key: "contracts/one.pdf" }),
+);
+
+// aws:kms, from the Bucket's configuration and from the Object it stamped.
+console.log(
+  configured.ServerSideEncryptionConfiguration?.Rules?.[0]
+    ?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm,
+  read.ServerSideEncryption,
+);

--- a/docs/services/s3/sim-s3-lifecycle-transition.example.ts
+++ b/docs/services/s3/sim-s3-lifecycle-transition.example.ts
@@ -1,0 +1,51 @@
+/**
+ * Moving simulated S3 Objects between storage classes on a lifecycle rule.
+ */
+
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutBucketLifecycleConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+await simS3.putBucketLifecycleConfiguration(
+  new PutBucketLifecycleConfigurationCommand({
+    Bucket: "logs",
+    LifecycleConfiguration: {
+      Rules: [
+        {
+          ID: "cool-then-freeze",
+          Status: "Enabled",
+          Filter: { Prefix: "raw/" },
+          Transitions: [
+            { Days: 30, StorageClass: "STANDARD_IA" },
+            { Days: 90, StorageClass: "GLACIER" },
+          ],
+        },
+      ],
+    },
+  }),
+);
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "logs",
+    Key: "raw/2026-08-24.gz",
+    Body: "one raw log line",
+  }),
+);
+
+await simAws.clock().advanceBy({ days: 90 });
+
+const listing = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "logs", Prefix: "raw/" }),
+);
+
+// GLACIER, the last transition the clock reached.
+console.log(listing.Contents?.[0]?.StorageClass);

--- a/docs/services/s3/sim-s3-storage-class.example.ts
+++ b/docs/services/s3/sim-s3-storage-class.example.ts
@@ -1,0 +1,35 @@
+/**
+ * Writing a simulated S3 Object into an archival storage class.
+ */
+
+import {
+  CreateBucketCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simS3 = simAws.region("eu-west-2").s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "archive" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "archive",
+    Key: "ledgers/2026.csv",
+    Body: "a,b",
+    StorageClass: "GLACIER",
+  }),
+);
+
+const listing = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "archive" }),
+);
+const head = await simS3.headObject(
+  new HeadObjectCommand({ Bucket: "archive", Key: "ledgers/2026.csv" }),
+);
+
+// GLACIER, from the listing and from the Object itself.
+console.log(listing.Contents?.[0]?.StorageClass, head.StorageClass);

--- a/src/service/s3/bucket/encryption/sim-s3-bucket-encryption.iso.test.ts
+++ b/src/service/s3/bucket/encryption/sim-s3-bucket-encryption.iso.test.ts
@@ -1,0 +1,221 @@
+import {
+  CreateBucketCommand,
+  DeleteBucketEncryptionCommand,
+  GetBucketEncryptionCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutBucketEncryptionCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3InvalidArgument } from "../../error/sim-s3.error.js";
+import type { SimS3 } from "../../sim-s3.js";
+
+/**
+ * A Bucket to write Objects into.
+ */
+async function documentSimulation(): Promise<SimS3> {
+  const simS3 = new SimAws().region("eu-west-2").s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "documents" }));
+
+  return simS3;
+}
+
+/**
+ * The algorithm a Bucket's configuration reports.
+ */
+async function configuredAlgorithm(simS3: SimS3): Promise<string | undefined> {
+  const read = await simS3.getBucketEncryption(
+    new GetBucketEncryptionCommand({ Bucket: "documents" }),
+  );
+
+  return read.ServerSideEncryptionConfiguration?.Rules?.[0]
+    ?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm;
+}
+
+/**
+ * The default encryption of a simulated S3 Bucket, and what it stamps on the
+ * Objects written into it.
+ *
+ * Nothing is encrypted. The bytes are stored as they arrive, and what these
+ * cover is what S3 says about them.
+ */
+describe("Simulated S3 Bucket encryption", () => {
+  it("reports SSE-S3 for a Bucket nobody has configured", async () => {
+    // Given a Bucket with no encryption configuration of its own.
+    const simS3 = await documentSimulation();
+
+    // When its encryption is read.
+    const algorithm = await configuredAlgorithm(simS3);
+
+    // Then it is the SSE-S3 default real S3 has applied to every Bucket since
+    // January 2023, rather than an error or an empty answer.
+    assertIdentical(algorithm, "AES256");
+  });
+
+  it("stamps a Bucket's default on an Object written without one", async () => {
+    // Given a Bucket configured for KMS.
+    const simS3 = await documentSimulation();
+    await simS3.putBucketEncryption(
+      new PutBucketEncryptionCommand({
+        Bucket: "documents",
+        ServerSideEncryptionConfiguration: {
+          Rules: [
+            {
+              ApplyServerSideEncryptionByDefault: { SSEAlgorithm: "aws:kms" },
+              BucketKeyEnabled: true,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is written without naming an algorithm.
+    const written = await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "documents",
+        Key: "contracts/one.pdf",
+        Body: "one",
+      }),
+    );
+
+    // Then the write and both reads report the Bucket's algorithm, and the
+    // ETag is still the digest of the bytes as it is under SSE-S3.
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "documents", Key: "contracts/one.pdf" }),
+    );
+    const head = await simS3.headObject(
+      new HeadObjectCommand({ Bucket: "documents", Key: "contracts/one.pdf" }),
+    );
+
+    assertIdentical(written.ServerSideEncryption, "aws:kms");
+    assertIdentical(read.ServerSideEncryption, "aws:kms");
+    assertIdentical(head.ServerSideEncryption, "aws:kms");
+    assertIdentical(read.ETag, '"f97c5d29941bfb1b2fdab0874906ab82"');
+  });
+
+  it("lets a write name its own algorithm over the Bucket's", async () => {
+    // Given a Bucket configured for KMS.
+    const simS3 = await documentSimulation();
+    await simS3.putBucketEncryption(
+      new PutBucketEncryptionCommand({
+        Bucket: "documents",
+        ServerSideEncryptionConfiguration: {
+          Rules: [
+            { ApplyServerSideEncryptionByDefault: { SSEAlgorithm: "aws:kms" } },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is written naming SSE-S3.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "documents",
+        Key: "contracts/two.pdf",
+        Body: "two",
+        ServerSideEncryption: "AES256",
+      }),
+    );
+
+    // Then the write has the last word.
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "documents", Key: "contracts/two.pdf" }),
+    );
+
+    assertIdentical(read.ServerSideEncryption, "AES256");
+  });
+
+  it("keeps what an Object was written with when the Bucket changes", async () => {
+    // Given an Object written into an unconfigured Bucket.
+    const simS3 = await documentSimulation();
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "documents",
+        Key: "contracts/old.pdf",
+        Body: "old",
+      }),
+    );
+
+    // When the Bucket is configured for KMS afterwards.
+    await simS3.putBucketEncryption(
+      new PutBucketEncryptionCommand({
+        Bucket: "documents",
+        ServerSideEncryptionConfiguration: {
+          Rules: [
+            { ApplyServerSideEncryptionByDefault: { SSEAlgorithm: "aws:kms" } },
+          ],
+        },
+      }),
+    );
+
+    // Then the Object still reports what it was stored under, as real S3
+    // leaves the Objects already in a Bucket alone.
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "documents", Key: "contracts/old.pdf" }),
+    );
+
+    assertIdentical(read.ServerSideEncryption, "AES256");
+  });
+
+  it("puts a Bucket back to SSE-S3 when its configuration is removed", async () => {
+    // Given a Bucket configured for KMS.
+    const simS3 = await documentSimulation();
+    await simS3.putBucketEncryption(
+      new PutBucketEncryptionCommand({
+        Bucket: "documents",
+        ServerSideEncryptionConfiguration: {
+          Rules: [
+            { ApplyServerSideEncryptionByDefault: { SSEAlgorithm: "aws:kms" } },
+          ],
+        },
+      }),
+    );
+
+    // When the configuration is removed.
+    await simS3.deleteBucketEncryption(
+      new DeleteBucketEncryptionCommand({ Bucket: "documents" }),
+    );
+
+    // Then the Bucket is SSE-S3 encrypted rather than unencrypted, because
+    // there is no such thing as an unencrypted Bucket.
+    assertIdentical(await configuredAlgorithm(simS3), "AES256");
+  });
+
+  it("refuses a configuration naming an algorithm S3 does not apply", async () => {
+    // Given a Bucket.
+    const simS3 = await documentSimulation();
+
+    // When a configuration names something that is not an algorithm.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketEncryption(
+        new PutBucketEncryptionCommand({
+          Bucket: "documents",
+          ServerSideEncryptionConfiguration: {
+            Rules: [
+              {
+                ApplyServerSideEncryptionByDefault: {
+                  SSEAlgorithm: "ROT13" as "AES256",
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then it is refused, and the Bucket is left as it was.
+    assertInstanceOf(error, SimS3InvalidArgument);
+    assertStringIncludes(error.message, "ROT13");
+    assertIdentical(await configuredAlgorithm(simS3), "AES256");
+  });
+});

--- a/src/service/s3/bucket/encryption/sim-s3-bucket-encryption.ts
+++ b/src/service/s3/bucket/encryption/sim-s3-bucket-encryption.ts
@@ -1,0 +1,123 @@
+import {
+  simS3DefaultServerSideEncryption,
+  simS3ServerSideEncryptionFrom,
+  type SimS3ServerSideEncryption,
+} from "../../object/s3-server-side-encryption.js";
+
+/**
+ * The encryption a Bucket applies to an Object whose write named none.
+ */
+export interface SimS3ServerSideEncryptionByDefault {
+  readonly SSEAlgorithm?: string | undefined;
+  readonly KMSMasterKeyID?: string | undefined;
+}
+
+/**
+ * One rule of a Bucket's default encryption configuration.
+ *
+ * Real S3 takes exactly one. `BucketKeyEnabled` says whether S3 uses a bucket
+ * key to cut KMS calls, and is stored and read back here without acting.
+ */
+export interface SimS3ServerSideEncryptionRule {
+  readonly ApplyServerSideEncryptionByDefault?:
+    | SimS3ServerSideEncryptionByDefault
+    | undefined;
+  readonly BucketKeyEnabled?: boolean | undefined;
+}
+
+/**
+ * A Bucket's default encryption configuration, as a request states it.
+ */
+export interface SimS3ServerSideEncryptionConfiguration {
+  readonly Rules?: readonly SimS3ServerSideEncryptionRule[] | undefined;
+}
+
+interface SimS3BucketEncryptionProperties {
+  readonly rules?: readonly SimS3ServerSideEncryptionRule[] | undefined;
+}
+
+/**
+ * The default encryption of one simulated S3 Bucket.
+ *
+ * Nothing is encrypted. The bytes of an Object are stored as they arrive, and
+ * its ETag stays the MD5 of them, which is what real S3 reports for an
+ * SSE-S3 Object as well. What this decides is the algorithm a write stamps on
+ * an Object when it names none itself, and what `GetBucketEncryption` answers.
+ *
+ * A Bucket nobody has configured is SSE-S3 encrypted. Real S3 has applied that
+ * default to every Bucket since January 2023, and answers a read of an
+ * unconfigured Bucket with the same `AES256` rule as one configured that way.
+ */
+export class SimS3BucketEncryption {
+  private readonly storedRules: readonly SimS3ServerSideEncryptionRule[];
+
+  constructor(properties: SimS3BucketEncryptionProperties = {}) {
+    this.storedRules = structuredClone(properties.rules ?? defaultRules);
+  }
+
+  /**
+   * The encryption a Bucket nobody has configured has, which is what
+   * `DeleteBucketEncryption` puts a Bucket back to.
+   */
+  static default(): SimS3BucketEncryption {
+    return new SimS3BucketEncryption();
+  }
+
+  /**
+   * The encryption a PutBucketEncryption request asks for.
+   *
+   * Every algorithm named is read here, before the Bucket is changed, so a
+   * configuration real S3 refuses leaves the Bucket as it was.
+   */
+  static fromConfiguration(
+    configuration: SimS3ServerSideEncryptionConfiguration,
+    bucketName: string,
+  ): SimS3BucketEncryption {
+    const rules = configuration.Rules ?? [];
+
+    for (const rule of rules) {
+      simS3ServerSideEncryptionFrom(
+        rule.ApplyServerSideEncryptionByDefault?.SSEAlgorithm,
+        `the default encryption of Bucket ${bucketName}`,
+      );
+    }
+
+    return new SimS3BucketEncryption({ rules });
+  }
+
+  /**
+   * The algorithm this Bucket stamps on an Object written without one.
+   */
+  get algorithm(): SimS3ServerSideEncryption {
+    const named = this.storedRules
+      .map((rule) => rule.ApplyServerSideEncryptionByDefault?.SSEAlgorithm)
+      .find((algorithm) => algorithm !== undefined);
+
+    return (
+      simS3ServerSideEncryptionFrom(named, "a stored Bucket configuration") ??
+      simS3DefaultServerSideEncryption
+    );
+  }
+
+  /**
+   * The configuration a read of the Bucket answers with.
+   *
+   * Cloned on the way out, so a caller holding what it was given cannot change
+   * what the Bucket applies by mutating it.
+   */
+  get configuration(): SimS3ServerSideEncryptionConfiguration {
+    return { Rules: structuredClone(this.storedRules) };
+  }
+}
+
+/**
+ * The rule real S3 reports for a Bucket nobody has configured.
+ */
+const defaultRules: readonly SimS3ServerSideEncryptionRule[] = [
+  {
+    ApplyServerSideEncryptionByDefault: {
+      SSEAlgorithm: simS3DefaultServerSideEncryption,
+    },
+    BucketKeyEnabled: false,
+  },
+];

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-abandoned-uploads.iso.test.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-abandoned-uploads.iso.test.ts
@@ -18,7 +18,7 @@ import { describe, it } from "vitest";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimS3NoSuchUpload } from "../../error/sim-s3.error.js";
+import { SimS3NoSuchUpload } from "../../error/sim-s3-upload.error.js";
 
 const startedAt = new Date("2026-08-24T09:00:00.000Z");
 

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-configuration.ts
@@ -114,7 +114,7 @@ export class SimS3LifecycleConfiguration {
    * shortest one.
    */
   expires(object: SimS3LifecycleObject, now: Date): boolean {
-    return this.enabledRules().some(
+    return this.enabledRules.some(
       (rule) =>
         rule.Expiration !== undefined &&
         simS3LifecycleRuleSelects(rule, object) &&
@@ -137,7 +137,7 @@ export class SimS3LifecycleConfiguration {
     version: SimS3LifecycleNoncurrentVersion,
     now: Date,
   ): boolean {
-    return this.enabledRules().some((rule) => {
+    return this.enabledRules.some((rule) => {
       const expiration = rule.NoncurrentVersionExpiration;
 
       return (
@@ -162,7 +162,7 @@ export class SimS3LifecycleConfiguration {
    * key in a listing once its last version has gone.
    */
   expiresDeleteMarker(key: string): boolean {
-    return this.enabledRules().some(
+    return this.enabledRules.some(
       (rule) =>
         rule.Expiration?.ExpiredObjectDeleteMarker === true &&
         simS3LifecycleRuleSelects(rule, { key }),
@@ -174,7 +174,7 @@ export class SimS3LifecycleConfiguration {
    * instant.
    */
   abandons(upload: SimS3LifecycleUpload, now: Date): boolean {
-    return this.enabledRules().some(
+    return this.enabledRules.some(
       (rule) =>
         rule.AbortIncompleteMultipartUpload !== undefined &&
         simS3LifecycleRuleSelects(rule, { key: upload.key }) &&
@@ -193,9 +193,10 @@ export class SimS3LifecycleConfiguration {
    *
    * Read from the stored rules rather than from `rules`, because every read of
    * a Bucket asks and cloning the whole configuration each time would be the
-   * cost of having one.
+   * cost of having one. A transition is worked out from these by
+   * `simS3TransitionedObjectClass`.
    */
-  private enabledRules(): readonly SimS3LifecycleRule[] {
+  get enabledRules(): readonly SimS3LifecycleRule[] {
     return this.storedRules.filter((rule) => rule.Status === "Enabled");
   }
 }

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-expiry.ts
@@ -24,7 +24,7 @@ export function simS3ObjectExpiryInstant(
   writtenAt: Date,
 ): Date | undefined {
   if (expiration.Days !== undefined) {
-    return afterDays(writtenAt, expiration.Days);
+    return simS3LifecycleAfterDays(writtenAt, expiration.Days);
   }
 
   if (expiration.Date !== undefined) {
@@ -54,7 +54,7 @@ export function simS3NoncurrentExpiryInstant(
     return undefined;
   }
 
-  return afterDays(noncurrentSince, expiration.NoncurrentDays);
+  return simS3LifecycleAfterDays(noncurrentSince, expiration.NoncurrentDays);
 }
 
 /**
@@ -69,7 +69,7 @@ export function simS3UploadAbortInstant(
     return undefined;
   }
 
-  return afterDays(initiated, abort.DaysAfterInitiation);
+  return simS3LifecycleAfterDays(initiated, abort.DaysAfterInitiation);
 }
 
 /**
@@ -82,6 +82,10 @@ export function simS3LifecycleReached(
   return boundary !== undefined && now.getTime() >= boundary.getTime();
 }
 
-function afterDays(from: Date, days: number): Date {
+/**
+ * The instant a number of days after another one, which is how every lifecycle
+ * boundary measured in days is reached.
+ */
+export function simS3LifecycleAfterDays(from: Date, days: number): Date {
   return new Date(from.getTime() + days * millisecondsPerDay);
 }

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-sweep.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-sweep.ts
@@ -5,6 +5,7 @@ import type {
   SimS3LifecycleConfiguration,
   SimS3LifecycleObject,
 } from "./sim-s3-lifecycle-configuration.js";
+import { simS3TransitionedObjectClass } from "./sim-s3-lifecycle-transition.js";
 
 /**
  * One pass over what a Bucket's lifecycle rules have expired.
@@ -17,6 +18,11 @@ import type {
  * carrying no rules paying one comparison for the check. See
  * `simS3ObjectExpiryInstant` for why the boundary is a pure function of the
  * current time.
+ *
+ * A transition is answered here as well. An Object past the day a
+ * `Transitions` rule names reads back in the class that rule moves it to, and
+ * the bytes stay where they are, which is all a transition does to an Object a
+ * caller can still read.
  *
  * Nothing is announced. Real S3 raises `s3:LifecycleExpiration:Delete` for an
  * expiry, and that event family is among the ones simulated S3 leaves out.
@@ -44,8 +50,12 @@ export class SimS3LifecycleSweep {
   async object(
     object: SimS3Object | undefined,
   ): Promise<SimS3Object | undefined> {
-    if (object === undefined || !this.expires(object)) {
+    if (object === undefined) {
       return object;
+    }
+
+    if (!this.expires(object)) {
+      return this.transitioned(object);
     }
 
     await this.expire(object.key);
@@ -72,7 +82,35 @@ export class SimS3LifecycleSweep {
       }),
     );
 
-    return objects.filter((object) => !expiredKeys.has(object.key));
+    return objects
+      .filter((object) => !expiredKeys.has(object.key))
+      .map((object) => this.transitioned(object));
+  }
+
+  /**
+   * The Object in the class the rules have transitioned it into.
+   *
+   * The class is worked out on each read rather than written back, for the
+   * same reason an expiry is: it is a pure function of the rules and the
+   * current time, and storage that maps Objects onto files has nowhere to
+   * record one. See `simS3ObjectExpiryInstant`.
+   */
+  private transitioned(object: SimS3Object): SimS3Object {
+    if (this.lifecycle.isEmpty) {
+      return object;
+    }
+
+    const storageClass = simS3TransitionedObjectClass(
+      this.lifecycle.enabledRules,
+      lifecycleObject(object),
+      this.now,
+    );
+
+    if (storageClass === undefined || storageClass === object.storageClass) {
+      return object;
+    }
+
+    return object.withStorageClass(storageClass);
   }
 
   /**

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-transition-instant.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-transition-instant.ts
@@ -1,0 +1,107 @@
+import type {
+  SimS3LifecycleNoncurrentVersionTransition,
+  SimS3LifecycleTransition,
+} from "../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+import {
+  simS3StorageClassFrom,
+  type SimS3StorageClass,
+} from "../../object/s3-storage-class.js";
+import type { SimS3LifecycleNoncurrentVersion } from "./sim-s3-lifecycle-configuration.js";
+import {
+  simS3LifecycleAfterDays,
+  simS3LifecycleReached,
+} from "./sim-s3-lifecycle-expiry.js";
+
+/**
+ * One transition a rule has reached, as the class it moves an Object into and
+ * the instant it moved.
+ *
+ * The instant is what decides between two transitions that have both been
+ * reached. Real S3 walks an Object down the classes a rule lists as their days
+ * pass, so the one that came last is where the Object is now.
+ */
+export interface SimS3ReachedTransition {
+  readonly storageClass: SimS3StorageClass;
+  readonly at: Date;
+}
+
+/**
+ * The transition a `Transitions` entry has made by an instant, if it has.
+ *
+ * `Days` counts from when the Object was written and `Date` names the day
+ * itself, the same two forms an `Expiration` takes. A transition naming
+ * neither, or naming no storage class, moves nothing.
+ */
+export function simS3ReachedTransitionOf(
+  transition: SimS3LifecycleTransition,
+  writtenAt: Date,
+  now: Date,
+): SimS3ReachedTransition | undefined {
+  return reached(
+    transitionInstant(transition, writtenAt),
+    transition.StorageClass,
+    now,
+  );
+}
+
+/**
+ * The transition a `NoncurrentVersionTransitions` entry has made by an
+ * instant, counted from when the version stopped being the current one.
+ *
+ * A version that is still current has no such instant, as it has none for a
+ * `NoncurrentVersionExpiration`. `NewerNoncurrentVersions` holds back the most
+ * recent noncurrent versions as it does for an expiry, so a rule keeping two
+ * reaches the third and everything older.
+ */
+export function simS3ReachedNoncurrentTransitionOf(
+  transition: SimS3LifecycleNoncurrentVersionTransition,
+  version: SimS3LifecycleNoncurrentVersion,
+  now: Date,
+): SimS3ReachedTransition | undefined {
+  const { noncurrentSince } = version;
+
+  if (
+    noncurrentSince === undefined ||
+    transition.NoncurrentDays === undefined ||
+    version.newerVersionsAhead < (transition.NewerNoncurrentVersions ?? 0)
+  ) {
+    return undefined;
+  }
+
+  return reached(
+    simS3LifecycleAfterDays(noncurrentSince, transition.NoncurrentDays),
+    transition.StorageClass,
+    now,
+  );
+}
+
+function transitionInstant(
+  transition: SimS3LifecycleTransition,
+  writtenAt: Date,
+): Date | undefined {
+  if (transition.Days !== undefined) {
+    return simS3LifecycleAfterDays(writtenAt, transition.Days);
+  }
+
+  if (transition.Date !== undefined) {
+    return new Date(transition.Date);
+  }
+
+  return undefined;
+}
+
+function reached(
+  at: Date | undefined,
+  storageClass: string | undefined,
+  now: Date,
+): SimS3ReachedTransition | undefined {
+  const target = simS3StorageClassFrom(storageClass, "a lifecycle transition");
+
+  if (at === undefined || target === undefined) {
+    return undefined;
+  }
+
+  return simS3LifecycleReached(at, now)
+    ? { storageClass: target, at }
+    : undefined;
+}

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-transition.iso.test.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-transition.iso.test.ts
@@ -1,0 +1,255 @@
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  ListObjectVersionsCommand,
+  PutBucketLifecycleConfigurationCommand,
+  PutBucketVersioningCommand,
+  PutObjectCommand,
+  type LifecycleRule,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3InvalidStorageClass } from "../../error/sim-s3.error.js";
+
+const startedAt = new Date("2026-08-24T09:00:00.000Z");
+
+const coolThenFreeze: LifecycleRule = {
+  ID: "cool-then-freeze",
+  Status: "Enabled",
+  Filter: { Prefix: "raw/" },
+  Transitions: [
+    { Days: 30, StorageClass: "STANDARD_IA" },
+    { Days: 90, StorageClass: "GLACIER" },
+  ],
+};
+
+/**
+ * A Bucket holding one raw log and one report, configured with the given
+ * rules.
+ */
+async function loggingSimulation(
+  rules: readonly LifecycleRule[],
+): Promise<SimAws> {
+  const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+  const simS3 = simAws.region("eu-west-2").s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+  await simS3.putBucketLifecycleConfiguration(
+    new PutBucketLifecycleConfigurationCommand({
+      Bucket: "logs",
+      LifecycleConfiguration: { Rules: [...rules] },
+    }),
+  );
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "logs",
+      Key: "raw/2026-08-24.gz",
+      Body: "one raw log line",
+    }),
+  );
+  await simS3.putObject(
+    new PutObjectCommand({
+      Bucket: "logs",
+      Key: "reports/august.csv",
+      Body: "a,b",
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * The class a listing reports for one key.
+ */
+async function listedClass(
+  simAws: SimAws,
+  key: string,
+): Promise<string | undefined> {
+  const listing = await simAws
+    .region("eu-west-2")
+    .s3()
+    .listObjectsV2(new ListObjectsV2Command({ Bucket: "logs" }));
+
+  return (listing.Contents ?? []).find((entry) => entry.Key === key)
+    ?.StorageClass;
+}
+
+/**
+ * Transitioning simulated S3 Objects between storage classes.
+ *
+ * A transition is applied when the Bucket is read, as an expiry is, so moving
+ * the clock is all a test does to reach one.
+ */
+describe("Simulated S3 lifecycle transitions", () => {
+  it("leaves an Object the clock has not carried to a transition", async () => {
+    // Given a Bucket cooling its raw logs after thirty days.
+    const simAws = await loggingSimulation([coolThenFreeze]);
+
+    // When simulated time moves on by less than that.
+    await simAws.clock().advanceBy({ days: 29 });
+
+    // Then the log is where it was written.
+    assertIdentical(await listedClass(simAws, "raw/2026-08-24.gz"), "STANDARD");
+  });
+
+  it("moves an Object the moment the clock reaches a transition", async () => {
+    // Given a Bucket cooling its raw logs after thirty days.
+    const simAws = await loggingSimulation([coolThenFreeze]);
+
+    // When simulated time reaches the thirty days exactly.
+    await simAws.clock().advanceBy({ days: 30 });
+
+    // Then the log has moved, and the report the rule does not select stays
+    // where it is.
+    assertIdentical(
+      await listedClass(simAws, "raw/2026-08-24.gz"),
+      "STANDARD_IA",
+    );
+    assertIdentical(
+      await listedClass(simAws, "reports/august.csv"),
+      "STANDARD",
+    );
+  });
+
+  it("walks an Object down the classes a rule lists", async () => {
+    // Given a Bucket cooling its raw logs and then freezing them.
+    const simAws = await loggingSimulation([coolThenFreeze]);
+
+    // When simulated time passes both boundaries.
+    await simAws.clock().advanceBy({ days: 90 });
+
+    // Then the Object is in the class of the last transition it reached.
+    const read = await simAws
+      .region("eu-west-2")
+      .s3()
+      .getObject(
+        new GetObjectCommand({ Bucket: "logs", Key: "raw/2026-08-24.gz" }),
+      );
+
+    assertIdentical(read.StorageClass, "GLACIER");
+  });
+
+  it("expires a transitioned Object at its own age", async () => {
+    // Given a Bucket that both cools and expires the same raw logs.
+    const simAws = await loggingSimulation([
+      coolThenFreeze,
+      {
+        ID: "expire-raw-logs",
+        Status: "Enabled",
+        Filter: { Prefix: "raw/" },
+        Expiration: { Days: 365 },
+      },
+    ]);
+
+    // When simulated time reaches the expiry.
+    await simAws.clock().advanceBy({ days: 365 });
+
+    // Then the transitions did nothing to hold the Object back from it.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .region("eu-west-2")
+        .s3()
+        .getObject(
+          new GetObjectCommand({ Bucket: "logs", Key: "raw/2026-08-24.gz" }),
+        ),
+    );
+
+    assertStringIncludes(error.message, "raw/2026-08-24.gz");
+  });
+
+  it("transitions a noncurrent version once it has been displaced", async () => {
+    // Given a versioned Bucket whose noncurrent versions cool after a week.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const simS3 = simAws.region("eu-west-2").s3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+    await simS3.putBucketVersioning(
+      new PutBucketVersioningCommand({
+        Bucket: "logs",
+        VersioningConfiguration: { Status: "Enabled" },
+      }),
+    );
+    await simS3.putBucketLifecycleConfiguration(
+      new PutBucketLifecycleConfigurationCommand({
+        Bucket: "logs",
+        LifecycleConfiguration: {
+          Rules: [
+            {
+              ID: "cool-old-versions",
+              Status: "Enabled",
+              Filter: { Prefix: "raw/" },
+              NoncurrentVersionTransitions: [
+                { NoncurrentDays: 7, StorageClass: "GLACIER_IR" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    // When a second write displaces the first version and a week passes.
+    await simS3.putObject(
+      new PutObjectCommand({ Bucket: "logs", Key: "raw/log.gz", Body: "one" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({ Bucket: "logs", Key: "raw/log.gz", Body: "two" }),
+    );
+    await simAws.clock().advanceBy({ days: 7 });
+
+    // Then the displaced version has moved and the current one has not.
+    const versions = await simS3.listObjectVersions(
+      new ListObjectVersionsCommand({ Bucket: "logs" }),
+    );
+    const classes = (versions.Versions ?? []).map(
+      (version) =>
+        `${version.IsLatest ? "current" : "noncurrent"}:${version.StorageClass}`,
+    );
+
+    assertIdentical(
+      classes.toSorted((one, other) => one.localeCompare(other)).join(","),
+      "current:STANDARD,noncurrent:GLACIER_IR",
+    );
+  });
+
+  it("refuses a rule transitioning to a class S3 has no such class for", async () => {
+    // Given a Bucket.
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const simS3 = simAws.region("eu-west-2").s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "logs" }));
+
+    // When a rule names something that is not a storage class.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putBucketLifecycleConfiguration(
+        new PutBucketLifecycleConfigurationCommand({
+          Bucket: "logs",
+          LifecycleConfiguration: {
+            Rules: [
+              {
+                ID: "freeze",
+                Status: "Enabled",
+                Filter: { Prefix: "raw/" },
+                Transitions: [
+                  { Days: 30, StorageClass: "PERMAFROST" as "GLACIER" },
+                ],
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    // Then the configuration is refused where it is stored, before it is
+    // applied to anything.
+    assertInstanceOf(error, SimS3InvalidStorageClass);
+    assertStringIncludes(error.message, "freeze");
+  });
+});

--- a/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-transition.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-lifecycle-transition.ts
@@ -1,0 +1,83 @@
+import type { SimS3LifecycleRule } from "../../command/put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
+import type { SimS3StorageClass } from "../../object/s3-storage-class.js";
+import type {
+  SimS3LifecycleNoncurrentVersion,
+  SimS3LifecycleObject,
+} from "./sim-s3-lifecycle-configuration.js";
+import {
+  simS3ReachedNoncurrentTransitionOf,
+  simS3ReachedTransitionOf,
+  type SimS3ReachedTransition,
+} from "./sim-s3-lifecycle-transition-instant.js";
+import { simS3LifecycleRuleSelects } from "./sim-s3-lifecycle-selection.js";
+
+/**
+ * The class the rules have transitioned an Object into by an instant.
+ *
+ * Every rule selecting the Object contributes the transitions it has reached,
+ * because real S3 applies the whole configuration to a key rather than the
+ * first rule that matches it.
+ */
+export function simS3TransitionedObjectClass(
+  rules: readonly SimS3LifecycleRule[],
+  object: SimS3LifecycleObject,
+  now: Date,
+): SimS3StorageClass | undefined {
+  return latestReached(
+    rules
+      .filter((rule) => simS3LifecycleRuleSelects(rule, object))
+      .flatMap((rule) =>
+        reachedTransitions(rule.Transitions, (transition) =>
+          simS3ReachedTransitionOf(transition, object.lastModified, now),
+        ),
+      ),
+  );
+}
+
+/**
+ * The class the rules have transitioned a noncurrent version into by an
+ * instant.
+ */
+export function simS3TransitionedVersionClass(
+  rules: readonly SimS3LifecycleRule[],
+  version: SimS3LifecycleNoncurrentVersion,
+  now: Date,
+): SimS3StorageClass | undefined {
+  return latestReached(
+    rules
+      .filter((rule) => simS3LifecycleRuleSelects(rule, version))
+      .flatMap((rule) =>
+        reachedTransitions(rule.NoncurrentVersionTransitions, (transition) =>
+          simS3ReachedNoncurrentTransitionOf(transition, version, now),
+        ),
+      ),
+  );
+}
+
+/**
+ * The transitions among a rule's that have been reached.
+ */
+function reachedTransitions<Transition>(
+  transitions: readonly Transition[] | undefined,
+  reach: (transition: Transition) => SimS3ReachedTransition | undefined,
+): SimS3ReachedTransition[] {
+  return (transitions ?? [])
+    .map((transition) => reach(transition))
+    .filter((transition) => transition !== undefined);
+}
+
+/**
+ * The class an Object is in once every transition that has been reached has
+ * been applied, or nothing where none has.
+ *
+ * The latest one wins. Two reached at the same instant are settled by the
+ * order the rules list them in, so the last transition a configuration states
+ * is where an Object past all of them ends up.
+ */
+function latestReached(
+  transitions: readonly SimS3ReachedTransition[],
+): SimS3StorageClass | undefined {
+  return transitions
+    .toSorted((one, other) => one.at.getTime() - other.at.getTime())
+    .at(-1)?.storageClass;
+}

--- a/src/service/s3/bucket/lifecycle/sim-s3-noncurrent-sweep.ts
+++ b/src/service/s3/bucket/lifecycle/sim-s3-noncurrent-sweep.ts
@@ -1,6 +1,7 @@
 import type { SimS3BucketVersions } from "../versioning/sim-s3-bucket-versions.js";
 import type { SimS3ObjectVersion } from "../versioning/sim-s3-object-version.js";
 import type { SimS3LifecycleConfiguration } from "./sim-s3-lifecycle-configuration.js";
+import { simS3TransitionedVersionClass } from "./sim-s3-lifecycle-transition.js";
 
 /**
  * One pass over what a Bucket's rules have expired in its version history.
@@ -57,6 +58,7 @@ export class SimS3NoncurrentSweep {
     for (const [index, version] of held.entries()) {
       if (index === 0 || !this.expires(version, index - 1)) {
         kept.push(version);
+        this.transition(version, index - 1);
         continue;
       }
 
@@ -85,6 +87,34 @@ export class SimS3NoncurrentSweep {
       this.lifecycle.expiresDeleteMarker(marker.key)
     ) {
       versions.removeExpired(marker.key, marker.versionId);
+    }
+  }
+
+  /**
+   * Move a surviving noncurrent version into the class the rules have
+   * transitioned it to.
+   *
+   * The current version and a delete marker are left alone. Neither is
+   * something a `NoncurrentVersionTransitions` rule reaches.
+   */
+  private transition(version: SimS3ObjectVersion, ahead: number): void {
+    if (ahead < 0 || version.isDeleteMarker) {
+      return;
+    }
+
+    const storageClass = simS3TransitionedVersionClass(
+      this.lifecycle.enabledRules,
+      {
+        key: version.key,
+        size: version.object.body.length,
+        noncurrentSince: version.noncurrentSince,
+        newerVersionsAhead: ahead,
+      },
+      this.now,
+    );
+
+    if (storageClass !== undefined) {
+      version.transitionTo(storageClass);
     }
   }
 

--- a/src/service/s3/bucket/sim-s3-bucket-properties.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-properties.ts
@@ -1,0 +1,42 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+import type { SimS3BucketStorage } from "../storage/s3-bucket-storage.js";
+import type { SimS3BucketEncryption } from "./encryption/sim-s3-bucket-encryption.js";
+import type { SimS3LifecycleConfiguration } from "./lifecycle/sim-s3-lifecycle-configuration.js";
+import type { SimS3NotificationConfiguration } from "./notification/sim-s3-notification-configuration.js";
+import type { SimS3PublicAccessBlock } from "./public-access/sim-s3-public-access-block.js";
+import type { SimS3BucketName } from "./sim-s3-bucket.js";
+import type { SimS3BucketWebsite } from "./website/sim-s3-bucket-website.js";
+
+/**
+ * What a simulated S3 Bucket is made of.
+ *
+ * Every one of these has a default, apart from the name. A Bucket made by
+ * CreateBucket states only its name and its scope, and the configuration
+ * properties are what a Bucket built directly in a test starts out with.
+ */
+export interface SimS3BucketProperties {
+  readonly bucketName: SimS3BucketName | string;
+  readonly accountRegionScope?: SimAwsAccountRegionScope;
+  readonly storage?: SimS3BucketStorage;
+  readonly website?: SimS3BucketWebsite;
+  readonly policy?: SimIamPolicyDocument | undefined;
+  readonly publicAccessBlock?: SimS3PublicAccessBlock;
+  readonly notifications?: SimS3NotificationConfiguration;
+  readonly lifecycle?: SimS3LifecycleConfiguration;
+  readonly encryption?: SimS3BucketEncryption;
+  /**
+   * The simulation's sense of time, which is what a lifecycle rule is measured
+   * against. A Bucket made outside a simulated environment has none to be
+   * given, and runs on the host clock.
+   */
+  readonly clock?: SimClock;
+  /**
+   * When the Bucket came into being, in simulated time.
+   *
+   * Real S3 reports this on every Bucket a listing returns, and the `aws` CLI
+   * reads it from each entry, so a Bucket without one cannot be listed.
+   */
+  readonly creationDate?: Date;
+}

--- a/src/service/s3/bucket/sim-s3-bucket.ts
+++ b/src/service/s3/bucket/sim-s3-bucket.ts
@@ -1,5 +1,5 @@
 import type { Brand } from "../../../util/brand.type.js";
-import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
+import { SimRealClock } from "../../../util/clock/sim-clock.js";
 import type { SimS3BucketStorage } from "../storage/s3-bucket-storage.js";
 import type { SimS3Object } from "../object/s3-object.js";
 import { MemoryS3BucketStorage } from "../storage/s3-memory-storage.js";
@@ -12,6 +12,7 @@ import type { SimS3ObjectVersion } from "./versioning/sim-s3-object-version.js";
 import { SimS3BucketWebsite } from "./website/sim-s3-bucket-website.js";
 import { SimS3PublicAccessBlock } from "./public-access/sim-s3-public-access-block.js";
 import { SimS3NotificationConfiguration } from "./notification/sim-s3-notification-configuration.js";
+import { SimS3BucketEncryption } from "./encryption/sim-s3-bucket-encryption.js";
 import { SimS3LifecycleConfiguration } from "./lifecycle/sim-s3-lifecycle-configuration.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
@@ -20,32 +21,9 @@ import { validateS3BucketName } from "./validate/validate-s3-bucket-name.js";
 import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
 import { SimS3BucketSystemMetadata } from "./sim-s3-bucket-system-metadata.js";
 import type { SimS3MultipartUploads } from "../upload/sim-s3-multipart-uploads.js";
+import type { SimS3BucketProperties } from "./sim-s3-bucket-properties.js";
 
 export type SimS3BucketName = Brand<string, "SimS3BucketName">;
-
-interface SimS3BucketProperties {
-  readonly bucketName: SimS3BucketName | string;
-  readonly accountRegionScope?: SimAwsAccountRegionScope;
-  readonly storage?: SimS3BucketStorage;
-  readonly website?: SimS3BucketWebsite;
-  readonly policy?: SimIamPolicyDocument | undefined;
-  readonly publicAccessBlock?: SimS3PublicAccessBlock;
-  readonly notifications?: SimS3NotificationConfiguration;
-  readonly lifecycle?: SimS3LifecycleConfiguration;
-  /**
-   * The simulation's sense of time, which is what a lifecycle rule is measured
-   * against. A Bucket made outside a simulated environment has none to be
-   * given, and runs on the host clock.
-   */
-  readonly clock?: SimClock;
-  /**
-   * When the Bucket came into being, in simulated time.
-   *
-   * Real S3 reports this on every Bucket a listing returns, and the `aws` CLI
-   * reads it from each entry, so a Bucket without one cannot be listed.
-   */
-  readonly creationDate?: Date;
-}
 
 /**
  * Simulated S3 Bucket.
@@ -61,6 +39,7 @@ export class SimS3Bucket {
   private policy: SimIamPolicyDocument | undefined;
   private publicAccessBlock: SimS3PublicAccessBlock;
   private notifications: SimS3NotificationConfiguration;
+  private encryption: SimS3BucketEncryption;
 
   constructor(properties: SimS3BucketProperties) {
     const {
@@ -72,6 +51,7 @@ export class SimS3Bucket {
       publicAccessBlock = SimS3PublicAccessBlock.blockingAll(),
       notifications = SimS3NotificationConfiguration.empty(),
       lifecycle = SimS3LifecycleConfiguration.empty(),
+      encryption = SimS3BucketEncryption.default(),
       clock = new SimRealClock(),
       creationDate = clock.now(),
     } = properties;
@@ -85,6 +65,7 @@ export class SimS3Bucket {
     this.policy = policy;
     this.publicAccessBlock = publicAccessBlock;
     this.notifications = notifications;
+    this.encryption = encryption;
     this.creationDate = creationDate;
   }
 
@@ -246,9 +227,7 @@ export class SimS3Bucket {
     this.notifications = notifications;
   }
 
-  /**
-   * Get this Bucket's event notification configuration.
-   */
+  /** Get this Bucket's event notification configuration. */
   getNotifications(): SimS3NotificationConfiguration {
     return this.notifications;
   }
@@ -278,6 +257,26 @@ export class SimS3Bucket {
    */
   deleteLifecycle(): void {
     this.objects.deleteLifecycle();
+  }
+
+  /** Replace this Bucket's default encryption configuration. */
+  configureEncryption(encryption: SimS3BucketEncryption): void {
+    this.encryption = encryption;
+  }
+
+  /** Get this Bucket's default encryption configuration. */
+  getEncryption(): SimS3BucketEncryption {
+    return this.encryption;
+  }
+
+  /**
+   * Put this Bucket back to the encryption every Bucket has.
+   *
+   * Real S3 DeleteBucketEncryption leaves the Bucket SSE-S3 encrypted rather
+   * than unencrypted, because there is no such thing as an unencrypted Bucket.
+   */
+  deleteEncryption(): void {
+    this.encryption = SimS3BucketEncryption.default();
   }
 
   /**

--- a/src/service/s3/bucket/versioning/sim-s3-object-version.ts
+++ b/src/service/s3/bucket/versioning/sim-s3-object-version.ts
@@ -1,6 +1,7 @@
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { SimS3ObjectLock } from "../lock/sim-s3-object-lock.js";
 import type { SimS3Object } from "../../object/s3-object.js";
+import type { SimS3StorageClass } from "../../object/s3-storage-class.js";
 import { simS3NullVersionId } from "./sim-s3-bucket-versioning.js";
 
 interface SimS3ObjectVersionProperties {
@@ -39,7 +40,7 @@ export class SimS3ObjectVersion {
   private displaced: Date | undefined;
 
   private readonly createdAt: Date;
-  private readonly stored: SimS3Object | undefined;
+  private stored: SimS3Object | undefined;
 
   constructor(properties: SimS3ObjectVersionProperties) {
     this.versionId = properties.versionId;
@@ -61,6 +62,17 @@ export class SimS3ObjectVersion {
       createdAt: object.lastModified,
       object,
     });
+  }
+
+  /**
+   * Move the Object this version holds into another storage class.
+   *
+   * A lifecycle rule transitions a noncurrent version where it lies, so the
+   * class is recorded on the version rather than derived on each read of it. A
+   * delete marker holds no Object and transitions nowhere.
+   */
+  transitionTo(storageClass: SimS3StorageClass): void {
+    this.stored = this.stored?.withStorageClass(storageClass);
   }
 
   /**

--- a/src/service/s3/cfn/bucket/encryption/sim-cfn-s3-bucket-encryption.iso.test.ts
+++ b/src/service/s3/cfn/bucket/encryption/sim-cfn-s3-bucket-encryption.iso.test.ts
@@ -1,0 +1,108 @@
+import {
+  GetBucketEncryptionCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { assertDefined } from "../../../../../util/type-guard/defined.js";
+import type { CfnTemplateBodyRecord } from "../../../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValue } from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+
+/**
+ * A template declaring one Bucket with the given encryption property.
+ */
+function bucketTemplate(
+  encryption: SimCfnTemplateValue,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      DocumentBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: "documents",
+          BucketEncryption: encryption,
+        },
+      },
+    },
+  };
+}
+
+/**
+ * The BucketEncryption property of an AWS::S3::Bucket Resource.
+ */
+describe("S3 CloudFormation Bucket encryption", () => {
+  it("applies the default encryption a template declares", async () => {
+    // Given a template declaring KMS encryption on its Bucket.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    await simAws.cloudFormation().deployTemplate({
+      stackName: "documents",
+      template: bucketTemplate({
+        ServerSideEncryptionConfiguration: [
+          {
+            BucketKeyEnabled: true,
+            ServerSideEncryptionByDefault: { SSEAlgorithm: "aws:kms" },
+          },
+        ],
+      }),
+    });
+
+    // Then the Bucket reports it, and stamps it on what is written there.
+    // CloudFormation states the rule under a name of its own, which is what
+    // the Resource translates for the request.
+    const simS3 = simAws.s3();
+    const configured = await simS3.getBucketEncryption(
+      new GetBucketEncryptionCommand({ Bucket: "documents" }),
+    );
+
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "documents",
+        Key: "contracts/one.pdf",
+        Body: "one",
+      }),
+    );
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "documents", Key: "contracts/one.pdf" }),
+    );
+
+    const rule = configured.ServerSideEncryptionConfiguration?.Rules?.[0];
+
+    assertDefined(rule, "the encryption rule");
+    assertIdentical(
+      rule.ApplyServerSideEncryptionByDefault?.SSEAlgorithm,
+      "aws:kms",
+    );
+    assertTrue(rule.BucketKeyEnabled);
+    assertIdentical(read.ServerSideEncryption, "aws:kms");
+  });
+
+  it("fails the Resource for an algorithm S3 does not apply", async () => {
+    // Given a template naming something that is not an algorithm.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.cloudFormation().deployTemplate({
+        stackName: "documents",
+        template: bucketTemplate({
+          ServerSideEncryptionConfiguration: [
+            { ServerSideEncryptionByDefault: { SSEAlgorithm: "ROT13" } },
+          ],
+        }),
+      }),
+    );
+
+    // Then the Stack fails in the words an SDK caller is refused in.
+    assertStringIncludes(error.message, "ROT13");
+  });
+});

--- a/src/service/s3/cfn/bucket/encryption/sim-cfn-s3-bucket-encryption.ts
+++ b/src/service/s3/cfn/bucket/encryption/sim-cfn-s3-bucket-encryption.ts
@@ -1,0 +1,71 @@
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { SimCfnValueShape } from "../../../../cloudformation/template/value/sim-cfn-value-shape.js";
+import type {
+  SimS3ServerSideEncryptionConfiguration,
+  SimS3ServerSideEncryptionRule,
+} from "../../../bucket/encryption/sim-s3-bucket-encryption.js";
+import { s3BucketResourceError } from "../error/sim-cfn-s3-bucket-error.js";
+
+/**
+ * Reads the `BucketEncryption` property of an AWS::S3::Bucket Resource into a
+ * PutBucketEncryption request.
+ *
+ * CloudFormation and the API disagree about one name. A template states
+ * `ServerSideEncryptionByDefault` inside each rule where the request states
+ * `ApplyServerSideEncryptionByDefault`, so that one is translated here and
+ * everything else is handed on as it was declared.
+ */
+export class SimCfnS3BucketEncryption {
+  private readonly properties: SimCfnTemplateValueRecord;
+  private readonly shape: SimCfnValueShape;
+
+  constructor(logicalId: string, properties: SimCfnTemplateValueRecord) {
+    this.properties = properties;
+    this.shape = new SimCfnValueShape((reason) =>
+      s3BucketResourceError(logicalId, reason),
+    );
+  }
+
+  /**
+   * The configuration to apply, or nothing when the Resource declares none.
+   */
+  read(): SimS3ServerSideEncryptionConfiguration | undefined {
+    const declared = this.properties["BucketEncryption"];
+
+    if (declared === undefined) {
+      return undefined;
+    }
+
+    const encryption = this.shape.record(declared, "BucketEncryption");
+    const rules = this.shape.list(
+      encryption["ServerSideEncryptionConfiguration"] ?? [],
+      "BucketEncryption ServerSideEncryptionConfiguration",
+    );
+
+    return { Rules: rules.map((rule, index) => this.readRule(rule, index)) };
+  }
+
+  private readRule(
+    value: SimCfnTemplateValue,
+    index: number,
+  ): SimS3ServerSideEncryptionRule {
+    const named = `BucketEncryption rule ${index}`;
+    const rule = this.shape.record(value, named);
+    const byDefault = rule["ServerSideEncryptionByDefault"];
+
+    return {
+      ...(byDefault !== undefined && {
+        ApplyServerSideEncryptionByDefault: this.shape.record(
+          byDefault,
+          `${named} ServerSideEncryptionByDefault`,
+        ),
+      }),
+      ...(rule["BucketKeyEnabled"] !== undefined && {
+        BucketKeyEnabled: rule["BucketKeyEnabled"] === true,
+      }),
+    };
+  }
+}

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-configurator.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-configurator.ts
@@ -58,6 +58,7 @@ export class SimCfnS3BucketConfigurator {
     await this.declared.applyVersioning();
     await this.declared.applyObjectLock();
     await this.declared.applyLifecycle();
+    await this.declared.applyEncryption();
     await this.configureNotifications();
   }
 

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-declared-configurations.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-declared-configurations.ts
@@ -1,6 +1,7 @@
 import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimS3 } from "../../sim-s3.js";
+import { SimCfnS3BucketEncryption } from "./encryption/sim-cfn-s3-bucket-encryption.js";
 import { SimCfnS3BucketLifecycleConfiguration } from "./lifecycle/sim-cfn-s3-bucket-lifecycle-configuration.js";
 import { SimCfnS3BucketObjectLockConfiguration } from "./lock/sim-cfn-s3-bucket-object-lock-configuration.js";
 import { SimCfnS3BucketPublicAccessConfiguration } from "./public-access/sim-cfn-s3-bucket-public-access-configuration.js";
@@ -19,7 +20,7 @@ interface SimCfnS3BucketDeclaredConfigurationsProperties {
  * The AWS::S3::Bucket properties that are read straight off the Resource and
  * handed to a command.
  *
- * Five properties with one shape between them. Each is read from the Resource,
+ * Six properties with one shape between them. Each is read from the Resource,
  * left alone where the Resource omitted it, and otherwise applied through the
  * command an SDK caller would reach, so a template and an SDK caller are
  * validated identically. The event notification configuration is the one that
@@ -45,46 +46,47 @@ export class SimCfnS3BucketDeclaredConfigurations {
    * Apply the website configuration the Resource declares.
    */
   async applyWebsite(): Promise<void> {
-    const WebsiteConfiguration = this.read(SimCfnS3BucketWebsiteConfiguration);
-
-    if (WebsiteConfiguration !== undefined) {
-      await this.simS3.putBucketWebsite(
-        { input: { Bucket: this.bucketName, WebsiteConfiguration } },
-        this.options,
-      );
-    }
+    await this.applyDeclared(
+      SimCfnS3BucketWebsiteConfiguration,
+      async (WebsiteConfiguration) => {
+        await this.simS3.putBucketWebsite(
+          { input: { Bucket: this.bucketName, WebsiteConfiguration } },
+          this.options,
+        );
+      },
+    );
   }
 
   /**
    * Apply the Block Public Access settings the Resource declares.
    */
   async applyPublicAccess(): Promise<void> {
-    const PublicAccessBlockConfiguration = this.read(
+    await this.applyDeclared(
       SimCfnS3BucketPublicAccessConfiguration,
+      async (PublicAccessBlockConfiguration) => {
+        await this.simS3.putPublicAccessBlock(
+          {
+            input: { Bucket: this.bucketName, PublicAccessBlockConfiguration },
+          },
+          this.options,
+        );
+      },
     );
-
-    if (PublicAccessBlockConfiguration !== undefined) {
-      await this.simS3.putPublicAccessBlock(
-        { input: { Bucket: this.bucketName, PublicAccessBlockConfiguration } },
-        this.options,
-      );
-    }
   }
 
   /**
    * Apply the versioning configuration the Resource declares.
    */
   async applyVersioning(): Promise<void> {
-    const VersioningConfiguration = this.read(
+    await this.applyDeclared(
       SimCfnS3BucketVersioningConfiguration,
+      async (VersioningConfiguration) => {
+        await this.simS3.putBucketVersioning(
+          { input: { Bucket: this.bucketName, VersioningConfiguration } },
+          this.options,
+        );
+      },
     );
-
-    if (VersioningConfiguration !== undefined) {
-      await this.simS3.putBucketVersioning(
-        { input: { Bucket: this.bucketName, VersioningConfiguration } },
-        this.options,
-      );
-    }
   }
 
   /**
@@ -96,31 +98,71 @@ export class SimCfnS3BucketDeclaredConfigurations {
    * the words an SDK caller is refused in.
    */
   async applyObjectLock(): Promise<void> {
-    const ObjectLockConfiguration = this.read(
+    await this.applyDeclared(
       SimCfnS3BucketObjectLockConfiguration,
+      async (ObjectLockConfiguration) => {
+        await this.simS3.putObjectLockConfiguration(
+          { input: { Bucket: this.bucketName, ObjectLockConfiguration } },
+          this.options,
+        );
+      },
     );
-
-    if (ObjectLockConfiguration !== undefined) {
-      await this.simS3.putObjectLockConfiguration(
-        { input: { Bucket: this.bucketName, ObjectLockConfiguration } },
-        this.options,
-      );
-    }
   }
 
   /**
    * Apply the lifecycle rules the Resource declares.
    */
   async applyLifecycle(): Promise<void> {
-    const LifecycleConfiguration = this.read(
+    await this.applyDeclared(
       SimCfnS3BucketLifecycleConfiguration,
+      async (LifecycleConfiguration) => {
+        await this.simS3.putBucketLifecycleConfiguration(
+          { input: { Bucket: this.bucketName, LifecycleConfiguration } },
+          this.options,
+        );
+      },
     );
+  }
 
-    if (LifecycleConfiguration !== undefined) {
-      await this.simS3.putBucketLifecycleConfiguration(
-        { input: { Bucket: this.bucketName, LifecycleConfiguration } },
-        this.options,
-      );
+  /**
+   * Apply the default encryption the Resource declares.
+   */
+  async applyEncryption(): Promise<void> {
+    await this.applyDeclared(
+      SimCfnS3BucketEncryption,
+      async (ServerSideEncryptionConfiguration) => {
+        await this.simS3.putBucketEncryption(
+          {
+            input: {
+              Bucket: this.bucketName,
+              ServerSideEncryptionConfiguration,
+            },
+          },
+          this.options,
+        );
+      },
+    );
+  }
+
+  /**
+   * Apply one declared property, or leave the Bucket alone where the Resource
+   * omitted it.
+   *
+   * The one absence check for all six of them lives here. Each property is
+   * otherwise the same shape: read it off the Resource, and hand it to the
+   * command an SDK caller would reach.
+   */
+  private async applyDeclared<T>(
+    Reader: new (
+      logicalId: string,
+      properties: SimCfnTemplateValueRecord,
+    ) => { read(): T | undefined },
+    apply: (declared: T) => Promise<void>,
+  ): Promise<void> {
+    const declared = this.read(Reader);
+
+    if (declared !== undefined) {
+      await apply(declared);
     }
   }
 

--- a/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
+++ b/src/service/s3/cfn/bucket/sim-cfn-s3-bucket-property-names.ts
@@ -2,6 +2,7 @@
  * The AWS::S3::Bucket properties this simulation acts on.
  */
 export const simulatedPropertyNames: ReadonlySet<string> = new Set([
+  "BucketEncryption",
   "BucketName",
   "LifecycleConfiguration",
   "ObjectLockConfiguration",
@@ -15,16 +16,11 @@ export const simulatedPropertyNames: ReadonlySet<string> = new Set([
 /**
  * Real AWS::S3::Bucket properties this simulation reads and does nothing with.
  *
- * Nothing this simulator models can tell the difference. There is no simulated
- * KMS and Object bytes are stored as they arrive, so an encrypted Bucket and an
- * unencrypted one answer every simulated command identically, and no simulated
- * service reads a Bucket tag. So these are not recorded as ignored either: a
- * report of differences that make no difference is one nobody can read.
+ * Nothing this simulator models can tell the difference. No simulated service
+ * reads a Bucket tag, so this is not recorded as ignored either: a report of
+ * differences that make no difference is one nobody can read.
  */
-export const inertPropertyNames: ReadonlySet<string> = new Set([
-  "BucketEncryption",
-  "Tags",
-]);
+export const inertPropertyNames: ReadonlySet<string> = new Set(["Tags"]);
 
 import type {
   SimCfnSkippedPropertyRule,
@@ -65,7 +61,8 @@ export const unsimulatedPropertyReasons: SimCfnSkippedPropertyRules = new Map<
   ],
   [
     "IntelligentTieringConfigurations",
-    "storage classes are not simulated, so nothing transitions between them",
+    "Objects are not moved between storage classes by access pattern, and " +
+      "only a lifecycle rule transitions one",
   ],
   ["InventoryConfigurations", "Bucket inventory reports are not simulated"],
   ["LoggingConfiguration", "server access logging is not simulated"],

--- a/src/service/s3/command/copy-object/copy-object-builder.ts
+++ b/src/service/s3/command/copy-object/copy-object-builder.ts
@@ -1,6 +1,11 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import { SimS3Object } from "../../object/s3-object.js";
+import type { SimS3ServerSideEncryption } from "../../object/s3-server-side-encryption.js";
 import { simS3WriteMetadata } from "../../object/s3-write-metadata.js";
+import {
+  simS3WriteEncryption,
+  simS3WriteStorageClass,
+} from "../../object/s3-write-storage.js";
 import type { SimCopyObjectCommandInput } from "./copy-object.command.js";
 
 interface CopyObjectBuilderProperties {
@@ -34,12 +39,19 @@ export class CopyObjectBuilder {
    * its own to carry. An Object uploaded in parts keeps the multipart ETag it
    * was given, and real S3 rewrites a copy of one as a single part. The copy's
    * ETag is therefore the plain digest of its bytes.
+   *
+   * The storage class and the encryption come from the request and the
+   * destination Bucket. Real S3 stores a copy in the default class where the
+   * request names none, whatever class the source was in.
    */
   build(
     input: SimCopyObjectCommandInput,
     key: string,
     source: SimS3Object,
+    destinationEncryption: SimS3ServerSideEncryption,
   ): SimS3Object {
+    const storageClass = simS3WriteStorageClass(input, "CopyObjectCommand");
+
     return new SimS3Object({
       key,
       body: Buffer.from(source.body),
@@ -48,6 +60,12 @@ export class CopyObjectBuilder {
           ? simS3WriteMetadata(input)
           : source.metadata,
       lastModified: this.clock.now(),
+      ...(storageClass !== undefined && { storageClass }),
+      serverSideEncryption: simS3WriteEncryption(
+        input,
+        destinationEncryption,
+        "CopyObjectCommand",
+      ),
     });
   }
 }

--- a/src/service/s3/command/copy-object/copy-object.command.ts
+++ b/src/service/s3/command/copy-object/copy-object.command.ts
@@ -1,5 +1,6 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimS3ObjectWriteMetadata } from "../../object/s3-write-metadata.js";
+import type { SimS3ObjectWriteStorage } from "../../object/s3-write-storage.js";
 
 /**
  * Minimal structural sim S3 CopyObject command.
@@ -15,7 +16,8 @@ export interface SimCopyObjectCommand {
  * apply to the destination Object under `MetadataDirective: REPLACE`. Under
  * the default `COPY` they are ignored, as real S3 ignores them.
  */
-export interface SimCopyObjectCommandInput extends SimS3ObjectWriteMetadata {
+export interface SimCopyObjectCommandInput
+  extends SimS3ObjectWriteMetadata, SimS3ObjectWriteStorage {
   readonly Bucket?: string | undefined;
   readonly Key?: string | undefined;
   /** The source Object, as `sourceBucket/sourceKey`, URL-encoded. */
@@ -34,6 +36,8 @@ export interface SimCopyObjectCommandInput extends SimS3ObjectWriteMetadata {
 export interface SimCopyObjectCommandOutput {
   readonly CopyObjectResult?: SimCopyObjectResult;
   readonly VersionId?: string | undefined;
+  /** The encryption S3 stamped on the copy it stored. */
+  readonly ServerSideEncryption?: string | undefined;
   readonly $metadata: SimResponseMetadata;
 }
 

--- a/src/service/s3/command/copy-object/copy-object.handler.ts
+++ b/src/service/s3/command/copy-object/copy-object.handler.ts
@@ -114,7 +114,12 @@ export class CopyObjectCommandHandler implements CommandHandler<
     );
 
     const stored = await simS3CopySourceObject(source, from.key);
-    const object = this.objectBuilder.build(command.input, key, stored);
+    const object = this.objectBuilder.build(
+      command.input,
+      key,
+      stored,
+      destination.getEncryption().algorithm,
+    );
     const version = await destination.putObject(object);
 
     this.notifications.objectCreated({
@@ -131,6 +136,7 @@ export class CopyObjectCommandHandler implements CommandHandler<
         LastModified: object.lastModified,
       },
       ...(version !== undefined && { VersionId: version.versionId }),
+      ServerSideEncryption: object.serverSideEncryption,
       $metadata: {},
     };
   }

--- a/src/service/s3/command/create-multipart-upload/create-multipart-upload.command.ts
+++ b/src/service/s3/command/create-multipart-upload/create-multipart-upload.command.ts
@@ -1,5 +1,6 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimS3ObjectWriteMetadata } from "../../object/s3-write-metadata.js";
+import type { SimS3ObjectWriteStorage } from "../../object/s3-write-storage.js";
 
 /**
  * Minimal structural sim S3 CreateMultipartUpload command.
@@ -14,7 +15,8 @@ export interface SimCreateMultipartUploadCommand {
  * This is the request that says what the Object will be, so it carries the same
  * metadata members a `PutObject` does. None of the Object's bytes arrive here.
  */
-export interface SimCreateMultipartUploadCommandInput extends SimS3ObjectWriteMetadata {
+export interface SimCreateMultipartUploadCommandInput
+  extends SimS3ObjectWriteMetadata, SimS3ObjectWriteStorage {
   readonly Bucket?: string | undefined;
   readonly Key?: string | undefined;
 }
@@ -26,6 +28,8 @@ export interface SimCreateMultipartUploadCommandInput extends SimS3ObjectWriteMe
  */
 export interface SimCreateMultipartUploadCommandOutput {
   readonly Bucket?: string;
+  /** The encryption S3 will stamp on the Object the upload completes into. */
+  readonly ServerSideEncryption?: string | undefined;
   readonly Key?: string;
   readonly UploadId?: string;
   readonly $metadata: SimResponseMetadata;

--- a/src/service/s3/command/create-multipart-upload/create-multipart-upload.handler.ts
+++ b/src/service/s3/command/create-multipart-upload/create-multipart-upload.handler.ts
@@ -2,6 +2,10 @@ import type { CommandHandler } from "../../../../command/command-handler.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { simS3WriteMetadata } from "../../object/s3-write-metadata.js";
 import {
+  simS3WriteEncryption,
+  simS3WriteStorageClass,
+} from "../../object/s3-write-storage.js";
+import {
   SimS3MultipartAccess,
   type SimS3MultipartAccessProperties,
 } from "../multipart/sim-s3-multipart-access.js";
@@ -42,16 +46,28 @@ export class CreateMultipartUploadCommandHandler implements CommandHandler<
 
     const { bucket } = await this.access.reach(Bucket, Key, options);
 
+    const storageClass = simS3WriteStorageClass(
+      command.input,
+      "CreateMultipartUploadCommand",
+    );
+
     const upload = bucket.getMultipartUploads().start({
       key: Key,
       metadata: simS3WriteMetadata(command.input),
       initiated: this.access.now(),
+      ...(storageClass !== undefined && { storageClass }),
+      serverSideEncryption: simS3WriteEncryption(
+        command.input,
+        bucket.getEncryption().algorithm,
+        "CreateMultipartUploadCommand",
+      ),
     });
 
     return {
       Bucket: bucket.bucketName,
       Key: upload.key,
       UploadId: upload.uploadId,
+      ServerSideEncryption: upload.serverSideEncryption,
       $metadata: {},
     };
   }

--- a/src/service/s3/command/delete-bucket-encryption/delete-bucket-encryption.command.ts
+++ b/src/service/s3/command/delete-bucket-encryption/delete-bucket-encryption.command.ts
@@ -1,0 +1,22 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+
+/**
+ * Minimal structural sim S3 DeleteBucketEncryption command.
+ */
+export interface SimDeleteBucketEncryptionCommand {
+  readonly input: SimDeleteBucketEncryptionCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 DeleteBucketEncryption input.
+ */
+export interface SimDeleteBucketEncryptionCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 DeleteBucketEncryption output.
+ */
+export interface SimDeleteBucketEncryptionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/delete-bucket-encryption/delete-bucket-encryption.handler.ts
+++ b/src/service/s3/command/delete-bucket-encryption/delete-bucket-encryption.handler.ts
@@ -1,0 +1,82 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3EncryptionAuthorizer } from "../encryption/sim-s3-encryption-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimDeleteBucketEncryptionCommand,
+  SimDeleteBucketEncryptionCommandOutput,
+} from "./delete-bucket-encryption.command.js";
+
+interface DeleteBucketEncryptionHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 DeleteBucketEncryptionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/DeleteBucketEncryptionCommand/
+ */
+export class DeleteBucketEncryptionCommandHandler implements CommandHandler<
+  SimDeleteBucketEncryptionCommand,
+  SimDeleteBucketEncryptionCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3EncryptionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: DeleteBucketEncryptionHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3EncryptionAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and put a Bucket back to the encryption every Bucket has.
+   *
+   * Real S3 leaves the Bucket SSE-S3 encrypted rather than unencrypted, and
+   * the request is idempotent, so this reports nothing about what was there.
+   */
+  async handle(
+    command: SimDeleteBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimDeleteBucketEncryptionCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "DeleteBucketEncryptionCommand.input.Bucket",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeWrite(bucket, options);
+
+    bucket.deleteEncryption();
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/encryption/sim-s3-encryption-authorizer.ts
+++ b/src/service/s3/command/encryption/sim-s3-encryption-authorizer.ts
@@ -1,0 +1,67 @@
+import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simS3BucketArn } from "../../bucket/sim-s3-bucket-arn.js";
+import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import { simS3BucketResourcePolicies } from "../authorize/sim-s3-bucket-resource-policies.js";
+import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+interface SimS3EncryptionAuthorizerProperties {
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Applies IAM authorization to the S3 Bucket encryption commands.
+ *
+ * Two actions for three commands. Real S3 governs both applying and removing a
+ * default encryption configuration with s3:PutEncryptionConfiguration, since
+ * removing one is applying the default in its place.
+ */
+export class SimS3EncryptionAuthorizer {
+  private static readonly readAction = "s3:GetEncryptionConfiguration";
+  private static readonly writeAction = "s3:PutEncryptionConfiguration";
+
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimS3EncryptionAuthorizerProperties) {
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may read the Bucket's default encryption.
+   */
+  authorizeRead(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
+    this.authorize(SimS3EncryptionAuthorizer.readAction, bucket, options);
+  }
+
+  /**
+   * Ensure the caller may change the Bucket's default encryption.
+   */
+  authorizeWrite(bucket: SimS3Bucket, options?: SimS3RequestOptions): void {
+    this.authorize(SimS3EncryptionAuthorizer.writeAction, bucket, options);
+  }
+
+  private authorize(
+    action: string,
+    bucket: SimS3Bucket,
+    options?: SimS3RequestOptions,
+  ): void {
+    const resource = simS3BucketArn(bucket.bucketName);
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller: options?.caller,
+      conditionContext: simS3ConditionContext(options),
+      resourcePolicies: simS3BucketResourcePolicies(bucket),
+    });
+
+    if (decision.isDenied) {
+      throw new SimIamAccessDenied({
+        principal: decision.caller.principal,
+        reason: decision.denialReason,
+        action,
+        resource,
+      });
+    }
+  }
+}

--- a/src/service/s3/command/encryption/sim-s3-encryption-commands.ts
+++ b/src/service/s3/command/encryption/sim-s3-encryption-commands.ts
@@ -1,0 +1,56 @@
+import { DeleteBucketEncryptionCommandHandler } from "../delete-bucket-encryption/delete-bucket-encryption.handler.js";
+import { GetBucketEncryptionCommandHandler } from "../get-bucket-encryption/get-bucket-encryption.handler.js";
+import { PutBucketEncryptionCommandHandler } from "../put-bucket-encryption/put-bucket-encryption.handler.js";
+import type { SimS3BucketCommandState } from "../sim-s3-bucket-command-state.js";
+import type * as simS3Commands from "../sim-s3-command.types.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+
+/**
+ * The default encryption commands of one simulated S3 scope.
+ */
+export class SimS3EncryptionCommands {
+  private readonly state: SimS3BucketCommandState;
+
+  constructor(state: SimS3BucketCommandState) {
+    this.state = state;
+  }
+
+  /**
+   * Apply a Bucket's default encryption.
+   */
+  async put(
+    command: simS3Commands.SimPutBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketEncryptionCommandOutput> {
+    return await new PutBucketEncryptionCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Read a Bucket's default encryption.
+   */
+  async get(
+    command: simS3Commands.SimGetBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketEncryptionCommandOutput> {
+    return await new GetBucketEncryptionCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+
+  /**
+   * Put a Bucket back to the encryption every Bucket has.
+   */
+  async delete(
+    command: simS3Commands.SimDeleteBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteBucketEncryptionCommandOutput> {
+    return await new DeleteBucketEncryptionCommandHandler(this.state).handle(
+      command,
+      options,
+    );
+  }
+}

--- a/src/service/s3/command/get-bucket-encryption/get-bucket-encryption.command.ts
+++ b/src/service/s3/command/get-bucket-encryption/get-bucket-encryption.command.ts
@@ -1,0 +1,27 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3ServerSideEncryptionConfiguration } from "../../bucket/encryption/sim-s3-bucket-encryption.js";
+
+/**
+ * Minimal structural sim S3 GetBucketEncryption command.
+ */
+export interface SimGetBucketEncryptionCommand {
+  readonly input: SimGetBucketEncryptionCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 GetBucketEncryption input.
+ */
+export interface SimGetBucketEncryptionCommandInput {
+  readonly Bucket?: string | undefined;
+}
+
+/**
+ * Minimal structural sim S3 GetBucketEncryption output.
+ *
+ * A Bucket nobody has configured answers with the SSE-S3 rule real S3 applies
+ * to every Bucket, rather than with an error.
+ */
+export interface SimGetBucketEncryptionCommandOutput {
+  readonly ServerSideEncryptionConfiguration?: SimS3ServerSideEncryptionConfiguration;
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/get-bucket-encryption/get-bucket-encryption.handler.ts
+++ b/src/service/s3/command/get-bucket-encryption/get-bucket-encryption.handler.ts
@@ -1,0 +1,82 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3EncryptionAuthorizer } from "../encryption/sim-s3-encryption-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimGetBucketEncryptionCommand,
+  SimGetBucketEncryptionCommandOutput,
+} from "./get-bucket-encryption.command.js";
+
+interface GetBucketEncryptionHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 GetBucketEncryptionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/GetBucketEncryptionCommand/
+ */
+export class GetBucketEncryptionCommandHandler implements CommandHandler<
+  SimGetBucketEncryptionCommand,
+  SimGetBucketEncryptionCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3EncryptionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: GetBucketEncryptionHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3EncryptionAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and report a Bucket's default encryption.
+   *
+   * A Bucket nobody has configured answers with the SSE-S3 rule rather than an
+   * error, which is what real S3 has answered since it began encrypting every
+   * Bucket by default.
+   */
+  async handle(
+    command: SimGetBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimGetBucketEncryptionCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "GetBucketEncryptionCommand.input.Bucket",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeRead(bucket, options);
+
+    return {
+      ServerSideEncryptionConfiguration: bucket.getEncryption().configuration,
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/get-object/get-object-loader.ts
+++ b/src/service/s3/command/get-object/get-object-loader.ts
@@ -2,6 +2,7 @@ import { Readable } from "node:stream";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
 import { simS3QuotedETag } from "../../object/s3-object-etag.js";
+import { simS3ObjectStorageReport } from "../../object/s3-object-storage-report.js";
 import {
   simS3ContentRange,
   simS3ReadObjectRange,
@@ -66,6 +67,7 @@ export class GetObjectLoader {
       LastModified: object.lastModified,
       ContentLength: body.length,
       ...(read.versionId !== undefined && { VersionId: read.versionId }),
+      ...simS3ObjectStorageReport(object),
       ...read.lock?.reported,
       ...(range !== undefined && {
         ContentRange: simS3ContentRange(range, size),

--- a/src/service/s3/command/get-object/get-object.command.ts
+++ b/src/service/s3/command/get-object/get-object.command.ts
@@ -1,6 +1,7 @@
 import type { Readable } from "node:stream";
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimS3ObjectLockOutput } from "../../bucket/lock/sim-s3-object-lock-output.js";
+import type { SimS3ObjectStorageReport } from "../../object/s3-object-storage-report.js";
 import type { SimS3SystemMetadataOutput } from "../../object/s3-system-metadata-read.js";
 
 /**
@@ -45,7 +46,10 @@ export interface SimGetObjectCommandInput {
  * nothing else.
  */
 export interface SimGetObjectCommandOutput
-  extends SimS3SystemMetadataOutput, SimS3ObjectLockOutput {
+  extends
+    SimS3SystemMetadataOutput,
+    SimS3ObjectLockOutput,
+    SimS3ObjectStorageReport {
   readonly Body?: Readable;
   readonly Metadata?: Record<string, string>;
   readonly ETag?: string;

--- a/src/service/s3/command/head-object/head-object-loader.ts
+++ b/src/service/s3/command/head-object/head-object-loader.ts
@@ -1,6 +1,7 @@
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { SimS3NotFound } from "../../error/sim-s3.error.js";
 import { simS3QuotedETag } from "../../object/s3-object-etag.js";
+import { simS3ObjectStorageReport } from "../../object/s3-object-storage-report.js";
 import { simS3ReadObjectVersion } from "../object/sim-s3-read-object-version.js";
 import type { SimHeadObjectCommandOutput } from "./head-object.command.js";
 
@@ -35,6 +36,7 @@ export class HeadObjectLoader {
       ETag: simS3QuotedETag(object.etag),
       LastModified: object.lastModified,
       ...(read.versionId !== undefined && { VersionId: read.versionId }),
+      ...simS3ObjectStorageReport(object),
       ...read.lock?.reported,
       $metadata: {},
     };

--- a/src/service/s3/command/head-object/head-object.command.ts
+++ b/src/service/s3/command/head-object/head-object.command.ts
@@ -1,5 +1,6 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimS3ObjectLockOutput } from "../../bucket/lock/sim-s3-object-lock-output.js";
+import type { SimS3ObjectStorageReport } from "../../object/s3-object-storage-report.js";
 import type { SimS3SystemMetadataOutput } from "../../object/s3-system-metadata-read.js";
 
 /**
@@ -30,7 +31,10 @@ export interface SimHeadObjectCommandInput {
  * the length that body would have had.
  */
 export interface SimHeadObjectCommandOutput
-  extends SimS3SystemMetadataOutput, SimS3ObjectLockOutput {
+  extends
+    SimS3SystemMetadataOutput,
+    SimS3ObjectLockOutput,
+    SimS3ObjectStorageReport {
   readonly ContentLength?: number;
   readonly Metadata?: Record<string, string>;
   readonly ETag?: string;

--- a/src/service/s3/command/lifecycle/sim-s3-lifecycle-rules-validation.ts
+++ b/src/service/s3/command/lifecycle/sim-s3-lifecycle-rules-validation.ts
@@ -1,5 +1,6 @@
 import type { SimS3BucketName } from "../../bucket/sim-s3-bucket.js";
 import { SimS3MalformedXml } from "../../error/sim-s3.error.js";
+import { simS3StorageClassFrom } from "../../object/s3-storage-class.js";
 import type {
   SimS3LifecycleConfiguration,
   SimS3LifecycleRule,
@@ -74,6 +75,33 @@ function validateRule(
     throw new SimS3MalformedXml(
       `Lifecycle rule ${named} for S3 Bucket ${bucketName} must state at ` +
         `least one of ${ruleActionNames}`,
+    );
+  }
+
+  validateTransitionClasses(rule, named, bucketName);
+}
+
+/**
+ * Refuse a transition to a storage class S3 has no such class for.
+ *
+ * The class is read here, where the configuration is stored, so a rule that
+ * names one nothing can transition to is refused before it is applied to
+ * anything.
+ */
+function validateTransitionClasses(
+  rule: SimS3LifecycleRule,
+  named: string,
+  bucketName: SimS3BucketName,
+): void {
+  const transitions = [
+    ...(rule.Transitions ?? []),
+    ...(rule.NoncurrentVersionTransitions ?? []),
+  ];
+
+  for (const transition of transitions) {
+    simS3StorageClassFrom(
+      transition.StorageClass,
+      `lifecycle rule ${named} of S3 Bucket ${bucketName}`,
     );
   }
 }

--- a/src/service/s3/command/list-multipart-uploads/list-multipart-uploads.handler.ts
+++ b/src/service/s3/command/list-multipart-uploads/list-multipart-uploads.handler.ts
@@ -1,6 +1,5 @@
 import type { CommandHandler } from "../../../../command/command-handler.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import { simS3DefaultStorageClass } from "../../object/s3-object-summary.js";
 import {
   SimS3MultipartAccess,
   type SimS3MultipartAccessProperties,
@@ -54,7 +53,7 @@ export class ListMultipartUploadsCommandHandler implements CommandHandler<
               Key: upload.key,
               UploadId: upload.uploadId,
               Initiated: upload.initiated,
-              StorageClass: simS3DefaultStorageClass,
+              StorageClass: upload.storageClass,
             })),
       IsTruncated: false,
       $metadata: {},

--- a/src/service/s3/command/list-object-versions/list-object-versions-summaries.ts
+++ b/src/service/s3/command/list-object-versions/list-object-versions-summaries.ts
@@ -1,6 +1,5 @@
 import type { SimS3ObjectVersion } from "../../bucket/versioning/sim-s3-object-version.js";
 import { simS3QuotedETag } from "../../object/s3-object-etag.js";
-import { simS3DefaultStorageClass } from "../../object/s3-object-summary.js";
 import type {
   SimS3DeleteMarkerSummary,
   SimS3ObjectVersionSummary,
@@ -27,7 +26,7 @@ export function simS3ObjectVersionSummaries(
       LastModified: version.lastModified,
       ETag: simS3QuotedETag(version.object.etag),
       Size: version.object.body.length,
-      StorageClass: simS3DefaultStorageClass,
+      StorageClass: version.object.storageClass,
     }));
 }
 

--- a/src/service/s3/command/list-parts/list-parts.handler.ts
+++ b/src/service/s3/command/list-parts/list-parts.handler.ts
@@ -1,7 +1,6 @@
 import type { CommandHandler } from "../../../../command/command-handler.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import { simS3QuotedETag } from "../../object/s3-object-etag.js";
-import { simS3DefaultStorageClass } from "../../object/s3-object-summary.js";
 import {
   SimS3MultipartAccess,
   type SimS3MultipartAccessProperties,
@@ -44,7 +43,8 @@ export class ListPartsCommandHandler implements CommandHandler<
     assertDefined(UploadId, "ListPartsCommand.input.UploadId");
 
     const { bucket } = await this.access.reach(Bucket, Key, options);
-    const parts = this.access.requireUpload(bucket, UploadId).storedParts();
+    const upload = this.access.requireUpload(bucket, UploadId);
+    const parts = upload.storedParts();
 
     return {
       Bucket: bucket.bucketName,
@@ -59,7 +59,7 @@ export class ListPartsCommandHandler implements CommandHandler<
               Size: part.body.length,
               LastModified: part.lastModified,
             })),
-      StorageClass: simS3DefaultStorageClass,
+      StorageClass: upload.storageClass,
       IsTruncated: false,
       $metadata: {},
     };

--- a/src/service/s3/command/multipart/sim-s3-multipart-access.ts
+++ b/src/service/s3/command/multipart/sim-s3-multipart-access.ts
@@ -11,7 +11,7 @@ import type {
   SimS3Bucket,
   SimS3BucketName,
 } from "../../bucket/sim-s3-bucket.js";
-import { SimS3NoSuchUpload } from "../../error/sim-s3.error.js";
+import { SimS3NoSuchUpload } from "../../error/sim-s3-upload.error.js";
 import type { SimS3MultipartUpload } from "../../upload/sim-s3-multipart-upload.js";
 import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
 import type { SimS3RequestOptions } from "../sim-s3-request-options.js";

--- a/src/service/s3/command/put-bucket-encryption/put-bucket-encryption.command.ts
+++ b/src/service/s3/command/put-bucket-encryption/put-bucket-encryption.command.ts
@@ -1,0 +1,26 @@
+import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimS3ServerSideEncryptionConfiguration } from "../../bucket/encryption/sim-s3-bucket-encryption.js";
+
+/**
+ * Minimal structural sim S3 PutBucketEncryption command.
+ */
+export interface SimPutBucketEncryptionCommand {
+  readonly input: SimPutBucketEncryptionCommandInput;
+}
+
+/**
+ * Minimal structural sim S3 PutBucketEncryption input.
+ */
+export interface SimPutBucketEncryptionCommandInput {
+  readonly Bucket?: string | undefined;
+  readonly ServerSideEncryptionConfiguration?:
+    | SimS3ServerSideEncryptionConfiguration
+    | undefined;
+}
+
+/**
+ * Minimal structural sim S3 PutBucketEncryption output.
+ */
+export interface SimPutBucketEncryptionCommandOutput {
+  readonly $metadata: SimResponseMetadata;
+}

--- a/src/service/s3/command/put-bucket-encryption/put-bucket-encryption.handler.ts
+++ b/src/service/s3/command/put-bucket-encryption/put-bucket-encryption.handler.ts
@@ -1,0 +1,93 @@
+import type { CommandHandler } from "../../../../command/command-handler.js";
+import {
+  type BackgroundScheduler,
+  BackgroundTasks,
+} from "../../../../util/background/background.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import {
+  SimIamAllowAllAuth,
+  type SimIamInterServiceAuthZ,
+} from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimS3BucketEncryption } from "../../bucket/encryption/sim-s3-bucket-encryption.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
+import { SimS3EncryptionAuthorizer } from "../encryption/sim-s3-encryption-authorizer.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
+import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
+import type {
+  SimPutBucketEncryptionCommand,
+  SimPutBucketEncryptionCommandOutput,
+} from "./put-bucket-encryption.command.js";
+
+interface PutBucketEncryptionHandlerProperties {
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly iam?: SimIamInterServiceAuthZ;
+  readonly background?: BackgroundScheduler;
+}
+
+/**
+ * Simulated S3 PutBucketEncryptionCommand handler.
+ *
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/command/PutBucketEncryptionCommand/
+ */
+export class PutBucketEncryptionCommandHandler implements CommandHandler<
+  SimPutBucketEncryptionCommand,
+  SimPutBucketEncryptionCommandOutput
+> {
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  private readonly authorizer: SimS3EncryptionAuthorizer;
+  private readonly background: BackgroundScheduler;
+
+  constructor(properties: PutBucketEncryptionHandlerProperties) {
+    const {
+      buckets,
+      iam = new SimIamAllowAllAuth(),
+      background = new BackgroundTasks(),
+    } = properties;
+
+    this.buckets = buckets;
+    this.authorizer = new SimS3EncryptionAuthorizer({ iam });
+    this.background = background;
+  }
+
+  /**
+   * Authorize and apply a Bucket's default encryption.
+   *
+   * The configuration decides the algorithm an Object written without one is
+   * stamped with. Objects already in the Bucket keep what they were written
+   * with, as they do in real S3.
+   */
+  async handle(
+    command: SimPutBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<SimPutBucketEncryptionCommandOutput> {
+    assertDefined(
+      command.input.Bucket,
+      "PutBucketEncryptionCommand.input.Bucket",
+    );
+    assertDefined(
+      command.input.ServerSideEncryptionConfiguration,
+      "PutBucketEncryptionCommand.input.ServerSideEncryptionConfiguration",
+    );
+
+    const bucketName = command.input.Bucket as SimS3BucketName;
+    const bucket = requireSimS3Bucket(this.buckets, bucketName);
+
+    await this.background.sequence();
+
+    this.authorizer.authorizeWrite(bucket, options);
+
+    bucket.configureEncryption(
+      SimS3BucketEncryption.fromConfiguration(
+        command.input.ServerSideEncryptionConfiguration,
+        bucketName,
+      ),
+    );
+
+    return {
+      $metadata: {},
+    };
+  }
+}

--- a/src/service/s3/command/put-object/put-object-builder.ts
+++ b/src/service/s3/command/put-object/put-object-builder.ts
@@ -1,6 +1,11 @@
 import { SimS3Object } from "../../object/s3-object.js";
+import type { SimS3ServerSideEncryption } from "../../object/s3-server-side-encryption.js";
 import { simS3WriteBodyBuffer } from "../../object/s3-write-body.js";
 import { simS3WriteMetadata } from "../../object/s3-write-metadata.js";
+import {
+  simS3WriteEncryption,
+  simS3WriteStorageClass,
+} from "../../object/s3-write-storage.js";
 import type { SimPutObjectCommand } from "./put-object.command.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
@@ -34,14 +39,31 @@ export class PutObjectBuilder {
    *
    * The Object is dated by the simulation's clock rather than the host's, so a
    * test that freezes time gets a last-modified time it can assert on.
+   *
+   * The Bucket's default encryption is passed in because the request has the
+   * last word on it and the Bucket answers for a request that names none.
    */
-  build(command: SimPutObjectCommand): SimS3Object {
+  build(
+    command: SimPutObjectCommand,
+    bucketEncryption: SimS3ServerSideEncryption,
+  ): SimS3Object {
     assertDefined(command.input.Key, "PutObjectCommand.input.Key");
+    const storageClass = simS3WriteStorageClass(
+      command.input,
+      "PutObjectCommand",
+    );
+
     return new SimS3Object({
       key: command.input.Key,
       body: simS3WriteBodyBuffer(command.input.Body, "PutObjectCommand"),
       metadata: simS3WriteMetadata(command.input),
       lastModified: this.clock.now(),
+      ...(storageClass !== undefined && { storageClass }),
+      serverSideEncryption: simS3WriteEncryption(
+        command.input,
+        bucketEncryption,
+        "PutObjectCommand",
+      ),
     });
   }
 }

--- a/src/service/s3/command/put-object/put-object.command.ts
+++ b/src/service/s3/command/put-object/put-object.command.ts
@@ -1,6 +1,7 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimS3WriteBody } from "../../object/s3-write-body.js";
 import type { SimS3ObjectWriteMetadata } from "../../object/s3-write-metadata.js";
+import type { SimS3ObjectWriteStorage } from "../../object/s3-write-storage.js";
 
 /**
  * Minimal structural sim S3 PutObject command.
@@ -16,7 +17,8 @@ export interface SimPutObjectCommand {
  * Object carries, which is why they are declared once in
  * `SimS3ObjectWriteMetadata` and shared with `CreateMultipartUpload`.
  */
-export interface SimPutObjectCommandInput extends SimS3ObjectWriteMetadata {
+export interface SimPutObjectCommandInput
+  extends SimS3ObjectWriteMetadata, SimS3ObjectWriteStorage {
   readonly Bucket?: string | undefined;
   readonly Key?: string | undefined;
   readonly Body?: SimPutObjectBody;
@@ -33,6 +35,8 @@ export interface SimPutObjectCommandInput extends SimS3ObjectWriteMetadata {
 export interface SimPutObjectCommandOutput {
   readonly ETag?: string;
   readonly VersionId?: string | undefined;
+  /** The encryption S3 stamped on the Object it stored. */
+  readonly ServerSideEncryption?: string | undefined;
   readonly $metadata: SimResponseMetadata;
 }
 

--- a/src/service/s3/command/put-object/put-object.handler.ts
+++ b/src/service/s3/command/put-object/put-object.handler.ts
@@ -85,7 +85,10 @@ export class PutObjectCommandHandler implements CommandHandler<
 
     const caller = this.authorizer.authorize(bucket, Key, options);
 
-    const object = this.objectBuilder.build(command);
+    const object = this.objectBuilder.build(
+      command,
+      bucket.getEncryption().algorithm,
+    );
     const version = await bucket.putObject(object);
     const versionId = version?.versionId;
 
@@ -102,6 +105,7 @@ export class PutObjectCommandHandler implements CommandHandler<
     return {
       ETag: simS3QuotedETag(object.etag),
       ...(versionId !== undefined && { VersionId: versionId }),
+      ServerSideEncryption: object.serverSideEncryption,
       $metadata: {},
     };
   }

--- a/src/service/s3/command/sim-s3-command.types.ts
+++ b/src/service/s3/command/sim-s3-command.types.ts
@@ -60,9 +60,21 @@ export type {
   SimS3LifecycleRule,
 } from "./put-bucket-lifecycle-configuration/put-bucket-lifecycle-configuration.command.js";
 export type {
+  SimDeleteBucketEncryptionCommand,
+  SimDeleteBucketEncryptionCommandOutput,
+} from "./delete-bucket-encryption/delete-bucket-encryption.command.js";
+export type {
+  SimGetBucketEncryptionCommand,
+  SimGetBucketEncryptionCommandOutput,
+} from "./get-bucket-encryption/get-bucket-encryption.command.js";
+export type {
   SimGetBucketVersioningCommand,
   SimGetBucketVersioningCommandOutput,
 } from "./get-bucket-versioning/get-bucket-versioning.command.js";
+export type {
+  SimPutBucketEncryptionCommand,
+  SimPutBucketEncryptionCommandOutput,
+} from "./put-bucket-encryption/put-bucket-encryption.command.js";
 export type {
   SimPutBucketVersioningCommand,
   SimPutBucketVersioningCommandOutput,

--- a/src/service/s3/error/sim-s3-upload.error.ts
+++ b/src/service/s3/error/sim-s3-upload.error.ts
@@ -1,0 +1,54 @@
+import { SimS3Error } from "./sim-s3.error.js";
+
+/**
+ * The errors a multipart upload answers with.
+ *
+ * An upload is the one S3 operation made of several requests, so these are
+ * about the upload as a whole rather than about one Object or one Bucket.
+ */
+
+/**
+ * Simulated S3 NoSuchUpload error.
+ *
+ * What real S3 answers when a request names a multipart upload id it did not
+ * issue, or one belonging to an upload that has since been completed or
+ * aborted.
+ */
+export class SimS3NoSuchUpload extends SimS3Error {
+  public override readonly name = "NoSuchUpload";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 404 });
+  }
+}
+
+/**
+ * Simulated S3 InvalidPart error.
+ *
+ * A completion naming a part that was never uploaded, or naming an ETag other
+ * than the one that part was stored under. Real S3 refuses rather than
+ * assembling what it can, because a caller that lost a part should not end up
+ * with an Object silently missing its middle.
+ */
+export class SimS3InvalidPart extends SimS3Error {
+  public override readonly name = "InvalidPart";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
+ * Simulated S3 InvalidPartOrder error.
+ *
+ * A completion listing its parts in an order other than ascending part number.
+ * The parts themselves can be uploaded in any order; it is the list in the
+ * completion request that real S3 requires to be sorted.
+ */
+export class SimS3InvalidPartOrder extends SimS3Error {
+  public override readonly name = "InvalidPartOrder";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}

--- a/src/service/s3/error/sim-s3.error.ts
+++ b/src/service/s3/error/sim-s3.error.ts
@@ -195,6 +195,20 @@ export class SimS3InvalidArgument extends SimS3Error {
 }
 
 /**
+ * Simulated S3 InvalidStorageClass error.
+ *
+ * Real S3 answers this for a write naming a storage class it has no such class
+ * for, and refuses the write rather than storing the Object in the default one.
+ */
+export class SimS3InvalidStorageClass extends SimS3Error {
+  public override readonly name = "InvalidStorageClass";
+
+  constructor(message: string) {
+    super(message, { httpStatusCode: 400 });
+  }
+}
+
+/**
  * Simulated S3 NotImplemented error.
  *
  * Something real S3 does that the simulator refuses rather than approximates.
@@ -213,52 +227,6 @@ export class SimS3NotImplemented extends SimS3Error {
  */
 export class SimS3InvalidBucketName extends SimS3Error {
   public override readonly name = "InvalidBucketName";
-
-  constructor(message: string) {
-    super(message, { httpStatusCode: 400 });
-  }
-}
-
-/**
- * Simulated S3 NoSuchUpload error.
- *
- * What real S3 answers when a request names a multipart upload id it did not
- * issue, or one belonging to an upload that has since been completed or
- * aborted.
- */
-export class SimS3NoSuchUpload extends SimS3Error {
-  public override readonly name = "NoSuchUpload";
-
-  constructor(message: string) {
-    super(message, { httpStatusCode: 404 });
-  }
-}
-
-/**
- * Simulated S3 InvalidPart error.
- *
- * A completion naming a part that was never uploaded, or naming an ETag other
- * than the one that part was stored under. Real S3 refuses rather than
- * assembling what it can, because a caller that lost a part should not end up
- * with an Object silently missing its middle.
- */
-export class SimS3InvalidPart extends SimS3Error {
-  public override readonly name = "InvalidPart";
-
-  constructor(message: string) {
-    super(message, { httpStatusCode: 400 });
-  }
-}
-
-/**
- * Simulated S3 InvalidPartOrder error.
- *
- * A completion listing its parts in an order other than ascending part number.
- * The parts themselves can be uploaded in any order; it is the list in the
- * completion request that real S3 requires to be sorted.
- */
-export class SimS3InvalidPartOrder extends SimS3Error {
-  public override readonly name = "InvalidPartOrder";
 
   constructor(message: string) {
     super(message, { httpStatusCode: 400 });

--- a/src/service/s3/object/s3-object-response-headers.ts
+++ b/src/service/s3/object/s3-object-response-headers.ts
@@ -17,6 +17,13 @@ export interface SimS3ObjectResponseDescription {
    * of them rather than all of them.
    */
   readonly contentRange?: string | undefined;
+  /**
+   * The storage class the Object is in, for one outside the default class.
+   * Real S3 leaves the header off a Standard Object.
+   */
+  readonly storageClass?: string | undefined;
+  /** The encryption S3 applied when it stored the Object. */
+  readonly serverSideEncryption?: string | undefined;
 }
 
 /**
@@ -28,6 +35,11 @@ export interface SimS3ObjectResponseDescription {
  * Object stored as brotli and served without its encoding header is bytes no
  * client can decode. `Cache-Control` matters for a different reason, being the
  * only one of these a caller can set per Object rather than per response.
+ *
+ * `x-amz-storage-class` and `x-amz-server-side-encryption` say where and how
+ * S3 keeps the Object. The class is set for an Object outside the default one,
+ * as real S3 sets it, and the encryption is set for every Object S3 stored
+ * itself.
  *
  * `ETag` and `Last-Modified` are not metadata but facts about the stored bytes,
  * and are what makes a conditional request or a content-hash comparison
@@ -64,6 +76,14 @@ export function simS3ObjectResponseHeaders(
 
   if (description.contentRange !== undefined) {
     headers["content-range"] = description.contentRange;
+  }
+
+  if (description.storageClass !== undefined) {
+    headers["x-amz-storage-class"] = description.storageClass;
+  }
+
+  if (description.serverSideEncryption !== undefined) {
+    headers["x-amz-server-side-encryption"] = description.serverSideEncryption;
   }
 
   return headers;

--- a/src/service/s3/object/s3-object-storage-report.ts
+++ b/src/service/s3/object/s3-object-storage-report.ts
@@ -1,0 +1,35 @@
+import type { SimS3Object } from "./s3-object.js";
+import type { SimS3ServerSideEncryption } from "./s3-server-side-encryption.js";
+import {
+  simS3ReportedStorageClass,
+  type SimS3StorageClass,
+} from "./s3-storage-class.js";
+
+/**
+ * What a read says about where and how S3 keeps an Object.
+ */
+export interface SimS3ObjectStorageReport {
+  readonly StorageClass?: SimS3StorageClass;
+  readonly ServerSideEncryption?: SimS3ServerSideEncryption;
+}
+
+/**
+ * Describe where and how S3 keeps an Object, as `GetObject` and `HeadObject`
+ * report it.
+ *
+ * Real S3 leaves the storage class out of a read of a Standard Object and
+ * reports it for every other class. An Object's encryption is reported
+ * whatever it is, because S3 encrypts every Object it stores.
+ */
+export function simS3ObjectStorageReport(
+  object: SimS3Object,
+): SimS3ObjectStorageReport {
+  const storageClass = simS3ReportedStorageClass(object.storageClass);
+
+  return {
+    ...(storageClass !== undefined && { StorageClass: storageClass }),
+    ...(object.serverSideEncryption !== undefined && {
+      ServerSideEncryption: object.serverSideEncryption,
+    }),
+  };
+}

--- a/src/service/s3/object/s3-object-summary.ts
+++ b/src/service/s3/object/s3-object-summary.ts
@@ -1,15 +1,6 @@
 import { simS3QuotedETag } from "./s3-object-etag.js";
 import type { SimS3Object } from "./s3-object.js";
-
-/**
- * The storage class S3 reports for an Object nobody asked to store elsewhere.
- *
- * Storage classes are not simulated, and this is the one real S3 puts an Object
- * in unless told otherwise. It is reported rather than omitted because a
- * listing that leaves it out reads as an Object of unknown class, which is a
- * different thing from a Standard one.
- */
-export const simS3DefaultStorageClass = "STANDARD";
+import type { SimS3StorageClass } from "./s3-storage-class.js";
 
 /**
  * One Object as a listing describes it.
@@ -23,7 +14,7 @@ export interface SimS3ObjectSummary {
   readonly Size?: number;
   readonly ETag?: string;
   readonly LastModified?: Date;
-  readonly StorageClass?: string;
+  readonly StorageClass?: SimS3StorageClass;
 }
 
 /**
@@ -39,7 +30,7 @@ export function simS3ObjectSummary(object: SimS3Object): SimS3ObjectSummary {
     Size: object.body.length,
     ETag: simS3QuotedETag(object.etag),
     LastModified: object.lastModified,
-    StorageClass: simS3DefaultStorageClass,
+    StorageClass: object.storageClass,
   };
 }
 

--- a/src/service/s3/object/s3-object.ts
+++ b/src/service/s3/object/s3-object.ts
@@ -1,4 +1,9 @@
 import { simS3ObjectETag } from "./s3-object-etag.js";
+import type { SimS3ServerSideEncryption } from "./s3-server-side-encryption.js";
+import {
+  simS3DefaultStorageClass,
+  type SimS3StorageClass,
+} from "./s3-storage-class.js";
 import {
   simS3SystemMetadataOutput,
   simS3UserDefinedMetadata,
@@ -41,6 +46,17 @@ interface SimS3ObjectProperties {
    * them. Only a multipart upload produces one.
    */
   readonly etag?: string;
+  /**
+   * The storage class the Object is in. An Object nobody asked to store
+   * elsewhere is in the default class.
+   */
+  readonly storageClass?: SimS3StorageClass;
+  /**
+   * The encryption S3 applied when it stored these bytes, from the write or
+   * from the Bucket's default. The bytes are stored as they arrived whatever
+   * this says, and it is what a read reports about them.
+   */
+  readonly serverSideEncryption?: SimS3ServerSideEncryption | undefined;
 }
 
 /**
@@ -50,6 +66,8 @@ export class SimS3Object {
   public readonly key: string;
   public readonly body: Buffer;
   public readonly metadata: SimS3ObjectMetadata;
+  public readonly storageClass: SimS3StorageClass;
+  public readonly serverSideEncryption: SimS3ServerSideEncryption | undefined;
 
   private readonly writtenAt: Date;
   private readonly givenETag: string | undefined;
@@ -60,13 +78,36 @@ export class SimS3Object {
       body = Buffer.alloc(0),
       metadata = new SimS3ObjectMetadata(),
       lastModified = new Date(),
+      storageClass = simS3DefaultStorageClass,
     } = properties;
 
     this.key = key;
     this.body = body;
     this.metadata = metadata;
+    this.storageClass = storageClass;
+    this.serverSideEncryption = properties.serverSideEncryption;
     this.writtenAt = new Date(lastModified);
     this.givenETag = properties.etag;
+  }
+
+  /**
+   * The same Object in another storage class, for a lifecycle rule that has
+   * transitioned it.
+   *
+   * The bytes are shared with the Object this came from. A transition moves
+   * where S3 keeps an Object and leaves the Object itself alone, so its ETag,
+   * its metadata and the instant it was last written all carry over.
+   */
+  withStorageClass(storageClass: SimS3StorageClass): SimS3Object {
+    return new SimS3Object({
+      key: this.key,
+      body: this.body,
+      metadata: this.metadata,
+      lastModified: this.writtenAt,
+      storageClass,
+      serverSideEncryption: this.serverSideEncryption,
+      ...(this.givenETag !== undefined && { etag: this.givenETag }),
+    });
   }
 
   /**

--- a/src/service/s3/object/s3-server-side-encryption.ts
+++ b/src/service/s3/object/s3-server-side-encryption.ts
@@ -1,0 +1,64 @@
+import { SimS3InvalidArgument } from "../error/sim-s3.error.js";
+
+/**
+ * The server-side encryption algorithms S3 applies to an Object.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html
+ */
+export const simS3ServerSideEncryptionAlgorithms = [
+  "AES256",
+  "aws:kms",
+  "aws:kms:dsse",
+] as const;
+
+/**
+ * One server-side encryption algorithm.
+ */
+export type SimS3ServerSideEncryption =
+  (typeof simS3ServerSideEncryptionAlgorithms)[number];
+
+/**
+ * The encryption every Bucket applies to an Object whose write named none.
+ *
+ * Real S3 has encrypted every new Object with SSE-S3 since January 2023, and
+ * reports `AES256` for one written into a Bucket carrying no default of its
+ * own. Nothing is encrypted here. The bytes are stored as they arrive, and this
+ * is what a read says about them.
+ */
+export const simS3DefaultServerSideEncryption: SimS3ServerSideEncryption =
+  "AES256";
+
+/**
+ * Read the encryption a request or a Bucket configuration named, refusing an
+ * algorithm S3 does not apply.
+ *
+ * Real S3 answers `InvalidArgument` for an unsupported algorithm on a write.
+ */
+export function simS3ServerSideEncryptionFrom(
+  value: string | undefined,
+  context: string,
+): SimS3ServerSideEncryption | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isSimS3ServerSideEncryption(value)) {
+    throw new SimS3InvalidArgument(
+      `${value} is not a server-side encryption algorithm for ${context}. ` +
+        `It is one of ${simS3ServerSideEncryptionAlgorithms.join(", ")}.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Whether a value names a server-side encryption algorithm.
+ */
+export function isSimS3ServerSideEncryption(
+  value: string,
+): value is SimS3ServerSideEncryption {
+  return (simS3ServerSideEncryptionAlgorithms as readonly string[]).includes(
+    value,
+  );
+}

--- a/src/service/s3/object/s3-storage-class.iso.test.ts
+++ b/src/service/s3/object/s3-storage-class.iso.test.ts
@@ -1,0 +1,211 @@
+import {
+  CompleteMultipartUploadCommand,
+  CopyObjectCommand,
+  CreateBucketCommand,
+  CreateMultipartUploadCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  UploadPartCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { SimS3InvalidStorageClass } from "../error/sim-s3.error.js";
+import type { SimS3 } from "../sim-s3.js";
+
+/**
+ * A Bucket to write Objects into.
+ */
+async function archiveSimulation(): Promise<SimS3> {
+  const simS3 = new SimAws().region("eu-west-2").s3();
+
+  await simS3.createBucket(new CreateBucketCommand({ Bucket: "archive" }));
+
+  return simS3;
+}
+
+/**
+ * The class a listing reports for one key.
+ */
+async function listedClass(
+  simS3: SimS3,
+  key: string,
+): Promise<string | undefined> {
+  const listing = await simS3.listObjectsV2(
+    new ListObjectsV2Command({ Bucket: "archive" }),
+  );
+
+  return (listing.Contents ?? []).find((entry) => entry.Key === key)
+    ?.StorageClass;
+}
+
+/**
+ * The storage class a simulated S3 Object is written in and read back under.
+ */
+describe("Simulated S3 Object storage classes", () => {
+  it("stores an Object in the class its write names", async () => {
+    // Given a Bucket.
+    const simS3 = await archiveSimulation();
+
+    // When an Object is written into one of the archival classes.
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "archive",
+        Key: "ledgers/2026.csv",
+        Body: "a,b",
+        StorageClass: "GLACIER",
+      }),
+    );
+
+    // Then every way of asking about it says where it is.
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "archive", Key: "ledgers/2026.csv" }),
+    );
+    const head = await simS3.headObject(
+      new HeadObjectCommand({ Bucket: "archive", Key: "ledgers/2026.csv" }),
+    );
+
+    assertIdentical(read.StorageClass, "GLACIER");
+    assertIdentical(head.StorageClass, "GLACIER");
+    assertIdentical(await listedClass(simS3, "ledgers/2026.csv"), "GLACIER");
+  });
+
+  it("leaves the class out of a read of a Standard Object", async () => {
+    // Given an Object written without a class named.
+    const simS3 = await archiveSimulation();
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "archive",
+        Key: "ledgers/current.csv",
+        Body: "a,b",
+      }),
+    );
+
+    // When it is read and asked about.
+    const read = await simS3.getObject(
+      new GetObjectCommand({ Bucket: "archive", Key: "ledgers/current.csv" }),
+    );
+    const head = await simS3.headObject(
+      new HeadObjectCommand({ Bucket: "archive", Key: "ledgers/current.csv" }),
+    );
+
+    // Then neither reports a class, as real S3 leaves the header off a
+    // Standard Object, and a listing still names the class it is in.
+    assertUndefined(read.StorageClass);
+    assertUndefined(head.StorageClass);
+    assertIdentical(
+      await listedClass(simS3, "ledgers/current.csv"),
+      "STANDARD",
+    );
+  });
+
+  it("refuses a write naming a class S3 has no such class for", async () => {
+    // Given a Bucket.
+    const simS3 = await archiveSimulation();
+
+    // When a write names something that is not a storage class.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.putObject(
+        new PutObjectCommand({
+          Bucket: "archive",
+          Key: "ledgers/2026.csv",
+          Body: "a,b",
+          StorageClass: "PERMAFROST" as "GLACIER",
+        }),
+      ),
+    );
+
+    // Then it is refused, and nothing was stored under the key.
+    assertInstanceOf(error, SimS3InvalidStorageClass);
+    assertStringIncludes(error.message, "PERMAFROST");
+    assertUndefined(await listedClass(simS3, "ledgers/2026.csv"));
+  });
+
+  it("stores a copy in the class the copy names", async () => {
+    // Given an Object in an archival class.
+    const simS3 = await archiveSimulation();
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "archive",
+        Key: "ledgers/2026.csv",
+        Body: "a,b",
+        StorageClass: "DEEP_ARCHIVE",
+      }),
+    );
+
+    // When it is copied twice, once naming a class and once not.
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "ledgers/2026-working.csv",
+        CopySource: "archive/ledgers/2026.csv",
+      }),
+    );
+    await simS3.copyObject(
+      new CopyObjectCommand({
+        Bucket: "archive",
+        Key: "ledgers/2026-cold.csv",
+        CopySource: "archive/ledgers/2026.csv",
+        StorageClass: "GLACIER_IR",
+      }),
+    );
+
+    // Then the copy that named none is Standard rather than the source's
+    // class, which is what real S3 stores a copy as.
+    assertIdentical(
+      await listedClass(simS3, "ledgers/2026-working.csv"),
+      "STANDARD",
+    );
+    assertIdentical(
+      await listedClass(simS3, "ledgers/2026-cold.csv"),
+      "GLACIER_IR",
+    );
+  });
+
+  it("completes a multipart upload into the class it was started in", async () => {
+    // Given an upload started in an infrequent access class.
+    const simS3 = await archiveSimulation();
+    const upload = await simS3.createMultipartUpload(
+      new CreateMultipartUploadCommand({
+        Bucket: "archive",
+        Key: "ledgers/large.csv",
+        StorageClass: "STANDARD_IA",
+      }),
+    );
+    const part = await simS3.uploadPart(
+      new UploadPartCommand({
+        Bucket: "archive",
+        Key: "ledgers/large.csv",
+        UploadId: upload.UploadId,
+        PartNumber: 1,
+        Body: "a,b",
+      }),
+    );
+
+    // When the upload is completed.
+    await simS3.completeMultipartUpload(
+      new CompleteMultipartUploadCommand({
+        Bucket: "archive",
+        Key: "ledgers/large.csv",
+        UploadId: upload.UploadId,
+        MultipartUpload: { Parts: [{ PartNumber: 1, ETag: part.ETag }] },
+      }),
+    );
+
+    // Then the Object it made is in the class the upload named, which real S3
+    // takes at the start of an upload rather than at its completion.
+    assertIdentical(
+      await listedClass(simS3, "ledgers/large.csv"),
+      "STANDARD_IA",
+    );
+  });
+});

--- a/src/service/s3/object/s3-storage-class.ts
+++ b/src/service/s3/object/s3-storage-class.ts
@@ -1,0 +1,86 @@
+import { SimS3InvalidStorageClass } from "../error/sim-s3.error.js";
+
+/**
+ * The storage class S3 puts an Object in when the write names none.
+ *
+ * Reported rather than omitted from a listing, because a listing that leaves it
+ * out reads as an Object of unknown class. Real S3 answers `STANDARD` there and
+ * leaves the `x-amz-storage-class` header off a read of one, which is what
+ * `simS3ReportedStorageClass` is for.
+ */
+export const simS3DefaultStorageClass = "STANDARD";
+
+/**
+ * The storage classes an Object can be in.
+ *
+ * These are the ones a write can name or a lifecycle rule can transition to.
+ * Nothing here changes what a read costs or how long it takes, so the class is
+ * a fact about the Object that S3 reports and applies its rules to.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html
+ */
+export const simS3StorageClasses = [
+  simS3DefaultStorageClass,
+  "REDUCED_REDUNDANCY",
+  "STANDARD_IA",
+  "ONEZONE_IA",
+  "INTELLIGENT_TIERING",
+  "GLACIER_IR",
+  "GLACIER",
+  "DEEP_ARCHIVE",
+  "EXPRESS_ONEZONE",
+  "OUTPOSTS",
+  "SNOW",
+] as const;
+
+/**
+ * One storage class an Object can be in.
+ */
+export type SimS3StorageClass = (typeof simS3StorageClasses)[number];
+
+/**
+ * Read the storage class a request named, refusing one S3 has no such class
+ * for.
+ *
+ * A request naming none leaves the Object in the default class. Real S3
+ * answers `InvalidStorageClass` for a name it does not know, and does it
+ * before storing anything.
+ */
+export function simS3StorageClassFrom(
+  value: string | undefined,
+  context: string,
+): SimS3StorageClass | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isSimS3StorageClass(value)) {
+    throw new SimS3InvalidStorageClass(
+      `${value} is not an S3 storage class for ${context}. It is one of ` +
+        `${simS3StorageClasses.join(", ")}.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * The storage class a read of an Object reports, which is nothing for one in
+ * the default class.
+ *
+ * Real S3 leaves `x-amz-storage-class` off a `GetObject` or a `HeadObject`
+ * response for a Standard Object, and sets it for every other class. A listing
+ * is the other way around and always carries one.
+ */
+export function simS3ReportedStorageClass(
+  storageClass: SimS3StorageClass,
+): SimS3StorageClass | undefined {
+  return storageClass === simS3DefaultStorageClass ? undefined : storageClass;
+}
+
+/**
+ * Whether a value names a storage class.
+ */
+export function isSimS3StorageClass(value: string): value is SimS3StorageClass {
+  return (simS3StorageClasses as readonly string[]).includes(value);
+}

--- a/src/service/s3/object/s3-write-storage.ts
+++ b/src/service/s3/object/s3-write-storage.ts
@@ -1,0 +1,52 @@
+import {
+  simS3DefaultServerSideEncryption,
+  simS3ServerSideEncryptionFrom,
+  type SimS3ServerSideEncryption,
+} from "./s3-server-side-encryption.js";
+import {
+  simS3StorageClassFrom,
+  type SimS3StorageClass,
+} from "./s3-storage-class.js";
+
+/**
+ * The members of a request that say where and how S3 keeps an Object.
+ *
+ * `PutObject`, `CopyObject` and `CreateMultipartUpload` all carry these
+ * alongside the metadata that says what the Object is. Both are read before
+ * anything is stored, because real S3 refuses a write naming a storage class
+ * or an algorithm it has no such thing for.
+ */
+export interface SimS3ObjectWriteStorage {
+  readonly StorageClass?: string | undefined;
+  readonly ServerSideEncryption?: string | undefined;
+}
+
+/**
+ * The storage class a write asks for, or nothing where it asks for none.
+ */
+export function simS3WriteStorageClass(
+  input: SimS3ObjectWriteStorage,
+  context: string,
+): SimS3StorageClass | undefined {
+  return simS3StorageClassFrom(input.StorageClass, context);
+}
+
+/**
+ * The encryption S3 stamps on the Object a write is storing.
+ *
+ * The write has the last word, the Bucket's default configuration comes next,
+ * and an Object written into a Bucket carrying neither is SSE-S3 encrypted.
+ * Real S3 has encrypted every new Object that way since January 2023, so
+ * `AES256` is what a read reports for one nobody configured anything for.
+ */
+export function simS3WriteEncryption(
+  input: SimS3ObjectWriteStorage,
+  bucketDefault: SimS3ServerSideEncryption | undefined,
+  context: string,
+): SimS3ServerSideEncryption {
+  return (
+    simS3ServerSideEncryptionFrom(input.ServerSideEncryption, context) ??
+    bucketDefault ??
+    simS3DefaultServerSideEncryption
+  );
+}

--- a/src/service/s3/sdk/sim-s3-sdk-bucket-routes.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-bucket-routes.ts
@@ -127,6 +127,30 @@ export function simS3SdkBucketRoutes(
         ),
     ],
     [
+      "PutBucketEncryptionCommand",
+      async (command, context): Promise<unknown> =>
+        await simS3.putBucketEncryption(
+          command as simS3Commands.SimPutBucketEncryptionCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "GetBucketEncryptionCommand",
+      async (command, context): Promise<unknown> =>
+        await simS3.getBucketEncryption(
+          command as simS3Commands.SimGetBucketEncryptionCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
+      "DeleteBucketEncryptionCommand",
+      async (command, context): Promise<unknown> =>
+        await simS3.deleteBucketEncryption(
+          command as simS3Commands.SimDeleteBucketEncryptionCommand,
+          simSdkCallerOptions(context),
+        ),
+    ],
+    [
       "PutBucketWebsiteCommand",
       async (command, context): Promise<unknown> =>
         await simS3.putBucketWebsite(

--- a/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
+++ b/src/service/s3/sdk/sim-s3-sdk-command-router.iso.test.ts
@@ -312,9 +312,12 @@ describe("simulated S3 SDK Command routing", () => {
 
     const supported = router.supportedCommandNames();
 
-    assertArrayLength(supported, 37);
+    assertArrayLength(supported, 40);
     assertArrayIncludes(supported, "CopyObjectCommand");
     assertArrayIncludes(supported, "PutBucketVersioningCommand");
+    assertArrayIncludes(supported, "PutBucketEncryptionCommand");
+    assertArrayIncludes(supported, "GetBucketEncryptionCommand");
+    assertArrayIncludes(supported, "DeleteBucketEncryptionCommand");
     assertArrayIncludes(supported, "GetBucketVersioningCommand");
     assertArrayIncludes(supported, "ListObjectVersionsCommand");
     assertArrayIncludes(supported, "PutObjectLockConfigurationCommand");

--- a/src/service/s3/serve/api/sim-s3-api-bucket-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-bucket-routes.ts
@@ -1,4 +1,5 @@
 import { readSimS3NotificationConfiguration } from "./sim-s3-api-notification-read.js";
+import { readSimS3EncryptionConfiguration } from "./sim-s3-api-encryption-read.js";
 import {
   readSimS3DeleteRequest,
   readSimS3PublicAccessBlock,
@@ -45,6 +46,13 @@ export const simS3BucketApiRoutes: readonly SimS3ApiRoute[] = [
     target: "bucket",
     subResource: "publicAccessBlock",
     commandName: "GetPublicAccessBlockCommand",
+    input: bucketInput,
+  },
+  {
+    method: "GET",
+    target: "bucket",
+    subResource: "encryption",
+    commandName: "GetBucketEncryptionCommand",
     input: bucketInput,
   },
   {
@@ -109,6 +117,18 @@ export const simS3BucketApiRoutes: readonly SimS3ApiRoute[] = [
   {
     method: "PUT",
     target: "bucket",
+    subResource: "encryption",
+    commandName: "PutBucketEncryptionCommand",
+    input: (request) =>
+      bucketBodyInput(
+        request,
+        "ServerSideEncryptionConfiguration",
+        readSimS3EncryptionConfiguration,
+      ),
+  },
+  {
+    method: "PUT",
+    target: "bucket",
     subResource: "notification",
     commandName: "PutBucketNotificationConfigurationCommand",
     input: (request) =>
@@ -137,6 +157,13 @@ export const simS3BucketApiRoutes: readonly SimS3ApiRoute[] = [
     target: "bucket",
     subResource: "policy",
     commandName: "DeleteBucketPolicyCommand",
+    input: bucketInput,
+  },
+  {
+    method: "DELETE",
+    target: "bucket",
+    subResource: "encryption",
+    commandName: "DeleteBucketEncryptionCommand",
     input: bucketInput,
   },
   {

--- a/src/service/s3/serve/api/sim-s3-api-configuration-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-configuration-output.ts
@@ -27,6 +27,46 @@ export function publicAccessBlockXml(output: Record<string, unknown>): string {
   );
 }
 
+interface EncryptionRule {
+  readonly ApplyServerSideEncryptionByDefault?:
+    | { readonly SSEAlgorithm?: string; readonly KMSMasterKeyID?: string }
+    | undefined;
+  readonly BucketKeyEnabled?: boolean | undefined;
+}
+
+/**
+ * Write a Bucket's default encryption configuration.
+ */
+export function encryptionConfigurationXml(
+  output: Record<string, unknown>,
+): string {
+  const configuration = (output["ServerSideEncryptionConfiguration"] ?? {}) as {
+    readonly Rules?: readonly EncryptionRule[];
+  };
+
+  return xmlDocument(
+    "ServerSideEncryptionConfiguration",
+    (configuration.Rules ?? [])
+      .map((rule) =>
+        xmlElement(
+          "Rule",
+          xmlElement(
+            "ApplyServerSideEncryptionByDefault",
+            xmlValue(
+              "SSEAlgorithm",
+              rule.ApplyServerSideEncryptionByDefault?.SSEAlgorithm,
+            ) +
+              xmlValue(
+                "KMSMasterKeyID",
+                rule.ApplyServerSideEncryptionByDefault?.KMSMasterKeyID,
+              ),
+          ) + xmlValue("BucketKeyEnabled", rule.BucketKeyEnabled),
+        ),
+      )
+      .join(""),
+  );
+}
+
 interface NotificationEntry {
   readonly Id?: string | undefined;
   readonly Events?: readonly string[] | undefined;

--- a/src/service/s3/serve/api/sim-s3-api-encryption-read.ts
+++ b/src/service/s3/serve/api/sim-s3-api-encryption-read.ts
@@ -1,0 +1,43 @@
+import {
+  parseXmlDocument,
+  xmlBoolean,
+  xmlChild,
+  xmlChildren,
+  xmlText,
+} from "../../../../util/xml/xml-document.js";
+
+/**
+ * Read a default encryption configuration.
+ *
+ * Real S3 takes one rule and the SDK sends a list, so the list is read here
+ * and the Bucket decides what to do with more than one of them.
+ */
+export function readSimS3EncryptionConfiguration(body: string): object {
+  const root = parseXmlDocument(body);
+
+  return {
+    Rules: xmlChildren(root, "Rule").map((rule) => {
+      const byDefault = xmlChild(rule, "ApplyServerSideEncryptionByDefault");
+
+      return {
+        ...(byDefault !== undefined && {
+          ApplyServerSideEncryptionByDefault: {
+            ...defined("SSEAlgorithm", xmlText(byDefault, "SSEAlgorithm")),
+            ...defined("KMSMasterKeyID", xmlText(byDefault, "KMSMasterKeyID")),
+          },
+        }),
+        ...defined("BucketKeyEnabled", xmlBoolean(rule, "BucketKeyEnabled")),
+      };
+    }),
+  };
+}
+
+/**
+ * One member of a request document, or nothing where it was absent.
+ */
+function defined<Value>(
+  name: string,
+  value: Value | undefined,
+): Record<string, Value> {
+  return value === undefined ? {} : { [name]: value };
+}

--- a/src/service/s3/serve/api/sim-s3-api-head-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-head-output.ts
@@ -25,6 +25,10 @@ export function simS3HeadObjectResponse(
       bodyLength: (output["ContentLength"] as number | undefined) ?? 0,
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,
+      storageClass: output["StorageClass"] as string | undefined,
+      serverSideEncryption: output["ServerSideEncryption"] as
+        | string
+        | undefined,
     }),
   });
 }

--- a/src/service/s3/serve/api/sim-s3-api-object-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-input.ts
@@ -75,6 +75,11 @@ export function createMultipartUploadInput(request: SimS3ApiRequest): object {
     ),
     ...optional("ContentEncoding", request.headers.get("content-encoding")),
     ...optional("ContentLanguage", request.headers.get("content-language")),
+    ...optional("StorageClass", request.headers.get("x-amz-storage-class")),
+    ...optional(
+      "ServerSideEncryption",
+      request.headers.get("x-amz-server-side-encryption"),
+    ),
     ...simS3UserMetadata(request.headers),
   };
 }

--- a/src/service/s3/serve/api/sim-s3-api-object-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-output.ts
@@ -46,6 +46,10 @@ export async function simS3GetObjectResponse(
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,
       contentRange,
+      storageClass: output["StorageClass"] as string | undefined,
+      serverSideEncryption: output["ServerSideEncryption"] as
+        | string
+        | undefined,
     }),
   });
 }

--- a/src/service/s3/serve/api/sim-s3-api-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-output.ts
@@ -1,5 +1,6 @@
 import {
   deleteResultXml,
+  encryptionConfigurationXml,
   notificationConfigurationXml,
   publicAccessBlockXml,
 } from "./sim-s3-api-configuration-output.js";
@@ -58,6 +59,9 @@ export async function simS3ApiResponse(
     }
     case "GetPublicAccessBlockCommand": {
       return xml(publicAccessBlockXml(value));
+    }
+    case "GetBucketEncryptionCommand": {
+      return xml(encryptionConfigurationXml(value));
     }
     case "GetBucketNotificationConfigurationCommand": {
       return xml(notificationConfigurationXml(value));

--- a/src/service/s3/serve/api/sim-s3-api-routes.ts
+++ b/src/service/s3/serve/api/sim-s3-api-routes.ts
@@ -18,6 +18,7 @@ const servedSubResources: readonly string[] = [
   "delete",
   "uploads",
   "uploadId",
+  "encryption",
 ];
 
 /**
@@ -35,7 +36,6 @@ const knownSubResources: ReadonlySet<string> = new Set([
   "acl",
   "analytics",
   "cors",
-  "encryption",
   "intelligent-tiering",
   "inventory",
   "legal-hold",

--- a/src/service/s3/serve/api/sim-s3-api-storage.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-storage.loc.test.ts
@@ -1,0 +1,147 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  DeleteBucketEncryptionCommand,
+  GetBucketEncryptionCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutBucketEncryptionCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { assertIdentical, assertTrue } from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/**
+ * Where and how S3 keeps an Object, over the served REST endpoint.
+ *
+ * The storage class and the encryption travel as headers on the way in and on
+ * the way out, and the Bucket's default encryption travels as an XML document,
+ * so what these cover is whether either survives the round trip.
+ */
+describe("Serving simulated S3 storage classes and encryption", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let client: S3Client;
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    const simIam = simAws.iam();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: "Writer" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Writer",
+        PolicyName: "Served",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Writer" }),
+    );
+
+    assertDefined(created.AccessKey.AccessKeyId, "the access key id");
+    assertDefined(created.AccessKey.SecretAccessKey, "the secret access key");
+
+    client = new S3Client({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("round-trips a default encryption configuration", async () => {
+    // Given a Bucket configured for KMS through the endpoint
+    await client.send(new CreateBucketCommand({ Bucket: "encrypted" }));
+    await client.send(
+      new PutBucketEncryptionCommand({
+        Bucket: "encrypted",
+        ServerSideEncryptionConfiguration: {
+          Rules: [
+            {
+              ApplyServerSideEncryptionByDefault: { SSEAlgorithm: "aws:kms" },
+              BucketKeyEnabled: true,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When the configuration is read back, and then removed
+    const read = await client.send(
+      new GetBucketEncryptionCommand({ Bucket: "encrypted" }),
+    );
+    await client.send(
+      new DeleteBucketEncryptionCommand({ Bucket: "encrypted" }),
+    );
+    const removed = await client.send(
+      new GetBucketEncryptionCommand({ Bucket: "encrypted" }),
+    );
+
+    // Then the rule survived the XML document in both directions, and the
+    // Bucket went back to the SSE-S3 default rather than to nothing at all
+    const rule = read.ServerSideEncryptionConfiguration?.Rules?.[0];
+    assertDefined(rule, "the encryption rule");
+    assertIdentical(
+      rule.ApplyServerSideEncryptionByDefault?.SSEAlgorithm,
+      "aws:kms",
+    );
+    assertTrue(rule.BucketKeyEnabled);
+    assertIdentical(
+      removed.ServerSideEncryptionConfiguration?.Rules?.[0]
+        ?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm,
+      "AES256",
+    );
+  });
+
+  it("carries an Object's storage class and encryption over the endpoint", async () => {
+    // Given an Object uploaded into an archival class through the endpoint
+    await client.send(new CreateBucketCommand({ Bucket: "endpoint-archive" }));
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "endpoint-archive",
+        Key: "ledgers/2026.csv",
+        Body: "a,b",
+        StorageClass: "GLACIER",
+      }),
+    );
+
+    // When the Object is read and listed
+    const read = await client.send(
+      new GetObjectCommand({
+        Bucket: "endpoint-archive",
+        Key: "ledgers/2026.csv",
+      }),
+    );
+    const listing = await client.send(
+      new ListObjectsV2Command({ Bucket: "endpoint-archive" }),
+    );
+
+    // Then the class arrived on the way in and comes back on the way out,
+    // alongside the encryption S3 stamped on it
+    assertIdentical(read.StorageClass, "GLACIER");
+    assertIdentical(read.ServerSideEncryption, "AES256");
+    assertIdentical(listing.Contents?.[0]?.StorageClass, "GLACIER");
+  });
+});

--- a/src/service/s3/serve/sim-s3-rest-object-reader.ts
+++ b/src/service/s3/serve/sim-s3-rest-object-reader.ts
@@ -46,6 +46,8 @@ export class SimS3RestObjectReader {
       etag: output.ETag,
       lastModified: output.LastModified,
       contentRange: output.ContentRange,
+      storageClass: output.StorageClass,
+      serverSideEncryption: output.ServerSideEncryption,
     });
 
     if (head) {

--- a/src/service/s3/sim-s3-commands.ts
+++ b/src/service/s3/sim-s3-commands.ts
@@ -8,6 +8,7 @@ import { simIamInRegion } from "../iam/authorize/sim-iam-region-auth-z.js";
 import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
 import { SimS3BucketCommands } from "./command/bucket/sim-s3-bucket-commands.js";
 import { SimS3BucketPolicyCommands } from "./command/bucket-policy/sim-s3-bucket-policy-commands.js";
+import { SimS3EncryptionCommands } from "./command/encryption/sim-s3-encryption-commands.js";
 import { SimS3LifecycleCommands } from "./command/lifecycle/sim-s3-lifecycle-commands.js";
 import { SimS3MultipartCommands } from "./command/multipart/sim-s3-multipart-commands.js";
 import { SimS3NotificationCommands } from "./command/notification/sim-s3-notification-commands.js";
@@ -65,6 +66,7 @@ export class SimS3Commands {
   public readonly notifications: SimS3NotificationCommands;
   public readonly lifecycles: SimS3LifecycleCommands;
   public readonly versioning: SimS3VersioningCommands;
+  public readonly encryption: SimS3EncryptionCommands;
   public readonly objectLock: SimS3ObjectLockCommands;
   public readonly objects: SimS3ObjectCommands;
   public readonly multipartUploads: SimS3MultipartCommands;
@@ -105,6 +107,7 @@ export class SimS3Commands {
     this.notifications = new SimS3NotificationCommands(state);
     this.lifecycles = new SimS3LifecycleCommands(state);
     this.versioning = new SimS3VersioningCommands(state);
+    this.encryption = new SimS3EncryptionCommands(state);
     this.objectLock = new SimS3ObjectLockCommands(state);
     this.objects = new SimS3ObjectCommands(state);
     this.multipartUploads = new SimS3MultipartCommands(state);

--- a/src/service/s3/sim-s3-operations.ts
+++ b/src/service/s3/sim-s3-operations.ts
@@ -100,6 +100,30 @@ export abstract class SimS3Operations extends SimS3VersionOperations {
     return await this.commands.publicAccessBlocks.delete(command, options);
   }
 
+  /** Handle a Put Bucket Encryption Command from the SDK. */
+  async putBucketEncryption(
+    command: simS3Commands.SimPutBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimPutBucketEncryptionCommandOutput> {
+    return await this.commands.encryption.put(command, options);
+  }
+
+  /** Handle a Get Bucket Encryption Command from the SDK. */
+  async getBucketEncryption(
+    command: simS3Commands.SimGetBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimGetBucketEncryptionCommandOutput> {
+    return await this.commands.encryption.get(command, options);
+  }
+
+  /** Handle a Delete Bucket Encryption Command from the SDK. */
+  async deleteBucketEncryption(
+    command: simS3Commands.SimDeleteBucketEncryptionCommand,
+    options?: SimS3RequestOptions,
+  ): Promise<simS3Commands.SimDeleteBucketEncryptionCommandOutput> {
+    return await this.commands.encryption.delete(command, options);
+  }
+
   /** Handle a Put Bucket Website Command from the SDK. */
   async putBucketWebsite(
     command: simS3Commands.SimPutBucketWebsiteCommand,

--- a/src/service/s3/upload/sim-s3-completed-upload.ts
+++ b/src/service/s3/upload/sim-s3-completed-upload.ts
@@ -1,8 +1,8 @@
+import { SimS3MalformedXml } from "../error/sim-s3.error.js";
 import {
   SimS3InvalidPart,
   SimS3InvalidPartOrder,
-  SimS3MalformedXml,
-} from "../error/sim-s3.error.js";
+} from "../error/sim-s3-upload.error.js";
 import { SimS3Object } from "../object/s3-object.js";
 import {
   simS3MultipartETag,
@@ -60,6 +60,8 @@ export function simS3CompletedUploadObject(
     metadata: upload.metadata,
     lastModified: properties.completedAt,
     etag: simS3MultipartETag(stored.map((part) => part.etag)),
+    storageClass: upload.storageClass,
+    serverSideEncryption: upload.serverSideEncryption,
   });
 }
 

--- a/src/service/s3/upload/sim-s3-multipart-upload.ts
+++ b/src/service/s3/upload/sim-s3-multipart-upload.ts
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 
 import type { Brand } from "../../../util/brand.type.js";
 import type { SimS3ObjectMetadata } from "../object/s3-object.js";
+import type { SimS3ServerSideEncryption } from "../object/s3-server-side-encryption.js";
+import {
+  simS3DefaultStorageClass,
+  type SimS3StorageClass,
+} from "../object/s3-storage-class.js";
 
 export type SimS3UploadId = Brand<string, "SimS3UploadId">;
 
@@ -32,6 +37,12 @@ interface SimS3MultipartUploadProperties {
   readonly key: string;
   readonly metadata: SimS3ObjectMetadata;
   readonly initiated: Date;
+  /**
+   * Where and how the completed Object will be stored. Real S3 takes both at
+   * `CreateMultipartUpload`, alongside the metadata, rather than at completion.
+   */
+  readonly storageClass?: SimS3StorageClass;
+  readonly serverSideEncryption?: SimS3ServerSideEncryption | undefined;
 }
 
 /**
@@ -52,6 +63,8 @@ export class SimS3MultipartUpload {
   public readonly key: string;
   public readonly metadata: SimS3ObjectMetadata;
   public readonly initiated: Date;
+  public readonly storageClass: SimS3StorageClass;
+  public readonly serverSideEncryption: SimS3ServerSideEncryption | undefined;
 
   private readonly parts = new Map<number, SimS3UploadPart>();
 
@@ -60,6 +73,8 @@ export class SimS3MultipartUpload {
     this.key = properties.key;
     this.metadata = properties.metadata;
     this.initiated = new Date(properties.initiated);
+    this.storageClass = properties.storageClass ?? simS3DefaultStorageClass;
+    this.serverSideEncryption = properties.serverSideEncryption;
   }
 
   /**

--- a/src/service/s3/upload/sim-s3-multipart-uploads.ts
+++ b/src/service/s3/upload/sim-s3-multipart-uploads.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 
 import type { SimS3ObjectMetadata } from "../object/s3-object.js";
+import type { SimS3ServerSideEncryption } from "../object/s3-server-side-encryption.js";
+import type { SimS3StorageClass } from "../object/s3-storage-class.js";
 import {
   SimS3MultipartUpload,
   type SimS3UploadId,
@@ -10,6 +12,8 @@ interface SimS3StartUploadProperties {
   readonly key: string;
   readonly metadata: SimS3ObjectMetadata;
   readonly initiated: Date;
+  readonly storageClass?: SimS3StorageClass;
+  readonly serverSideEncryption?: SimS3ServerSideEncryption | undefined;
 }
 
 /**
@@ -36,6 +40,10 @@ export class SimS3MultipartUploads {
       key: properties.key,
       metadata: properties.metadata,
       initiated: properties.initiated,
+      ...(properties.storageClass !== undefined && {
+        storageClass: properties.storageClass,
+      }),
+      serverSideEncryption: properties.serverSideEncryption,
     });
 
     this.uploads.set(upload.uploadId, upload);


### PR DESCRIPTION
An Object now carries the storage class its write named and the encryption S3 stamped on it, and reports both on a listing, on a read and over the served REST endpoint. A lifecycle `Transitions` or `NoncurrentVersionTransitions` rule moves an Object between classes as simulated time passes the days it names, and `PutBucketEncryption`, `GetBucketEncryption` and `DeleteBucketEncryption` configure the default a Bucket stamps, alongside the `BucketEncryption` property of an `AWS::S3::Bucket`. Nothing is encrypted. The bytes are stored as they arrive and the ETag stays the MD5 of them, which is what real S3 reports for an SSE-S3 Object as well.

A transition is worked out when the Bucket is read, as an expiry already was, so a test reaches one by moving the clock. `BucketEncryption` leaves the inert property list, `IntelligentTieringConfigurations` keeps its skip with a reason that now holds, and a write or a rule naming a class S3 has no such class for is refused with `InvalidStorageClass` before it reaches anything.

Resolves #1229
