### PR TITLE
feat: give a simulated Stack its own stack ID

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,8 +4,15 @@
 # this repository only.
 reviews:
   auto_review:
-    # Review a pull request once, when it is opened.
-    enabled: true
+    # A pull request is not reviewed for being opened. Reviews are rationed, and
+    # a documentation change or a small one spends a review for little.
+    #
+    # The Review workflow decides which pull requests are worth one and labels
+    # those `review-ready`, which is what asks for the review. Anything it
+    # passes over can still be reviewed with an `@coderabbitai review` comment.
+    enabled: false
+    labels:
+      - review-ready
     # Do not review again on every push after that. Ask for another review with
     # an `@coderabbitai review` comment on the pull request.
     auto_incremental_review: false

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,79 @@
+---
+name: Review
+
+# CodeRabbit reviews nothing for being opened (see .coderabbit.yaml). This is
+# what asks it for a review, by labelling the pull requests worth one.
+#
+# A title edit counts as much as a push does, since the title is half of what
+# decides. A pull request that grows past the line count later is labelled then,
+# and one that shrinks keeps the label it already earned.
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+# Below this many changed lines, a pull request is read faster than it is
+# reviewed.
+env:
+  REVIEW_LINES: 500
+
+jobs:
+  review-ready:
+    name: Review ready
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      # There is no checkout here. The API already knows how big the pull
+      # request is, and asking it takes a few seconds against the minute a
+      # checkout and a pnpm install cost.
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          case "$PR_TITLE" in
+            docs:* | docs\(*\):*)
+              echo "A documentation pull request is not reviewed." \
+                >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+          esac
+
+          read -r additions deletions < <(
+            gh api "repos/$REPOSITORY/pulls/$PR_NUMBER" \
+              --jq '"\(.additions) \(.deletions)"'
+          )
+          lines=$((additions + deletions))
+
+          if [ "$lines" -lt "$REVIEW_LINES" ]; then
+            echo "$lines changed lines, under $REVIEW_LINES: not reviewed." \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Created here rather than by hand, so a fork or a fresh clone of this
+          # repository has everything the workflow needs. `--force` leaves an
+          # existing label as it is apart from its colour and description.
+          gh label create review-ready \
+            --repo "$REPOSITORY" \
+            --color 0e8a16 \
+            --description "Large enough to be worth a CodeRabbit review" \
+            --force
+
+          gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" --add-label review-ready
+
+          echo "$lines changed lines: asking for a review." \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -132,6 +132,66 @@ console.log(describeOutput.Stacks?.[0]?.StackStatus);
 continues asynchronously, similar to real CloudFormation. Use `waitForStackDeployComplete(...)` when
 you need final stack state.
 
+## Stack IDs
+
+A stack is given a stack ID when it is created, in the ARN shape CloudFormation gives one:
+
+```
+arn:aws:cloudformation:<region>:<account>:stack/<name>/<uuid>
+```
+
+The account and region are the ones the stack was created in. The UUID on the end is generated for
+each stack. Deploying the same name a second time produces a stack with an ID of its own.
+
+`CreateStackCommand` and `UpdateStackCommand` answer with the ID, `DescribeStacksCommand` reports it
+as `StackId`, and a template reading `AWS::StackId` resolves to it. `AWS::StackName` still resolves
+to the name. A `CREATE` change set makes the ID along with the stack it puts into review, and the
+change set commands report it as `StackId` too.
+
+`DescribeStacksCommand` accepts either a stack name or a stack ID in `StackName`, as CloudFormation
+does. A stack ID goes on working once the stack has been deleted (its name does not).
+
+```typescript sim-cloudformation-stack-id
+/**
+ * Describing a deleted simulated CloudFormation Stack by its Stack ID.
+ */
+
+import {
+  CreateStackCommand,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+
+const created = await simCfn.createStack(
+  new CreateStackCommand({
+    StackName: "identified-stack",
+    TemplateBody: JSON.stringify({ Resources: {} }),
+  }),
+);
+
+// arn:aws:cloudformation:<region>:<account>:stack/identified-stack/<uuid>
+console.log(created.StackId);
+
+await simCfn.waitForStackDeployComplete("identified-stack");
+
+await simCfn.deleteStack(
+  new DeleteStackCommand({ StackName: "identified-stack" }),
+);
+await simCfn.waitForStackDeleteComplete("identified-stack");
+
+const described = await simCfn.describeStacks(
+  new DescribeStacksCommand({ StackName: created.StackId }),
+);
+
+// DELETE_COMPLETE
+console.log(described.Stacks?.[0]?.StackStatus);
+```
+
 ## Stack deployment is asynchronous
 
 A stack may be visible before all resources have finished creating.
@@ -502,7 +562,8 @@ Deletion runs in the background, as deployment does. `deleteStack(...)` returns 
 moved to `DELETE_IN_PROGRESS`, and `waitForStackDeleteComplete(...)` waits for the resources to go.
 `DescribeStacksCommand` reports `DELETE_IN_PROGRESS` in between, and then refuses the stack name with
 a `ValidationError` once the deletion has finished. That is how CloudFormation answers a name it no
-longer holds.
+longer holds. The stack itself is still there under its
+[stack ID](#stack-ids), reporting `DELETE_COMPLETE` and the Outputs it finished with.
 
 Deleting a stack name that was never deployed succeeds, as it does in CloudFormation.
 
@@ -3653,6 +3714,8 @@ Sim CloudFormation currently supports:
 - `CreateChangeSetCommand`, `DescribeChangeSetCommand`, `ExecuteChangeSetCommand`,
   `DeleteChangeSetCommand` and `ListChangeSetsCommand`, for both `CREATE` and `UPDATE` change sets
 - Waiting for simulated stack deployment, update and deletion completion
+- Stack IDs in the CloudFormation ARN shape, accepted by `DescribeStacksCommand` in place of a stack
+  name, and still describing a stack once it has been deleted
 - The resource `DeletionPolicy` attribute, for `Retain` and `RetainExceptOnCreate`
 - `deployTemplate(...)` for parsed template objects, optionally naming the synthesized template file
   a template edited in memory came from
@@ -3774,8 +3837,10 @@ Each service's own docs describe what its resource types support.
 - `DeleteStackCommand` reads only `StackName`. `RetainResources`, `DeletionMode`, `RoleARN` and
   `ClientRequestToken` are not read, so a stack left in `DELETE_FAILED` cannot be forced through the
   way `FORCE_DELETE_STACK` forces it in AWS.
-- A deleted stack cannot be described. Real CloudFormation keeps a deleted stack readable by its
-  unique stack ID, and the simulator identifies a stack by its name alone.
+- A deleted stack stays describable by its stack ID for as long as the simulation lives. Real
+  CloudFormation drops it after 90 days. `DescribeStacks` with no `StackName` lists the live stacks
+  in both, and `ListStacks` is unsupported, so there is no way to find a deleted stack whose ID you
+  have lost.
 - `Fn::FindInMap` arguments are resolved from literals, `Parameters` and pseudo parameters. An
   argument that depends on a created resource, such as a `Ref` to a resource logical ID, fails the
   resource with a "could not find map" error. Real CloudFormation allows only `Ref` and a nested

--- a/docs/services/cloudformation/sim-cloudformation-stack-id.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-stack-id.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Describing a deleted simulated CloudFormation Stack by its Stack ID.
+ */
+
+import {
+  CreateStackCommand,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+
+const created = await simCfn.createStack(
+  new CreateStackCommand({
+    StackName: "identified-stack",
+    TemplateBody: JSON.stringify({ Resources: {} }),
+  }),
+);
+
+// arn:aws:cloudformation:<region>:<account>:stack/identified-stack/<uuid>
+console.log(created.StackId);
+
+await simCfn.waitForStackDeployComplete("identified-stack");
+
+await simCfn.deleteStack(
+  new DeleteStackCommand({ StackName: "identified-stack" }),
+);
+await simCfn.waitForStackDeleteComplete("identified-stack");
+
+const described = await simCfn.describeStacks(
+  new DescribeStacksCommand({ StackName: created.StackId }),
+);
+
+// DELETE_COMPLETE
+console.log(described.Stacks?.[0]?.StackStatus);

--- a/src/service/cloudformation/authorize/sim-cloudformation-authorization.ts
+++ b/src/service/cloudformation/authorize/sim-cloudformation-authorization.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import { SimIamActionAuthorizer } from "../../iam/authorize/sim-iam-action-authorizer.js";
+import { isSimCfnStackId } from "../stack/sim-cfn-stack-id.js";
 import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
 
 interface SimCloudFormationAuthorizationProperties {
@@ -102,8 +103,15 @@ export class SimCloudFormationAuthorization {
   /**
    * The Stack ARN a command operates on. A command naming no Stack, which
    * DescribeStacks allows, is asking about every Stack in the scope.
+   *
+   * A command that named the Stack by its ID named the ARN itself, so that is
+   * what gets authorized rather than an ARN built around it.
    */
   private stackArn(stackName: string | undefined): string {
+    if (stackName !== undefined && isSimCfnStackId(stackName)) {
+      return stackName;
+    }
+
     const { accountId, regionName } = this.accountRegionScope;
 
     return `arn:aws:cloudformation:${regionName}:${accountId}:stack/${stackName ?? "*"}/*`;

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-stack-id.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-stack-id.ts
@@ -1,0 +1,31 @@
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
+import {
+  makeSimCfnStackId,
+  type SimCfnStackId,
+} from "../stack/sim-cfn-stack-id.js";
+
+interface SimCfnChangeSetStackIdProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly stacks: ReadonlyMap<SimCloudFormationStackName, SimCfnStack>;
+  readonly stackName: SimCloudFormationStackName;
+}
+
+/**
+ * The Stack ID a change set's template resolves `AWS::StackId` to.
+ *
+ * An `UPDATE` change set is held against a Stack that already has one. A
+ * `CREATE` change set brings the Stack into being, and this is the ID that
+ * Stack keeps for the rest of its life.
+ */
+export function simCfnChangeSetStackId(
+  properties: SimCfnChangeSetStackIdProperties,
+): SimCfnStackId {
+  const { accountRegionScope, stacks, stackName } = properties;
+
+  return (
+    stacks.get(stackName)?.stackId ??
+    makeSimCfnStackId({ accountRegionScope, stackName })
+  );
+}

--- a/src/service/cloudformation/changeset/sim-cfn-change-set-stack.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set-stack.ts
@@ -6,6 +6,7 @@ import type { SimAws } from "../../aws/sim-aws.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import { SimCfnStack } from "../stack/sim-cfn-stack.js";
+import type { SimCfnStackId } from "../stack/sim-cfn-stack-id.js";
 import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
@@ -21,6 +22,7 @@ interface SimCfnChangeSetStackProperties {
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
   readonly background: BackgroundScheduler & BackgroundCompleter;
   readonly stackName: SimCloudFormationStackName;
+  readonly stackId: SimCfnStackId;
   readonly type: SimCfnChangeSetType;
   readonly template: SimCfnTemplate;
   readonly caller?: SimAwsCaller | undefined;
@@ -65,6 +67,7 @@ export function simCfnChangeSetStack(
     accountRegionScope: properties.accountRegionScope,
     background: properties.background,
     stackName,
+    stackId: properties.stackId,
     template: properties.template,
     caller: properties.caller,
     exports: properties.exports,

--- a/src/service/cloudformation/changeset/sim-cfn-change-set.ts
+++ b/src/service/cloudformation/changeset/sim-cfn-change-set.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
 import type { SimCloudFormationStackName } from "../stack/sim-cfn-stack.type.js";
+import type { SimCfnStackId } from "../stack/sim-cfn-stack-id.js";
 import { simCfnChangeSetArn } from "./sim-cfn-change-set-arn.js";
 import type {
   SimCfnChangeSetExecutionStatus,
@@ -14,6 +15,7 @@ interface SimCfnChangeSetProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly changeSetName: SimCfnChangeSetName;
   readonly stackName: SimCloudFormationStackName;
+  readonly stackId: SimCfnStackId;
   readonly type: SimCfnChangeSetType;
   readonly template: SimCfnTemplate;
   readonly changes: readonly SimCfnResourceChange[];
@@ -45,6 +47,7 @@ export class SimCfnChangeSet {
   public readonly changeSetId: string;
   public readonly changeSetName: SimCfnChangeSetName;
   public readonly stackName: SimCloudFormationStackName;
+  public readonly stackId: SimCfnStackId;
   public readonly type: SimCfnChangeSetType;
   public readonly template: SimCfnTemplate;
   public readonly changes: readonly SimCfnResourceChange[];
@@ -66,6 +69,7 @@ export class SimCfnChangeSet {
 
     this.changeSetName = changeSetName;
     this.stackName = properties.stackName;
+    this.stackId = properties.stackId;
     this.type = properties.type;
     this.template = properties.template;
     this.changes = properties.changes;

--- a/src/service/cloudformation/command/create-change-set/create-change-set.handler.ts
+++ b/src/service/cloudformation/command/create-change-set/create-change-set.handler.ts
@@ -17,6 +17,7 @@ import type { SimCfnChangeSetName } from "../../changeset/sim-cfn-change-set.typ
 import { simCfnChangeSetPlan } from "../../changeset/sim-cfn-change-set-changes.js";
 import { simCfnChangeSetRequest } from "../../changeset/sim-cfn-change-set-input.js";
 import { simCfnChangeSetStack } from "../../changeset/sim-cfn-change-set-stack.js";
+import { simCfnChangeSetStackId } from "../../changeset/sim-cfn-change-set-stack-id.js";
 import { simCfnChangeSetFailure } from "../../changeset/sim-cfn-change-set-failure.js";
 import type {
   SimCreateChangeSetCommand,
@@ -65,14 +66,20 @@ export class CreateChangeSetCommandHandler implements CommandHandler<
 
     this.assertNameFree(request.stackName, request.changeSetName);
 
+    const stackId = simCfnChangeSetStackId({
+      ...this.properties,
+      ...request,
+    });
     const template = simCfnCommandTemplate({
       ...this.properties,
       ...request,
+      stackId,
       input: command.input,
     });
     const stack = simCfnChangeSetStack({
       ...this.properties,
       ...request,
+      stackId,
       template,
     });
     const changes = simCfnChangeSetPlan({
@@ -85,6 +92,7 @@ export class CreateChangeSetCommandHandler implements CommandHandler<
     const changeSet = new SimCfnChangeSet({
       ...this.properties,
       ...request,
+      stackId,
       template,
       changes,
       plannedFrom: stack.currentTemplate,
@@ -101,7 +109,7 @@ export class CreateChangeSetCommandHandler implements CommandHandler<
 
     return {
       Id: changeSet.changeSetId,
-      StackId: stack.stackName,
+      StackId: stack.stackId,
       $metadata: {},
     };
   }

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -11,6 +11,7 @@ import {
   SimCfnStack,
   type SimCloudFormationStackName,
 } from "../../stack/sim-cfn-stack.js";
+import { makeSimCfnStackId } from "../../stack/sim-cfn-stack-id.js";
 import { SimCloudFormationAlreadyExistsException } from "../../error/sim-cloudformation.error.js";
 import type {
   SimCreateStackCommand,
@@ -107,10 +108,16 @@ export class CreateStackCommandHandler implements CommandHandler<
       );
     }
 
+    const stackId = makeSimCfnStackId({
+      accountRegionScope: this.accountRegionScope,
+      stackName,
+    });
+
     const template = simCfnCommandTemplate({
       simAws: this.simAws,
       accountRegionScope: this.accountRegionScope,
       stackName,
+      stackId,
       templateBody: command.input.TemplateBody,
       input: command.input,
       exports: this.exports,
@@ -121,6 +128,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       accountRegionScope: this.accountRegionScope,
       background: this.background,
       stackName,
+      stackId,
       template,
       cdkOutContext: this.cdkOutContext,
       bindings: this.bindings,
@@ -134,7 +142,7 @@ export class CreateStackCommandHandler implements CommandHandler<
     await stack.deploy();
 
     return {
-      StackId: stack.stackName,
+      StackId: stack.stackId,
       $metadata: {},
     };
   }

--- a/src/service/cloudformation/command/create-stack/create-stack.iso.test.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.iso.test.ts
@@ -5,6 +5,7 @@ import {
   assertNonNullable,
   assertThrowsErrorAsync,
   assertInstanceOf,
+  assertStringIncludes,
 } from "@kensio/smartass";
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimCloudFormationAlreadyExistsException } from "../../error/sim-cloudformation.error.js";
@@ -31,7 +32,7 @@ describe("CloudFormation CreateStackCommand", () => {
     );
 
     // Then the Stack is registered and starts deploying in the background.
-    assertIdentical(stackCreation.StackId, "test-stack");
+    assertStringIncludes(stackCreation.StackId, ":stack/test-stack/");
 
     const describeStacksOut = await cloudFormation.describeStacks(
       new DescribeStacksCommand({
@@ -40,7 +41,7 @@ describe("CloudFormation CreateStackCommand", () => {
     );
 
     assertArrayLength(describeStacksOut.Stacks, 1);
-    assertIdentical(describeStacksOut.Stacks[0].StackId, "test-stack");
+    assertIdentical(describeStacksOut.Stacks[0].StackId, stackCreation.StackId);
     assertIdentical(describeStacksOut.Stacks[0].StackName, "test-stack");
     assertIdentical(
       describeStacksOut.Stacks[0].StackStatus,

--- a/src/service/cloudformation/command/delete-stack/delete-stack.handler.ts
+++ b/src/service/cloudformation/command/delete-stack/delete-stack.handler.ts
@@ -8,6 +8,7 @@ import type {
   SimCfnStack,
   SimCloudFormationStackName,
 } from "../../stack/sim-cfn-stack.js";
+import type { SimCfnDeletedStacks } from "../../stack/sim-cfn-deleted-stacks.js";
 import type {
   SimDeleteStackCommand,
   SimDeleteStackCommandOutput,
@@ -15,6 +16,10 @@ import type {
 
 interface DeleteStackCommandHandlerProperties {
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+
+  /** Where a Stack that has finished deleting is kept, to stay describable. */
+  readonly deleted: SimCfnDeletedStacks;
+
   readonly background: BackgroundScheduler & BackgroundCompleter;
 }
 
@@ -28,10 +33,12 @@ export class DeleteStackCommandHandler implements CommandHandler<
   SimDeleteStackCommandOutput
 > {
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  private readonly deleted: SimCfnDeletedStacks;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
 
   constructor(properties: DeleteStackCommandHandlerProperties) {
     this.stacks = properties.stacks;
+    this.deleted = properties.deleted;
     this.background = properties.background;
   }
 
@@ -47,6 +54,9 @@ export class DeleteStackCommandHandler implements CommandHandler<
    * the background, and the Stack name is only released when that finishes, so
    * a CreateStack that reuses the name should follow a wait for deletion to
    * complete.
+   *
+   * The Stack itself is kept once its name has gone, so DescribeStacks can
+   * still answer for it by Stack ID, as CloudFormation does for 90 days.
    */
   async handle(
     command: SimDeleteStackCommand,
@@ -62,9 +72,14 @@ export class DeleteStackCommandHandler implements CommandHandler<
     const stackName = command.input.StackName as SimCloudFormationStackName;
     const stack = this.stacks.get(stackName);
 
-    await stack?.delete({
+    if (stack === undefined) {
+      return { $metadata: {} };
+    }
+
+    await stack.delete({
       onDeleteComplete: (): void => {
         this.stacks.delete(stackName);
+        this.deleted.record(stack);
       },
     });
 

--- a/src/service/cloudformation/command/describe-change-set/describe-change-set.handler.ts
+++ b/src/service/cloudformation/command/describe-change-set/describe-change-set.handler.ts
@@ -53,7 +53,7 @@ export class DescribeChangeSetCommandHandler implements CommandHandler<
     return {
       ChangeSetId: changeSet.changeSetId,
       ChangeSetName: changeSet.changeSetName,
-      StackId: changeSet.stackName,
+      StackId: changeSet.stackId,
       StackName: changeSet.stackName,
       Description: changeSet.description,
       Status: changeSet.status,

--- a/src/service/cloudformation/command/describe-stacks/describe-stacks.handler.ts
+++ b/src/service/cloudformation/command/describe-stacks/describe-stacks.handler.ts
@@ -11,11 +11,13 @@ import type {
   SimDescribeStacksCommand,
   SimDescribeStacksCommandOutput,
 } from "./describe-stacks.command.js";
+import type { SimCfnDeletedStacks } from "../../stack/sim-cfn-deleted-stacks.js";
 import { SimCfnStackDescriber } from "./sim-cfn-stack-describer.js";
 import { SimCfnDescribedStacks } from "./sim-cfn-described-stacks.js";
 
 interface DescribeStacksCommandHandlerProperties {
   readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  readonly deleted: SimCfnDeletedStacks;
   readonly background?: BackgroundScheduler;
   readonly describer?: SimCfnStackDescriber;
 }
@@ -30,17 +32,20 @@ export class DescribeStacksCommandHandler implements CommandHandler<
   SimDescribeStacksCommandOutput
 > {
   private readonly stacks: Map<SimCloudFormationStackName, SimCfnStack>;
+  private readonly deleted: SimCfnDeletedStacks;
   private readonly background: BackgroundScheduler;
   private readonly describer: SimCfnStackDescriber;
 
   constructor(properties: DescribeStacksCommandHandlerProperties) {
     const {
       stacks,
+      deleted,
       background = new BackgroundTasks(),
       describer = new SimCfnStackDescriber(),
     } = properties;
 
     this.stacks = stacks;
+    this.deleted = deleted;
     this.background = background;
     this.describer = describer;
   }
@@ -54,13 +59,12 @@ export class DescribeStacksCommandHandler implements CommandHandler<
     // Allow for potential non-deterministic sequencing of async events.
     await this.background.sequence();
 
-    const stackName = command.input.StackName as
-      | SimCloudFormationStackName
-      | undefined;
-
     return {
-      Stacks: new SimCfnDescribedStacks(this.stacks)
-        .matching(stackName)
+      Stacks: new SimCfnDescribedStacks({
+        stacks: this.stacks,
+        deleted: this.deleted,
+      })
+        .matching(command.input.StackName)
         .map((stack) => this.describer.describe(stack)),
       $metadata: {},
     };

--- a/src/service/cloudformation/command/describe-stacks/describe-stacks.iso.test.ts
+++ b/src/service/cloudformation/command/describe-stacks/describe-stacks.iso.test.ts
@@ -47,21 +47,18 @@ describe("CloudFormation DescribeStacksCommand", () => {
     // Then all existing Stacks are returned in creation order.
     assertArrayLength(describeStacksOutput.Stacks, 3);
 
-    assertIdentical(describeStacksOutput.Stacks[0].StackId, "stack-a");
     assertIdentical(describeStacksOutput.Stacks[0].StackName, "stack-a");
     assertIdentical(
       describeStacksOutput.Stacks[0].StackStatus,
       "CREATE_IN_PROGRESS",
     );
 
-    assertIdentical(describeStacksOutput.Stacks[1].StackId, "stack-b");
     assertIdentical(describeStacksOutput.Stacks[1].StackName, "stack-b");
     assertIdentical(
       describeStacksOutput.Stacks[1].StackStatus,
       "CREATE_IN_PROGRESS",
     );
 
-    assertIdentical(describeStacksOutput.Stacks[2].StackId, "stack-c");
     assertIdentical(describeStacksOutput.Stacks[2].StackName, "stack-c");
     assertIdentical(
       describeStacksOutput.Stacks[2].StackStatus,
@@ -98,7 +95,6 @@ describe("CloudFormation DescribeStacksCommand", () => {
     // Then only the matching Stack description is returned.
     assertArrayLength(describeStacksOutput.Stacks, 1);
 
-    assertIdentical(describeStacksOutput.Stacks[0].StackId, "stack-b");
     assertIdentical(describeStacksOutput.Stacks[0].StackName, "stack-b");
     assertIdentical(
       describeStacksOutput.Stacks[0].StackStatus,
@@ -131,7 +127,6 @@ describe("CloudFormation DescribeStacksCommand", () => {
     // Then the Stack description includes the completed Stack status.
     assertArrayLength(describeStacksOutput.Stacks, 1);
 
-    assertIdentical(describeStacksOutput.Stacks[0].StackId, "test-stack");
     assertIdentical(describeStacksOutput.Stacks[0].StackName, "test-stack");
     assertIdentical(
       describeStacksOutput.Stacks[0].StackStatus,

--- a/src/service/cloudformation/command/describe-stacks/sim-cfn-described-stacks.ts
+++ b/src/service/cloudformation/command/describe-stacks/sim-cfn-described-stacks.ts
@@ -2,7 +2,14 @@ import type {
   SimCfnStack,
   SimCloudFormationStackName,
 } from "../../stack/sim-cfn-stack.js";
+import type { SimCfnDeletedStacks } from "../../stack/sim-cfn-deleted-stacks.js";
+import { isSimCfnStackId } from "../../stack/sim-cfn-stack-id.js";
 import { SimCloudFormationValidationError } from "../../error/sim-cloudformation.error.js";
+
+interface SimCfnDescribedStacksProperties {
+  readonly stacks: ReadonlyMap<SimCloudFormationStackName, SimCfnStack>;
+  readonly deleted: SimCfnDeletedStacks;
+}
 
 /**
  * Chooses which Stacks a DescribeStacks request is about.
@@ -15,28 +22,32 @@ import { SimCloudFormationValidationError } from "../../error/sim-cloudformation
  * request handling to the command handler.
  */
 export class SimCfnDescribedStacks {
-  constructor(
-    private readonly stacks: ReadonlyMap<
-      SimCloudFormationStackName,
-      SimCfnStack
-    >,
-  ) {}
+  private readonly stacks: ReadonlyMap<SimCloudFormationStackName, SimCfnStack>;
+  private readonly deleted: SimCfnDeletedStacks;
+
+  constructor(properties: SimCfnDescribedStacksProperties) {
+    this.stacks = properties.stacks;
+    this.deleted = properties.deleted;
+  }
 
   /**
    * The Stacks to describe for a request naming this Stack, or all of them if
    * it names none.
    *
-   * A named Stack that is not there is refused with the ValidationError
-   * CloudFormation answers with. A deleted Stack name reaches this too:
-   * CloudFormation only describes a deleted Stack by its unique Stack ID, and
-   * answers its name the same way as a name that never existed.
+   * `StackName` carries either a Stack name or a Stack ID, as it does in
+   * CloudFormation, and a Stack ID reaches a deleted Stack as well as a live
+   * one. A deleted Stack's name does not: the name is back in circulation, and
+   * is refused the same way as a name that never existed.
+   *
+   * An unnamed request answers with the live Stacks alone. CloudFormation
+   * leaves deleted Stacks out of it too.
    */
-  matching(stackName: SimCloudFormationStackName | undefined): SimCfnStack[] {
+  matching(stackName: string | undefined): SimCfnStack[] {
     if (stackName === undefined) {
       return this.stacks.values().toArray();
     }
 
-    const stack = this.stacks.get(stackName);
+    const stack = this.find(stackName);
 
     if (stack === undefined) {
       throw new SimCloudFormationValidationError(
@@ -45,5 +56,17 @@ export class SimCfnDescribedStacks {
     }
 
     return [stack];
+  }
+
+  private find(stackName: string): SimCfnStack | undefined {
+    if (isSimCfnStackId(stackName)) {
+      return this.withStackId(stackName) ?? this.deleted.get(stackName);
+    }
+
+    return this.stacks.get(stackName as SimCloudFormationStackName);
+  }
+
+  private withStackId(stackId: string): SimCfnStack | undefined {
+    return this.stacks.values().find((stack) => stack.stackId === stackId);
   }
 }

--- a/src/service/cloudformation/command/describe-stacks/sim-cfn-stack-describer.ts
+++ b/src/service/cloudformation/command/describe-stacks/sim-cfn-stack-describer.ts
@@ -21,7 +21,7 @@ export class SimCfnStackDescriber {
    */
   describe(stack: SimCfnStack): SimCloudFormationStackDescription {
     return {
-      StackId: stack.stackName,
+      StackId: stack.stackId,
       StackName: stack.stackName,
       StackStatus: stack.status,
       StackStatusReason: stack.error?.message,

--- a/src/service/cloudformation/command/list-change-sets/list-change-sets.handler.ts
+++ b/src/service/cloudformation/command/list-change-sets/list-change-sets.handler.ts
@@ -53,7 +53,7 @@ export class ListChangeSetsCommandHandler implements CommandHandler<
       Summaries: this.changeSets.forStack(stackName).map((changeSet) => ({
         ChangeSetId: changeSet.changeSetId,
         ChangeSetName: changeSet.changeSetName,
-        StackId: changeSet.stackName,
+        StackId: changeSet.stackId,
         StackName: changeSet.stackName,
         Description: changeSet.description,
         Status: changeSet.status,

--- a/src/service/cloudformation/command/update-stack/update-stack.handler.ts
+++ b/src/service/cloudformation/command/update-stack/update-stack.handler.ts
@@ -109,6 +109,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
         simAws: this.simAws,
         accountRegionScope: this.accountRegionScope,
         stackName,
+        stackId: stack.stackId,
         templateBody: command.input.TemplateBody,
         input: command.input,
         exports: this.exports,
@@ -117,7 +118,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
     );
 
     return {
-      StackId: stack.stackName,
+      StackId: stack.stackId,
       $metadata: {},
     };
   }

--- a/src/service/cloudformation/parameters/pseudo/sim-cfn-pseudo-parameters.iso.test.ts
+++ b/src/service/cloudformation/parameters/pseudo/sim-cfn-pseudo-parameters.iso.test.ts
@@ -62,7 +62,7 @@ describe("sim CloudFormation pseudo parameters", () => {
     assertIdentical(resource.properties["Region"], "eu-west-2");
     assertIdentical(resource.properties["Partition"], "aws");
     assertIdentical(resource.properties["StackName"], "PseudoResourceStack");
-    assertIdentical(resource.properties["StackId"], "PseudoResourceStack");
+    assertIdentical(resource.properties["StackId"], stack.stackId);
     assertIdentical(resource.properties["NoValue"], "");
     assertIdentical(resource.properties["URLSuffix"], "sim-aws.localhost");
 
@@ -143,7 +143,7 @@ describe("sim CloudFormation pseudo parameters", () => {
     assertIdentical(stack.outputs.get("Region")?.value, "ap-southeast-2");
     assertIdentical(stack.outputs.get("Partition")?.value, "aws");
     assertIdentical(stack.outputs.get("StackName")?.value, "PseudoOutputStack");
-    assertIdentical(stack.outputs.get("StackId")?.value, "PseudoOutputStack");
+    assertIdentical(stack.outputs.get("StackId")?.value, stack.stackId);
     assertIdentical(stack.outputs.get("NoValue")?.value, "");
     assertIdentical(stack.outputs.get("URLSuffix")?.value, "sim-aws.localhost");
     assertIdentical(

--- a/src/service/cloudformation/parameters/pseudo/sim-cfn-pseudo-parameters.ts
+++ b/src/service/cloudformation/parameters/pseudo/sim-cfn-pseudo-parameters.ts
@@ -7,6 +7,13 @@ import { DEFAULT_SIM_AWS_REGION_NAME } from "../../../aws/sim-aws-region.js";
 interface SimCfnPseudoParametersProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
   readonly stackName?: string | undefined;
+
+  /**
+   * The Stack's unique ID, for a template being resolved for a Stack that has
+   * one. A template resolved outside a Stack has none, and reads `AWS::StackId`
+   * as the Stack name, which is the closest thing to an identity it has.
+   */
+  readonly stackId?: string | undefined;
 }
 
 /**
@@ -15,10 +22,12 @@ interface SimCfnPseudoParametersProperties {
 export class SimCfnPseudoParameters {
   private readonly accountRegionScope: SimAwsAccountRegionScope | undefined;
   private readonly stackName: string | undefined;
+  private readonly stackId: string | undefined;
 
   constructor(properties: SimCfnPseudoParametersProperties) {
     this.accountRegionScope = properties.accountRegionScope;
     this.stackName = properties.stackName;
+    this.stackId = properties.stackId;
   }
 
   /**
@@ -45,7 +54,7 @@ export class SimCfnPseudoParameters {
       }
 
       case "AWS::StackId": {
-        return this.stackName;
+        return this.stackId ?? this.stackName;
       }
 
       case "AWS::NotificationARNs": {

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -53,6 +53,7 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
       accountRegionScope = simAwsAccountRegionScopeFactory.make(),
       logicalId = "Resource",
       stackName,
+      stackId,
       template = {},
       parameters,
       resourceLogicalIds = new Set(),
@@ -75,6 +76,7 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
       pseudoParameters: new SimCfnPseudoParameters({
         accountRegionScope: this.accountRegionScope,
         stackName,
+        stackId,
       }),
       propertyIgnorer: this,
       resourceType: this.type,

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -15,6 +15,7 @@ export interface SimCloudFormationResourceProperties {
   readonly background?: BackgroundScheduler;
   readonly logicalId?: string;
   readonly stackName?: string | undefined;
+  readonly stackId?: string | undefined;
   readonly template?: SimCfnTemplateValueRecord;
   readonly cfnResourceFactory?: SimCfnServiceResourceFactory | undefined;
   readonly parameters?: SimCfnParameters | undefined;

--- a/src/service/cloudformation/sdk/sim-cloudformation-sdk-command-router.iso.test.ts
+++ b/src/service/cloudformation/sdk/sim-cloudformation-sdk-command-router.iso.test.ts
@@ -37,7 +37,7 @@ describe("simulated CloudFormation SDK Command routing", () => {
         }),
       }),
     );
-    assertIdentical(stackCreation.StackId, "intercepted-stack");
+    assertStringIncludes(stackCreation.StackId, ":stack/intercepted-stack/");
 
     // Stack creation returns before resources finish deploying.
     await simSdk.simAws
@@ -164,7 +164,7 @@ describe("simulated CloudFormation SDK Command routing", () => {
         }),
       }),
     );
-    assertIdentical(stackUpdate.StackId, "updatable-stack");
+    assertStringIncludes(stackUpdate.StackId, ":stack/updatable-stack/");
 
     await cloudFormation.waitForStackUpdateComplete("updatable-stack");
 

--- a/src/service/cloudformation/serve/sim-cfn-change-set-api.loc.test.ts
+++ b/src/service/cloudformation/serve/sim-cfn-change-set-api.loc.test.ts
@@ -16,6 +16,7 @@ import {
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
+  assertStringIncludes,
 } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
 
@@ -98,7 +99,7 @@ describe("Serving simulated CloudFormation change sets on an endpoint URL", () =
       }),
     );
     assertNonNullable(created.Id, "CreateChangeSet answered with an ARN");
-    assertIdentical(created.StackId, "site");
+    assertStringIncludes(created.StackId, ":stack/site/");
 
     // When it is described over the same endpoint
     const described = await client.send(
@@ -154,7 +155,7 @@ describe("Serving simulated CloudFormation change sets on an endpoint URL", () =
     // Then the executed one and the pending one are both there
     assertArrayLength(listed.Summaries, 2);
     assertIdentical(listed.Summaries[1].ChangeSetName, "site-rename");
-    assertIdentical(listed.Summaries[1].StackId, "site");
+    assertStringIncludes(listed.Summaries[1].StackId, ":stack/site/");
     assertIdentical(listed.Summaries[1].StackName, "site");
     assertIdentical(listed.Summaries[1].ExecutionStatus, "AVAILABLE");
 

--- a/src/service/cloudformation/serve/sim-cloudformation-api.loc.test.ts
+++ b/src/service/cloudformation/serve/sim-cloudformation-api.loc.test.ts
@@ -104,7 +104,7 @@ describe("Serving simulated CloudFormation on an endpoint URL", () => {
         ],
       }),
     );
-    assertIdentical(created.StackId, "site");
+    assertStringIncludes(created.StackId, ":stack/site/");
 
     // When the deployment the call started has finished
     await simAws.cloudFormation().waitForStackDeployComplete("site");
@@ -153,7 +153,7 @@ describe("Serving simulated CloudFormation on an endpoint URL", () => {
         ],
       }),
     );
-    assertIdentical(updated.StackId, "reports");
+    assertStringIncludes(updated.StackId, ":stack/reports/");
     await simAws.cloudFormation().waitForStackUpdateComplete("reports");
 
     // Then the Stack reports the update and the Bucket it now holds

--- a/src/service/cloudformation/sim-cloudformation.ts
+++ b/src/service/cloudformation/sim-cloudformation.ts
@@ -59,6 +59,7 @@ import type { SimCloudFormationDeployTemplateFileProperties as SimCloudFormation
 import type { SimCloudFormationDeployCdkOutProperties } from "./deploy/sim-cfn-cdk-out-deployer.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
 import { SimCfnExports } from "./export/sim-cfn-exports.js";
+import { SimCfnDeletedStacks } from "./stack/sim-cfn-deleted-stacks.js";
 import { SimCloudFormationSdkCommandRouter } from "./sdk/sim-cloudformation-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/index.js";
 import type { SimAwsCaller } from "../aws/caller/sim-aws-caller.js";
@@ -89,6 +90,7 @@ export class SimCloudFormation {
   private readonly simAws: SimAws;
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly stacks = new Map<SimCloudFormationStackName, SimCfnStack>();
+  private readonly deletedStacks = new SimCfnDeletedStacks();
   private readonly exports = new SimCfnExports();
   private readonly templateDeployer: SimCloudFormationTemplateDeployer;
   private readonly sdkRouter = new SimCloudFormationSdkCommandRouter(this);
@@ -161,11 +163,11 @@ export class SimCloudFormation {
     options?: SimCloudFormationRequestOptions,
   ): Promise<SimDescribeStacksCommandOutput> {
     this.authorization.describeStacks(command.input.StackName, options?.caller);
-    const handler = new DescribeStacksCommandHandler({
+    return await new DescribeStacksCommandHandler({
       stacks: this.stacks,
+      deleted: this.deletedStacks,
       background: this.background,
-    });
-    return await handler.handle(command);
+    }).handle(command);
   }
 
   /**
@@ -176,14 +178,13 @@ export class SimCloudFormation {
     options?: SimCloudFormationRequestOptions,
   ): Promise<SimUpdateStackCommandOutput> {
     this.authorization.updateStack(command.input.StackName, options?.caller);
-    const handler = new UpdateStackCommandHandler({
+    return await new UpdateStackCommandHandler({
       simAws: this.simAws,
       accountRegionScope: this.accountRegionScope,
       stacks: this.stacks,
       background: this.background,
       exports: this.exports,
-    });
-    return await handler.handle(command);
+    }).handle(command);
   }
 
   /**
@@ -194,11 +195,11 @@ export class SimCloudFormation {
     options?: SimCloudFormationRequestOptions,
   ): Promise<SimDeleteStackCommandOutput> {
     this.authorization.deleteStack(command.input.StackName, options?.caller);
-    const handler = new DeleteStackCommandHandler({
+    return await new DeleteStackCommandHandler({
       stacks: this.stacks,
+      deleted: this.deletedStacks,
       background: this.background,
-    });
-    return await handler.handle(command);
+    }).handle(command);
   }
 
   /**

--- a/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-map.ts
+++ b/src/service/cloudformation/stack/resource-map/sim-cfn-stack-resource-map.ts
@@ -31,6 +31,7 @@ export function makeSimCfnStackResourceMap(
         background,
         logicalId: resourceTemplate.logicalId,
         stackName: template.stackName,
+        stackId: template.stackId,
         template: resourceTemplate.template,
         parameters: template.parameters,
         resourceLogicalIds,

--- a/src/service/cloudformation/stack/sim-cfn-deleted-stacks.ts
+++ b/src/service/cloudformation/stack/sim-cfn-deleted-stacks.ts
@@ -1,0 +1,28 @@
+import type { SimCfnStack } from "./sim-cfn-stack.js";
+import type { SimCfnStackId } from "./sim-cfn-stack-id.js";
+
+/**
+ * The Stacks that have finished deleting, kept by Stack ID.
+ *
+ * A deleted Stack gives its name back, so the map of live Stacks can no longer
+ * hold it: the next Stack of that name is a different Stack. CloudFormation
+ * still answers `DescribeStacks` for it by its Stack ID, for 90 days, and this
+ * is where the Stack it answers with is kept.
+ *
+ * Nothing expires here. A simulation lasts a test rather than three months, so
+ * a deleted Stack stays readable for as long as the simulated CloudFormation
+ * it was deleted from does.
+ */
+export class SimCfnDeletedStacks {
+  private readonly stacks = new Map<SimCfnStackId, SimCfnStack>();
+
+  /** Keep a Stack that has finished deleting, so its ID still describes it. */
+  record(stack: SimCfnStack): void {
+    this.stacks.set(stack.stackId, stack);
+  }
+
+  /** The deleted Stack with this Stack ID, if one was deleted under it. */
+  get(stackId: string): SimCfnStack | undefined {
+    return this.stacks.get(stackId as SimCfnStackId);
+  }
+}

--- a/src/service/cloudformation/stack/sim-cfn-deployed-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-deployed-stack.type.ts
@@ -19,6 +19,13 @@ export interface SimCfnDeployedStack {
   /** What the Stack was deployed as. */
   readonly stackName: string;
 
+  /**
+   * The Stack's unique ID, which is the ARN CloudFormation gave it when it was
+   * created. A Stack deployed again under the same name gets a new one, and a
+   * deleted Stack is described by this rather than by the name it gave back.
+   */
+  readonly stackId: string;
+
   /** What CloudFormation last did to the Stack. */
   readonly status: SimCloudFormationStackStatus;
 

--- a/src/service/cloudformation/stack/sim-cfn-stack-id.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-id.iso.test.ts
@@ -1,0 +1,237 @@
+import { describe, it } from "vitest";
+import { faker } from "@faker-js/faker";
+import {
+  assertArrayLength,
+  assertFalse,
+  assertIdentical,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertStringStartsWith,
+  assertThrowsErrorAsync,
+  assertUuidV4,
+} from "@kensio/smartass";
+import {
+  CreateChangeSetCommand,
+  CreateStackCommand,
+  DeleteStackCommand,
+  DescribeChangeSetCommand,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simAwsAccountRegionScopeFactory } from "../../aws/sim-aws-account-region-scope.factory.js";
+import { SimCloudFormationValidationError } from "../error/sim-cloudformation.error.js";
+import { jsonStringify } from "../../../util/type-guard/json.js";
+
+describe("sim CloudFormation Stack IDs", () => {
+  it("gives a created Stack an ARN Stack ID in its own scope", async () => {
+    // Given a simulated CloudFormation in an Account and Region of its own.
+    const { accountId, regionName } = simAwsAccountRegionScopeFactory.make();
+    const simAws = new SimAws();
+    const cloudFormation = simAws
+      .account(accountId)
+      .region(regionName)
+      .cloudFormation();
+    const stackName = `orders-${faker.string.alphanumeric(8)}`;
+
+    // When a Stack is created there.
+    const stackCreation = await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: stackName,
+        TemplateBody: jsonStringify({ Resources: {} }),
+      }),
+    );
+
+    // Then it was given the ARN CloudFormation shapes a Stack ID as, naming
+    // the Account and Region it was created in, and DescribeStacks reports it.
+    const stackIdPrefix = `arn:aws:cloudformation:${regionName}:${accountId}:stack/${stackName}/`;
+
+    assertStringStartsWith(stackCreation.StackId, stackIdPrefix);
+    assertUuidV4(stackCreation.StackId.slice(stackIdPrefix.length));
+
+    const described = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: stackName }),
+    );
+
+    assertArrayLength(described.Stacks, 1);
+    assertIdentical(described.Stacks[0].StackId, stackCreation.StackId);
+  });
+
+  it("gives a Stack deployed again under a freed name a new Stack ID", async () => {
+    // Given a Stack that was deployed, deleted, and deployed again as itself.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const stackName = `billing-${faker.string.alphanumeric(8)}`;
+    const template = jsonStringify({ Resources: {} });
+
+    const firstDeployment = await cloudFormation.createStack(
+      new CreateStackCommand({ StackName: stackName, TemplateBody: template }),
+    );
+
+    await cloudFormation.deleteStack(
+      new DeleteStackCommand({ StackName: stackName }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When the freed name is used again.
+    const secondDeployment = await cloudFormation.createStack(
+      new CreateStackCommand({ StackName: stackName, TemplateBody: template }),
+    );
+
+    // Then the second Stack is a different Stack, rather than the first one
+    // under a name it happens to share.
+    assertFalse(secondDeployment.StackId === firstDeployment.StackId);
+  });
+
+  it("resolves AWS::StackId to the Stack ID and AWS::StackName to the name", async () => {
+    // Given a template reading both of the pseudo parameters that name a Stack.
+    const simAws = new SimAws();
+    const stackName = `catalogue-${faker.string.alphanumeric(8)}`;
+
+    // When it is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName,
+      template: {
+        Resources: {
+          Handle: { Type: "AWS::CloudFormation::WaitConditionHandle" },
+        },
+        Outputs: {
+          Id: { Value: { Ref: "AWS::StackId" } },
+          Name: { Value: { Ref: "AWS::StackName" } },
+        },
+      },
+    });
+
+    // Then the two resolve to different things, where they used to be the same
+    // value under two names.
+    assertIdentical(stack.output("Id"), stack.stackId);
+    assertIdentical(stack.output("Name"), stackName);
+  });
+
+  it("gives the Stack a CREATE change set reviews its Stack ID", async () => {
+    // Given a change set that brings a Stack into being in review.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const stackName = `planned-${faker.string.alphanumeric(8)}`;
+
+    const changeSet = await cloudFormation.createChangeSet(
+      new CreateChangeSetCommand({
+        StackName: stackName,
+        ChangeSetName: "first-plan",
+        ChangeSetType: "CREATE",
+        TemplateBody: jsonStringify({
+          Resources: {},
+          Outputs: { Id: { Value: { Ref: "AWS::StackId" } } },
+        }),
+      }),
+    );
+
+    // When the Stack the change set is held against is described.
+    const described = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: stackName }),
+    );
+
+    // Then the change set and the Stack in review name the same Stack ID.
+    assertStringIncludes(changeSet.StackId, `:stack/${stackName}/`);
+    assertArrayLength(described.Stacks, 1);
+    assertIdentical(described.Stacks[0].StackId, changeSet.StackId);
+
+    const describedChangeSet = await cloudFormation.describeChangeSet(
+      new DescribeChangeSetCommand({
+        StackName: stackName,
+        ChangeSetName: "first-plan",
+      }),
+    );
+
+    assertIdentical(describedChangeSet.StackId, changeSet.StackId);
+  });
+
+  it("describes a live Stack by its Stack ID", async () => {
+    // Given a deployed Stack, alongside another that could be answered instead.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    const stack = await cloudFormation.deployTemplate({
+      stackName: `reports-${faker.string.alphanumeric(8)}`,
+      template: { Resources: {} },
+    });
+    await cloudFormation.deployTemplate({
+      stackName: `reports-${faker.string.alphanumeric(8)}`,
+      template: { Resources: {} },
+    });
+
+    // When DescribeStacks is given the Stack ID rather than the Stack name.
+    const described = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: stack.stackId }),
+    );
+
+    // Then it describes that Stack.
+    assertArrayLength(described.Stacks, 1);
+    assertIdentical(described.Stacks[0].StackName, stack.stackName);
+    assertIdentical(described.Stacks[0].StackId, stack.stackId);
+  });
+
+  it("describes a deleted Stack by its Stack ID", async () => {
+    // Given a Stack with an Output that has finished deleting.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const stackName = `archive-${faker.string.alphanumeric(8)}`;
+    const queueName = `archive-queue-${faker.string.alphanumeric(8)}`;
+
+    const stack = await cloudFormation.deployTemplate({
+      stackName,
+      template: {
+        Resources: {
+          Queue: {
+            Type: "AWS::SQS::Queue",
+            Properties: { QueueName: queueName },
+          },
+        },
+        Outputs: { QueueUrl: { Value: { Ref: "Queue" } } },
+      },
+    });
+
+    await cloudFormation.deleteStack(
+      new DeleteStackCommand({ StackName: stackName }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When DescribeStacks is given the Stack ID it was deleted under.
+    const described = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: stack.stackId }),
+    );
+
+    // Then the Stack is still readable, with what it finished with.
+    assertArrayLength(described.Stacks, 1);
+    assertIdentical(described.Stacks[0].StackStatus, "DELETE_COMPLETE");
+    assertIdentical(described.Stacks[0].StackName, stackName);
+    assertArrayLength(described.Stacks[0].Outputs, 1);
+    assertStringIncludes(described.Stacks[0].Outputs[0].OutputValue, queueName);
+  });
+
+  it("refuses to describe a deleted Stack by name", async () => {
+    // Given a Stack that has finished deleting, so its name is free again.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const stackName = `retired-${faker.string.alphanumeric(8)}`;
+
+    await cloudFormation.deployTemplate({
+      stackName,
+      template: { Resources: {} },
+    });
+    await cloudFormation.deleteStack(
+      new DeleteStackCommand({ StackName: stackName }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // When DescribeStacks is given the name rather than the Stack ID, then it
+    // is refused the way a name that never existed is.
+    const error = await assertThrowsErrorAsync(async () =>
+      cloudFormation.describeStacks(
+        new DescribeStacksCommand({ StackName: stackName }),
+      ),
+    );
+
+    assertInstanceOf(error, SimCloudFormationValidationError);
+    assertIdentical(error.message, `Stack with id ${stackName} does not exist`);
+  });
+});

--- a/src/service/cloudformation/stack/sim-cfn-stack-id.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-id.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from "node:crypto";
+import type { Brand } from "../../../util/brand.type.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { parseSimArn } from "../../aws/arn.js";
+
+/**
+ * The unique ID CloudFormation gives a Stack when it creates it.
+ *
+ * An ARN rather than a name, and a new one every time a Stack of that name is
+ * created, which is what lets a deleted Stack still be told apart from the one
+ * that took its name.
+ */
+export type SimCfnStackId = Brand<string, "SimCfnStackId">;
+
+interface SimCfnStackIdProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly stackName: string;
+}
+
+/**
+ * Make the Stack ID for a Stack being created.
+ *
+ * The Account and Region are the ones the Stack is being created in, and the
+ * UUID on the end is what makes this Stack a different Stack from the last one
+ * of the same name.
+ */
+export function makeSimCfnStackId(
+  properties: SimCfnStackIdProperties,
+): SimCfnStackId {
+  const { accountRegionScope, stackName } = properties;
+  const { accountId, regionName } = accountRegionScope;
+
+  return `arn:aws:cloudformation:${regionName}:${accountId}:stack/${stackName}/${randomUUID()}` as SimCfnStackId;
+}
+
+/**
+ * Whether a value naming a Stack is a Stack ID rather than a Stack name.
+ *
+ * `DescribeStacks` takes either in `StackName`, so what a caller gave has to be
+ * read before it can be looked up.
+ */
+export function isSimCfnStackId(value: string): boolean {
+  const arn = parseSimArn(value);
+
+  return arn?.service === "cloudformation" && arn.resourceType === "stack";
+}

--- a/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.iso.test.ts
@@ -26,7 +26,7 @@ describe("SimCfnStack", () => {
     );
     const stack = cloudFormation.getStackByName("TestStack");
 
-    assertIdentical(stackCreation.StackId, "TestStack");
+    assertStringIncludes(stackCreation.StackId, ":stack/TestStack/");
     assertIdentical(stack?.status, "CREATE_IN_PROGRESS");
 
     await simAws.backgroundTasksComplete();

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -21,6 +21,7 @@ import { SimCfnStackOutputLookup } from "./output/sim-cfn-stack-output-lookup.js
 import { SimCfnStackResourceReport } from "./report/sim-cfn-stack-resource-report.js";
 import { SimCfnStackOperationStatus } from "./status/sim-cfn-stack-operation-status.js";
 import { validateSimCfnExecutableResourceBindings } from "../bind/validate/sim-cfn-exec-binding-validator.js";
+import type { SimCfnStackId } from "./sim-cfn-stack-id.js";
 import type {
   SimCloudFormationStackProperties,
   SimCloudFormationStackStatus,
@@ -48,6 +49,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
   public readonly updating: SimCfnStackUpdateLifecycle;
   public readonly deletion: SimCfnStackDeletionLifecycle;
   public readonly stackName: SimCloudFormationStackName;
+  public readonly stackId: SimCfnStackId;
   public readonly resourceMap: Map<string, SimCfnResource>;
   public outputs = new Map<string, SimCfnStackOutput>();
 
@@ -63,6 +65,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
       accountRegionScope,
       background,
       stackName,
+      stackId,
       template,
       cdkOutContext,
       bindings,
@@ -73,6 +76,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
 
     this.background = background;
     this.stackName = stackName;
+    this.stackId = stackId;
     this.stackOutputs = new SimCfnStackOutputs({ stackName, exports });
     this.cfnTemplate = template;
     this.resourceMap = makeSimCfnStackResourceMap({

--- a/src/service/cloudformation/stack/sim-cfn-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.type.ts
@@ -8,6 +8,7 @@ import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
 import type { SimCfnResourceOrder } from "./deploy/sim-cfn-resource-order.js";
+import type { SimCfnStackId } from "./sim-cfn-stack-id.js";
 
 export type SimCloudFormationStackName = Brand<
   string,
@@ -47,6 +48,13 @@ export interface SimCloudFormationStackProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly background: BackgroundScheduler;
   readonly stackName: SimCloudFormationStackName;
+
+  /**
+   * The unique ID this Stack was created with, which is what a deleted Stack
+   * is still described by once its name has gone back into circulation.
+   */
+  readonly stackId: SimCfnStackId;
+
   readonly template: SimCfnTemplate;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;

--- a/src/service/cloudformation/template/sim-cfn-command-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-command-template.ts
@@ -11,6 +11,10 @@ interface SimCfnCommandTemplateProperties {
   readonly simAws: SimAws;
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly stackName: SimCloudFormationStackName;
+
+  /** The ID of the Stack the template is for, where the Stack has one yet. */
+  readonly stackId?: string | undefined;
+
   readonly templateBody: string;
 
   /** The command input the template's Parameter values are read from. */
@@ -29,10 +33,12 @@ interface SimCfnCommandTemplateProperties {
 export function simCfnCommandTemplate(
   properties: SimCfnCommandTemplateProperties,
 ): SimCfnTemplate {
-  const { simAws, accountRegionScope, stackName, exports } = properties;
+  const { simAws, accountRegionScope, stackName, stackId, exports } =
+    properties;
 
   return SimCfnTemplate.fromTemplateBody(properties.templateBody, {
     stackName,
+    stackId,
     parameters: SimCfnParameters.fromInput(properties.input, {
       stackName,
       parameterStore: makeSimCfnParameterStore({ simAws, accountRegionScope }),

--- a/src/service/cloudformation/template/sim-cfn-template.ts
+++ b/src/service/cloudformation/template/sim-cfn-template.ts
@@ -53,12 +53,14 @@ interface SimCfnTemplateProperties {
   readonly template: CfnTemplateBodyRecord;
   readonly parameters?: SimCfnParameters | undefined;
   readonly stackName?: string | undefined;
+  readonly stackId?: string | undefined;
   readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
   readonly exports?: SimCfnExports | undefined;
 }
 
 interface SimCfnTemplateFromBodyProperties {
   readonly stackName?: string | undefined;
+  readonly stackId?: string | undefined;
   readonly parameters?: SimCfnParameters | undefined;
   readonly accountRegionScope?: SimAwsAccountRegionScope | undefined;
   readonly exports?: SimCfnExports | undefined;
@@ -72,6 +74,8 @@ interface SimCfnTemplateFromBodyProperties {
 export class SimCfnTemplate {
   public readonly template: CfnTemplateBodyRecord;
   public readonly stackName: string | undefined;
+  /** The unique ID of the Stack this template is being deployed as. */
+  public readonly stackId: string | undefined;
   public readonly parameters: SimCfnParameters;
   /** The export names a Stack deployed from this template can import. */
   public readonly exports: SimCfnExports | undefined;
@@ -79,11 +83,18 @@ export class SimCfnTemplate {
   private evaluatedConditions: SimCfnConditions | undefined;
 
   constructor(properties: SimCfnTemplateProperties) {
-    const { template, parameters, stackName, accountRegionScope, exports } =
-      properties;
+    const {
+      template,
+      parameters,
+      stackName,
+      stackId,
+      accountRegionScope,
+      exports,
+    } = properties;
 
     this.template = template;
     this.stackName = stackName;
+    this.stackId = stackId;
     this.accountRegionScope = accountRegionScope;
     this.exports = exports;
 
@@ -118,6 +129,7 @@ export class SimCfnTemplate {
       template: samExpandedTemplate(template),
       parameters: properties.parameters,
       stackName: properties.stackName,
+      stackId: properties.stackId,
       accountRegionScope: properties.accountRegionScope,
       exports: properties.exports,
     });
@@ -200,6 +212,7 @@ export class SimCfnTemplate {
     return new SimCfnPseudoParameters({
       accountRegionScope: this.accountRegionScope,
       stackName: this.stackName,
+      stackId: this.stackId,
     });
   }
 


### PR DESCRIPTION
A stack is created with an ARN stack ID in the shape CloudFormation gives one, built from the account and region the stack deploys into and a UUID of its own. `AWS::StackId` resolves to it, the stack and change set commands answer with it, and `DescribeStacks` takes either a stack name or a stack ID in `StackName`. A stack that has finished deleting keeps its ID and stays describable by it, reporting `DELETE_COMPLETE` and the Outputs it had, while its name goes free for the next stack. Describing a deleted stack by name is still refused, as it is in AWS.

A second commit rations CodeRabbit reviews, which is unrelated to the issue and rides along here. CodeRabbit no longer reviews a pull request for being opened. The Review workflow labels a pull request `review-ready` when it is neither a documentation change nor under 500 lines, and that label is what asks for the review.

Resolves #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)