### PR TITLE
feat: apply Function URL CORS configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
 
 .worktrees/
+.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,5 @@ test/terraform/**/builds/
 test/terraform/**/terraform.tfstate*
 test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
+
+.worktrees/

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2507,8 +2507,7 @@ time window gets `OFF`.
 once, and a failed one is recorded by the rule or the schedule that made it.
 
 A `FunctionUrlConfig` on the function expands into an `AWS::Lambda::Url` named after it, `RatesUrl`
-for a function called `Rates`. `AuthType` and `InvokeMode` carry over. `Cors` is left out (the
-simulated Function URL answers no preflight request).
+for a function called `Rates`. `AuthType`, `InvokeMode` and `Cors` carry over.
 
 ### Queue, stream, topic and bucket events
 

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2364,10 +2364,114 @@ the route key, the stage and the path parameters are the endpoint's rather than 
 ### Managing a Function URL
 
 `GetFunctionUrlConfigCommand` reads the configuration back, `UpdateFunctionUrlConfigCommand`
-changes the `AuthType` or `InvokeMode` while keeping the same endpoint, and
+changes the `AuthType`, `InvokeMode` or `Cors` while keeping the same endpoint, and
 `DeleteFunctionUrlConfigCommand` removes it, after which the hostname stops resolving and returns
 `404`. `ListFunctionUrlConfigsCommand` lists what a function has, which is one configuration or
 none, since a function has at most one Function URL.
+
+A `Cors` block on an update replaces the whole block the URL was created with. An update that leaves
+`Cors` out keeps the block already in place.
+
+### Cross-origin resource sharing
+
+A Function URL created with a `Cors` block sends the CORS headers that block describes on every
+response it serves, and answers a browser preflight from the block alone.
+
+```typescript sim-lambda-function-url-cors
+/**
+ * Serving a simulated Lambda Function URL configured for CORS.
+ */
+
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "rates",
+    Role: "arn:aws:iam::111111111111:role/RatesRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ gbp: 1.27 }),
+      })),
+    },
+  }),
+);
+
+const urlConfig = await lambda.createFunctionUrlConfig(
+  new CreateFunctionUrlConfigCommand({
+    FunctionName: "rates",
+    AuthType: "NONE",
+    Cors: {
+      AllowOrigins: ["https://shop.example.com"],
+      AllowMethods: ["GET", "POST"],
+      AllowHeaders: ["content-type"],
+      ExposeHeaders: ["x-request-id"],
+      AllowCredentials: true,
+      MaxAge: 600,
+    },
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const endpoint = srv.localUrl(urlConfig.FunctionUrl);
+
+try {
+  const preflight = await fetch(endpoint, {
+    method: "OPTIONS",
+    headers: {
+      origin: "https://shop.example.com",
+      "access-control-request-method": "GET",
+    },
+  });
+
+  // 200 https://shop.example.com GET,POST
+  console.log(
+    preflight.status,
+    preflight.headers.get("access-control-allow-origin"),
+    preflight.headers.get("access-control-allow-methods"),
+  );
+
+  const response = await fetch(endpoint, {
+    headers: { origin: "https://shop.example.com" },
+  });
+
+  // {"gbp":1.27} x-request-id
+  console.log(
+    await response.text(),
+    response.headers.get("access-control-expose-headers"),
+  );
+} finally {
+  await srv.close();
+}
+```
+
+`AllowOrigins` decides what goes in `Access-Control-Allow-Origin`. A list holding `*` allows every
+Origin. Any other list is matched against the `Origin` header the request carried, and a request
+from an Origin the list does not name gets no `Access-Control-Allow-Origin` header. `AllowMethods`,
+`AllowHeaders` and `ExposeHeaders` each go out as one comma-separated header, and an empty list
+leaves its header off. `AllowCredentials` sends `Access-Control-Allow-Credentials: true` when it is
+set. `MaxAge` sets `Access-Control-Max-Age` in seconds.
+
+A preflight is an `OPTIONS` request carrying both `Origin` and `Access-Control-Request-Method`.
+Lambda answers it from the configuration and the function never runs. Every other method reaches the
+handler, and the configured headers are added to the response it returned. A handler that sends CORS
+headers of its own leaves the response carrying both values, which is what real Lambda serves.
+Browsers report the duplicate as an error, so keep CORS on the Function URL and leave it out of the
+handler.
+
+An `AWS_IAM` Function URL authorizes a preflight the way it authorizes any other request. A browser
+cannot sign the preflight it sends, and an unsigned request to that URL is answered with `403`.
 
 ### IAM-authenticated Function URLs
 
@@ -3539,6 +3643,8 @@ Sim Lambda currently supports:
   event to a simulated SQS queue or SNS topic
 - Function URLs, created with `CreateFunctionUrlConfigCommand` and served over HTTP on localhost
   with `serveSimAws`
+- `Cors` on a Function URL, adding the configured headers to every response and answering a browser
+  preflight without invoking the function
 - `iam:PassRole` authorization of the execution role named by `CreateFunctionCommand` and
   `UpdateFunctionConfigurationCommand`, with `iam:PassedToService` supplied
 - `AuthType: "AWS_IAM"` Function URLs, authorizing `lambda:InvokeFunctionUrl` against the caller
@@ -3638,7 +3744,9 @@ Current documented limitations:
 - `requestContext.authorizer.iam` reports `accessKey` as empty, and `callerId` and `userId` as the
   caller ARN rather than the opaque unique id real AWS uses. `cognitoIdentity` and `principalOrgId`
   are always null.
-- The Function URL `Cors` configuration is left out, including OPTIONS preflight handling.
+- A Function URL's `Cors` block is checked against the bounds the Lambda API documents for each
+  member. Values inside those bounds are taken as they are. An `AllowOrigins` entry that is not a
+  well-formed Origin is stored and matches no request.
 - `InvokeMode: "RESPONSE_STREAM"` is accepted and reported, but responses are always served
   buffered.
 - A function has at most one Function URL, and qualified (version or alias) Function URLs are left

--- a/docs/services/lambda/sim-lambda-function-url-cors.example.ts
+++ b/docs/services/lambda/sim-lambda-function-url-cors.example.ts
@@ -1,0 +1,76 @@
+/**
+ * Serving a simulated Lambda Function URL configured for CORS.
+ */
+
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "rates",
+    Role: "arn:aws:iam::111111111111:role/RatesRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ gbp: 1.27 }),
+      })),
+    },
+  }),
+);
+
+const urlConfig = await lambda.createFunctionUrlConfig(
+  new CreateFunctionUrlConfigCommand({
+    FunctionName: "rates",
+    AuthType: "NONE",
+    Cors: {
+      AllowOrigins: ["https://shop.example.com"],
+      AllowMethods: ["GET", "POST"],
+      AllowHeaders: ["content-type"],
+      ExposeHeaders: ["x-request-id"],
+      AllowCredentials: true,
+      MaxAge: 600,
+    },
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+const endpoint = srv.localUrl(urlConfig.FunctionUrl);
+
+try {
+  const preflight = await fetch(endpoint, {
+    method: "OPTIONS",
+    headers: {
+      origin: "https://shop.example.com",
+      "access-control-request-method": "GET",
+    },
+  });
+
+  // 200 https://shop.example.com GET,POST
+  console.log(
+    preflight.status,
+    preflight.headers.get("access-control-allow-origin"),
+    preflight.headers.get("access-control-allow-methods"),
+  );
+
+  const response = await fetch(endpoint, {
+    headers: { origin: "https://shop.example.com" },
+  });
+
+  // {"gbp":1.27} x-request-id
+  console.log(
+    await response.text(),
+    response.headers.get("access-control-expose-headers"),
+  );
+} finally {
+  await srv.close();
+}

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-url.iso.test.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-url.iso.test.ts
@@ -3,6 +3,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertObjectEquals,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -56,6 +57,39 @@ describe("SAM function FunctionUrlConfig expansion", () => {
     );
 
     assertIdentical(await response.text(), "rates at /rates");
+  });
+
+  it("carries the config's CORS settings over to the URL", async () => {
+    // Given a SAM function whose Function URL config allows one Origin
+    const simAws = new SimAws();
+
+    // When it is deployed
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "rates-cors-stack",
+      template: simCfnSamFunctionTemplateFactory.make({
+        functionProperties: {
+          FunctionUrlConfig: {
+            AuthType: "NONE",
+            Cors: {
+              AllowOrigins: ["https://rates.example.com"],
+              AllowMethods: ["GET"],
+              MaxAge: 300,
+            },
+          },
+        },
+      }),
+    });
+
+    // Then the expanded Function URL holds them
+    const functionUrl = stack.getResource(
+      `${samFunctionTemplateLogicalId}Url`,
+    )?.simResource;
+    assertInstanceOf(functionUrl, SimLambdaFunctionUrl);
+    assertObjectEquals(functionUrl.cors, {
+      AllowOrigins: ["https://rates.example.com"],
+      AllowMethods: ["GET"],
+      MaxAge: 300,
+    });
   });
 
   it("leaves a function stating no URL config without one", async () => {

--- a/src/service/cloudformation/sam/function/sim-cfn-sam-function-url.ts
+++ b/src/service/cloudformation/sam/function/sim-cfn-sam-function-url.ts
@@ -13,11 +13,8 @@ interface SamFunctionUrlProperties {
 
 /**
  * The `FunctionUrlConfig` properties the AWS::Lambda::Url carries over.
- *
- * `Cors` is left out. The simulated Function URL answers no preflight request,
- * and carrying the property over would say it did.
  */
-const carriedNames = new Set(["AuthType", "InvokeMode"]);
+const carriedNames = new Set(["AuthType", "InvokeMode", "Cors"]);
 
 /**
  * The AWS::Lambda::Url a function's `FunctionUrlConfig` is expanded into.

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -633,6 +633,29 @@ The endpoint's own error responses (403 for a denied caller, 404 for an unknown 
 for a handler error) are AWS-shaped JSON documents. The 403 body is real Lambda's wording; the other
 two are approximations.
 
+### CORS
+
+`SimLambdaUrlCorsHeaders` (`serve/response/`) turns a URL's `Cors` block into headers. The
+controller uses it around the invocation, after the auth type has had its say. A preflight (an
+`OPTIONS` request carrying `Origin` and `Access-Control-Request-Method`) is answered from the
+configuration and the function never runs. Any other request reaches the handler and has the
+configured headers appended to whatever it returned, so a handler sending its own CORS header leaves
+the response carrying both values, which is what AWS documents.
+
+Ordering CORS after authorization is a deliberate call. A browser cannot sign a preflight, so an
+`AWS_IAM` URL answers one with 403. Answering the preflight first would make the CORS block a way
+past the URL's auth type, and AWS documents no such exemption.
+
+`Access-Control-Allow-Origin` is the one header the request decides. A block naming `*` allows every
+Origin, and any other block echoes the request's `Origin` when the list holds it, since a browser
+reads one value there.
+
+`command/function-url/function-url-cors-input.ts` checks the block before the store is touched. It
+applies only the bounds the Lambda API publishes (list sizes, member lengths and the `MaxAge` range)
+because a refusal AWS would not make costs a working deployment. The six-character cap on
+`AllowMethods` is what keeps `OPTIONS` out of a configuration, which follows from Lambda answering
+preflight itself.
+
 ### Invocation events without a request
 
 `factory/lambda-function-url-event.factory.ts` exports `lambdaFunctionUrlEventFactory`, which makes
@@ -790,7 +813,6 @@ and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
   `AWS::Lambda::EventSourceMapping` and `AWS::Lambda::EventInvokeConfig`
 - event sources other than SQS queues and DynamoDB streams, `FilterCriteria`,
   `UpdateEventSourceMapping`, and polling concurrency
-- Function URL `Cors` configuration and OPTIONS preflight handling
 - `InvokeMode: RESPONSE_STREAM`, which is accepted and reported but always served buffered
 - ES module function code (`.mjs` / `export` syntax) in the vm runtime
 - running a container image: nothing reads one, so a function naming `Code.ImageUri` runs the real

--- a/src/service/lambda/cfn/url/sim-cfn-lambda-url-cors.ts
+++ b/src/service/lambda/cfn/url/sim-cfn-lambda-url-cors.ts
@@ -1,0 +1,79 @@
+import { isRecord } from "../../../../util/type-guard/record.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimLambdaFunctionUrlCors } from "../../function/url/sim-lambda-function-url-cors.js";
+import type { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
+
+interface SimCfnLambdaUrlCorsProperties {
+  readonly parser: SimCfnLambdaPropertyParser;
+  readonly resource: SimCfnResource;
+  readonly value: SimCfnTemplateValue | undefined;
+}
+
+/**
+ * Read the `Cors` block of an `AWS::Lambda::Url` Resource.
+ *
+ * The members go to `CreateFunctionUrlConfig` as they are written. The bounds
+ * Lambda puts on them are applied there, once. This reader settles only the
+ * template question, whether each property is the shape CloudFormation says it
+ * is.
+ *
+ * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-url-cors.html
+ */
+export function simCfnLambdaUrlCors(
+  properties: SimCfnLambdaUrlCorsProperties,
+): SimLambdaFunctionUrlCors | undefined {
+  const { parser, resource, value } = properties;
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw parser.invalidPropertyError(resource, "Cors", "an object");
+  }
+
+  const cors = value as Record<string, SimCfnTemplateValue | undefined>;
+
+  // A member the template said nothing about is left out. What the Lambda API
+  // reports back is then what the template wrote.
+  return withoutAbsentMembers({
+    AllowCredentials: parser.optionalBoolean(
+      resource,
+      cors["AllowCredentials"],
+      "Cors.AllowCredentials",
+    ),
+    AllowHeaders: parser.optionalStringList(
+      resource,
+      cors["AllowHeaders"],
+      "Cors.AllowHeaders",
+    ),
+    AllowMethods: parser.optionalStringList(
+      resource,
+      cors["AllowMethods"],
+      "Cors.AllowMethods",
+    ),
+    AllowOrigins: parser.optionalStringList(
+      resource,
+      cors["AllowOrigins"],
+      "Cors.AllowOrigins",
+    ),
+    ExposeHeaders: parser.optionalStringList(
+      resource,
+      cors["ExposeHeaders"],
+      "Cors.ExposeHeaders",
+    ),
+    MaxAge: parser.optionalNumber(resource, cors["MaxAge"], "Cors.MaxAge"),
+  });
+}
+
+/**
+ * Drop the members the template did not state.
+ */
+function withoutAbsentMembers(
+  cors: SimLambdaFunctionUrlCors,
+): SimLambdaFunctionUrlCors {
+  return Object.fromEntries(
+    Object.entries(cors).filter(([, member]) => member !== undefined),
+  );
+}

--- a/src/service/lambda/cfn/url/sim-cfn-lambda-url-creator.ts
+++ b/src/service/lambda/cfn/url/sim-cfn-lambda-url-creator.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../function/url/sim-lambda-function-url.js";
 import type { SimLambda } from "../../sim-lambda.js";
 import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
+import { simCfnLambdaUrlCors } from "./sim-cfn-lambda-url-cors.js";
 import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
 import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
@@ -59,6 +60,11 @@ export class SimCfnLambdaUrlCreator {
             properties["InvokeMode"],
             "InvokeMode",
           ) as SimLambdaFunctionUrlInvokeMode | undefined,
+          Cors: simCfnLambdaUrlCors({
+            parser: this.propertyParser,
+            resource,
+            value: properties["Cors"],
+          }),
         },
       },
       options,

--- a/src/service/lambda/cfn/url/sim-cfn-lambda-url.iso.test.ts
+++ b/src/service/lambda/cfn/url/sim-cfn-lambda-url.iso.test.ts
@@ -1,7 +1,9 @@
+import { GetFunctionUrlConfigCommand } from "@aws-sdk/client-lambda";
 import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertObjectEquals,
   assertStringIncludes,
   assertStringMatches,
   assertThrowsErrorAsync,
@@ -180,6 +182,111 @@ describe("Lambda CloudFormation Function URL deployment", () => {
     assertNonNullable(functionUrl);
     assertIdentical(functionUrl.authType, "AWS_IAM");
     assertIdentical(functionUrl.invokeMode, "RESPONSE_STREAM");
+  });
+
+  it("deploys the CORS configuration the template states", async () => {
+    // Given a template whose Function URL is configured for CORS.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "greeter-stack",
+      template: greeterTemplate({
+        TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+        AuthType: "NONE",
+        Cors: {
+          AllowCredentials: true,
+          AllowHeaders: ["content-type", "x-api-key"],
+          AllowMethods: ["GET", "POST"],
+          AllowOrigins: ["https://shop.example.com"],
+          ExposeHeaders: ["x-request-id"],
+          MaxAge: 600,
+        },
+      }),
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the Lambda API reports the configuration the template carried.
+    const { Cors } = await simAws
+      .lambda()
+      .getFunctionUrlConfig(
+        new GetFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+      );
+    assertObjectEquals(Cors, {
+      AllowCredentials: true,
+      AllowHeaders: ["content-type", "x-api-key"],
+      AllowMethods: ["GET", "POST"],
+      AllowOrigins: ["https://shop.example.com"],
+      ExposeHeaders: ["x-request-id"],
+      MaxAge: 600,
+    });
+
+    // And the served endpoint answers a preflight from that Origin itself.
+    const functionUrl = simAws.lambda().getSimFunctionUrl("greeter");
+    assertNonNullable(functionUrl);
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      new SimAwsLocalUrl({ input: functionUrl.url }).toString(),
+      {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://shop.example.com",
+          "access-control-request-method": "POST",
+        },
+      },
+    );
+    assertIdentical(
+      response.headers.get("access-control-allow-origin"),
+      "https://shop.example.com",
+    );
+    assertIdentical(response.headers.get("access-control-max-age"), "600");
+  });
+
+  it("fails the Resource when Cors is not an object", async () => {
+    // Given a template whose Function URL states a CORS block as a string.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "greeter-stack",
+        template: greeterTemplate({
+          TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+          AuthType: "NONE",
+          Cors: "everyone",
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the failure names the Resource type, property and logical ID.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::Url GreeterUrl: Cors must be an object",
+    );
+  });
+
+  it("fails the Resource when a Cors member has the wrong shape", async () => {
+    // Given a template stating one allowed Origin rather than a list of them.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const error = await assertThrowsErrorAsync(async () => {
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "greeter-stack",
+        template: greeterTemplate({
+          TargetFunctionArn: { "Fn::GetAtt": ["GreeterFunction", "Arn"] },
+          AuthType: "NONE",
+          Cors: { AllowOrigins: "https://shop.example.com" },
+        }),
+      });
+      await stack.waitForDeployComplete();
+    });
+
+    // Then the failure names the member inside the block.
+    assertStringIncludes(
+      error.message,
+      "Invalid AWS::Lambda::Url GreeterUrl: Cors.AllowOrigins must be a list",
+    );
   });
 
   it("fails the Resource when TargetFunctionArn is missing", async () => {

--- a/src/service/lambda/command/create-function-url-config/create-function-url-config.command.ts
+++ b/src/service/lambda/command/create-function-url-config/create-function-url-config.command.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionUrlCors } from "../../function/url/sim-lambda-function-url-cors.js";
 import type {
   SimLambdaFunctionUrlAuthType,
   SimLambdaFunctionUrlConfiguration,
@@ -18,14 +19,12 @@ export interface SimCreateFunctionUrlConfigCommand {
 
 /**
  * Minimal structural sim Lambda CreateFunctionUrlConfig input.
- *
- * The Cors block real Lambda accepts here is not simulated, so it is left out
- * rather than accepted and ignored.
  */
 export interface SimCreateFunctionUrlConfigCommandInput {
   readonly FunctionName?: string | undefined;
   readonly AuthType?: SimLambdaFunctionUrlAuthType | undefined;
   readonly InvokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+  readonly Cors?: SimLambdaFunctionUrlCors | undefined;
 }
 
 /**

--- a/src/service/lambda/command/create-function-url-config/create-function-url-config.handler.ts
+++ b/src/service/lambda/command/create-function-url-config/create-function-url-config.handler.ts
@@ -87,6 +87,7 @@ export class CreateFunctionUrlConfigCommandHandler implements CommandHandler<
       invokeMode: this.inputParser.parseOptionalInvokeMode(
         command.input.InvokeMode,
       ),
+      cors: this.inputParser.parseOptionalCors(command.input.Cors),
     });
 
     return {

--- a/src/service/lambda/command/function-url/function-url-cors-constraints.ts
+++ b/src/service/lambda/command/function-url/function-url-cors-constraints.ts
@@ -1,0 +1,79 @@
+/**
+ * One list member of a `Cors` block and the bounds Lambda puts on it.
+ *
+ * `AllowMethods` is capped at six characters. That is what leaves `OPTIONS`
+ * out of the list a caller may state, since Lambda answers the preflight
+ * itself.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/api/API_Cors.html
+ */
+export interface CorsListConstraint {
+  readonly member:
+    | "AllowHeaders"
+    | "AllowMethods"
+    | "AllowOrigins"
+    | "ExposeHeaders";
+  readonly field: string;
+  readonly maxItems: number;
+  readonly minLength: number;
+  readonly maxLength: number;
+}
+
+/**
+ * The bounds Lambda publishes for each list member of a `Cors` block.
+ */
+export const corsListConstraints: readonly CorsListConstraint[] = [
+  {
+    member: "AllowHeaders",
+    field: "cors.allowHeaders",
+    maxItems: 100,
+    minLength: 0,
+    maxLength: 1024,
+  },
+  {
+    member: "AllowMethods",
+    field: "cors.allowMethods",
+    maxItems: 6,
+    minLength: 0,
+    maxLength: 6,
+  },
+  {
+    member: "AllowOrigins",
+    field: "cors.allowOrigins",
+    maxItems: 100,
+    minLength: 1,
+    maxLength: 253,
+  },
+  {
+    member: "ExposeHeaders",
+    field: "cors.exposeHeaders",
+    maxItems: 100,
+    minLength: 0,
+    maxLength: 1024,
+  },
+];
+
+/**
+ * The bound a list broke, worded as Lambda words it, or nothing when the list
+ * is within every bound.
+ */
+export function corsListViolation(
+  values: readonly string[],
+  constraint: CorsListConstraint,
+): string | undefined {
+  const { maxItems, minLength, maxLength } = constraint;
+
+  if (values.length > maxItems) {
+    return `Member must have length less than or equal to ${String(maxItems)}`;
+  }
+
+  const outOfRange = values.some(
+    (value) => value.length < minLength || value.length > maxLength,
+  );
+
+  return outOfRange
+    ? "Member must satisfy constraint: [Member must have length less than " +
+        `or equal to ${String(maxLength)}, Member must have length greater ` +
+        `than or equal to ${String(minLength)}]`
+    : undefined;
+}

--- a/src/service/lambda/command/function-url/function-url-cors-input.ts
+++ b/src/service/lambda/command/function-url/function-url-cors-input.ts
@@ -1,0 +1,85 @@
+import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaFunctionUrlCors } from "../../function/url/sim-lambda-function-url-cors.js";
+import {
+  corsListConstraints,
+  corsListViolation,
+} from "./function-url-cors-constraints.js";
+
+const maxAgeSeconds = 86_400;
+
+/**
+ * Validates the `Cors` block of Function URL config command input.
+ *
+ * Every check here is against a bound real Lambda publishes. A configuration
+ * this accepts is one the API would have taken. Nothing else is checked,
+ * because a refusal the real service would not make costs a working
+ * deployment.
+ *
+ * The check runs before the Function URL is created or updated, leaving a
+ * refused configuration with the URL as it was.
+ */
+export class FunctionUrlCorsInputParser {
+  /**
+   * Parse an optional `Cors` block, which every Function URL config command
+   * allows a caller to leave out.
+   */
+  parseOptional(
+    cors: SimLambdaFunctionUrlCors | undefined,
+  ): SimLambdaFunctionUrlCors | undefined {
+    if (cors === undefined) {
+      return undefined;
+    }
+
+    for (const constraint of corsListConstraints) {
+      const values = cors[constraint.member];
+
+      if (values !== undefined) {
+        this.refuse(
+          `[${values.join(", ")}]`,
+          constraint.field,
+          corsListViolation(values, constraint),
+        );
+      }
+    }
+
+    this.checkMaxAge(cors.MaxAge);
+
+    return cors;
+  }
+
+  private checkMaxAge(maxAge: number | undefined): void {
+    if (maxAge === undefined) {
+      return;
+    }
+
+    this.refuse(String(maxAge), "cors.maxAge", this.maxAgeViolation(maxAge));
+  }
+
+  private maxAgeViolation(maxAge: number): string | undefined {
+    if (maxAge > maxAgeSeconds) {
+      return `Member must have value less than or equal to ${String(maxAgeSeconds)}`;
+    }
+
+    return maxAge < 0
+      ? "Member must have value greater than or equal to 0"
+      : undefined;
+  }
+
+  /**
+   * Fail the way Lambda fails a request that broke one bound.
+   */
+  private refuse(
+    value: string,
+    field: string,
+    violation: string | undefined,
+  ): void {
+    if (violation === undefined) {
+      return;
+    }
+
+    throw new SimLambdaValidationException(
+      `1 validation error detected: Value '${value}' at '${field}' failed ` +
+        `to satisfy constraint: ${violation}`,
+    );
+  }
+}

--- a/src/service/lambda/command/function-url/function-url-cors.iso.test.ts
+++ b/src/service/lambda/command/function-url/function-url-cors.iso.test.ts
@@ -1,0 +1,324 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+  GetFunctionUrlConfigCommand,
+  ListFunctionUrlConfigsCommand,
+  UpdateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import { faker } from "@faker-js/faker";
+import {
+  assertArrayEquals,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
+import { makeLambdaZipFileInput } from "../../function/code/lambda-zip-file-input.js";
+import { simLambdaFunctionUrlCorsFactory } from "../../function/url/sim-lambda-function-url-cors.factory.js";
+import type { SimLambda } from "../../sim-lambda.js";
+
+describe("Lambda Function URL CORS configuration", () => {
+  async function functionWithoutUrl(): Promise<SimLambda> {
+    const lambda = new SimAws().lambda();
+    await lambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: { ZipFile: makeLambdaZipFileInput(() => "hello") },
+      }),
+    );
+
+    return lambda;
+  }
+
+  it("carries every CORS member through create and get", async () => {
+    // Given a function and a CORS configuration stating all six members.
+    const lambda = await functionWithoutUrl();
+    const cors = simLambdaFunctionUrlCorsFactory.make({
+      AllowCredentials: true,
+      AllowHeaders: ["content-type", "x-api-key"],
+      AllowMethods: ["GET", "POST"],
+      AllowOrigins: ["https://shop.example.com"],
+      ExposeHeaders: ["x-request-id", "x-page-count"],
+      MaxAge: 600,
+    });
+
+    // When the Function URL is created with it and read back.
+    const created = await lambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+        Cors: cors,
+      }),
+    );
+    const read = await lambda.getFunctionUrlConfig(
+      new GetFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+    );
+
+    // Then both report the configuration as it was sent.
+    assertObjectEquals(created.Cors, cors);
+    assertObjectEquals(read.Cors, cors);
+  });
+
+  it("lists the CORS configuration a Function URL was given", async () => {
+    // Given a Function URL configured to expose a header to one Origin.
+    const lambda = await functionWithoutUrl();
+    await lambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+        Cors: simLambdaFunctionUrlCorsFactory.make({
+          AllowOrigins: ["https://shop.example.com"],
+          ExposeHeaders: ["x-request-id"],
+        }),
+      }),
+    );
+
+    // When the function's Function URL configurations are listed.
+    const listed = await lambda.listFunctionUrlConfigs(
+      new ListFunctionUrlConfigsCommand({ FunctionName: "greeter" }),
+    );
+
+    // Then the one configuration carries the CORS block.
+    const [configuration] = listed.FunctionUrlConfigs;
+    assertArrayEquals(configuration?.Cors?.AllowOrigins, [
+      "https://shop.example.com",
+    ]);
+    assertArrayEquals(configuration.Cors.ExposeHeaders, ["x-request-id"]);
+  });
+
+  it("reports no CORS block for a URL created without one", async () => {
+    // Given a Function URL created without CORS.
+    const lambda = await functionWithoutUrl();
+
+    // When it is created and read back.
+    const created = await lambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+      }),
+    );
+
+    // Then nothing is reported. An empty block would decide headers of its
+    // own.
+    assertUndefined(created.Cors);
+  });
+
+  it("replaces the whole CORS block on update", async () => {
+    // Given a Function URL allowing one Origin and one method.
+    const lambda = await functionWithoutUrl();
+    await lambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+        Cors: simLambdaFunctionUrlCorsFactory.make({
+          AllowOrigins: ["https://shop.example.com"],
+          AllowMethods: ["GET"],
+        }),
+      }),
+    );
+
+    // When it is updated with a block naming only the Origins.
+    const updated = await lambda.updateFunctionUrlConfig(
+      new UpdateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        Cors: { AllowOrigins: ["https://admin.example.com"] },
+      }),
+    );
+
+    // Then the new block is the whole configuration. The methods the URL was
+    // created with went with the block that held them.
+    assertArrayEquals(updated.Cors?.AllowOrigins, [
+      "https://admin.example.com",
+    ]);
+    assertUndefined(updated.Cors.AllowMethods);
+  });
+
+  it("keeps the CORS block an update leaves out", async () => {
+    // Given a Function URL with a CORS configuration.
+    const lambda = await functionWithoutUrl();
+    await lambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+        Cors: simLambdaFunctionUrlCorsFactory.make({
+          AllowOrigins: ["https://shop.example.com"],
+        }),
+      }),
+    );
+
+    // When only the auth type is updated.
+    const updated = await lambda.updateFunctionUrlConfig(
+      new UpdateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "AWS_IAM",
+      }),
+    );
+
+    // Then the CORS configuration is still there.
+    assertIdentical(updated.AuthType, "AWS_IAM");
+    assertArrayEquals(updated.Cors?.AllowOrigins, ["https://shop.example.com"]);
+  });
+
+  it("refuses more allowed origins than Lambda takes", async () => {
+    // Given a configuration naming a hundred and one Origins.
+    const lambda = await functionWithoutUrl();
+    const allowOrigins = faker.helpers.multiple(
+      () => `https://${faker.string.alphanumeric(8)}.example.com`,
+      { count: 101 },
+    );
+
+    // When a Function URL is created with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await lambda.createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+          Cors: simLambdaFunctionUrlCorsFactory.make({
+            AllowOrigins: allowOrigins,
+          }),
+        }),
+      );
+    });
+
+    // Then it is refused the way Lambda refuses it, naming the member.
+    assertInstanceOf(error, SimLambdaValidationException);
+    assertStringIncludes(
+      error.message,
+      "at 'cors.allowOrigins' failed to satisfy constraint: Member must have " +
+        "length less than or equal to 100",
+    );
+  });
+
+  it("refuses an allowed method longer than Lambda takes", async () => {
+    // Given a configuration naming OPTIONS, which is longer than the six
+    // characters the member allows because Lambda answers preflight itself.
+    const lambda = await functionWithoutUrl();
+
+    // When a Function URL is created with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await lambda.createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+          Cors: simLambdaFunctionUrlCorsFactory.make({
+            AllowMethods: ["OPTIONS"],
+          }),
+        }),
+      );
+    });
+
+    // Then the refusal names the member and the bound it broke.
+    assertStringIncludes(
+      error.message,
+      "Value '[OPTIONS]' at 'cors.allowMethods' failed to satisfy constraint: " +
+        "Member must satisfy constraint: [Member must have length less than " +
+        "or equal to 6, Member must have length greater than or equal to 0]",
+    );
+  });
+
+  it("refuses a maximum age outside the range Lambda takes", async () => {
+    // Given a function.
+    const lambda = await functionWithoutUrl();
+
+    // When a Function URL is created with a day and a second of caching.
+    const tooLong = await assertThrowsErrorAsync(async () => {
+      await lambda.createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+          Cors: simLambdaFunctionUrlCorsFactory.make({ MaxAge: 86_401 }),
+        }),
+      );
+    });
+
+    // And when one is created with a negative age.
+    const negative = await assertThrowsErrorAsync(async () => {
+      await lambda.createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+          Cors: simLambdaFunctionUrlCorsFactory.make({ MaxAge: -1 }),
+        }),
+      );
+    });
+
+    // Then both are refused against the bound they broke.
+    assertStringIncludes(
+      tooLong.message,
+      "at 'cors.maxAge' failed to satisfy constraint: Member must have value " +
+        "less than or equal to 86400",
+    );
+    assertStringIncludes(
+      negative.message,
+      "at 'cors.maxAge' failed to satisfy constraint: Member must have value " +
+        "greater than or equal to 0",
+    );
+  });
+
+  it("leaves the configuration alone when an update is refused", async () => {
+    // Given a Function URL allowing one Origin.
+    const lambda = await functionWithoutUrl();
+    await lambda.createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: "NONE",
+        Cors: simLambdaFunctionUrlCorsFactory.make({
+          AllowOrigins: ["https://shop.example.com"],
+        }),
+      }),
+    );
+
+    // When an update states an auth type alongside a CORS block Lambda refuses.
+    await assertThrowsErrorAsync(async () => {
+      await lambda.updateFunctionUrlConfig(
+        new UpdateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "AWS_IAM",
+          Cors: { MaxAge: 90_000 },
+        }),
+      );
+    });
+
+    // Then nothing about the URL changed. The auth type stayed where it was
+    // alongside the CORS block.
+    const read = await lambda.getFunctionUrlConfig(
+      new GetFunctionUrlConfigCommand({ FunctionName: "greeter" }),
+    );
+    assertIdentical(read.AuthType, "NONE");
+    assertArrayEquals(read.Cors?.AllowOrigins, ["https://shop.example.com"]);
+  });
+
+  it("refuses an allowed origin longer than Lambda takes", async () => {
+    // Given a configuration naming an Origin over 253 characters.
+    const lambda = await functionWithoutUrl();
+    const origin = `https://${faker.string.alphanumeric(250)}.example.com`;
+
+    // When a Function URL is created with it.
+    const error = await assertThrowsErrorAsync(async () => {
+      await lambda.createFunctionUrlConfig(
+        new CreateFunctionUrlConfigCommand({
+          FunctionName: "greeter",
+          AuthType: "NONE",
+          Cors: simLambdaFunctionUrlCorsFactory.make({
+            AllowOrigins: [origin],
+          }),
+        }),
+      );
+    });
+
+    // Then the refusal names the length bound the member broke.
+    assertStringIncludes(
+      error.message,
+      "at 'cors.allowOrigins' failed to satisfy constraint: Member must " +
+        "satisfy constraint: [Member must have length less than or equal to " +
+        "253, Member must have length greater than or equal to 1]",
+    );
+  });
+});

--- a/src/service/lambda/command/function-url/function-url-input.ts
+++ b/src/service/lambda/command/function-url/function-url-input.ts
@@ -1,8 +1,10 @@
 import { SimLambdaValidationException } from "../../error/sim-lambda.error.js";
+import type { SimLambdaFunctionUrlCors } from "../../function/url/sim-lambda-function-url-cors.js";
 import type {
   SimLambdaFunctionUrlAuthType,
   SimLambdaFunctionUrlInvokeMode,
 } from "../../function/url/sim-lambda-function-url.js";
+import { FunctionUrlCorsInputParser } from "./function-url-cors-input.js";
 
 const authTypes: readonly string[] = ["NONE", "AWS_IAM"];
 const invokeModes: readonly string[] = ["BUFFERED", "RESPONSE_STREAM"];
@@ -15,6 +17,8 @@ const invokeModes: readonly string[] = ["BUFFERED", "RESPONSE_STREAM"];
  * runtime and reported the way real Lambda reports a bad enum member.
  */
 export class FunctionUrlInputParser {
+  private readonly corsParser = new FunctionUrlCorsInputParser();
+
   /**
    * Parse a required AuthType, as CreateFunctionUrlConfig requires one.
    */
@@ -58,6 +62,16 @@ export class FunctionUrlInputParser {
     }
 
     return value as SimLambdaFunctionUrlInvokeMode;
+  }
+
+  /**
+   * Parse an optional `Cors` block, which every Function URL config command
+   * allows a caller to leave out.
+   */
+  parseOptionalCors(
+    value: SimLambdaFunctionUrlCors | undefined,
+  ): SimLambdaFunctionUrlCors | undefined {
+    return this.corsParser.parseOptional(value);
   }
 
   private parseAuthType(value: string): SimLambdaFunctionUrlAuthType {

--- a/src/service/lambda/command/update-function-url-config/update-function-url-config.command.ts
+++ b/src/service/lambda/command/update-function-url-config/update-function-url-config.command.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
+import type { SimLambdaFunctionUrlCors } from "../../function/url/sim-lambda-function-url-cors.js";
 import type {
   SimLambdaFunctionUrlAuthType,
   SimLambdaFunctionUrlConfiguration,
@@ -26,6 +27,7 @@ export interface SimUpdateFunctionUrlConfigCommandInput {
   readonly FunctionName?: string | undefined;
   readonly AuthType?: SimLambdaFunctionUrlAuthType | undefined;
   readonly InvokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+  readonly Cors?: SimLambdaFunctionUrlCors | undefined;
 }
 
 /**

--- a/src/service/lambda/command/update-function-url-config/update-function-url-config.handler.ts
+++ b/src/service/lambda/command/update-function-url-config/update-function-url-config.handler.ts
@@ -88,6 +88,7 @@ export class UpdateFunctionUrlConfigCommandHandler implements CommandHandler<
       invokeMode: this.inputParser.parseOptionalInvokeMode(
         command.input.InvokeMode,
       ),
+      cors: this.inputParser.parseOptionalCors(command.input.Cors),
     });
 
     return {

--- a/src/service/lambda/function/url/sim-lambda-function-url-cors.factory.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url-cors.factory.ts
@@ -1,0 +1,33 @@
+import { faker } from "@faker-js/faker";
+import { DynamicFactory } from "@kensio/part-factory";
+
+/**
+ * A CORS configuration whose lists are mutable. That is the shape the AWS
+ * SDK's own command input takes, so a test can hand what this factory makes
+ * straight to a `CreateFunctionUrlConfigCommand`.
+ */
+export interface SimLambdaFunctionUrlCorsParts {
+  AllowCredentials: boolean;
+  AllowHeaders: string[];
+  AllowMethods: string[];
+  AllowOrigins: string[];
+  ExposeHeaders: string[];
+  MaxAge: number;
+}
+
+/**
+ * Makes a valid Function URL CORS configuration, so a test states only the
+ * part of it the test is about.
+ *
+ * The default allows one named Origin. That is the case where the headers
+ * served depend on the request that asked for them.
+ */
+export const simLambdaFunctionUrlCorsFactory =
+  new DynamicFactory<SimLambdaFunctionUrlCorsParts>(() => ({
+    AllowCredentials: false,
+    AllowHeaders: ["content-type"],
+    AllowMethods: ["GET"],
+    AllowOrigins: [`https://${faker.internet.domainName()}`],
+    ExposeHeaders: ["x-request-id"],
+    MaxAge: faker.number.int({ min: 1, max: 86_400 }),
+  }));

--- a/src/service/lambda/function/url/sim-lambda-function-url-cors.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url-cors.ts
@@ -1,0 +1,16 @@
+/**
+ * The cross-origin resource sharing settings of one Function URL.
+ *
+ * The member names are AWS's own. What `GetFunctionUrlConfig` reports is the
+ * record `CreateFunctionUrlConfig` was given.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/api/API_Cors.html
+ */
+export interface SimLambdaFunctionUrlCors {
+  readonly AllowCredentials?: boolean | undefined;
+  readonly AllowHeaders?: readonly string[] | undefined;
+  readonly AllowMethods?: readonly string[] | undefined;
+  readonly AllowOrigins?: readonly string[] | undefined;
+  readonly ExposeHeaders?: readonly string[] | undefined;
+  readonly MaxAge?: number | undefined;
+}

--- a/src/service/lambda/function/url/sim-lambda-function-url-factory.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url-factory.ts
@@ -1,6 +1,7 @@
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimLambdaUrlRegistry } from "../../registry/sim-lambda-url-registry.js";
 import type { SimLambdaFunction } from "../sim-lambda-function.js";
+import type { SimLambdaFunctionUrlCors } from "./sim-lambda-function-url-cors.js";
 import {
   SimLambdaFunctionUrl,
   type SimLambdaFunctionUrlAuthType,
@@ -21,6 +22,7 @@ interface MakeSimLambdaFunctionUrlProperties {
   readonly simFunction: SimLambdaFunction;
   readonly authType?: SimLambdaFunctionUrlAuthType | undefined;
   readonly invokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+  readonly cors?: SimLambdaFunctionUrlCors | undefined;
 }
 
 /**
@@ -44,7 +46,7 @@ export class SimLambdaFunctionUrlFactory {
    * Make a registered Function URL for a function.
    */
   make(properties: MakeSimLambdaFunctionUrlProperties): SimLambdaFunctionUrl {
-    const { simFunction, authType, invokeMode } = properties;
+    const { simFunction, authType, invokeMode, cors } = properties;
     const urlId = this.urlRegistry.allocateFunctionUrlId();
 
     this.urlRegistry.registerFunctionUrl(
@@ -59,6 +61,7 @@ export class SimLambdaFunctionUrlFactory {
       accountRegionScope: this.accountRegionScope,
       authType,
       invokeMode,
+      cors,
       clock: this.clock,
     });
   }

--- a/src/service/lambda/function/url/sim-lambda-function-url-store.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url-store.ts
@@ -10,6 +10,7 @@ import {
   SimLambdaFunctionUrlFactory,
   type SimLambdaFunctionUrlFactoryProperties,
 } from "./sim-lambda-function-url-factory.js";
+import type { SimLambdaFunctionUrlCors } from "./sim-lambda-function-url-cors.js";
 import type {
   SimLambdaFunctionUrl,
   SimLambdaFunctionUrlAuthType,
@@ -21,6 +22,7 @@ interface CreateSimLambdaFunctionUrlProperties {
   readonly simFunction: SimLambdaFunction;
   readonly authType?: SimLambdaFunctionUrlAuthType | undefined;
   readonly invokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+  readonly cors?: SimLambdaFunctionUrlCors | undefined;
 }
 
 /**

--- a/src/service/lambda/function/url/sim-lambda-function-url.ts
+++ b/src/service/lambda/function/url/sim-lambda-function-url.ts
@@ -3,6 +3,7 @@ import { faker } from "@faker-js/faker";
 import type { Brand } from "../../../../util/brand.type.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import type { SimLambdaFunctionName } from "../sim-lambda-function.js";
+import type { SimLambdaFunctionUrlCors } from "./sim-lambda-function-url-cors.js";
 import { simLambdaFunctionUrlHost } from "./sim-lambda-function-url-host.js";
 import {
   type SimClock,
@@ -44,6 +45,7 @@ interface SimLambdaFunctionUrlProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
   readonly authType?: SimLambdaFunctionUrlAuthType | undefined;
   readonly invokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+  readonly cors?: SimLambdaFunctionUrlCors | undefined;
   /**
    * Clock stamping this Function URL's creation and last modified times. A
    * Function URL built standalone, outside a SimAws instance, falls back to the
@@ -56,12 +58,16 @@ interface SimLambdaFunctionUrlProperties {
  * Minimal structural Function URL configuration, as returned by the
  * CreateFunctionUrlConfig, GetFunctionUrlConfig and UpdateFunctionUrlConfig
  * commands.
+ *
+ * A URL configured without CORS has no `Cors` member at all. An empty block
+ * would still decide headers.
  */
 export interface SimLambdaFunctionUrlConfiguration {
   FunctionUrl: string;
   FunctionArn: string;
   AuthType: SimLambdaFunctionUrlAuthType;
   InvokeMode: SimLambdaFunctionUrlInvokeMode;
+  Cors?: SimLambdaFunctionUrlCors | undefined;
   CreationTime: string;
   LastModifiedTime: string;
 }
@@ -82,6 +88,7 @@ export class SimLambdaFunctionUrl {
 
   #authType: SimLambdaFunctionUrlAuthType;
   #invokeMode: SimLambdaFunctionUrlInvokeMode;
+  #cors: SimLambdaFunctionUrlCors | undefined;
   #lastModifiedTime: string;
   private readonly clock: SimClock;
 
@@ -93,6 +100,7 @@ export class SimLambdaFunctionUrl {
       accountRegionScope,
       authType = "NONE",
       invokeMode = "BUFFERED",
+      cors,
       clock = new SimRealClock(),
     } = properties;
 
@@ -104,6 +112,7 @@ export class SimLambdaFunctionUrl {
     this.accountRegionScope = accountRegionScope;
     this.#authType = authType;
     this.#invokeMode = invokeMode;
+    this.#cors = cors;
     this.creationTime = clock.now().toISOString();
     this.#lastModifiedTime = this.creationTime;
   }
@@ -120,6 +129,14 @@ export class SimLambdaFunctionUrl {
    */
   get invokeMode(): SimLambdaFunctionUrlInvokeMode {
     return this.#invokeMode;
+  }
+
+  /**
+   * Get the CORS configuration for this Function URL. A URL without one sends
+   * no CORS headers of its own.
+   */
+  get cors(): SimLambdaFunctionUrlCors | undefined {
+    return this.#cors;
   }
 
   /**
@@ -144,13 +161,19 @@ export class SimLambdaFunctionUrl {
    * Apply an update to this Function URL's configuration.
    *
    * Omitted values are left as they are, as real UpdateFunctionUrlConfig does.
+   *
+   * A stated `Cors` replaces the whole block. An update naming only
+   * `AllowOrigins` drops the methods and headers the URL was created with, the
+   * way it does on AWS.
    */
   update(properties: {
     readonly authType?: SimLambdaFunctionUrlAuthType | undefined;
     readonly invokeMode?: SimLambdaFunctionUrlInvokeMode | undefined;
+    readonly cors?: SimLambdaFunctionUrlCors | undefined;
   }): void {
     this.#authType = properties.authType ?? this.#authType;
     this.#invokeMode = properties.invokeMode ?? this.#invokeMode;
+    this.#cors = properties.cors ?? this.#cors;
     this.#lastModifiedTime = this.clock.now().toISOString();
   }
 
@@ -163,6 +186,7 @@ export class SimLambdaFunctionUrl {
       FunctionArn: this.functionArn,
       AuthType: this.#authType,
       InvokeMode: this.#invokeMode,
+      ...(this.#cors !== undefined && { Cors: this.#cors }),
       CreationTime: this.creationTime,
       LastModifiedTime: this.#lastModifiedTime,
     };

--- a/src/service/lambda/serve/response/sim-lambda-url-cors-headers.ts
+++ b/src/service/lambda/serve/response/sim-lambda-url-cors-headers.ts
@@ -1,0 +1,120 @@
+import type { SimLambdaFunctionUrlCors } from "../../function/url/sim-lambda-function-url-cors.js";
+
+/**
+ * The request header a browser states the method it is asking about in.
+ *
+ * A preflight names it and nothing else does. That is what separates a
+ * preflight from an ordinary `OPTIONS` request the function should handle.
+ */
+const requestMethodHeader = "access-control-request-method";
+
+/**
+ * The CORS headers one Function URL configuration decides for a request.
+ *
+ * Lambda adds these to every response the URL serves, and answers a preflight
+ * with them itself. `AllowOrigins` is the one member whose header depends on
+ * the request. A browser reads one value there, so Lambda sends back either the
+ * Origin that asked or the wildcard.
+ *
+ * https://docs.aws.amazon.com/lambda/latest/dg/urls-configuration.html
+ */
+export class SimLambdaUrlCorsHeaders {
+  private readonly cors: SimLambdaFunctionUrlCors;
+
+  constructor(cors: SimLambdaFunctionUrlCors) {
+    this.cors = cors;
+  }
+
+  /**
+   * Whether this request is the preflight a browser sends before a
+   * cross-origin call it is not allowed to make blind.
+   */
+  isPreflight(request: Request): boolean {
+    return (
+      request.method === "OPTIONS" &&
+      request.headers.has("origin") &&
+      request.headers.has(requestMethodHeader)
+    );
+  }
+
+  /**
+   * The answer Lambda gives a preflight request itself.
+   *
+   * The function never runs for one. The configured headers are the whole
+   * response, and the handler has said nothing that could conflict with them.
+   */
+  preflightResponse(request: Request): Response {
+    const headers = new Headers();
+    this.apply(headers, request);
+
+    return new Response(null, { status: 200, headers });
+  }
+
+  /**
+   * Add the configured CORS headers to a response the function produced.
+   *
+   * They are appended. A handler that sends CORS headers of its own keeps them
+   * and the response carries both values, which is what AWS documents for
+   * anything but a preflight.
+   */
+  apply(headers: Headers, request: Request): void {
+    const allowOrigin = this.allowOrigin(request.headers.get("origin"));
+
+    if (allowOrigin !== undefined) {
+      headers.append("access-control-allow-origin", allowOrigin);
+    }
+
+    // A false Access-Control-Allow-Credentials is not a value the fetch spec
+    // recognises. The header is left off instead.
+    if (this.cors.AllowCredentials === true) {
+      headers.append("access-control-allow-credentials", "true");
+    }
+
+    this.appendList(headers, "allow-methods", this.cors.AllowMethods);
+    this.appendList(headers, "allow-headers", this.cors.AllowHeaders);
+    this.appendList(headers, "expose-headers", this.cors.ExposeHeaders);
+
+    if (this.cors.MaxAge !== undefined) {
+      headers.append("access-control-max-age", String(this.cors.MaxAge));
+    }
+  }
+
+  /**
+   * Which Origin this request is told it may read the response from.
+   *
+   * A list holding the wildcard allows every Origin outright. Otherwise the
+   * Origin has to be one the list names. A request carrying no Origin at all,
+   * such as one from curl, is told nothing.
+   */
+  private allowOrigin(requestOrigin: string | null): string | undefined {
+    const allowOrigins = this.cors.AllowOrigins ?? [];
+
+    if (allowOrigins.includes("*")) {
+      return "*";
+    }
+
+    if (requestOrigin === null || !allowOrigins.includes(requestOrigin)) {
+      return undefined;
+    }
+
+    return requestOrigin;
+  }
+
+  /**
+   * Send a configured list as one comma-separated header.
+   *
+   * An empty list names nothing. A header carrying an empty value says
+   * something else to a browser, so the header is left off.
+   */
+  private appendList(
+    headers: Headers,
+    suffix: string,
+    values: readonly string[] | undefined,
+  ): void {
+    if (values === undefined || values.length === 0) {
+      return;
+    }
+
+    headers.append(`access-control-${suffix}`, values.join(","));
+  }
+}

--- a/src/service/lambda/serve/sim-lambda-controller.ts
+++ b/src/service/lambda/serve/sim-lambda-controller.ts
@@ -6,6 +6,7 @@ import { SimPayload2EventBuilder } from "../../../serve/payload-2/sim-payload-2-
 import { SimPayload2ResponseBuilder } from "../../../serve/payload-2/sim-payload-2-response-builder.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { simLambdaUrlEndpoint } from "./event/sim-lambda-url-endpoint.js";
+import { SimLambdaUrlCorsHeaders } from "./response/sim-lambda-url-cors-headers.js";
 import { SimLambdaUrlErrorResponse } from "./response/sim-lambda-url-error-response.js";
 import {
   type SimLambdaFunctionUrlRoute,
@@ -31,6 +32,11 @@ interface SimLambdaServiceControllerProperties {
  * Either way the function itself runs as its execution Role, as it does for
  * any other invocation. Who invoked it and what it runs as are separate
  * questions on real Lambda, and stay separate here.
+ *
+ * A URL configured for CORS answers a preflight request itself, once the
+ * request has got past whatever its auth type asks of it. A browser cannot sign
+ * a preflight, and an `AWS_IAM` URL refuses one on the same terms it refuses
+ * any other unsigned request.
  */
 export class SimLambdaServiceController implements SimAwsServiceController {
   private readonly router: SimLambdaUrlRouter;
@@ -112,7 +118,42 @@ export class SimLambdaServiceController implements SimAwsServiceController {
     return await this.invoke(route, serviceRequest.request, caller);
   }
 
+  /**
+   * Serve a request the Function URL has admitted.
+   *
+   * CORS is settled around the invocation. A preflight is answered from the
+   * configuration alone, and every other response carries the configured
+   * headers alongside whatever the handler sent, including a duplicate where
+   * the two disagree.
+   */
   private async invoke(
+    route: SimLambdaFunctionUrlRoute,
+    request: Request,
+    authenticatedCaller?: SimAwsRequestCaller,
+  ): Promise<Response> {
+    const { cors } = route.functionUrl;
+
+    if (cors === undefined) {
+      return await this.invokeFunction(route, request, authenticatedCaller);
+    }
+
+    const corsHeaders = new SimLambdaUrlCorsHeaders(cors);
+
+    if (corsHeaders.isPreflight(request)) {
+      return corsHeaders.preflightResponse(request);
+    }
+
+    const response = await this.invokeFunction(
+      route,
+      request,
+      authenticatedCaller,
+    );
+    corsHeaders.apply(response.headers, request);
+
+    return response;
+  }
+
+  private async invokeFunction(
     route: SimLambdaFunctionUrlRoute,
     request: Request,
     authenticatedCaller?: SimAwsRequestCaller,

--- a/src/service/lambda/serve/sim-lambda-url-cors-serve.iso.test.ts
+++ b/src/service/lambda/serve/sim-lambda-url-cors-serve.iso.test.ts
@@ -1,0 +1,319 @@
+import {
+  CreateFunctionCommand,
+  CreateFunctionUrlConfigCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertResponseStatus,
+  assertStringIncludes,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+import type { SimLambdaFunctionUrlCorsParts } from "../function/url/sim-lambda-function-url-cors.factory.js";
+import { simLambdaFunctionUrlCorsFactory } from "../function/url/sim-lambda-function-url-cors.factory.js";
+
+describe("Serving a sim Lambda Function URL configured for CORS", () => {
+  interface ServedFunctionUrl {
+    readonly simAws: SimAws;
+    readonly url: string;
+  }
+
+  interface GreeterProperties {
+    readonly cors?: Partial<SimLambdaFunctionUrlCorsParts> | undefined;
+    readonly authType?: "NONE" | "AWS_IAM" | undefined;
+    readonly zipFile?: Uint8Array | undefined;
+  }
+
+  async function greeterUrl(
+    properties: GreeterProperties = {},
+  ): Promise<ServedFunctionUrl> {
+    const simAws = new SimAws();
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "greeter",
+        Role: "arn:aws:iam::111111111111:role/GreeterRole",
+        Code: {
+          ZipFile:
+            properties.zipFile ??
+            makeLambdaZipFileInput(() => ({
+              statusCode: 200,
+              headers: { "content-type": "text/plain" },
+              body: "Hello from a sim Lambda",
+            })),
+        },
+      }),
+    );
+
+    const { FunctionUrl } = await simAws.lambda().createFunctionUrlConfig(
+      new CreateFunctionUrlConfigCommand({
+        FunctionName: "greeter",
+        AuthType: properties.authType ?? "NONE",
+        ...(properties.cors !== undefined && { Cors: properties.cors }),
+      }),
+    );
+    assertNonNullable(FunctionUrl);
+
+    return {
+      simAws,
+      url: new SimAwsLocalUrl({ input: FunctionUrl }).toString(),
+    };
+  }
+
+  function preflight(origin: string, method = "POST"): RequestInit {
+    return {
+      method: "OPTIONS",
+      headers: {
+        origin,
+        "access-control-request-method": method,
+      },
+    };
+  }
+
+  it("answers a preflight without invoking the handler", async () => {
+    // Given a Function URL whose handler fails whenever it runs at all.
+    const { simAws, url } = await greeterUrl({
+      cors: simLambdaFunctionUrlCorsFactory.make({
+        AllowOrigins: ["https://shop.example.com"],
+        AllowMethods: ["GET", "POST"],
+        AllowHeaders: ["content-type", "x-api-key"],
+        MaxAge: 600,
+      }),
+      zipFile: makeLambdaZipFileInput(() => {
+        throw new Error("the preflight reached the handler");
+      }),
+    });
+
+    // When a browser sends the preflight for a cross-origin POST.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      url,
+      preflight("https://shop.example.com"),
+    );
+
+    // Then it is answered from the configuration alone. A handler that threw
+    // would have produced the bad gateway a Function URL answers with.
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(await response.text(), "");
+    assertIdentical(
+      response.headers.get("access-control-allow-origin"),
+      "https://shop.example.com",
+    );
+    assertIdentical(
+      response.headers.get("access-control-allow-methods"),
+      "GET,POST",
+    );
+    assertIdentical(
+      response.headers.get("access-control-allow-headers"),
+      "content-type,x-api-key",
+    );
+    assertIdentical(response.headers.get("access-control-max-age"), "600");
+  });
+
+  it("allows every origin when the configuration names the wildcard", async () => {
+    // Given a Function URL open to any Origin.
+    const { simAws, url } = await greeterUrl({
+      cors: simLambdaFunctionUrlCorsFactory.make({ AllowOrigins: ["*"] }),
+    });
+
+    // When a preflight arrives from an Origin the configuration never names.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      url,
+      preflight("https://anywhere.example.org"),
+    );
+
+    // Then the wildcard is what comes back, and not the Origin that asked.
+    assertIdentical(response.headers.get("access-control-allow-origin"), "*");
+  });
+
+  it("tells an origin outside the list nothing about being allowed", async () => {
+    // Given a Function URL allowing one Origin.
+    const { simAws, url } = await greeterUrl({
+      cors: simLambdaFunctionUrlCorsFactory.make({
+        AllowOrigins: ["https://shop.example.com"],
+      }),
+    });
+
+    // When a preflight arrives from a different Origin.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      url,
+      preflight("https://attacker.example.org"),
+    );
+
+    // Then no Origin is allowed, which is what stops the browser making the
+    // call it was asking about.
+    assertIdentical(response.headers.get("access-control-allow-origin"), null);
+  });
+
+  it("adds the configured headers to a response the handler produced", async () => {
+    // Given a Function URL exposing a header and allowing credentials.
+    const { simAws, url } = await greeterUrl({
+      cors: simLambdaFunctionUrlCorsFactory.make({
+        AllowCredentials: true,
+        AllowOrigins: ["https://shop.example.com"],
+        ExposeHeaders: ["x-request-id", "x-page-count"],
+      }),
+    });
+
+    // When the function is called from that Origin.
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { origin: "https://shop.example.com" },
+    });
+
+    // Then the handler's own response carries the configured CORS headers.
+    assertIdentical(await response.text(), "Hello from a sim Lambda");
+    assertIdentical(
+      response.headers.get("access-control-allow-origin"),
+      "https://shop.example.com",
+    );
+    assertIdentical(
+      response.headers.get("access-control-allow-credentials"),
+      "true",
+    );
+    assertIdentical(
+      response.headers.get("access-control-expose-headers"),
+      "x-request-id,x-page-count",
+    );
+  });
+
+  it("keeps a CORS header the handler sent as well as the configured one", async () => {
+    // Given a Function URL whose handler answers with a CORS header of its own.
+    const { simAws, url } = await greeterUrl({
+      cors: simLambdaFunctionUrlCorsFactory.make({ AllowOrigins: ["*"] }),
+      zipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        headers: { "access-control-allow-origin": "https://shop.example.com" },
+        body: "Hello from a sim Lambda",
+      })),
+    });
+
+    // When the function is called.
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { origin: "https://shop.example.com" },
+    });
+
+    // Then both values are there. That is the duplicate a browser complains
+    // about on AWS, and the simulator leaves it in place.
+    assertStringIncludes(
+      response.headers.get("access-control-allow-origin"),
+      "https://shop.example.com",
+    );
+    assertStringIncludes(
+      response.headers.get("access-control-allow-origin"),
+      "*",
+    );
+  });
+
+  it("sends only the headers the configuration states", async () => {
+    // Given a Function URL whose CORS block names one exposed header and
+    // nothing else.
+    const { simAws, url } = await greeterUrl({
+      cors: { ExposeHeaders: ["x-request-id"] },
+    });
+
+    // When the function is called from an Origin.
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      headers: { origin: "https://shop.example.com" },
+    });
+
+    // Then that is the only CORS header on the response. A block naming no
+    // Origins allows none, rather than allowing the one that asked.
+    assertIdentical(
+      response.headers.get("access-control-expose-headers"),
+      "x-request-id",
+    );
+    assertIdentical(response.headers.get("access-control-allow-origin"), null);
+    assertIdentical(response.headers.get("access-control-allow-methods"), null);
+    assertIdentical(response.headers.get("access-control-max-age"), null);
+    assertIdentical(
+      response.headers.get("access-control-allow-credentials"),
+      null,
+    );
+  });
+
+  it("leaves off a header whose configured list is empty", async () => {
+    // Given a Function URL open to any Origin with an empty method list.
+    const { simAws, url } = await greeterUrl({
+      cors: { AllowOrigins: ["*"], AllowMethods: [] },
+    });
+
+    // When a preflight arrives.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      url,
+      preflight("https://shop.example.com"),
+    );
+
+    // Then no method is allowed. An empty header value would say something
+    // else to a browser.
+    assertIdentical(response.headers.get("access-control-allow-origin"), "*");
+    assertIdentical(response.headers.get("access-control-allow-methods"), null);
+  });
+
+  it("leaves a URL without CORS answering OPTIONS from the handler", async () => {
+    // Given a Function URL with no CORS configuration.
+    const { simAws, url } = await greeterUrl({
+      zipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 204,
+        headers: { allow: "GET, POST" },
+        body: "",
+      })),
+    });
+
+    // When a preflight arrives.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      url,
+      preflight("https://shop.example.com"),
+    );
+
+    // Then the handler answered it, and nothing added CORS headers.
+    assertResponseStatus(response, 204, await describeResponse(response));
+    assertIdentical(response.headers.get("allow"), "GET, POST");
+    assertIdentical(response.headers.get("access-control-allow-origin"), null);
+  });
+
+  it("refuses an unsigned preflight to an IAM-authenticated URL", async () => {
+    // Given an AWS_IAM Function URL configured for CORS.
+    const { simAws, url } = await greeterUrl({
+      authType: "AWS_IAM",
+      cors: simLambdaFunctionUrlCorsFactory.make({ AllowOrigins: ["*"] }),
+    });
+
+    // When a browser sends the preflight it cannot sign.
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      url,
+      preflight("https://shop.example.com"),
+    );
+
+    // Then the URL refuses it, as it refuses any unsigned request.
+    assertResponseStatus(response, 403, await describeResponse(response));
+    assertIdentical(response.headers.get("access-control-allow-origin"), null);
+  });
+
+  it("leaves an OPTIONS request that is not a preflight to the handler", async () => {
+    // Given a Function URL configured for CORS.
+    const { simAws, url } = await greeterUrl({
+      cors: simLambdaFunctionUrlCorsFactory.make({ AllowOrigins: ["*"] }),
+      zipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        headers: { allow: "GET, POST" },
+        body: "options from the handler",
+      })),
+    });
+
+    // When an OPTIONS request arrives naming no method to be preflighted.
+    const response = await new SimAwsHttp({ simAws }).fetch(url, {
+      method: "OPTIONS",
+      headers: { origin: "https://shop.example.com" },
+    });
+
+    // Then the handler answered it, with the configured headers added the way
+    // they are on any other response.
+    assertIdentical(await response.text(), "options from the handler");
+    assertIdentical(response.headers.get("allow"), "GET, POST");
+    assertIdentical(response.headers.get("access-control-allow-origin"), "*");
+  });
+});


### PR DESCRIPTION
Yulin accepted a Function URL's `Cors` block and discarded it. A template could deploy clean while its browser preflight and response headers differed from AWS. The configuration is now held on the Function URL and round-trips through the create, get, update and list commands. `AWS::Lambda::Url.Cors` and SAM's `FunctionUrlConfig` deploy it by that same path. The HTTP controller answers a valid preflight from the configuration without invoking the handler, and adds the configured headers to every other response alongside the ones the handler sent, duplicates included. Values outside the bounds the Lambda API publishes are refused before the URL configuration changes.

Resolves #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)