### PR TITLE
feat: fill three CFN template language gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
 
 .worktrees/
+.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,5 @@ test/terraform/**/builds/
 test/terraform/**/terraform.tfstate*
 test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
+
+.worktrees/

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -771,6 +771,23 @@ The value a lookup returns can be any type. A list value is returned as a list.
 used in resource properties and in `Outputs`. A map name or key missing from `Mappings` fails the
 deployment with an error naming the path that could not be found.
 
+A fourth argument of `{ "DefaultValue": ... }` gives the lookup an answer for that case.
+
+```json
+{
+  "Fn::FindInMap": [
+    "EnvironmentMap",
+    { "Ref": "Environment" },
+    "BucketName",
+    { "DefaultValue": "fallback-site-bucket" }
+  ]
+}
+```
+
+The default answers a map name, a top-level key or a second-level key the `Mappings` section does
+not carry. It is a template value like any other, so it can itself be a `Ref` or a nested
+expression. A lookup that finds its value in the map ignores the default.
+
 ### `Fn::Split` and `Fn::Select`
 
 `Fn::Split` cuts a string into a list on a delimiter. `Fn::Select` reads one value out of a list by
@@ -1002,10 +1019,10 @@ console.log(stack.getResource("Backups") !== undefined);
 
 ### Writing a condition
 
-A condition is built from `Fn::Equals`, `Fn::And`, `Fn::Or` and `Fn::Not`. `Fn::And` and `Fn::Or`
-take a list of two to ten conditions, and `Fn::Not` takes a list of exactly one. A condition can
-name another condition with `{ "Condition": "OtherCondition" }`, in any order, so a condition may
-name one written below it in the section.
+A condition is built from `Fn::Equals`, `Fn::And`, `Fn::Or`, `Fn::Not` and `Fn::If`. `Fn::And` and
+`Fn::Or` take a list of two to ten conditions, and `Fn::Not` takes a list of exactly one. A
+condition can name another condition with `{ "Condition": "OtherCondition" }`, in any order, so a
+condition may name one written below it in the section.
 
 ```json
 {
@@ -1020,9 +1037,27 @@ name one written below it in the section.
 `Fn::Equals` compares its two values as strings, as CloudFormation does. A JSON number in the
 template matches the string a parameter carries.
 
+An `Fn::If` inside the section takes a condition name and two conditions, and evaluates whichever
+one the named condition selects. The condition it names can be written anywhere in the section.
+
+```json
+{
+  "IsProd": { "Fn::Equals": [{ "Ref": "EnvName" }, "prod"] },
+  "IsBackedUp": {
+    "Fn::If": [
+      "IsProd",
+      { "Fn::Equals": [{ "Ref": "BackupPlan" }, "nightly"] },
+      { "Fn::Equals": ["never", "nightly"] }
+    ]
+  }
+}
+```
+
 The whole section is evaluated once per deployment, before any resource is created. A condition can
 read parameters and pseudo parameters and nothing else. A comparison that would need a created
-resource, such as an `Fn::GetAtt`, fails the deployment rather than reading as false.
+resource, such as an `Fn::GetAtt`, fails the deployment rather than reading as false. A condition
+that closes a cycle through `{ "Condition": ... }` or `Fn::If` fails the deployment naming the route
+it took back to itself.
 
 ### `Fn::If`
 
@@ -1045,6 +1080,15 @@ resources and the condition. That covers a `Ref` or `Fn::GetAtt` that is actuall
 fails.
 
 A `Condition` attribute naming a condition the template leaves undefined fails the same way.
+
+### The output `Condition` attribute
+
+An output carrying a `Condition` attribute whose condition is false is left out of the stack. It is
+absent from `stack.outputs` and from `DescribeStacks`, and the export name it carries is never
+published, so another stack's `Fn::ImportValue` for that name finds nothing.
+
+An output whose condition is true resolves and exports as any other output does. One naming a
+condition the template leaves undefined fails the deployment.
 
 ## Resource dependencies
 
@@ -3500,8 +3544,9 @@ Sim CloudFormation currently supports:
 - Template `Parameters` with supplied values and defaults
 - Template `Outputs`, resolved after resource creation and read from `stack.outputs`
 - Template `Mappings`, read with `Fn::FindInMap`
-- Template `Conditions`, built from `Fn::Equals`, `Fn::And`, `Fn::Or` and `Fn::Not`
-- The resource `Condition` attribute, which decides whether a resource is created
+- Template `Conditions`, built from `Fn::Equals`, `Fn::And`, `Fn::Or`, `Fn::Not` and `Fn::If`
+- The `Condition` attribute on a resource, which decides whether the resource is created, and on an
+  output, which decides whether the output and its export are published
 - The `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub`, `Fn::FindInMap`, `Fn::If`, `Fn::Split` and
   `Fn::Select` intrinsic functions
 - Explicit resource dependencies with `DependsOn`
@@ -3611,21 +3656,16 @@ Each service's own docs describe what its resource types support.
   way `FORCE_DELETE_STACK` forces it in AWS.
 - A deleted stack cannot be described. Real CloudFormation keeps a deleted stack readable by its
   unique stack ID, and the simulator identifies a stack by its name alone.
-- `Fn::FindInMap` accepts only the three-argument form. The four-argument form, where the fourth
-  argument is `{ "DefaultValue": ... }`, is rejected.
 - `Fn::FindInMap` arguments are resolved from literals, `Parameters` and pseudo parameters. An
   argument that depends on a created resource, such as a `Ref` to a resource logical ID, fails the
   resource with a "could not find map" error. Real CloudFormation allows only `Ref` and a nested
   `Fn::FindInMap` inside `Fn::FindInMap`. The templates affected here are ones real CloudFormation
   would reject as well. The simulator just rejects them later rather than up front.
-- `Fn::If` is unsupported inside the `Conditions` section itself. It is rejected there rather than
-  read against a half-evaluated section.
+- `Fn::If` is a condition function inside the `Conditions` section, and is not a value an
+  `Fn::Equals` can compare. Real CloudFormation allows only `Ref` and `Fn::FindInMap` there.
 - `Fn::Split` and `Fn::Select` accept any argument that resolves to the type they need. Real
   CloudFormation allows only a named set of functions inside each of them. A template the simulator
   resolves may still be one CloudFormation rejects.
-- The `Condition` attribute is read on resources but not on outputs. An output carrying one is
-  resolved and present in `stack.outputs` whichever way its condition falls, where real
-  CloudFormation would leave it out.
 - The SAM transform is expanded for `AWS::Serverless::Function`, `AWS::Serverless::SimpleTable`,
   `AWS::Serverless::HttpApi` and `AWS::Serverless::Api`. Every other `AWS::Serverless::*` resource
   type is recorded as unsupported. `Api`, `HttpApi`, `SQS`, `DynamoDB`, `SNS`, `S3`, `Schedule`,

--- a/src/service/cloudformation/template/condition/sim-cfn-condition-expression.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-condition-expression.ts
@@ -23,9 +23,9 @@ interface SimCfnConditionExpressionProperties {
  *
  * The tree is `Fn::Equals` at the leaves and `Fn::And`, `Fn::Or` and `Fn::Not`
  * above them, with `{ "Condition": "OtherCondition" }` handing off to the
- * Condition of that name. Where that other Condition comes from is the
- * evaluator's business, so it arrives as a reader rather than being looked up
- * here.
+ * Condition of that name. `Fn::If` picks one of two conditions by the answer to
+ * a third. Where a named Condition comes from is the evaluator's business, so it
+ * arrives as a reader rather than being looked up here.
  *
  * A function name this simulation has no behaviour for is refused rather than
  * read as false, which would deploy a Stack the template did not describe. The
@@ -84,6 +84,10 @@ export class SimCfnConditionExpression {
       return this.negated(value);
     }
 
+    if (functionName === "Fn::If") {
+      return this.selected(value);
+    }
+
     if (functionName === "Condition") {
       return this.named(
         this.shape.string(value, `${this.label} Condition reference`),
@@ -109,6 +113,38 @@ export class SimCfnConditionExpression {
     }
 
     return listed.map((operand) => this.evaluate(operand));
+  }
+
+  /**
+   * Evaluate whichever of an `Fn::If`'s two conditions its Condition selects.
+   *
+   * Only the selected one is evaluated, as CloudFormation resolves only the
+   * branch it takes. The name goes through the same reader a
+   * `{ "Condition": ... }` reference uses, so an `Fn::If` that closes a cycle
+   * is caught by the chain the evaluator carries rather than recursing.
+   */
+  private selected(value: SimCfnTemplateValue): boolean {
+    const listed = this.shape.list(value, `${this.label} Fn::If`);
+
+    if (listed.length !== 3) {
+      throw this.error(
+        `${this.label} Fn::If must be a list of a Condition name and two ` +
+          "conditions",
+      );
+    }
+
+    const conditionName = listed[0];
+    const whenTrue = listed[1];
+    const whenFalse = listed[2];
+    assertDefined(conditionName, `${this.label} Fn::If Condition name`);
+    assertDefined(whenTrue, `${this.label} Fn::If condition if true`);
+    assertDefined(whenFalse, `${this.label} Fn::If condition if false`);
+
+    const selected = this.named(
+      this.shape.string(conditionName, `${this.label} Fn::If Condition name`),
+    );
+
+    return this.evaluate(selected ? whenTrue : whenFalse);
   }
 
   private negated(value: SimCfnTemplateValue): boolean {

--- a/src/service/cloudformation/template/condition/sim-cfn-condition-refusals.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-condition-refusals.iso.test.ts
@@ -238,9 +238,73 @@ describe("SimCfnTemplate Conditions refusals", () => {
     );
   });
 
-  it("refuses Fn::If inside the Conditions section", () => {
-    // Given a Condition built from Fn::If, which needs the very Conditions
-    // being evaluated.
+  it("refuses a Condition whose Fn::If closes a cycle", () => {
+    // Given two Conditions each choosing a branch by the other.
+    const conditions = {
+      IsProd: {
+        "Fn::If": ["IsNotProd", { Condition: "IsNotProd" }, falseCondition()],
+      },
+      IsNotProd: {
+        "Fn::If": ["IsProd", { Condition: "IsProd" }, falseCondition()],
+      },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the cycle is named rather than recursing.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd refers to " +
+        "itself through IsProd -> IsNotProd -> IsProd",
+    );
+  });
+
+  it("refuses an Fn::If that does not carry three values", () => {
+    // Given an Fn::If with no false branch.
+    const conditions = {
+      IsProd: { "Fn::If": ["IsStaging", falseCondition()] },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd Fn::If " +
+        "must be a list of a Condition name and two conditions",
+    );
+  });
+
+  it("refuses an Fn::If Condition name that is not a string", () => {
+    // Given an Fn::If choosing by a Parameter rather than by a Condition name.
+    const conditions = {
+      IsProd: {
+        "Fn::If": [{ Ref: "EnvName" }, falseCondition(), falseCondition()],
+      },
+    };
+
+    // When the Conditions are evaluated.
+    const error = assertThrowsError(() => {
+      evaluateWith(conditions);
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack conditions-stack Condition IsProd Fn::If " +
+        "Condition name must be a string",
+    );
+  });
+
+  it("refuses Fn::If as a value an Fn::Equals compares", () => {
+    // Given an Fn::Equals reading an Fn::If, which CloudFormation allows only
+    // a Ref or an Fn::FindInMap inside.
     const conditions = {
       IsProd: {
         "Fn::Equals": [{ "Fn::If": ["IsProd", "a", "b"] }, "a"],
@@ -295,6 +359,13 @@ function evaluateWith(conditions: Record<string, SimCfnTemplateValue>): void {
     },
     parameters: SimCfnParameters.fromValues({ EnvName: "prod" }),
   }).conditions();
+}
+
+/**
+ * A condition that is false whatever the Stack's Parameters say.
+ */
+function falseCondition(): SimCfnTemplateValue {
+  return { "Fn::Equals": ["never", "always"] };
 }
 
 /**

--- a/src/service/cloudformation/template/condition/sim-cfn-conditions.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-conditions.iso.test.ts
@@ -165,6 +165,47 @@ describe("SimCfnTemplate Conditions", () => {
     assertFalse(evaluated.value("IsProd"));
   });
 
+  it("picks a condition with Fn::If", () => {
+    // Given a Condition that chooses between two conditions by a third.
+    const conditions = {
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+      IsBackedUp: {
+        "Fn::If": [
+          "IsProd",
+          { "Fn::Equals": ["nightly", "nightly"] },
+          { "Fn::Equals": ["never", "nightly"] },
+        ],
+      },
+    };
+
+    // When the Stack is deployed with the value the chooser agrees with.
+    const evaluated = evaluateWith(conditions, "prod");
+
+    // Then the branch it selected is the one that answered.
+    assertTrue(evaluated.value("IsBackedUp"));
+
+    // And another value takes the other branch.
+    assertFalse(evaluateWith(conditions, "dev").value("IsBackedUp"));
+  });
+
+  it("evaluates an Fn::If naming a Condition written below it", () => {
+    // Given an Fn::If whose chooser and branches all name Conditions the
+    // section carries further down, as a template section has no ordering.
+    const conditions = {
+      IsBackedUp: {
+        "Fn::If": ["IsProd", { Condition: "IsNamed" }, { Condition: "IsProd" }],
+      },
+      IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+      IsNamed: { "Fn::Not": [{ "Fn::Equals": [{ Ref: "EnvName" }, ""] }] },
+    };
+
+    // When the Stack is deployed as prod.
+    const evaluated = evaluateWith(conditions, "prod");
+
+    // Then the Fn::If answers with the Condition its true branch names.
+    assertTrue(evaluated.value("IsBackedUp"));
+  });
+
   it("reads a template with no Conditions section", () => {
     // Given a template with no Conditions.
     const template = new SimCfnTemplate({ template: { Resources: {} } });

--- a/src/service/cloudformation/template/condition/sim-cfn-output-conditions.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-output-conditions.iso.test.ts
@@ -1,0 +1,216 @@
+import { DescribeStacksCommand } from "@aws-sdk/client-cloudformation";
+import {
+  assertIdentical,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../sim-cfn-template.js";
+
+describe("SimCfnStack Output Condition", () => {
+  it("leaves out an Output whose Condition is false", async () => {
+    // Given a Stack whose backup Output only production gets.
+    const simAws = new SimAws();
+
+    // When it is deployed as dev.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "output-condition-stack",
+      template: conditionedTemplate(),
+      parameters: { EnvName: "dev" },
+    });
+
+    // Then the Stack has no such Output at all.
+    assertUndefined(stack.outputs.get("BackupsBucketName"));
+
+    // And the Output the Condition kept is there.
+    assertIdentical(stack.outputs.get("SiteBucketName")?.value, "site-bucket");
+  });
+
+  it("leaves a false Output out of DescribeStacks", async () => {
+    // Given the same Stack deployed as dev.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.deployTemplate({
+      stackName: "output-condition-stack",
+      template: conditionedTemplate(),
+      parameters: { EnvName: "dev" },
+    });
+
+    // When the Stack is described.
+    const result = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: "output-condition-stack" }),
+    );
+    const outputKeys = result.Stacks?.[0]?.Outputs?.map(
+      (output) => output.OutputKey,
+    );
+
+    // Then only the Output whose Condition is true is listed.
+    assertIdentical(outputKeys?.join(","), "SiteBucketName");
+  });
+
+  it("resolves and exports an Output whose Condition is true", async () => {
+    // Given the same Stack deployed as prod.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    const stack = await cloudFormation.deployTemplate({
+      stackName: "output-condition-stack",
+      template: conditionedTemplate(),
+      parameters: { EnvName: "prod" },
+    });
+
+    // Then the Output resolves and carries its export name.
+    assertIdentical(
+      stack.outputs.get("BackupsBucketName")?.value,
+      "site-backups",
+    );
+
+    // And another Stack can import the export it published.
+    await cloudFormation.deployTemplate({
+      stackName: "output-condition-importing-stack",
+      template: importingTemplate(),
+    });
+
+    assertIdentical(
+      simAws.s3().getSimBucketByName("site-backups-copy")?.bucketName,
+      "site-backups-copy",
+    );
+  });
+
+  it("publishes no export for an Output whose Condition is false", async () => {
+    // Given the Stack deployed as dev, so its backup Output is left out.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.deployTemplate({
+      stackName: "output-condition-stack",
+      template: conditionedTemplate(),
+      parameters: { EnvName: "dev" },
+    });
+
+    // When another Stack imports the export name that Output carried.
+    const error = await assertThrowsErrorAsync(async () => {
+      await cloudFormation.deployTemplate({
+        stackName: "output-condition-importing-stack",
+        template: importingTemplate(),
+      });
+    });
+
+    // Then the import finds nothing, because nothing was published.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource BackupsCopy value at Properties.BucketName: " +
+        "No export named BackupsBucketName found",
+    );
+  });
+
+  it("refuses an Output naming a Condition the template does not define", async () => {
+    // Given an Output whose Condition is not in the Conditions section.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "output-condition-stack",
+        template: {
+          Conditions: { IsProd: { "Fn::Equals": ["a", "b"] } },
+          Resources: {},
+          Outputs: {
+            BackupsBucketName: {
+              Value: "site-backups",
+              Condition: "IsStaging",
+            },
+          },
+        },
+      });
+    });
+
+    // Then the error names the Output and the Condition.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack output-condition-stack Output " +
+        "BackupsBucketName names Condition IsStaging, which the template does " +
+        "not define",
+    );
+  });
+
+  it("refuses an Output Condition that is not a string", async () => {
+    // Given an Output whose Condition is written as an expression.
+    const simAws = new SimAws();
+
+    // When the Stack is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "output-condition-stack",
+        template: {
+          Conditions: { IsProd: { "Fn::Equals": ["a", "b"] } },
+          Resources: {},
+          Outputs: {
+            BackupsBucketName: {
+              Value: "site-backups",
+              Condition: { Condition: "IsProd" },
+            },
+          },
+        },
+      });
+    });
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Stack output-condition-stack Output " +
+        "BackupsBucketName Condition must be a string",
+    );
+  });
+});
+
+/**
+ * A Stack exporting a backup Bucket name only production has an Output for.
+ */
+function conditionedTemplate(): CfnTemplateBodyRecord {
+  return {
+    Parameters: { EnvName: { Type: "String" } },
+    Conditions: { IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] } },
+    Resources: {
+      Site: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-bucket" },
+      },
+      Backups: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: "site-backups" },
+      },
+    },
+    Outputs: {
+      SiteBucketName: { Value: { Ref: "Site" } },
+      BackupsBucketName: {
+        Condition: "IsProd",
+        Value: { Ref: "Backups" },
+        Export: { Name: "BackupsBucketName" },
+      },
+    },
+  };
+}
+
+/**
+ * A Stack naming its Bucket after the export the other Stack may have made.
+ */
+function importingTemplate(): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      BackupsCopy: {
+        Type: "AWS::S3::Bucket",
+        Properties: {
+          BucketName: {
+            "Fn::Join": [
+              "-",
+              [{ "Fn::ImportValue": "BackupsBucketName" }, "copy"],
+            ],
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-output-conditions.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-output-conditions.ts
@@ -1,0 +1,61 @@
+import type { SimCfnTemplateValueRecord } from "../value/sim-cfn-template-value.js";
+import type { SimCfnConditions } from "./sim-cfn-conditions.js";
+
+interface SimCfnOutputConditionsProperties {
+  readonly conditions: SimCfnConditions;
+  readonly stackName?: string | undefined;
+}
+
+/**
+ * Applies the Output-level `Condition` attribute to a template's Outputs.
+ *
+ * An Output whose Condition is false is left out of the Stack altogether. It is
+ * never resolved, so it is absent from `stack.outputs` and from `DescribeStacks`,
+ * and the export name it carries is never published for another Stack to import.
+ *
+ * Naming a Condition the template does not define fails the deployment, the way
+ * it does on a Resource. An Output that quietly disappeared because its
+ * Condition was misspelled is worse than a Stack that refuses to deploy.
+ */
+export class SimCfnOutputConditions {
+  private readonly conditions: SimCfnConditions;
+  private readonly stackName: string | undefined;
+
+  constructor(properties: SimCfnOutputConditionsProperties) {
+    this.conditions = properties.conditions;
+    this.stackName = properties.stackName;
+  }
+
+  /**
+   * Whether the template asked for this Output but its Condition is false.
+   */
+  excludes(
+    outputKey: string,
+    outputTemplate: SimCfnTemplateValueRecord,
+  ): boolean {
+    const conditionName = outputTemplate["Condition"];
+
+    if (conditionName === undefined) {
+      return false;
+    }
+
+    if (typeof conditionName !== "string") {
+      throw this.error(`Output ${outputKey} Condition must be a string`);
+    }
+
+    if (!this.conditions.has(conditionName)) {
+      throw this.error(
+        `Output ${outputKey} names Condition ${conditionName}, which the ` +
+          "template does not define",
+      );
+    }
+
+    return !this.conditions.value(conditionName);
+  }
+
+  private error(detail: string): Error {
+    return new Error(
+      `Sim CloudFormation Stack ${this.stackName ?? "unknown"} ${detail}`,
+    );
+  }
+}

--- a/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.iso.test.ts
+++ b/src/service/cloudformation/template/condition/sim-cfn-resource-conditions.iso.test.ts
@@ -52,6 +52,45 @@ describe("SimCfnStack Resource Condition", () => {
     assertIdentical(simAws.s3().getSimBucketByName("site")?.bucketName, "site");
   });
 
+  it("creates a Resource gated by a Condition built from Fn::If", async () => {
+    // Given a Stack whose Backups Bucket is gated by a Condition that chooses
+    // between two other conditions.
+    const simAws = new SimAws();
+
+    // When it is deployed with a Parameter value the chosen branch agrees with.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "resource-condition-stack",
+      template: {
+        Parameters: { EnvName: { Type: "String" } },
+        Conditions: {
+          IsProd: { "Fn::Equals": [{ Ref: "EnvName" }, "prod"] },
+          IsBackedUp: {
+            "Fn::If": [
+              "IsProd",
+              { "Fn::Equals": ["nightly", "nightly"] },
+              { "Fn::Equals": ["never", "nightly"] },
+            ],
+          },
+        },
+        Resources: {
+          Backups: {
+            Type: "AWS::S3::Bucket",
+            Condition: "IsBackedUp",
+            Properties: { BucketName: "site-backups" },
+          },
+        },
+      },
+      parameters: { EnvName: "prod" },
+    });
+
+    // Then the Bucket the Fn::If gated is created.
+    assertNonNullable(stack.getResource("Backups"), "Backups Resource");
+    assertIdentical(
+      simAws.s3().getSimBucketByName("site-backups")?.bucketName,
+      "site-backups",
+    );
+  });
+
   it("refuses a Resource naming a Condition the template does not define", async () => {
     // Given a Resource whose Condition is not in the Conditions section.
     const simAws = new SimAws();

--- a/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-find-in-map-default-value.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-find-in-map-default-value.iso.test.ts
@@ -1,0 +1,240 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertObjectMatches,
+  assertThrowsError,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { CfnTemplateBodyRecord } from "../../../sim-cfn-template.js";
+import { SimCfnTemplate } from "../../../sim-cfn-template.js";
+import type {
+  SimCfnTemplateValue,
+  SimCfnTemplateValueRecord,
+} from "../../../value/sim-cfn-template-value.js";
+
+describe("SimCfnTemplate Fn::FindInMap DefaultValue", () => {
+  it("reads the mapped value where the Mappings have one", () => {
+    // Given a lookup that finds its value, carrying a DefaultValue as well.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate([
+        "EnvironmentMap",
+        "prod",
+        "BucketName",
+        { DefaultValue: "fallback-bucket" },
+      ]),
+    });
+
+    // When the Resource template values are resolved.
+    const resolved = resolvedTemplate(template);
+
+    // Then the mapped value wins over the default.
+    assertObjectMatches(resolved, {
+      Properties: { BucketName: "production-bucket" },
+    });
+  });
+
+  it("answers a missing map with the DefaultValue", () => {
+    // Given a lookup naming a map the Mappings section does not carry.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate([
+        "RegionMap",
+        "prod",
+        "BucketName",
+        { DefaultValue: "fallback-bucket" },
+      ]),
+    });
+
+    // When the Resource template values are resolved.
+    const resolved = resolvedTemplate(template);
+
+    // Then the default answers instead of failing the Resource.
+    assertObjectMatches(resolved, {
+      Properties: { BucketName: "fallback-bucket" },
+    });
+  });
+
+  it("answers a missing top level key with the DefaultValue", () => {
+    // Given a lookup naming a top level key the map does not carry.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate([
+        "EnvironmentMap",
+        "staging",
+        "BucketName",
+        { DefaultValue: "fallback-bucket" },
+      ]),
+    });
+
+    // When the Resource template values are resolved.
+    const resolved = resolvedTemplate(template);
+
+    // Then the default answers.
+    assertObjectMatches(resolved, {
+      Properties: { BucketName: "fallback-bucket" },
+    });
+  });
+
+  it("answers a missing second level key with the DefaultValue", () => {
+    // Given a lookup naming a second level key the map does not carry.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate([
+        "EnvironmentMap",
+        "prod",
+        "QueueName",
+        { DefaultValue: "fallback-bucket" },
+      ]),
+    });
+
+    // When the Resource template values are resolved.
+    const resolved = resolvedTemplate(template);
+
+    // Then the default answers.
+    assertObjectMatches(resolved, {
+      Properties: { BucketName: "fallback-bucket" },
+    });
+  });
+
+  it("resolves a DefaultValue written as an expression", () => {
+    // Given a default that reads the Parameter the lookup key came from.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate([
+        "EnvironmentMap",
+        { Ref: "Environment" },
+        "BucketName",
+        {
+          DefaultValue: {
+            "Fn::Join": ["-", [{ Ref: "Environment" }, "bucket"]],
+          },
+        },
+      ]),
+    });
+
+    // When the Resource template values are resolved, with the Parameter
+    // defaulting to a key the map does not carry.
+    const resolved = resolvedTemplate(template);
+
+    // Then the default resolves as any other template value does.
+    assertObjectMatches(resolved, {
+      Properties: { BucketName: "staging-bucket" },
+    });
+  });
+
+  it("fails a missing map where no DefaultValue is given", () => {
+    // Given the same missing key without a fourth argument.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate(["RegionMap", "prod", "BucketName"]),
+    });
+
+    // When the Resource template values are resolved.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the lookup still fails, naming the path it could not find.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Resource SiteBucket value at Properties.BucketName: " +
+        "Sim CloudFormation Fn::FindInMap could not find map RegionMap.prod",
+    );
+  });
+
+  it("keeps the DefaultValue on a lookup left for a later pass", () => {
+    // Given a lookup whose key only a created Resource can answer.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate([
+        "EnvironmentMap",
+        { Ref: "SiteBucket" },
+        "BucketName",
+        { DefaultValue: "fallback-bucket" },
+      ]),
+    });
+
+    // When the Resource template values are resolved.
+    const resolved = resolvedTemplate(template);
+
+    // Then the expression that is left carries the default with it.
+    assertObjectMatches(resolved, {
+      Properties: {
+        BucketName: {
+          "Fn::FindInMap": [
+            "EnvironmentMap",
+            { Ref: "SiteBucket" },
+            "BucketName",
+            { DefaultValue: "fallback-bucket" },
+          ],
+        },
+      },
+    });
+  });
+
+  it("refuses a fourth argument that is not a DefaultValue", () => {
+    // Given a fourth argument naming something else.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate([
+        "EnvironmentMap",
+        "prod",
+        "BucketName",
+        { Fallback: "fallback-bucket" },
+      ]),
+    });
+
+    // When the Resource template values are resolved.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then it is refused rather than read as a default.
+    assertIdentical(
+      error.message,
+      'Sim CloudFormation Fn::FindInMap fourth value must be { "DefaultValue": ... }',
+    );
+  });
+
+  it("refuses more arguments than Fn::FindInMap takes", () => {
+    // Given a fifth argument.
+    const template = new SimCfnTemplate({
+      template: lookupTemplate([
+        "EnvironmentMap",
+        "prod",
+        "BucketName",
+        { DefaultValue: "fallback-bucket" },
+        "extra",
+      ]),
+    });
+
+    // When the Resource template values are resolved.
+    const error = assertThrowsError(() => template.resourceTemplates());
+
+    // Then the shape is refused.
+    assertIdentical(
+      error.message,
+      "Sim CloudFormation Fn::FindInMap value must be [mapName, topLevelKey, " +
+        'secondLevelKey] with an optional { "DefaultValue": ... }',
+    );
+  });
+});
+
+/**
+ * A Stack naming its Bucket after whatever the given Fn::FindInMap answers.
+ */
+function lookupTemplate(
+  findInMap: SimCfnTemplateValue[],
+): CfnTemplateBodyRecord {
+  return {
+    Parameters: { Environment: { Type: "String", Default: "staging" } },
+    Mappings: {
+      EnvironmentMap: { prod: { BucketName: "production-bucket" } },
+    },
+    Resources: {
+      SiteBucket: {
+        Type: "AWS::S3::Bucket",
+        Properties: { BucketName: { "Fn::FindInMap": findInMap } },
+      },
+    },
+  };
+}
+
+/**
+ * The SiteBucket Resource template, with its values resolved.
+ */
+function resolvedTemplate(template: SimCfnTemplate): SimCfnTemplateValueRecord {
+  const resourceTemplate = template.resourceTemplates()[0];
+  assertNonNullable(resourceTemplate, "SiteBucket Resource template");
+
+  return resourceTemplate.template;
+}

--- a/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-find-in-map.iso.test.ts
+++ b/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-find-in-map.iso.test.ts
@@ -88,7 +88,7 @@ describe("SimCfnTemplate Fn::FindInMap Resources", () => {
     });
   });
 
-  it("throws when Fn::FindInMap is not a three-item array", () => {
+  it("throws when Fn::FindInMap carries fewer than three values", () => {
     // Given a template with an invalid Fn::FindInMap value.
     const template = new SimCfnTemplate({
       template: {
@@ -118,7 +118,8 @@ describe("SimCfnTemplate Fn::FindInMap Resources", () => {
     // Then a clear validation error is thrown.
     assertIdentical(
       error.message,
-      "Sim CloudFormation Fn::FindInMap value must be [mapName, topLevelKey, secondLevelKey]",
+      "Sim CloudFormation Fn::FindInMap value must be [mapName, topLevelKey, " +
+        'secondLevelKey] with an optional { "DefaultValue": ... }',
     );
   });
 

--- a/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-fn-find-in-map.ts
+++ b/src/service/cloudformation/template/node/fn/find-in-map/sim-cfn-fn-find-in-map.ts
@@ -2,19 +2,36 @@ import { SimCfnNode } from "../../sim-cfn-node.js";
 import type { SimCfnResolveContext } from "../../../resolve/sim-cfn-resolve-context.js";
 import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
 import { isRecord } from "../../../../../../util/type-guard/record.js";
-import { assertDefined } from "../../../../../../util/type-guard/defined.js";
 import { isSimCfnUnresolvedExpression } from "../../../value/sim-cfn-unresolved-expression.js";
+
+interface SimCfnFnFindInMapProperties {
+  readonly mapName: SimCfnNode;
+  readonly topLevelKey: SimCfnNode;
+  readonly secondLevelKey: SimCfnNode;
+  readonly defaultValue?: SimCfnNode | undefined;
+}
 
 /**
  * Simulated CloudFormation `Fn::FindInMap` intrinsic function.
+ *
+ * The fourth argument a template can carry, `{ "DefaultValue": ... }`, answers
+ * a lookup the Mappings section has no value for. Without it a missing map or
+ * key fails the Resource, because a template that reads a key it never wrote is
+ * a mistake worth being told about.
  */
 export class SimCfnFnFindInMap extends SimCfnNode {
-  constructor(
-    private readonly mapName: SimCfnNode,
-    private readonly topLevelKey: SimCfnNode,
-    private readonly secondLevelKey: SimCfnNode,
-  ) {
+  private readonly mapName: SimCfnNode;
+  private readonly topLevelKey: SimCfnNode;
+  private readonly secondLevelKey: SimCfnNode;
+  private readonly defaultValue: SimCfnNode | undefined;
+
+  constructor(properties: SimCfnFnFindInMapProperties) {
     super();
+
+    this.mapName = properties.mapName;
+    this.topLevelKey = properties.topLevelKey;
+    this.secondLevelKey = properties.secondLevelKey;
+    this.defaultValue = properties.defaultValue;
   }
 
   /**
@@ -30,27 +47,25 @@ export class SimCfnFnFindInMap extends SimCfnNode {
       !this.isResolvedKey(topLevelKey) ||
       !this.isResolvedKey(secondLevelKey)
     ) {
-      return {
-        "Fn::FindInMap": [mapName, topLevelKey, secondLevelKey],
-      };
+      return this.unresolved([mapName, topLevelKey, secondLevelKey], context);
     }
 
     // oxlint-disable-next-line security/detect-object-injection
     const topLevel = context.mappings?.[mapName]?.[topLevelKey];
 
-    /* v8 ignore if -- defensive */
     if (!isRecord(topLevel)) {
-      throw new Error(
-        `Sim CloudFormation Fn::FindInMap could not find map ${mapName}.${topLevelKey}`,
-      );
+      return this.missing(`${mapName}.${topLevelKey}`, context);
     }
 
     // oxlint-disable-next-line security/detect-object-injection
     const value = topLevel[secondLevelKey];
-    assertDefined(
-      value,
-      `Sim CloudFormation Fn::FindInMap could not find map ${mapName}.${topLevelKey}.${secondLevelKey}`,
-    );
+
+    if (value === undefined) {
+      return this.missing(
+        `${mapName}.${topLevelKey}.${secondLevelKey}`,
+        context,
+      );
+    }
 
     return value;
   }
@@ -64,7 +79,46 @@ export class SimCfnFnFindInMap extends SimCfnNode {
       ...this.mapName.referencedNames(),
       ...this.topLevelKey.referencedNames(),
       ...this.secondLevelKey.referencedNames(),
+      ...(this.defaultValue?.referencedNames() ?? []),
     ];
+  }
+
+  /**
+   * The `DefaultValue` a lookup falls back to, or a failure naming the path.
+   */
+  private missing(
+    path: string,
+    context: SimCfnResolveContext,
+  ): SimCfnTemplateValue {
+    if (this.defaultValue !== undefined) {
+      return this.defaultValue.resolve(context);
+    }
+
+    throw new Error(
+      `Sim CloudFormation Fn::FindInMap could not find map ${path}`,
+    );
+  }
+
+  /**
+   * The expression left for a later pass, once a key can be a string.
+   *
+   * The `DefaultValue` goes back with it, so the lookup that eventually reads
+   * the Mappings still has the answer for a key that is not there.
+   */
+  private unresolved(
+    keys: readonly SimCfnTemplateValue[],
+    context: SimCfnResolveContext,
+  ): SimCfnTemplateValue {
+    if (this.defaultValue === undefined) {
+      return { "Fn::FindInMap": [...keys] };
+    }
+
+    return {
+      "Fn::FindInMap": [
+        ...keys,
+        { DefaultValue: this.defaultValue.resolve(context) },
+      ],
+    };
   }
 
   private resolveKey(

--- a/src/service/cloudformation/template/parse/fn/find-in-map/sim-cfn-fn-find-in-map-parser.ts
+++ b/src/service/cloudformation/template/parse/fn/find-in-map/sim-cfn-fn-find-in-map-parser.ts
@@ -1,7 +1,9 @@
 import { SimCfnFnFindInMap as SimCfnFunctionFindInMap } from "../../../node/fn/find-in-map/sim-cfn-fn-find-in-map.js";
+import type { SimCfnNode } from "../../../node/sim-cfn-node.js";
 import type { SimCfnTemplateValue } from "../../../value/sim-cfn-template-value.js";
 import type { SimCfnValueParser } from "../../value/sim-cfn-value-parser.type.js";
 import { assertDefined } from "../../../../../../util/type-guard/defined.js";
+import { isRecord } from "../../../../../../util/type-guard/record.js";
 
 /**
  * Parses CloudFormation Fn::FindInMap values.
@@ -11,11 +13,15 @@ export class SimCfnFnFindInMapParser {
 
   /**
    * Parse and validate the value inside a Fn::FindInMap expression.
+   *
+   * The optional fourth argument is the `{ "DefaultValue": ... }` object
+   * CloudFormation answers a missing map or key with.
    */
   parse(value: SimCfnTemplateValue): SimCfnFunctionFindInMap {
-    if (!Array.isArray(value) || value.length !== 3) {
+    if (!Array.isArray(value) || value.length < 3 || value.length > 4) {
       throw new Error(
-        "Sim CloudFormation Fn::FindInMap value must be [mapName, topLevelKey, secondLevelKey]",
+        "Sim CloudFormation Fn::FindInMap value must be [mapName, " +
+          'topLevelKey, secondLevelKey] with an optional { "DefaultValue": ... }',
       );
     }
 
@@ -27,10 +33,37 @@ export class SimCfnFnFindInMapParser {
     assertDefined(topLevelKey, "Fn::FindInMap top level key");
     assertDefined(secondLevelKey, "Fn::FindInMap second level key");
 
-    return new SimCfnFunctionFindInMap(
-      this.valueParser.parse(mapName),
-      this.valueParser.parse(topLevelKey),
-      this.valueParser.parse(secondLevelKey),
-    );
+    return new SimCfnFunctionFindInMap({
+      mapName: this.valueParser.parse(mapName),
+      topLevelKey: this.valueParser.parse(topLevelKey),
+      secondLevelKey: this.valueParser.parse(secondLevelKey),
+      defaultValue: this.defaultValue(value[3]),
+    });
+  }
+
+  /**
+   * Parse the fourth argument, which the template need not carry.
+   */
+  private defaultValue(
+    value: SimCfnTemplateValue | undefined,
+  ): SimCfnNode | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (
+      !isRecord(value) ||
+      Object.keys(value).length !== 1 ||
+      !("DefaultValue" in value)
+    ) {
+      throw new Error(
+        'Sim CloudFormation Fn::FindInMap fourth value must be { "DefaultValue": ... }',
+      );
+    }
+
+    const defaultValue = value["DefaultValue"];
+    assertDefined(defaultValue, "Fn::FindInMap DefaultValue");
+
+    return this.valueParser.parse(defaultValue);
   }
 }

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -16,6 +16,7 @@ import type {
   SimCfnConditions,
   SimCfnConditionsSection,
 } from "./condition/sim-cfn-conditions.js";
+import { SimCfnOutputConditions } from "./condition/sim-cfn-output-conditions.js";
 import { SimCfnResourceConditions } from "./condition/sim-cfn-resource-conditions.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 import { samExpandedTemplate } from "../sam/sim-cfn-sam-expansion.js";
@@ -162,14 +163,25 @@ export class SimCfnTemplate {
    *
    * Resource-backed intrinsic functions are left unresolved here because
    * Outputs are resolved after Resource creation.
+   *
+   * An Output whose `Condition` attribute is false is left out entirely, so it
+   * never reaches the Stack's Outputs and publishes no export.
    */
   outputTemplates(): SimCfnOutputTemplateRecord[] {
     const valueResolver = this.valueResolver();
+    const outputConditions = new SimCfnOutputConditions({
+      conditions: this.conditions(),
+      stackName: this.stackName,
+    });
 
     return Object.entries(this.template.Outputs ?? {})
       .filter((entry): entry is [string, SimCfnTemplateValueRecord] => {
         return isRecord(entry[1]);
       })
+      .filter(
+        ([outputKey, outputTemplate]) =>
+          !outputConditions.excludes(outputKey, outputTemplate),
+      )
       .map(([outputKey, outputTemplate]) => ({
         outputKey,
         template: valueResolver.resolveRecordFor(


### PR DESCRIPTION
`Fn::If` evaluates inside the `Conditions` section, picking a branch from a condition the evaluator has already answered. A cycle it closes fails with the self-reference error the evaluator already carried. An output whose `Condition` is false is left out of the stack, absent from `stack.outputs` and `DescribeStacks` and publishing no export, while an output naming a condition the template never defines fails the deployment the way a resource does. `Fn::FindInMap` takes a fourth `{ "DefaultValue": ... }` argument and answers a missing map, top level key or second level key with it. A lookup without one still fails.

Resolves #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)