### PR TITLE
feat: honor stream mapping retry limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
 
 .worktrees/
+.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,5 @@ test/terraform/**/builds/
 test/terraform/**/terraform.tfstate*
 test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
+
+.worktrees/

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1755,15 +1755,152 @@ Advancing the simulation's clock is what hands the batch over again:
 await simAws.clock().advanceBy({ seconds: 30 });
 ```
 
-The batch is delivered again five times, after 1, 2, 4, 8 and 16 seconds, so six deliveries in all.
-Then it is discarded and the mapping carries on with the stream, as AWS does once a stream mapping's
-error handling has run out.
+A mapping that asks for no limit of its own delivers the batch again five times, after 1, 2, 4, 8
+and 16 seconds, so six deliveries in all. Then it is discarded and the mapping carries on with the
+stream, as AWS does once a stream mapping's error handling has run out.
 
-Both the cadence and the number of attempts are simulator constraints rather than AWS behaviour. AWS
-documents no delay between attempts and retries until the records age out of the stream, a day
-later. A delay of zero here would fall due at the instant the clock already reads. A handler that
-always throws would then leave `advanceBy` with work falling due forever, and waiting out a
-simulated day is the same problem with more steps.
+The delays are a simulator constraint. AWS documents no delay between attempts. A delay of zero here
+would fall due at the instant the clock already reads, and a handler that always throws would leave
+`advanceBy` with work falling due forever. The growing delay is also what lets a test walk through
+the attempts by advancing the clock.
+
+The five attempts are a cap on a mapping that named neither of the limits below. AWS retries until
+the records age out of the stream, a day later, and waiting out a simulated day is the same hang
+with more steps.
+
+### Limiting the retries and the record age
+
+`MaximumRetryAttempts` and `MaximumRecordAgeInSeconds` govern the same failed-batch lifecycle, and a
+stream mapping keeps both. `MaximumRetryAttempts: 0` makes one delivery and no retries, and a
+positive value allows that many retries after the first delivery. `MaximumRecordAgeInSeconds`
+discards a record once the next attempt would fall past that age. Lambda's `-1` means no limit
+(that is what a mapping naming neither reports back).
+
+```typescript sim-lambda-stream-retry-limits
+/**
+ * Giving up on a stream batch once its retries have run out.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaDynamoDbStreamEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+const { TableDescription } = await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "orders",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    },
+  }),
+);
+
+const streamArn = TableDescription?.LatestStreamArn;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderProjectorRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderProjectorRole",
+    PolicyName: "ReadOrdersStream",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: [
+            "dynamodb:DescribeStream",
+            "dynamodb:GetRecords",
+            "dynamodb:GetShardIterator",
+          ],
+          Resource: streamArn,
+        },
+        { Effect: "Allow", Action: "dynamodb:ListStreams", Resource: "*" },
+      ],
+    }),
+  }),
+);
+
+// The handler never gets through the batch, so the retries are what decide
+// how many times it is given one.
+const deliveries: SimLambdaDynamoDbStreamEvent[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-projector",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: SimLambdaDynamoDbStreamEvent): undefined => {
+          deliveries.push(event);
+
+          throw new Error("Projector could not handle the batch");
+        },
+      ),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: streamArn,
+    FunctionName: "order-projector",
+    StartingPosition: "TRIM_HORIZON",
+    MaximumRetryAttempts: 2,
+    MaximumRecordAgeInSeconds: 120,
+  }),
+);
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+// The two retries fall due 1 and 2 seconds after the deliveries they follow.
+await simAws.clock().advanceBy({ seconds: 30 });
+
+console.log(deliveries.length); // 3
+```
+
+Records age out of the front of a batch, since a batch is in stream order. A batch whose oldest
+records are past the age goes over again from the first record that is still young enough, and the
+shard keeps moving. A batch that has had its retries, or whose records have all aged out, is
+discarded, and the mapping reads on from behind it.
+
+`GetEventSourceMapping` and `ListEventSourceMappings` report both values, and
+`AWS::Lambda::EventSourceMapping` takes both in a template. A value outside Lambda's range (`-1` to
+10,000 retries, `-1` to 604,800 seconds) is a `ValidationException`. A queue mapping takes neither,
+because a message the handler never takes is left to the queue's own redrive policy.
 
 ### Reporting individual record failures
 
@@ -1797,7 +1934,7 @@ why a stream consumer has to be idempotent.
 
 So a report naming only the last record of a batch delivers that record again. A report naming the
 first record delivers the whole batch again. The redelivery is a retry like any other. It waits out
-the same backoff, counts against the same five attempts, and what is left is discarded when they run
+the same backoff, counts against the same retries, and what is left is discarded when they run
 out.
 
 A report naming a sequence number that was not in the batch delivers the whole batch again, as real
@@ -2167,6 +2304,8 @@ AWS managed policy and CDK's own grant give a stream consumer. A role missing on
 handler names a record by its `sequenceNumber`, and the mapping goes back to the lowest one the
 report names, so that record and everything after it on that shard is delivered again. A failing
 batch blocks its own shard and no other.
+[`MaximumRetryAttempts` and `MaximumRecordAgeInSeconds`](#limiting-the-retries-and-the-record-age)
+work the same way here, and each shard counts its own attempts.
 
 A mapping naming an enhanced fan-out consumer ARN is refused, since consumers are unsimulated.
 `AWS::Lambda::EventSourceMapping` deploys a Kinesis mapping the same way it deploys a DynamoDB one.
@@ -3554,6 +3693,8 @@ Sim Lambda currently supports:
   DynamoDB stream and Kinesis events and honouring `BatchSize`
 - `StartingPosition: "TRIM_HORIZON"` and `"LATEST"` on a stream mapping, and `"AT_TIMESTAMP"` on a
   Kinesis one, with a failing batch blocking its shard until it is through or discarded
+- `MaximumRetryAttempts` and `MaximumRecordAgeInSeconds` on a stream mapping, ending the retries at
+  a quota or at a record age
 - Every shard of a Kinesis stream read by a processor of its own, as real Lambda reads one
 - `FunctionResponseTypes: ["ReportBatchItemFailures"]` on a queue mapping, returning only the
   message ids the handler reported, and on a stream mapping, rewinding to the lowest sequence number
@@ -3703,15 +3844,15 @@ Current documented limitations:
   it stands.
 - SQS queues, DynamoDB streams and Kinesis streams are the only event sources. Kafka, DocumentDB and
   Kinesis enhanced fan-out consumers are refused outright, and so are `FilterCriteria`,
-  `ScalingConfig`, `DestinationConfig`, `MaximumRetryAttempts`, `BisectBatchOnFunctionError`,
-  `ParallelizationFactor`, `TumblingWindowInSeconds` and the other mapping inputs this simulation
-  has no behaviour for.
-- A stream batch is delivered again five times, after 1, 2, 4, 8 and 16 seconds, and then discarded.
-  AWS documents no delay between attempts and retries until the records age out. Both differences
-  are deliberate. A delay of zero falls due at the instant the clock already reads, and a handler
-  that always throws would leave `advanceBy` with work falling due forever. A batch item failure
-  report counts against the same five attempts, and never starts them again for the records it
-  rewound to.
+  `ScalingConfig`, `DestinationConfig`, `BisectBatchOnFunctionError`, `ParallelizationFactor`,
+  `TumblingWindowInSeconds` and the other mapping inputs this simulation has no behaviour for.
+- A failed stream batch waits 1, 2, 4, 8 and 16 seconds between attempts, where AWS documents no
+  delay. That is deliberate. A delay of zero falls due at the instant the clock already reads, and a
+  handler that always throws would leave `advanceBy` with work falling due forever. A mapping that
+  names neither `MaximumRetryAttempts` nor `MaximumRecordAgeInSeconds` gets five retries and then
+  discards the batch, where AWS goes on until the records age out a day later. A batch item failure
+  report counts against the same retries, and never starts them again for the records it rewound
+  to.
 - A handler writing into the table whose stream invoked it is refused with
   `SimLambdaStreamCascadeError` rather than being delivered its own writes forever. Real Lambda runs
   that loop.

--- a/docs/services/lambda/sim-lambda-stream-retry-limits.example.ts
+++ b/docs/services/lambda/sim-lambda-stream-retry-limits.example.ts
@@ -1,0 +1,113 @@
+/**
+ * Giving up on a stream batch once its retries have run out.
+ */
+
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaDynamoDbStreamEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+const { TableDescription } = await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "orders",
+    KeySchema: [{ AttributeName: "orderId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "orderId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+    StreamSpecification: {
+      StreamEnabled: true,
+      StreamViewType: "NEW_AND_OLD_IMAGES",
+    },
+  }),
+);
+
+const streamArn = TableDescription?.LatestStreamArn;
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "OrderProjectorRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "OrderProjectorRole",
+    PolicyName: "ReadOrdersStream",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: [
+            "dynamodb:DescribeStream",
+            "dynamodb:GetRecords",
+            "dynamodb:GetShardIterator",
+          ],
+          Resource: streamArn,
+        },
+        { Effect: "Allow", Action: "dynamodb:ListStreams", Resource: "*" },
+      ],
+    }),
+  }),
+);
+
+// The handler never gets through the batch, so the retries are what decide
+// how many times it is given one.
+const deliveries: SimLambdaDynamoDbStreamEvent[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "order-projector",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(
+        (event: SimLambdaDynamoDbStreamEvent): undefined => {
+          deliveries.push(event);
+
+          throw new Error("Projector could not handle the batch");
+        },
+      ),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: streamArn,
+    FunctionName: "order-projector",
+    StartingPosition: "TRIM_HORIZON",
+    MaximumRetryAttempts: 2,
+    MaximumRecordAgeInSeconds: 120,
+  }),
+);
+
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "orders",
+    Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+  }),
+);
+
+await simAws.backgroundTasksComplete();
+
+// The two retries fall due 1 and 2 seconds after the deliveries they follow.
+await simAws.clock().advanceBy({ seconds: 30 });
+
+console.log(deliveries.length); // 3

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -526,11 +526,21 @@ including the records after it that the function handled. Partitioning a stream 
 queue batch is partitioned would checkpoint past records the function never reached and lose them
 with no error. Reading the report itself is shared with the queue in `SimLambdaBatchItemFailures`,
 and so is the defence that a report naming something outside the batch fails the whole batch.
-`SimLambdaStreamRetryBackoff` is why the wait is strictly positive and why the attempts are counted.
-A retry scheduled at the instant the clock already reads falls due inside every interval
-`advanceBy` walks, so a handler that always throws would never let it return, and both that trap and
-its guard tests are in
+`SimLambdaStreamRetry` decides whether a failed batch goes over again, from which record, and after
+how long. `SimLambdaStreamRetryBackoff` is why the wait is strictly positive and why the attempts
+are counted. A retry scheduled at the instant the clock already reads falls due inside every
+interval `advanceBy` walks, so a handler that always throws would never let it return, and both that
+trap and its guard tests are in
 [issue 341](https://github.com/KensioSoftware/yulin/issues/341).
+
+`SimLambdaStreamRetryLimits` holds the mapping's `MaximumRetryAttempts` and
+`MaximumRecordAgeInSeconds` and answers two questions from them: how many attempts a batch gets, and
+whether a record is too old to be handed over again. Ages are read at the instant the next delivery
+falls due, because the wait before it is what ages the records out. A batch is in stream order, so
+records age out of its front and the retry position moves to the first record that is still young
+enough. The five-attempt cap applies to a mapping that named neither limit
+([issue 1219](https://github.com/KensioSoftware/yulin/issues/1219)). One that named a record age has
+an end of its own, and retries until the records reach it.
 
 Two polls must never overlap, which a queue mapping does not have to care about: a received message
 is hidden and a read record is not, so a second poll from the same checkpoint would deliver the same

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-dynamodb-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-dynamodb-event-source-mapping.iso.test.ts
@@ -1,4 +1,5 @@
 import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { ListEventSourceMappingsCommand } from "@aws-sdk/client-lambda";
 import {
   assertArrayLength,
   assertIdentical,
@@ -180,6 +181,54 @@ describe("Lambda CloudFormation DynamoDB stream event source mapping", () => {
     assertNonNullable(record);
     assertIdentical(record.eventName, "INSERT");
     assertIdentical(record.dynamodb.NewImage?.["total"]?.N, "101");
+  });
+
+  it("deploys a mapping with the failed-batch limits the template states", async () => {
+    // Given a template stating a retry quota and a record age on the mapping.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: projectorTemplate({
+        ...mappingProperties,
+        MaximumRetryAttempts: 2,
+        MaximumRecordAgeInSeconds: 300,
+      }),
+      bindings: [
+        {
+          logicalId: "ProjectorFunction",
+          handler: (): undefined => undefined,
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // When the mappings of the deployed function are listed.
+    const listed = await simAws
+      .lambda()
+      .listEventSourceMappings(
+        new ListEventSourceMappingsCommand({ FunctionName: "order-projector" }),
+      );
+
+    // Then the mapping keeps both, rather than the no-limit defaults a mapping
+    // stating neither of them gets.
+    assertArrayLength(listed.EventSourceMappings, 1);
+    assertIdentical(listed.EventSourceMappings[0].MaximumRetryAttempts, 2);
+    assertIdentical(
+      listed.EventSourceMappings[0].MaximumRecordAgeInSeconds,
+      300,
+    );
+  });
+
+  it("refuses a failed-batch limit outside the range Lambda takes", async () => {
+    // Given a template asking for more retries than Lambda's maximum.
+    const error = await projectorDeployError({
+      ...mappingProperties,
+      MaximumRetryAttempts: 10_001,
+    });
+
+    // Then the Resource fails the stack, in the words CreateEventSourceMapping
+    // refuses an SDK caller in, rather than being skipped as unsupported.
+    assertStringIncludes(error.message, "maximumRetryAttempts");
   });
 
   it("refuses a stream mapping with no StartingPosition", async () => {

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
@@ -78,6 +78,16 @@ export class SimCfnLambdaEventSourceMappingProperties {
         this.properties["MaximumBatchingWindowInSeconds"],
         "MaximumBatchingWindowInSeconds",
       ),
+      MaximumRetryAttempts: this.parser.optionalNumber(
+        this.resource,
+        this.properties["MaximumRetryAttempts"],
+        "MaximumRetryAttempts",
+      ),
+      MaximumRecordAgeInSeconds: this.parser.optionalNumber(
+        this.resource,
+        this.properties["MaximumRecordAgeInSeconds"],
+        "MaximumRecordAgeInSeconds",
+      ),
       StartingPosition: this.parser.optionalString(
         this.resource,
         this.properties["StartingPosition"],

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
@@ -7,7 +7,9 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
  * unsimulated ones because whether a mapping may carry one is the event
  * source's own rule: a stream has to be given a position and a queue is refused
  * for naming one. That is decided by CreateEventSourceMapping, which knows
- * which source the ARN names, so both are read and passed on.
+ * which source the ARN names, so both are read and passed on. The two
+ * failed-batch limits are read for the same reason: a stream mapping keeps them
+ * and a queue mapping is refused for naming one.
  */
 const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "BatchSize",
@@ -16,6 +18,8 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "FunctionName",
   "FunctionResponseTypes",
   "MaximumBatchingWindowInSeconds",
+  "MaximumRecordAgeInSeconds",
+  "MaximumRetryAttempts",
   "StartingPosition",
   "StartingPositionTimestamp",
 ]);
@@ -35,8 +39,6 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "DocumentDBEventSourceConfig",
   "FilterCriteria",
   "KmsKeyArn",
-  "MaximumRecordAgeInSeconds",
-  "MaximumRetryAttempts",
   "MetricsConfig",
   "ParallelizationFactor",
   "ProvisionedPollerConfig",

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -4,6 +4,7 @@ import {
   simLambdaEventSourceArnOf,
 } from "../../event-source/sim-lambda-event-source-arn.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
+import type { SimLambdaStreamRetryLimits } from "../../event-source/sim-lambda-stream-retry-limits.js";
 import type { SimLambdaEventSourceStart } from "../../event-source/sim-lambda-event-source-starting-position.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { simLambdaFunctionReferenceOf } from "../../function/sim-lambda-function-reference.js";
@@ -25,6 +26,7 @@ interface SimLambdaEventSourceMappingInputProperties {
   readonly start: SimLambdaEventSourceStart | undefined;
   readonly enabled: boolean;
   readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
+  readonly streamRetryLimits: SimLambdaStreamRetryLimits | undefined;
 }
 
 /**
@@ -54,6 +56,12 @@ export class SimLambdaEventSourceMappingInput {
   public readonly enabled: boolean;
   public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 
+  /**
+   * When a failed batch stops being delivered again, for a source that leaves
+   * the counting to the mapping.
+   */
+  public readonly streamRetryLimits: SimLambdaStreamRetryLimits | undefined;
+
   private constructor(properties: SimLambdaEventSourceMappingInputProperties) {
     this.eventSourceArn = properties.eventSourceArn;
     this.functionName = properties.functionName;
@@ -62,6 +70,7 @@ export class SimLambdaEventSourceMappingInput {
     this.start = properties.start;
     this.enabled = properties.enabled;
     this.functionResponseTypes = properties.functionResponseTypes;
+    this.streamRetryLimits = properties.streamRetryLimits;
   }
 
   /**
@@ -89,6 +98,10 @@ export class SimLambdaEventSourceMappingInput {
       }),
       enabled: input.Enabled ?? true,
       functionResponseTypes: functionResponseTypesIn(input),
+      streamRetryLimits: eventSourceArn.retryLimitRules.limitsIn({
+        maximumRetryAttempts: input.MaximumRetryAttempts,
+        maximumRecordAgeInSeconds: input.MaximumRecordAgeInSeconds,
+      }),
     });
   }
 }

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -20,11 +20,6 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
       "of attempts is discarded rather than sent anywhere",
   ],
   [
-    "MaximumRetryAttempts",
-    "the number of times a stream batch is delivered again is fixed",
-  ],
-  ["MaximumRecordAgeInSeconds", "record ages are not simulated"],
-  [
     "BisectBatchOnFunctionError",
     "batch bisection is not simulated, so a failing stream batch is retried " +
       "whole",
@@ -54,7 +49,8 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
  *
  * `StartingPosition` is not among them, because whether a source has one is the
  * source's own rule: a stream is refused without it and a queue is refused with
- * it.
+ * it. The two failed-batch limits are left out for the same reason: a stream
+ * mapping keeps them and a queue mapping is refused for naming one.
  */
 const unsupportedEventSourceInputs: ReadonlySet<string> = new Set([
   "Topics",

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -189,6 +189,33 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     assertStringIncludes(error.message, "MaximumBatchingWindowInSeconds");
   });
 
+  it("refuses a failed-batch limit on a queue mapping", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping on the queue asks for a retry quota.
+    const error = await refusedMapping(ready, { MaximumRetryAttempts: 2 });
+
+    // Then it is refused, because a message the function never handles goes
+    // back to the queue and is the queue's own redrive policy to answer for.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "redrive policy");
+  });
+
+  it("refuses a record age on a queue mapping", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping on the queue asks to discard old messages.
+    const error = await refusedMapping(ready, {
+      MaximumRecordAgeInSeconds: 60,
+    });
+
+    // Then it is refused rather than accepted and never acted on.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(error.message, "MaximumRecordAgeInSeconds");
+  });
+
   it("refuses a function response type Lambda does not have", async () => {
     // Given a queue and a function.
     const ready = await simAwsReadyToMap();

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -144,6 +144,7 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
       start: input.start,
       enabled: input.enabled,
       functionResponseTypes: input.functionResponseTypes,
+      streamRetryLimits: input.streamRetryLimits,
       createdAt: this.properties.background.now(),
     });
 

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-pollers.iso.test.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-pollers.iso.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "vitest";
 import { BackgroundTasks } from "../../../../../util/background/background.js";
 import type { SimLambdaFunctionLookup } from "../../../function/url/sim-lambda-function-lookup.js";
 import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-mapping.js";
+import { SimLambdaStreamRetryLimits } from "../../sim-lambda-stream-retry-limits.js";
 import { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
 import type {
   SimLambdaKinesisStreamBatch,
@@ -24,6 +25,7 @@ const mapping = {
   batchSize: 10,
   reportsBatchItemFailures: false,
   start: { position: "TRIM_HORIZON" },
+  streamRetryLimits: new SimLambdaStreamRetryLimits(),
 } as unknown as SimLambdaEventSourceMapping;
 
 const functions = {

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
@@ -4,7 +4,7 @@ import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-la
 import type { SimLambdaKinesisStreamRecord } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
 import { SimLambdaStreamCascadeGuard } from "../../stream/sim-lambda-stream-cascade-guard.js";
 import { countSimLambdaKinesisIteratorAge } from "../sim-lambda-stream-iterator-age.js";
-import { simLambdaStreamSequenceNumbers } from "../sim-lambda-stream-sequence-numbers.js";
+import { simLambdaKinesisStreamRecordTimes } from "../sim-lambda-stream-record-times.js";
 import type { SimLambdaStreamBatchOutcome } from "../sim-lambda-stream-batch-outcome.js";
 import { SimLambdaStreamBatchResponse } from "../sim-lambda-stream-batch-response.js";
 import { SimLambdaKinesisStreamEventBuilder } from "./sim-lambda-kinesis-stream-event.js";
@@ -78,28 +78,19 @@ export class SimLambdaKinesisStreamDelivery {
     simFunction: SimLambdaFunction,
     records: readonly SimLambdaKinesisStreamRecord[],
   ): Promise<SimLambdaStreamBatchOutcome> {
+    const times = simLambdaKinesisStreamRecordTimes(records);
+
     try {
       return this.batchResponse.handled(
-        sequenceNumbersOf(records),
+        times,
         await simFunction.invoke(this.eventBuilder.of(records)),
       );
     } catch {
       // As on real Lambda, the handler error goes to the function's logs. What
       // the stream sees is the batch being tried again.
-      return this.batchResponse.failed();
+      return this.batchResponse.failed(times);
     } finally {
       countSimLambdaKinesisIteratorAge(simFunction, records);
     }
   }
-}
-
-/**
- * The sequence numbers this batch's records can be named by.
- */
-function sequenceNumbersOf(
-  records: readonly SimLambdaKinesisStreamRecord[],
-): readonly string[] {
-  return simLambdaStreamSequenceNumbers(
-    records.map((one) => one.SequenceNumber),
-  );
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
@@ -5,7 +5,7 @@ import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-even
 import { SimLambdaStreamCascadeGuard } from "../stream/sim-lambda-stream-cascade-guard.js";
 import { SimLambdaDynamoDbStreamEventBuilder } from "./sim-lambda-dynamodb-stream-event.js";
 import { countSimLambdaDynamoDbIteratorAge } from "./sim-lambda-stream-iterator-age.js";
-import { simLambdaStreamSequenceNumbers } from "./sim-lambda-stream-sequence-numbers.js";
+import { simLambdaDynamoDbStreamRecordTimes } from "./sim-lambda-stream-record-times.js";
 import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 import { SimLambdaStreamBatchResponse } from "./sim-lambda-stream-batch-response.js";
 
@@ -76,28 +76,19 @@ export class SimLambdaDynamoDbStreamDelivery {
     simFunction: SimLambdaFunction,
     records: readonly SimLambdaEventSourceStreamRecord[],
   ): Promise<SimLambdaStreamBatchOutcome> {
+    const times = simLambdaDynamoDbStreamRecordTimes(records);
+
     try {
       return this.batchResponse.handled(
-        sequenceNumbersOf(records),
+        times,
         await simFunction.invoke(this.eventBuilder.of(records)),
       );
     } catch {
       // As on real Lambda, the handler error goes to the function's logs. What
       // the table sees is the batch being tried again.
-      return this.batchResponse.failed();
+      return this.batchResponse.failed(times);
     } finally {
       countSimLambdaDynamoDbIteratorAge(simFunction, records);
     }
   }
-}
-
-/**
- * The sequence numbers this batch's records can be named by.
- */
-function sequenceNumbersOf(
-  records: readonly SimLambdaEventSourceStreamRecord[],
-): readonly string[] {
-  return simLambdaStreamSequenceNumbers(
-    records.map((one) => one.dynamodb?.SequenceNumber),
-  );
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-outcome.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-outcome.ts
@@ -1,4 +1,11 @@
 import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+
+interface SimLambdaStreamBatchOutcomeProperties {
+  readonly isHandled: boolean;
+  readonly records: readonly SimLambdaStreamRecordTime[];
+  readonly rewindTo?: string | undefined;
+}
 
 /**
  * What became of one batch of stream records handed to a function.
@@ -8,37 +15,81 @@ import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-ev
  * batch does not split. The mapping holds one place on the shard, so the answer
  * is one place: either the batch is finished with, or reading goes back to a
  * record and everything from there is delivered again.
+ *
+ * The batch's own records travel with the answer, because what happens to a
+ * batch that failed depends on them: they carry the names it can be sent back
+ * to and the instants its records are aged from.
  */
 export class SimLambdaStreamBatchOutcome {
   public readonly isHandled: boolean;
 
+  /**
+   * The records the batch carried, in stream order.
+   */
+  public readonly records: readonly SimLambdaStreamRecordTime[];
+
   private readonly rewindTo: string | undefined;
 
-  private constructor(isHandled: boolean, rewindTo: string | undefined) {
-    this.isHandled = isHandled;
-    this.rewindTo = rewindTo;
+  private constructor(properties: SimLambdaStreamBatchOutcomeProperties) {
+    this.isHandled = properties.isHandled;
+    this.records = properties.records;
+    this.rewindTo = properties.rewindTo;
   }
 
   /**
    * A batch the function took in full.
    */
-  static handled(): SimLambdaStreamBatchOutcome {
-    return new SimLambdaStreamBatchOutcome(true, undefined);
+  static handled(
+    records: readonly SimLambdaStreamRecordTime[],
+  ): SimLambdaStreamBatchOutcome {
+    return new SimLambdaStreamBatchOutcome({ isHandled: true, records });
   }
 
   /**
    * A batch the function did not take, which is read again from where it was.
    */
-  static failed(): SimLambdaStreamBatchOutcome {
-    return new SimLambdaStreamBatchOutcome(false, undefined);
+  static failed(
+    records: readonly SimLambdaStreamRecordTime[],
+  ): SimLambdaStreamBatchOutcome {
+    return new SimLambdaStreamBatchOutcome({ isHandled: false, records });
   }
 
   /**
    * A batch the function reported failing partway through, which is read again
    * from the record it named.
    */
-  static failedFrom(sequenceNumber: string): SimLambdaStreamBatchOutcome {
-    return new SimLambdaStreamBatchOutcome(false, sequenceNumber);
+  static failedFrom(
+    records: readonly SimLambdaStreamRecordTime[],
+    sequenceNumber: string,
+  ): SimLambdaStreamBatchOutcome {
+    return new SimLambdaStreamBatchOutcome({
+      isHandled: false,
+      records,
+      rewindTo: sequenceNumber,
+    });
+  }
+
+  /**
+   * Where in the batch the next delivery starts, as a position in the records
+   * the batch carried.
+   *
+   * A batch that failed whole starts at the first record. One the function
+   * reported on starts at the record it named, which the batch response has
+   * already checked was in the batch, so a name that is not there is the whole
+   * batch again rather than a guess.
+   */
+  get retryIndex(): number {
+    const sequenceNumber = this.rewindTo;
+
+    if (sequenceNumber === undefined) {
+      return 0;
+    }
+
+    const index = this.records.findIndex(
+      (record) => record.sequenceNumber === sequenceNumber,
+    );
+
+    return index === -1 ? 0 : index;
   }
 
   /**

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.iso.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "vitest";
 
 import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaStreamBatchResponse } from "./sim-lambda-stream-batch-response.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
 
 /**
  * Where the mapping read this batch from, which is where a batch that failed
@@ -14,9 +15,13 @@ const readFrom: SimLambdaEventSourceStreamPosition = {
 };
 
 /**
- * The sequence numbers one batch carried, in stream order.
+ * The records one batch carried, in stream order.
  */
-const records: readonly string[] = ["100", "200", "300"];
+const records: readonly SimLambdaStreamRecordTime[] = [
+  { sequenceNumber: "100", at: undefined },
+  { sequenceNumber: "200", at: undefined },
+  { sequenceNumber: "300", at: undefined },
+];
 
 /**
  * The sequence number the next read starts at, or the iterator it starts from
@@ -129,7 +134,7 @@ describe("sim Lambda stream batch responses", () => {
     const response = new SimLambdaStreamBatchResponse(true);
 
     // When the function threw rather than returning anything.
-    const outcome = response.failed();
+    const outcome = response.failed(records);
 
     // Then the batch is read again from where it was.
     assertIdentical(

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-response.ts
@@ -1,5 +1,7 @@
 import { SimLambdaBatchItemFailures } from "./sim-lambda-batch-item-failures.js";
 import { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+import { simLambdaStreamSequenceNumbers } from "./sim-lambda-stream-sequence-numbers.js";
 
 /**
  * Reads what a function said about the batch of stream records it was given.
@@ -26,36 +28,38 @@ export class SimLambdaStreamBatchResponse {
   /**
    * What became of a batch the function returned from.
    *
-   * The sequence numbers are the batch's own, in stream order, and each source
-   * cuts them out of its own record shape. A record carrying none is left out
-   * rather than given an empty name, so a report entry with no identifier names
-   * nothing and the whole batch goes back.
+   * The records are the batch's own, in stream order, and each source cuts them
+   * out of its own record shape. A record carrying no sequence number cannot be
+   * named, and is left out of the names a report is read against, so a report
+   * entry with no identifier names nothing and the whole batch goes back.
    */
   handled(
-    sequenceNumbers: readonly string[],
+    records: readonly SimLambdaStreamRecordTime[],
     result: unknown,
   ): SimLambdaStreamBatchOutcome {
     const failedIds = this.batchItemFailures.idsIn(result);
 
     if (failedIds === undefined) {
-      return SimLambdaStreamBatchOutcome.handled();
+      return SimLambdaStreamBatchOutcome.handled(records);
     }
 
-    const rewindTo = rewindPoint(failedIds, sequenceNumbers);
+    const rewindTo = rewindPoint(failedIds, records);
 
     if (rewindTo === undefined) {
-      return this.failed();
+      return this.failed(records);
     }
 
-    return SimLambdaStreamBatchOutcome.failedFrom(rewindTo);
+    return SimLambdaStreamBatchOutcome.failedFrom(records, rewindTo);
   }
 
   /**
    * What becomes of a batch the function threw on: the whole of it is read
    * again.
    */
-  failed(): SimLambdaStreamBatchOutcome {
-    return SimLambdaStreamBatchOutcome.failed();
+  failed(
+    records: readonly SimLambdaStreamRecordTime[],
+  ): SimLambdaStreamBatchOutcome {
+    return SimLambdaStreamBatchOutcome.failed(records);
   }
 }
 
@@ -68,8 +72,12 @@ export class SimLambdaStreamBatchResponse {
  */
 function rewindPoint(
   failedIds: readonly string[],
-  sequenceNumbers: readonly string[],
+  records: readonly SimLambdaStreamRecordTime[],
 ): string | undefined {
+  const sequenceNumbers = simLambdaStreamSequenceNumbers(
+    records.map((record) => record.sequenceNumber),
+  );
+
   if (failedIds.some((failedId) => !sequenceNumbers.includes(failedId))) {
     return undefined;
   }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-checkpoint.ts
@@ -1,6 +1,5 @@
 import type { SimLambdaEventSourceStart } from "../sim-lambda-event-source-starting-position.js";
 import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
-import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 
 /**
  * How far along its stream one mapping has got.
@@ -8,9 +7,11 @@ import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outc
  * This is the difference between a stream and a queue. A queue hands a message
  * out and hides it, so a failed batch is the queue's problem afterwards. A
  * stream hands out a place, and the reader is the only thing that remembers it,
- * so a batch that failed is read again from exactly where it was. The
- * checkpoint therefore only moves when a batch is finished with: handled, or
- * discarded after its retries.
+ * so a batch that failed is read again from exactly where it was.
+ *
+ * The place is all this holds. Which place the next read starts from is decided
+ * by what became of the batch and what the mapping is willing to keep trying,
+ * and that decision is made elsewhere.
  */
 export class SimLambdaStreamCheckpoint {
   #position: SimLambdaEventSourceStreamPosition;
@@ -27,22 +28,12 @@ export class SimLambdaStreamCheckpoint {
   }
 
   /**
-   * Move past a batch that is finished with.
+   * Move to where the next read starts.
+   *
+   * That is past a batch the mapping is finished with, and back to the record a
+   * batch it is not finished with is delivered again from.
    */
   advanceTo(position: SimLambdaEventSourceStreamPosition): void {
     this.#position = position;
-  }
-
-  /**
-   * Take a batch the function did not finish.
-   *
-   * A batch that failed whole is read again from where it was. One the function
-   * reported failing partway through moves the checkpoint to the record it
-   * named, so that record and everything after it goes over again, including
-   * the records after it that the function did handle. The records before it
-   * are finished with.
-   */
-  retry(outcome: SimLambdaStreamBatchOutcome): void {
-    this.#position = outcome.retryPosition(this.#position);
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
@@ -11,7 +11,7 @@ import type {
 import { PollSchedule } from "../../../../util/background/poll-schedule.js";
 import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 import { SimLambdaStreamCheckpoint } from "./sim-lambda-stream-checkpoint.js";
-import { SimLambdaStreamRetryBackoff } from "./sim-lambda-stream-retry-backoff.js";
+import { SimLambdaStreamRetry } from "./sim-lambda-stream-retry.js";
 
 interface SimLambdaStreamProgressProperties {
   readonly mapping: SimLambdaEventSourceMapping;
@@ -32,17 +32,22 @@ interface SimLambdaStreamProgressProperties {
  */
 export class SimLambdaStreamProgress {
   private readonly checkpoint: SimLambdaStreamCheckpoint;
-  private readonly backoff = new SimLambdaStreamRetryBackoff();
+  private readonly retry: SimLambdaStreamRetry;
   private readonly schedule: PollSchedule;
 
   constructor(properties: SimLambdaStreamProgressProperties) {
     // A stream mapping is refused at creation unless it names a starting
     // position, so one that has got this far without one is the simulator
     // having gone wrong rather than a request having been wrong.
-    const { start } = properties.mapping;
+    const { start, streamRetryLimits } = properties.mapping;
     assertDefined(start, "stream mapping start position");
+    assertDefined(streamRetryLimits, "stream mapping retry limits");
 
     this.checkpoint = new SimLambdaStreamCheckpoint(start);
+    this.retry = new SimLambdaStreamRetry({
+      limits: streamRetryLimits,
+      clock: properties.background,
+    });
     this.schedule = new PollSchedule(properties);
   }
 
@@ -88,10 +93,13 @@ export class SimLambdaStreamProgress {
   }
 
   /**
-   * Move past a batch the function took, and read on.
+   * Move past a batch that is finished with, and read on.
+   *
+   * A batch the function took is finished with, and so is one the mapping has
+   * given up on.
    */
   handled(batch: SimLambdaEventSourceStreamProgressBatch): void {
-    this.backoff.reset();
+    this.retry.reset();
     this.checkpoint.advanceTo(batch.next);
 
     if (!batch.drained) {
@@ -106,22 +114,25 @@ export class SimLambdaStreamProgress {
    * what AWS does when a stream mapping's error handling runs out. Parking the
    * shard instead would be a simulator invention.
    *
-   * A report naming a record moves the checkpoint before the wait, so what goes
-   * over again is the batch from that record on. The attempts are still counted
-   * against the same limit: a batch that keeps failing partway through has as
-   * many tries as one that keeps failing whole.
+   * A batch runs out either by having had its retries or by every record left
+   * in it being older than the mapping will carry. Records that aged out of the
+   * front of a batch are left behind, and the ones behind them go over again,
+   * so a mapping given a record age keeps working through its shard rather than
+   * stalling on the oldest record on it.
    */
   failed(
     outcome: SimLambdaStreamBatchOutcome,
     batch: SimLambdaEventSourceStreamProgressBatch,
   ): void {
-    if (this.backoff.isExhausted) {
+    const again = this.retry.after(outcome, this.checkpoint.position);
+
+    if (again === undefined) {
       this.handled(batch);
 
       return;
     }
 
-    this.checkpoint.retry(outcome);
-    this.schedule.afterSeconds(this.backoff.nextSeconds());
+    this.checkpoint.advanceTo(again.position);
+    this.schedule.afterSeconds(again.afterSeconds);
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-record-times.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-record-times.ts
@@ -1,0 +1,40 @@
+import type { SimLambdaKinesisStreamRecord } from "../stream/kinesis/sim-lambda-kinesis-streams.js";
+import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
+
+/**
+ * One record of a delivered batch, as deciding what to do with a failed batch
+ * sees it.
+ *
+ * Two things about a record matter once its function has failed: the name the
+ * mapping can be sent back to, and the instant its age is measured from. Each
+ * stream service cuts both out of its own record shape, the way it already does
+ * for the sequence numbers a batch item failure report names.
+ */
+export interface SimLambdaStreamRecordTime {
+  readonly sequenceNumber: string | undefined;
+  readonly at: Date | undefined;
+}
+
+/**
+ * What a DynamoDB Streams batch's records are named by and dated from.
+ */
+export function simLambdaDynamoDbStreamRecordTimes(
+  records: readonly SimLambdaEventSourceStreamRecord[],
+): readonly SimLambdaStreamRecordTime[] {
+  return records.map((one) => ({
+    sequenceNumber: one.dynamodb?.SequenceNumber,
+    at: one.dynamodb?.ApproximateCreationDateTime,
+  }));
+}
+
+/**
+ * What a Kinesis batch's records are named by and dated from.
+ */
+export function simLambdaKinesisStreamRecordTimes(
+  records: readonly SimLambdaKinesisStreamRecord[],
+): readonly SimLambdaStreamRecordTime[] {
+  return records.map((one) => ({
+    sequenceNumber: one.SequenceNumber,
+    at: one.ApproximateArrivalTimestamp,
+  }));
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-retry-backoff.iso.test.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-retry-backoff.iso.test.ts
@@ -1,0 +1,62 @@
+import { assertArrayEquals, assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimLambdaStreamRetryBackoff } from "./sim-lambda-stream-retry-backoff.js";
+
+/**
+ * The largest retry quota Lambda takes, which is what a mapping can ask a
+ * failed batch to be delivered again for.
+ */
+const maximumRetryAttempts = 10_000;
+
+describe("the wait before a failed stream batch is delivered again", () => {
+  it("doubles for each attempt a test walks through", () => {
+    // Given a mapping allowing a handful of retries.
+    const backoff = new SimLambdaStreamRetryBackoff(10);
+
+    // When the first three of them are taken.
+    const waits = [
+      backoff.nextSeconds(),
+      backoff.nextSeconds(),
+      backoff.nextSeconds(),
+    ];
+
+    // Then each waits twice as long as the one before, starting at a second,
+    // which is the cadence a test advances the clock through.
+    assertArrayEquals(waits, [1, 2, 4]);
+  });
+
+  it("starts over once a batch is finished with", () => {
+    // Given a backoff that has already waited out two attempts.
+    const backoff = new SimLambdaStreamRetryBackoff(10);
+    backoff.nextSeconds();
+    backoff.nextSeconds();
+
+    // When the batch it was counting for is finished with.
+    backoff.reset();
+
+    // Then the next batch waits a second again rather than carrying on from
+    // where the last one left off.
+    assertArrayEquals([backoff.nextSeconds()], [1]);
+  });
+
+  it("stays a wait the simulation's clock can be scheduled at", () => {
+    // Given a mapping allowing the most retries Lambda takes, which is more
+    // than a doubling wait can go on doubling for.
+    const backoff = new SimLambdaStreamRetryBackoff(maximumRetryAttempts);
+
+    // When a batch fails past the point where doubling leaves the range a date
+    // can hold.
+    let wait = 0;
+
+    for (let attempt = 0; attempt < maximumRetryAttempts; attempt += 1) {
+      wait = backoff.nextSeconds();
+    }
+
+    // Then the wait is still an instant the clock can be scheduled at, rather
+    // than a duration no date can be made from.
+    const scheduledAt = new Date(Date.now() + wait * 1000);
+
+    assertTrue(Number.isFinite(scheduledAt.getTime()));
+  });
+});

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-retry-backoff.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-retry-backoff.ts
@@ -1,36 +1,33 @@
 /**
- * How many times one batch is delivered again before it is given up on.
- */
-const attemptLimit = 5;
-
-/**
  * How long a mapping waits before handing a failed batch to its function
- * again, and when it stops trying.
+ * again, and how many waits it has left.
  *
- * Both are simulator constraints rather than AWS behaviour, and both are
- * deliberate.
- *
- * AWS documents no delay between attempts. A delay of zero here would be
- * scheduled at the instant the clock already reads, and advancing the clock
- * keeps dispatching whatever falls due inside the interval it is moving
+ * The delay is a simulator constraint rather than AWS behaviour, and it is
+ * deliberate. AWS documents no delay between attempts. A delay of zero here
+ * would be scheduled at the instant the clock already reads, and advancing the
+ * clock keeps dispatching whatever falls due inside the interval it is moving
  * through, so a batch the function always throws on would leave `advanceBy`
  * with work to do forever. The delay is therefore strictly positive and grows
- * with each attempt, which is also what a consumer under load actually wants.
+ * with each attempt, which is also what a consumer under load actually wants,
+ * and it is what lets a test walk through the attempts by advancing the clock.
  *
- * AWS retries a stream batch until the records age out of the stream, which is
- * a day. Waiting out a simulated day for a handler that is never going to
- * succeed is the same hang with more steps, so the attempts are counted
- * instead. What happens at the end is AWS's own behaviour: the records are
- * discarded and the mapping carries on with the stream.
+ * How many attempts there are belongs to the mapping rather than to this: a
+ * mapping that asked for a retry quota gets the quota it asked for, and one
+ * that asked for neither limit gets the simulator's own cap.
  */
 export class SimLambdaStreamRetryBackoff {
+  private readonly attemptLimit: number;
   private attempts = 0;
+
+  constructor(attemptLimit: number) {
+    this.attemptLimit = attemptLimit;
+  }
 
   /**
    * Whether this batch has had all the attempts it gets.
    */
   get isExhausted(): boolean {
-    return this.attempts >= attemptLimit;
+    return this.attempts >= this.attemptLimit;
   }
 
   /**

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-retry-backoff.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-retry-backoff.ts
@@ -1,4 +1,15 @@
 /**
+ * The longest wait, in seconds, the simulation's clock can be scheduled at.
+ *
+ * A `Date` holds about 275,000 years either side of the epoch, and a wait past
+ * that would be scheduled at an instant that is not a date at all. Doubling
+ * reaches it on the 44th attempt, which is further than any test can advance
+ * the clock, so this is a guard on the arithmetic rather than a wait a mapping
+ * meets.
+ */
+const longestWaitSeconds = 2 ** 42;
+
+/**
  * How long a mapping waits before handing a failed batch to its function
  * again, and how many waits it has left.
  *
@@ -36,7 +47,7 @@ export class SimLambdaStreamRetryBackoff {
   nextSeconds(): number {
     this.attempts += 1;
 
-    return 2 ** (this.attempts - 1);
+    return Math.min(2 ** (this.attempts - 1), longestWaitSeconds);
   }
 
   /**

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-retry.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-retry.ts
@@ -1,0 +1,139 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimLambdaStreamRetryLimits } from "../sim-lambda-stream-retry-limits.js";
+import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+import { SimLambdaStreamRetryBackoff } from "./sim-lambda-stream-retry-backoff.js";
+
+const millisecondsPerSecond = 1000;
+
+interface SimLambdaStreamRetryProperties {
+  readonly limits: SimLambdaStreamRetryLimits;
+  readonly clock: SimClock;
+}
+
+/**
+ * One more delivery of a failed batch: where it starts, and how long the
+ * mapping waits first.
+ */
+export interface SimLambdaStreamRetryAttempt {
+  readonly position: SimLambdaEventSourceStreamPosition;
+  readonly afterSeconds: number;
+}
+
+/**
+ * Whether a failed batch is handed over again, and from which record.
+ *
+ * Both of Lambda's failed-batch limits end here because they end the same
+ * thing. A batch stops being delivered when it has had its retries, and a
+ * record stops being delivered when it is older than the mapping will carry;
+ * whichever comes first, what is left of the batch is discarded and the mapping
+ * reads on. Records age out of the front of a batch, because a batch is in
+ * stream order, so the answer is one record to start from rather than a list of
+ * survivors.
+ *
+ * Ages are read at the instant the next delivery falls due rather than now,
+ * because the wait before it is what ages the records out. A record judged now
+ * would be handed to the function and only then found to be too old.
+ */
+export class SimLambdaStreamRetry {
+  private readonly limits: SimLambdaStreamRetryLimits;
+  private readonly clock: SimClock;
+  private readonly backoff: SimLambdaStreamRetryBackoff;
+
+  constructor(properties: SimLambdaStreamRetryProperties) {
+    this.limits = properties.limits;
+    this.clock = properties.clock;
+    this.backoff = new SimLambdaStreamRetryBackoff(
+      properties.limits.attemptLimit,
+    );
+  }
+
+  /**
+   * The next delivery of a failed batch, or nothing when the batch is finished
+   * with.
+   */
+  after(
+    outcome: SimLambdaStreamBatchOutcome,
+    readFrom: SimLambdaEventSourceStreamPosition,
+  ): SimLambdaStreamRetryAttempt | undefined {
+    if (this.backoff.isExhausted) {
+      return undefined;
+    }
+
+    const afterSeconds = this.backoff.nextSeconds();
+    const deliveryAt = this.deliveryAt(afterSeconds);
+    const position = this.retryPosition(outcome, readFrom, deliveryAt);
+
+    if (position === undefined) {
+      return undefined;
+    }
+
+    return { position, afterSeconds };
+  }
+
+  /**
+   * Start counting again, which a batch that is finished with does.
+   */
+  reset(): void {
+    this.backoff.reset();
+  }
+
+  /**
+   * Where the next delivery starts, or nothing when every record left in the
+   * batch has aged out.
+   */
+  private retryPosition(
+    outcome: SimLambdaStreamBatchOutcome,
+    readFrom: SimLambdaEventSourceStreamPosition,
+    deliveryAt: Date,
+  ): SimLambdaEventSourceStreamPosition | undefined {
+    const { records, retryIndex } = outcome;
+    const live = this.firstLiveIndex(records, retryIndex, deliveryAt);
+
+    if (live === undefined) {
+      return undefined;
+    }
+
+    const sequenceNumber = records.at(live)?.sequenceNumber;
+
+    // Nothing aged out of the front, so the batch goes back exactly where the
+    // report left it. A record that aged out but cannot be named leaves the
+    // batch where it was too, since skipping past a record the mapping cannot
+    // name would skip the records after it as well.
+    if (live === retryIndex || sequenceNumber === undefined) {
+      return outcome.retryPosition(readFrom);
+    }
+
+    return { kind: "sequence", sequenceNumber };
+  }
+
+  /**
+   * The first record from `from` on that is still young enough to deliver.
+   */
+  private firstLiveIndex(
+    records: readonly SimLambdaStreamRecordTime[],
+    from: number,
+    deliveryAt: Date,
+  ): number | undefined {
+    const index = records.findIndex(
+      (record, position) =>
+        position >= from && !this.limits.hasAgedOut(record.at, deliveryAt),
+    );
+
+    return index === -1 ? undefined : index;
+  }
+
+  /**
+   * When the next delivery falls due, which is what a record's age is judged
+   * against.
+   *
+   * Judging it now would hand a record over and only then notice that it was
+   * too old to be worth handing over, since the wait is what makes it too old.
+   */
+  private deliveryAt(afterSeconds: number): Date {
+    return new Date(
+      this.clock.now().getTime() + afterSeconds * millisecondsPerSecond,
+    );
+  }
+}

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-arn.ts
@@ -1,11 +1,13 @@
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import { sqsQueueUrl } from "../../../sqs/queue/sim-sqs-queue-arn.js";
 import type { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import type { SimLambdaEventSourceRetryLimitRules } from "../sim-lambda-event-source-retry-limits.js";
 import { SimLambdaEventSourcePollingPermission } from "../sim-lambda-event-source-polling-permission.js";
 import type { SimLambdaEventSourceStartingPositionRules } from "../sim-lambda-event-source-starting-position.js";
 import {
   sqsBatchRules,
   sqsPollingOperations,
+  sqsRetryLimitRules,
   sqsStartingPositionRules,
 } from "./sim-lambda-sqs-event-source-rules.js";
 
@@ -92,6 +94,14 @@ export class SimLambdaSqsEventSourceArn {
    */
   get startingPositionRules(): SimLambdaEventSourceStartingPositionRules {
     return sqsStartingPositionRules;
+  }
+
+  /**
+   * The failed-batch limits a mapping on this queue may be created with, which
+   * is neither of them.
+   */
+  get retryLimitRules(): SimLambdaEventSourceRetryLimitRules {
+    return sqsRetryLimitRules;
   }
 
   /**

--- a/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-rules.ts
+++ b/src/service/lambda/event-source/queue/sim-lambda-sqs-event-source-rules.ts
@@ -1,4 +1,5 @@
 import { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaNoRetryLimits } from "../sim-lambda-event-source-retry-limits.js";
 import { SimLambdaNoStartingPosition } from "../sim-lambda-event-source-starting-position.js";
 
 /**
@@ -34,4 +35,14 @@ export const sqsBatchRules = new SimLambdaEventSourceBatchRules({
  */
 export const sqsStartingPositionRules = new SimLambdaNoStartingPosition(
   "a queue",
+);
+
+/**
+ * A queue keeps its own count of how often a message has been received, so
+ * neither of Lambda's failed-batch limits is a queue mapping's to keep.
+ */
+export const sqsRetryLimitRules = new SimLambdaNoRetryLimits(
+  "a queue",
+  "a message the function never handles is left to the queue's own redrive " +
+    "policy",
 );

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -3,6 +3,10 @@ import { randomUUID } from "node:crypto";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimLambdaFunctionArn } from "../function/sim-lambda-function-configuration.js";
 import type {
+  SimLambdaStreamRetryLimits,
+  SimLambdaStreamRetryLimitsConfiguration,
+} from "./sim-lambda-stream-retry-limits.js";
+import type {
   SimLambdaEventSourceStart,
   SimLambdaEventSourceStartingPosition,
 } from "./sim-lambda-event-source-starting-position.js";
@@ -44,6 +48,7 @@ interface SimLambdaEventSourceMappingProperties {
   readonly functionResponseTypes?:
     | readonly SimLambdaFunctionResponseType[]
     | undefined;
+  readonly streamRetryLimits?: SimLambdaStreamRetryLimits | undefined;
   readonly createdAt: Date;
 }
 
@@ -52,7 +57,7 @@ interface SimLambdaEventSourceMappingProperties {
  * CreateEventSourceMapping, GetEventSourceMapping, ListEventSourceMappings and
  * DeleteEventSourceMapping responses all report it.
  */
-export interface SimLambdaEventSourceMappingConfiguration {
+export interface SimLambdaEventSourceMappingConfiguration extends Partial<SimLambdaStreamRetryLimitsConfiguration> {
   readonly UUID: string;
   readonly EventSourceMappingArn: SimLambdaEventSourceMappingArn;
   readonly EventSourceArn: string;
@@ -100,6 +105,15 @@ export class SimLambdaEventSourceMapping {
   public readonly start: SimLambdaEventSourceStart | undefined;
   public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 
+  /**
+   * When this mapping stops delivering a batch its function keeps failing, for
+   * a source that leaves the counting to the mapping.
+   *
+   * A queue mapping has none, because a message the function never handles is
+   * the queue's own problem once the batch comes back.
+   */
+  public readonly streamRetryLimits: SimLambdaStreamRetryLimits | undefined;
+
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly enabled: boolean;
   private readonly lastModified: Date;
@@ -116,6 +130,7 @@ export class SimLambdaEventSourceMapping {
     // Copied rather than held, so a caller keeping the list it passed in
     // cannot change what this mapping does with a batch afterwards.
     this.functionResponseTypes = [...(properties.functionResponseTypes ?? [])];
+    this.streamRetryLimits = properties.streamRetryLimits;
     this.enabled = properties.enabled ?? true;
     this.lastModified = properties.createdAt;
   }
@@ -177,6 +192,10 @@ export class SimLambdaEventSourceMapping {
       // Partial batches are delivered as soon as anything is available, so the
       // batching window is always zero. Anything else is refused at creation.
       MaximumBatchingWindowInSeconds: 0,
+      // Real Lambda reports both failed-batch limits for a stream mapping and
+      // neither for a queue one, so a mapping with no limits to keep leaves
+      // them out rather than reporting a limit it does not have.
+      ...this.streamRetryLimits?.configuration(),
       FunctionResponseTypes: this.functionResponseTypes,
       State: this.#state,
       StateTransitionReason: "USER_INITIATED",

--- a/src/service/lambda/event-source/sim-lambda-event-source-retry-limits.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-retry-limits.ts
@@ -1,0 +1,86 @@
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+import {
+  type SimLambdaEventSourceRetryLimitsInput,
+  SimLambdaStreamRetryLimits,
+} from "./sim-lambda-stream-retry-limits.js";
+
+/**
+ * Whether the event source a mapping names has failed-batch limits at all.
+ *
+ * A stream does: a record stays on the stream whatever the function makes of
+ * it, so the mapping is the only thing that decides when to stop trying. A
+ * queue does not, because a message the function never handles goes to the
+ * queue's own redrive policy, and real Lambda refuses a request that names
+ * either limit for one.
+ */
+export interface SimLambdaEventSourceRetryLimitRules {
+  /**
+   * The limits a mapping on this source keeps, or nothing for a source that has
+   * none, refusing a request that asks for limits this source does not have.
+   */
+  limitsIn(
+    input: SimLambdaEventSourceRetryLimitsInput,
+  ): SimLambdaStreamRetryLimits | undefined;
+}
+
+/**
+ * The rules for an event source that decides for itself when to give up.
+ */
+export class SimLambdaNoRetryLimits implements SimLambdaEventSourceRetryLimitRules {
+  private readonly sourceDescription: string;
+  private readonly insteadDescription: string;
+
+  constructor(sourceDescription: string, insteadDescription: string) {
+    this.sourceDescription = sourceDescription;
+    this.insteadDescription = insteadDescription;
+  }
+
+  /**
+   * Refuse both limits, since this source is not the one counting.
+   */
+  limitsIn(
+    input: SimLambdaEventSourceRetryLimitsInput,
+  ): SimLambdaStreamRetryLimits | undefined {
+    const named = namedLimit(input);
+
+    if (named === undefined) {
+      return undefined;
+    }
+
+    throw new SimLambdaInvalidParameterValueException(
+      `${named} is not valid for ${this.sourceDescription}: ${
+        this.insteadDescription
+      }`,
+    );
+  }
+}
+
+/**
+ * The rules for a stream, which counts a failed batch's attempts itself.
+ */
+export class SimLambdaStreamRetryLimitRules implements SimLambdaEventSourceRetryLimitRules {
+  /**
+   * The limits a mapping on this stream keeps, which are Lambda's own defaults
+   * of no limit when the request named neither.
+   */
+  limitsIn(
+    input: SimLambdaEventSourceRetryLimitsInput,
+  ): SimLambdaStreamRetryLimits {
+    return new SimLambdaStreamRetryLimits(input);
+  }
+}
+
+/**
+ * Which limit a request named, for a refusal to name it back.
+ */
+function namedLimit(
+  input: SimLambdaEventSourceRetryLimitsInput,
+): string | undefined {
+  if (input.maximumRetryAttempts !== undefined) {
+    return "MaximumRetryAttempts";
+  }
+
+  return input.maximumRecordAgeInSeconds === undefined
+    ? undefined
+    : "MaximumRecordAgeInSeconds";
+}

--- a/src/service/lambda/event-source/sim-lambda-stream-record-age.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-record-age.iso.test.ts
@@ -1,0 +1,161 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import {
+  assertArrayEquals,
+  assertArrayIncludes,
+  assertArrayLength,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaKinesisStreamEvent } from "./poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.types.js";
+
+/**
+ * A handler that never gets through a batch, so the record age is the only
+ * thing that ends the retries.
+ */
+function throwing(): never {
+  throw new Error("Projector could not handle the batch");
+}
+
+/**
+ * Write one order to the table, which is one record on its stream.
+ */
+async function writeOrder(
+  simAws: SimAws,
+  tableName: string,
+  orderId: string,
+): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: { orderId: { S: orderId } },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * Put one order onto the stream, on the shard the other orders go to.
+ */
+async function putOrder(simAws: SimAws, orderId: string): Promise<void> {
+  await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: "customer-1",
+      Data: new TextEncoder().encode(orderId),
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * The orders each delivery of a DynamoDB stream batch carried.
+ */
+function deliveries(
+  events: readonly SimLambdaDynamoDbStreamEvent[],
+): readonly string[] {
+  return events.map((event) =>
+    event.Records.map(
+      (record) => record.dynamodb.Keys?.["orderId"]?.S ?? "",
+    ).join(", "),
+  );
+}
+
+/**
+ * The orders each delivery of a Kinesis batch carried.
+ */
+function kinesisDeliveries(
+  events: readonly SimLambdaKinesisStreamEvent[],
+): readonly string[] {
+  return events.map((event) =>
+    event.Records.map((record) =>
+      Buffer.from(record.kinesis.data, "base64").toString("utf8"),
+    ).join(", "),
+  );
+}
+
+describe("the record age a stream event source mapping keeps delivering", () => {
+  it("stops delivering a record once the next attempt would be past its age", async () => {
+    // Given a stream mapping that discards records older than ten seconds,
+    // whose handler cannot get through a batch.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+      maximumRecordAgeInSeconds: 10,
+    });
+
+    // When a change is written and an hour of simulated time passes.
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the record was handed over at 0, 1, 3 and 7 seconds, and the
+    // attempt that would have fallen at 15 seconds was not made, because the
+    // record would have been older by then than the mapping carries.
+    assertArrayLength(events, 4);
+  });
+
+  it("carries on with the stream once its records have aged out", async () => {
+    // Given a stream mapping that discards records older than ten seconds.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+      maximumRecordAgeInSeconds: 10,
+    });
+
+    // When one change ages out and another is written behind it.
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await writeOrder(simAws, tableName, "order-2");
+
+    // Then the aged-out record moved the checkpoint, so the record behind it
+    // was delivered rather than waiting behind one nothing will handle.
+    assertArrayIncludes(deliveries(events), "order-2");
+  });
+
+  it("leaves behind only the records that have aged out", async () => {
+    // Given a stream mapping that discards records older than a minute, whose
+    // handler cannot get through a batch, so nothing ever leaves the batch by
+    // being handled.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+      maximumRecordAgeInSeconds: 60,
+    });
+
+    // When one change is written, and a second thirty seconds later, so the
+    // two records of the blocked batch age out thirty seconds apart.
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.clock().advanceBy({ seconds: 30 });
+    await writeOrder(simAws, tableName, "order-2");
+
+    // When an hour of simulated time passes.
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the batch carried both records while both were young enough, and
+    // the older one was left behind on its own, so the younger one went on
+    // being delivered rather than being discarded alongside it.
+    assertArrayEquals(deliveries(events).slice(-2), [
+      "order-1, order-2",
+      "order-2",
+    ]);
+  });
+
+  it("stops delivering a Kinesis record once it is past its age", async () => {
+    // Given a Kinesis mapping that discards records older than ten seconds,
+    // whose handler cannot get through a batch.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      handlerResult: throwing,
+      maximumRecordAgeInSeconds: 10,
+    });
+
+    // When a record is put on, ages out, and another is put on behind it.
+    await putOrder(simAws, "order-1");
+    await simAws.clock().advanceBy({ minutes: 1 });
+    await putOrder(simAws, "order-2");
+
+    // Then the shard carried on rather than stalling on the record nothing
+    // will handle.
+    assertArrayIncludes(kinesisDeliveries(events), "order-2");
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-stream-retry-attempts.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-retry-attempts.iso.test.ts
@@ -1,0 +1,180 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import { assertArrayEquals, assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.types.js";
+
+/**
+ * A handler that never gets through a batch, which is what makes the retries
+ * the only thing deciding how many deliveries there are.
+ */
+function throwing(): never {
+  throw new Error("Projector could not handle the batch");
+}
+
+/**
+ * Write one order to the table, which is one record on its stream.
+ */
+async function writeOrder(
+  simAws: SimAws,
+  tableName: string,
+  orderId: string,
+): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: { orderId: { S: orderId } },
+    }),
+  );
+}
+
+/**
+ * Put one order onto the stream, on the shard the other orders go to.
+ */
+async function putOrder(simAws: SimAws, orderId: string): Promise<void> {
+  await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: "customer-1",
+      Data: new TextEncoder().encode(orderId),
+    }),
+  );
+}
+
+/**
+ * The orders each delivery carried, one line per delivery.
+ */
+function deliveries(
+  events: readonly SimLambdaDynamoDbStreamEvent[],
+): readonly string[] {
+  return events.map((event) =>
+    event.Records.map(
+      (record) => record.dynamodb.Keys?.["orderId"]?.S ?? "",
+    ).join(", "),
+  );
+}
+
+describe("the retries a stream event source mapping allows a failed batch", () => {
+  it("makes one delivery and no retries when the mapping allows none", async () => {
+    // Given a stream mapping that allows a failed batch no retries at all,
+    // whose handler cannot get through a batch.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+      maximumRetryAttempts: 0,
+    });
+
+    // When a change is written and an hour of simulated time passes.
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the batch was handed over once and discarded, rather than waiting
+    // out the retries a mapping that asked for no limit would have had.
+    assertArrayLength(events, 1);
+  });
+
+  it("carries on with the stream once a batch has had its retries", async () => {
+    // Given a stream mapping that allows a failed batch no retries.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+      maximumRetryAttempts: 0,
+    });
+
+    // When one change is written, given up on, and another written behind it.
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.backgroundTasksComplete();
+    await writeOrder(simAws, tableName, "order-2");
+    await simAws.backgroundTasksComplete();
+
+    // Then the discarded record moved the checkpoint, so the record behind it
+    // was delivered rather than waiting behind a batch nothing will handle.
+    assertArrayEquals(deliveries(events), ["order-1", "order-2"]);
+  });
+
+  it("allows exactly the retries a stream mapping asked for", async () => {
+    // Given a stream mapping that allows a failed batch two retries.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+      maximumRetryAttempts: 2,
+    });
+
+    // When a change is written and an hour of simulated time passes.
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the batch was handed over once and then twice more, after 1 and 2
+    // seconds, rather than the five times a mapping with no limit gets.
+    assertArrayLength(events, 3);
+  });
+
+  it("allows exactly the retries a Kinesis mapping asked for", async () => {
+    // Given a Kinesis mapping that allows a failed batch one retry.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      handlerResult: throwing,
+      maximumRetryAttempts: 1,
+    });
+
+    // When a record is put onto the stream and an hour of simulated time
+    // passes.
+    await putOrder(simAws, "order-1");
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the batch was handed over once and then once more.
+    assertArrayLength(events, 2);
+  });
+
+  it("counts a redelivery from a reported record against the same retries", async () => {
+    // Given a mapping allowing one retry, whose handler always reports the
+    // second record of whatever batch it is given.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      functionResponseTypes: ["ReportBatchItemFailures"],
+      maximumRetryAttempts: 1,
+      handlerResult: (event: SimLambdaDynamoDbStreamEvent): unknown => ({
+        batchItemFailures: [
+          { itemIdentifier: event.Records[1]?.dynamodb.SequenceNumber },
+        ],
+      }),
+    });
+
+    // When three changes are written and an hour of simulated time passes.
+    await writeOrder(simAws, tableName, "order-1");
+    await writeOrder(simAws, tableName, "order-2");
+    await writeOrder(simAws, tableName, "order-3");
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the report sent the batch back to the record it named, and that
+    // redelivery was the one retry the mapping allows rather than a fresh
+    // start on a smaller batch.
+    assertArrayEquals(deliveries(events).slice(-2), [
+      "order-1, order-2, order-3",
+      "order-2, order-3",
+    ]);
+  });
+
+  it("keeps the five retries a mapping asking for no limit has always had", async () => {
+    // Given a stream mapping that asks for no limit on either retries or
+    // record age, which is what Lambda's own -1 means.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwing,
+      maximumRetryAttempts: -1,
+      maximumRecordAgeInSeconds: -1,
+    });
+
+    // When a change is written and an hour of simulated time passes.
+    await writeOrder(simAws, tableName, "order-1");
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the batch was delivered again five times, after 1, 2, 4, 8 and 16
+    // seconds, which is the cap that keeps a handler that always throws from
+    // leaving the clock with work falling due forever.
+    assertArrayLength(events, 6);
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-stream-retry-limits.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-retry-limits.iso.test.ts
@@ -1,0 +1,202 @@
+import {
+  CreateEventSourceMappingCommand,
+  GetEventSourceMappingCommand,
+  ListEventSourceMappingsCommand,
+} from "@aws-sdk/client-lambda";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithSqsEventSource } from "../../../../test/lambda/event-source-fixture.js";
+import {
+  makeSourceStream,
+  makeStreamPollingRole,
+} from "../../../../test/lambda/stream-event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCreateEventSourceMappingCommandOutput } from "../command/event-source-mapping/event-source-mapping.command.js";
+import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.js";
+
+/**
+ * The failed-batch limits a request can ask a stream mapping for.
+ */
+interface RetryLimitsRequest {
+  readonly MaximumRetryAttempts?: number;
+  readonly MaximumRecordAgeInSeconds?: number;
+}
+
+/**
+ * One simulated AWS with a stream and a function, ready to be mapped.
+ */
+interface MappableStream {
+  readonly simAws: SimAws;
+  readonly streamArn: string;
+}
+
+async function simAwsReadyToMap(): Promise<MappableStream> {
+  const simAws = new SimAws();
+  const { streamArn } = await makeSourceStream(simAws);
+  const roleArn = await makeStreamPollingRole(simAws, streamArn);
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "order-projector",
+      Role: roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput((): undefined => undefined) },
+    },
+  });
+
+  return { simAws, streamArn };
+}
+
+/**
+ * Create a stream mapping asking for failed-batch limits.
+ */
+async function createStreamMapping(
+  ready: MappableStream,
+  request: RetryLimitsRequest,
+): Promise<SimCreateEventSourceMappingCommandOutput> {
+  return await ready.simAws.lambda().createEventSourceMapping(
+    new CreateEventSourceMappingCommand({
+      EventSourceArn: ready.streamArn,
+      FunctionName: "order-projector",
+      StartingPosition: "TRIM_HORIZON",
+      ...request,
+    }),
+  );
+}
+
+/**
+ * Try to create a stream mapping, and answer with what it was refused with.
+ */
+async function refusedStreamMapping(
+  request: RetryLimitsRequest,
+): Promise<Error> {
+  const ready = await simAwsReadyToMap();
+
+  return await assertThrowsErrorAsync(async () => {
+    await createStreamMapping(ready, request);
+  });
+}
+
+describe("the failed-batch limits a stream event source mapping is created with", () => {
+  it("reports the limits the request asked for", async () => {
+    // Given a stream and a function to map it to.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping is created with a retry quota and a record age.
+    const created = await createStreamMapping(ready, {
+      MaximumRetryAttempts: 3,
+      MaximumRecordAgeInSeconds: 120,
+    });
+
+    // Then the mapping reports both back rather than the defaults.
+    assertIdentical(created.MaximumRetryAttempts, 3);
+    assertIdentical(created.MaximumRecordAgeInSeconds, 120);
+  });
+
+  it("reports the limits through Get and List", async () => {
+    // Given a mapping created with a retry quota and a record age.
+    const ready = await simAwsReadyToMap();
+    const created = await createStreamMapping(ready, {
+      MaximumRetryAttempts: 3,
+      MaximumRecordAgeInSeconds: 120,
+    });
+
+    // When the mapping is read back and listed.
+    const read = await ready.simAws
+      .lambda()
+      .getEventSourceMapping(
+        new GetEventSourceMappingCommand({ UUID: created.UUID }),
+      );
+    const listed = await ready.simAws
+      .lambda()
+      .listEventSourceMappings(
+        new ListEventSourceMappingsCommand({ EventSourceArn: ready.streamArn }),
+      );
+
+    // Then both report what the mapping was created with.
+    assertIdentical(read.MaximumRetryAttempts, 3);
+    assertIdentical(read.MaximumRecordAgeInSeconds, 120);
+    assertArrayLength(listed.EventSourceMappings, 1);
+    assertIdentical(
+      listed.EventSourceMappings[0].MaximumRecordAgeInSeconds,
+      120,
+    );
+  });
+
+  it("reports no limit for a mapping that asked for neither", async () => {
+    // Given a stream and a function to map it to.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping is created without either limit.
+    const created = await createStreamMapping(ready, {});
+
+    // Then it reports Lambda's own -1 for both, which is what a stream mapping
+    // on AWS reports when nothing has been asked for.
+    assertIdentical(created.MaximumRetryAttempts, -1);
+    assertIdentical(created.MaximumRecordAgeInSeconds, -1);
+  });
+
+  it("leaves both out of a queue mapping, which has neither", async () => {
+    // Given a mapping between a queue and a function.
+    const { simAws, uuid } = await simAwsWithSqsEventSource();
+
+    // When it is read back.
+    const read = await simAws
+      .lambda()
+      .getEventSourceMapping(new GetEventSourceMappingCommand({ UUID: uuid }));
+
+    // Then neither limit is reported, because a message the function never
+    // handles is left to the queue rather than counted by the mapping.
+    assertUndefined(read.MaximumRetryAttempts);
+    assertUndefined(read.MaximumRecordAgeInSeconds);
+  });
+
+  it("refuses more retries than Lambda takes", async () => {
+    // Given a stream and a function.
+    // When a mapping asks for more retries than Lambda's maximum.
+    const error = await refusedStreamMapping({ MaximumRetryAttempts: 10_001 });
+
+    // Then it is refused rather than promising a quota nothing would honour.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "maximumRetryAttempts");
+  });
+
+  it("refuses a record age older than Lambda takes", async () => {
+    // Given a stream and a function.
+    // When a mapping asks to carry records for longer than Lambda's maximum.
+    const error = await refusedStreamMapping({
+      MaximumRecordAgeInSeconds: 604_801,
+    });
+
+    // Then it is refused, naming the setting that is out of range.
+    assertIdentical(error.name, "ValidationException");
+    assertStringIncludes(error.message, "maximumRecordAgeInSeconds");
+  });
+
+  it("refuses a limit below the -1 that means no limit", async () => {
+    // Given a stream and a function.
+    // When a mapping asks for a negative quota that is not Lambda's -1.
+    const error = await refusedStreamMapping({ MaximumRetryAttempts: -2 });
+
+    // Then it is refused rather than read as no limit at all.
+    assertIdentical(error.name, "ValidationException");
+  });
+
+  it("refuses a limit that is not a whole number", async () => {
+    // Given a stream and a function.
+    // When a mapping asks for a fractional record age.
+    const error = await refusedStreamMapping({
+      MaximumRecordAgeInSeconds: 90.5,
+    });
+
+    // Then it is refused here rather than deciding later what half a second of
+    // record age means.
+    assertIdentical(error.name, "ValidationException");
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-stream-retry-limits.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-retry-limits.iso.test.ts
@@ -123,6 +123,7 @@ describe("the failed-batch limits a stream event source mapping is created with"
     assertIdentical(read.MaximumRetryAttempts, 3);
     assertIdentical(read.MaximumRecordAgeInSeconds, 120);
     assertArrayLength(listed.EventSourceMappings, 1);
+    assertIdentical(listed.EventSourceMappings[0].MaximumRetryAttempts, 3);
     assertIdentical(
       listed.EventSourceMappings[0].MaximumRecordAgeInSeconds,
       120,

--- a/src/service/lambda/event-source/sim-lambda-stream-retry-limits.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-retry-limits.ts
@@ -1,0 +1,158 @@
+import { SimLambdaValidationException } from "../error/sim-lambda.error.js";
+
+/**
+ * The value both settings take to mean no limit, and what a mapping that named
+ * neither of them reports.
+ */
+const infinite = -1;
+
+/**
+ * The largest number of retries Lambda takes.
+ */
+const maximumRetryAttemptsLimit = 10_000;
+
+/**
+ * The oldest record age Lambda takes, which is seven days.
+ */
+const maximumRecordAgeLimit = 604_800;
+
+/**
+ * How many times a failed batch is delivered again when the mapping asked for
+ * no limit of its own.
+ *
+ * A batch a handler always throws on has to stop somewhere. AWS keeps retrying
+ * until the records age out of the stream, a day later, and waiting out a
+ * simulated day is a hang with more steps.
+ */
+const defaultAttemptLimit = 5;
+
+const millisecondsPerSecond = 1000;
+
+/**
+ * The parts of a request that say how long a failed batch keeps being
+ * delivered.
+ *
+ * Taken as its own small input rather than as the whole command input, so the
+ * rules stay with the event source they belong to rather than importing the
+ * command they are read from.
+ */
+export interface SimLambdaEventSourceRetryLimitsInput {
+  readonly maximumRetryAttempts?: number | undefined;
+  readonly maximumRecordAgeInSeconds?: number | undefined;
+}
+
+/**
+ * The failed-batch limits a mapping reports back, as Lambda names them.
+ */
+export interface SimLambdaStreamRetryLimitsConfiguration {
+  readonly MaximumRetryAttempts: number;
+  readonly MaximumRecordAgeInSeconds: number;
+}
+
+/**
+ * When a stream mapping stops delivering a batch its function keeps failing.
+ *
+ * The two limits are one thing rather than two, because they end the same
+ * lifecycle: a record leaves the mapping when it has had its retries or when it
+ * is too old to be worth another, whichever comes first. Both are held as
+ * Lambda states them, with `-1` for no limit, so a Get or a List reports back
+ * exactly what was asked for.
+ */
+export class SimLambdaStreamRetryLimits {
+  public readonly maximumRetryAttempts: number;
+  public readonly maximumRecordAgeInSeconds: number;
+
+  constructor(input: SimLambdaEventSourceRetryLimitsInput = {}) {
+    this.maximumRetryAttempts = checkedLimit({
+      value: input.maximumRetryAttempts,
+      field: "maximumRetryAttempts",
+      maximum: maximumRetryAttemptsLimit,
+      unit: "retries",
+    });
+    this.maximumRecordAgeInSeconds = checkedLimit({
+      value: input.maximumRecordAgeInSeconds,
+      field: "maximumRecordAgeInSeconds",
+      maximum: maximumRecordAgeLimit,
+      unit: "seconds",
+    });
+  }
+
+  /**
+   * The two limits as a Get, a List or a create response reports them.
+   */
+  configuration(): SimLambdaStreamRetryLimitsConfiguration {
+    return {
+      MaximumRetryAttempts: this.maximumRetryAttempts,
+      MaximumRecordAgeInSeconds: this.maximumRecordAgeInSeconds,
+    };
+  }
+
+  /**
+   * How many times a failed batch is delivered again before it is discarded.
+   *
+   * A mapping that named neither limit gets the simulator's own cap of five,
+   * which is what keeps a handler that always throws from leaving the clock
+   * with work falling due forever. A mapping that named a record age has an end
+   * of its own, so the cap is out of the way and the records age out as they do
+   * on AWS.
+   */
+  get attemptLimit(): number {
+    if (this.maximumRetryAttempts !== infinite) {
+      return this.maximumRetryAttempts;
+    }
+
+    return this.maximumRecordAgeInSeconds === infinite
+      ? defaultAttemptLimit
+      : Infinity;
+  }
+
+  /**
+   * Whether a record written at an instant is too old to be handed over again.
+   *
+   * A record the stream gave up without a time has no age to read, and is
+   * discarded alongside the ones that aged out rather than kept forever against
+   * a limit that is about age. Both simulated stream services stamp every
+   * record, so this is a guard rather than a case a test can reach.
+   */
+  hasAgedOut(writtenAt: Date | undefined, now: Date): boolean {
+    if (this.maximumRecordAgeInSeconds === infinite) {
+      return false;
+    }
+
+    if (writtenAt === undefined) {
+      return true;
+    }
+
+    const age = now.getTime() - writtenAt.getTime();
+
+    return age > this.maximumRecordAgeInSeconds * millisecondsPerSecond;
+  }
+}
+
+interface CheckedLimitProperties {
+  readonly value: number | undefined;
+  readonly field: string;
+  readonly maximum: number;
+  readonly unit: string;
+}
+
+/**
+ * One limit as Lambda takes it, refusing a value outside the range it documents.
+ */
+function checkedLimit(properties: CheckedLimitProperties): number {
+  const { value, field, maximum, unit } = properties;
+
+  if (value === undefined) {
+    return infinite;
+  }
+
+  if (!Number.isSafeInteger(value) || value < infinite || value > maximum) {
+    throw new SimLambdaValidationException(
+      `1 validation error detected: Value ${String(value)} at '${field}' ` +
+        "failed to satisfy constraint: Member must be a whole number of " +
+        `${unit} between 0 and ${String(maximum)}, or -1 for no limit`,
+    );
+  }
+
+  return value;
+}

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-arn.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-arn.ts
@@ -1,10 +1,12 @@
 import { SimLambdaInvalidParameterValueException } from "../../../error/sim-lambda.error.js";
 import type { SimLambdaEventSourceBatchRules } from "../../sim-lambda-event-source-batch-rules.js";
+import type { SimLambdaEventSourceRetryLimitRules } from "../../sim-lambda-event-source-retry-limits.js";
 import { SimLambdaEventSourcePollingPermission } from "../../sim-lambda-event-source-polling-permission.js";
 import type { SimLambdaEventSourceStartingPositionRules } from "../../sim-lambda-event-source-starting-position.js";
 import {
   kinesisStreamBatchRules,
   kinesisStreamPollingOperations,
+  kinesisStreamRetryLimitRules,
   kinesisStreamStartingPositionRules,
 } from "./sim-lambda-kinesis-event-source-rules.js";
 
@@ -105,6 +107,13 @@ export class SimLambdaKinesisEventSourceArn {
    */
   get startingPositionRules(): SimLambdaEventSourceStartingPositionRules {
     return kinesisStreamStartingPositionRules;
+  }
+
+  /**
+   * The failed-batch limits a mapping on this stream may be created with.
+   */
+  get retryLimitRules(): SimLambdaEventSourceRetryLimitRules {
+    return kinesisStreamRetryLimitRules;
   }
 
   /**

--- a/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-rules.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-lambda-kinesis-event-source-rules.ts
@@ -1,4 +1,5 @@
 import { SimLambdaEventSourceBatchRules } from "../../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaStreamRetryLimitRules } from "../../sim-lambda-event-source-retry-limits.js";
 import { SimLambdaStreamStartingPosition } from "../../sim-lambda-event-source-starting-position.js";
 
 /**
@@ -41,3 +42,10 @@ export const kinesisStreamStartingPositionRules =
     positions: ["TRIM_HORIZON", "LATEST", "AT_TIMESTAMP"],
     sourceDescription: "a Kinesis stream",
   });
+
+/**
+ * A Kinesis stream mapping counts a failed batch's attempts itself, so it takes
+ * both of Lambda's failed-batch limits.
+ */
+export const kinesisStreamRetryLimitRules =
+  new SimLambdaStreamRetryLimitRules();

--- a/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-arn.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-arn.ts
@@ -1,10 +1,12 @@
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
 import type { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
-import { SimLambdaEventSourcePollingPermission } from "../sim-lambda-event-source-polling-permission.js";
+import type { SimLambdaEventSourcePollingPermission } from "../sim-lambda-event-source-polling-permission.js";
+import type { SimLambdaEventSourceRetryLimitRules } from "../sim-lambda-event-source-retry-limits.js";
 import type { SimLambdaEventSourceStartingPositionRules } from "../sim-lambda-event-source-starting-position.js";
 import {
   dynamoDbStreamBatchRules,
-  dynamoDbStreamPollingOperations,
+  dynamoDbStreamPollingPermissions,
+  dynamoDbStreamRetryLimitRules,
   dynamoDbStreamStartingPositionRules,
 } from "./sim-lambda-dynamodb-stream-event-source-rules.js";
 
@@ -49,16 +51,7 @@ export class SimLambdaDynamoDbStreamEventSourceArn {
     this.accountId = parts["account"] ?? "";
     this.tableName = parts["table"] ?? "";
     this.label = parts["label"] ?? "";
-    this.pollingPermissions = [
-      ...dynamoDbStreamPollingOperations.map(
-        (operation) =>
-          new SimLambdaEventSourcePollingPermission(
-            `dynamodb:${operation}`,
-            value,
-          ),
-      ),
-      new SimLambdaEventSourcePollingPermission("dynamodb:ListStreams", "*"),
-    ];
+    this.pollingPermissions = dynamoDbStreamPollingPermissions(value);
   }
 
   /**
@@ -107,6 +100,13 @@ export class SimLambdaDynamoDbStreamEventSourceArn {
    */
   get startingPositionRules(): SimLambdaEventSourceStartingPositionRules {
     return dynamoDbStreamStartingPositionRules;
+  }
+
+  /**
+   * The failed-batch limits a mapping on this stream may be created with.
+   */
+  get retryLimitRules(): SimLambdaEventSourceRetryLimitRules {
+    return dynamoDbStreamRetryLimitRules;
   }
 
   /**

--- a/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-rules.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-dynamodb-stream-event-source-rules.ts
@@ -1,4 +1,6 @@
 import { SimLambdaEventSourceBatchRules } from "../sim-lambda-event-source-batch-rules.js";
+import { SimLambdaEventSourcePollingPermission } from "../sim-lambda-event-source-polling-permission.js";
+import { SimLambdaStreamRetryLimitRules } from "../sim-lambda-event-source-retry-limits.js";
 import { SimLambdaStreamStartingPosition } from "../sim-lambda-event-source-starting-position.js";
 
 /**
@@ -10,11 +12,30 @@ import { SimLambdaStreamStartingPosition } from "../sim-lambda-event-source-star
  * here ever calls it, but both the AWS managed policy and CDK's own grant
  * include it, so a role that would work on AWS is a role that works here.
  */
-export const dynamoDbStreamPollingOperations = [
+const dynamoDbStreamPollingOperations = [
   "DescribeStream",
   "GetRecords",
   "GetShardIterator",
 ] as const;
+
+/**
+ * What an execution role has to be allowed before a mapping on one stream can
+ * be created, as the permissions simulated IAM is asked for.
+ */
+export function dynamoDbStreamPollingPermissions(
+  streamArn: string,
+): readonly SimLambdaEventSourcePollingPermission[] {
+  return [
+    ...dynamoDbStreamPollingOperations.map(
+      (operation) =>
+        new SimLambdaEventSourcePollingPermission(
+          `dynamodb:${operation}`,
+          streamArn,
+        ),
+    ),
+    new SimLambdaEventSourcePollingPermission("dynamodb:ListStreams", "*"),
+  ];
+}
 
 /**
  * The batch sizes a DynamoDB stream event source delivers with.
@@ -42,3 +63,10 @@ export const dynamoDbStreamStartingPositionRules =
     sourceDescription: "a DynamoDB stream",
     positionElsewhere: "AT_TIMESTAMP is for a Kinesis stream",
   });
+
+/**
+ * A DynamoDB stream mapping counts a failed batch's attempts itself, so it
+ * takes both of Lambda's failed-batch limits.
+ */
+export const dynamoDbStreamRetryLimitRules =
+  new SimLambdaStreamRetryLimitRules();

--- a/test/lambda/kinesis-event-source-fixture.ts
+++ b/test/lambda/kinesis-event-source-fixture.ts
@@ -102,6 +102,8 @@ interface KinesisEventSourceOptions {
   readonly startingPosition?: EventSourcePosition;
   readonly startingPositionTimestamp?: Date;
   readonly functionResponseTypes?: readonly "ReportBatchItemFailures"[];
+  readonly maximumRetryAttempts?: number;
+  readonly maximumRecordAgeInSeconds?: number;
 }
 
 /**
@@ -143,6 +145,12 @@ export async function simAwsWithKinesisEventSource(
       ...(options.batchSize !== undefined && { BatchSize: options.batchSize }),
       ...(options.functionResponseTypes !== undefined && {
         FunctionResponseTypes: [...options.functionResponseTypes],
+      }),
+      ...(options.maximumRetryAttempts !== undefined && {
+        MaximumRetryAttempts: options.maximumRetryAttempts,
+      }),
+      ...(options.maximumRecordAgeInSeconds !== undefined && {
+        MaximumRecordAgeInSeconds: options.maximumRecordAgeInSeconds,
       }),
     }),
   );

--- a/test/lambda/stream-event-source-fixture.ts
+++ b/test/lambda/stream-event-source-fixture.ts
@@ -138,6 +138,8 @@ interface StreamEventSourceOptions {
   readonly batchSize?: number;
   readonly startingPosition?: EventSourcePosition;
   readonly functionResponseTypes?: readonly "ReportBatchItemFailures"[];
+  readonly maximumRetryAttempts?: number;
+  readonly maximumRecordAgeInSeconds?: number;
 }
 
 /**
@@ -170,6 +172,12 @@ export async function simAwsWithStreamEventSource(
       ...(options.batchSize !== undefined && { BatchSize: options.batchSize }),
       ...(options.functionResponseTypes !== undefined && {
         FunctionResponseTypes: [...options.functionResponseTypes],
+      }),
+      ...(options.maximumRetryAttempts !== undefined && {
+        MaximumRetryAttempts: options.maximumRetryAttempts,
+      }),
+      ...(options.maximumRecordAgeInSeconds !== undefined && {
+        MaximumRecordAgeInSeconds: options.maximumRecordAgeInSeconds,
       }),
     }),
   );


### PR DESCRIPTION
DynamoDB Streams and Kinesis event source mappings now take `MaximumRetryAttempts` and `MaximumRecordAgeInSeconds`, hold them, and report them through create, get and list. A failed batch stops being delivered once it has had its retries or once the next attempt would fall past the record age, and what is left is discarded, moving the checkpoint on so later records run. Records age out of the front of a batch, and the ones behind an expired record go over again on their own. Values outside Lambda's documented ranges are refused as validation errors, a queue mapping is refused for naming either, and a mapping naming neither keeps the documented five-retry cap.

Resolves #1219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring maximum retry attempts and record age for DynamoDB and Kinesis stream event-source mappings.
  * Stream mappings now apply retry limits, exponential backoff, and record-age expiration during failed-batch processing.
  * Retry settings are preserved when mappings are retrieved or listed.
  * Queue event-source mappings reject stream-only retry settings.

* **Documentation**
  * Updated Lambda retry behavior documentation and added a runnable example.

* **Bug Fixes**
  * Improved stream record timing and partial-batch retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->