### PR TITLE
feat: raise S3 events a deployment causes

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2028,6 +2028,11 @@ around it are read the same way:
   the deployment turns it off, as the construct is. Pruning only considers what the filters and the
   key prefix select, and leaves alone any Object the deployment would never have copied.
 
+A Bucket with an event notification configuration hears the deployment. Every file the deployment
+writes raises `s3:ObjectCreated:Put`, and every Object a pruning deployment removes raises
+`s3:ObjectRemoved:Delete`, the two the real provider function's sync raises. See
+[Event notifications](https://yulinsim.dev/services/s3/#event-notifications).
+
 Several deployments can share one Bucket. That is the usual arrangement when the headers differ by
 file type, since a `BucketDeployment` sets them for all of its files at once. A second deployment is
 how the rest of the site gets different ones. Give the second one `prune: false`, or filters that miss

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1290,6 +1290,11 @@ The event types a configuration can name are `s3:ObjectCreated:*`, `s3:ObjectCre
 `s3:ObjectRemoved:*` and `s3:ObjectRemoved:Delete`. Any other S3 event type is refused by name rather
 than stored and never raised.
 
+A CDK [`BucketDeployment`](https://yulinsim.dev/services/cloudformation/#cdk-s3-bucketdeployment) raises
+both. It copies its files in one Object at a time, so each file the deployment writes raises
+`ObjectCreated:Put`, and each Object a pruning deployment removes raises `ObjectRemoved:Delete`. The
+sync it stands in for raises the same two in AWS.
+
 A configuration can filter on an object key prefix, a suffix, or both. Two configurations that share
 an event type and whose filters could both match the same key are refused with `InvalidArgument`, as
 real S3 refuses them. Overlapping prefixes are fine when the suffixes do not overlap, so one function
@@ -2008,9 +2013,11 @@ writes fall outside it. Without that, the simulation stops after a thousand deli
   same way.
 - The KMS key policy statement CDK's `SqsDestination` writes for an encrypted queue is ignored.
   Queue encryption is left out.
-- A CDK `BucketDeployment` and `mountBucketFilesystem(...)` both replace the whole storage backend
-  rather than putting Objects, and neither raises an event. Real CDK `BucketDeployment` fires one
-  `ObjectCreated:Put` per file.
+- `mountBucketFilesystem(...)` replaces the storage with the directory, and a file written there by
+  something other than S3 raises nothing. The watcher reports that the directory changed without
+  naming the file, and comparing the whole key set on every reload is a larger change than this
+  earns. A delete through S3 raises `ObjectRemoved:Delete` on a mount that
+  [allows deletion](#deleting-the-files-under-a-mount).
 - A topic destination publishes with no message attributes, since real S3 publishes none. The only
   thing on the message besides the event document is the `Amazon S3 Notification` subject.
 - `s3:TestEvent` is left out. Real S3 puts one on a queue or topic when a configuration naming it is
@@ -3348,13 +3355,7 @@ Filesystem storage is somewhat restrictive to make it slightly safer:
 - Object keys must not be absolute paths or contain `..`
 - Only files whose extension is on a cautious list are served (see below)
 - Symlinks are ignored when listing Objects
-- Deletion is refused, and never unlinks a real file
-
-`DeleteObject` against a filesystem-backed Bucket raises `NotImplemented`, and `DeleteObjects`
-reports the same code for every key. This is stricter than real S3, deliberately. The directory a
-Bucket is mounted on is an ordinary directory of yours, and removing files from it because a test
-called `DeleteObject` would be a poor default. Leave a Bucket on the default in-memory storage
-when a test needs deletion to work.
+- Deletion is refused until the mount asks for it (see below)
 
 When reading files from filesystem-backed storage, Yulin infers common `content-type` metadata from
 file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`, `.csv`, `.pdf`,
@@ -3362,6 +3363,43 @@ file extensions such as `.html`, `.css`, `.js`, `.json`, `.png`, `.svg`, `.txt`,
 `binary/octet-stream`, as S3 reports for an Object whose type it was never told. That only comes up
 for an extension a mount named itself, below. No other file is served at all, with or without a
 type.
+
+### Deleting the files under a mount
+
+`DeleteObject` against a filesystem-backed Bucket raises `NotImplemented`, and `DeleteObjects`
+reports the same code for every key. This is stricter than real S3, deliberately. The directory a
+Bucket is mounted on is an ordinary directory of yours, and removing files from it because a test
+called `DeleteObject` would be a poor default.
+
+Code that deletes what it uploaded needs a Bucket that can. A mount says so with `allowDelete`, and
+a delete then unlinks the file, reports the removal and raises the `ObjectRemoved:Delete` event an
+in-memory Bucket raises:
+
+```typescript sim-s3-mount-allow-delete
+/**
+ * Letting a mounted Bucket delete the files it serves.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+simAws
+  .s3()
+  .mountBucketFilesystem("uploads", path.join(process.cwd(), "assets"), {
+    allowDelete: true,
+  });
+```
+
+The key goes through the checks above either way. A delete naming a path that climbs out of the
+directory is refused, and so is one naming a file type the mount does not serve. The directory the
+file was in stays where it is, since a Bucket has no directories for an empty one to be. Leave the
+option off and the refusal stands, naming the directory it would have unlinked from.
 
 ### Serving a file extension of your own
 
@@ -3659,9 +3697,9 @@ Sim S3 currently supports:
 - Bucket-global uniqueness within a `SimAws` instance across simulated Accounts and Regions
 - In-memory Object storage by default
 - Optional filesystem-backed Bucket storage with `mountBucketFilesystem(...)`, watching the mounted
-  directory and reloading connected browsers when it is rebuilt, and reporting the system metadata a
+  directory and reloading connected browsers when it is rebuilt, reporting the system metadata a
   CDK `BucketDeployment` into the same Bucket published, alongside anything the mount declares for a
-  key prefix itself
+  key prefix itself, and deleting the files under it where the mount allows that
 
 The simulator aims at useful behaviour for tests and local development, short of full S3 feature
 parity. Unsupported S3 options may be ignored or may throw errors depending on whether the simulator
@@ -3678,8 +3716,11 @@ These apply across the page. The sections above each list what is specific to th
 - Object tags, ACLs and replication are left out. Server-side encryption is reported and never
   applied, and an `aws:kms` Object names no key, because there is no simulated KMS behind it. See
   [Default encryption](#default-encryption).
-- A Bucket using filesystem-backed storage cannot delete Objects, and raises no event
-  notifications, because it swaps the whole storage backend in place of putting Objects.
+- A Bucket using filesystem-backed storage refuses a delete unless the mount allowed one, and hears
+  nothing about a file something else wrote under the directory. See
+  [Deleting the files under a mount](#deleting-the-files-under-a-mount).
+- Multipart upload parts for a mounted Bucket are held in memory, and only the assembled Object
+  reaches the directory.
 - An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, leaving
   a presigned `PUT` unable to set the rest. A `PutObjectCommand` through the SDK keeps all of them.
 - A presigned `GetObject` ignores the `response-content-type`, `response-cache-control` and other

--- a/docs/services/s3/sim-s3-mount-allow-delete.example.ts
+++ b/docs/services/s3/sim-s3-mount-allow-delete.example.ts
@@ -1,0 +1,18 @@
+/**
+ * Letting a mounted Bucket delete the files it serves.
+ */
+
+import path from "node:path";
+
+import { CreateBucketCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+simAws
+  .s3()
+  .mountBucketFilesystem("uploads", path.join(process.cwd(), "assets"), {
+    allowDelete: true,
+  });

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-copier.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-copier.iso.test.ts
@@ -13,6 +13,12 @@ import {
 } from "../../../../../s3/object/s3-object.js";
 import { TemporaryDirectory } from "../../../../../../util/filesystem/temporary-directory.js";
 import { SimCdkBucketDeployProperties } from "../property/sim-cdk-bucket-deploy-properties.js";
+import {
+  type SimCdkBucketDeployNotifier,
+  simCdkBucketDeployNotifier,
+} from "../notify/sim-cdk-bucket-deploy-notifier.js";
+import { SimAws } from "../../../../../aws/sim-aws.js";
+import type { SimCloudFormationResourceCreateContext } from "../../../../resource/sim-cfn-resource.js";
 import { SimCdkBucketDeployCopier } from "./sim-cdk-bucket-deploy-copier.js";
 
 describe("SimCdkBucketDeployCopier", () => {
@@ -45,6 +51,17 @@ describe("SimCdkBucketDeployCopier", () => {
     return await temporaryDirectory.resolvePath();
   }
 
+  /**
+   * The events a deployment into this Bucket raises. Nothing here is
+   * configured to hear them. These tests are about what ends up in the Bucket.
+   */
+  function notifier(bucket: SimS3Bucket): SimCdkBucketDeployNotifier {
+    return simCdkBucketDeployNotifier(resource, bucket, {
+      simAws: new SimAws(),
+      resources: new Map(),
+    } satisfies SimCloudFormationResourceCreateContext);
+  }
+
   async function objectKeys(bucket: SimS3Bucket): Promise<string[]> {
     const objects = await bucket.listObjects();
 
@@ -64,6 +81,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When the deployment is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties(),
     }).copy([sourcePath]);
 
@@ -87,6 +105,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When a deployment with both sources is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties({
         SourceObjectKeys: ["abc123.zip", "def456.zip"],
       }),
@@ -106,6 +125,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When it is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties({ DestinationBucketKeyPrefix: "assets" }),
     }).copy([sourcePath]);
 
@@ -126,6 +146,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When it is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties({ Exclude: ["*"], Include: ["*.txt"] }),
     }).copy([sourcePath]);
 
@@ -143,6 +164,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When it is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties({
         SystemMetadata: {
           "content-type": "text/plain",
@@ -173,6 +195,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When it is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties(),
     }).copy([sourcePath]);
 
@@ -200,6 +223,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When a pruning deployment is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties(),
     }).copy([sourcePath]);
 
@@ -227,6 +251,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // turned off, which is what lets two of them share a Bucket.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties({ Prune: false }),
     }).copy([sourcePath]);
 
@@ -253,6 +278,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When a pruning deployment into a prefix is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties({ DestinationBucketKeyPrefix: "assets" }),
     }).copy([sourcePath]);
 
@@ -281,6 +307,7 @@ describe("SimCdkBucketDeployCopier", () => {
     // When a pruning deployment excluding that directory is copied in.
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties({ Exclude: ["data/*"] }),
     }).copy([sourcePath]);
 
@@ -301,6 +328,7 @@ describe("SimCdkBucketDeployCopier", () => {
 
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties(),
     }).copy([firstPath]);
 
@@ -309,6 +337,7 @@ describe("SimCdkBucketDeployCopier", () => {
 
     await new SimCdkBucketDeployCopier({
       bucket,
+      notifier: notifier(bucket),
       properties: properties(),
     }).copy([secondPath]);
 

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-copier.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-copier.ts
@@ -1,5 +1,6 @@
 import type { SimS3Bucket } from "../../../../../s3/bucket/sim-s3-bucket.js";
 import { SimCdkBucketDeployFilter } from "../filter/sim-cdk-bucket-deploy-filter.js";
+import type { SimCdkBucketDeployNotifier } from "../notify/sim-cdk-bucket-deploy-notifier.js";
 import type { SimCdkBucketDeployProperties } from "../property/sim-cdk-bucket-deploy-properties.js";
 import { SimCdkBucketDeployFile } from "./sim-cdk-bucket-deploy-file.js";
 import { simCdkBucketDeployFiles } from "./sim-cdk-bucket-deploy-files.js";
@@ -8,6 +9,7 @@ import { SimCdkBucketDeployPruner } from "./sim-cdk-bucket-deploy-pruner.js";
 interface SimCdkBucketDeployCopierProperties {
   readonly bucket: SimS3Bucket;
   readonly properties: SimCdkBucketDeployProperties;
+  readonly notifier: SimCdkBucketDeployNotifier;
 }
 
 /**
@@ -40,6 +42,7 @@ export class SimCdkBucketDeployCopier {
       bucket: properties.bucket,
       filter: this.filter,
       keyPrefix: this.properties.destinationKeyPrefix,
+      notifier: properties.notifier,
     });
   }
 

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-file.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-file.ts
@@ -7,11 +7,13 @@ import {
   SimS3ObjectMetadata,
 } from "../../../../../s3/object/s3-object.js";
 import { metadataForFilesystemS3ObjectKey } from "../../../../../s3/storage/filesystem/s3-filesystem-object-metadata.js";
+import type { SimCdkBucketDeployNotifier } from "../notify/sim-cdk-bucket-deploy-notifier.js";
 import type { SimCdkBucketDeployProperties } from "../property/sim-cdk-bucket-deploy-properties.js";
 
 interface SimCdkBucketDeployFileProperties {
   readonly bucket: SimS3Bucket;
   readonly properties: SimCdkBucketDeployProperties;
+  readonly notifier: SimCdkBucketDeployNotifier;
 }
 
 /**
@@ -23,14 +25,20 @@ interface SimCdkBucketDeployFileProperties {
 export class SimCdkBucketDeployFile {
   private readonly bucket: SimS3Bucket;
   private readonly properties: SimCdkBucketDeployProperties;
+  private readonly notifier: SimCdkBucketDeployNotifier;
 
   constructor(properties: SimCdkBucketDeployFileProperties) {
     this.bucket = properties.bucket;
     this.properties = properties.properties;
+    this.notifier = properties.notifier;
   }
 
   /**
    * Store one file as an Object, and answer with the key it went under.
+   *
+   * The Object goes into the Bucket rather than through PutObject, so the
+   * event a Put would have raised is raised here, once the write has happened
+   * and carrying the version it was given.
    */
   async copy(
     sourceDirectoryPath: string,
@@ -40,9 +48,14 @@ export class SimCdkBucketDeployFile {
     // oxlint-disable-next-line security/detect-non-literal-fs-filename
     const body = await readFile(path.join(sourceDirectoryPath, relativePath));
 
-    await this.bucket.putObject(
-      new SimS3Object({ key, body, metadata: this.metadata(relativePath) }),
-    );
+    const object = new SimS3Object({
+      key,
+      body,
+      metadata: this.metadata(relativePath),
+    });
+    const version = await this.bucket.putObject(object);
+
+    this.notifier.deployed(object, version?.versionId);
 
     return key;
   }

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-pruner.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/copy/sim-cdk-bucket-deploy-pruner.ts
@@ -1,10 +1,12 @@
 import type { SimS3Bucket } from "../../../../../s3/bucket/sim-s3-bucket.js";
 import type { SimCdkBucketDeployFilter } from "../filter/sim-cdk-bucket-deploy-filter.js";
+import type { SimCdkBucketDeployNotifier } from "../notify/sim-cdk-bucket-deploy-notifier.js";
 
 interface SimCdkBucketDeployPrunerProperties {
   readonly bucket: SimS3Bucket;
   readonly filter: SimCdkBucketDeployFilter;
   readonly keyPrefix: string;
+  readonly notifier: SimCdkBucketDeployNotifier;
 }
 
 /**
@@ -21,15 +23,20 @@ export class SimCdkBucketDeployPruner {
   private readonly bucket: SimS3Bucket;
   private readonly filter: SimCdkBucketDeployFilter;
   private readonly keyPrefix: string;
+  private readonly notifier: SimCdkBucketDeployNotifier;
 
   constructor(properties: SimCdkBucketDeployPrunerProperties) {
     this.bucket = properties.bucket;
     this.filter = properties.filter;
     this.keyPrefix = properties.keyPrefix;
+    this.notifier = properties.notifier;
   }
 
   /**
    * Remove everything this deployment would have copied and did not.
+   *
+   * Each removal raises what a DeleteObject would have raised, since the sync
+   * this stands in for deletes through the API like any other caller.
    */
   async prune(deployedKeys: ReadonlySet<string>): Promise<void> {
     const existing = await this.bucket.listObjects(this.keyPrefix);
@@ -39,7 +46,9 @@ export class SimCdkBucketDeployPruner {
 
     await Promise.all(
       stale.map(async (object) => {
-        await this.bucket.deleteObject(object.key);
+        const deletion = await this.bucket.deleteObject(object.key);
+
+        this.notifier.pruned(object.key, deletion);
       }),
     );
   }

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/notify/sim-cdk-bucket-deploy-notifier.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/notify/sim-cdk-bucket-deploy-notifier.ts
@@ -1,0 +1,96 @@
+import type { SimAwsResolvedCaller } from "../../../../../aws/caller/sim-aws-caller-resolver.js";
+import { makeSimAwsAccountRootPrincipal } from "../../../../../aws/caller/sim-aws-account-root-principal.js";
+import { simAwsResolvedCallerOf } from "../../../../../aws/caller/sim-aws-resolved-caller.js";
+import type { SimS3Bucket } from "../../../../../s3/bucket/sim-s3-bucket.js";
+import type { SimS3ObjectDeletion } from "../../../../../s3/bucket/sim-s3-object-deletion.js";
+import { simS3NotifyDeleted } from "../../../../../s3/command/delete-object/sim-s3-notify-deleted.js";
+import type { SimS3ObjectNotifier } from "../../../../../s3/notification/sim-s3-object-notifier.js";
+import type { SimS3Object } from "../../../../../s3/object/s3-object.js";
+import type {
+  SimCfnResource,
+  SimCloudFormationResourceCreateContext,
+} from "../../../../resource/sim-cfn-resource.js";
+
+interface SimCdkBucketDeployNotifierProperties {
+  readonly bucket: SimS3Bucket;
+  readonly notifications: SimS3ObjectNotifier;
+  readonly caller: SimAwsResolvedCaller;
+}
+
+/**
+ * Raises the S3 Object events a deployment into a Bucket earns.
+ *
+ * A deployment writes Objects rather than sending S3 commands, so it says here
+ * what a command would have said for it. Real CDK runs a provider function
+ * that syncs the staged asset into the Bucket, one PutObject per file and one
+ * DeleteObject per Object the sync deletes, and a Bucket with a notification
+ * configuration hears all of them.
+ */
+export class SimCdkBucketDeployNotifier {
+  private readonly bucket: SimS3Bucket;
+  private readonly notifications: SimS3ObjectNotifier;
+  private readonly caller: SimAwsResolvedCaller;
+
+  constructor(properties: SimCdkBucketDeployNotifierProperties) {
+    this.bucket = properties.bucket;
+    this.notifications = properties.notifications;
+    this.caller = properties.caller;
+  }
+
+  /**
+   * Say that the deployment wrote an Object.
+   */
+  deployed(object: SimS3Object, versionId: string | undefined): void {
+    this.notifications.objectCreated({
+      bucket: this.bucket,
+      object,
+      caller: this.caller,
+      eventName: "s3:ObjectCreated:Put",
+      versionId,
+    });
+  }
+
+  /**
+   * Say that the deployment pruned a key, as far as the delete got.
+   *
+   * A pruning deployment deletes rather than removes. A versioned Bucket keeps
+   * what it held behind a marker, and the event says so. That is the same
+   * three-way answer a DeleteObject command gets, so the same reading of it
+   * serves here.
+   */
+  pruned(key: string, deletion: SimS3ObjectDeletion): void {
+    simS3NotifyDeleted({
+      notifications: this.notifications,
+      bucket: this.bucket,
+      key,
+      caller: this.caller,
+      deletion,
+    });
+  }
+}
+
+/**
+ * The notifier for one deployment, reaching the Bucket's own simulated S3.
+ *
+ * The events are attributed to the Account root rather than to the deployment's
+ * caller. Real S3 names the identity that wrote the Object, which for a CDK
+ * BucketDeployment is the provider function's execution role, and neither that
+ * function nor its role is simulated. Root is what simulated AWS attributes an
+ * unstated caller to everywhere else.
+ */
+export function simCdkBucketDeployNotifier(
+  resource: SimCfnResource,
+  bucket: SimS3Bucket,
+  context: SimCloudFormationResourceCreateContext,
+): SimCdkBucketDeployNotifier {
+  const { accountId, regionName } = resource.accountRegionScope;
+
+  return new SimCdkBucketDeployNotifier({
+    bucket,
+    notifications: context.simAws
+      .accountRegionScope(accountId, regionName)
+      .s3()
+      .objectNotifier(),
+    caller: simAwsResolvedCallerOf(makeSimAwsAccountRootPrincipal(accountId)),
+  });
+}

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment-events.iso.test.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment-events.iso.test.ts
@@ -1,0 +1,238 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  type Event,
+  PutBucketNotificationConfigurationCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayEmpty,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../../../lambda/function/code/lambda-zip-file-input.js";
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+import { TemporaryDirectory } from "../../../../../util/filesystem/temporary-directory.js";
+
+/**
+ * The part of the S3 event document these tests read.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    {
+      readonly eventName: string;
+      readonly s3: { readonly object: { readonly key: string } };
+    },
+  ];
+}
+
+/**
+ * What a Bucket hears when a CDK BucketDeployment fills it.
+ *
+ * Real CDK runs a provider function that syncs the staged asset into the
+ * Bucket, one PutObject per file and one DeleteObject per Object the sync
+ * prunes. A Bucket notifying a function of its uploads is told about the
+ * deployment's files the same way it is told about anyone else's.
+ */
+describe("Events from a CDK BucketDeployment [iso]", () => {
+  const bucketName = "site-bucket";
+  const siteAsset = "asset.aaaa1111";
+  const templatePathParts = ["cdk.out", "FooStack.template.json"];
+
+  /**
+   * A cloud assembly holding one deployment, publishing the files it is given.
+   */
+  async function writeAssembly(files: Record<string, string>): Promise<string> {
+    const temporaryDirectory = new TemporaryDirectory();
+
+    await Promise.all(
+      Object.entries(files).map(async ([relativePath, content]) => {
+        await temporaryDirectory.writeFile(
+          ["cdk.out", siteAsset, ...relativePath.split("/")],
+          content,
+        );
+      }),
+    );
+
+    await temporaryDirectory.writeFile(
+      templatePathParts,
+      jsonStringify({
+        Resources: {
+          DeploySite: {
+            Type: "Custom::CDKBucketDeployment",
+            Properties: {
+              DestinationBucketName: bucketName,
+              SourceObjectKeys: ["site.zip"],
+            },
+          },
+        },
+      }),
+    );
+
+    await temporaryDirectory.writeFile(
+      ["cdk.out", "FooStack.assets.json"],
+      jsonStringify({
+        files: {
+          site: {
+            source: { path: siteAsset, packaging: "zip" },
+            destinations: {
+              "current_account-current_region": { objectKey: "site.zip" },
+            },
+          },
+        },
+      }),
+    );
+
+    return temporaryDirectory.join(...templatePathParts);
+  }
+
+  /**
+   * A Bucket that tells a function about the events it is asked to watch, and
+   * the documents the function was called with.
+   */
+  async function watchingBucket(
+    simAws: SimAws,
+    events: readonly Event[],
+  ): Promise<S3EventDocument[]> {
+    const received: S3EventDocument[] = [];
+
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "auditor",
+        Role: "arn:aws:iam::888888888888:role/AuditorRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "audited";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "auditor",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: `arn:aws:s3:::${bucketName}`,
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: bucketName,
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "deployments",
+              Events: [...events],
+              LambdaFunctionArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:auditor`,
+            },
+          ],
+        },
+      }),
+    );
+
+    return received;
+  }
+
+  /** What the function was told, as one record each. */
+  function records(
+    received: readonly S3EventDocument[],
+  ): { eventName: string; key: string }[] {
+    return received
+      .flatMap((document) => document.Records)
+      .map((record) => ({
+        eventName: record.eventName,
+        key: record.s3.object.key,
+      }))
+      .toSorted((one, other) => one.key.localeCompare(other.key));
+  }
+
+  it("raises one created event for each file it publishes", async () => {
+    // Given a Bucket that tells a function about the Objects created in it
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    const received = await watchingBucket(simAws, ["s3:ObjectCreated:*"]);
+
+    // When a deployment publishes two files into it
+    const templatePath = await writeAssembly({
+      "index.html": "<h1>Hello</h1>",
+      "js/app.js": "console.log('hi');",
+    });
+
+    await simAws.cloudFormation().deployTemplateFile(templatePath);
+    await simAws.backgroundTasksComplete();
+
+    // Then the function heard about each file as the Put that real CDK's sync
+    // makes of it
+    const raised = records(received);
+
+    assertArrayLength(raised, 2);
+    assertIdentical(raised[0].eventName, "ObjectCreated:Put");
+    assertIdentical(raised[0].key, "index.html");
+    assertIdentical(raised[1].eventName, "ObjectCreated:Put");
+    assertIdentical(raised[1].key, "js/app.js");
+  });
+
+  it("raises a removed event for each Object it prunes", async () => {
+    // Given a Bucket holding an Object from an earlier deployment, telling a
+    // function about the Objects removed from it
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "gone.html",
+        Body: "<h1>Gone</h1>",
+      }),
+    );
+    const received = await watchingBucket(simAws, ["s3:ObjectRemoved:*"]);
+
+    // When a deployment whose source no longer holds it publishes
+    const templatePath = await writeAssembly({ "index.html": "<h1>Hi</h1>" });
+
+    await simAws.cloudFormation().deployTemplateFile(templatePath);
+    await simAws.backgroundTasksComplete();
+
+    // Then the function heard about the pruned Object as the delete the sync
+    // makes of it
+    const raised = records(received);
+
+    assertArrayLength(raised, 1);
+    assertIdentical(raised[0].eventName, "ObjectRemoved:Delete");
+    assertIdentical(raised[0].key, "gone.html");
+  });
+
+  it("publishes into a Bucket with no notification configuration", async () => {
+    // Given a Bucket nothing is configured to hear about
+    const simAws = new SimAws();
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    // When a deployment publishes into it
+    const templatePath = await writeAssembly({ "index.html": "<h1>Hi</h1>" });
+
+    await simAws.cloudFormation().deployTemplateFile(templatePath);
+    await simAws.backgroundTasksComplete();
+
+    // Then the file is there, and nothing was attempted with the event
+    const bucket = simAws.s3().getSimBucketByName(bucketName);
+
+    assertNonNullable(bucket);
+    assertNonNullable(await bucket.getObject("index.html"));
+    assertArrayEmpty([...simAws.s3().getNotificationDeliveryFailures()]);
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/sim-cdk-bucket-deployment.ts
@@ -7,6 +7,7 @@ import { SimCdkBucketDeploySource } from "./source/sim-cdk-bucket-deploy-source.
 import { SimCdkBucketDeployCopier } from "./copy/sim-cdk-bucket-deploy-copier.js";
 import { SimCdkBucketDeployProperties } from "./property/sim-cdk-bucket-deploy-properties.js";
 import { declareSimCdkBucketDeployMetadata } from "./metadata/sim-cdk-bucket-deploy-metadata.js";
+import { simCdkBucketDeployNotifier } from "./notify/sim-cdk-bucket-deploy-notifier.js";
 import { simCdkBucketDeployDestination } from "./destination/sim-cdk-bucket-deploy-destination.js";
 
 /**
@@ -64,18 +65,19 @@ export class SimCdkBucketDeploymentResourceFactory implements SimCfnServiceResou
 
     const bucket = simCdkBucketDeployDestination(resource, properties, context);
 
-    const sourceDirectoryPaths = properties.sourceObjectKeys.map(
-      (sourceObjectKey) =>
-        this.sourceResolver.sourceDirectoryPathForObjectKey(
-          resource,
-          sourceObjectKey,
-          context.cdkOutContext,
-        ),
+    const sourceDirectoryPaths = this.sourceResolver.sourceDirectoryPaths(
+      resource,
+      properties.sourceObjectKeys,
+      context.cdkOutContext,
     );
 
+    // The copier writes Objects into the Bucket instead of sending PutObject,
+    // and a Bucket configured to notify still hears about every file it writes
+    // and every Object it prunes.
     const publishedKeys = await new SimCdkBucketDeployCopier({
       bucket,
       properties,
+      notifier: simCdkBucketDeployNotifier(resource, bucket, context),
     }).copy(sourceDirectoryPaths);
 
     // Said as well as set. The Objects above carry these headers themselves,

--- a/src/service/cloudformation/cdk/s3/bucket-deployment/source/sim-cdk-bucket-deploy-source.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-deployment/source/sim-cdk-bucket-deploy-source.ts
@@ -12,6 +12,20 @@ import { SimCdkBucketDeployErrorMessage } from "../error-message/sim-cdk-bucket-
  */
 export class SimCdkBucketDeploySource {
   /**
+   * Find the local source directory for every source object key a deployment
+   * names, in the order it names them.
+   */
+  sourceDirectoryPaths(
+    resource: SimCfnResource,
+    sourceObjectKeys: readonly string[],
+    cdkOutContext: SimCdkOutContext | undefined,
+  ): string[] {
+    return sourceObjectKeys.map((objectKey) =>
+      this.sourceDirectoryPathForObjectKey(resource, objectKey, cdkOutContext),
+    );
+  }
+
+  /**
    * Find the local source directory for a CDK BucketDeployment source object key.
    */
   sourceDirectoryPathForObjectKey(

--- a/src/service/s3/bucket/sim-s3-bucket-access.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-access.ts
@@ -1,6 +1,6 @@
 import { assertDefined } from "../../../util/type-guard/defined.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
-import { FilesystemS3BucketStorage } from "../storage/filesystem/s3-filesystem-storage.js";
+import { filesystemS3MountStorage } from "../storage/filesystem/s3-filesystem-deleting-storage.js";
 import { simS3BucketUrl, simS3ServiceUrl } from "./sim-s3-endpoint-url.js";
 import type { SimS3Bucket, SimS3BucketName } from "./sim-s3-bucket.js";
 import { SimS3DeclaredSystemMetadata } from "../object/s3-declared-system-metadata.js";
@@ -98,6 +98,9 @@ export class SimS3BucketAccess {
    * cached. A deployment into the same Bucket has already said it, so the mount
    * inherits what the Bucket was told, and `systemMetadata` is where it
    * declares the rest or answers differently.
+   *
+   * The Bucket serves and accepts writes but refuses a delete, since the files
+   * are the user's own. `allowDelete` is how a mount asks for one.
    */
   mountFilesystem(
     bucketName: SimS3BucketName | string,
@@ -111,11 +114,12 @@ export class SimS3BucketAccess {
     });
 
     bucket.configureSimStorage(
-      new FilesystemS3BucketStorage({
+      filesystemS3MountStorage({
         directoryPath,
         ...(options.additionalFileExtensions !== undefined && {
           additionalFileExtensions: options.additionalFileExtensions,
         }),
+        allowDelete: options.allowDelete,
         systemMetadata,
       }),
     );

--- a/src/service/s3/mount/sim-s3-mount-delete.iso.test.ts
+++ b/src/service/s3/mount/sim-s3-mount-delete.iso.test.ts
@@ -1,0 +1,165 @@
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  PutBucketNotificationConfigurationCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayEmpty,
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import { SimS3NotImplemented } from "../error/sim-s3.error.js";
+
+/**
+ * The part of the S3 event document this test reads.
+ */
+interface S3EventDocument {
+  readonly Records: readonly [
+    {
+      readonly eventName: string;
+      readonly s3: { readonly object: { readonly key: string } };
+    },
+  ];
+}
+
+/**
+ * Deleting an Object out of a Bucket serving a directory.
+ *
+ * A mounted Bucket is pointed at files the user wrote, so it refuses a delete
+ * unless the mount asked for one. Code that deletes what it uploaded is then
+ * testable against a mounted Bucket, and code that deletes by accident still
+ * cannot take a build directory with it.
+ */
+describe("Deleting from a mounted simulated S3 Bucket [iso]", () => {
+  /**
+   * A Bucket serving a directory holding one file, and the function it tells
+   * about Object removals.
+   */
+  async function mountedSite(
+    simAws: SimAws,
+    directoryPath: string,
+    options: { readonly allowDelete?: boolean } = {},
+  ): Promise<S3EventDocument[]> {
+    const received: S3EventDocument[] = [];
+
+    await simAws.s3().createBucket(new CreateBucketCommand({ Bucket: "site" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "auditor",
+        Role: "arn:aws:iam::888888888888:role/AuditorRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput((event: S3EventDocument) => {
+            received.push(event);
+
+            return "audited";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "auditor",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::site",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "site",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Id: "removals",
+              Events: ["s3:ObjectRemoved:*"],
+              LambdaFunctionArn: `arn:aws:lambda:${simAws.defaultRegionName}:${simAws.defaultAccountId}:function:auditor`,
+            },
+          ],
+        },
+      }),
+    );
+
+    simAws.s3().mountBucketFilesystem("site", directoryPath, options);
+
+    return received;
+  }
+
+  it("removes the file and raises the removal event when the mount allows it", async () => {
+    // Given a Bucket serving a build directory it may delete from, notifying a
+    // function of removals
+    const buildDirectory = new TemporaryDirectory();
+    await buildDirectory.writeFile(["public", "stale.html"], "<h1>Stale</h1>");
+
+    const simAws = new SimAws();
+    const received = await mountedSite(simAws, buildDirectory.join("public"), {
+      allowDelete: true,
+    });
+
+    // When the Object is deleted through S3
+    await simAws
+      .s3()
+      .deleteObject(
+        new DeleteObjectCommand({ Bucket: "site", Key: "stale.html" }),
+      );
+    await simAws.backgroundTasksComplete();
+
+    // Then the Bucket no longer holds it, and the function heard about it the
+    // way it hears about an in-memory Bucket
+    const bucket = simAws.s3().getSimBucketByName("site");
+
+    assertNonNullable(bucket);
+    assertUndefined(await bucket.getObject("stale.html"));
+
+    assertArrayLength(received, 1);
+    const records = received[0].Records;
+    assertArrayLength(records, 1);
+    assertIdentical(records[0].eventName, "ObjectRemoved:Delete");
+    assertIdentical(records[0].s3.object.key, "stale.html");
+  });
+
+  it("refuses the delete and keeps the file when the mount does not allow it", async () => {
+    // Given a Bucket serving a build directory, mounted as it is by default
+    const buildDirectory = new TemporaryDirectory();
+    await buildDirectory.writeFile(["public", "index.html"], "<h1>Hello</h1>");
+
+    const simAws = new SimAws();
+    const received = await mountedSite(simAws, buildDirectory.join("public"));
+
+    // When the Object is deleted through S3
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws
+        .s3()
+        .deleteObject(
+          new DeleteObjectCommand({ Bucket: "site", Key: "index.html" }),
+        );
+    });
+    await simAws.backgroundTasksComplete();
+
+    // Then the refusal names the directory it would have unlinked a file from
+    assertInstanceOf(error, SimS3NotImplemented);
+    assertStringIncludes(error.message, "will not delete index.html");
+    assertStringIncludes(error.message, buildDirectory.join("public"));
+
+    // And the file is still served, with nothing raised about it
+    const bucket = simAws.s3().getSimBucketByName("site");
+
+    assertNonNullable(bucket);
+    assertNonNullable(await bucket.getObject("index.html"));
+    assertArrayEmpty(received);
+  });
+});

--- a/src/service/s3/mount/sim-s3-mount.type.ts
+++ b/src/service/s3/mount/sim-s3-mount.type.ts
@@ -33,6 +33,17 @@ export interface SimS3MountFilesystemOptions {
   readonly settleMs?: number | undefined;
 
   /**
+   * Let a DeleteObject remove the file behind an Object key.
+   *
+   * A mounted Bucket refuses a delete by default, because the files under the
+   * directory are the user's own and a test that empties a Bucket would empty
+   * their build output with it. A mount that says so gets the deletion an
+   * in-memory Bucket performs, event notification included, within the same
+   * key and extension checks a read goes through.
+   */
+  readonly allowDelete?: boolean | undefined;
+
+  /**
    * File extensions to serve in addition to the usual web ones.
    *
    * A mounted Bucket only serves files whose extension is on a cautious list —

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -10,6 +10,7 @@ import { SimS3Operations } from "./sim-s3-operations.js";
 import { SimS3SdkCommandRouter } from "./sdk/sim-s3-sdk-command-router.js";
 import type { SimSdkCommandRouter } from "../../sdk/router/sim-sdk-command-router.type.js";
 import type { SimS3NotificationDeliveryFailure } from "./notification/sim-s3-notification-failures.js";
+import type { SimS3ObjectNotifier } from "./notification/sim-s3-object-notifier.js";
 import type { SimS3MountFilesystemOptions } from "./mount/sim-s3-mount.type.js";
 
 /**
@@ -74,6 +75,20 @@ export class SimS3 extends SimS3Operations {
    */
   getNotificationDeliveryFailures(): readonly SimS3NotificationDeliveryFailure[] {
     return this.commands.objectNotifier.deliveryFailures;
+  }
+
+  /**
+   * Get the notifier this scope's Object commands raise their events through.
+   *
+   * A write that reaches a Bucket without going through an S3 command still
+   * owes the Bucket's destinations an event. A CDK BucketDeployment is one. It
+   * stands in for a provider function that syncs a directory into the Bucket,
+   * and the Bucket notifies whatever it was configured to notify. One notifier
+   * serves the scope, so the events a deployment raises are sequenced against
+   * the commands' own rather than starting a sequence beside them.
+   */
+  objectNotifier(): SimS3ObjectNotifier {
+    return this.commands.objectNotifier;
   }
 
   /**

--- a/src/service/s3/storage/filesystem/s3-filesystem-deleting-storage.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-deleting-storage.ts
@@ -1,0 +1,48 @@
+import { unlinkFilesystemS3File } from "./s3-filesystem-deletion.js";
+import {
+  FilesystemS3BucketStorage,
+  type FilesystemS3BucketStorageProperties,
+} from "./s3-filesystem-storage.js";
+
+interface FilesystemS3MountStorageProperties extends FilesystemS3BucketStorageProperties {
+  /**
+   * Whether the mount asked to be able to delete the files under it.
+   */
+  readonly allowDelete?: boolean | undefined;
+}
+
+/**
+ * Filesystem-backed storage for a mount that asked to be able to delete.
+ *
+ * A mounted Bucket refuses a delete by default, for the reason
+ * `FilesystemS3BucketStorage.deleteObject` gives. `allowDelete` on the mount
+ * is what puts this in its place, and the Bucket then deletes the way an
+ * in-memory one does.
+ */
+export class DeletingFilesystemS3BucketStorage extends FilesystemS3BucketStorage {
+  /**
+   * Remove the file backing a simulated Object.
+   *
+   * The removal is reported, so the Bucket raises the event a removal raises,
+   * and the key goes through the same safety checks a read and a write do. A
+   * delete naming a path or a file type those refuse is refused here too.
+   */
+  override async deleteObject(key: string): Promise<boolean> {
+    return await unlinkFilesystemS3File(this.objectKeys.filePathFor(key));
+  }
+}
+
+/**
+ * The storage a mounted directory gets, deleting only where the mount said so.
+ *
+ * The choice is made once, when the directory is mounted, so a Bucket that may
+ * delete and a Bucket that may not are two different pieces of storage rather
+ * than one holding a flag.
+ */
+export function filesystemS3MountStorage(
+  properties: FilesystemS3MountStorageProperties,
+): FilesystemS3BucketStorage {
+  return properties.allowDelete === true
+    ? new DeletingFilesystemS3BucketStorage(properties)
+    : new FilesystemS3BucketStorage(properties);
+}

--- a/src/service/s3/storage/filesystem/s3-filesystem-deletion.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-deletion.ts
@@ -1,0 +1,29 @@
+import { unlink } from "node:fs/promises";
+
+import { isMissingFilesystemPathError } from "./filesystem-path-exists.js";
+
+/**
+ * Remove one file, reporting whether there was one to remove.
+ *
+ * A key the directory does not hold is what an idempotent S3 delete of a
+ * missing Object looks like, and the Bucket raises no removal event for it.
+ * The directory the file was in stays where it is, since a Bucket has no
+ * directories for an empty one to be.
+ */
+export async function unlinkFilesystemS3File(
+  filePath: string,
+): Promise<boolean> {
+  try {
+    // oxlint-disable-next-line security/detect-non-literal-fs-filename
+    await unlink(filePath);
+  } catch (error) {
+    if (isMissingFilesystemPathError(error)) {
+      return false;
+    }
+
+    /* v8 ignore next */
+    throw error;
+  }
+
+  return true;
+}

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.iso.test.ts
@@ -5,14 +5,17 @@ import {
   assertArrayEmpty,
   assertArrayLength,
   assertBufferEqual,
+  assertFalse,
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertTrue,
   assertUndefined,
 } from "@kensio/smartass";
 import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
+import { DeletingFilesystemS3BucketStorage } from "./s3-filesystem-deleting-storage.js";
 import { FilesystemS3BucketStorage } from "./s3-filesystem-storage.js";
 import { SimS3Object } from "../../object/s3-object.js";
 import { TemporaryDirectory as TemporaryDirectory } from "../../../../util/filesystem/temporary-directory.js";
@@ -274,9 +277,85 @@ describe("Filesystem simulated S3 storage", () => {
       await storage.deleteObject("keep.txt");
     });
 
-    // Then the refusal is reported, and the file is still there
+    // Then the refusal is reported, naming the directory the file is in, and
+    // the file is still there
     assertInstanceOf(error, SimS3NotImplemented);
     assertStringIncludes(error.message, "will not delete keep.txt");
+    assertStringIncludes(error.message, testDirectory.join("public"));
     assertNonNullable(await storage.getObject("keep.txt"));
+  });
+
+  it("deletes an Object by unlinking its file when the mount allows it", async () => {
+    // Given a directory mounted with deletion allowed, backing an Object
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(["public", "stale.txt"], "stale");
+
+    const storage = new DeletingFilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+    });
+
+    // When the Object is deleted
+    const removed = await storage.deleteObject("stale.txt");
+
+    // Then the removal is reported and the file has gone with it
+    assertTrue(removed);
+    assertUndefined(await storage.getObject("stale.txt"));
+    assertArrayEmpty(await storage.listObjects());
+  });
+
+  it("reports no removal for a key the directory does not hold", async () => {
+    // Given a directory mounted with deletion allowed, holding one file
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(["public", "kept.txt"], "kept");
+
+    const storage = new DeletingFilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+    });
+
+    // When a key that was never there is deleted
+    const removed = await storage.deleteObject("never-there.txt");
+
+    // Then nothing was removed, which is what S3 says of an idempotent delete,
+    // and the file beside it is untouched
+    assertFalse(removed);
+    assertNonNullable(await storage.getObject("kept.txt"));
+  });
+
+  it("refuses to delete through a key climbing out of the directory", async () => {
+    // Given a mount allowing deletion, and a file outside the directory
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(["public", "index.html"], "site");
+    await testDirectory.writeFile("outside.txt", "outside");
+
+    const storage = new DeletingFilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+    });
+
+    // When a key pointing above the directory is deleted
+    const error = await assertThrowsErrorAsync(async () => {
+      await storage.deleteObject("../outside.txt");
+    });
+
+    // Then the key is refused by the same check a read goes through
+    assertStringIncludes(error.message, "must not contain '..'");
+  });
+
+  it("refuses to delete a file whose extension it would not serve", async () => {
+    // Given a mount allowing deletion, and a file it does not serve
+    const testDirectory = new TemporaryDirectory();
+    await testDirectory.writeFile(["public", "private.pem"], "key material");
+
+    const storage = new DeletingFilesystemS3BucketStorage({
+      directoryPath: testDirectory.join("public"),
+    });
+
+    // When that file's key is deleted
+    const error = await assertThrowsErrorAsync(async () => {
+      await storage.deleteObject("private.pem");
+    });
+
+    // Then it is refused, because allowing a delete widens what a Bucket may
+    // remove rather than what it may reach
+    assertStringIncludes(error.message, "unsupported file extension");
   });
 });

--- a/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
+++ b/src/service/s3/storage/filesystem/s3-filesystem-storage.ts
@@ -10,7 +10,7 @@ import { SimS3NotImplemented } from "../../error/sim-s3.error.js";
 import { SimS3DeclaredSystemMetadata } from "../../object/s3-declared-system-metadata.js";
 import { filesystemS3ObjectFile } from "./s3-filesystem-object-file.js";
 
-interface FilesystemS3BucketStorageProperties {
+export interface FilesystemS3BucketStorageProperties {
   readonly directoryPath: string;
   readonly allowedDirectoryNames?: readonly string[];
   readonly additionalFileExtensions?: readonly string[];
@@ -32,9 +32,9 @@ interface FilesystemS3BucketStorageProperties {
  * potential safety issues.
  */
 export class FilesystemS3BucketStorage implements SimS3BucketStorage {
+  protected readonly objectKeys: FilesystemS3ObjectKeys;
   private readonly directoryPath: string;
   private readonly safety: FilesystemS3StorageSafety;
-  private readonly objectKeys: FilesystemS3ObjectKeys;
   private readonly systemMetadata: SimS3DeclaredSystemMetadata;
 
   constructor(properties: FilesystemS3BucketStorageProperties) {
@@ -106,14 +106,16 @@ export class FilesystemS3BucketStorage implements SimS3BucketStorage {
    * a Bucket at an ordinary directory of the user's, and the safety checks here
    * are local-development tooling rather than a sandbox boundary. Unlinking
    * someone's files because a test called DeleteObject is the wrong default, so
-   * filesystem-backed Buckets are read and written but never emptied.
+   * a mount that wants deletes asks for one with `allowDelete` and gets
+   * `DeletingFilesystemS3BucketStorage` in place of this.
    */
   deleteObject(key: string): Promise<boolean> {
     return Promise.reject(
       new SimS3NotImplemented(
         `Simulated S3 will not delete ${key} from filesystem-backed storage ` +
           `at ${this.directoryPath}, because it would remove a real file. ` +
-          `Use the default in-memory Bucket storage to simulate deletion.`,
+          `Mount the directory with { allowDelete: true } to allow it, or use ` +
+          `the default in-memory Bucket storage to simulate deletion.`,
       ),
     );
   }


### PR DESCRIPTION
A CDK BucketDeployment raises one `s3:ObjectCreated:Put` for each file it writes and one `s3:ObjectRemoved:Delete` for each Object a pruning deployment removes, as the sync it stands in for does in AWS. A Bucket with no notification configuration behaves as it did. Mounting a directory with `allowDelete` gives the Bucket the deletion an in-memory one performs. A DeleteObject then unlinks the file, reports the removal and raises the removal event, inside the key path and extension checks a read already goes through. Leaving the option off keeps the refusal and its message naming the directory.

Resolves #1232