### PR TITLE
feat: capture Lambda output without printing it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
 
 .worktrees/
+.pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,5 @@ test/terraform/**/builds/
 test/terraform/**/terraform.tfstate*
 test/terraform/**/.terraform.tfstate.lock.info
 *.tfplan
+
+.worktrees/

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -286,6 +286,70 @@ console.log(logged.events?.map((event) => event.message));
 await simAws.backgroundTasksComplete();
 ```
 
+#### Keeping handler output out of the test console
+
+A handler that logs on every invocation makes that tee expensive. Powertools' `Metrics` writes an
+EMF document for every metric it counts, and a suite invoking a function a few hundred times buries
+its own output under them. `captureOnly()` stops the forwarding for every function of one simulated
+Lambda:
+
+```typescript sim-lambda-capture-only-output
+/**
+ * Recording what a handler prints without printing it again.
+ */
+
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "user",
+    Role: "arn:aws:iam::111111111111:role/UserRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        // What AWS Lambda Powertools' Metrics writes for every metric it
+        // counts, once per request.
+        process.stdout.write(
+          `${JSON.stringify({ service: "user", UserRequest: 1 })}\n`,
+        );
+
+        return { statusCode: 200 };
+      }),
+    },
+  }),
+);
+
+// The test run's own console stays clean from here on.
+simAws.lambda().output().captureOnly();
+
+await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "user" }));
+
+// The log group holds the line, as it did before.
+const found = await simAws
+  .logs()
+  .filterLogEvents(
+    new FilterLogEventsCommand({ logGroupName: "/aws/lambda/user" }),
+  );
+
+console.log(found.events?.[0]?.message);
+```
+
+The log group holds every line either way. Nothing is lost by it, and `teeToHost()` puts the
+forwarding back.
+
+The settings belong to one Account and Region, as the functions do. A suite invoking through
+`simAws.region("eu-west-1")` sets them on that scope. They are read as each line is written. A
+change reaches a function that has already cold started.
+
+A function with no simulated CloudWatch Logs behind it goes on printing whatever the settings say.
+That is a function on a standalone `SimLambda`, built outside a `SimAws` instance, and it has no log
+group for its output to be read back out of.
+
 ### When a handler throws
 
 An invocation that ends in an error nothing caught leaves an `ERROR Invoke Error` line in the
@@ -3565,6 +3629,8 @@ Sim Lambda currently supports:
 - A Node.js `vm` runtime for zip-packaged code, with warm module state across invocations, and
   writable standard streams for handler output, including a bundled AWS Lambda Powertools logger's
   own console
+- Handler output recorded into the function's log group and forwarded to the host console, with
+  `simAws.lambda().output().captureOnly()` to drop the forwarding
 - Per-function environment variables with `Environment.Variables`
 - Runtime-provided `@aws-sdk/*` packages inside function code, routed into the owning simulated AWS
   environment

--- a/docs/services/lambda/sim-lambda-capture-only-output.example.ts
+++ b/docs/services/lambda/sim-lambda-capture-only-output.example.ts
@@ -1,0 +1,43 @@
+/**
+ * Recording what a handler prints without printing it again.
+ */
+
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "user",
+    Role: "arn:aws:iam::111111111111:role/UserRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => {
+        // What AWS Lambda Powertools' Metrics writes for every metric it
+        // counts, once per request.
+        process.stdout.write(
+          `${JSON.stringify({ service: "user", UserRequest: 1 })}\n`,
+        );
+
+        return { statusCode: 200 };
+      }),
+    },
+  }),
+);
+
+// The test run's own console stays clean from here on.
+simAws.lambda().output().captureOnly();
+
+await simAws.lambda().invoke(new InvokeCommand({ FunctionName: "user" }));
+
+// The log group holds the line, as it did before.
+const found = await simAws
+  .logs()
+  .filterLogEvents(
+    new FilterLogEventsCommand({ logGroupName: "/aws/lambda/user" }),
+  );
+
+console.log(found.events?.[0]?.message);

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -17,6 +17,7 @@ import type { SimLambdaContainerImages } from "../../function/code/image/sim-lam
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import type { SimCloudWatchServiceWriter } from "../../../cloudwatch/write/sim-cloudwatch-service-writer.js";
+import type { SimLambdaOutput } from "../../function/logging/sim-lambda-output.js";
 import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-outbound-http.js";
 import { SimLambdaEnvironmentConflicts } from "../../function/environment/sim-lambda-environment-conflicts.js";
@@ -51,6 +52,7 @@ interface CreateFunctionCommandHandlerProperties {
   vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
   environmentConflicts?: SimLambdaEnvironmentConflicts;
   logs?: SimLogsServiceWriter | undefined;
+  output?: SimLambdaOutput | undefined;
   metrics?: SimCloudWatchServiceWriter | undefined;
   outboundHttp?: SimLambdaOutboundHttp | undefined;
 }
@@ -76,6 +78,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
   private readonly codeResolver: SimLambdaCodeResolver;
   private readonly environmentConflicts: SimLambdaEnvironmentConflicts;
   private readonly logs: SimLogsServiceWriter | undefined;
+  private readonly output: SimLambdaOutput | undefined;
   private readonly metrics: SimCloudWatchServiceWriter | undefined;
   private readonly outboundHttp: SimLambdaOutboundHttp | undefined;
 
@@ -91,6 +94,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       vmSdkModuleProvider,
       environmentConflicts = new SimLambdaEnvironmentConflicts(),
       logs,
+      output,
       metrics,
       outboundHttp,
     } = properties;
@@ -110,6 +114,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
     });
     this.environmentConflicts = environmentConflicts;
     this.logs = logs;
+    this.output = output;
     this.metrics = metrics;
     this.outboundHttp = outboundHttp;
   }
@@ -157,6 +162,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       runAsOwner: this.runAsOwner,
       clock: this.background,
       logs: this.logs,
+      output: this.output,
       metrics: this.metrics,
       outboundHttp: this.outboundHttp,
     });

--- a/src/service/lambda/command/function/sim-lambda-function-commands.ts
+++ b/src/service/lambda/command/function/sim-lambda-function-commands.ts
@@ -7,6 +7,7 @@ import type { SimLambdaContainerImages } from "../../function/code/image/sim-lam
 import type { SimLambdaCodeStore } from "../../function/code/store/sim-lambda-code-store.js";
 import type { SimLambdaVmSdkModuleProvider } from "../../function/code/vm/sdk/sim-lambda-vm-sdk-module-provider.js";
 import type { SimCloudWatchServiceWriter } from "../../../cloudwatch/write/sim-cloudwatch-service-writer.js";
+import type { SimLambdaOutput } from "../../function/logging/sim-lambda-output.js";
 import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutboundHttp } from "../../function/outbound/sim-lambda-outbound-http.js";
 import type { SimLambdaDestinationTargets } from "../../destination/sim-lambda-destination-targets.js";
@@ -68,6 +69,7 @@ interface SimLambdaFunctionCommandsProperties {
   readonly containerImages?: SimLambdaContainerImages | undefined;
   readonly vmSdkModuleProvider?: SimLambdaVmSdkModuleProvider | undefined;
   readonly logs?: SimLogsServiceWriter | undefined;
+  readonly output?: SimLambdaOutput | undefined;
   readonly metrics?: SimCloudWatchServiceWriter | undefined;
   readonly outboundHttp?: SimLambdaOutboundHttp | undefined;
 }

--- a/src/service/lambda/function/code/sim-lambda-executable-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-executable-code.ts
@@ -1,4 +1,5 @@
 import type { SimLambdaEnvironment } from "../environment/sim-lambda-environment.js";
+import type { SimLambdaOutput } from "../logging/sim-lambda-output.js";
 import type { SimLambdaOutputSink } from "../logging/sim-lambda-output-sink.js";
 import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
 
@@ -35,8 +36,12 @@ export interface SimLambdaExecutableCode {
   /**
    * Record what this code writes to its standard streams, so an invocation's
    * output reaches the function's log group.
+   *
+   * The output settings come with the sink because they decide what happens to
+   * a line once it has been recorded, and only code with somewhere to record
+   * is ever given either.
    */
-  recordOutputTo(sink: SimLambdaOutputSink): void;
+  recordOutputTo(sink: SimLambdaOutputSink, output: SimLambdaOutput): void;
 
   /**
    * This code under changed function settings, cold rather than warm.
@@ -72,7 +77,8 @@ export class SimLambdaHandlerReferenceCode implements SimLambdaExecutableCode {
    * function closing over the test's own module scope, and it prints through
    * the process console and the process standard streams. Its invocation is
    * run with those bridged to the function's sink instead, the way the clock
-   * and process.env are bridged for the same code.
+   * and process.env are bridged for the same code. The output settings reach
+   * that bridge by the same route.
    */
   recordOutputTo(): void {
     // Recorded by the invocation, from the process globals.

--- a/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
+++ b/src/service/lambda/function/code/sim-lambda-vm-zip-code.ts
@@ -14,11 +14,16 @@ import {
   makeSimLambdaVmContext,
   type SimLambdaVmContextProperties,
 } from "./vm/sim-lambda-vm-context.js";
+import type { SimLambdaOutput } from "../logging/sim-lambda-output.js";
 import {
   simLambdaNoOutputSink,
   type SimLambdaOutputSink,
 } from "../logging/sim-lambda-output-sink.js";
 import { SimLambdaVmModules } from "./vm/sim-lambda-vm-modules.js";
+import {
+  importSimLambdaHandlerModule,
+  simLambdaExportedHandler,
+} from "./vm/sim-lambda-vm-handler-lookup.js";
 
 /**
  * The archive and handler this code runs, on top of everything its sandbox is
@@ -46,7 +51,10 @@ export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
   readonly runsInHostScope = false;
 
   #handler: SimLambdaHandler | undefined;
-  #sink: SimLambdaOutputSink = simLambdaNoOutputSink;
+  /** Where this execution environment's output goes, and what happens to it. */
+  #recording: Pick<SimLambdaVmContextProperties, "sink" | "output"> = {
+    sink: simLambdaNoOutputSink,
+  };
 
   constructor(private readonly properties: SimLambdaVmZipCodeProperties) {}
 
@@ -57,8 +65,8 @@ export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
    * asks for the handler, so the streams function code is handed already carry
    * the sink by the time any of it runs.
    */
-  recordOutputTo(sink: SimLambdaOutputSink): void {
-    this.#sink = sink;
+  recordOutputTo(sink: SimLambdaOutputSink, output: SimLambdaOutput): void {
+    this.#recording = { sink, output };
   }
 
   /**
@@ -92,16 +100,22 @@ export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
 
     const modules = new SimLambdaVmModules({
       archive,
-      context: makeSimLambdaVmContext({ ...this.properties, sink: this.#sink }),
+      context: makeSimLambdaVmContext({
+        ...this.properties,
+        ...this.#recording,
+      }),
       sdkModuleProvider:
         sdkModuleProvider ?? new SimLambdaNoVmSdkModuleProvider(),
     });
-    const moduleExports = this.importHandlerModule(
+    const moduleExports = importSimLambdaHandlerModule(
       modules,
       parsedName.modulePath,
     );
+    const handler = simLambdaExportedHandler(
+      moduleExports,
+      parsedName.exportName,
+    );
 
-    const handler = this.exportedHandler(moduleExports, parsedName.exportName);
     if (typeof handler !== "function") {
       throw new SimLambdaRuntimeError(
         "Runtime.HandlerNotFound",
@@ -109,42 +123,5 @@ export class SimLambdaVmZipCode implements SimLambdaExecutableCode {
       );
     }
     return handler as SimLambdaHandler;
-  }
-
-  /**
-   * Look up the handler export, tolerating a module that exported a nullish
-   * value so the lookup still reports Runtime.HandlerNotFound.
-   *
-   * Only own exports count. Walking the prototype chain would let a handler
-   * name like `index.constructor` resolve to an `Object.prototype` member and
-   * be invoked as the handler, where real Lambda reports HandlerNotFound.
-   */
-  private exportedHandler(moduleExports: unknown, exportName: string): unknown {
-    if (moduleExports === null || moduleExports === undefined) {
-      return undefined;
-    }
-    const exportedValues = moduleExports as Record<string, unknown>;
-    if (!Object.hasOwn(exportedValues, exportName)) {
-      return undefined;
-    }
-    return Reflect.get(exportedValues, exportName);
-  }
-
-  private importHandlerModule(
-    modules: SimLambdaVmModules,
-    modulePath: string,
-  ): unknown {
-    try {
-      return modules.requireModule(`./${modulePath}`);
-    } catch (error) {
-      if (error instanceof SimLambdaRuntimeError) {
-        throw error;
-      }
-      let message = String(error);
-      if (error instanceof Error) {
-        message = error.message;
-      }
-      throw new SimLambdaRuntimeError("Runtime.ImportModuleError", message);
-    }
   }
 }

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
@@ -6,6 +6,7 @@ import {
   SimRealClock,
 } from "../../../../../util/clock/sim-clock.js";
 import type { SimLambdaEnvironment } from "../../environment/sim-lambda-environment.js";
+import type { SimLambdaOutput } from "../../logging/sim-lambda-output.js";
 import {
   simLambdaNoOutputSink,
   type SimLambdaOutputSink,
@@ -25,6 +26,13 @@ export interface SimLambdaVmContextProperties {
 
   /** Where the sandbox's output is recorded, nowhere by default. */
   readonly sink?: SimLambdaOutputSink | undefined;
+
+  /**
+   * Whether what the sandbox prints also reaches the host standard streams.
+   * A sandbox given none forwards everything, which is what a function with
+   * nowhere to record its output needs.
+   */
+  readonly output?: SimLambdaOutput | undefined;
 
   /**
    * Where the sandbox's `fetch` requests to hostnames the simulation serves
@@ -57,14 +65,15 @@ export function makeSimLambdaVmContext(
     environment,
     clock = new SimRealClock(),
     sink = simLambdaNoOutputSink,
+    output,
     outboundHttp,
   } = properties;
 
   // Writable standard streams, as the real runtime provides. Code that builds
   // its own console over them, as AWS Lambda Powertools' logger does, throws
   // at module load without them.
-  const stdout = new SimLambdaVmOutputStream(() => process.stdout);
-  const stderr = new SimLambdaVmOutputStream(() => process.stderr);
+  const stdout = new SimLambdaVmOutputStream(() => process.stdout, output);
+  const stderr = new SimLambdaVmOutputStream(() => process.stderr, output);
 
   // What function code writes reaches the function's log group through here.
   stdout.recordTo(sink);

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-handler-lookup.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-handler-lookup.ts
@@ -1,0 +1,58 @@
+import { SimLambdaRuntimeError } from "../../../error/sim-lambda-runtime.error.js";
+import type { SimLambdaVmModules } from "./sim-lambda-vm-modules.js";
+
+/**
+ * Importing a function's handler module and finding the export it names.
+ *
+ * Both steps report the AWS-like `Runtime.*` error a real cold start reports,
+ * which is why they sit together.
+ */
+
+/**
+ * Import the module a handler name points at.
+ *
+ * Anything the import threw that is not already a runtime error becomes a
+ * `Runtime.ImportModuleError`, as it does on real Lambda.
+ */
+export function importSimLambdaHandlerModule(
+  modules: SimLambdaVmModules,
+  modulePath: string,
+): unknown {
+  try {
+    return modules.requireModule(`./${modulePath}`);
+  } catch (error) {
+    if (error instanceof SimLambdaRuntimeError) {
+      throw error;
+    }
+
+    throw new SimLambdaRuntimeError(
+      "Runtime.ImportModuleError",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+/**
+ * Look up the handler export, tolerating a module that exported a nullish
+ * value so the lookup still reports Runtime.HandlerNotFound.
+ *
+ * Only own exports count. Walking the prototype chain would let a handler
+ * name like `index.constructor` resolve to an `Object.prototype` member and
+ * be invoked as the handler, where real Lambda reports HandlerNotFound.
+ */
+export function simLambdaExportedHandler(
+  moduleExports: unknown,
+  exportName: string,
+): unknown {
+  if (moduleExports === null || moduleExports === undefined) {
+    return undefined;
+  }
+
+  const exportedValues = moduleExports as Record<string, unknown>;
+
+  if (!Object.hasOwn(exportedValues, exportName)) {
+    return undefined;
+  }
+
+  return Reflect.get(exportedValues, exportName);
+}

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-output-stream.ts
@@ -1,5 +1,6 @@
 import { Writable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
+import type { SimLambdaOutput } from "../../logging/sim-lambda-output.js";
 import {
   simLambdaNoOutputSink,
   type SimLambdaOutputSink,
@@ -25,14 +26,20 @@ import {
  * standard output to standard output and standard error to standard error, and
  * recorded to the sink the code was given, which is what puts a handler's
  * output in its log group. Forwarding to the host is a tee rather than a
- * redirect: real Lambda sends output to CloudWatch Logs and nowhere else, but
- * a test tool that swallowed it would make a failing test harder to debug than
- * it is with none of this.
+ * redirect. Real Lambda sends output to CloudWatch Logs and nowhere else, and a
+ * test tool that swallowed it would make a failing test harder to debug than it
+ * is with none of this.
  * The sandbox's own console is built over these streams too, so a handler's
  * output arrives there whether it printed through the console or wrote to the
  * stream itself, instead of one of the two disappearing. The host stream is
  * read per write, so a test that starts capturing host output after the
  * function has cold-started still sees what the handler writes.
+ *
+ * A simulated Lambda told to capture only (see `SimLambdaOutput`) drops the
+ * forwarding and carries on recording. Those settings are read per write as
+ * well, so a sandbox that has already cold started follows a change. A stream
+ * built without them forwards everything, which is what a function with
+ * nowhere to record its output needs.
  */
 export class SimLambdaVmOutputStream extends Writable {
   #sink: SimLambdaOutputSink = simLambdaNoOutputSink;
@@ -49,7 +56,10 @@ export class SimLambdaVmOutputStream extends Writable {
    */
   readonly #decoder = new StringDecoder("utf8");
 
-  constructor(private readonly hostStream: () => NodeJS.WritableStream) {
+  constructor(
+    private readonly hostStream: () => NodeJS.WritableStream,
+    private readonly output?: SimLambdaOutput,
+  ) {
     super();
   }
 
@@ -75,7 +85,11 @@ export class SimLambdaVmOutputStream extends Writable {
     done: (error?: Error) => void,
   ): void {
     this.#sink.write(this.#decoder.write(chunk));
-    this.hostStream().write(chunk);
+
+    if (this.output?.reachesHost() ?? true) {
+      this.hostStream().write(chunk);
+    }
+
     done();
   }
 }

--- a/src/service/lambda/function/invoke/sim-lambda-host-scope.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-host-scope.ts
@@ -1,4 +1,5 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimLambdaOutput } from "../logging/sim-lambda-output.js";
 import type { SimLambdaOutputSink } from "../logging/sim-lambda-output-sink.js";
 import type { SimLambdaOutboundHttp } from "../outbound/sim-lambda-outbound-http.js";
 import { simLambdaProcessClock } from "./sim-lambda-process-clock.js";
@@ -25,6 +26,13 @@ interface SimLambdaHostScope {
    * and its output reaches the host console alone.
    */
   readonly output: SimLambdaOutputSink | undefined;
+
+  /**
+   * Whether what the invocation prints also reaches the host console once it
+   * has been recorded. Read only where there is a sink, because a function
+   * with nowhere to record has the host console alone.
+   */
+  readonly outputSettings: SimLambdaOutput;
 }
 
 /**
@@ -40,12 +48,13 @@ export async function runSimLambdaInHostScope<T>(
   scope: SimLambdaHostScope,
   run: () => Promise<T>,
 ): Promise<T> {
-  const { clock, outboundHttp, output } = scope;
+  const { clock, outboundHttp, output, outputSettings } = scope;
 
   const recording =
     output === undefined
       ? run
-      : async (): Promise<T> => await simLambdaProcessOutput.run(output, run);
+      : async (): Promise<T> =>
+          await simLambdaProcessOutput.run(output, outputSettings, run);
 
   const reachingTheSimulation =
     outboundHttp === undefined

--- a/src/service/lambda/function/invoke/sim-lambda-process-output.iso.test.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-process-output.iso.test.ts
@@ -1,6 +1,12 @@
-import { assertArrayEquals, assertIdentical } from "@kensio/smartass";
+import {
+  assertArrayEmpty,
+  assertArrayEquals,
+  assertIdentical,
+  assertTrue,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { SimLambdaOutput } from "../logging/sim-lambda-output.js";
 import type { SimLambdaOutputSink } from "../logging/sim-lambda-output-sink.js";
 import {
   SimLambdaProcessOutput,
@@ -68,6 +74,13 @@ function watchedGlobals(): {
 }
 
 /**
+ * Output settings left at their default, for a test that is not about them.
+ */
+function teeing(): SimLambdaOutput {
+  return new SimLambdaOutput();
+}
+
+/**
  * Resolve after a real pause, so a test can interleave two runs and prove they
  * do not record into each other's sink.
  */
@@ -85,7 +98,7 @@ describe("sim Lambda process output", () => {
     const sink = new RecordingSink();
 
     // When a run prints.
-    await output.run(sink, async () => {
+    await output.run(sink, teeing(), async () => {
       globals.console.log("INFO handling order-1");
       await Promise.resolve();
     });
@@ -102,7 +115,7 @@ describe("sim Lambda process output", () => {
     const sink = new RecordingSink();
 
     // When a run prints one line through it.
-    await output.run(sink, async () => {
+    await output.run(sink, teeing(), async () => {
       globals.console.error("ERROR order has no items");
       await Promise.resolve();
     });
@@ -119,7 +132,7 @@ describe("sim Lambda process output", () => {
     const sink = new RecordingSink();
 
     // When a run writes to a stream itself.
-    await output.run(sink, async () => {
+    await output.run(sink, teeing(), async () => {
       globals.stdout.write("no newline");
       globals.stderr.write(Buffer.from("bytes\n"));
       await Promise.resolve();
@@ -139,7 +152,7 @@ describe("sim Lambda process output", () => {
     const bytes = Buffer.from("玉\n");
 
     // When a run writes it a byte at a time.
-    await output.run(sink, async () => {
+    await output.run(sink, teeing(), async () => {
       globals.stdout.write(bytes.subarray(0, 1));
       globals.stdout.write(bytes.subarray(1));
       await Promise.resolve();
@@ -149,13 +162,94 @@ describe("sim Lambda process output", () => {
     assertIdentical(sink.recorded.join(""), "玉\n");
   });
 
+  it("keeps a printed line off the host console when capturing only", async () => {
+    // Given a simulated Lambda told to record its functions' output and stop
+    // there, as a suite drowning in Powertools metric documents does.
+    const { globals, stdout } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const sink = new RecordingSink();
+    const settings = new SimLambdaOutput();
+
+    settings.captureOnly();
+
+    // When a run prints.
+    await output.run(sink, settings, async () => {
+      globals.console.log("INFO handling order-1");
+      await Promise.resolve();
+    });
+
+    // Then the line was recorded, and the host console was left alone.
+    assertArrayEquals(sink.recorded, ["INFO handling order-1\n"]);
+    assertArrayEmpty(stdout.written);
+  });
+
+  it("keeps a stream write off the host stream when capturing only", async () => {
+    // Given a run whose simulated Lambda is capturing only. Powertools'
+    // metrics writes to the stream directly rather than through the console.
+    const { globals, stdout } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const sink = new RecordingSink();
+    const settings = new SimLambdaOutput();
+
+    settings.captureOnly();
+
+    // When the run writes to standard output.
+    const accepted = await output.run(sink, settings, () =>
+      Promise.resolve(globals.stdout.write("EMF document\n")),
+    );
+
+    // Then the write was recorded and reported as accepted, and the host
+    // stream never saw it. Code awaiting a drain carries on.
+    assertArrayEquals(sink.recorded, ["EMF document\n"]);
+    assertArrayEmpty(stdout.written);
+    assertTrue(accepted);
+  });
+
+  it("prints what the test run itself writes while capturing only", async () => {
+    // Given a run that has installed the patches under capture-only settings.
+    const { globals, stdout } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const settings = new SimLambdaOutput();
+
+    settings.captureOnly();
+    await output.run(new RecordingSink(), settings, () => Promise.resolve());
+
+    // When the rest of the test run prints.
+    globals.console.log("a line from the test");
+
+    // Then it reached the host console. The settings cover what a function
+    // prints, and the test run's own output is not a function's.
+    assertArrayEquals(stdout.written, ["a line from the test\n"]);
+  });
+
+  it("follows settings changed while an invocation is in flight", async () => {
+    // Given a run printing on either side of a change to the settings.
+    const { globals, stdout } = watchedGlobals();
+    const output = new SimLambdaProcessOutput(() => globals);
+    const sink = new RecordingSink();
+    const settings = new SimLambdaOutput();
+
+    // When the settings change part way through it.
+    await output.run(sink, settings, async () => {
+      globals.console.log("before");
+      settings.captureOnly();
+      await Promise.resolve();
+      globals.console.log("after");
+    });
+
+    // Then both lines were recorded and only the first was printed. The
+    // settings are read as each line is written.
+    assertArrayEquals(sink.recorded, ["before\n", "after\n"]);
+    assertArrayEquals(stdout.written, ["before\n"]);
+  });
+
   it("leaves output made outside a run alone", async () => {
     // Given a run that has installed the patches.
     const { globals, stdout } = watchedGlobals();
     const output = new SimLambdaProcessOutput(() => globals);
     const sink = new RecordingSink();
 
-    await output.run(sink, () => Promise.resolve());
+    await output.run(sink, teeing(), () => Promise.resolve());
 
     // When the rest of the test run prints.
     globals.console.log("a line from the test");
@@ -175,12 +269,12 @@ describe("sim Lambda process output", () => {
 
     // When both print on either side of a pause.
     await Promise.all([
-      output.run(orders, async () => {
+      output.run(orders, teeing(), async () => {
         globals.console.log("order-1");
         await tick(20);
         globals.console.log("order-2");
       }),
-      output.run(invoices, async () => {
+      output.run(invoices, teeing(), async () => {
         await tick(10);
         globals.console.log("invoice-1");
       }),

--- a/src/service/lambda/function/invoke/sim-lambda-process-output.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-process-output.ts
@@ -2,7 +2,20 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { StringDecoder } from "node:string_decoder";
 import { format } from "node:util";
 
+import type { SimLambdaOutput } from "../logging/sim-lambda-output.js";
 import type { SimLambdaOutputSink } from "../logging/sim-lambda-output-sink.js";
+
+/**
+ * What one invocation of host-scope code prints, and where it goes.
+ *
+ * The output settings are held rather than read once, so a simulated Lambda
+ * told to capture only part way through a run reaches an invocation already in
+ * flight.
+ */
+interface SimLambdaRecordedOutput {
+  readonly sink: SimLambdaOutputSink;
+  readonly output: SimLambdaOutput;
+}
 
 /**
  * The console methods an invocation's output is taken from.
@@ -81,7 +94,7 @@ function hostProcessGlobals(): SimLambdaProcessGlobals {
  * instance over streams it can watch. Everything else shares the one below.
  */
 export class SimLambdaProcessOutput {
-  private readonly storage = new AsyncLocalStorage<SimLambdaOutputSink>();
+  private readonly storage = new AsyncLocalStorage<SimLambdaRecordedOutput>();
   private installed = false;
 
   constructor(
@@ -91,10 +104,14 @@ export class SimLambdaProcessOutput {
   /**
    * Run an invocation with the given sink recording what it prints.
    */
-  async run<T>(sink: SimLambdaOutputSink, run: () => Promise<T>): Promise<T> {
+  async run<T>(
+    sink: SimLambdaOutputSink,
+    output: SimLambdaOutput,
+    run: () => Promise<T>,
+  ): Promise<T> {
     this.install();
 
-    return await this.storage.run(sink, run);
+    return await this.storage.run({ sink, output }, run);
   }
 
   /**
@@ -130,6 +147,10 @@ export class SimLambdaProcessOutput {
    * console afterwards wraps the patch, so its own interception still sees
    * every write, and one that replaces the console object outright takes the
    * patch with it and gets the output the handler wrote.
+   *
+   * An invocation whose simulated Lambda is capturing only stops at the
+   * recording. A line printed outside any invocation goes to the host as it
+   * always did.
    */
   private patchConsole(hostConsole: SimLambdaProcessConsole): void {
     for (const method of CONSOLE_METHODS) {
@@ -138,7 +159,13 @@ export class SimLambdaProcessOutput {
 
       // oxlint-disable-next-line security/detect-object-injection -- one of this module's own fixed method names.
       hostConsole[method] = (...arguments_: readonly unknown[]): void => {
-        this.storage.getStore()?.write(`${format(...arguments_)}\n`);
+        const recorded = this.storage.getStore();
+
+        recorded?.sink.write(`${format(...arguments_)}\n`);
+
+        if (recorded !== undefined && !recorded.output.reachesHost()) {
+          return;
+        }
 
         // Delegated outside the store, because the host console writing to
         // process.stdout would otherwise record the same line a second time.
@@ -162,12 +189,18 @@ export class SimLambdaProcessOutput {
     const decoder = new StringDecoder("utf8");
 
     hostStream.write = (chunk: StreamChunk, ...rest: never[]): boolean => {
-      const sink = this.storage.getStore();
+      const recorded = this.storage.getStore();
 
-      if (sink !== undefined) {
-        sink.write(
+      if (recorded !== undefined) {
+        recorded.sink.write(
           typeof chunk === "string" ? chunk : decoder.write(Buffer.from(chunk)),
         );
+
+        // Written and done with. The stream reports the write as accepted,
+        // which is what it would have answered had the host taken it.
+        if (!recorded.output.reachesHost()) {
+          return true;
+        }
       }
 
       return hostWrite(chunk, ...rest);

--- a/src/service/lambda/function/logging/sim-lambda-function-logging.ts
+++ b/src/service/lambda/function/logging/sim-lambda-function-logging.ts
@@ -1,6 +1,7 @@
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimLogsServiceWriter } from "../../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutputSink } from "./sim-lambda-output-sink.js";
+import { SimLambdaOutput } from "./sim-lambda-output.js";
 import type { SimLambdaExecutableCode } from "../code/sim-lambda-executable-code.js";
 import { simLambdaInvokeErrorLine } from "./sim-lambda-invoke-error-log.js";
 import { SimLambdaLogWriter } from "./sim-lambda-log-writer.js";
@@ -18,6 +19,13 @@ interface SimLambdaFunctionLoggingProperties {
    * instance, has no simulated CloudWatch Logs to record to.
    */
   readonly logs?: SimLogsServiceWriter | undefined;
+
+  /**
+   * Where this function's output goes besides its log group. Shared with every
+   * other function of the same simulated Lambda, and read as each line is
+   * written.
+   */
+  readonly output?: SimLambdaOutput | undefined;
 }
 
 /**
@@ -37,6 +45,9 @@ interface SimLambdaFunctionLoggingProperties {
 export class SimLambdaFunctionLogging {
   readonly logGroupName: string;
 
+  /** Where this function's output goes besides its log group. */
+  readonly output: SimLambdaOutput;
+
   readonly #logs: SimLogsServiceWriter | undefined;
   readonly #clock: SimClock;
   #writer: SimLambdaLogWriter | undefined;
@@ -46,6 +57,7 @@ export class SimLambdaFunctionLogging {
     this.logGroupName = simLambdaLogGroupName(properties.functionName);
     this.#logs = properties.logs;
     this.#clock = properties.clock;
+    this.output = properties.output ?? new SimLambdaOutput();
   }
 
   /**
@@ -72,7 +84,7 @@ export class SimLambdaFunctionLogging {
     const writer = this.#writer;
 
     if (writer !== undefined) {
-      code.recordOutputTo(writer);
+      code.recordOutputTo(writer, this.output);
     }
   }
 
@@ -86,6 +98,17 @@ export class SimLambdaFunctionLogging {
    */
   outputSink(): SimLambdaOutputSink | undefined {
     return this.#writer;
+  }
+
+  /**
+   * Both halves of where a host-scope invocation's output goes, ready to
+   * bridge to the process globals it prints through.
+   */
+  outputScope(): {
+    readonly output: SimLambdaOutputSink | undefined;
+    readonly outputSettings: SimLambdaOutput;
+  } {
+    return { output: this.#writer, outputSettings: this.output };
   }
 
   /**

--- a/src/service/lambda/function/logging/sim-lambda-output-capture-only.iso.test.ts
+++ b/src/service/lambda/function/logging/sim-lambda-output-capture-only.iso.test.ts
@@ -1,0 +1,218 @@
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayEmpty,
+  assertArrayEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it, vi } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimLambda } from "../../sim-lambda.js";
+import { makeLambdaCodeZip } from "../code/make-lambda-code-zip.js";
+import { makeLambdaZipFileInput } from "../code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+
+/**
+ * A handler writing to standard output directly, as AWS Lambda Powertools'
+ * metrics does to emit an Embedded Metric Format document.
+ */
+const emittingSource = String.raw`
+  exports.handler = async (event) => {
+    process.stdout.write(JSON.stringify(event) + "\n");
+    return null;
+  };
+`;
+
+/**
+ * Capture what reaches the host's standard output, which is the console a test
+ * run prints to.
+ */
+function captureHostStdout(): string[] {
+  const written: string[] = [];
+
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk): boolean => {
+    written.push(String(chunk));
+    return true;
+  });
+
+  return written;
+}
+
+/**
+ * A simulated AWS holding one function of the given code.
+ */
+async function simAwsWithFunction(
+  functionName: string,
+  code: { readonly ZipFile: Uint8Array },
+): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: `arn:aws:iam::${simAws.defaultAccountId}:role/${functionName}Role`,
+      Handler: "index.handler",
+      Code: code,
+    }),
+  );
+
+  await simAws.backgroundTasksComplete();
+
+  return simAws;
+}
+
+async function messagesIn(
+  simAws: SimAws,
+  logGroupName: string,
+): Promise<readonly string[]> {
+  const { events } = await simAws
+    .logs()
+    .filterLogEvents(new FilterLogEventsCommand({ logGroupName }));
+
+  return events?.map((event) => event.message) ?? [];
+}
+
+describe("a simulated Lambda capturing function output only", () => {
+  it("keeps what zip code prints out of the test run's console", async () => {
+    // Given a function whose handler writes a metric document on every
+    // invocation, and a simulated Lambda told to capture only.
+    const simAws = await simAwsWithFunction("user", {
+      ZipFile: makeLambdaCodeZip(emittingSource),
+    });
+
+    simAws.lambda().output().captureOnly();
+
+    const printed = captureHostStdout();
+
+    // When it is invoked.
+    await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "user",
+        Payload: JSON.stringify({ UserRequest: 1 }),
+      }),
+    );
+
+    // Then the host console was left alone, and the line is in the function's
+    // log group where a test can still read it.
+    assertArrayEmpty(printed);
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/user"), [
+      '{"UserRequest":1}',
+    ]);
+  });
+
+  it("prints as well as records until it is told otherwise", async () => {
+    // Given the same function under the settings a simulated Lambda starts
+    // with.
+    const simAws = await simAwsWithFunction("orders", {
+      ZipFile: makeLambdaCodeZip(emittingSource),
+    });
+    const printed = captureHostStdout();
+
+    // When it is invoked.
+    await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: "orders",
+        Payload: JSON.stringify({ OrderPlaced: 1 }),
+      }),
+    );
+
+    // Then the line reached both, which is what makes a failing test readable.
+    assertStringIncludes(printed.join(""), '{"OrderPlaced":1}');
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/orders"), [
+      '{"OrderPlaced":1}',
+    ]);
+  });
+
+  it("records what a bound handler prints while printing none of it", async () => {
+    // Given a function bound to an in-process handler, which prints through
+    // the host process globals rather than through a sandbox of its own.
+    const handler: SimLambdaHandler = () => {
+      // oxlint-disable-next-line no-console -- printing is what this handler is here to do.
+      console.log("INFO handling invoice-1");
+
+      return "done";
+    };
+    const simAws = await simAwsWithFunction("invoices", {
+      ZipFile: makeLambdaZipFileInput(handler),
+    });
+
+    simAws.lambda().output().captureOnly();
+
+    const printed = captureHostStdout();
+
+    // When it is invoked.
+    await simAws
+      .lambda()
+      .invoke(new InvokeCommand({ FunctionName: "invoices" }));
+
+    // Then the line is in the log group and nowhere else. Both paths a
+    // function prints through follow the same settings.
+    assertArrayEmpty(printed);
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/invoices"), [
+      "INFO handling invoice-1",
+    ]);
+  });
+
+  it("follows a change made after a function has cold started", async () => {
+    // Given a function that has already been invoked once, so its execution
+    // environment is warm and its sandbox is built.
+    const simAws = await simAwsWithFunction("payments", {
+      ZipFile: makeLambdaCodeZip(emittingSource),
+    });
+    const printed = captureHostStdout();
+    const invoke = async (attempt: number): Promise<void> => {
+      await simAws.lambda().invoke(
+        new InvokeCommand({
+          FunctionName: "payments",
+          Payload: JSON.stringify({ attempt }),
+        }),
+      );
+    };
+
+    await invoke(1);
+
+    // When the simulated Lambda is told to capture only, and it is invoked
+    // again.
+    simAws.lambda().output().captureOnly();
+    await invoke(2);
+
+    // Then only the first invocation printed, and the log group holds both.
+    assertArrayEquals(printed, ['{"attempt":1}\n']);
+    assertArrayEquals(await messagesIn(simAws, "/aws/lambda/payments"), [
+      '{"attempt":1}',
+      '{"attempt":2}',
+    ]);
+  });
+
+  it("goes on printing where there is no log group to read back from", async () => {
+    // Given a standalone simulated Lambda, which has no simulated CloudWatch
+    // Logs beside it, told to capture only.
+    const simLambda = new SimLambda();
+
+    simLambda.output().captureOnly();
+
+    await simLambda.createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "standalone",
+        Role: "arn:aws:iam::123456789012:role/StandaloneRole",
+        Handler: "index.handler",
+        Code: { ZipFile: makeLambdaCodeZip(emittingSource) },
+      }),
+    );
+
+    const printed = captureHostStdout();
+
+    // When it is invoked.
+    await simLambda.invoke(
+      new InvokeCommand({
+        FunctionName: "standalone",
+        Payload: JSON.stringify({ standalone: true }),
+      }),
+    );
+
+    // Then the line still reached the host console. Nothing recorded it, and
+    // silencing it would have lost it altogether.
+    assertStringIncludes(printed.join(""), '{"standalone":true}');
+  });
+});

--- a/src/service/lambda/function/logging/sim-lambda-output.ts
+++ b/src/service/lambda/function/logging/sim-lambda-output.ts
@@ -1,0 +1,65 @@
+/**
+ * Where a simulated Lambda's functions send what they print.
+ *
+ * Function output always reaches the function's log group. This settles the
+ * second destination, the host console the test run itself prints to. Real
+ * Lambda sends output to CloudWatch Logs and nowhere else, and Yulin forwards
+ * it to the host as well so that a failing test is as easy to read as one
+ * whose handler was never simulated.
+ *
+ * A handler that logs on every request makes that forwarding expensive. AWS
+ * Lambda Powertools writes an Embedded Metric Format document for every metric
+ * it counts, and a suite invoking a function a few hundred times buries its own
+ * output under them. `captureOnly` turns the forwarding off for every function
+ * of one simulated Lambda:
+ *
+ * ```typescript
+ * simAws.lambda().output().captureOnly();
+ * ```
+ *
+ * Nothing is lost by it. The log group holds every line either way, and
+ * `FilterLogEvents` reads them back.
+ *
+ * ## What it leaves alone
+ *
+ * A function with no simulated CloudWatch Logs behind it keeps printing to the
+ * host whatever this says. That is a function built on a standalone SimLambda,
+ * outside a SimAws instance, and it has no log group for its output to be read
+ * back out of. Silencing it would lose the output altogether.
+ *
+ * The setting is read as each line is written, so a test can turn forwarding
+ * off part way through a run and the functions that have already cold started
+ * follow it.
+ */
+export class SimLambdaOutput {
+  #toHost = true;
+
+  /**
+   * Record function output to its log group alone.
+   *
+   * Lines written from then on stay out of the host console. Everything
+   * written before it is already printed.
+   */
+  captureOnly(): void {
+    this.#toHost = false;
+  }
+
+  /**
+   * Forward function output to the host console as well as recording it, which
+   * is what a simulated Lambda does until told otherwise.
+   */
+  teeToHost(): void {
+    this.#toHost = true;
+  }
+
+  /**
+   * Whether a recorded line still reaches the host console.
+   *
+   * Read by the two paths that write one, the vm sandbox's standard streams
+   * and the process globals a host-scope handler prints through.
+   * @internal
+   */
+  reachesHost(): boolean {
+    return this.#toHost;
+  }
+}

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -110,7 +110,6 @@ export class SimLambdaFunction {
       runAsOwner = this,
       version = SIM_LAMBDA_LATEST_VERSION,
       clock = new SimRealClock(),
-      logs,
       metrics,
       outboundHttp,
     } = properties;
@@ -140,7 +139,8 @@ export class SimLambdaFunction {
     this.metrics = new SimLambdaFunctionMetrics({ metrics, clock });
     this.logging = new SimLambdaFunctionLogging({
       functionName: name,
-      logs,
+      logs: properties.logs,
+      output: properties.output,
       clock,
     });
   }
@@ -293,8 +293,8 @@ export class SimLambdaFunction {
     }
 
     const { clock, outboundHttp } = this;
-    const output = this.logging.outputSink();
+    const scope = { clock, outboundHttp, ...this.logging.outputScope() };
 
-    return await runSimLambdaInHostScope({ clock, outboundHttp, output }, run);
+    return await runSimLambdaInHostScope(scope, run);
   }
 }

--- a/src/service/lambda/function/sim-lambda-function.type.ts
+++ b/src/service/lambda/function/sim-lambda-function.type.ts
@@ -3,6 +3,7 @@ import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimAwsRunAsOwner } from "../../aws/caller/sim-aws-run-as-context.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCloudWatchServiceWriter } from "../../cloudwatch/write/sim-cloudwatch-service-writer.js";
+import type { SimLambdaOutput } from "./logging/sim-lambda-output.js";
 import type { SimLogsServiceWriter } from "../../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaExecutableCode } from "./code/sim-lambda-executable-code.js";
 import type { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
@@ -54,6 +55,13 @@ export interface SimLambdaFunctionProperties {
    * only to the host streams.
    */
   logs?: SimLogsServiceWriter | undefined;
+  /**
+   * Where this function's output goes besides its log group, shared with every
+   * other function of the same simulated Lambda. A function built standalone
+   * gets settings of its own, which nothing else can reach and which leave the
+   * host console printing.
+   */
+  output?: SimLambdaOutput | undefined;
   /**
    * Where this function's invocations are counted. A function built
    * standalone, outside a SimAws instance, has no simulated CloudWatch to

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -1,4 +1,5 @@
 export { SimLambda } from "./sim-lambda.js";
+export { SimLambdaOutput } from "./function/logging/sim-lambda-output.js";
 export {
   SimLambdaNoVmSdkModuleProvider,
   type SimLambdaVmSdkModuleProvider,

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -33,6 +33,7 @@ import type { SimCloudWatchServiceWriter } from "../cloudwatch/write/sim-cloudwa
 import type { SimLogsServiceWriter } from "../logs/write/sim-logs-service-writer.js";
 import type { SimLambdaOutboundHttp } from "./function/outbound/sim-lambda-outbound-http.js";
 import { SimLambdaEnvironmentConflicts } from "./function/environment/sim-lambda-environment-conflicts.js";
+import { SimLambdaOutput } from "./function/logging/sim-lambda-output.js";
 import { SimLambdaEventInvokeConfigStore } from "./function/event-invoke/sim-lambda-event-invoke-config-store.js";
 import {
   type SimLambdaDestinationTargets,
@@ -103,6 +104,16 @@ export class SimLambdaCommands {
   public readonly aliasStore = new SimLambdaFunctionAliasStore({
     versions: this.versionStore,
   });
+  /**
+   * Where this simulated Lambda's functions send what they print, besides
+   * their own log groups.
+   *
+   * Shared across every function so that one setting covers a simulation with
+   * several of them, and read as each line is written so that a function that
+   * has already cold started follows a change.
+   */
+  public readonly output = new SimLambdaOutput();
+
   public readonly functionLookup: SimLambdaFunctionLookup;
   public readonly eventInvokeConfigStore: SimLambdaEventInvokeConfigStore;
   public readonly functions: SimLambdaFunctionCommands;
@@ -219,6 +230,7 @@ export class SimLambdaCommands {
       containerImages,
       vmSdkModuleProvider,
       logs,
+      output: this.output,
       metrics,
       outboundHttp,
     });

--- a/src/service/lambda/sim-lambda.ts
+++ b/src/service/lambda/sim-lambda.ts
@@ -2,6 +2,7 @@ import type { SimSdkCommandRouter } from "../../sdk/index.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { SimLambdaCloudFormationResourceFactory } from "./cfn/sim-cfn-lambda-resource-factory.js";
 import type { SimLambdaContainerImages } from "./function/code/image/sim-lambda-container-images.js";
+import type { SimLambdaOutput } from "./function/logging/sim-lambda-output.js";
 import type { SimLambdaFunctionMap } from "./function/sim-lambda-function.js";
 import type * as simLambdaCommands from "./command/sim-lambda-command.types.js";
 import {
@@ -56,6 +57,20 @@ export class SimLambda extends SimLambdaEventInvokeOperations {
    */
   containerImages(): SimLambdaContainerImages {
     return this.commands.containerImages;
+  }
+
+  /**
+   * Where this simulated Lambda's functions send what they print, besides the
+   * log group they always reach. The host console gets a copy until told
+   * otherwise, and these settings belong to one Account and Region as the
+   * functions do.
+   *
+   * ```typescript
+   * simAws.lambda().output().captureOnly();
+   * ```
+   */
+  output(): SimLambdaOutput {
+    return this.commands.output;
   }
 
   /** Handle a Create Function Command from the SDK. */


### PR DESCRIPTION
A simulated Lambda forwards what its functions print to the host console as well as recording it into their log groups. A handler using AWS Lambda Powertools writes an Embedded Metric Format document for every metric it counts, and a suite invoking such a function a few hundred times buries its own output under them. `simAws.lambda().output().captureOnly()` drops the forwarding for every function of one simulated Lambda, leaving the recording alone, and `teeToHost()` puts it back. The settings live on the service accessor rather than on `SimAws`, alongside `simAws.rekognition().moderation()` and `simAws.bedrock().responses()`, and they belong to one Account and Region as the functions do.

Both paths a function prints through follow the settings. Host-scope code prints through the process console and standard streams, which the invocation already bridges to the function's sink, and zip code prints through the vm sandbox's own streams. Neither reads the setting once: it is read as each line is written, so a function that has already cold started follows a change. A function with no simulated CloudWatch Logs behind it goes on printing whatever the settings say, since silencing it would lose the output rather than move it.

`SimLambdaVmZipCode` sat at an FTA score of 49.93 against a threshold of 50, so the handler lookup it carried moved to `sim-lambda-vm-handler-lookup.ts`. That is the only change here that is not the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)