### PR TITLE
feat: keep a resource through replace or delete

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -757,6 +757,19 @@
       }
     },
     {
+      // The simulated CloudFormation Stack. Its length tracks the size of the
+      // surface a Stack exposes rather than the complexity of anything in it:
+      // identity, template, three operation lifecycles, Resources, Outputs and
+      // the Resource reports, nearly every one of them a doc comment and a
+      // line of delegation to the collaborator that owns the work. Splitting
+      // that surface would only move the delegations somewhere the caller has
+      // to go looking for them.
+      "files": ["src/service/cloudformation/stack/sim-cfn-stack.ts"],
+      "rules": {
+        "eslint/max-lines": ["error", 350]
+      }
+    },
+    {
       // The CloudFormation service facade. As with the IAM one below, it
       // carries one method per SDK command CloudFormation handles, each a doc
       // comment and a line or two of delegation. The Stack commands and the

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -374,15 +374,87 @@ Two things follow from replacement:
 - A resource naming a replaced resource is replaced too, all the way up the dependency chain, and
   nothing is left pointing at a resource that has gone. Real CloudFormation hands the dependent the
   new physical name and leaves it standing.
-- `UpdateReplacePolicy` is not read. Honouring `Retain` would leave the old resource holding the
-  name the replacement needs, and CDK marks buckets and tables with it as a matter of course, so
-  every such update would fail. The old resource is deleted whatever the policy says.
+- A resource declared with `UpdateReplacePolicy: Retain` is kept, and the replacement is created
+  beside it. See [`UpdateReplacePolicy`](#updatereplacepolicy) below.
 
 A failed update leaves the stack in `UPDATE_FAILED` with the reason on it, and leaves the resources
 where the update got to. There is no rollback to the previous template.
 `waitForStackUpdateComplete(...)` rethrows the error, and `DescribeStacksCommand` reports it as
 `StackStatusReason`. Dealing with the cause and sending `UpdateStackCommand` again applies the rest
 of the change.
+
+### `UpdateReplacePolicy`
+
+A resource declared with `UpdateReplacePolicy: Retain` is left in simulated AWS when an update
+replaces it. The stack stops tracking it, the replacement takes over its logical ID, and the kept
+resource is reported on the stack the way a retained resource is after a teardown.
+
+```typescript sim-cloudformation-update-replace-policy
+/**
+ * Keeping a Resource an update replaces.
+ */
+
+import {
+  CreateStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+
+function reportsTemplate(bucketName: string): string {
+  return JSON.stringify({
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        UpdateReplacePolicy: "Retain",
+        Properties: { BucketName: bucketName },
+      },
+    },
+  });
+}
+
+await simCfn.createStack(
+  new CreateStackCommand({
+    StackName: "reports",
+    TemplateBody: reportsTemplate("reports-2025"),
+  }),
+);
+await simCfn.waitForStackDeployComplete("reports");
+
+// Renaming the bucket replaces it.
+await simCfn.updateStack(
+  new UpdateStackCommand({
+    StackName: "reports",
+    TemplateBody: reportsTemplate("reports-2026"),
+  }),
+);
+await simCfn.waitForStackUpdateComplete("reports");
+
+// The bucket the update replaced is still in simulated S3.
+console.log(simAws.s3().getSimBucketByName("reports-2025"));
+
+// And so is the one created in its place.
+console.log(simAws.s3().getSimBucketByName("reports-2026"));
+
+// The stack reports what it kept.
+const stack = simCfn.getStackByName("reports");
+console.log(stack?.retainedResources.map((resource) => resource.logicalId));
+```
+
+`DeletionPolicy` has no say in this. CloudFormation reads `DeletionPolicy` for a resource an update
+drops from the template, and `UpdateReplacePolicy` for one it replaces. A bucket marked only with
+`DeletionPolicy: Retain` still goes when its replacement is created. `Snapshot` is treated as
+`Delete`, because no simulated service takes snapshots.
+
+The kept resource holds the name it was created with. Real CloudFormation gives the replacement a
+fresh random name, while simulated CloudFormation generates the same name for the same stack name
+and logical ID every time (see
+[names CloudFormation generates](#names-cloudformation-generates)). A replacement whose name the
+template leaves to CloudFormation therefore asks for a name the kept resource still holds, and fails
+to create. Name the replacement in the template, as the example above does, to have both.
 
 ## Deploying through a change set
 
@@ -590,6 +662,77 @@ Retained resources are readable from the stack:
 ```typescript
 console.log(stack.retainedResources.map((resource) => resource.logicalId));
 ```
+
+### `RetainResources`
+
+`DeleteStackCommand` takes `RetainResources`, naming resources to leave in simulated AWS. Each one
+is kept whatever its own `DeletionPolicy` says, and the stack deletes around it and reaches
+`DELETE_COMPLETE`.
+
+```typescript sim-cloudformation-retain-resources
+/**
+ * Keeping named Resources when a Stack is deleted.
+ */
+
+import {
+  CreateStackCommand,
+  DeleteStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+
+await simCfn.createStack(
+  new CreateStackCommand({
+    StackName: "reports-stack",
+    TemplateBody: JSON.stringify({
+      Resources: {
+        ReportsBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "reports" },
+        },
+        ArchiveBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "archive" },
+        },
+      },
+    }),
+  }),
+);
+await simCfn.waitForStackDeployComplete("reports-stack");
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "reports",
+    Key: "january.csv",
+    Body: "reported",
+  }),
+);
+
+await simCfn.deleteStack(
+  new DeleteStackCommand({
+    StackName: "reports-stack",
+    RetainResources: ["ReportsBucket"],
+  }),
+);
+await simCfn.waitForStackDeleteComplete("reports-stack");
+
+// The named bucket is still in simulated S3, with the object it held.
+console.log(simAws.s3().getSimBucketByName("reports"));
+
+// The bucket the call did not name has gone.
+console.log(simAws.s3().getSimBucketByName("archive"));
+```
+
+Keeping a bucket that holds objects is one reason to reach for this. S3 refuses to delete such a
+bucket, which fails the whole teardown, and naming it here steps over it.
+
+A name the stack has no resource for is refused with a `ValidationError`, as CloudFormation refuses
+one. A CDK construct ID resolves here as well as a logical ID, the same way `stack.getResource(...)`
+takes either.
 
 ## Parameters
 
@@ -3878,7 +4021,9 @@ Sim CloudFormation currently supports:
 - Waiting for simulated stack deployment, update and deletion completion
 - Stack IDs in the CloudFormation ARN shape, accepted by `DescribeStacksCommand` in place of a stack
   name, and still describing a stack once it has been deleted
-- The resource `DeletionPolicy` attribute, for `Retain` and `RetainExceptOnCreate`
+- The resource `DeletionPolicy` attribute, for `Retain` and `RetainExceptOnCreate`, and
+  `UpdateReplacePolicy`, for `Retain`
+- `RetainResources` on `DeleteStackCommand`, naming resources a teardown leaves in simulated AWS
 - `deployTemplate(...)` for parsed template objects, optionally naming the synthesized template file
   a template edited in memory came from
 - `deployTemplateFile(...)` for template files, written as JSON or as YAML with short-form
@@ -3996,13 +4141,16 @@ Each service's own docs describe what its resource types support.
   creates but cannot delete is recorded in `stack.skippedResourceDeletions` and stepped over, the
   same way an unsupported resource type is on create, and the stack still deletes with that resource
   left behind.
-- `DeletionPolicy` is read for `Retain` and `RetainExceptOnCreate` only. `Snapshot` is treated as
-  `Delete`, because no simulated service takes snapshots.
-- `UpdateReplacePolicy` is not read. A replaced resource is deleted whatever it says, for the reason
-  given under [changed resources are replaced](#changed-resources-are-replaced).
-- `DeleteStackCommand` reads only `StackName`. `RetainResources`, `DeletionMode`, `RoleARN` and
-  `ClientRequestToken` are not read, so a stack left in `DELETE_FAILED` cannot be forced through the
-  way `FORCE_DELETE_STACK` forces it in AWS.
+- `DeletionPolicy` is read for `Retain` and `RetainExceptOnCreate` only, and `UpdateReplacePolicy`
+  for `Retain` only. `Snapshot` is treated as `Delete` in both, because no simulated service takes
+  snapshots.
+- A resource kept by `UpdateReplacePolicy: Retain` holds the name it was created with, and a
+  replacement whose name the template leaves to CloudFormation asks for that same name and fails to
+  create. Real CloudFormation gives the replacement a fresh random name. See
+  [`UpdateReplacePolicy`](#updatereplacepolicy).
+- `DeleteStackCommand` reads `StackName` and `RetainResources`. `DeletionMode`, `RoleARN` and
+  `ClientRequestToken` are not read, and a stack left in `DELETE_FAILED` cannot be forced through
+  the way `FORCE_DELETE_STACK` forces it in AWS.
 - A deleted stack stays describable by its stack ID for as long as the simulation lives. Real
   CloudFormation drops it after 90 days. `DescribeStacks` with no `StackName` lists the live stacks
   in both, and `ListStacks` is unsupported, so there is no way to find a deleted stack whose ID you

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -444,6 +444,10 @@ const stack = simCfn.getStackByName("reports");
 console.log(stack?.retainedResources.map((resource) => resource.logicalId));
 ```
 
+The attribute is read from the template being applied, which is where CloudFormation reads it. An
+update that adds `UpdateReplacePolicy: Retain` keeps the resource it replaces, and one that drops
+the attribute deletes it.
+
 `DeletionPolicy` has no say in this. CloudFormation reads `DeletionPolicy` for a resource an update
 drops from the template, and `UpdateReplacePolicy` for one it replaces. A bucket marked only with
 `DeletionPolicy: Retain` still goes when its replacement is created. `Snapshot` is treated as

--- a/docs/services/cloudformation/sim-cloudformation-retain-resources.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-retain-resources.example.ts
@@ -1,0 +1,55 @@
+/**
+ * Keeping named Resources when a Stack is deleted.
+ */
+
+import {
+  CreateStackCommand,
+  DeleteStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+
+await simCfn.createStack(
+  new CreateStackCommand({
+    StackName: "reports-stack",
+    TemplateBody: JSON.stringify({
+      Resources: {
+        ReportsBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "reports" },
+        },
+        ArchiveBucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "archive" },
+        },
+      },
+    }),
+  }),
+);
+await simCfn.waitForStackDeployComplete("reports-stack");
+
+await simAws.s3().putObject(
+  new PutObjectCommand({
+    Bucket: "reports",
+    Key: "january.csv",
+    Body: "reported",
+  }),
+);
+
+await simCfn.deleteStack(
+  new DeleteStackCommand({
+    StackName: "reports-stack",
+    RetainResources: ["ReportsBucket"],
+  }),
+);
+await simCfn.waitForStackDeleteComplete("reports-stack");
+
+// The named bucket is still in simulated S3, with the object it held.
+console.log(simAws.s3().getSimBucketByName("reports"));
+
+// The bucket the call did not name has gone.
+console.log(simAws.s3().getSimBucketByName("archive"));

--- a/docs/services/cloudformation/sim-cloudformation-update-replace-policy.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-update-replace-policy.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Keeping a Resource an update replaces.
+ */
+
+import {
+  CreateStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simCfn = simAws.cloudFormation();
+
+function reportsTemplate(bucketName: string): string {
+  return JSON.stringify({
+    Resources: {
+      ReportsBucket: {
+        Type: "AWS::S3::Bucket",
+        UpdateReplacePolicy: "Retain",
+        Properties: { BucketName: bucketName },
+      },
+    },
+  });
+}
+
+await simCfn.createStack(
+  new CreateStackCommand({
+    StackName: "reports",
+    TemplateBody: reportsTemplate("reports-2025"),
+  }),
+);
+await simCfn.waitForStackDeployComplete("reports");
+
+// Renaming the bucket replaces it.
+await simCfn.updateStack(
+  new UpdateStackCommand({
+    StackName: "reports",
+    TemplateBody: reportsTemplate("reports-2026"),
+  }),
+);
+await simCfn.waitForStackUpdateComplete("reports");
+
+// The bucket the update replaced is still in simulated S3.
+console.log(simAws.s3().getSimBucketByName("reports-2025"));
+
+// And so is the one created in its place.
+console.log(simAws.s3().getSimBucketByName("reports-2026"));
+
+// The stack reports what it kept.
+const stack = simCfn.getStackByName("reports");
+console.log(stack?.retainedResources.map((resource) => resource.logicalId));

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -516,9 +516,10 @@ resource holds, and it is recorded in the usage docs rather than hidden. Two thi
 - A resource naming a replaced resource is replaced too, all the way up the chain, so nothing is
   left pointing at a resource that has gone. Real CloudFormation hands the dependent the new
   physical name instead.
-- A resource carrying `UpdateReplacePolicy: Retain` is kept. The plan tells the deleter which
-  logical IDs it is replacing, through `SimCfnResourceRetention`, and the replaced half of each one
-  reads that attribute where a dropped resource reads `DeletionPolicy`. The kept resource holds the
+- A resource carrying `UpdateReplacePolicy: Retain` is kept. `SimCfnResourceRetention` carries what
+  the new half of each replacement says about keeping the deployed one, since CloudFormation reads
+  the attribute off the template it is applying, and a resource the template drops instead reads its
+  own `DeletionPolicy`. The kept resource holds the
   name it was created with, and a replacement whose name comes from `SimCfnGeneratedResourceName`
   asks for that same name and fails, since the generated name is a hash of the stack name and the
   logical ID. Real CloudFormation gives the replacement a fresh random name.

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -516,9 +516,15 @@ resource holds, and it is recorded in the usage docs rather than hidden. Two thi
 - A resource naming a replaced resource is replaced too, all the way up the chain, so nothing is
   left pointing at a resource that has gone. Real CloudFormation hands the dependent the new
   physical name instead.
-- `UpdateReplacePolicy` is not read. Retaining the old resource would leave it holding the name its
-  replacement needs, and CDK marks buckets and tables `Retain` as a matter of course, so honouring
-  it would fail every such update.
+- A resource carrying `UpdateReplacePolicy: Retain` is kept. The plan tells the deleter which
+  logical IDs it is replacing, through `SimCfnResourceRetention`, and the replaced half of each one
+  reads that attribute where a dropped resource reads `DeletionPolicy`. The kept resource holds the
+  name it was created with, and a replacement whose name comes from `SimCfnGeneratedResourceName`
+  asks for that same name and fails, since the generated name is a hash of the stack name and the
+  logical ID. Real CloudFormation gives the replacement a fresh random name.
+- `SimCfnStackResourceOperations` keeps the resources an update retained. The stack cannot, since
+  the resource map has already given the logical ID to the replacement, and
+  `stack.retainedResources` reads both lists.
 
 ## Change sets
 
@@ -683,10 +689,14 @@ same teardown.
 `SimCfnResourceDeleteOperation` owns the asynchronous lifecycle for deleting one resource, and is
 the mirror image of the creation operation.
 
-A resource whose `DeletionPolicy` is `Retain` never reaches the operation at all. `SimCfnResource`
-answers the deletion itself by marking the resource `DELETE_SKIPPED`, which is the status
-CloudFormation reports for a resource it stepped over, and the stack reads them back as
-`stack.retainedResources`. `RetainExceptOnCreate` is treated the same way, because the two differ
+A resource the operation's `SimCfnResourceRetention` keeps never reaches `SimCfnResourceDeleter` at
+all. The operation marks the resource `DELETE_SKIPPED`, which is the status CloudFormation reports
+for a resource it stepped over, and the stack reads them back as `stack.retainedResources`.
+
+`SimCfnResourceRetention` gathers the three things that can keep a resource. A `DeleteStack` call
+naming it in `RetainResources` keeps it whatever its attributes say. Otherwise a resource an update
+is replacing reads `UpdateReplacePolicy` and one being removed reads `DeletionPolicy`, which is the
+split CloudFormation makes. `RetainExceptOnCreate` is treated as `Retain`, because the two differ
 only in what a rolled back creation does and sim CloudFormation does not roll a deployment back.
 `Snapshot` is treated as `Delete`, because no simulated service takes snapshots.
 
@@ -982,7 +992,7 @@ Useful areas:
 
 - `command/delete-stack/*.iso.test.ts`
   - stack deletion and stack name release
-  - `DeletionPolicy` handling
+  - `DeletionPolicy` and `RetainResources` handling
   - failed teardowns and the statuses they leave behind
 
 - `command/update-stack/*.iso.test.ts`

--- a/src/service/cloudformation/command/delete-stack/delete-stack-retain-resources.iso.test.ts
+++ b/src/service/cloudformation/command/delete-stack/delete-stack-retain-resources.iso.test.ts
@@ -1,0 +1,179 @@
+import { buffer } from "node:stream/consumers";
+import { describe, it } from "vitest";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import {
+  CreateStackCommand,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+} from "@aws-sdk/client-cloudformation";
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+import { SimCloudFormationValidationError } from "../../error/sim-cloudformation.error.js";
+
+const template = {
+  Resources: {
+    ReportsBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "reports" },
+    },
+    ArchiveBucket: {
+      Type: "AWS::S3::Bucket",
+      Properties: { BucketName: "archive" },
+    },
+  },
+};
+
+describe("CloudFormation DeleteStackCommand RetainResources", () => {
+  /** Deploy the two-Bucket Stack above and put an Object in the first. */
+  async function deployReportsStack(simAws: SimAws): Promise<string> {
+    const cloudFormation = simAws.cloudFormation();
+    const creation = await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "reports-stack",
+        TemplateBody: jsonStringify(template),
+      }),
+    );
+
+    await cloudFormation.waitForStackDeployComplete("reports-stack");
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "reports",
+        Key: "january.csv",
+        Body: "reported",
+      }),
+    );
+
+    return creation.StackId ?? "";
+  }
+
+  it("leaves a named Resource and what it holds in simulated AWS", async () => {
+    // Given a deployed Stack of two Buckets, one of them holding an Object.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+    const stackId = await deployReportsStack(simAws);
+    const stack = cloudFormation.getStackByName("reports-stack");
+
+    assertNonNullable(stack);
+
+    // When the Stack is deleted, keeping the Bucket that holds the Object.
+    await cloudFormation.deleteStack(
+      new DeleteStackCommand({
+        StackName: "reports-stack",
+        RetainResources: ["ReportsBucket"],
+      }),
+    );
+    await stack.waitForDeleteComplete();
+
+    // Then the kept Bucket is still in simulated S3 with what it held, which
+    // is also why S3 did not refuse the Stack a Bucket with an Object in it.
+    const kept = await simAws
+      .s3()
+      .getObject(
+        new GetObjectCommand({ Bucket: "reports", Key: "january.csv" }),
+      );
+    assertNonNullable(kept.Body);
+
+    const keptBytes = await buffer(kept.Body);
+
+    assertIdentical(keptBytes.toString(), "reported");
+
+    // And the Bucket the call did not name has gone.
+    assertUndefined(simAws.s3().getSimBucketByName("archive"));
+
+    // And the kept Bucket is reported the way a retained Resource is.
+    assertIdentical(
+      stack.getResource("ReportsBucket")?.status,
+      "DELETE_SKIPPED",
+    );
+    assertArrayLength(stack.retainedResources, 1);
+
+    // And the Stack itself finished deleting around it, so its name is free
+    // and its Stack ID still describes it.
+    assertUndefined(cloudFormation.getStackByName("reports-stack"));
+
+    const described = await cloudFormation.describeStacks(
+      new DescribeStacksCommand({ StackName: stackId }),
+    );
+
+    assertIdentical(described.Stacks?.[0]?.StackStatus, "DELETE_COMPLETE");
+  });
+
+  it("refuses a logical ID the Stack has no Resource for", async () => {
+    // Given a deployed Stack that has no Resource called ReportBucket, which
+    // is the sort of thing a caller writes meaning ReportsBucket.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await deployReportsStack(simAws);
+
+    // When the Stack is deleted keeping that name.
+    const error = await assertThrowsErrorAsync(async () =>
+      cloudFormation.deleteStack(
+        new DeleteStackCommand({
+          StackName: "reports-stack",
+          RetainResources: ["ReportBucket"],
+        }),
+      ),
+    );
+
+    // Then the call is refused rather than deleting the Bucket it was meant
+    // to keep, and the message says which name found nothing.
+    assertInstanceOf(error, SimCloudFormationValidationError);
+    assertStringIncludes(error.message, "ReportBucket");
+
+    // And the Stack is still deployed, with both Buckets where they were.
+    await simAws.backgroundTasksComplete();
+
+    assertNonNullable(cloudFormation.getStackByName("reports-stack"));
+    assertNonNullable(simAws.s3().getSimBucketByName("reports"));
+    assertNonNullable(simAws.s3().getSimBucketByName("archive"));
+  });
+
+  it("keeps a Resource named by its CDK construct ID", async () => {
+    // Given a Stack whose logical IDs carry the hash CDK synthesizes onto the
+    // construct ID, which is not what a test written against the CDK app has.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "site-stack",
+        TemplateBody: jsonStringify({
+          Resources: {
+            SiteBucket43A2B1C9: {
+              Type: "AWS::S3::Bucket",
+              Metadata: { "aws:cdk:path": "SiteStack/SiteBucket/Resource" },
+              Properties: { BucketName: "site" },
+            },
+          },
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("site-stack");
+
+    const stack = cloudFormation.getStackByName("site-stack");
+    assertNonNullable(stack);
+
+    // When the Stack is deleted keeping the Bucket by its construct ID.
+    await cloudFormation.deleteStack(
+      new DeleteStackCommand({
+        StackName: "site-stack",
+        RetainResources: ["SiteBucket"],
+      }),
+    );
+    await stack.waitForDeleteComplete();
+
+    // Then the Bucket the construct ID resolved to was kept.
+    assertNonNullable(simAws.s3().getSimBucketByName("site"));
+    assertArrayLength(stack.retainedResources, 1);
+  });
+});

--- a/src/service/cloudformation/command/delete-stack/delete-stack.command.ts
+++ b/src/service/cloudformation/command/delete-stack/delete-stack.command.ts
@@ -14,6 +14,13 @@ export interface SimDeleteStackCommand {
  */
 export interface SimDeleteStackCommandInput {
   readonly StackName?: string | undefined;
+
+  /**
+   * Logical IDs of Resources to leave in simulated AWS. Each one is stepped
+   * over the way a DeletionPolicy of Retain steps over a Resource, and an ID
+   * the Stack has no Resource for is refused.
+   */
+  readonly RetainResources?: string[] | undefined;
 }
 
 /**

--- a/src/service/cloudformation/command/delete-stack/delete-stack.handler.ts
+++ b/src/service/cloudformation/command/delete-stack/delete-stack.handler.ts
@@ -57,6 +57,10 @@ export class DeleteStackCommandHandler implements CommandHandler<
    *
    * The Stack itself is kept once its name has gone, so DescribeStacks can
    * still answer for it by Stack ID, as CloudFormation does for 90 days.
+   *
+   * RetainResources names Resources to leave behind. They stay in simulated AWS
+   * and are reported as retained on the deleted Stack, and the Stack still
+   * reaches DELETE_COMPLETE around them.
    */
   async handle(
     command: SimDeleteStackCommand,
@@ -77,6 +81,7 @@ export class DeleteStackCommandHandler implements CommandHandler<
     }
 
     await stack.delete({
+      retainResources: command.input.RetainResources,
       onDeleteComplete: (): void => {
         this.stacks.delete(stackName);
         this.deleted.record(stack);

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-delete-operation.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-delete-operation.ts
@@ -3,6 +3,7 @@ import type { SimCfnResource } from "../sim-cfn-resource.js";
 import type { SimCloudFormationResourceDeleteContext } from "../sim-cfn-resource.type.js";
 import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-factory.type.js";
 import { SimCfnResourceDeleter } from "./sim-cfn-resource-deleter.js";
+import { SimCfnResourceRetention } from "./sim-cfn-resource-retention.js";
 import { isSimCfnUnsupportedResourceError } from "../unsupported/sim-cfn-unsupported-resource.js";
 
 interface SimCfnResourceDeleteOperationProperties<T extends object> {
@@ -42,8 +43,20 @@ export class SimCfnResourceDeleteOperation<T extends object = object> {
    * while the Resource itself is updated through CloudFormation delete states:
    * in progress before scheduling, complete after the deleter returns, skipped
    * if nothing can delete the Resource type, or failed if the deleter throws.
+   *
+   * A Resource the operation's retention keeps never reaches the deleter at
+   * all. CloudFormation leaves it where it is and reports it as DELETE_SKIPPED,
+   * so the Stack can finish deleting around it.
    */
   run(context: SimCloudFormationResourceDeleteContext): Promise<void> {
+    const retention = context.retention ?? new SimCfnResourceRetention();
+
+    if (retention.retains(this.resource)) {
+      this.resource.markDeleteRetained();
+
+      return Promise.resolve();
+    }
+
     this.resource.markDeleteInProgress();
 
     return new Promise<void>((resolve, reject) => {

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-retention.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-retention.ts
@@ -2,10 +2,15 @@ import type { SimCfnResourceRecord } from "../sim-cfn-resource-record.js";
 
 interface SimCfnResourceRetentionProperties {
   /**
-   * The logical IDs this operation is replacing rather than removing, whose
-   * deployed half is kept by UpdateReplacePolicy.
+   * For each logical ID this operation is replacing, whether the definition
+   * taking its place says to keep the deployed Resource.
+   *
+   * The answer comes from the new definition because that is the template
+   * CloudFormation is applying. An update that adds `UpdateReplacePolicy:
+   * Retain` keeps the Resource it replaces, and one that drops the attribute
+   * deletes it.
    */
-  readonly replaced?: ReadonlySet<string> | undefined;
+  readonly replaced?: ReadonlyMap<string, boolean> | undefined;
 
   /**
    * The logical IDs the caller asked for by name, kept whatever their policy
@@ -31,11 +36,11 @@ interface SimCfnResourceRetentionProperties {
  * does.
  */
 export class SimCfnResourceRetention {
-  private readonly replaced: ReadonlySet<string>;
+  private readonly replaced: ReadonlyMap<string, boolean>;
   private readonly named: ReadonlySet<string>;
 
   constructor(properties: SimCfnResourceRetentionProperties = {}) {
-    this.replaced = properties.replaced ?? new Set();
+    this.replaced = properties.replaced ?? new Map();
     this.named = properties.named ?? new Set();
   }
 
@@ -47,8 +52,6 @@ export class SimCfnResourceRetention {
       return true;
     }
 
-    return this.replaced.has(resource.logicalId)
-      ? resource.retainedOnReplace
-      : resource.retainedOnDelete;
+    return this.replaced.get(resource.logicalId) ?? resource.retainedOnDelete;
   }
 }

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-retention.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-retention.ts
@@ -1,0 +1,54 @@
+import type { SimCfnResourceRecord } from "../sim-cfn-resource-record.js";
+
+interface SimCfnResourceRetentionProperties {
+  /**
+   * The logical IDs this operation is replacing rather than removing, whose
+   * deployed half is kept by UpdateReplacePolicy.
+   */
+  readonly replaced?: ReadonlySet<string> | undefined;
+
+  /**
+   * The logical IDs the caller asked for by name, kept whatever their policy
+   * attributes say. DeleteStack RetainResources is what names them.
+   */
+  readonly named?: ReadonlySet<string> | undefined;
+}
+
+/**
+ * Which of the Resources an operation is deleting it has to leave behind.
+ *
+ * Three things can keep a Resource in simulated AWS, and they are gathered here
+ * so one delete has one answer rather than each caller reading a policy of its
+ * own: the DeleteStack call naming it, UpdateReplacePolicy on a Resource being
+ * replaced, and DeletionPolicy on one being removed.
+ *
+ * Which of the two attributes applies is the part worth stating. CloudFormation
+ * reads UpdateReplacePolicy for a replacement and DeletionPolicy for a removal,
+ * and neither stands in for the other, so a Resource marked to survive a
+ * teardown still goes when an update replaces it.
+ *
+ * A retention with nothing in it reads DeletionPolicy, which is what a plain
+ * teardown does.
+ */
+export class SimCfnResourceRetention {
+  private readonly replaced: ReadonlySet<string>;
+  private readonly named: ReadonlySet<string>;
+
+  constructor(properties: SimCfnResourceRetentionProperties = {}) {
+    this.replaced = properties.replaced ?? new Set();
+    this.named = properties.named ?? new Set();
+  }
+
+  /**
+   * Whether this Resource is to be left in simulated AWS rather than deleted.
+   */
+  retains(resource: SimCfnResourceRecord): boolean {
+    if (this.named.has(resource.logicalId)) {
+      return true;
+    }
+
+    return this.replaced.has(resource.logicalId)
+      ? resource.retainedOnReplace
+      : resource.retainedOnDelete;
+  }
+}

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-retention.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-retention.ts
@@ -17,18 +17,18 @@ interface SimCfnResourceRetentionProperties {
 /**
  * Which of the Resources an operation is deleting it has to leave behind.
  *
- * Three things can keep a Resource in simulated AWS, and they are gathered here
- * so one delete has one answer rather than each caller reading a policy of its
- * own: the DeleteStack call naming it, UpdateReplacePolicy on a Resource being
- * replaced, and DeletionPolicy on one being removed.
+ * Three things can keep a Resource in simulated AWS. The DeleteStack call can
+ * name it, UpdateReplacePolicy can keep one a Stack update is replacing, and
+ * DeletionPolicy can keep one being removed. They are gathered here so that one
+ * delete has one answer.
  *
  * Which of the two attributes applies is the part worth stating. CloudFormation
  * reads UpdateReplacePolicy for a replacement and DeletionPolicy for a removal,
- * and neither stands in for the other, so a Resource marked to survive a
- * teardown still goes when an update replaces it.
+ * and neither stands in for the other. A Resource marked to survive a teardown
+ * still goes when an update replaces it.
  *
- * A retention with nothing in it reads DeletionPolicy, which is what a plain
- * teardown does.
+ * A retention with nothing in it reads DeletionPolicy, the way a plain teardown
+ * does.
  */
 export class SimCfnResourceRetention {
   private readonly replaced: ReadonlySet<string>;

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -159,8 +159,8 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
    * where it is.
    *
    * UpdateReplacePolicy decides this on its own. CloudFormation does not fall
-   * back to DeletionPolicy for a Resource it is replacing, so a Resource kept
-   * on teardown still goes when its replacement is created, unless it says
+   * back to DeletionPolicy for a Resource it is replacing. A Resource kept on
+   * teardown still goes when its replacement is created, unless it says
    * otherwise here.
    */
   public get retainedOnReplace(): boolean {

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -147,6 +147,27 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
   }
 
   /**
+   * The UpdateReplacePolicy attribute from the Resource template, if it has
+   * one.
+   */
+  public get updateReplacePolicy(): string | undefined {
+    return this.resourceTemplateReader.updateReplacePolicy();
+  }
+
+  /**
+   * Whether an update that replaces this Resource should leave the deployed one
+   * where it is.
+   *
+   * UpdateReplacePolicy decides this on its own. CloudFormation does not fall
+   * back to DeletionPolicy for a Resource it is replacing, so a Resource kept
+   * on teardown still goes when its replacement is created, unless it says
+   * otherwise here.
+   */
+  public get retainedOnReplace(): boolean {
+    return this.updateReplacePolicy === "Retain";
+  }
+
+  /**
    * The value returned when this Resource is referenced via { "Ref": logicalId }.
    *
    * Mirroring CloudFormation, Resource Ref behavior is Resource-type specific.

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -181,8 +181,8 @@ export class SimCfnResource<
   }
 
   /**
-   * Whether this Resource was left in simulated AWS by a Stack teardown,
-   * because its DeletionPolicy says to keep it.
+   * Whether this Resource was left in simulated AWS rather than deleted,
+   * because a policy or the caller said to keep it.
    */
   public get retained(): boolean {
     return this.deletionState.retained;
@@ -191,20 +191,11 @@ export class SimCfnResource<
   /**
    * Start deleting this Resource from simulated AWS.
    *
-   * A Resource whose DeletionPolicy retains it never reaches the delete
-   * operation. CloudFormation leaves it where it is and reports it as
-   * DELETE_SKIPPED, so the Stack can finish deleting around it.
-   *
    * The actual work is delegated to SimCfnResourceDeleteOperation, for the same
-   * reason creation is.
+   * reason creation is. That includes deciding whether to delete the Resource
+   * at all, since a retained Resource is a deletion outcome like any other.
    */
   delete(context: SimCloudFormationResourceDeleteContext): Promise<void> {
-    if (this.retainedOnDelete) {
-      this.deletionState.markDeleteRetained();
-
-      return Promise.resolve();
-    }
-
     return new SimCfnResourceDeleteOperation({
       background: this.background,
       resource: this,
@@ -273,6 +264,14 @@ export class SimCfnResource<
    */
   markDeleteComplete(): void {
     this.deletionState.markDeleteComplete();
+  }
+
+  /**
+   * Mark this Resource as left in simulated AWS rather than deleted, because a
+   * policy or the DeleteStack call said to keep it.
+   */
+  markDeleteRetained(): void {
+    this.deletionState.markDeleteRetained();
   }
 
   /**

--- a/src/service/cloudformation/resource/sim-cfn-resource.type.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.type.ts
@@ -9,6 +9,7 @@ import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCfnResource } from "./sim-cfn-resource.js";
 import type { SimCfnExports } from "../export/sim-cfn-exports.js";
+import type { SimCfnResourceRetention } from "./delete/sim-cfn-resource-retention.js";
 
 export interface SimCloudFormationResourceProperties {
   readonly accountRegionScope?: SimAwsAccountRegionScope;
@@ -103,6 +104,13 @@ export interface SimCloudFormationResourceDeleteContext {
 
   /** The principal the teardown runs as, as creation carries it. */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * Which of the Resources this operation is deleting it has to leave in
+   * simulated AWS. An omitted retention reads each Resource's DeletionPolicy,
+   * which is what a Stack teardown asked for nothing else does.
+   */
+  readonly retention?: SimCfnResourceRetention | undefined;
 }
 
 /**

--- a/src/service/cloudformation/resource/state/sim-cfn-resource-deletion-state.ts
+++ b/src/service/cloudformation/resource/state/sim-cfn-resource-deletion-state.ts
@@ -33,8 +33,8 @@ export class SimCfnResourceDeletionState {
   }
 
   /**
-   * Whether this Resource was left in simulated AWS because its DeletionPolicy
-   * says to keep it.
+   * Whether this Resource was left in simulated AWS because a policy attribute
+   * or the DeleteStack call said to keep it.
    */
   public get retained(): boolean {
     return this.#status === "DELETE_SKIPPED";
@@ -107,7 +107,7 @@ export class SimCfnResourceDeletionState {
   }
 
   /**
-   * Mark this Resource as kept because its DeletionPolicy is Retain.
+   * Mark this Resource as kept in simulated AWS.
    *
    * DELETE_SKIPPED is the status CloudFormation itself reports for a retained
    * Resource, and it counts as terminal so the rest of the teardown carries on

--- a/src/service/cloudformation/resource/template/sim-cfn-resource-template-reader.ts
+++ b/src/service/cloudformation/resource/template/sim-cfn-resource-template-reader.ts
@@ -38,6 +38,17 @@ export class SimCfnResourceTemplateReader {
   }
 
   /**
+   * The CloudFormation UpdateReplacePolicy attribute, for example Retain.
+   */
+  updateReplacePolicy(): string | undefined {
+    const updateReplacePolicy = this.template["UpdateReplacePolicy"];
+
+    return typeof updateReplacePolicy === "string"
+      ? updateReplacePolicy
+      : undefined;
+  }
+
+  /**
    * The CloudFormation Resource properties object.
    *
    * CloudFormation Resources may omit Properties. In that case, and when the

--- a/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
@@ -66,12 +66,12 @@ export class SimCfnStackResourceOperations {
   private caller: SimAwsCaller | undefined;
 
   /**
-   * Resources an update left in simulated AWS rather than deleting.
+   * Resources an update kept in simulated AWS.
    *
-   * Kept here rather than on the Stack because the Stack stops holding them as
-   * soon as the update applies: a replaced Resource gives its logical ID up to
-   * the Resource created in its place. A teardown's retained Resources are
-   * still on the Stack, and are read off it.
+   * They are held here because the Stack cannot hold them. A replaced Resource
+   * gives its logical ID up to the Resource created in its place as soon as the
+   * update applies. A teardown's retained Resources are still on the Stack, and
+   * are read off it.
    */
   private readonly retainedByUpdates: SimCfnResource[] = [];
 
@@ -137,7 +137,7 @@ export class SimCfnStackResourceOperations {
     await this.creator(resources).create(creating);
   }
 
-  /** Resources an update left in simulated AWS rather than deleting. */
+  /** Resources an update kept in simulated AWS. */
   public get retainedResources(): readonly SimCfnResource[] {
     return this.retainedByUpdates;
   }

--- a/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
@@ -6,6 +6,8 @@ import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
 import { SimCdkAssetsPublisher } from "../cdk/assets/sim-cdk-assets-publisher.js";
 import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
+import { SimCfnResourceRetention } from "../resource/delete/sim-cfn-resource-retention.js";
+import { simCfnStackRetainedLogicalIds } from "./teardown/sim-cfn-stack-retained-logical-ids.js";
 import type { SimCfnTemplate } from "../template/sim-cfn-template.js";
 import { SimCfnStackResourceCreator } from "./deploy/sim-cfn-stack-resource-creator.js";
 import type { SimCfnResourceOrder } from "./deploy/sim-cfn-resource-order.js";
@@ -62,6 +64,16 @@ export class SimCfnStackResourceOperations {
   private readonly resourceOrder: SimCfnResourceOrder | undefined;
   private cdkOutContext: SimCdkOutContext | undefined;
   private caller: SimAwsCaller | undefined;
+
+  /**
+   * Resources an update left in simulated AWS rather than deleting.
+   *
+   * Kept here rather than on the Stack because the Stack stops holding them as
+   * soon as the update applies: a replaced Resource gives its logical ID up to
+   * the Resource created in its place. A teardown's retained Resources are
+   * still on the Stack, and are read off it.
+   */
+  private readonly retainedByUpdates: SimCfnResource[] = [];
 
   constructor(properties: SimCfnStackResourceOperationsProperties) {
     const {
@@ -125,13 +137,42 @@ export class SimCfnStackResourceOperations {
     await this.creator(resources).create(creating);
   }
 
+  /** Resources an update left in simulated AWS rather than deleting. */
+  public get retainedResources(): readonly SimCfnResource[] {
+    return this.retainedByUpdates;
+  }
+
   /**
-   * Delete every Resource in the given Stack Resource map.
+   * Refuse a teardown that names a Resource the Stack does not have, before
+   * anything is deleted.
+   */
+  assertRetainable(
+    resources: ReadonlyMap<string, SimCfnResource>,
+    retainResources: readonly string[] | undefined,
+  ): void {
+    this.teardownRetention(resources, retainResources);
+  }
+
+  /**
+   * Delete every Resource in the given Stack Resource map, apart from any the
+   * teardown named as ones to keep.
    */
   async deleteAll(
     resources: ReadonlyMap<string, SimCfnResource>,
+    retainResources?: readonly string[],
   ): Promise<void> {
-    await this.deleter(resources).deleteAll();
+    await this.deleter(
+      resources,
+      this.teardownRetention(resources, retainResources),
+    ).deleteAll();
+  }
+
+  /**
+   * Take a record of the Resources an update kept, which the Stack is about to
+   * stop holding.
+   */
+  recordRetained(resources: readonly SimCfnResource[]): void {
+    this.retainedByUpdates.push(...resources);
   }
 
   /**
@@ -141,8 +182,9 @@ export class SimCfnStackResourceOperations {
   async delete(
     resources: ReadonlyMap<string, SimCfnResource>,
     deleting: readonly SimCfnResource[],
+    retention?: SimCfnResourceRetention,
   ): Promise<void> {
-    await this.deleter(resources).delete(deleting);
+    await this.deleter(resources, retention).delete(deleting);
   }
 
   /**
@@ -184,6 +226,23 @@ export class SimCfnStackResourceOperations {
     });
   }
 
+  /**
+   * What a teardown of these Resources is to leave behind: the ones it named,
+   * and the ones their own DeletionPolicy keeps.
+   */
+  private teardownRetention(
+    resources: ReadonlyMap<string, SimCfnResource>,
+    retainResources: readonly string[] | undefined,
+  ): SimCfnResourceRetention {
+    return new SimCfnResourceRetention({
+      named: simCfnStackRetainedLogicalIds({
+        stackName: this.stackName,
+        resources,
+        retainResources,
+      }),
+    });
+  }
+
   private async publishAssets(): Promise<void> {
     await new SimCdkAssetsPublisher({
       simAws: this.simAws,
@@ -210,12 +269,14 @@ export class SimCfnStackResourceOperations {
 
   private deleter(
     resources: ReadonlyMap<string, SimCfnResource>,
+    retention: SimCfnResourceRetention | undefined,
   ): SimCfnStackResourceDeleter {
     return new SimCfnStackResourceDeleter({
       simAws: this.simAws,
       resources,
       stackName: this.stackName,
       caller: this.caller,
+      retention,
     });
   }
 }

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -210,9 +210,10 @@ export class SimCfnStack implements SimCfnDeployedStack {
    * once the teardown has finished successfully, which is when the Stack name
    * becomes free to use again.
    *
-   * Resources named in retainResources are checked against the Stack here
-   * rather than in the background, so a caller naming one the Stack does not
-   * have is refused while it can still be told about it.
+   * Resources named in retainResources are checked against the Stack before
+   * the teardown is scheduled. A caller naming one the Stack does not have is
+   * refused there, where a check in the background would only fail the
+   * deletion.
    */
   async delete(properties: SimCfnStackDeleteProperties = {}): Promise<void> {
     this.operations.assertRetainable(
@@ -285,8 +286,8 @@ export class SimCfnStack implements SimCfnDeployedStack {
   }
 
   /**
-   * Resources left in simulated AWS rather than deleted, whether a teardown
-   * stepped over them or an update replaced them and kept the deployed one.
+   * Resources left in simulated AWS, whether a teardown stepped over them or
+   * an update replaced them and kept the deployed one.
    */
   public get retainedResources(): readonly SimCfnResource[] {
     return [...this.report.retained, ...this.operations.retainedResources];

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -109,8 +109,10 @@ export class SimCfnStack implements SimCfnDeployedStack {
     this.updating = new SimCfnStackUpdateLifecycle({ background, stackName });
     this.deletion = new SimCfnStackDeletionLifecycle({
       background,
-      runTeardown: async (): Promise<void> => {
-        await this.teardown();
+      runTeardown: async (
+        deleteProperties: SimCfnStackDeleteProperties,
+      ): Promise<void> => {
+        await this.teardown(deleteProperties);
       },
     });
     this.operationStatus = new SimCfnStackOperationStatus({
@@ -207,8 +209,17 @@ export class SimCfnStack implements SimCfnDeployedStack {
    * before the Resources have gone. The optional onDeleteComplete callback runs
    * once the teardown has finished successfully, which is when the Stack name
    * becomes free to use again.
+   *
+   * Resources named in retainResources are checked against the Stack here
+   * rather than in the background, so a caller naming one the Stack does not
+   * have is refused while it can still be told about it.
    */
   async delete(properties: SimCfnStackDeleteProperties = {}): Promise<void> {
+    this.operations.assertRetainable(
+      this.resourceMap,
+      properties.retainResources,
+    );
+
     await this.deletion.delete(properties);
   }
 
@@ -224,8 +235,11 @@ export class SimCfnStack implements SimCfnDeployedStack {
    * The Resource half of deleting a Stack, without the Stack-level status or
    * the Stack name release that delete() puts on top of it.
    */
-  async teardown(): Promise<void> {
-    await this.operations.deleteAll(this.resourceMap);
+  async teardown(properties: SimCfnStackDeleteProperties = {}): Promise<void> {
+    await this.operations.deleteAll(
+      this.resourceMap,
+      properties.retainResources,
+    );
     this.stackOutputs.release();
   }
 
@@ -270,9 +284,12 @@ export class SimCfnStack implements SimCfnDeployedStack {
     return this.report.deletionSkipped;
   }
 
-  /** Resources a teardown left in simulated AWS, as their policy says to. */
+  /**
+   * Resources left in simulated AWS rather than deleted, whether a teardown
+   * stepped over them or an update replaced them and kept the deployed one.
+   */
   public get retainedResources(): readonly SimCfnResource[] {
-    return this.report.retained;
+    return [...this.report.retained, ...this.operations.retainedResources];
   }
 
   /** Every property or Parameter that did not reach simulated AWS as written. */

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -214,14 +214,17 @@ export class SimCfnStack implements SimCfnDeployedStack {
    * the teardown is scheduled. A caller naming one the Stack does not have is
    * refused there, where a check in the background would only fail the
    * deletion.
+   *
+   * The names are copied as the request is accepted. The teardown runs in the
+   * background, and a caller holding the array it passed could otherwise change
+   * which Resources are kept after the Stack agreed to keep them.
    */
   async delete(properties: SimCfnStackDeleteProperties = {}): Promise<void> {
-    this.operations.assertRetainable(
-      this.resourceMap,
-      properties.retainResources,
-    );
+    const retainResources = [...(properties.retainResources ?? [])];
 
-    await this.deletion.delete(properties);
+    this.operations.assertRetainable(this.resourceMap, retainResources);
+
+    await this.deletion.delete({ ...properties, retainResources });
   }
 
   /** Wait for the scheduled Stack deletion to finish. */

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-deletion-lifecycle.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-deletion-lifecycle.ts
@@ -13,7 +13,9 @@ interface SimCfnStackDeletionLifecycleProperties {
    * stays outside this class, while status, error and completion handling stay
    * inside it.
    */
-  readonly runTeardown: () => Promise<void>;
+  readonly runTeardown: (
+    properties: SimCfnStackDeleteProperties,
+  ) => Promise<void>;
 }
 
 export interface SimCfnStackDeleteProperties {
@@ -24,6 +26,13 @@ export interface SimCfnStackDeleteProperties {
    * lifecycle only says when the name is free rather than freeing it.
    */
   readonly onDeleteComplete?: (() => void) | undefined;
+
+  /**
+   * Resources to leave in simulated AWS, named by logical ID or CDK construct
+   * ID. What DeleteStack RetainResources asks for, and it overrides whatever
+   * the Resource's own DeletionPolicy says.
+   */
+  readonly retainResources?: readonly string[] | undefined;
 }
 
 /**
@@ -39,7 +48,9 @@ export interface SimCfnStackDeleteProperties {
  */
 export class SimCfnStackDeletionLifecycle {
   private readonly background: BackgroundScheduler;
-  private readonly runTeardown: () => Promise<void>;
+  private readonly runTeardown: (
+    properties: SimCfnStackDeleteProperties,
+  ) => Promise<void>;
   #status: SimCloudFormationStackStatus | undefined;
 
   private completePromise: Promise<void> | undefined;
@@ -98,7 +109,9 @@ export class SimCfnStackDeletionLifecycle {
     await scheduler.sequence();
 
     this.completePromise = scheduler.schedule({
-      operation: this.runTeardown,
+      operation: async (): Promise<void> => {
+        await this.runTeardown(properties);
+      },
       onSuccess: () => {
         this.#status = "DELETE_COMPLETE";
         properties.onDeleteComplete?.();

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-batch-deleter.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-batch-deleter.ts
@@ -1,11 +1,13 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import type { SimCfnResourceRetention } from "../../resource/delete/sim-cfn-resource-retention.js";
 
 interface SimCfnStackResourceBatchDeleterProperties {
   readonly simAws: SimAws;
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly caller?: SimAwsCaller | undefined;
+  readonly retention?: SimCfnResourceRetention | undefined;
 }
 
 /**
@@ -22,11 +24,13 @@ export class SimCfnStackResourceBatchDeleter {
   private readonly simAws: SimAws;
   private readonly resources: ReadonlyMap<string, SimCfnResource>;
   private readonly caller: SimAwsCaller | undefined;
+  private readonly retention: SimCfnResourceRetention | undefined;
 
   constructor(properties: SimCfnStackResourceBatchDeleterProperties) {
     this.simAws = properties.simAws;
     this.resources = properties.resources;
     this.caller = properties.caller;
+    this.retention = properties.retention;
   }
 
   /**
@@ -41,6 +45,7 @@ export class SimCfnStackResourceBatchDeleter {
           simAws: this.simAws,
           resources: this.resources,
           caller: this.caller,
+          retention: this.retention,
         });
       }),
     );

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-deleter.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-resource-deleter.ts
@@ -1,6 +1,7 @@
 import type { SimAws } from "../../../aws/sim-aws.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import type { SimCfnResourceRetention } from "../../resource/delete/sim-cfn-resource-retention.js";
 import { SimCfnStackPendingDeletions } from "./sim-cfn-stack-pending-deletions.js";
 import { SimCfnStackResourceBatchDeleter } from "./sim-cfn-stack-resource-batch-deleter.js";
 
@@ -9,6 +10,9 @@ interface SimCfnStackResourceDeleterProperties {
   readonly resources: ReadonlyMap<string, SimCfnResource>;
   readonly stackName: string;
   readonly caller?: SimAwsCaller | undefined;
+
+  /** Which of the Resources being deleted are to be left in simulated AWS. */
+  readonly retention?: SimCfnResourceRetention | undefined;
 }
 
 /**
@@ -32,7 +36,7 @@ export class SimCfnStackResourceDeleter {
   private readonly batchDeleter: SimCfnStackResourceBatchDeleter;
 
   constructor(properties: SimCfnStackResourceDeleterProperties) {
-    const { simAws, resources, stackName, caller } = properties;
+    const { simAws, resources, stackName, caller, retention } = properties;
 
     this.resources = resources;
     this.stackName = stackName;
@@ -40,6 +44,7 @@ export class SimCfnStackResourceDeleter {
       simAws,
       resources,
       caller,
+      retention,
     });
   }
 

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-retained-logical-ids.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-retained-logical-ids.ts
@@ -1,0 +1,47 @@
+import { SimCloudFormationValidationError } from "../../error/sim-cloudformation.error.js";
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import { SimCfnStackResourceLookup } from "../resource-map/sim-cfn-stack-resource-lookup.js";
+
+interface SimCfnStackRetainedLogicalIdsProperties {
+  readonly stackName: string;
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+
+  /** The identifiers DeleteStack named in RetainResources. */
+  readonly retainResources?: readonly string[] | undefined;
+}
+
+/**
+ * The logical IDs a DeleteStack call asked to keep, resolved against the Stack.
+ *
+ * An identifier the Stack has no Resource for is refused rather than ignored,
+ * as CloudFormation refuses one: a caller who misspells the Resource they meant
+ * to keep would otherwise watch it go. CDK construct IDs resolve here too, the
+ * same way `getResource(...)` accepts them, so a test written against a
+ * synthesized template need not carry the hashed logical ID.
+ */
+export function simCfnStackRetainedLogicalIds(
+  properties: SimCfnStackRetainedLogicalIdsProperties,
+): ReadonlySet<string> {
+  const { stackName, resources, retainResources = [] } = properties;
+  const lookup = new SimCfnStackResourceLookup(resources);
+  const retained = new Set<string>();
+  const missing: string[] = [];
+
+  for (const identifier of retainResources) {
+    const resource = lookup.find(identifier);
+
+    if (resource === undefined) {
+      missing.push(identifier);
+    } else {
+      retained.add(resource.logicalId);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new SimCloudFormationValidationError(
+      `Invalid RetainResources: [${missing.join(", ")}] not found in Stack ${stackName}`,
+    );
+  }
+
+  return retained;
+}

--- a/src/service/cloudformation/stack/teardown/sim-cfn-stack-retained-logical-ids.ts
+++ b/src/service/cloudformation/stack/teardown/sim-cfn-stack-retained-logical-ids.ts
@@ -13,11 +13,11 @@ interface SimCfnStackRetainedLogicalIdsProperties {
 /**
  * The logical IDs a DeleteStack call asked to keep, resolved against the Stack.
  *
- * An identifier the Stack has no Resource for is refused rather than ignored,
- * as CloudFormation refuses one: a caller who misspells the Resource they meant
- * to keep would otherwise watch it go. CDK construct IDs resolve here too, the
- * same way `getResource(...)` accepts them, so a test written against a
- * synthesized template need not carry the hashed logical ID.
+ * An identifier the Stack has no Resource for is refused, as CloudFormation
+ * refuses one. A caller who misspells the Resource they meant to keep would
+ * otherwise watch it go. CDK construct IDs resolve here as well as logical IDs,
+ * the same way `getResource(...)` takes either. A test written against a
+ * synthesized template then needs no hashed logical ID.
  */
 export function simCfnStackRetainedLogicalIds(
   properties: SimCfnStackRetainedLogicalIdsProperties,

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-update-plan.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-update-plan.ts
@@ -42,11 +42,18 @@ export class SimCfnStackUpdatePlan {
 
   public readonly updated: ReadonlyMap<string, SimCfnResource>;
 
+  /**
+   * The logical IDs being replaced rather than removed, which is what decides
+   * whether UpdateReplacePolicy or DeletionPolicy can keep a deleted Resource.
+   */
+  public readonly replaced: ReadonlySet<string>;
+
   constructor(properties: SimCfnStackUpdatePlanProperties) {
     const { current, updated } = properties;
     const replaced = simCfnStackReplacedLogicalIds({ current, updated });
 
     this.updated = updated;
+    this.replaced = replaced;
     this.replacements = replaced
       .values()
       .map((logicalId) => {

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-update-plan.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-update-plan.ts
@@ -42,18 +42,11 @@ export class SimCfnStackUpdatePlan {
 
   public readonly updated: ReadonlyMap<string, SimCfnResource>;
 
-  /**
-   * The logical IDs being replaced rather than removed, which is what decides
-   * whether UpdateReplacePolicy or DeletionPolicy can keep a deleted Resource.
-   */
-  public readonly replaced: ReadonlySet<string>;
-
   constructor(properties: SimCfnStackUpdatePlanProperties) {
     const { current, updated } = properties;
     const replaced = simCfnStackReplacedLogicalIds({ current, updated });
 
     this.updated = updated;
-    this.replaced = replaced;
     this.replacements = replaced
       .values()
       .map((logicalId) => {
@@ -88,6 +81,23 @@ export class SimCfnStackUpdatePlan {
         );
       })
       .toArray();
+  }
+
+  /**
+   * For each logical ID the update is replacing, whether the definition taking
+   * its place says to keep the deployed Resource.
+   *
+   * The new half answers it because CloudFormation reads UpdateReplacePolicy
+   * off the template it is applying. An update that adds the attribute keeps
+   * the Resource it replaces, and one that drops it deletes that Resource.
+   */
+  replacementRetentions(): ReadonlyMap<string, boolean> {
+    return new Map(
+      this.replacements.map(({ current, updated }) => [
+        current.logicalId,
+        updated.retainedOnReplace,
+      ]),
+    );
   }
 
   /**

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-update-replace-policy.iso.test.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-update-replace-policy.iso.test.ts
@@ -1,0 +1,240 @@
+import { buffer } from "node:stream/consumers";
+import { describe, it } from "vitest";
+import {
+  assertArrayEmpty,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertUndefined,
+} from "@kensio/smartass";
+import {
+  CreateStackCommand,
+  UpdateStackCommand,
+} from "@aws-sdk/client-cloudformation";
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { jsonStringify } from "../../../../util/type-guard/json.js";
+
+describe("simulated CloudFormation UpdateReplacePolicy", () => {
+  /**
+   * A Stack of one Bucket, declared with whatever policy attributes the case
+   * under test needs and named so the update can move it.
+   */
+  function bucketTemplate(properties: {
+    readonly attributes: Record<string, string>;
+    readonly bucketName: string;
+  }): string {
+    return jsonStringify({
+      Resources: {
+        ReportsBucket: {
+          Type: "AWS::S3::Bucket",
+          ...properties.attributes,
+          Properties: { BucketName: properties.bucketName },
+        },
+      },
+    });
+  }
+
+  it("keeps a replaced Resource its UpdateReplacePolicy retains", async () => {
+    // Given a deployed Bucket holding an Object, marked with
+    // UpdateReplacePolicy Retain the way CDK marks one.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "reports-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { UpdateReplacePolicy: "Retain" },
+          bucketName: "reports-first",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("reports-stack");
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "reports-first",
+        Key: "january.csv",
+        Body: "reported",
+      }),
+    );
+
+    // When an update renames the Bucket, which replaces it.
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "reports-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { UpdateReplacePolicy: "Retain" },
+          bucketName: "reports-second",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("reports-stack");
+
+    // Then the deployed Bucket is still in simulated S3 with what it held.
+    const kept = await simAws
+      .s3()
+      .getObject(
+        new GetObjectCommand({ Bucket: "reports-first", Key: "january.csv" }),
+      );
+    assertNonNullable(kept.Body);
+
+    const keptBytes = await buffer(kept.Body);
+
+    assertIdentical(keptBytes.toString(), "reported");
+
+    // And the replacement was created beside it.
+    assertNonNullable(simAws.s3().getSimBucketByName("reports-second"));
+
+    // And the Stack reports the Bucket it kept, having stopped tracking it:
+    // the logical ID now answers for the replacement.
+    const stack = cloudFormation.getStackByName("reports-stack");
+    assertNonNullable(stack);
+    assertIdentical(stack.status, "UPDATE_COMPLETE");
+    assertArrayLength(stack.retainedResources, 1);
+    assertIdentical(stack.retainedResources[0].status, "DELETE_SKIPPED");
+    assertIdentical(
+      stack.getResource("ReportsBucket")?.status,
+      "CREATE_COMPLETE",
+    );
+  });
+
+  it("deletes a replaced Resource whose UpdateReplacePolicy is Delete", async () => {
+    // Given a deployed Bucket that says to delete the replaced instance.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "archive-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { UpdateReplacePolicy: "Delete" },
+          bucketName: "archive-first",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("archive-stack");
+
+    // When an update replaces it.
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "archive-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { UpdateReplacePolicy: "Delete" },
+          bucketName: "archive-second",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("archive-stack");
+
+    // Then the deployed Bucket has gone and nothing is reported as kept.
+    assertUndefined(simAws.s3().getSimBucketByName("archive-first"));
+    assertNonNullable(simAws.s3().getSimBucketByName("archive-second"));
+
+    const stack = cloudFormation.getStackByName("archive-stack");
+    assertNonNullable(stack);
+    assertArrayEmpty(stack.retainedResources);
+  });
+
+  it("deletes a replaced Resource with no UpdateReplacePolicy", async () => {
+    // Given a deployed Bucket carrying no policy attributes at all.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "plain-stack",
+        TemplateBody: bucketTemplate({
+          attributes: {},
+          bucketName: "plain-first",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("plain-stack");
+
+    // When an update replaces it.
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "plain-stack",
+        TemplateBody: bucketTemplate({
+          attributes: {},
+          bucketName: "plain-second",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("plain-stack");
+
+    // Then the deployed Bucket has gone, as it did before the policy was read.
+    assertUndefined(simAws.s3().getSimBucketByName("plain-first"));
+    assertNonNullable(simAws.s3().getSimBucketByName("plain-second"));
+  });
+
+  it("deletes a replaced Resource whose UpdateReplacePolicy is Snapshot", async () => {
+    // Given a deployed Bucket asking for a snapshot no simulated service can
+    // take, which leaves nothing to keep the Bucket for.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "snapshot-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { UpdateReplacePolicy: "Snapshot" },
+          bucketName: "snapshot-first",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("snapshot-stack");
+
+    // When an update replaces it.
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "snapshot-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { UpdateReplacePolicy: "Snapshot" },
+          bucketName: "snapshot-second",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("snapshot-stack");
+
+    // Then the deployed Bucket has gone, as a Delete policy leaves it.
+    assertUndefined(simAws.s3().getSimBucketByName("snapshot-first"));
+    assertNonNullable(simAws.s3().getSimBucketByName("snapshot-second"));
+  });
+
+  it("replaces a Resource its DeletionPolicy alone would have kept", async () => {
+    // Given a deployed Bucket marked to survive a teardown, and nothing more.
+    // CloudFormation reads DeletionPolicy for a Resource being removed, never
+    // for one being replaced, so this one has nothing keeping it.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "kept-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { DeletionPolicy: "Retain" },
+          bucketName: "kept-first",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("kept-stack");
+
+    // When an update replaces it.
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "kept-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { DeletionPolicy: "Retain" },
+          bucketName: "kept-second",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("kept-stack");
+
+    // Then the deployed Bucket has gone.
+    assertUndefined(simAws.s3().getSimBucketByName("kept-first"));
+    assertNonNullable(simAws.s3().getSimBucketByName("kept-second"));
+  });
+});

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-update-replace-policy.iso.test.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-update-replace-policy.iso.test.ts
@@ -203,6 +203,73 @@ describe("simulated CloudFormation UpdateReplacePolicy", () => {
     assertNonNullable(simAws.s3().getSimBucketByName("snapshot-second"));
   });
 
+  it("reads the policy the Resource taking the place of the old one carries", async () => {
+    // Given a deployed Bucket carrying no policy attributes.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "adopted-stack",
+        TemplateBody: bucketTemplate({
+          attributes: {},
+          bucketName: "adopted-first",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("adopted-stack");
+
+    // When an update replaces it, and the new template asks to keep it.
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "adopted-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { UpdateReplacePolicy: "Retain" },
+          bucketName: "adopted-second",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("adopted-stack");
+
+    // Then the deployed Bucket is kept, because CloudFormation applies the
+    // template it was given rather than the one the Stack was deployed from.
+    assertNonNullable(simAws.s3().getSimBucketByName("adopted-first"));
+    assertNonNullable(simAws.s3().getSimBucketByName("adopted-second"));
+  });
+
+  it("deletes a Resource whose replacement drops the policy that kept it", async () => {
+    // Given a deployed Bucket declared with UpdateReplacePolicy Retain.
+    const simAws = new SimAws();
+    const cloudFormation = simAws.cloudFormation();
+
+    await cloudFormation.createStack(
+      new CreateStackCommand({
+        StackName: "dropped-stack",
+        TemplateBody: bucketTemplate({
+          attributes: { UpdateReplacePolicy: "Retain" },
+          bucketName: "dropped-first",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackDeployComplete("dropped-stack");
+
+    // When an update replaces it, and the new template drops the attribute.
+    await cloudFormation.updateStack(
+      new UpdateStackCommand({
+        StackName: "dropped-stack",
+        TemplateBody: bucketTemplate({
+          attributes: {},
+          bucketName: "dropped-second",
+        }),
+      }),
+    );
+    await cloudFormation.waitForStackUpdateComplete("dropped-stack");
+
+    // Then the deployed Bucket has gone, for the same reason.
+    assertUndefined(simAws.s3().getSimBucketByName("dropped-first"));
+    assertNonNullable(simAws.s3().getSimBucketByName("dropped-second"));
+  });
+
   it("replaces a Resource its DeletionPolicy alone would have kept", async () => {
     // Given a deployed Bucket marked to survive a teardown, and nothing more.
     // CloudFormation reads DeletionPolicy for a Resource being removed, never

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-updater.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-updater.ts
@@ -7,6 +7,7 @@ import type { SimCfnStackResourceOperations } from "../sim-cfn-stack-resource-op
 import { makeSimCfnStackResourceMap } from "../resource-map/sim-cfn-stack-resource-map.js";
 import { SimCfnStackUpdatePlan } from "./sim-cfn-stack-update-plan.js";
 import { simCfnStackTemplateChanged } from "./sim-cfn-stack-template-changes.js";
+import { SimCfnResourceRetention } from "../../resource/delete/sim-cfn-resource-retention.js";
 
 /**
  * What CloudFormation answers an update that would change nothing.
@@ -87,9 +88,20 @@ export class SimCfnStackUpdater {
       plan.replacements,
     );
 
-    await operations.delete(resources, plan.deletions);
+    await operations.delete(
+      resources,
+      plan.deletions,
+      new SimCfnResourceRetention({ replaced: plan.replaced }),
+    );
 
     plan.applyTo(resources);
+
+    // Once the Stack has stopped holding them, and before the replacements are
+    // created, so an update that keeps a Resource and then fails to create the
+    // one taking its place still reports what it kept.
+    operations.recordRetained(
+      plan.deletions.filter((resource) => resource.retained),
+    );
 
     await operations.create(resources, plan.creations);
   }

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-updater.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-updater.ts
@@ -91,7 +91,7 @@ export class SimCfnStackUpdater {
     await operations.delete(
       resources,
       plan.deletions,
-      new SimCfnResourceRetention({ replaced: plan.replaced }),
+      new SimCfnResourceRetention({ replaced: plan.replacementRetentions() }),
     );
 
     plan.applyTo(resources);

--- a/src/service/cloudformation/stack/update/sim-cfn-stack-updater.ts
+++ b/src/service/cloudformation/stack/update/sim-cfn-stack-updater.ts
@@ -97,8 +97,8 @@ export class SimCfnStackUpdater {
     plan.applyTo(resources);
 
     // Once the Stack has stopped holding them, and before the replacements are
-    // created, so an update that keeps a Resource and then fails to create the
-    // one taking its place still reports what it kept.
+    // created. An update that keeps a Resource and then fails to create the one
+    // taking its place still reports what it kept.
     operations.recordRetained(
       plan.deletions.filter((resource) => resource.retained),
     );


### PR DESCRIPTION
Simulated CloudFormation now reads `UpdateReplacePolicy` on a resource an update replaces, and `RetainResources` on `DeleteStackCommand`. Either one leaves the deployed resource in simulated AWS and reports it on the stack the way a `DeletionPolicy` of `Retain` is reported, and the stack still reaches `UPDATE_COMPLETE` or `DELETE_COMPLETE` around it. `DeletionPolicy` no longer keeps a resource an update replaces, which is the split CloudFormation makes between the two attributes, and a `RetainResources` entry the stack has no resource for is refused with a validation error. A kept resource holds the name it was created with. A replacement whose name Yulin generates asks for that name too and fails to create, and the docs record it.

Resolves #1223