### PR TITLE
feat: route bundled Lambda S3 calls to sim S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
 
 .worktrees/
+.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,5 @@ test/terraform/**/builds/
 test/terraform/**/terraform.tfstate*
 test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
+
+.worktrees/

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -687,7 +687,13 @@ AWS JSON protocol. Those are the ones that can be read back without the operatio
 ACM, CloudWatch Logs, Cognito Identity Provider, DynamoDB, DynamoDB Streams, ECS, EventBridge, KMS,
 Rekognition, Secrets Manager, SQS and SSM.
 
-A bundled call to any other simulated service, such as S3, SNS, SES or Lambda itself, fails with an
+S3 states its operation in the method and the path. A bundled S3 client reaches the endpoint that
+already serves S3 to a client given `--endpoint-url`, in either of the two addressing styles an SDK
+sends. A function can read and write Objects with an `S3Client` its archive inlines. The execution
+Role authorizes each request, and a read it holds no `s3:GetObject` for comes back to the SDK as
+`AccessDenied`.
+
+A bundled call to any other simulated service, such as SNS, SES or Lambda itself, fails with an
 error naming the service. Leaving the SDK out of that archive puts it back
 on the module interception path above, which every simulated service is reachable through.
 

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -326,6 +326,16 @@ without Lambda knowing which of them it is. An AWS service API endpoint goes to
 Command. Resolution is asked first, since a load balancer's own `.elb.amazonaws.com` name ends in a
 service API suffix while naming something served over HTTP.
 
+`SimLambdaAwsApiOutbound` reads the SigV4 credential scope to decide which of two things answers a
+service API request. A request signed for S3 goes to `SimS3ApiEndpoint`, the same endpoint the
+served AWS API routes S3 to, since S3 states its operation in the method and the path where the
+wire dispatcher looks for a header. Everything else goes to the wire dispatcher.
+
+Neither is given a caller. The SDK signs with the placeholder credentials in
+`sim-lambda-execution-credentials.ts`, and the simulation authenticates those against nothing. What
+the request runs as comes from the invocation. It is already running as the execution Role, and
+`SimSdkCommandDispatcher` picks that ambient caller up for a Command arriving without one.
+
 A service API endpoint also serves documents over plain HTTP, and a user pool's JWKS is the one a
 handler asks for. `isSimAwsApiRequest` is the test that separates the two, on the operation header
 of the AWS JSON protocol and the SigV4 credential scope, since a client fetching a published

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-bundled-sdk.loc.test.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-bundled-sdk.loc.test.ts
@@ -1,10 +1,13 @@
+import { faker } from "@faker-js/faker";
 import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
 import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { build } from "esbuild";
 import {
   assertIdentical,
   assertNonNullable,
+  assertObjectEquals,
   assertStringIncludes,
   assertUndefined,
 } from "@kensio/smartass";
@@ -35,16 +38,52 @@ export const handler = async (event: { orderId: string }) => {
 `;
 
 /**
- * A handler reading an S3 object, which is the same shape of call to a service
+ * A handler reading an S3 Object, which is the same shape of call to a service
  * whose requests carry no operation header.
+ *
+ * It reports whatever the SDK gave it, an Object or an error. Either one can
+ * then be asserted on.
  */
 const readObjectHandlerSource = `
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 
 const s3 = new S3Client({});
 
+export const handler = async (event: { bucket: string; key: string }) => {
+  try {
+    const output = await s3.send(
+      new GetObjectCommand({ Bucket: event.bucket, Key: event.key }),
+    );
+
+    return {
+      body: await output.Body?.transformToString(),
+      contentType: output.ContentType,
+      eTag: output.ETag,
+    };
+  } catch (error) {
+    return { errorName: (error as Error).name };
+  }
+};
+`;
+
+/**
+ * A handler calling a service the simulation still cannot read a serialized
+ * request for, since SES states its operation in the method and path and has
+ * no endpoint of its own here.
+ */
+const sendEmailHandlerSource = `
+import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
+
+const ses = new SESv2Client({});
+
 export const handler = async () => {
-  await s3.send(new GetObjectCommand({ Bucket: "data", Key: "greeting.txt" }));
+  await ses.send(
+    new SendEmailCommand({
+      FromEmailAddress: "orders@example.com",
+      Destination: { ToAddresses: ["customer@example.com"] },
+      Content: { Simple: { Subject: { Data: "Hello" }, Body: {} } },
+    }),
+  );
 
   return "unreachable";
 };
@@ -72,7 +111,11 @@ describe("sim Lambda vm code with a bundled AWS SDK", () => {
     );
 
     // And an execution role allowed to read it.
-    const roleArn = await readerRoleArn(simAws);
+    const roleArn = await executionRoleArn(simAws, {
+      roleName: "ItemReaderRole",
+      action: "dynamodb:GetItem",
+      resource: "arn:aws:dynamodb:*:*:table/orders",
+    });
 
     // And a function whose deployment package bundles the SDK, as a CDK
     // NodejsFunction with no external modules produces.
@@ -102,15 +145,118 @@ describe("sim Lambda vm code with a bundled AWS SDK", () => {
     await simAws.backgroundTasksComplete();
   });
 
-  it("reports a service whose requests cannot be routed", async () => {
-    // Given a function bundling an SDK client for a service that does not use
-    // the AWS JSON protocol.
+  it("reads simulated S3 from a handler that bundles the SDK", async () => {
+    // Given a simulated Bucket holding an Object.
     const simAws = new SimAws();
+    const bucketName = faker.string.alpha({ length: 12, casing: "lower" });
+    const objectKey = `${faker.word.noun()}/greeting.txt`;
+    const greeting = faker.lorem.sentence();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    const upload = await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: objectKey,
+        Body: greeting,
+        ContentType: "text/plain",
+      }),
+    );
+
+    // And a function bundling an S3 client, whose execution Role may read it.
+    const roleArn = await executionRoleArn(simAws, {
+      roleName: "ObjectReaderRole",
+      action: "s3:GetObject",
+      resource: `arn:aws:s3:::${bucketName}/*`,
+    });
     const zipFile = makeLambdaCodeZip(await bundle(readObjectHandlerSource));
     await simAws.lambda().createFunction(
       new CreateFunctionCommand({
         FunctionName: "object-reader",
-        Role: "arn:aws:iam::111111111111:role/ObjectReaderRole",
+        Role: roleArn,
+        Handler: "index.handler",
+        Code: { ZipFile: zipFile },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "object-reader",
+        Payload: JSON.stringify({ bucket: bucketName, key: objectKey }),
+      }),
+    );
+
+    // Then the bundled SDK decoded the Object the simulation answered with,
+    // bytes and metadata alike.
+    assertUndefined(output.FunctionError);
+    assertObjectEquals(payloadDocument(output.Payload), {
+      body: greeting,
+      contentType: "text/plain",
+      eTag: upload.ETag,
+    });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("refuses a bundled S3 read the execution Role is not allowed", async () => {
+    // Given a Bucket holding an Object, and a function whose execution Role
+    // is allowed everything but reading one.
+    const simAws = new SimAws();
+    const bucketName = faker.string.alpha({ length: 12, casing: "lower" });
+    const objectKey = `${faker.word.noun()}/secret.txt`;
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: objectKey,
+        Body: faker.lorem.sentence(),
+      }),
+    );
+    const roleArn = await executionRoleArn(simAws, {
+      roleName: "ObjectWriterRole",
+      action: "s3:PutObject",
+      resource: `arn:aws:s3:::${bucketName}/*`,
+    });
+    const zipFile = makeLambdaCodeZip(await bundle(readObjectHandlerSource));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "object-reader",
+        Role: roleArn,
+        Handler: "index.handler",
+        Code: { ZipFile: zipFile },
+      }),
+    );
+
+    // When the function is invoked.
+    const output = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "object-reader",
+        Payload: JSON.stringify({ bucket: bucketName, key: objectKey }),
+      }),
+    );
+
+    // Then the SDK caught the refusal S3 sends a caller without the
+    // permission, rather than reading the Object anyway.
+    assertUndefined(output.FunctionError);
+    assertObjectEquals(payloadDocument(output.Payload), {
+      errorName: "AccessDenied",
+    });
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("reports a service whose requests cannot be routed", async () => {
+    // Given a function bundling an SDK client for a service that neither uses
+    // the AWS JSON protocol nor has an endpoint reading its own.
+    const simAws = new SimAws();
+    const zipFile = makeLambdaCodeZip(await bundle(sendEmailHandlerSource));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "notifier",
+        Role: "arn:aws:iam::111111111111:role/NotifierRole",
         Handler: "index.handler",
         Code: { ZipFile: zipFile },
       }),
@@ -119,13 +265,13 @@ describe("sim Lambda vm code with a bundled AWS SDK", () => {
     // When the function is invoked.
     const output = await simAws
       .lambda()
-      .invoke(new InvokeCommand({ FunctionName: "object-reader" }));
+      .invoke(new InvokeCommand({ FunctionName: "notifier" }));
 
     // Then the failure names the service and what to do about it, rather than
     // reporting missing credentials or hanging on an endpoint.
     assertIdentical(output.FunctionError, "Unhandled");
     const errorMessage = payload(output.Payload);
-    assertStringIncludes(errorMessage, "request to s3");
+    assertStringIncludes(errorMessage, "request to ses");
     assertStringIncludes(errorMessage, "AWS JSON protocol");
     assertStringIncludes(errorMessage, "leaving the SDK out");
 
@@ -134,13 +280,26 @@ describe("sim Lambda vm code with a bundled AWS SDK", () => {
 });
 
 /**
- * Create an execution role allowed to read the table, so what the handler does
- * is authorized as the role rather than as anything ambient.
+ * What an execution Role is created to be allowed, which is the one thing the
+ * test's handler does and nothing else.
  */
-async function readerRoleArn(simAws: SimAws): Promise<string> {
+interface ExecutionRoleInput {
+  readonly roleName: string;
+  readonly action: string;
+  readonly resource: string;
+}
+
+/**
+ * Create an execution role allowed one action, so what the handler does is
+ * authorized as the role rather than as anything ambient.
+ */
+async function executionRoleArn(
+  simAws: SimAws,
+  role: ExecutionRoleInput,
+): Promise<string> {
   const creation = await simAws.iam().createRole(
     new CreateRoleCommand({
-      RoleName: "ReaderRole",
+      RoleName: role.roleName,
       AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
         Statement: {
           Principal: { Service: "lambda.amazonaws.com" },
@@ -151,13 +310,10 @@ async function readerRoleArn(simAws: SimAws): Promise<string> {
   );
   await simAws.iam().putRolePolicy(
     new PutRolePolicyCommand({
-      RoleName: "ReaderRole",
-      PolicyName: "ReadOrders",
+      RoleName: role.roleName,
+      PolicyName: `${role.roleName}Policy`,
       PolicyDocument: simIamPolicyDocumentFactory.make({
-        Statement: {
-          Action: "dynamodb:GetItem",
-          Resource: "arn:aws:dynamodb:*:*:table/orders",
-        },
+        Statement: { Action: role.action, Resource: role.resource },
       }),
     }),
   );
@@ -169,6 +325,13 @@ function payload(payloadBytes: Uint8Array | undefined): string {
   assertNonNullable(payloadBytes);
 
   return Buffer.from(payloadBytes).toString();
+}
+
+/**
+ * What a handler returned, read back as the document it answered with.
+ */
+function payloadDocument(payloadBytes: Uint8Array | undefined): unknown {
+  return JSON.parse(payload(payloadBytes)) as unknown;
 }
 
 /**

--- a/src/service/lambda/function/outbound/sim-lambda-aws-api-outbound.iso.test.ts
+++ b/src/service/lambda/function/outbound/sim-lambda-aws-api-outbound.iso.test.ts
@@ -1,14 +1,19 @@
 import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { faker } from "@faker-js/faker";
 import {
   assertFalse,
+  assertIdentical,
   assertObjectMatches,
   assertResponseStatus,
+  assertStringIncludes,
   assertTrue,
   describeResponse,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
 import {
   isSimAwsApiRequest,
   isSimAwsEndpointHostname,
@@ -139,5 +144,86 @@ describe("The AWS service API a sim Lambda's requests reach", () => {
     assertObjectMatches(await response.json(), {
       Item: { total: { N: "42" } },
     });
+  });
+
+  it("answers a request an SDK signed for S3, which names no operation header", async () => {
+    // Given a simulation holding an Object, and the outbound HTTP a function
+    // in it reaches AWS through.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const bucketName = faker.string.alpha({ length: 10, casing: "lower" });
+    const greeting = faker.lorem.sentence();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "greeting.txt",
+        Body: greeting,
+      }),
+    );
+    const outbound = new SimLambdaAwsApiOutbound({
+      simAws,
+      regionName: "eu-west-2",
+    });
+
+    // When a signed GetObject arrives, addressed the way an SDK resolving
+    // S3's own endpoint sends it.
+    const response = await outbound.fetch(
+      new Request(
+        `https://${bucketName}.s3.eu-west-2.amazonaws.com/greeting.txt?x-id=GetObject`,
+        { headers: { authorization: signedFor("s3") } },
+      ),
+    );
+
+    // Then simulated S3 answered with the Object, rather than the request
+    // being refused for carrying no operation header.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), greeting);
+  });
+
+  it("runs an S3 request as the caller the function is running as", async () => {
+    // Given a simulation holding an Object, and a Role that may write to the
+    // Bucket but not read from it.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const bucketName = faker.string.alpha({ length: 10, casing: "lower" });
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "greeting.txt",
+        Body: faker.lorem.sentence(),
+      }),
+    );
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ObjectWriterRole",
+        actions: ["s3:PutObject"],
+        resource: `arn:aws:s3:::${bucketName}/*`,
+      },
+      simAws,
+    );
+    const outbound = new SimLambdaAwsApiOutbound({
+      simAws,
+      regionName: "eu-west-2",
+    });
+
+    // When a signed GetObject arrives while that Role is the ambient caller,
+    // as it is throughout a sim Lambda invocation.
+    const response = await simAws.runAs({ kind: "arn", arn: role.Arn }, () =>
+      outbound.fetch(
+        new Request(
+          `https://${bucketName}.s3.eu-west-2.amazonaws.com/greeting.txt?x-id=GetObject`,
+          { headers: { authorization: signedFor("s3") } },
+        ),
+      ),
+    );
+
+    // Then S3 refused it as the Role, in the response an SDK reads back as an
+    // AccessDenied error.
+    assertResponseStatus(response, 403, await describeResponse(response));
+    assertStringIncludes(await response.text(), "AccessDenied");
   });
 });

--- a/src/service/lambda/function/outbound/sim-lambda-aws-api-outbound.ts
+++ b/src/service/lambda/function/outbound/sim-lambda-aws-api-outbound.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../../sdk/wire/sim-sdk-wire-operation.js";
 import type { AwsRegionName } from "../../../aws/sim-aws-region.js";
 import type { SimAws } from "../../../aws/sim-aws.js";
+import { SimS3ApiEndpoint } from "../../../s3/serve/api/sim-s3-api.js";
 import type { SimLambdaOutboundHttp } from "./sim-lambda-outbound-http.js";
 import {
   simLambdaOutboundWireRequest,
@@ -38,6 +39,18 @@ const awsEndpointSuffixes: readonly string[] = [
  * way it answers for every other hostname a resource is issued.
  */
 const resourceEndpointLabel = ".execute-api.";
+
+/**
+ * The SigV4 signing name of the one service here whose requests an endpoint of
+ * its own reads.
+ *
+ * S3 states its operation in the method, the path and a query-string
+ * sub-resource. `SimS3ApiEndpoint` reads those. The signing name is where a
+ * signed request says which service it is for, whatever protocol that service
+ * speaks, and that is what selects the endpoint here, as it is on the served
+ * AWS API endpoint.
+ */
+const s3SigningName = "s3";
 
 /**
  * Whether a hostname is an AWS service API endpoint.
@@ -93,12 +106,14 @@ interface SimLambdaAwsApiOutboundProperties {
  */
 export class SimLambdaAwsApiOutbound implements SimLambdaOutboundHttp {
   private readonly dispatcher: SimSdkWireDispatcher;
+  private readonly s3: SimS3ApiEndpoint;
 
   constructor(properties: SimLambdaAwsApiOutboundProperties) {
     this.dispatcher = new SimSdkWireDispatcher(
       properties.simAws,
       properties.regionName,
     );
+    this.s3 = new SimS3ApiEndpoint({ simAws: properties.simAws });
   }
 
   /**
@@ -110,12 +125,29 @@ export class SimLambdaAwsApiOutbound implements SimLambdaOutboundHttp {
 
   /**
    * Answer an AWS API request from the simulated operation it names.
+   *
+   * A request signed for S3 goes to the endpoint that reads S3's protocol,
+   * since S3 names its operation where the wire dispatcher looks for a header.
+   * No caller travels with it. The SDK signed it with the placeholder
+   * credentials the runtime puts in the environment, and the invocation is
+   * already running as the execution Role, the ambient caller every other call
+   * out of function code runs as.
    */
   async fetch(request: Request): Promise<Response> {
+    const wireRequest = await simLambdaOutboundWireRequest(request);
+    const scope = readSimSdkWireCredentialScope(wireRequest);
+
+    if (scope?.signingName === s3SigningName) {
+      return await this.s3.handle(
+        request,
+        wireRequest.body,
+        undefined,
+        scope.regionName,
+      );
+    }
+
     return simLambdaOutboundWireResponse(
-      await this.dispatcher.dispatch(
-        await simLambdaOutboundWireRequest(request),
-      ),
+      await this.dispatcher.dispatch(wireRequest),
     );
   }
 }

--- a/src/service/lambda/function/outbound/sim-lambda-outbound-http.iso.test.ts
+++ b/src/service/lambda/function/outbound/sim-lambda-outbound-http.iso.test.ts
@@ -1,3 +1,5 @@
+import { CreateBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { faker } from "@faker-js/faker";
 import {
   assertFalse,
   assertIdentical,
@@ -76,29 +78,72 @@ describe("What a simulated environment answers its functions for", () => {
     assertResponseStatus(response, 200, await describeResponse(response));
   });
 
+  it("answers a signed request to S3's own endpoint from the Bucket", async () => {
+    // Given a simulation holding an Object, and a request signed the way a
+    // bundled SDK signs one inside a function, with credentials nothing in
+    // the simulation would verify.
+    const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
+    const bucketName = faker.string.alpha({ length: 10, casing: "lower" });
+    const greeting = faker.lorem.sentence();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "greeting.txt",
+        Body: greeting,
+      }),
+    );
+    const outbound = makeSimLambdaOutboundHttp({ simAws });
+
+    // When it arrives.
+    const response = await outbound.fetch(
+      new Request(
+        `https://${bucketName}.s3.eu-west-2.amazonaws.com/greeting.txt`,
+        {
+          headers: {
+            authorization:
+              "AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260818/eu-west-2/" +
+              "s3/aws4_request, SignedHeaders=host, Signature=00",
+          },
+        },
+      ),
+    );
+
+    // Then it was read as the AWS API request it is, and simulated S3
+    // answered it with the Object.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), greeting);
+  });
+
   it("leaves a signed request to a service endpoint to be routed as a Command", async () => {
-    // Given a simulation, and a signed request to a service whose endpoint it
-    // does serve over HTTP.
+    // Given a simulation, and a signed request to a service whose serialized
+    // requests it cannot read back.
     const simAws = new SimAws({ defaultRegionName: "eu-west-2" });
     const outbound = makeSimLambdaOutboundHttp({ simAws });
 
     // When it arrives.
     const error = await assertThrowsErrorAsync(async () =>
       outbound.fetch(
-        new Request("https://data.s3.eu-west-2.amazonaws.com/greeting.txt", {
-          headers: {
-            authorization:
-              "AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260818/eu-west-2/" +
-              "s3/aws4_request, SignedHeaders=host, Signature=00",
+        new Request(
+          "https://email.eu-west-2.amazonaws.com/v2/email/outbound-emails",
+          {
+            method: "POST",
+            headers: {
+              authorization:
+                "AWS4-HMAC-SHA256 Credential=ASIAEXAMPLE/20260818/eu-west-2/" +
+                "ses/aws4_request, SignedHeaders=host, Signature=00",
+            },
           },
-        }),
+        ),
       ),
     );
 
     // Then it was read as the AWS API request it is, and refused as one, so
     // that a bundled SDK is told what to do about the protocol its requests
     // cannot be routed back from.
-    assertStringIncludes(error.message, "request to s3");
+    assertStringIncludes(error.message, "request to ses");
     assertStringIncludes(error.message, "AWS JSON protocol");
   });
 

--- a/src/service/s3/serve/api/sim-s3-api-request.iso.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-request.iso.test.ts
@@ -1,0 +1,77 @@
+import { faker } from "@faker-js/faker";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { readSimS3ApiRequest } from "./sim-s3-api-request.js";
+
+/**
+ * Which Bucket and Object a request named, which S3 lets a client state in
+ * either the hostname or the path.
+ */
+describe("Reading what an S3 REST request addressed", () => {
+  function addressed(url: string): { bucketName: string; objectKey: string } {
+    const { bucketName, objectKey } = readSimS3ApiRequest(
+      new Request(url),
+      Buffer.alloc(0),
+    );
+
+    return { bucketName, objectKey };
+  }
+
+  it("reads a Bucket a client stated in the path", () => {
+    // Given a request to the endpoint URL a client was given, which addresses
+    // every service on one hostname and so names its Bucket in the path.
+    const bucketName = faker.string.alpha({ length: 10, casing: "lower" });
+
+    // When it is read.
+    const request = addressed(
+      `http://localhost:1234/${bucketName}/notes/today.txt`,
+    );
+
+    // Then the first path segment is the Bucket and the rest is the key.
+    assertIdentical(request.bucketName, bucketName);
+    assertIdentical(request.objectKey, "notes/today.txt");
+  });
+
+  it("reads a Bucket the SDK stated in the hostname", () => {
+    // Given a request an SDK resolving S3's own endpoint sent, which puts the
+    // Bucket in front of the endpoint hostname.
+    const bucketName = faker.string.alpha({ length: 10, casing: "lower" });
+
+    // When it is read.
+    const request = addressed(
+      `https://${bucketName}.s3.eu-west-2.amazonaws.com/notes/today.txt?x-id=GetObject`,
+    );
+
+    // Then the Bucket comes from the hostname, leaving the whole path as the
+    // key rather than the first segment of it.
+    assertIdentical(request.bucketName, bucketName);
+    assertIdentical(request.objectKey, "notes/today.txt");
+  });
+
+  it("keeps the dots in a Bucket name the hostname spells out", () => {
+    // Given a virtual host request for a Bucket whose name contains dots, so
+    // that the Bucket is several hostname labels rather than one.
+    const bucketName = `${faker.word.noun()}.${faker.word.noun()}`;
+
+    // When it is read.
+    const request = addressed(
+      `https://${bucketName}.s3.eu-west-2.amazonaws.com/today.txt`,
+    );
+
+    // Then every label before the endpoint is part of the Bucket name.
+    assertIdentical(request.bucketName, bucketName);
+    assertIdentical(request.objectKey, "today.txt");
+  });
+
+  it("names no Bucket for the path-style S3 endpoint itself", () => {
+    // Given a request to S3's own path-style endpoint, which carries the
+    // service-level operations.
+    // When it is read.
+    const request = addressed("https://s3.eu-west-2.amazonaws.com/");
+
+    // Then it names no Bucket, which is what makes it service-level.
+    assertIdentical(request.bucketName, "");
+    assertIdentical(request.objectKey, "");
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-api-request.ts
+++ b/src/service/s3/serve/api/sim-s3-api-request.ts
@@ -1,4 +1,9 @@
 /**
+ * The hostname label S3's own REST endpoints carry.
+ */
+const s3EndpointLabel = "s3";
+
+/**
  * An S3 REST request as the route table reads it.
  *
  * The path has already been taken apart, because which operation a request
@@ -18,26 +23,23 @@ export interface SimS3ApiRequest {
 }
 
 /**
- * Read a request that arrived at the served AWS API endpoint as an S3 request.
+ * Read a request addressed to the S3 REST API as an S3 request.
  *
- * Only path-style addressing is read here. A virtual-host request names its
- * Bucket in the hostname, and simulated Route 53 resolves that to the Bucket's
- * own endpoint before this endpoint is ever reached, so a request that gets
- * this far put its Bucket in the path.
+ * Both of the addressing styles real S3 offers are read, because both arrive
+ * here. A client given an endpoint URL sends path style, with the Bucket as
+ * the first path segment. An SDK resolving S3's own endpoint sends virtual
+ * host style, with the Bucket in the hostname, and function code bundling the
+ * SDK reaches this endpoint with exactly that.
  */
 export function readSimS3ApiRequest(
   request: Request,
   body: Uint8Array,
 ): SimS3ApiRequest {
   const url = new URL(request.url);
-
-  // The first segment is the Bucket and everything after it is the key, which
-  // can itself contain slashes.
-  const path = url.pathname.replace(/^\//, "");
-  const separator = path.indexOf("/");
-
-  const bucketName = separator === -1 ? path : path.slice(0, separator);
-  const objectKey = separator === -1 ? "" : path.slice(separator + 1);
+  const { bucketName, objectKey } = simS3ApiRequestTargetNames(
+    url.hostname,
+    url.pathname.replace(/^\//, ""),
+  );
 
   return {
     method: request.method,
@@ -47,6 +49,58 @@ export function readSimS3ApiRequest(
     headers: request.headers,
     body,
   };
+}
+
+/**
+ * Split what a request addressed into the Bucket it names and the Object key
+ * below it, still encoded as they were sent.
+ *
+ * A virtual host request names its Bucket in the hostname, which leaves its
+ * whole path as the key. A path style request names both in the path, where
+ * the first segment is the Bucket and everything after it is the key, which
+ * can itself contain slashes.
+ */
+function simS3ApiRequestTargetNames(
+  hostname: string,
+  path: string,
+): { readonly bucketName: string; readonly objectKey: string } {
+  const hostedBucketName = simS3VirtualHostBucketName(hostname);
+  if (hostedBucketName !== undefined) {
+    return { bucketName: hostedBucketName, objectKey: path };
+  }
+
+  const separator = path.indexOf("/");
+  if (separator === -1) {
+    return { bucketName: path, objectKey: "" };
+  }
+
+  return {
+    bucketName: path.slice(0, separator),
+    objectKey: path.slice(separator + 1),
+  };
+}
+
+/**
+ * The Bucket a virtual host style hostname names, or nothing for a hostname
+ * that names none.
+ *
+ * S3's own endpoint hostnames carry an `s3` label, and virtual host style puts
+ * the Bucket in front of it, as in `<bucket>.s3.<region>.amazonaws.com`. Path
+ * style is the same hostname with nothing in front. The labels before the
+ * first `s3` label are the Bucket, and an empty set of them is path style.
+ *
+ * A Bucket name can contain dots. One Bucket is then several hostname labels,
+ * joined back together here.
+ *
+ * A hostname carrying no `s3` label names no Bucket. That covers the local
+ * endpoint an `--endpoint-url` client sends, which addresses every service on
+ * one hostname and can only be path style.
+ */
+function simS3VirtualHostBucketName(hostname: string): string | undefined {
+  const labels = hostname.split(".");
+  const endpoint = labels.indexOf(s3EndpointLabel);
+
+  return endpoint <= 0 ? undefined : labels.slice(0, endpoint).join(".");
 }
 
 /**

--- a/src/service/s3/serve/api/sim-s3-api.ts
+++ b/src/service/s3/serve/api/sim-s3-api.ts
@@ -46,11 +46,17 @@ export class SimS3ApiEndpoint {
    * The Region is the one the request was signed for, read from its credential
    * scope, so it arrives as whatever the client wrote rather than as a Region
    * the simulator has already recognised.
+   *
+   * A request nothing has authenticated arrives with no caller, and runs as
+   * the ambient caller of whatever sent it, in the same way an intercepted SDK
+   * client's Command does. A sim Lambda's outbound call relies on that. Its
+   * signature is over placeholder credentials, and the invocation is already
+   * running as the execution Role.
    */
   async handle(
     request: Request,
     body: Uint8Array,
-    caller: SimAwsCaller,
+    caller: SimAwsCaller | undefined,
     regionName: string,
   ): Promise<Response> {
     const apiRequest = readSimS3ApiRequest(request, body);


### PR DESCRIPTION
Resolves #1227

A zip-packaged function whose bundle inlines an S3 client could not reach simulated S3. Every signed request out of a function went to the wire dispatcher, which reads the AWS JSON operation header, and S3 names its operation in the method and the path instead. `SimLambdaAwsApiOutbound` now reads the SigV4 signing name and sends an S3 request to `SimS3ApiEndpoint`, the endpoint the served AWS API already routes S3 to. No caller travels with it, so the request runs as the execution Role the invocation is already running as, and a missing `s3:GetObject` reaches the SDK as `AccessDenied`. `readSimS3ApiRequest` now reads virtual host addressing alongside path style, since that is how an SDK resolving S3's own endpoint addresses a Bucket.