### PR TITLE
feat: expand what a served S3 request can say

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -418,6 +418,65 @@ for (const object of objectContentItems) {
 The marker is exclusive and lexicographic. A listing resumes after the key it names whether or not
 the Bucket still holds it.
 
+### Asking for encoded keys
+
+An Object key can hold characters an XML document cannot carry, and a listing writes its keys into
+XML. `EncodingType: "url"` asks for them encoded. Simulated S3 encodes every `Key`, the `Prefix` and
+`Delimiter` the request named, each prefix in `CommonPrefixes`, and the marker or `StartAfter` key
+the response carries, as real S3 encodes them. The listing reports `EncodingType` back.
+
+```typescript sim-s3-list-objects-encoded-keys
+/**
+ * Listing a simulated S3 Bucket with its keys encoded.
+ */
+
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simS3 = new SimAws().s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "invoices/March 2027 & April.pdf",
+    Body: "invoice bytes",
+  }),
+);
+
+const listed = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "uploads", EncodingType: "url" }),
+);
+
+console.log(listed.EncodingType); // url
+
+const listedObjects = listed.Contents ?? [];
+
+for (const listedObject of listedObjects) {
+  const encodedKey = listedObject.Key ?? "";
+
+  console.log(encodedKey); // invoices/March+2027+%26+April.pdf
+
+  // S3 form-encodes a key, and a plus sign in one stands for a space.
+  console.log(decodeURIComponent(encodedKey.replaceAll("+", " ")));
+}
+```
+
+The encoding is the one an event notification record carries a key in. A space becomes a plus sign,
+and the slashes of a key prefix are left as they are. Continuation tokens are left alone in either
+version of the operation, being opaque already.
+
+A listing that names no `EncodingType` answers with the keys as they were written, and says nothing
+about an encoding. Any other value is refused with `InvalidArgument`.
+
+The `encoding-type` query parameter carries this over a
+[served endpoint](#serve-simulated-s3-on-localhost), and the SDK sets it from `EncodingType`.
+
 ## Object ETags
 
 Every Object has an ETag, the MD5 of its body in hex and quoted, as real S3 gives it for a
@@ -3086,6 +3145,51 @@ const s3Client = new S3Client({
 });
 ```
 
+### What an upload says about the Object
+
+An upload keeps the metadata headers it was sent. `cache-control`, `content-disposition`,
+`content-encoding`, `content-language`, `content-type` and `expires` are stored, and a read is
+served every one of them, the way it serves an Object written by a `PutObjectCommand`. See
+[Object system metadata](#object-system-metadata). An `x-amz-meta-` header is stored too, and an
+in-process read reports it in `Metadata`.
+
+```typescript
+await fetch(url, {
+  method: "PUT",
+  body: styleSheet,
+  headers: {
+    "content-type": "text/css",
+    "cache-control": "public, max-age=31536000, immutable",
+  },
+});
+```
+
+### Headers the URL asks for
+
+A read can name the headers it wants the Object served with. The SDK sets them from
+`ResponseContentType`, `ResponseContentDisposition`, `ResponseCacheControl`,
+`ResponseContentEncoding`, `ResponseContentLanguage` and `ResponseExpires`, and carries them in the
+`response-` query parameters real S3 reads. Simulated S3 serves those values in place of the
+Object's own.
+
+```typescript
+const url = await getSignedUrl(
+  s3Client,
+  new GetObjectCommand({
+    Bucket: "reports",
+    Key: "q3/report.pdf",
+    ResponseContentType: "application/octet-stream",
+    ResponseContentDisposition: 'attachment; filename="q3-report.pdf"',
+  }),
+  { expiresIn: 900 },
+);
+```
+
+The Object keeps the metadata it was written with. One URL can hand a browser a download while
+another shows the same Object in the page. A `HEAD` reads the parameters as a `GET` does, and the
+API endpoint honours them for any read rather than only a presigned one. The website endpoint serves
+none of them, as real S3 serves none there.
+
 ### Limitations
 
 - `GET`, `HEAD`, `PUT` and `DELETE` of an Object are served over a Bucket's own REST endpoint, which
@@ -3561,7 +3665,9 @@ Every path that serves an Object goes through the same mapping. The REST endpoin
 for it. `content-encoding` is the one that matters most. Bytes served without it are bytes no client
 can decode, and an Object stored as brotli is only usable if the header comes back with it.
 
-`PutObjectCommand` sets them, one request field per header.
+`PutObjectCommand` sets them, one request field per header. An upload over a
+[served endpoint](#presigned-urls) sets them in the headers themselves, which is the form the SDK
+sends them in.
 
 ```typescript sim-s3-object-system-metadata
 /**
@@ -3609,6 +3715,10 @@ read of an Object written without one reports `binary/octet-stream`.
 `Expires` is the one field that takes something other than a string. The SDK takes a `Date` on the
 way in. A read hands back the stored HTTP date as `ExpiresString`, alongside the same value parsed
 into a `Date` as `Expires`.
+
+A read can ask for headers of its own in place of these. See
+[Headers the URL asks for](#headers-the-url-asks-for). The Object goes on holding what it was
+written with.
 
 A CDK BucketDeployment's `SystemMetadata` sets the same headers on every Object it copies. See
 [CDK S3 BucketDeployment](https://yulinsim.dev/services/cloudformation/#cdk-s3-bucketdeployment). A
@@ -3685,8 +3795,11 @@ Sim S3 currently supports:
 - Serving Object `GET`, `HEAD`, `PUT` and `DELETE` over the S3 REST endpoint, authorized by sim IAM,
   and the `?uploads` and `?uploadId` sub-resources a multipart upload is made of
 - Presigned URLs built by the real `@aws-sdk/s3-request-presigner`, with expiry in simulated time
-- Object system metadata set by a `PutObjectCommand` and returned on a read, over every endpoint
-  that serves an Object
+- Object system metadata set by a `PutObjectCommand`, or by the headers of an upload over a served
+  endpoint, and returned on a read, over every endpoint that serves an Object
+- `response-` parameters on a read, serving the headers the request named in place of the Object's
+  own, which is what a presigned URL offering a download uses
+- `EncodingType` on a listing, encoding the keys, prefixes and markers it answers with
 - Object storage classes, named on a write and moved by a lifecycle rule, reported on a listing and
   on a read
 - `PutBucketEncryptionCommand`, `GetBucketEncryptionCommand` and `DeleteBucketEncryptionCommand`,
@@ -3712,7 +3825,8 @@ These apply across the page. The sections above each list what is specific to th
 - A storage class says where S3 keeps an Object and nothing else. Every Object is readable whatever
   class it is in, `RestoreObject` is left out, and nothing costs or takes longer in one class than
   another. See [Storage classes](#storage-classes).
-- `EncodingType` is ignored on a listing, and keys come back unencoded.
+- `EncodingType` is read on `ListObjects` and `ListObjectsV2`. `ListMultipartUploads` and
+  `ListParts` ignore it, and both answer on one page.
 - Object tags, ACLs and replication are left out. Server-side encryption is reported and never
   applied, and an `aws:kms` Object names no key, because there is no simulated KMS behind it. See
   [Default encryption](#default-encryption).
@@ -3721,8 +3835,6 @@ These apply across the page. The sections above each list what is specific to th
   [Deleting the files under a mount](#deleting-the-files-under-a-mount).
 - Multipart upload parts for a mounted Bucket are held in memory, and only the assembled Object
   reaches the directory.
-- An upload over the S3 REST endpoint keeps its `content-type` and no other system metadata, leaving
-  a presigned `PUT` unable to set the rest. A `PutObjectCommand` through the SDK keeps all of them.
-- A presigned `GetObject` ignores the `response-content-type`, `response-cache-control` and other
-  `response-*` parameters that override a response header in real S3. An Object is served with the
-  system metadata it was written with.
+- User-defined `x-amz-meta-` metadata is stored by every write and reported in `Metadata` by an
+  in-process read. A response served over an endpoint carries the system metadata headers and leaves
+  the user metadata out.

--- a/docs/services/s3/sim-s3-list-objects-encoded-keys.example.ts
+++ b/docs/services/s3/sim-s3-list-objects-encoded-keys.example.ts
@@ -1,0 +1,39 @@
+/**
+ * Listing a simulated S3 Bucket with its keys encoded.
+ */
+
+import {
+  CreateBucketCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simS3 = new SimAws().s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+
+await simS3.putObject(
+  new PutObjectCommand({
+    Bucket: "uploads",
+    Key: "invoices/March 2027 & April.pdf",
+    Body: "invoice bytes",
+  }),
+);
+
+const listed = await simS3.listObjectsV2(
+  new ListObjectsV2Command({ Bucket: "uploads", EncodingType: "url" }),
+);
+
+console.log(listed.EncodingType); // url
+
+const listedObjects = listed.Contents ?? [];
+
+for (const listedObject of listedObjects) {
+  const encodedKey = listedObject.Key ?? "";
+
+  console.log(encodedKey); // invoices/March+2027+%26+April.pdf
+
+  // S3 form-encodes a key, and a plus sign in one stands for a space.
+  console.log(decodeURIComponent(encodedKey.replaceAll("+", " ")));
+}

--- a/src/service/s3/command/list-objects-v2/list-objects-v2-page-builder.ts
+++ b/src/service/s3/command/list-objects-v2/list-objects-v2-page-builder.ts
@@ -1,6 +1,7 @@
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3CommonPrefixes } from "../../object/s3-common-prefix.js";
 import { simS3ObjectPage } from "../../object/s3-object-listing.js";
+import type { SimS3ListingEncoding } from "../../object/s3-listing-encoding.js";
 import { simS3ObjectSummaries } from "../../object/s3-object-summary.js";
 import {
   simS3ContinuationToken,
@@ -15,6 +16,7 @@ interface ListObjectsV2PageInput {
   readonly continuationToken?: string | undefined;
   readonly startAfter?: string | undefined;
   readonly maxKeys: number;
+  readonly encoding: SimS3ListingEncoding;
 }
 
 /**
@@ -23,6 +25,10 @@ interface ListObjectsV2PageInput {
  * Authorization is completed by the command handler before this class is
  * called, as it is for the first version of the operation, so a denied request
  * cannot examine Object keys or sizes.
+ *
+ * The keys, the prefix, the delimiter and the key a first page started after
+ * are written the way the listing asked for them, which is encoded or as they
+ * are stored. A continuation token is not, because it is opaque either way.
  *
  * The keys on a page are chosen exactly as ListObjects chooses them. What
  * differs is how a caller says where to carry on from: a continuation token
@@ -45,12 +51,16 @@ export class ListObjectsV2PageBuilder {
       maxKeys: input.maxKeys,
     });
 
+    const { encoding } = input;
+
     return {
-      Contents: simS3ObjectSummaries(page.objects),
-      CommonPrefixes: simS3CommonPrefixes(page.commonPrefixes),
+      Contents: encoding.summaries(simS3ObjectSummaries(page.objects)),
+      CommonPrefixes: encoding.commonPrefixes(
+        simS3CommonPrefixes(page.commonPrefixes),
+      ),
       Name: input.bucket.bucketName,
-      Prefix: input.prefix,
-      Delimiter: input.delimiter,
+      Prefix: encoding.value(input.prefix),
+      Delimiter: encoding.value(input.delimiter),
       MaxKeys: input.maxKeys,
       KeyCount: page.objects.length + page.commonPrefixes.length,
       IsTruncated: page.isTruncated,
@@ -59,7 +69,8 @@ export class ListObjectsV2PageBuilder {
         page.resumeAfter === undefined
           ? undefined
           : simS3ContinuationToken(page.resumeAfter),
-      StartAfter: input.startAfter,
+      StartAfter: encoding.value(input.startAfter),
+      EncodingType: encoding.encodingType,
       $metadata: {},
     };
   }

--- a/src/service/s3/command/list-objects-v2/list-objects-v2.command.ts
+++ b/src/service/s3/command/list-objects-v2/list-objects-v2.command.ts
@@ -14,7 +14,9 @@ export interface SimListObjectsV2Command {
  *
  * `ContinuationToken` resumes a truncated listing and takes precedence over
  * `StartAfter`, which only positions the first page. `Delimiter` rolls every
- * key holding it after the `Prefix` up into a common prefix.
+ * key holding it after the `Prefix` up into a common prefix. `EncodingType`
+ * asks for the keys the listing answers with to be encoded, so that a key
+ * holding a character XML cannot carry survives the response.
  */
 export interface SimListObjectsV2CommandInput {
   readonly Bucket?: string | undefined;
@@ -23,6 +25,7 @@ export interface SimListObjectsV2CommandInput {
   readonly MaxKeys?: number | undefined;
   readonly ContinuationToken?: string | undefined;
   readonly StartAfter?: string | undefined;
+  readonly EncodingType?: string | undefined;
 }
 
 /**
@@ -45,5 +48,6 @@ export interface SimListObjectsV2CommandOutput {
   readonly ContinuationToken?: string | undefined;
   readonly NextContinuationToken?: string | undefined;
   readonly StartAfter?: string | undefined;
+  readonly EncodingType?: string | undefined;
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/s3/command/list-objects-v2/list-objects-v2.handler.ts
+++ b/src/service/s3/command/list-objects-v2/list-objects-v2.handler.ts
@@ -17,6 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimS3ListingEncoding } from "../../object/s3-listing-encoding.js";
 import { simS3EffectiveMaxKeys } from "../../object/s3-object-listing.js";
 import { SimS3ObjectListingLimits } from "../../object/s3-object-listing-limits.js";
 import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
@@ -86,6 +87,10 @@ export class ListObjectsV2CommandHandler implements CommandHandler<
     // Complete request sequencing before authorization and storage access.
     await this.background.sequence();
 
+    // Refused before anything is listed, the way real S3 refuses an argument
+    // it cannot read, rather than after a page has been built.
+    const encoding = new SimS3ListingEncoding(command.input.EncodingType);
+
     const maxKeys = simS3EffectiveMaxKeys(
       command.input.MaxKeys,
       this.listing.maxKeysPerPage,
@@ -106,6 +111,7 @@ export class ListObjectsV2CommandHandler implements CommandHandler<
       continuationToken: command.input.ContinuationToken,
       startAfter: command.input.StartAfter,
       maxKeys,
+      encoding,
     });
   }
 }

--- a/src/service/s3/command/list-objects/list-objects-page-builder.ts
+++ b/src/service/s3/command/list-objects/list-objects-page-builder.ts
@@ -1,6 +1,7 @@
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
 import { simS3CommonPrefixes } from "../../object/s3-common-prefix.js";
 import { simS3ObjectPage } from "../../object/s3-object-listing.js";
+import type { SimS3ListingEncoding } from "../../object/s3-listing-encoding.js";
 import { simS3ObjectSummaries } from "../../object/s3-object-summary.js";
 import type { SimListObjectsCommandOutput } from "./list-objects.command.js";
 
@@ -10,6 +11,7 @@ interface ListObjectsPageInput {
   readonly delimiter?: string | undefined;
   readonly marker?: string | undefined;
   readonly maxKeys: number;
+  readonly encoding: SimS3ListingEncoding;
 }
 
 /**
@@ -22,6 +24,9 @@ interface ListObjectsPageInput {
  * Ordering and page selection are shared with ListObjectsV2, since the two
  * operations differ in how a caller names where to resume rather than in which
  * keys a page holds. The marker is exclusive, so a page begins after it.
+ *
+ * The keys, the prefix, the delimiter and both markers are written the way the
+ * listing asked for them, which is encoded or as they are stored.
  *
  * NextMarker is returned only when another page exists, and identifies the
  * final entry in the current page. That entry is a common prefix where the
@@ -42,16 +47,21 @@ export class ListObjectsPageBuilder {
       maxKeys: input.maxKeys,
     });
 
+    const { encoding } = input;
+
     return {
-      Contents: simS3ObjectSummaries(page.objects),
-      CommonPrefixes: simS3CommonPrefixes(page.commonPrefixes),
+      Contents: encoding.summaries(simS3ObjectSummaries(page.objects)),
+      CommonPrefixes: encoding.commonPrefixes(
+        simS3CommonPrefixes(page.commonPrefixes),
+      ),
       Name: input.bucket.bucketName,
-      Prefix: input.prefix,
-      Delimiter: input.delimiter,
-      Marker: input.marker,
+      Prefix: encoding.value(input.prefix),
+      Delimiter: encoding.value(input.delimiter),
+      Marker: encoding.value(input.marker),
       MaxKeys: input.maxKeys,
       IsTruncated: page.isTruncated,
-      NextMarker: page.resumeAfter,
+      NextMarker: encoding.value(page.resumeAfter),
+      EncodingType: encoding.encodingType,
       $metadata: {},
     };
   }

--- a/src/service/s3/command/list-objects/list-objects.command.ts
+++ b/src/service/s3/command/list-objects/list-objects.command.ts
@@ -15,7 +15,9 @@ export interface SimListObjectsCommand {
  * Minimal structural sim S3 ListObjects input.
  *
  * `Delimiter` rolls every key holding it after the `Prefix` up into a common
- * prefix, which is how a Bucket is walked one folder at a time.
+ * prefix, which is how a Bucket is walked one folder at a time. `EncodingType`
+ * asks for the keys the listing answers with to be encoded, so that a key
+ * holding a character XML cannot carry survives the response.
  */
 export interface SimListObjectsCommandInput {
   readonly Bucket?: string | undefined;
@@ -23,6 +25,7 @@ export interface SimListObjectsCommandInput {
   readonly Delimiter?: string | undefined;
   readonly Marker?: string | undefined;
   readonly MaxKeys?: number | undefined;
+  readonly EncodingType?: string | undefined;
 }
 
 /**
@@ -38,5 +41,6 @@ export interface SimListObjectsCommandOutput {
   readonly MaxKeys?: number;
   readonly IsTruncated?: boolean;
   readonly NextMarker?: string | undefined;
+  readonly EncodingType?: string | undefined;
   readonly $metadata: SimResponseMetadata;
 }

--- a/src/service/s3/command/list-objects/list-objects.handler.ts
+++ b/src/service/s3/command/list-objects/list-objects.handler.ts
@@ -17,6 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { SimS3ListingEncoding } from "../../object/s3-listing-encoding.js";
 import { simS3EffectiveMaxKeys } from "../../object/s3-object-listing.js";
 import { SimS3ObjectListingLimits } from "../../object/s3-object-listing-limits.js";
 import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
@@ -81,6 +82,10 @@ export class ListObjectsCommandHandler implements CommandHandler<
     // Complete request sequencing before authorization and storage access.
     await this.background.sequence();
 
+    // Refused before anything is listed, the way real S3 refuses an argument
+    // it cannot read, rather than after a page has been built.
+    const encoding = new SimS3ListingEncoding(command.input.EncodingType);
+
     const maxKeys = simS3EffectiveMaxKeys(
       command.input.MaxKeys,
       this.listing.maxKeysPerPage,
@@ -100,6 +105,7 @@ export class ListObjectsCommandHandler implements CommandHandler<
       delimiter: command.input.Delimiter,
       marker: command.input.Marker,
       maxKeys,
+      encoding,
     });
   }
 }

--- a/src/service/s3/notification/event/sim-s3-event-records.ts
+++ b/src/service/s3/notification/event/sim-s3-event-records.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { simS3EncodedKey } from "../../object/s3-key-encoding.js";
 import type { SimS3Event } from "./sim-s3-event.type.js";
 import type { SimS3ObjectEvent } from "./sim-s3-object-event.js";
 
@@ -95,9 +96,10 @@ export function simS3EventRequestId(): string {
 /**
  * The object key as a record carries it.
  *
- * Real S3 form-URL-encodes the key, so a space becomes a plus sign, while the
- * slashes that make up a key prefix stay as they are.
+ * A record carries the key encoded, the same way a listing asked for one does,
+ * so a function reading a record has to decode it before the key names an
+ * Object.
  */
 export function simS3EventObjectKey(key: string): string {
-  return encodeURIComponent(key).replaceAll("%20", "+").replaceAll("%2F", "/");
+  return simS3EncodedKey(key);
 }

--- a/src/service/s3/object/s3-key-encoding.ts
+++ b/src/service/s3/object/s3-key-encoding.ts
@@ -1,0 +1,14 @@
+/**
+ * An Object key in the encoded form S3 hands one back in.
+ *
+ * S3 form-URL-encodes a key, so a space becomes a plus sign, while the slashes
+ * that make up a key prefix stay as they are. An event notification record
+ * carries a key this way, and so does a listing that asked for one.
+ *
+ * The encoding is what lets a key hold a character XML cannot carry. An
+ * unencoded key holding a control character is a document no parser will read,
+ * which is the reason `EncodingType` exists.
+ */
+export function simS3EncodedKey(key: string): string {
+  return encodeURIComponent(key).replaceAll("%20", "+").replaceAll("%2F", "/");
+}

--- a/src/service/s3/object/s3-listing-encoding.iso.test.ts
+++ b/src/service/s3/object/s3-listing-encoding.iso.test.ts
@@ -1,0 +1,160 @@
+import {
+  CreateBucketCommand,
+  ListObjectsCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimS3 } from "../sim-s3.js";
+
+/**
+ * The keys a listing hands back when it was asked to encode them.
+ *
+ * An Object key can hold characters an XML document cannot carry, and a
+ * listing that wrote one straight into its response would answer with a
+ * document no parser will read. `EncodingType` is what a caller asks for
+ * instead, and everything the listing says about keys is then encoded
+ * together: the keys, the prefix and delimiter it was asked for, and the
+ * marker the next page starts at.
+ */
+describe("Encoding the keys a simulated S3 listing answers with", () => {
+  async function bucketHolding(...keys: readonly string[]): Promise<SimS3> {
+    const simS3 = new SimS3();
+
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: "widgets" }));
+
+    await Promise.all(
+      keys.map(async (key) =>
+        simS3.putObject(
+          new PutObjectCommand({ Bucket: "widgets", Key: key, Body: key }),
+        ),
+      ),
+    );
+
+    return simS3;
+  }
+
+  it("encodes the keys a listing asked to have encoded", async () => {
+    // Given a Bucket holding keys a browser upload produced, with a space and
+    // an ampersand in them.
+    const simS3 = await bucketHolding("img/holiday photo.png", "docs/a&b.txt");
+
+    // When the Bucket is listed with URL encoding asked for.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "widgets", EncodingType: "url" }),
+    );
+
+    // Then each key comes back encoded the way S3 encodes one, and the
+    // listing says which encoding a caller is reading.
+    assertArrayLength(output.Contents, 2);
+    assertIdentical(output.Contents[0].Key, "docs/a%26b.txt");
+    assertIdentical(output.Contents[1].Key, "img/holiday+photo.png");
+    assertIdentical(output.EncodingType, "url");
+  });
+
+  it("encodes the prefix, delimiter and folders alongside the keys", async () => {
+    // Given a Bucket whose folder names hold a space.
+    const simS3 = await bucketHolding(
+      "site/holiday photos/one.png",
+      "site/index.html",
+    );
+
+    // When it is walked one folder at a time with URL encoding asked for.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({
+        Bucket: "widgets",
+        Prefix: "site/",
+        Delimiter: "/",
+        EncodingType: "url",
+      }),
+    );
+
+    // Then the rolled-up folder is encoded as a key is, and so are the prefix
+    // and delimiter the listing echoes back.
+    assertArrayLength(output.CommonPrefixes, 1);
+    assertIdentical(output.CommonPrefixes[0].Prefix, "site/holiday+photos/");
+    assertIdentical(output.Prefix, "site/");
+    assertIdentical(output.Delimiter, "/");
+  });
+
+  it("encodes the marker the next page of a first-version listing starts at", async () => {
+    // Given a Bucket holding more keys than one page can carry, where the
+    // first page ends on a key with a space in it.
+    const simS3 = await bucketHolding("a holiday.png", "b.png", "c.png");
+
+    // When the first page is listed with URL encoding asked for.
+    const output = await simS3.listObjects(
+      new ListObjectsCommand({
+        Bucket: "widgets",
+        MaxKeys: 1,
+        EncodingType: "url",
+      }),
+    );
+
+    // Then the marker the next page resumes from is encoded, which is what a
+    // caller decodes before sending it back.
+    assertIdentical(output.NextMarker, "a+holiday.png");
+    assertIdentical(output.EncodingType, "url");
+  });
+
+  it("reports the encoding of a listing that found nothing to encode", async () => {
+    // Given a Bucket holding nothing under the prefix being listed.
+    const simS3 = await bucketHolding("index.html");
+
+    // When it is listed with URL encoding asked for.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({
+        Bucket: "widgets",
+        Prefix: "img/",
+        EncodingType: "url",
+      }),
+    );
+
+    // Then the listing still says which encoding it answered in, and holds
+    // neither keys nor folders, as an empty listing does.
+    assertUndefined(output.Contents);
+    assertUndefined(output.CommonPrefixes);
+    assertIdentical(output.EncodingType, "url");
+  });
+
+  it("leaves the keys of a listing that asked for no encoding alone", async () => {
+    // Given a Bucket holding a key with a space in it.
+    const simS3 = await bucketHolding("img/holiday photo.png");
+
+    // When it is listed without asking for an encoding.
+    const output = await simS3.listObjectsV2(
+      new ListObjectsV2Command({ Bucket: "widgets" }),
+    );
+
+    // Then the key is the one that was written, and nothing says otherwise,
+    // so a caller that decodes nothing reads it correctly.
+    assertArrayLength(output.Contents, 1);
+    assertIdentical(output.Contents[0].Key, "img/holiday photo.png");
+    assertUndefined(output.EncodingType);
+  });
+
+  it("refuses an encoding real S3 does not have", async () => {
+    // Given a Bucket to list.
+    const simS3 = await bucketHolding("index.html");
+
+    // When a listing asks for an encoding by a name S3 has no encoding under.
+    const listing = async (): Promise<unknown> =>
+      await simS3.listObjectsV2(
+        new ListObjectsV2Command({
+          Bucket: "widgets",
+          EncodingType: "base64" as "url",
+        }),
+      );
+
+    // Then it is refused, rather than answered with keys the caller will
+    // decode as though they had been encoded.
+    await assertThrowsErrorAsync(listing, "Not an EncodingType real S3 has");
+  });
+});

--- a/src/service/s3/object/s3-listing-encoding.ts
+++ b/src/service/s3/object/s3-listing-encoding.ts
@@ -1,0 +1,95 @@
+import { SimS3InvalidArgument } from "../error/sim-s3.error.js";
+import type { SimS3CommonPrefix } from "./s3-common-prefix.js";
+import { simS3EncodedKey } from "./s3-key-encoding.js";
+import type { SimS3ObjectSummary } from "./s3-object-summary.js";
+
+/**
+ * The only encoding a listing can ask for, which is the only one real S3 has.
+ */
+const urlEncodingType = "url";
+
+/**
+ * How a listing writes the keys it answers with.
+ *
+ * A listing hands back keys, the prefix and delimiter it was asked for, and the
+ * marker the next page starts at. All of them are keys or parts of one, so all
+ * of them are encoded together or none of them are. That is what this decides,
+ * once, for the whole page.
+ *
+ * A listing that asked for no encoding is answered with the keys as they are
+ * stored, which is what almost every caller wants and what every caller got
+ * before `EncodingType` was read at all.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
+ */
+export class SimS3ListingEncoding {
+  /**
+   * The encoding type to report back, which real S3 echoes only when the
+   * listing asked for one.
+   */
+  readonly encodingType: string | undefined;
+
+  /**
+   * A value real S3 does not have is refused rather than quietly treated as no
+   * encoding, since a caller misspelling it would otherwise decode keys that
+   * were never encoded.
+   */
+  constructor(encodingType?: string) {
+    if (encodingType !== undefined && encodingType !== urlEncodingType) {
+      throw new SimS3InvalidArgument(
+        `Not an EncodingType real S3 has: ${encodingType}. ` +
+          `The only one is "${urlEncodingType}".`,
+      );
+    }
+
+    this.encodingType = encodingType;
+  }
+
+  /**
+   * One key, prefix, delimiter or marker as the listing carries it.
+   */
+  value(value: string | undefined): string | undefined {
+    if (value === undefined || this.encodingType === undefined) {
+      return value;
+    }
+
+    return simS3EncodedKey(value);
+  }
+
+  /**
+   * The Objects on a page, each under the key the listing carries.
+   */
+  summaries(
+    summaries: SimS3ObjectSummary[] | undefined,
+  ): SimS3ObjectSummary[] | undefined {
+    if (summaries === undefined || this.encodingType === undefined) {
+      return summaries;
+    }
+
+    return summaries.map((summary) =>
+      /* v8 ignore next -- a listed Object always has a key */
+      summary.Key === undefined
+        ? summary
+        : { ...summary, Key: simS3EncodedKey(summary.Key) },
+    );
+  }
+
+  /**
+   * The folders a page rolled keys up into, each under the prefix the listing
+   * carries.
+   */
+  commonPrefixes(
+    commonPrefixes: SimS3CommonPrefix[] | undefined,
+  ): SimS3CommonPrefix[] | undefined {
+    if (commonPrefixes === undefined || this.encodingType === undefined) {
+      return commonPrefixes;
+    }
+
+    return commonPrefixes.map((commonPrefix) =>
+      /* v8 ignore next -- a rolled-up folder always has a prefix */
+      commonPrefix.Prefix === undefined
+        ? commonPrefix
+        : { Prefix: simS3EncodedKey(commonPrefix.Prefix) },
+    );
+  }
+}

--- a/src/service/s3/object/s3-object-response-headers.ts
+++ b/src/service/s3/object/s3-object-response-headers.ts
@@ -6,6 +6,11 @@ import { simS3SystemMetadataHeaders } from "./s3-system-metadata.js";
 export interface SimS3ObjectResponseDescription {
   /** The system metadata S3 was told when the Object was written. */
   readonly metadata?: Readonly<Record<string, string>> | undefined;
+  /**
+   * The headers the read asked to be served in place of the Object's own,
+   * under the same names, from its `response-` parameters.
+   */
+  readonly overrides?: Readonly<Record<string, string>> | undefined;
   /** The length of the body being served, in bytes. */
   readonly bodyLength: number;
   /** The Object's ETag, quoted as an HTTP entity tag. */
@@ -59,7 +64,9 @@ export function simS3ObjectResponseHeaders(
   };
 
   for (const header of simS3SystemMetadataHeaders) {
-    const value = description.metadata?.[header.name];
+    const value =
+      description.overrides?.[header.name] ??
+      description.metadata?.[header.name];
 
     if (value !== undefined) {
       headers[header.name] = value;
@@ -87,4 +94,36 @@ export function simS3ObjectResponseHeaders(
   }
 
   return headers;
+}
+
+/**
+ * The prefix a read overrides a response header with.
+ */
+const responseOverridePrefix = "response-";
+
+/**
+ * The response headers a read asked to be served in place of the Object's own.
+ *
+ * Real S3 has one of these per system metadata header, named after it, so they
+ * are read by the same list rather than spelled out again. `Content-Type` and
+ * `Content-Disposition` are the two worth having: a presigned URL naming them
+ * decides whether the browser opens the file or saves it, and under what name,
+ * without anything being written to the Object.
+ *
+ * https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html
+ */
+export function simS3ResponseHeaderOverrides(
+  query: URLSearchParams,
+): Record<string, string> {
+  const overrides: Record<string, string> = {};
+
+  for (const header of simS3SystemMetadataHeaders) {
+    const value = query.get(`${responseOverridePrefix}${header.name}`);
+
+    if (value !== null) {
+      overrides[header.name] = value;
+    }
+  }
+
+  return overrides;
 }

--- a/src/service/s3/object/s3-write-metadata.ts
+++ b/src/service/s3/object/s3-write-metadata.ts
@@ -3,6 +3,7 @@ import {
   simS3DefaultContentType,
   simS3SystemMetadataHeaders,
   simS3UserMetadataPrefix,
+  type SimS3SystemMetadataValues,
 } from "./s3-system-metadata.js";
 
 /**
@@ -14,8 +15,9 @@ import {
  * headers S3 remembers about an Object and returns on a read. There is one for
  * every entry in `simS3SystemMetadataHeaders`, which is what the conversion
  * below reads them by, so a header added to that list without a field here
- * fails to compile. `Expires` is a `Date` because the SDK takes one and formats
- * it as an HTTP date.
+ * fails to compile. `Expires` is a `Date` where the SDK takes one and formats
+ * it as an HTTP date, and the formatted string itself where the write arrived
+ * over HTTP with the date already written out.
  */
 export interface SimS3ObjectWriteMetadata {
   readonly Metadata?: Record<string, string> | undefined;
@@ -24,7 +26,7 @@ export interface SimS3ObjectWriteMetadata {
   readonly ContentEncoding?: string | undefined;
   readonly ContentLanguage?: string | undefined;
   readonly ContentType?: string | undefined;
-  readonly Expires?: Date | undefined;
+  readonly Expires?: Date | string | undefined;
 }
 
 /**
@@ -76,4 +78,59 @@ function metadataValue(value: string | Date | undefined): string | undefined {
   }
 
   return value;
+}
+
+/**
+ * Read the metadata headers of an upload into the members a write carries.
+ *
+ * A request arriving over HTTP states its metadata in the headers real S3
+ * carries it in, which is the form a `PutObjectCommand` is serialized into by
+ * the SDK. Reading them by the same list a write and a read agree on is what
+ * keeps an upload over an endpoint describing an Object exactly as an
+ * in-process one does.
+ *
+ * Every value stays a string, expiry included, because it arrives as the HTTP
+ * date S3 stores rather than as a `Date` waiting to be formatted.
+ */
+export function simS3WriteMetadataHeaders(
+  headers: Headers,
+): SimS3ObjectWriteMetadata {
+  const written: SimS3SystemMetadataValues = {};
+
+  for (const header of simS3SystemMetadataHeaders) {
+    const value = headers.get(header.name);
+
+    if (value !== null) {
+      written[header.field] = value;
+    }
+  }
+
+  const attached = simS3AttachedMetadata(headers);
+
+  return attached === undefined ? written : { ...written, Metadata: attached };
+}
+
+/**
+ * The user-defined metadata an upload attached, or nothing where it attached
+ * none.
+ *
+ * S3 sends each entry as its own `x-amz-meta-` header and answers a read with
+ * the keys without the prefix, which is the form a write states them in. An
+ * upload that attached nothing leaves `Metadata` absent rather than empty, so
+ * a copy carrying the source's metadata is not handed an empty object to
+ * copy over it.
+ */
+function simS3AttachedMetadata(
+  headers: Headers,
+): Record<string, string> | undefined {
+  const attached: Record<string, string> = {};
+
+  for (const [name, value] of headers) {
+    if (name.toLowerCase().startsWith(simS3UserMetadataPrefix)) {
+      attached[name.slice(simS3UserMetadataPrefix.length).toLowerCase()] =
+        value;
+    }
+  }
+
+  return Object.keys(attached).length === 0 ? undefined : attached;
 }

--- a/src/service/s3/serve/api/sim-s3-api-head-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-head-output.ts
@@ -13,15 +13,19 @@ import { simS3SystemMetadataHeadersFrom } from "../../object/s3-system-metadata-
  * Answer a HEAD with what a read would have said and none of the Object.
  *
  * The `content-length` describes the Object rather than the response, which is
- * what makes a HEAD worth sending.
+ * what makes a HEAD worth sending. A HEAD reads the same `response-` parameters
+ * a GET does, so a caller can see what a presigned URL would serve without
+ * fetching the Object.
  */
 export function simS3HeadObjectResponse(
   output: Record<string, unknown>,
+  overrides: Readonly<Record<string, string>>,
 ): Response {
   return new Response(undefined, {
     status: 200,
     headers: simS3ObjectResponseHeaders({
       metadata: simS3SystemMetadataHeadersFrom(output),
+      overrides,
       bodyLength: (output["ContentLength"] as number | undefined) ?? 0,
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,

--- a/src/service/s3/serve/api/sim-s3-api-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-input.ts
@@ -48,6 +48,7 @@ export function listObjectsV2Input(request: SimS3ApiRequest): object {
     ...optional("ContinuationToken", request.query.get("continuation-token")),
     ...optional("StartAfter", request.query.get("start-after")),
     ...optionalNumber("MaxKeys", request.query.get("max-keys")),
+    ...optional("EncodingType", request.query.get("encoding-type")),
   };
 }
 
@@ -61,25 +62,8 @@ export function listObjectsInput(request: SimS3ApiRequest): object {
     ...optional("Delimiter", request.query.get("delimiter")),
     ...optional("Marker", request.query.get("marker")),
     ...optionalNumber("MaxKeys", request.query.get("max-keys")),
+    ...optional("EncodingType", request.query.get("encoding-type")),
   };
-}
-
-/**
- * The user metadata an upload carried, which S3 sends as `x-amz-meta-` headers.
- */
-export function simS3UserMetadata(headers: Headers): {
-  Metadata?: Record<string, string>;
-} {
-  const prefix = "x-amz-meta-";
-  const metadata: Record<string, string> = {};
-
-  for (const [name, value] of headers) {
-    if (name.toLowerCase().startsWith(prefix)) {
-      metadata[name.slice(prefix.length).toLowerCase()] = value;
-    }
-  }
-
-  return Object.keys(metadata).length === 0 ? {} : { Metadata: metadata };
 }
 
 /**

--- a/src/service/s3/serve/api/sim-s3-api-listing.ts
+++ b/src/service/s3/serve/api/sim-s3-api-listing.ts
@@ -35,6 +35,7 @@ interface ListObjectsOutput {
   readonly StartAfter?: string | undefined;
   readonly Marker?: string | undefined;
   readonly NextMarker?: string | undefined;
+  readonly EncodingType?: string | undefined;
 }
 
 interface ListBucketsOutput {
@@ -71,6 +72,10 @@ export function simS3ListBucketsXml(output: ListBucketsOutput): string {
  * Both listing versions answer in a `ListBucketResult`, and differ only in how
  * they say where the next page starts. The version is passed in because the
  * output alone cannot say which was asked for.
+ *
+ * The keys arrive encoded or not according to what the listing was asked for,
+ * so nothing is encoded here. `EncodingType` says which of the two a client is
+ * reading, and is absent from a listing that asked for no encoding.
  */
 export function simS3ListObjectsXml(
   output: ListObjectsOutput,
@@ -88,6 +93,7 @@ export function simS3ListObjectsXml(
     xmlValue("Name", output.Name) +
       xmlValue("Prefix", output.Prefix) +
       xmlValue("Delimiter", output.Delimiter) +
+      xmlValue("EncodingType", output.EncodingType) +
       xmlValue("MaxKeys", output.MaxKeys) +
       xmlValue("IsTruncated", output.IsTruncated ?? false) +
       pagingXml(output, version) +

--- a/src/service/s3/serve/api/sim-s3-api-object-headers.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-headers.loc.test.ts
@@ -1,0 +1,153 @@
+import {
+  CreateAccessKeyCommand,
+  CreateUserCommand,
+  PutUserPolicyCommand,
+} from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+import { SimAwsLocalServer } from "../../../../serve/index.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+
+/**
+ * What a client outside the process reads and writes about an Object beyond
+ * its bytes.
+ *
+ * The headers describing an Object and the encoding of the keys a listing
+ * answers with both travel in parts of the request that only exist over HTTP:
+ * a header, a query parameter, an XML element. A client reaching simulated S3
+ * through an endpoint URL is the only way to cover them end to end.
+ */
+describe("Serving what a simulated S3 request says about an Object", () => {
+  const simAws = new SimAws();
+  const srv = new SimAwsLocalServer({ simAws });
+
+  let client: S3Client;
+
+  beforeAll(async () => {
+    await srv.listen();
+
+    const simIam = simAws.iam();
+
+    await simIam.createUser(new CreateUserCommand({ UserName: "Publisher" }));
+    await simIam.putUserPolicy(
+      new PutUserPolicyCommand({
+        UserName: "Publisher",
+        PolicyName: "Published",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: { Effect: "Allow", Action: "*", Resource: "*" },
+        }),
+      }),
+    );
+    const created = await simIam.createAccessKey(
+      new CreateAccessKeyCommand({ UserName: "Publisher" }),
+    );
+
+    client = new S3Client({
+      region: simAws.defaultRegionName,
+      endpoint: `http://localhost:${srv.port}`,
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: created.AccessKey.AccessKeyId,
+        secretAccessKey: created.AccessKey.SecretAccessKey,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await srv.close();
+  });
+
+  it("keeps the metadata headers an upload was sent with", async () => {
+    // Given a Bucket to publish into
+    await client.send(new CreateBucketCommand({ Bucket: "described" }));
+
+    // When an Object is written with everything S3 remembers about one
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "described",
+        Key: "app.js",
+        Body: "compressed bytes",
+        CacheControl: "public, max-age=31536000, immutable",
+        ContentEncoding: "br",
+        ContentType: "text/javascript",
+        Expires: new Date("2027-01-02T03:04:05Z"),
+      }),
+    );
+
+    // Then a read describes it with all of them, expiry included, having
+    // carried each one over the wire as the header real S3 carries it in
+    const output = await client.send(
+      new GetObjectCommand({ Bucket: "described", Key: "app.js" }),
+    );
+    assertIdentical(output.CacheControl, "public, max-age=31536000, immutable");
+    assertIdentical(output.ContentEncoding, "br");
+    assertIdentical(output.ExpiresString, "Sat, 02 Jan 2027 03:04:05 GMT");
+  });
+
+  it("serves the headers a read named in place of the Object's own", async () => {
+    // Given a stored PDF
+    await client.send(new CreateBucketCommand({ Bucket: "reports" }));
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "reports",
+        Key: "q3.pdf",
+        Body: "quarterly numbers",
+        ContentType: "application/pdf",
+      }),
+    );
+
+    // When it is read by a request naming the headers it wants back
+    const output = await client.send(
+      new GetObjectCommand({
+        Bucket: "reports",
+        Key: "q3.pdf",
+        ResponseContentType: "application/octet-stream",
+        ResponseContentDisposition: 'attachment; filename="q3.pdf"',
+      }),
+    );
+
+    // Then the read is answered with those, while the Object goes on being
+    // the PDF it was stored as
+    assertIdentical(output.ContentType, "application/octet-stream");
+    assertIdentical(output.ContentDisposition, 'attachment; filename="q3.pdf"');
+
+    const stored = await client.send(
+      new GetObjectCommand({ Bucket: "reports", Key: "q3.pdf" }),
+    );
+    assertIdentical(stored.ContentType, "application/pdf");
+  });
+
+  it("encodes the keys of a listing that asked for encoded keys", async () => {
+    // Given a Bucket holding keys with characters a URL escapes
+    await client.send(new CreateBucketCommand({ Bucket: "uploads" }));
+
+    await Promise.all(
+      ["a&b.txt", "holiday photo.png"].map(async (key) =>
+        client.send(
+          new PutObjectCommand({ Bucket: "uploads", Key: key, Body: key }),
+        ),
+      ),
+    );
+
+    // When the Bucket is listed with URL encoding asked for
+    const output = await client.send(
+      new ListObjectsV2Command({ Bucket: "uploads", EncodingType: "url" }),
+    );
+
+    // Then the document carries the keys encoded, and says so, which is what
+    // lets a key hold a character XML cannot
+    assertArrayLength(output.Contents, 2);
+    assertIdentical(output.Contents[0].Key, "a%26b.txt");
+    assertIdentical(output.Contents[1].Key, "holiday+photo.png");
+    assertIdentical(output.EncodingType, "url");
+  });
+});

--- a/src/service/s3/serve/api/sim-s3-api-object-input.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-input.ts
@@ -1,4 +1,5 @@
-import { optional, simS3UserMetadata } from "./sim-s3-api-input.js";
+import { simS3WriteMetadataHeaders } from "../../object/s3-write-metadata.js";
+import { optional } from "./sim-s3-api-input.js";
 import type { SimS3ApiRequest } from "./sim-s3-api-request.js";
 
 /**
@@ -62,24 +63,21 @@ export function copyObjectInput(request: SimS3ApiRequest): object {
 /**
  * The input of a request that describes an Object without carrying its bytes,
  * which is what starting a multipart upload is.
+ *
+ * The metadata headers are read by the list a write and a read share, so an
+ * upload over this endpoint describes an Object exactly as a `PutObjectCommand`
+ * does. Where S3 keeps the Object and how it encrypts it are read alongside
+ * them, being facts about the storage rather than metadata about the Object.
  */
 export function createMultipartUploadInput(request: SimS3ApiRequest): object {
   return {
     Bucket: request.bucketName,
     Key: request.objectKey,
-    ...optional("ContentType", request.headers.get("content-type")),
-    ...optional("CacheControl", request.headers.get("cache-control")),
-    ...optional(
-      "ContentDisposition",
-      request.headers.get("content-disposition"),
-    ),
-    ...optional("ContentEncoding", request.headers.get("content-encoding")),
-    ...optional("ContentLanguage", request.headers.get("content-language")),
+    ...simS3WriteMetadataHeaders(request.headers),
     ...optional("StorageClass", request.headers.get("x-amz-storage-class")),
     ...optional(
       "ServerSideEncryption",
       request.headers.get("x-amz-server-side-encryption"),
     ),
-    ...simS3UserMetadata(request.headers),
   };
 }

--- a/src/service/s3/serve/api/sim-s3-api-object-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-output.ts
@@ -27,6 +27,9 @@ export function simS3CopyObjectXml(output: CopyObjectOutput): string {
 /**
  * Answer a read with the Object itself, headers and all.
  *
+ * The headers the read named in its `response-` parameters are served in place
+ * of the Object's own, leaving what the Object was written with alone.
+ *
  * A read that asked for part of the Object is answered `206 Partial Content`
  * and says which part it carries, because a client reading a large Object in
  * pieces at once writes each response at the offset it asked for, and a `200`
@@ -34,6 +37,7 @@ export function simS3CopyObjectXml(output: CopyObjectOutput): string {
  */
 export async function simS3GetObjectResponse(
   output: Record<string, unknown>,
+  overrides: Readonly<Record<string, string>>,
 ): Promise<Response> {
   const body = await objectBodyBytes(output["Body"]);
   const contentRange = output["ContentRange"] as string | undefined;
@@ -42,6 +46,7 @@ export async function simS3GetObjectResponse(
     status: contentRange === undefined ? 200 : 206,
     headers: simS3ObjectResponseHeaders({
       metadata: simS3SystemMetadataHeadersFrom(output),
+      overrides,
       bodyLength: body.length,
       etag: output["ETag"] as string | undefined,
       lastModified: output["LastModified"] as Date | undefined,

--- a/src/service/s3/serve/api/sim-s3-api-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-output.ts
@@ -17,6 +17,7 @@ import {
   simS3CopyObjectXml,
   simS3GetObjectResponse,
 } from "./sim-s3-api-object-output.js";
+import { simS3ResponseHeaderOverrides } from "../../object/s3-object-response-headers.js";
 
 const xmlContentType = { "content-type": "application/xml" };
 
@@ -27,10 +28,15 @@ const xmlContentType = { "content-type": "application/xml" };
  * the operation rather than of its output: a listing answers in XML, a read
  * answers with the Object itself, and a write answers with a status and
  * headers alone.
+ *
+ * The request's query string is read alongside the output because a read can
+ * name the headers it wants served in place of the Object's own, and those are
+ * a property of the request rather than of what the operation answered.
  */
 export async function simS3ApiResponse(
   commandName: string,
   output: unknown,
+  query: URLSearchParams,
 ): Promise<Response> {
   const value = output as Record<string, unknown>;
 
@@ -45,7 +51,10 @@ export async function simS3ApiResponse(
       return xml(simS3ListObjectsXml(value, 2));
     }
     case "GetObjectCommand": {
-      return await simS3GetObjectResponse(value);
+      return await simS3GetObjectResponse(
+        value,
+        simS3ResponseHeaderOverrides(query),
+      );
     }
     case "GetBucketPolicyCommand": {
       // A Bucket policy is a JSON document, and real S3 answers this one
@@ -70,7 +79,10 @@ export async function simS3ApiResponse(
       return xml(deleteResultXml(value));
     }
     case "HeadObjectCommand": {
-      return simS3HeadObjectResponse(value);
+      return simS3HeadObjectResponse(
+        value,
+        simS3ResponseHeaderOverrides(query),
+      );
     }
     case "HeadBucketCommand": {
       return simS3HeadBucketResponse(value);

--- a/src/service/s3/serve/api/sim-s3-api.ts
+++ b/src/service/s3/serve/api/sim-s3-api.ts
@@ -87,7 +87,11 @@ export class SimS3ApiEndpoint {
         caller,
       );
 
-      return await simS3ApiResponse(route.commandName, output);
+      return await simS3ApiResponse(
+        route.commandName,
+        output,
+        apiRequest.query,
+      );
     } catch (error) {
       if (error instanceof SimSdkUnsupportedCommandError) {
         return errors.notImplemented(error.message);

--- a/src/service/s3/serve/sim-s3-presigned-response-headers.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-presigned-response-headers.iso.test.ts
@@ -1,0 +1,105 @@
+import { GetObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { assertIdentical } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  presignBucketName,
+  presignObjectKey,
+  presignSimulation,
+} from "../../../../test/s3/presign-simulation.js";
+
+/**
+ * A presigned read naming the headers it wants the Object served with.
+ *
+ * Real S3 lets the URL rather than the Object decide how a browser treats what
+ * comes back, which is what turns one stored PDF into a link that opens it and
+ * a link that downloads it under a name the application chose. Nothing about
+ * the Object changes, so the same Object is served both ways at once.
+ */
+describe("A presigned read of simulated S3 overriding its response headers", () => {
+  it("serves the headers the read named in place of the Object's own", async () => {
+    // Given a URL presigned for a stored PDF, asking for it as a download
+    const { client, http } = await presignSimulation();
+    const url = await getSignedUrl(
+      client,
+      new GetObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+        ResponseContentType: "application/octet-stream",
+        ResponseContentDisposition: 'attachment; filename="q3-report.pdf"',
+        ResponseCacheControl: "no-store",
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When it is read
+    const response = await http.fetch(url);
+
+    // Then the response carries what the URL named rather than what the
+    // Object was written with, so the browser saves the file
+    assertIdentical(
+      response.headers.get("content-type"),
+      "application/octet-stream",
+    );
+    assertIdentical(
+      response.headers.get("content-disposition"),
+      'attachment; filename="q3-report.pdf"',
+    );
+    assertIdentical(response.headers.get("cache-control"), "no-store");
+  });
+
+  it("leaves the Object holding the metadata it was written with", async () => {
+    // Given the same Object read once through a URL that overrode its type
+    const { client, http } = await presignSimulation();
+    const overriding = await getSignedUrl(
+      client,
+      new GetObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+        ResponseContentType: "application/octet-stream",
+      }),
+      { expiresIn: 900 },
+    );
+    await http.fetch(overriding);
+
+    // When it is read again through a URL that overrides nothing
+    const plain = await getSignedUrl(
+      client,
+      new GetObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+      }),
+      { expiresIn: 900 },
+    );
+    const response = await http.fetch(plain);
+
+    // Then it is served as the PDF it was stored as: the first read named a
+    // header for itself rather than writing one over the Object
+    assertIdentical(response.headers.get("content-type"), "application/pdf");
+  });
+
+  it("answers a HEAD with the headers that read named", async () => {
+    // Given a presigned HEAD asking what a download of the Object would say
+    const { client, http } = await presignSimulation();
+    const url = await getSignedUrl(
+      client,
+      new HeadObjectCommand({
+        Bucket: presignBucketName,
+        Key: presignObjectKey,
+        ResponseContentDisposition: 'attachment; filename="q3-report.pdf"',
+      }),
+      { expiresIn: 900 },
+    );
+
+    // When it is sent
+    const response = await http.fetch(url, { method: "HEAD" });
+
+    // Then it describes the response the matching GET would send, which is
+    // what a client checking a link before following it reads
+    assertIdentical(
+      response.headers.get("content-disposition"),
+      'attachment; filename="q3-report.pdf"',
+    );
+  });
+});

--- a/src/service/s3/serve/sim-s3-presigned-upload.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-presigned-upload.iso.test.ts
@@ -1,4 +1,4 @@
-import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import {
   assertIdentical,
@@ -11,6 +11,7 @@ import {
   presignBucketName,
   presignSimulation,
 } from "../../../../test/s3/presign-simulation.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
 
 /**
  * Uploads through a presigned PUT URL, and the checksum trap that comes with
@@ -23,6 +24,9 @@ import {
  * one that proves it works here.
  */
 describe("Uploading through a presigned simulated S3 URL", () => {
+  const objectUrl = (key: string): string =>
+    `http://${presignBucketName}.s3.eu-west-2.sim-aws.localhost/${key}`;
+
   it("refuses a body that does not match the checksum the SDK hoisted", async () => {
     // Given a URL presigned by a client left on its default checksum setting
     const { client, http } = await presignSimulation({
@@ -71,6 +75,82 @@ describe("Uploading through a presigned simulated S3 URL", () => {
     assertIdentical(stored?.body.length, 0);
   });
 
+  it("keeps every system metadata header the upload was sent with", async () => {
+    // Given a presigned upload URL for a file a static site serves
+    const { client, http, userArn } = await presignSimulation();
+    const url = await getSignedUrl(
+      client,
+      new PutObjectCommand({ Bucket: presignBucketName, Key: "app.js" }),
+      { expiresIn: 900 },
+    );
+
+    // When it is uploaded with the headers a site deployment sets
+    await http.fetch(url, {
+      method: "PUT",
+      body: "compressed bytes",
+      headers: {
+        "cache-control": "public, max-age=31536000, immutable",
+        "content-disposition": 'inline; filename="app.js"',
+        "content-encoding": "br",
+        "content-language": "en-GB",
+        "content-type": "text/javascript",
+        expires: "Sat, 02 Jan 2027 03:04:05 GMT",
+      },
+    });
+
+    // Then a later read is served every one of them, so a browser is told the
+    // bytes are brotli and how long to keep them
+    const response = await http.fetch(objectUrl("app.js"), {
+      headers: { "x-sim-aws-caller": userArn },
+    });
+    assertIdentical(
+      response.headers.get("cache-control"),
+      "public, max-age=31536000, immutable",
+    );
+    assertIdentical(
+      response.headers.get("content-disposition"),
+      'inline; filename="app.js"',
+    );
+    assertIdentical(response.headers.get("content-encoding"), "br");
+    assertIdentical(response.headers.get("content-language"), "en-GB");
+    assertIdentical(
+      response.headers.get("expires"),
+      "Sat, 02 Jan 2027 03:04:05 GMT",
+    );
+  });
+
+  it("keeps the user metadata the upload attached to the Object", async () => {
+    // Given a presigned upload URL
+    const { client, http, simAws } = await presignSimulation();
+    const url = await getSignedUrl(
+      client,
+      new PutObjectCommand({ Bucket: presignBucketName, Key: "invoice.pdf" }),
+      { expiresIn: 900 },
+    );
+
+    // When the upload attaches metadata of the caller's own
+    await http.fetch(url, {
+      method: "PUT",
+      body: "invoice bytes",
+      headers: {
+        "x-amz-meta-customer-id": "cust-4192",
+        "x-amz-meta-uploaded-by": "billing-portal",
+      },
+    });
+
+    // Then a read describes the Object with it, under the keys a
+    // PutObjectCommand would have stored it under
+    const stored = await simAws.s3().getObject(
+      new GetObjectCommand({
+        Bucket: presignBucketName,
+        Key: "invoice.pdf",
+      }),
+    );
+    assertDefined(stored.Metadata, "the stored user metadata");
+    assertIdentical(stored.Metadata["customer-id"], "cust-4192");
+    assertIdentical(stored.Metadata["uploaded-by"], "billing-portal");
+  });
+
   it("keeps the content type the upload was sent with", async () => {
     // Given a presigned upload URL
     const { client, http, userArn } = await presignSimulation();
@@ -88,10 +168,9 @@ describe("Uploading through a presigned simulated S3 URL", () => {
     });
 
     // Then the stored Object is served back with it
-    const response = await http.fetch(
-      `http://${presignBucketName}.s3.eu-west-2.sim-aws.localhost/report.csv`,
-      { headers: { "x-sim-aws-caller": userArn } },
-    );
+    const response = await http.fetch(objectUrl("report.csv"), {
+      headers: { "x-sim-aws-caller": userArn },
+    });
     assertIdentical(response.headers.get("content-type"), "text/csv");
   });
 });

--- a/src/service/s3/serve/sim-s3-rest-controller.ts
+++ b/src/service/s3/serve/sim-s3-rest-controller.ts
@@ -3,7 +3,7 @@ import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service
 import type { SimS3RestObjectRoute } from "./sim-s3-route.js";
 import { SimS3RestErrorResponse } from "./sim-s3-rest-error-response.js";
 import { SimS3RestObjectReader } from "./sim-s3-rest-object-reader.js";
-import { SimS3UploadChecksum } from "./sim-s3-upload-checksum.js";
+import { simS3RestUploadInput } from "./sim-s3-rest-upload.js";
 import type { SimS3 } from "../sim-s3.js";
 
 interface SimS3RestControllerProperties {
@@ -80,33 +80,14 @@ export class SimS3RestController {
   }
 
   /**
-   * Store an uploaded Object.
-   *
-   * The stated checksum is checked before anything is stored, as real S3 does,
-   * so an upload that would be refused there is refused here rather than
-   * quietly landing in the Bucket.
+   * Store an uploaded Object, as whatever the request said about it.
    */
   private async putObject(
     route: SimS3RestObjectRoute,
     serviceRequest: SimAwsServiceRequest,
   ): Promise<Response> {
-    const { request, body } = serviceRequest;
-
-    SimS3UploadChecksum.stated(new URL(request.url), request.headers)?.check(
-      body,
-    );
-
-    const contentType = request.headers.get("content-type") ?? undefined;
-
     await this.s3For(route).putObject(
-      {
-        input: {
-          Bucket: route.bucket.bucketName,
-          Key: route.objectKey,
-          Body: body ?? new Uint8Array(),
-          ...(contentType !== undefined && { ContentType: contentType }),
-        },
-      },
+      { input: simS3RestUploadInput(route, serviceRequest) },
       { caller: serviceRequest.caller.toCaller() },
     );
 

--- a/src/service/s3/serve/sim-s3-rest-object-reader.ts
+++ b/src/service/s3/serve/sim-s3-rest-object-reader.ts
@@ -1,7 +1,10 @@
 import type { SimS3 } from "../sim-s3.js";
 import type { SimS3RestObjectRoute } from "./sim-s3-route.js";
 import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
-import { simS3ObjectResponseHeaders } from "../object/s3-object-response-headers.js";
+import {
+  simS3ObjectResponseHeaders,
+  simS3ResponseHeaderOverrides,
+} from "../object/s3-object-response-headers.js";
 import { simS3SystemMetadataHeadersFrom } from "../object/s3-system-metadata-read.js";
 
 /**
@@ -10,6 +13,9 @@ import { simS3SystemMetadataHeadersFrom } from "../object/s3-system-metadata-rea
  * The two share everything but the body, because a `HEAD` is a `GET` whose
  * response real S3 stops short of sending, so they are read the same way here
  * and differ only in what comes back.
+ *
+ * Either can name the headers it wants served in place of the Object's own,
+ * which is what a presigned URL handing a browser a download does.
  *
  * A `GET` may ask for part of the Object, and is answered with that part and
  * `206 Partial Content`. A `HEAD` may not. Simulated S3 describes the whole
@@ -42,6 +48,9 @@ export class SimS3RestObjectReader {
     const body = await bodyBytes(output.Body);
     const headers = simS3ObjectResponseHeaders({
       metadata: simS3SystemMetadataHeadersFrom(output),
+      overrides: simS3ResponseHeaderOverrides(
+        new URL(request.url).searchParams,
+      ),
       bodyLength: body.length,
       etag: output.ETag,
       lastModified: output.LastModified,

--- a/src/service/s3/serve/sim-s3-rest-upload.ts
+++ b/src/service/s3/serve/sim-s3-rest-upload.ts
@@ -1,0 +1,36 @@
+import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import type { SimPutObjectCommandInput } from "../command/put-object/put-object.command.js";
+import { simS3WriteMetadataHeaders } from "../object/s3-write-metadata.js";
+import type { SimS3RestObjectRoute } from "./sim-s3-route.js";
+import { SimS3UploadChecksum } from "./sim-s3-upload-checksum.js";
+
+/**
+ * The write an upload over the S3 REST endpoint asks for.
+ *
+ * A presigned `PUT` states everything about the Object in its headers, since
+ * that is the only place it has to put anything. The metadata headers are read
+ * by the same list a `PutObjectCommand` sets them with, so an upload here can
+ * describe an Object as fully as an in-process write can. A static site upload
+ * usually wants `cache-control` and `content-disposition`.
+ *
+ * The stated checksum is checked while the request is read, as real S3 checks
+ * it before storing anything, so an upload that would be refused there is
+ * refused here instead of quietly landing in the Bucket.
+ */
+export function simS3RestUploadInput(
+  route: SimS3RestObjectRoute,
+  serviceRequest: SimAwsServiceRequest,
+): SimPutObjectCommandInput {
+  const { request, body } = serviceRequest;
+
+  SimS3UploadChecksum.stated(new URL(request.url), request.headers)?.check(
+    body,
+  );
+
+  return {
+    Bucket: route.bucket.bucketName,
+    Key: route.objectKey,
+    Body: body ?? new Uint8Array(),
+    ...simS3WriteMetadataHeaders(request.headers),
+  };
+}


### PR DESCRIPTION
An upload over the S3 REST endpoint keeps every system metadata header it was sent and every `x-amz-meta-` header it attached, matching what a `PutObjectCommand` stores, and the API endpoint reads `expires` alongside the headers it already read. A read served over either endpoint honours the `response-` parameters naming the headers it wants back, leaving the Object's own metadata as it was written. A listing given `EncodingType=url` encodes the keys, prefixes, delimiter and markers it answers with, and reports the encoding back. The header reading is shared between the two endpoints, and the REST upload input moved into a module of its own to keep the controller under the FTA threshold.

Resolves #1231