### PR TITLE
feat: put Lambda timers on the simulated clock

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -3141,6 +3141,129 @@ otherwise. A time read at module scope is therefore read too early, exactly as i
 variables. See [simulated time](https://yulinsim.dev/time/) for the whole picture, including where real
 AWS puts the time on the event.
 
+## Timers and the invocation deadline
+
+A handler's `setTimeout`, `clearTimeout`, `setInterval` and `clearInterval` measure their delays on
+the simulation's clock. A handler that sleeps wakes when a test advances time past its delay, and a
+frozen clock holds it asleep for as long as the test wants. The timers belong to one invocation. Two
+simulations running at once each keep their own, and code outside an invocation keeps the host
+timers it already had.
+
+A sleeping handler is released by the clock. A test asks for the invocation and moves time before
+waiting on the answer.
+
+```typescript sim-lambda-handler-timers
+/**
+ * A simulated Lambda handler sleeping on the simulation's clock.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "batcher",
+    Role: "arn:aws:iam::111111111111:role/BatcherRole",
+    Timeout: 60,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(async () => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 30_000);
+        });
+
+        return "batched";
+      }),
+    },
+  }),
+);
+
+// Asked for and left running, because the handler is waiting on the clock.
+const invocation = lambda.invoke(
+  new InvokeCommand({ FunctionName: "batcher" }),
+);
+
+await simAws.clock().advanceBy({ seconds: 30 });
+
+const output = await invocation;
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());
+```
+
+An interval runs once for each period an advance covers. Advancing eleven seconds past a two second
+interval runs it five times. A delay of zero, or none at all, is due at the instant it was asked
+for, and a handler yielding with `setTimeout(resolve, 0)` gets going again without the clock moving.
+
+The function's `Timeout` is a deadline on the same clock. Where it arrives before the handler
+answers, the invocation ends in the error the real runtime reports.
+
+```typescript sim-lambda-invocation-timeout
+/**
+ * A simulated Lambda invocation running out of the time its Timeout allows.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "slowcoach",
+    Role: "arn:aws:iam::111111111111:role/SlowcoachRole",
+    Timeout: 3,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(async () => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 60_000);
+        });
+
+        return "too late";
+      }),
+    },
+  }),
+);
+
+const invocation = lambda.invoke(
+  new InvokeCommand({ FunctionName: "slowcoach" }),
+);
+
+await simAws.clock().advanceBy({ seconds: 10 });
+
+const output = await invocation;
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+
+// Unhandled
+console.log(output.FunctionError);
+
+const failure = JSON.parse(Buffer.from(output.Payload).toString()) as {
+  errorType: string;
+  errorMessage: string;
+};
+
+// Sandbox.Timedout
+console.log(failure.errorType);
+// <deadline instant> <request id> Task timed out after 3.00 seconds
+console.log(failure.errorMessage);
+```
+
+The log group gets the `ERROR Invoke Error` line the runtime writes, and `AWS/Lambda` counts an
+`Errors` datapoint beside the `Invocations`. A handler that answers after its deadline reaches
+nobody, and the timers it left running are given up with the rest of the invocation.
+
+For an `Event` invocation a timeout is a failed attempt. It goes to the same
+[retries and destinations](#asynchronous-retries-and-destinations) an attempt that threw goes to.
+
+A frozen clock never reaches the deadline. A handler under one runs for as long as the host process
+lets it, and `context.getRemainingTimeInMillis()` reports the same budget throughout.
+
 ## What an invocation counts in CloudWatch
 
 Every invocation publishes `Invocations` and a `Duration` into `AWS/Lambda`, dimensioned by
@@ -3956,6 +4079,8 @@ Sim Lambda currently supports:
 - `ListFunctionsCommand`, reporting every function in the Account and Region, and their published
   versions with `FunctionVersion: "ALL"`
 - `InvokeCommand`, with the `RequestResponse`, `Event` and `DryRun` invocation types
+- Handler timers on the simulation's clock, and the function's `Timeout` as a deadline on the same
+  clock, reported as real Lambda reports a timeout
 - Asynchronous invocation retries on the simulated clock, and `OnSuccess`/`OnFailure` destinations
   written with `PutFunctionEventInvokeConfigCommand`, delivering the AWS destination record to a
   simulated SQS queue, SNS topic, EventBridge event bus or Lambda function after authorizing the
@@ -4048,8 +4173,9 @@ Current documented limitations:
   no dead-letter target. The `AWS::Lambda::EventInvokeConfig` Resource and the `DeadLetterConfig`
   property a CloudFormation or CDK template writes are both deployed. See
   [retries and destinations in templates](#retries-and-destinations-in-templates).
-- Throttling and timeouts do not drive a retry. A retry follows a handler that threw, and the
-  `MaximumEventAgeInSeconds` a config carries is measured from when the invocation was accepted.
+- Throttling does not drive a retry. A retry follows a handler that threw or ran out of time, and
+  the `MaximumEventAgeInSeconds` a config carries is measured from when the invocation was
+  accepted.
 - `DestinationConfig` on an event source mapping is left out. It is a different mechanism from the
   asynchronous invocation destinations above.
 - A settings change takes effect at once. Real Lambda reports `LastUpdateStatus: "InProgress"` while
@@ -4123,9 +4249,15 @@ Current documented limitations:
 - An unsigned request to a service API endpoint is served over HTTP when the simulation serves that
   endpoint, which today means Cognito's regional endpoint and the S3 endpoints. Anywhere else it is
   read as a Command and refused as one.
-- `Timeout` is recorded and never interrupts handler execution.
-- Timers inside a handler are host timers. `setTimeout` waits in real time, and advancing the
-  simulation's clock leaves a sleeping handler asleep.
+- A handler is interrupted at its deadline only where it yields. The deadline waits on the
+  simulation's clock like any other work, and dispatching it needs the event loop, so a handler
+  looping over the CPU without awaiting anything runs to the end of its loop.
+- The global `setTimeout`, `clearTimeout`, `setInterval` and `clearInterval` are the timers on the
+  simulation's clock. `node:timers`, `node:timers/promises` and `util.promisify(setTimeout)` are
+  imported directly rather than read from the globals, and they wait in real time.
+- Module-scope initialization time and execution environment recycling are left out. A cold start
+  costs nothing against the deadline, and a function keeps one warm environment for as long as it
+  exists.
 - A time read at module scope, like an environment variable read there, is read before any
   invocation and sees the host clock. See [The time inside a handler](#the-time-inside-a-handler).
 - `Event` invocation retries and failure destinations are left out, and handler errors are dropped.

--- a/docs/services/lambda/sim-lambda-handler-timers.example.ts
+++ b/docs/services/lambda/sim-lambda-handler-timers.example.ts
@@ -1,0 +1,39 @@
+/**
+ * A simulated Lambda handler sleeping on the simulation's clock.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "batcher",
+    Role: "arn:aws:iam::111111111111:role/BatcherRole",
+    Timeout: 60,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(async () => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 30_000);
+        });
+
+        return "batched";
+      }),
+    },
+  }),
+);
+
+// Asked for and left running, because the handler is waiting on the clock.
+const invocation = lambda.invoke(
+  new InvokeCommand({ FunctionName: "batcher" }),
+);
+
+await simAws.clock().advanceBy({ seconds: 30 });
+
+const output = await invocation;
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+console.log(Buffer.from(output.Payload).toString());

--- a/docs/services/lambda/sim-lambda-invocation-timeout.example.ts
+++ b/docs/services/lambda/sim-lambda-invocation-timeout.example.ts
@@ -1,0 +1,50 @@
+/**
+ * A simulated Lambda invocation running out of the time its Timeout allows.
+ */
+
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const lambda = simAws.lambda();
+
+await lambda.createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "slowcoach",
+    Role: "arn:aws:iam::111111111111:role/SlowcoachRole",
+    Timeout: 3,
+    Code: {
+      ZipFile: makeLambdaZipFileInput(async () => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 60_000);
+        });
+
+        return "too late";
+      }),
+    },
+  }),
+);
+
+const invocation = lambda.invoke(
+  new InvokeCommand({ FunctionName: "slowcoach" }),
+);
+
+await simAws.clock().advanceBy({ seconds: 10 });
+
+const output = await invocation;
+if (output.Payload === undefined) throw new Error("No invoke Payload");
+
+// Unhandled
+console.log(output.FunctionError);
+
+const failure = JSON.parse(Buffer.from(output.Payload).toString()) as {
+  errorType: string;
+  errorMessage: string;
+};
+
+// Sandbox.Timedout
+console.log(failure.errorType);
+// <deadline instant> <request id> Task timed out after 3.00 seconds
+console.log(failure.errorMessage);

--- a/src/service/lambda/command/create-function/create-function.handler.ts
+++ b/src/service/lambda/command/create-function/create-function.handler.ts
@@ -161,6 +161,7 @@ export class CreateFunctionCommandHandler implements CommandHandler<
       accountRegionScope: this.accountRegionScope,
       runAsOwner: this.runAsOwner,
       clock: this.background,
+      background: this.background,
       logs: this.logs,
       output: this.output,
       metrics: this.metrics,

--- a/src/service/lambda/command/invoke/async/sim-lambda-async-timeout.iso.test.ts
+++ b/src/service/lambda/command/invoke/async/sim-lambda-async-timeout.iso.test.ts
@@ -1,0 +1,151 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  makeQueue,
+  putEventInvokeConfig,
+  receivedRecord,
+  simLambdaQueueArn,
+} from "../../../../../../test/lambda/async-destination-fixture.js";
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { makeLambdaZipFileInput } from "../../../index.js";
+
+const functionName = "orders";
+
+/**
+ * One simulation holding a function with three seconds to answer in, whose
+ * handler always sleeps for a minute, and a count of how often it started.
+ */
+async function simAwsWithSlowFunction(): Promise<{
+  readonly simAws: SimAws;
+  readonly attemptCount: () => number;
+}> {
+  const simAws = new SimAws();
+  let attempts = 0;
+  const executionRole = await simIamRoleWithPolicyFactory.make(
+    {
+      roleName: "OrdersRole",
+      policyName: "DestinationDelivery",
+      actions: ["sqs:SendMessage"],
+      resource: "*",
+    },
+    simAws,
+  );
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: executionRole.Arn,
+      Timeout: 3,
+      Code: {
+        ZipFile: makeLambdaZipFileInput(async () => {
+          attempts += 1;
+          await new Promise((resolve) => {
+            setTimeout(resolve, 60_000);
+          });
+
+          return "late";
+        }),
+      },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return { simAws, attemptCount: (): number => attempts };
+}
+
+async function invokeAsync(simAws: SimAws): Promise<void> {
+  await simAws.lambda().invoke(
+    new InvokeCommand({
+      FunctionName: functionName,
+      InvocationType: "Event",
+      Payload: JSON.stringify({ id: 7 }),
+    }),
+  );
+}
+
+describe("an asynchronous sim Lambda invocation that runs out of time", () => {
+  it("counts a timeout as a failed attempt and retries it", async () => {
+    // Given a function whose handler never answers inside its three seconds.
+    const { simAws, attemptCount } = await simAwsWithSlowFunction();
+
+    // When it is invoked asynchronously and every retry falls due.
+    await invokeAsync(simAws);
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then it ran three times, which is the first attempt and the two retries
+    // real Lambda makes by default. A timeout is a failed attempt.
+    assertIdentical(attemptCount(), 3);
+  });
+
+  it("leaves an attempt running while its deadline is still ahead", async () => {
+    // Given a function whose handler is part way through its first attempt.
+    const { simAws, attemptCount } = await simAwsWithSlowFunction();
+
+    // When it is invoked asynchronously and time moves on by less than its
+    // three seconds.
+    await invokeAsync(simAws);
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then the advance came back rather than waiting for a handler only the
+    // clock can release, and nothing has been retried.
+    assertIdentical(attemptCount(), 1);
+  });
+
+  it("sends the timeout on to the failure destination", async () => {
+    // Given a slow function that gives up after one retry and sends what it
+    // gave up on to a queue.
+    const { simAws } = await simAwsWithSlowFunction();
+    const queueUrl = await makeQueue(simAws, "failures");
+    await putEventInvokeConfig(simAws, {
+      MaximumRetryAttempts: 1,
+      OnFailure: simLambdaQueueArn("failures"),
+    });
+
+    // When it is invoked asynchronously and both attempts run out of time.
+    await invokeAsync(simAws);
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then the record says the retries were exhausted, and carries the
+    // timeout the last attempt ended in.
+    const record = await receivedRecord(simAws, queueUrl);
+    assertIdentical(record.requestContext.condition, "RetriesExhausted");
+    assertIdentical(record.requestContext.approximateInvokeCount, 2);
+    assertIdentical(record.responseContext?.functionError, "Unhandled");
+
+    const payload = record.responsePayload as { errorType?: string };
+    assertNonNullable(payload.errorType, "the record carries an error type");
+    assertIdentical(payload.errorType, "Sandbox.Timedout");
+  });
+
+  it("dead-letters an event its function never answered", async () => {
+    // Given a slow function with a dead-letter queue and no retries.
+    const { simAws } = await simAwsWithSlowFunction();
+    const queueUrl = await makeQueue(simAws, "abandoned");
+    await putEventInvokeConfig(simAws, { MaximumRetryAttempts: 0 });
+    await simAws.lambda().updateFunctionConfiguration({
+      input: {
+        FunctionName: functionName,
+        DeadLetterConfig: { TargetArn: simLambdaQueueArn("abandoned") },
+      },
+    });
+
+    // When it is invoked asynchronously and its one attempt times out.
+    await invokeAsync(simAws);
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then the event itself is on the dead-letter queue.
+    const { Messages } = await simAws.sqs().receiveMessage({
+      input: { QueueUrl: queueUrl },
+    });
+    const [message] = Messages ?? [];
+    assertNonNullable(message?.Body, "the event was dead-lettered");
+    assertStringIncludes(message.Body, '"id":7');
+  });
+});

--- a/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
+++ b/src/service/lambda/function/code/vm/sim-lambda-vm-context.ts
@@ -12,6 +12,14 @@ import {
   type SimLambdaOutputSink,
 } from "../../logging/sim-lambda-output-sink.js";
 import { makeSimLambdaOutboundFetch } from "../../outbound/sim-lambda-outbound-fetch.js";
+import {
+  simLambdaClearInterval,
+  simLambdaClearTimeout,
+} from "../../invoke/timer/sim-lambda-clear-timer.js";
+import {
+  simLambdaSetInterval,
+  simLambdaSetTimeout,
+} from "../../invoke/timer/sim-lambda-process-timers.js";
 import type { SimLambdaOutboundHttp } from "../../outbound/sim-lambda-outbound-http.js";
 import { SimLambdaVmOutputStream } from "./sim-lambda-vm-output-stream.js";
 
@@ -93,10 +101,14 @@ export function makeSimLambdaVmContext(
     // Function code asking JavaScript for the time gets the simulation's
     // time, so a frozen or advanced clock reaches the code under test.
     Date: makeSimClockDate(clock),
-    setTimeout,
-    clearTimeout,
-    setInterval,
-    clearInterval,
+    // Timers wait on the simulation's clock too, so a sandboxed handler that
+    // sleeps is released by a test advancing time rather than by the host.
+    // They belong to whichever invocation is running in the sandbox, which is
+    // why they are resolved per call rather than built into it.
+    setTimeout: simLambdaSetTimeout,
+    clearTimeout: simLambdaClearTimeout,
+    setInterval: simLambdaSetInterval,
+    clearInterval: simLambdaClearInterval,
     setImmediate,
     queueMicrotask,
     TextEncoder,

--- a/src/service/lambda/function/invoke/sim-lambda-host-scope.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-host-scope.ts
@@ -5,6 +5,7 @@ import type { SimLambdaOutboundHttp } from "../outbound/sim-lambda-outbound-http
 import { simLambdaProcessClock } from "./sim-lambda-process-clock.js";
 import { simLambdaProcessOutbound } from "./sim-lambda-process-outbound.js";
 import { simLambdaProcessOutput } from "./sim-lambda-process-output.js";
+import { simLambdaProcessTimers } from "./timer/sim-lambda-process-timers.js";
 
 /**
  * What an invocation of host-scope code has bridged to it.
@@ -49,6 +50,10 @@ export async function runSimLambdaInHostScope<T>(
   run: () => Promise<T>,
 ): Promise<T> {
   const { clock, outboundHttp, output, outputSettings } = scope;
+
+  // Host-scope code reaches for the global timer functions, so the invocation
+  // its handler runs in has to be findable from them.
+  simLambdaProcessTimers.install();
 
   const recording =
     output === undefined

--- a/src/service/lambda/function/invoke/sim-lambda-invocation-deadline.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-invocation-deadline.ts
@@ -1,0 +1,114 @@
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import { SimLambdaClockTimer } from "./timer/sim-lambda-clock-timer.js";
+import { SimLambdaInvocationTimers } from "./timer/sim-lambda-invocation-timers.js";
+import { simLambdaProcessTimers } from "./timer/sim-lambda-process-timers.js";
+import { simLambdaTimedOutError } from "./sim-lambda-timed-out.error.js";
+
+const millisecondsPerSecond = 1000;
+
+interface SimLambdaInvocationDeadlineProperties {
+  readonly background: BackgroundScheduler;
+  readonly timeoutSeconds: number;
+  readonly awsRequestId: string;
+}
+
+/**
+ * The time one invocation has to finish in, and the timers it gets while it
+ * runs.
+ *
+ * Both wait on the simulation's clock. Whichever arrives first decides: a
+ * handler that answers in time is answered with, and a deadline that arrives
+ * first ends the invocation in the timeout error real Lambda reports. Nothing
+ * waits for a handler that has been timed out, and what it goes on to do
+ * reaches nobody, which is the closest an in-process simulation gets to an
+ * execution environment being taken away.
+ */
+export class SimLambdaInvocationDeadline {
+  readonly #properties: SimLambdaInvocationDeadlineProperties;
+
+  constructor(properties: SimLambdaInvocationDeadlineProperties) {
+    this.#properties = properties;
+  }
+
+  /**
+   * Run the handler with timers of its own, up to this deadline.
+   */
+  async around<T>(handler: () => Promise<T>): Promise<T> {
+    const { background, awsRequestId, timeoutSeconds } = this.#properties;
+    const stopped = Promise.withResolvers<never>();
+
+    // Read whether or not the race gets that far, so an invocation the handler
+    // wins never leaves this rejection unhandled.
+    // oxlint-disable-next-line unicorn-js/prefer-await -- nothing awaits it.
+    stopped.promise.catch(() => {
+      //
+    });
+
+    // Everything this invocation has on the clock stops the instant it is
+    // over, and the instant is what matters. Whatever ended it is inside a
+    // clock advance already walking towards the next thing due, and a timer
+    // given up a few turns of the microtask queue later has had time to run
+    // first. So an invocation ends its timers as it ends, rather than as the
+    // answer works its way out through everything wrapped around it.
+    const ending = (): void => {
+      timers.cancelAll();
+      deadline.cancel();
+    };
+    const failing = (error: unknown): void => {
+      ending();
+      stopped.reject(error);
+    };
+    const timers = new SimLambdaInvocationTimers({
+      background,
+      failed: failing,
+    });
+    const deadline = new SimLambdaClockTimer({
+      background,
+      run: (): void => {
+        failing(
+          simLambdaTimedOutError({
+            at: background.now(),
+            awsRequestId,
+            timeoutSeconds,
+          }),
+        );
+      },
+    });
+
+    deadline.startAt(
+      new Date(
+        background.now().getTime() + timeoutSeconds * millisecondsPerSecond,
+      ),
+    );
+
+    try {
+      return await background.outstanding(
+        async () => await racing(timers, stopped, handler, ending),
+      );
+    } finally {
+      ending();
+    }
+  }
+}
+
+/**
+ * Answer with whichever comes first, the handler or the end of its time.
+ */
+async function racing<T>(
+  timers: SimLambdaInvocationTimers,
+  stopped: PromiseWithResolvers<never>,
+  handler: () => Promise<T>,
+  ending: () => void,
+): Promise<T> {
+  return await simLambdaProcessTimers.run(timers, async () => {
+    const answer = handler();
+
+    // Ended as the handler settles rather than as the invocation finishes
+    // unwinding, and read either way, so a handler that fails after being
+    // timed out has nobody left to be unhandled at.
+    // oxlint-disable-next-line unicorn-js/prefer-await -- not waited for.
+    answer.then(ending, ending);
+
+    return await Promise.race([answer, stopped.promise]);
+  });
+}

--- a/src/service/lambda/function/invoke/sim-lambda-invocation-timeout.iso.test.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-invocation-timeout.iso.test.ts
@@ -1,0 +1,247 @@
+import { FilterLogEventsCommand } from "@aws-sdk/client-cloudwatch-logs";
+import { GetMetricStatisticsCommand } from "@aws-sdk/client-cloudwatch";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimInvokeCommandOutput } from "../../command/invoke/invoke.command.js";
+import { makeLambdaZipFileInput } from "../code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+
+const functionName = "slowcoach";
+const roleArn = "arn:aws:iam::888888888888:role/SlowcoachRole";
+const startedAt = new Date("2026-08-30T09:00:00.000Z");
+
+/**
+ * What an Invoke answered with when the handler failed.
+ */
+interface InvokeFailure {
+  readonly functionError: string | undefined;
+  readonly errorType: string;
+  readonly errorMessage: string;
+}
+
+/**
+ * A simulation stopped at a known instant, holding one function that has three
+ * seconds to answer in.
+ */
+async function simAwsWithFunction(handler: SimLambdaHandler): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.clock().setTo(startedAt);
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: roleArn,
+      Timeout: 3,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+
+  return simAws;
+}
+
+function invoking(simAws: SimAws): Promise<SimInvokeCommandOutput> {
+  return simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: functionName }));
+}
+
+async function failedWith(
+  invocation: ReturnType<typeof invoking>,
+): Promise<InvokeFailure> {
+  const output = await invocation;
+  assertNonNullable(output.Payload, "the invocation answered with a payload");
+
+  const document = JSON.parse(Buffer.from(output.Payload).toString()) as {
+    errorType: string;
+    errorMessage: string;
+  };
+
+  return { functionError: output.FunctionError, ...document };
+}
+
+/** Everything the function wrote to its log group. */
+async function loggedLines(simAws: SimAws): Promise<readonly string[]> {
+  const { events } = await simAws.logs().filterLogEvents(
+    new FilterLogEventsCommand({
+      logGroupName: `/aws/lambda/${functionName}`,
+    }),
+  );
+
+  assertNonNullable(events, "the log group answered with its events");
+
+  return events.map((event) => event.message);
+}
+
+/** The `Sum` of one AWS/Lambda metric this function published. */
+async function counted(
+  simAws: SimAws,
+  metricName: string,
+): Promise<number | undefined> {
+  const statistics = new GetMetricStatisticsCommand({
+    Namespace: "AWS/Lambda",
+    MetricName: metricName,
+    Dimensions: [{ Name: "FunctionName", Value: functionName }],
+    StartTime: startedAt,
+    EndTime: new Date(startedAt.getTime() + 300_000),
+    Period: 300,
+    Statistics: ["Sum"],
+  });
+  const { Datapoints } = await simAws
+    .cloudWatch()
+    .getMetricStatistics(statistics);
+
+  return Datapoints?.at(0)?.Sum;
+}
+
+describe("a sim Lambda invocation that runs out of time", () => {
+  it("answers the caller with the Lambda timeout error", async () => {
+    // Given a function with three seconds to answer in, whose handler sleeps
+    // for a minute.
+    const simAws = await simAwsWithFunction(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 60_000);
+      });
+
+      return "late";
+    });
+
+    // When it is invoked and simulated time passes its deadline.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 10 });
+
+    // Then the caller got the error real Lambda reports for a timeout, timed
+    // and named as the runtime names it.
+    const failure = await failedWith(invocation);
+    assertIdentical(failure.functionError, "Unhandled");
+    assertIdentical(failure.errorType, "Sandbox.Timedout");
+    assertStringIncludes(
+      failure.errorMessage,
+      "Task timed out after 3.00 seconds",
+    );
+    assertStringIncludes(failure.errorMessage, "2026-08-30T09:00:03.000Z");
+  });
+
+  it("ignores what a handler goes on to do after its deadline", async () => {
+    // Given a handler that answers a minute after its three seconds are up,
+    // and sets a timer for after that.
+    let ranLate = false;
+    const simAws = await simAwsWithFunction(async () => {
+      setTimeout(() => {
+        ranLate = true;
+      }, 90_000);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 60_000);
+      });
+
+      return "late";
+    });
+
+    // When it is invoked and time passes both the deadline and the answer.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ minutes: 5 });
+
+    // Then the caller still has the timeout, and the timer the invocation
+    // left behind never ran.
+    const failure = await failedWith(invocation);
+    assertIdentical(failure.errorType, "Sandbox.Timedout");
+    assertFalse(ranLate, "the abandoned timer never ran");
+  });
+
+  it("records the timeout in the function's log group", async () => {
+    // Given a function whose handler never answers in time.
+    const simAws = await simAwsWithFunction(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 60_000);
+      });
+
+      return "late";
+    });
+
+    // When it is invoked and its deadline passes.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 10 });
+    await invocation;
+
+    // Then the runtime wrote the failure where a test goes looking for it.
+    const [line] = await loggedLines(simAws);
+    assertNonNullable(line, "the invocation logged something");
+    assertStringIncludes(line, "ERROR Invoke Error");
+    assertStringIncludes(line, "Sandbox.Timedout");
+  });
+
+  it("counts a timeout as an error the function published", async () => {
+    // Given a function whose handler never answers in time.
+    const simAws = await simAwsWithFunction(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 60_000);
+      });
+
+      return "late";
+    });
+
+    // When it is invoked and its deadline passes.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 10 });
+    await invocation;
+
+    // Then AWS/Lambda counted the invocation and counted it as an error, as
+    // it counts a handler that threw.
+    assertIdentical(await counted(simAws, "Invocations"), 1);
+    assertIdentical(await counted(simAws, "Errors"), 1);
+  });
+
+  it("leaves a handler that answers in time alone", async () => {
+    // Given a handler that sleeps for one of its three seconds.
+    const simAws = await simAwsWithFunction(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      });
+
+      return "in time";
+    });
+
+    // When it is invoked and time moves past both its sleep and its deadline.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 10 });
+
+    // Then it answered, and nothing counted an error: the deadline it beat is
+    // given up with the rest of the invocation.
+    const output = await invocation;
+    assertUndefined(output.FunctionError);
+    assertUndefined(await counted(simAws, "Errors"));
+  });
+
+  it("fails the invocation where a timer callback throws", async () => {
+    // Given a handler waiting on work a timer of its own does badly.
+    const simAws = await simAwsWithFunction(async () => {
+      setTimeout(() => {
+        throw new Error("timer callback failed");
+      }, 1000);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 2000);
+      });
+
+      return "unreached";
+    });
+
+    // When it is invoked and the timer falls due.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 2 });
+
+    // Then the invocation failed with what the callback threw, rather than
+    // the error escaping into whatever moved the clock.
+    const failure = await failedWith(invocation);
+    assertIdentical(failure.errorType, "Error");
+    assertIdentical(failure.errorMessage, "timer callback failed");
+  });
+});

--- a/src/service/lambda/function/invoke/sim-lambda-invocation.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-invocation.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from "node:crypto";
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+import { SimLambdaHandlerRunner } from "./sim-lambda-handler-runner.js";
+import { SimLambdaInvokeContextBuilder } from "./sim-lambda-invoke-context-builder.js";
+import { SimLambdaInvocationDeadline } from "./sim-lambda-invocation-deadline.js";
+
+interface SimLambdaInvocationProperties {
+  readonly functionName: string;
+
+  /** The version the invocation is running, which is `$LATEST` or a number. */
+  readonly functionVersion: string;
+  readonly invokedFunctionArn: string;
+  readonly timeoutSeconds: number;
+  readonly memorySizeMb: number;
+  readonly logGroupName: string;
+
+  /** The stream this invocation's execution environment writes to. */
+  readonly logStreamName: string;
+
+  /** The clock the remaining time is measured against. */
+  readonly clock: SimClock;
+
+  /**
+   * The scheduler this invocation's timers and deadline wait on. A function
+   * built standalone, outside a SimAws instance, has none, and its handler
+   * keeps the host timers every other line in the process uses.
+   */
+  readonly background: BackgroundScheduler | undefined;
+}
+
+/**
+ * One run of a sim Lambda function's handler.
+ *
+ * It holds what the handler's own context reports, including the request id
+ * the invocation is known by, and it runs the handler inside the time it has
+ * to finish in. A function built standalone, outside a SimAws instance, has no
+ * scheduler for that deadline to wait on, and its handler runs for as long as
+ * it likes on the host timers every other line in the process uses.
+ */
+export class SimLambdaInvocation {
+  readonly #properties: SimLambdaInvocationProperties;
+  readonly #runner = new SimLambdaHandlerRunner();
+  readonly #awsRequestId = randomUUID();
+
+  constructor(properties: SimLambdaInvocationProperties) {
+    this.#properties = properties;
+  }
+
+  /**
+   * Run a handler function for one invocation event, up to this invocation's
+   * deadline.
+   *
+   * Resolves with the handler result, or rejects with the handler error or
+   * the timeout.
+   */
+  async run(
+    handlerFunction: SimLambdaHandler,
+    event: unknown,
+  ): Promise<unknown> {
+    const contextBuilder = new SimLambdaInvokeContextBuilder({
+      ...this.#properties,
+      awsRequestId: this.#awsRequestId,
+    });
+
+    const handler = async (): Promise<unknown> =>
+      await this.#runner.run(handlerFunction, event, contextBuilder);
+    const { background, timeoutSeconds } = this.#properties;
+
+    if (background === undefined) {
+      return await handler();
+    }
+
+    return await new SimLambdaInvocationDeadline({
+      background,
+      timeoutSeconds,
+      awsRequestId: this.#awsRequestId,
+    }).around(handler);
+  }
+}

--- a/src/service/lambda/function/invoke/sim-lambda-invoke-context-builder.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-invoke-context-builder.ts
@@ -25,6 +25,13 @@ interface SimLambdaInvokeContextBuilderProperties {
    * handler with a constant budget, rather than one that drains in real time.
    */
   readonly clock?: SimClock | undefined;
+
+  /**
+   * The request id this invocation is known by. It comes from outside because
+   * the invocation names itself in the error it reports when it runs out of
+   * time, and a handler reading `awsRequestId` has to see the same one.
+   */
+  readonly awsRequestId?: string | undefined;
 }
 
 /**
@@ -51,9 +58,9 @@ export class SimLambdaInvokeContextBuilder {
       logGroupName,
       logStreamName,
       clock = new SimRealClock(),
+      awsRequestId = randomUUID(),
     } = this.properties;
     const startedAtMs = clock.now().getTime();
-    const awsRequestId = randomUUID();
 
     return {
       callbackWaitsForEmptyEventLoop: true,

--- a/src/service/lambda/function/invoke/sim-lambda-timed-out.error.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-timed-out.error.ts
@@ -1,0 +1,34 @@
+import { SimLambdaRuntimeError } from "../../error/sim-lambda-runtime.error.js";
+
+/** What real Lambda calls an invocation that ran out of time. */
+const timedOutErrorType = "Sandbox.Timedout";
+
+interface SimLambdaTimedOutProperties {
+  /** The instant the invocation's time ran out. */
+  readonly at: Date;
+  readonly awsRequestId: string;
+  readonly timeoutSeconds: number;
+}
+
+/**
+ * The error real Lambda answers a caller with when time ran out.
+ *
+ * The message names the invocation and how long it had, the way the runtime
+ * writes it to the log group and puts it in the Invoke response payload.
+ */
+export function simLambdaTimedOutError(
+  properties: SimLambdaTimedOutProperties,
+): SimLambdaRuntimeError {
+  const { at, awsRequestId, timeoutSeconds } = properties;
+  const error = new SimLambdaRuntimeError(
+    timedOutErrorType,
+    `${at.toISOString()} ${awsRequestId} Task timed out after ${timeoutSeconds.toFixed(2)} seconds`,
+  );
+
+  // Nothing in the handler threw, so there are no handler frames to report,
+  // and the simulator's own are no use to whoever reads the payload. Real
+  // Lambda reports a timeout without a stack at all.
+  error.stack = `${error.name}: ${error.message}`;
+
+  return error;
+}

--- a/src/service/lambda/function/invoke/timer/sim-lambda-clear-timer.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-clear-timer.ts
@@ -1,0 +1,42 @@
+import {
+  clearInterval as hostClearInterval,
+  clearTimeout as hostClearTimeout,
+} from "node:timers";
+import { SimLambdaTimerHandle } from "./sim-lambda-timer-handle.js";
+
+/** Whatever a caller passes to `clearTimeout` or `clearInterval`. */
+type SimLambdaTimerGiven = SimLambdaTimerHandle | NodeJS.Timeout | undefined;
+
+/**
+ * Give up a timer, whichever kind of timer it turned out to be.
+ */
+export function simLambdaClearTimeout(handle: SimLambdaTimerGiven): void {
+  giveUp(handle, hostClearTimeout);
+}
+
+/**
+ * Give up a repeating timer, whichever kind of timer it turned out to be.
+ */
+export function simLambdaClearInterval(handle: SimLambdaTimerGiven): void {
+  giveUp(handle, hostClearInterval);
+}
+
+/**
+ * Give up a timer on the timeline it was made on.
+ *
+ * The handle says which. A simulated one is given up on the invocation that
+ * made it rather than on whichever invocation is running now, so a handle
+ * passed around clears what it names.
+ */
+function giveUp(
+  handle: SimLambdaTimerGiven,
+  hostClear: (handle: NodeJS.Timeout | undefined) => void,
+): void {
+  if (handle instanceof SimLambdaTimerHandle) {
+    handle.cancel();
+
+    return;
+  }
+
+  hostClear(handle);
+}

--- a/src/service/lambda/function/invoke/timer/sim-lambda-clock-timer.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-clock-timer.ts
@@ -1,0 +1,133 @@
+import { clearTimeout, setTimeout } from "node:timers";
+import type {
+  BackgroundScheduler,
+  BackgroundTask,
+} from "../../../../../util/background/background.js";
+import { simLambdaTimerDelay } from "./sim-lambda-timer-delay.js";
+
+/** The longest delay a host timer takes before it fires straight away. */
+const longestHostDelayMilliseconds = 2_147_483_647;
+
+interface SimLambdaClockTimerProperties {
+  readonly background: BackgroundScheduler;
+
+  /** What happens once simulated time reaches this timer's instant. */
+  readonly run: () => void;
+}
+
+/**
+ * One thing that happens when a simulation's clock reaches an instant.
+ *
+ * The instant is what decides, and simulated time can arrive at it two ways. A
+ * test that moves the clock brings it there at once, which is what the
+ * scheduler's own clock-waiting queue is for. A simulation left running keeps
+ * time with the host, and nothing dispatches that queue, so the timer also
+ * keeps a host timer of its own and asks the clock again when it fires. A
+ * clock that has not got there yet is asked again later, which is what makes a
+ * frozen clock hold a timer indefinitely without spinning on it.
+ *
+ * The host timer is unreferenced, so a simulation nobody is driving never
+ * holds the process open.
+ */
+export class SimLambdaClockTimer {
+  readonly #background: BackgroundScheduler;
+  readonly #run: () => void;
+  readonly #task: BackgroundTask = (): Promise<void> => {
+    this.#dispatch();
+
+    return Promise.resolve();
+  };
+
+  #dueTime: Date;
+  #delay = 0;
+  #hostTimer: NodeJS.Timeout | undefined;
+
+  constructor(properties: SimLambdaClockTimerProperties) {
+    this.#background = properties.background;
+    this.#run = properties.run;
+    this.#dueTime = properties.background.now();
+  }
+
+  /**
+   * Wait a delay of simulated time, and answer with how long that turned out
+   * to be. A delay of nothing leaves the timer due where the clock already
+   * reads, which is not waiting on the clock at all.
+   */
+  startIn(delay: number | undefined): number {
+    this.#delay = simLambdaTimerDelay(delay);
+    this.startAt(new Date(this.#background.now().getTime() + this.#delay));
+
+    return this.#delay;
+  }
+
+  /**
+   * Wait the same delay again, measured from the instant this timer was last
+   * due rather than from the time its work ran, so an advance covering several
+   * periods runs the work once for each of them.
+   */
+  again(): void {
+    this.startAt(new Date(this.#dueTime.getTime() + this.#delay));
+  }
+
+  /**
+   * Wait for simulated time to reach an instant, giving up whatever this timer
+   * was waiting for before.
+   */
+  startAt(dueTime: Date): void {
+    this.cancel();
+    this.#dueTime = dueTime;
+    this.#background.scheduleAt(dueTime, this.#task);
+    this.#armHostTimer();
+  }
+
+  /**
+   * Give up on this timer, on both timelines.
+   */
+  cancel(): void {
+    this.#background.cancelScheduled(this.#task);
+    clearTimeout(this.#hostTimer);
+    this.#hostTimer = undefined;
+  }
+
+  /**
+   * Run this timer's work, on whichever timeline got there first.
+   *
+   * Taking it off both timelines first is what makes it happen once, and what
+   * leaves work that starts this timer again beginning from nothing rather
+   * than from a turn already queued.
+   */
+  #dispatch(): void {
+    this.cancel();
+    this.#run();
+  }
+
+  /**
+   * Ask the clock again when the host gets to the delay this timer has left.
+   */
+  #armHostTimer(): void {
+    this.#hostTimer = setTimeout(() => {
+      this.#hostTimer = undefined;
+
+      if (this.#dueTime.getTime() <= this.#background.now().getTime()) {
+        this.#dispatch();
+
+        return;
+      }
+
+      this.#armHostTimer();
+    }, this.#remainingHostDelay());
+    this.#hostTimer.unref();
+  }
+
+  /**
+   * How long the host should wait before asking the clock again, kept inside
+   * what a host timer can hold: a longer one fires at once, and a timer that
+   * fired at once and found nothing due would spin.
+   */
+  #remainingHostDelay(): number {
+    const remaining =
+      this.#dueTime.getTime() - this.#background.now().getTime();
+
+    return Math.min(Math.max(remaining, 0), longestHostDelayMilliseconds);
+  }
+}

--- a/src/service/lambda/function/invoke/timer/sim-lambda-handler-timers.iso.test.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-handler-timers.iso.test.ts
@@ -1,0 +1,350 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertFalse,
+  assertIdentical,
+  assertNonNullable,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import type { SimInvokeCommandOutput } from "../../../command/invoke/invoke.command.js";
+import { makeLambdaZipFileInput } from "../../code/lambda-zip-file-input.js";
+import { makeLambdaCodeZip } from "../../code/make-lambda-code-zip.js";
+import type { SimLambdaHandler } from "../../sim-lambda-handler.type.js";
+
+const functionName = "sleeper";
+const roleArn = "arn:aws:iam::888888888888:role/SleeperRole";
+
+/**
+ * Wait inside a handler, on whatever `setTimeout` means where it runs.
+ */
+async function sleep(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+/**
+ * Wait for real time to pass, which is what a test outside an invocation gets
+ * from a timer.
+ */
+async function hostPause(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+/**
+ * A simulation holding one function with room to run for five minutes, backed
+ * by a real in-process handler.
+ */
+async function simAwsWithHandler(handler: SimLambdaHandler): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: roleArn,
+      Timeout: 300,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * The same, backed by zip code running in the vm sandbox.
+ */
+async function simAwsWithZipCode(source: string): Promise<SimAws> {
+  const simAws = new SimAws();
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: roleArn,
+      Timeout: 300,
+      Handler: "index.handler",
+      Code: { ZipFile: makeLambdaCodeZip(source) },
+    }),
+  );
+
+  return simAws;
+}
+
+/**
+ * Ask for an invocation without waiting for it, so the clock can be moved
+ * while the handler is part way through.
+ */
+function invoking(simAws: SimAws): Promise<SimInvokeCommandOutput> {
+  return simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: functionName }));
+}
+
+async function answeredWith(
+  invocation: Promise<SimInvokeCommandOutput>,
+): Promise<unknown> {
+  const output = await invocation;
+  assertNonNullable(output.Payload, "the invocation answered with a payload");
+
+  return JSON.parse(Buffer.from(output.Payload).toString()) as unknown;
+}
+
+describe("the timers a sim Lambda handler is given", () => {
+  it("releases a sleeping handler when the clock reaches its timer", async () => {
+    // Given a function whose handler sleeps for half a minute.
+    const simAws = await simAwsWithHandler(async () => {
+      await sleep(30_000);
+
+      return "awake";
+    });
+
+    // When it is invoked and simulated time moves on by that long.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 30 });
+
+    // Then the handler woke up and answered, without half a minute of the
+    // test run having passed.
+    assertIdentical(await answeredWith(invocation), "awake");
+  });
+
+  it("leaves a sleeping handler asleep until its own instant arrives", async () => {
+    // Given a function whose handler sleeps for half a minute.
+    let woke = false;
+    const simAws = await simAwsWithHandler(async () => {
+      await sleep(30_000);
+      woke = true;
+
+      return "awake";
+    });
+
+    // When it is invoked and time moves on by less than that.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 29 });
+
+    // Then it is still asleep, and the last second releases it.
+    assertFalse(woke, "the handler was still sleeping");
+    await simAws.clock().advanceBy({ seconds: 1 });
+    assertIdentical(await answeredWith(invocation), "awake");
+  });
+
+  it("runs nothing for a timer the handler cleared", async () => {
+    // Given a handler that sets a timer and then thinks better of it.
+    let fired = false;
+    const simAws = await simAwsWithHandler(async () => {
+      const timer = setTimeout(() => {
+        fired = true;
+      }, 5000);
+      clearTimeout(timer);
+      await sleep(30_000);
+
+      return "done";
+    });
+
+    // When it is invoked and time moves well past the cleared timer.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 30 });
+    await invocation;
+
+    // Then the callback never ran.
+    assertFalse(fired, "the cleared timer stayed cleared");
+  });
+
+  it("runs an interval once for each period the clock passes", async () => {
+    // Given a handler counting a two second interval while it sleeps.
+    let ticks = 0;
+    const simAws = await simAwsWithHandler(async () => {
+      const interval = setInterval(() => {
+        ticks += 1;
+      }, 2000);
+      await sleep(11_000);
+      clearInterval(interval);
+
+      return ticks;
+    });
+
+    // When it is invoked and eleven seconds of simulated time pass.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 11 });
+
+    // Then the interval ran once for each of the five periods.
+    assertIdentical(await answeredWith(invocation), 5);
+  });
+
+  it("gives sandboxed zip code timers on the same clock", async () => {
+    // Given zip code that sleeps in the vm sandbox.
+    const simAws = await simAwsWithZipCode(`
+      exports.handler = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 45000));
+
+        return "awake";
+      };
+    `);
+
+    // When it is invoked and simulated time moves on by that long.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 45 });
+
+    // Then the sandboxed handler woke up too: its timers come from the
+    // simulation, as its Date does.
+    assertIdentical(await answeredWith(invocation), "awake");
+  });
+
+  it("answers with a handle a handler can ask about", async () => {
+    // Given a handler that asks its timer to stop holding the process open,
+    // as code written for the real runtime is free to.
+    const simAws = await simAwsWithHandler(async () => {
+      const timer = setTimeout(() => undefined, 5000);
+      const held = timer.unref().ref().hasRef();
+      clearTimeout(timer);
+      await sleep(1000);
+
+      return held;
+    });
+
+    // When it is invoked and its sleep falls due.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then the handle answered, and a simulated timer holds nothing open.
+    assertFalse(await answeredWith(invocation));
+  });
+
+  it("gives up the timers an invocation left running", async () => {
+    // Given a handler that sets a timer and returns without waiting for it.
+    let fired = false;
+    const simAws = await simAwsWithHandler(() => {
+      setTimeout(() => {
+        fired = true;
+      }, 5000);
+
+      return "returned";
+    });
+
+    // When it is invoked and time moves past what it left behind.
+    assertIdentical(await answeredWith(invoking(simAws)), "returned");
+    await simAws.clock().advanceBy({ seconds: 30 });
+
+    // Then nothing came of it: the invocation is over, and an execution
+    // environment that has answered runs nothing more.
+    assertFalse(fired, "the abandoned timer never ran");
+  });
+
+  it("keeps each simulation's timers to its own clock", async () => {
+    // Given two simulations, each with a handler sleeping ten seconds.
+    let slept = false;
+    const first = await simAwsWithHandler(async () => {
+      await sleep(10_000);
+
+      return "first";
+    });
+    const second = await simAwsWithHandler(async () => {
+      await sleep(10_000);
+      slept = true;
+
+      return "second";
+    });
+
+    // When both are invoked and only one simulation's clock moves.
+    const firstInvocation = invoking(first);
+    const secondInvocation = invoking(second);
+    await first.clock().advanceBy({ seconds: 10 });
+
+    // Then only that one's handler woke: moving time in one simulation
+    // reaches nothing in another.
+    assertIdentical(await answeredWith(firstInvocation), "first");
+    assertFalse(slept, "the other simulation's handler was still sleeping");
+
+    await second.clock().advanceBy({ seconds: 10 });
+    assertIdentical(await answeredWith(secondInvocation), "second");
+  });
+
+  it("holds a sleeping handler while host time passes and the clock does not", async () => {
+    // Given a handler sleeping five milliseconds, on a stopped clock.
+    let woke = false;
+    const simAws = await simAwsWithHandler(async () => {
+      await sleep(5);
+      woke = true;
+
+      return "awake";
+    });
+    simAws.clock().freeze();
+
+    // When it is invoked and real time passes without simulated time moving.
+    const invocation = invoking(simAws);
+    await hostPause(30);
+
+    // Then it is still asleep however long the host has been running, and the
+    // clock reaching its instant is what wakes it.
+    assertFalse(woke, "the handler slept through the host's own time");
+    await simAws.clock().advanceBy({ milliseconds: 5 });
+    assertIdentical(await answeredWith(invocation), "awake");
+  });
+
+  it("gets a handler going again for a timer that asked for no delay", async () => {
+    // Given a handler that yields the way ordinary JavaScript yields, on a
+    // stopped clock.
+    const simAws = await simAwsWithHandler(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve);
+      });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      return "yielded";
+    });
+    simAws.clock().freeze();
+
+    // When it is invoked and the clock is left where it is.
+    // Then it got going again: a timer that asked for no time needs none to
+    // pass, however still the simulation's clock is being held.
+    assertIdentical(await answeredWith(invoking(simAws)), "yielded");
+  });
+
+  it("holds a delay longer than a host timer can measure", async () => {
+    // Given a handler that sets a timer forty days out, past the longest
+    // delay a host timer holds, and then sleeps for a second.
+    let fired = false;
+    const simAws = await simAwsWithHandler(async () => {
+      setTimeout(
+        () => {
+          fired = true;
+        },
+        40 * 24 * 60 * 60 * 1000,
+      );
+      await sleep(1000);
+
+      return "awake";
+    });
+
+    // When it is invoked and a second of simulated time passes.
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy({ seconds: 1 });
+
+    // Then the far-off timer waited where it was put, rather than firing at
+    // once as a host timer given a delay it cannot hold does.
+    assertIdentical(await answeredWith(invocation), "awake");
+    assertFalse(fired, "the far-off timer stayed where it was put");
+  });
+
+  it("leaves the host's own timers alone outside an invocation", async () => {
+    // Given a simulation whose handler has run, installing the substitutes.
+    const simAws = await simAwsWithHandler(() => "done");
+    await answeredWith(invoking(simAws));
+
+    // When the test run sets timers of its own, on a clock it never moved.
+    let ticks = 0;
+    const repeating = setInterval(() => {
+      ticks += 1;
+    }, 1);
+    await hostPause(20);
+    clearInterval(repeating);
+
+    // Then they ran in real time, as they would have without a simulation in
+    // the process at all.
+    assertTrue(ticks > 0, "the host's own interval kept its own time");
+  });
+});

--- a/src/service/lambda/function/invoke/timer/sim-lambda-host-timers.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-host-timers.ts
@@ -1,0 +1,45 @@
+import {
+  setInterval as hostSetInterval,
+  setTimeout as hostSetTimeout,
+} from "node:timers";
+import type {
+  SimLambdaTimerCallback,
+  SimLambdaTimers,
+} from "./sim-lambda-timer-handle.js";
+
+/**
+ * The timers code outside a sim Lambda invocation gets, which are the host's
+ * own.
+ *
+ * A test run's own timers, a test framework's, and one simulation's while
+ * another is running an invocation all come through here, so the substitutes
+ * installed over the globals behave exactly as the globals they replaced.
+ */
+class SimLambdaHostTimers implements SimLambdaTimers {
+  /**
+   * Run a callback once a delay of real time has passed.
+   */
+  setTimeout(
+    callback: SimLambdaTimerCallback,
+    delay?: number,
+    ...arguments_: unknown[]
+  ): NodeJS.Timeout {
+    return hostSetTimeout(callback, delay, ...(arguments_ as []));
+  }
+
+  /**
+   * Run a callback every time a delay of real time passes.
+   */
+  setInterval(
+    callback: SimLambdaTimerCallback,
+    delay?: number,
+    ...arguments_: unknown[]
+  ): NodeJS.Timeout {
+    return hostSetInterval(callback, delay, ...(arguments_ as []));
+  }
+}
+
+/**
+ * Shared because it holds nothing: every caller wants the same host timers.
+ */
+export const simLambdaHostTimers = new SimLambdaHostTimers();

--- a/src/service/lambda/function/invoke/timer/sim-lambda-invocation-timers.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-invocation-timers.ts
@@ -1,0 +1,153 @@
+import type { BackgroundScheduler } from "../../../../../util/background/background.js";
+import { SimLambdaClockTimer } from "./sim-lambda-clock-timer.js";
+import {
+  type SimLambdaTimerCallback,
+  SimLambdaTimerHandle,
+  type SimLambdaTimerOwner,
+  type SimLambdaTimers,
+} from "./sim-lambda-timer-handle.js";
+
+interface SimLambdaInvocationTimersProperties {
+  readonly background: BackgroundScheduler;
+
+  /** Where an error thrown out of a timer callback goes. */
+  readonly failed: (error: unknown) => void;
+}
+
+/**
+ * The timers one sim Lambda invocation has asked for.
+ *
+ * A handler's `setTimeout` measures its delay on the simulation's clock, so a
+ * test advancing time by the delay is what releases a sleeping handler, and a
+ * frozen clock leaves it asleep for as long as the test likes. The timers
+ * belong to the invocation rather than to the process: two simulations running
+ * at once each keep their own, and each one's are given up when its invocation
+ * ends, the way a real execution environment is frozen once it has answered.
+ *
+ * While any of them is outstanding the invocation is waiting on the clock, so
+ * whatever is waiting for the simulation to settle stops waiting for it.
+ * Nothing but the clock is going to release it, and moving the clock is what
+ * that wait is holding up.
+ */
+export class SimLambdaInvocationTimers
+  implements SimLambdaTimers, SimLambdaTimerOwner
+{
+  readonly #background: BackgroundScheduler;
+  readonly #failed: (error: unknown) => void;
+  readonly #running = new Map<SimLambdaTimerHandle, SimLambdaClockTimer>();
+
+  #released: (() => void) | undefined;
+
+  constructor(properties: SimLambdaInvocationTimersProperties) {
+    this.#background = properties.background;
+    this.#failed = properties.failed;
+  }
+
+  /**
+   * Run a callback once simulated time has moved on by a delay.
+   */
+  setTimeout(
+    callback: SimLambdaTimerCallback,
+    delay?: number,
+    ...arguments_: unknown[]
+  ): SimLambdaTimerHandle {
+    return this.#start(delay, (handle) => {
+      this.#forget(handle);
+      this.#call(callback, arguments_);
+    });
+  }
+
+  /**
+   * Run a callback every time simulated time moves on by a delay.
+   */
+  setInterval(
+    callback: SimLambdaTimerCallback,
+    delay?: number,
+    ...arguments_: unknown[]
+  ): SimLambdaTimerHandle {
+    return this.#start(delay, (_handle, timer) => {
+      timer.again();
+      this.#call(callback, arguments_);
+    });
+  }
+
+  /**
+   * Give up one timer, as `clearTimeout` and `clearInterval` do.
+   */
+  clear(handle: SimLambdaTimerHandle): void {
+    this.#running.get(handle)?.cancel();
+    this.#forget(handle);
+  }
+
+  /**
+   * Give up every timer this invocation still has outstanding.
+   */
+  cancelAll(): void {
+    for (const timer of this.#running.values()) {
+      timer.cancel();
+    }
+
+    this.#running.clear();
+    this.#stopWaitingOnClock();
+  }
+
+  /**
+   * Put one timer on the clock, and keep it while it is outstanding.
+   *
+   * The work a timer does needs the timer itself, to start the next turn of an
+   * interval, and the timer needs the work to be built with, so the work is
+   * given both once both exist.
+   */
+  #start(
+    delay: number | undefined,
+    work: (handle: SimLambdaTimerHandle, timer: SimLambdaClockTimer) => void,
+  ): SimLambdaTimerHandle {
+    const handle = new SimLambdaTimerHandle(this);
+    const timer: SimLambdaClockTimer = new SimLambdaClockTimer({
+      background: this.#background,
+      run: () => {
+        work(handle, timer);
+      },
+    });
+
+    this.#running.set(handle, timer);
+
+    // A timer with nothing to wait for is not waiting on the clock: it is due
+    // at the instant the clock already reads, and the next turn of the host
+    // event loop runs it.
+    if (timer.startIn(delay) > 0) {
+      this.#released ??= this.#background.waitingOnClock();
+    }
+
+    return handle;
+  }
+
+  /**
+   * Run one timer's callback, failing the invocation where it throws.
+   *
+   * An uncaught exception out of a timer callback ends a real invocation, and
+   * this one has a whole simulation around it: left to escape, the error would
+   * come out of whatever moved the clock instead, which is nothing to do with
+   * the handler that scheduled it.
+   */
+  #call(callback: SimLambdaTimerCallback, arguments_: unknown[]): void {
+    try {
+      callback(...arguments_);
+    } catch (error) {
+      this.#failed(error);
+    }
+  }
+
+  #forget(handle: SimLambdaTimerHandle): void {
+    this.#running.delete(handle);
+
+    if (this.#running.size === 0) {
+      this.#stopWaitingOnClock();
+    }
+  }
+
+  #stopWaitingOnClock(): void {
+    this.#released?.();
+    this.#released = undefined;
+  }
+}

--- a/src/service/lambda/function/invoke/timer/sim-lambda-process-timers.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-process-timers.ts
@@ -1,0 +1,107 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  simLambdaClearInterval,
+  simLambdaClearTimeout,
+} from "./sim-lambda-clear-timer.js";
+import { simLambdaHostTimers } from "./sim-lambda-host-timers.js";
+import { defineSimLambdaTimer } from "./sim-lambda-timer-global.js";
+import type { SimLambdaInvocationTimers } from "./sim-lambda-invocation-timers.js";
+import type {
+  SimLambdaTimerCallback,
+  SimLambdaTimerHandle,
+  SimLambdaTimers,
+} from "./sim-lambda-timer-handle.js";
+
+/**
+ * The timer functions the code running now should be using.
+ *
+ * A handler function reference is a closure over its own module scope, so it
+ * reaches for the same global `setTimeout` as every other line in the test
+ * run. Zip code has a sandbox of its own and is given these directly. Both
+ * paths end up here, and both find the invocation that is running now through
+ * Node.js asynchronous context tracking, exactly as the substitute Date does.
+ *
+ * Outside an invocation there is nothing to find, and the host's own timers
+ * answer instead. That is what keeps the substitutes inert for a test run's
+ * own timers, for a test framework's, and for one simulation while another is
+ * running an invocation.
+ */
+class SimLambdaProcessTimers {
+  private readonly storage = new AsyncLocalStorage<SimLambdaInvocationTimers>();
+  private installed = false;
+
+  /**
+   * Run an invocation with timers of its own.
+   */
+  async run<T>(
+    timers: SimLambdaInvocationTimers,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    return await this.storage.run(timers, run);
+  }
+
+  /**
+   * The timers the code running now should use.
+   */
+  current(): SimLambdaTimers {
+    return this.storage.getStore() ?? simLambdaHostTimers;
+  }
+
+  /**
+   * Replace the global timer functions with ones that follow the store.
+   *
+   * Installed on the first invocation of host-scope code rather than at
+   * import, so a test run that never invokes one is left completely alone.
+   * Sandboxed code needs none of this: its own globals are built for it, and
+   * they are given the same substitutes directly.
+   *
+   * With no invocation running the substitutes call the host functions and
+   * answer with what they answer, so an installed patch behaves exactly like
+   * no patch at all. They are never removed, because removing one would be
+   * unsafe while another invocation is in flight and there is nothing to gain.
+   */
+  install(): void {
+    if (this.installed) {
+      return;
+    }
+
+    this.installed = true;
+    defineSimLambdaTimer("setTimeout", simLambdaSetTimeout);
+    defineSimLambdaTimer("clearTimeout", simLambdaClearTimeout);
+    defineSimLambdaTimer("setInterval", simLambdaSetInterval);
+    defineSimLambdaTimer("clearInterval", simLambdaClearInterval);
+  }
+}
+
+/**
+ * Shared because it patches process globals: one patch, one store.
+ */
+export const simLambdaProcessTimers = new SimLambdaProcessTimers();
+
+/**
+ * Run a callback once a delay has passed, on the clock of the invocation
+ * running now.
+ */
+export function simLambdaSetTimeout(
+  callback: SimLambdaTimerCallback,
+  delay?: number,
+  ...arguments_: unknown[]
+): SimLambdaTimerHandle | NodeJS.Timeout {
+  return simLambdaProcessTimers
+    .current()
+    .setTimeout(callback, delay, ...arguments_);
+}
+
+/**
+ * Run a callback every time a delay passes, on the clock of the invocation
+ * running now.
+ */
+export function simLambdaSetInterval(
+  callback: SimLambdaTimerCallback,
+  delay?: number,
+  ...arguments_: unknown[]
+): SimLambdaTimerHandle | NodeJS.Timeout {
+  return simLambdaProcessTimers
+    .current()
+    .setInterval(callback, delay, ...arguments_);
+}

--- a/src/service/lambda/function/invoke/timer/sim-lambda-timer-delay.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-timer-delay.ts
@@ -1,0 +1,16 @@
+/**
+ * The delay a timer waits, in whole milliseconds of simulated time.
+ *
+ * A delay that is missing, negative or not a number is no delay at all, which
+ * leaves the timer due at the instant it was asked for. Node.js rounds those
+ * up to a millisecond of host time; simulated time has nothing to round up to,
+ * and a handler yielding with `setTimeout(resolve, 0)` should not need a test
+ * to move the clock before it gets going again.
+ */
+export function simLambdaTimerDelay(delay: number | undefined): number {
+  if (delay === undefined || !Number.isFinite(delay)) {
+    return 0;
+  }
+
+  return Math.max(Math.trunc(delay), 0);
+}

--- a/src/service/lambda/function/invoke/timer/sim-lambda-timer-global.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-timer-global.ts
@@ -1,0 +1,26 @@
+/**
+ * Put a substitute in a global timer function's place, keeping everything else
+ * about it.
+ *
+ * The property stays the configurable, writable, non-enumerable global it
+ * already was, so anything else replacing it later finds what it expects. The
+ * host function's own symbols come across too: `setTimeout` carries the one
+ * that makes `util.promisify` answer with the promise form, and code reaching
+ * for that would otherwise get a promise of the handle instead.
+ */
+export function defineSimLambdaTimer(name: string, substitute: object): void {
+  const host = Reflect.get(globalThis, name) as object;
+
+  for (const symbol of Object.getOwnPropertySymbols(host)) {
+    Object.defineProperty(substitute, symbol, {
+      configurable: true,
+      value: Reflect.get(host, symbol),
+    });
+  }
+
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value: substitute,
+  });
+}

--- a/src/service/lambda/function/invoke/timer/sim-lambda-timer-handle.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-timer-handle.ts
@@ -1,0 +1,77 @@
+/**
+ * What a handler passes to `setTimeout` or `setInterval` to be run later.
+ */
+export type SimLambdaTimerCallback = (...arguments_: unknown[]) => void;
+
+/**
+ * Timer functions of the shape the Node.js runtime gives handler code.
+ */
+export interface SimLambdaTimers {
+  setTimeout(
+    callback: SimLambdaTimerCallback,
+    delay?: number,
+    ...arguments_: unknown[]
+  ): SimLambdaTimerHandle | NodeJS.Timeout;
+
+  setInterval(
+    callback: SimLambdaTimerCallback,
+    delay?: number,
+    ...arguments_: unknown[]
+  ): SimLambdaTimerHandle | NodeJS.Timeout;
+}
+
+/**
+ * Where a timer goes to be given up, which is the set it was made in.
+ */
+export interface SimLambdaTimerOwner {
+  clear(handle: SimLambdaTimerHandle): void;
+}
+
+/**
+ * The handle a handler gets back from `setTimeout` or `setInterval`.
+ *
+ * Real timer functions answer with an object rather than a number, and the
+ * only thing handler code usually does with it is hand it back to
+ * `clearTimeout`. It carries the set it belongs to, so clearing it reaches
+ * that set rather than whichever invocation happens to be running.
+ *
+ * Referencing is answered because a handler is free to ask. A simulated timer
+ * is unreferenced already: it waits on a clock a test moves, and holds nothing
+ * open whatever it is asked.
+ */
+export class SimLambdaTimerHandle {
+  readonly #owner: SimLambdaTimerOwner;
+
+  constructor(owner: SimLambdaTimerOwner) {
+    this.#owner = owner;
+  }
+
+  /**
+   * Give up this timer, as `clearTimeout` and `clearInterval` do.
+   */
+  cancel(): void {
+    this.#owner.clear(this);
+  }
+
+  /**
+   * Keep the simulation open for this timer, which it already is.
+   */
+  ref(): this {
+    return this;
+  }
+
+  /**
+   * Stop keeping the simulation open for this timer, which it never was.
+   */
+  unref(): this {
+    return this;
+  }
+
+  /**
+   * Whether this timer holds the process open, which a simulated one never
+   * does.
+   */
+  hasRef(): boolean {
+    return false;
+  }
+}

--- a/src/service/lambda/function/sim-lambda-function-clock.iso.test.ts
+++ b/src/service/lambda/function/sim-lambda-function-clock.iso.test.ts
@@ -23,10 +23,19 @@ const hostDate = Date;
  * Resolve after a real pause, so an invocation can be suspended part way
  * through while another one runs.
  */
-async function tick(milliseconds: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
+/**
+ * Suspend for a number of turns of the host event loop.
+ *
+ * Not a timer: a handler's timers wait on the simulation's clock, and these
+ * simulations are stopped, so a handler sleeping on one would stay asleep.
+ */
+async function tick(turns: number): Promise<void> {
+  for (let turn = 0; turn < turns; turn += 1) {
+    // oxlint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+  }
 }
 
 async function invokeStamper(simAws: SimAws): Promise<unknown> {

--- a/src/service/lambda/function/sim-lambda-function.ts
+++ b/src/service/lambda/function/sim-lambda-function.ts
@@ -19,11 +19,11 @@ import {
 import { SimLambdaEnvironment } from "./environment/sim-lambda-environment.js";
 import { SimLambdaFunctionLogging } from "./logging/sim-lambda-function-logging.js";
 import { SimLambdaFunctionPolicy } from "./policy/sim-lambda-function-policy.js";
-import { SimLambdaHandlerRunner } from "./invoke/sim-lambda-handler-runner.js";
+import { SimLambdaInvocation } from "./invoke/sim-lambda-invocation.js";
 import { SimLambdaFunctionMetrics } from "../metric/sim-lambda-function-metrics.js";
-import { SimLambdaInvokeContextBuilder } from "./invoke/sim-lambda-invoke-context-builder.js";
 import { runSimLambdaInHostScope } from "./invoke/sim-lambda-host-scope.js";
 import type { SimLambdaOutboundHttp } from "./outbound/sim-lambda-outbound-http.js";
+import type { BackgroundScheduler } from "../../../util/background/background.js";
 import { type SimClock, SimRealClock } from "../../../util/clock/sim-clock.js";
 import { defaultLambdaHandler } from "./sim-lambda-handler.type.js";
 import {
@@ -87,8 +87,8 @@ export class SimLambdaFunction {
   #code: SimLambdaExecutableCode;
   private readonly properties: SimLambdaFunctionProperties;
   private readonly runAsOwner: SimAwsRunAsOwner;
-  private readonly runner = new SimLambdaHandlerRunner();
   private readonly clock: SimClock;
+  private readonly background: BackgroundScheduler | undefined;
   private readonly logging: SimLambdaFunctionLogging;
   private readonly outboundHttp: SimLambdaOutboundHttp | undefined;
 
@@ -110,11 +110,13 @@ export class SimLambdaFunction {
       runAsOwner = this,
       version = SIM_LAMBDA_LATEST_VERSION,
       clock = new SimRealClock(),
+      background,
       metrics,
       outboundHttp,
     } = properties;
     this.properties = properties;
     this.clock = clock;
+    this.background = background;
     this.version = version;
     this.name = name as SimLambdaFunctionName;
     this.roleArn = roleArn;
@@ -246,13 +248,14 @@ export class SimLambdaFunction {
    * Runtime.* cold-start error.
    */
   async invoke(event: unknown): Promise<unknown> {
-    const contextBuilder = new SimLambdaInvokeContextBuilder({
+    const invocation = new SimLambdaInvocation({
       functionName: this.name,
       functionVersion: this.version,
       invokedFunctionArn: this.arn,
       timeoutSeconds: this.timeoutSeconds,
       memorySizeMb: this.memorySizeMb,
       clock: this.clock,
+      background: this.background,
       logGroupName: this.logging.logGroupName,
       logStreamName: this.logging.logStreamName(),
     });
@@ -270,11 +273,7 @@ export class SimLambdaFunction {
                 async () =>
                   await this.logging.around(
                     async () =>
-                      await this.runner.run(
-                        this.#code.handlerFunction(),
-                        event,
-                        contextBuilder,
-                      ),
+                      await invocation.run(this.#code.handlerFunction(), event),
                   ),
               ),
           ),

--- a/src/service/lambda/function/sim-lambda-function.type.ts
+++ b/src/service/lambda/function/sim-lambda-function.type.ts
@@ -1,3 +1,4 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
 import type { Brand } from "../../../util/brand.type.js";
 import type { SimClock } from "../../../util/clock/sim-clock.js";
 import type { SimAwsRunAsOwner } from "../../aws/caller/sim-aws-run-as-context.js";
@@ -49,6 +50,12 @@ export interface SimLambdaFunctionProperties {
    * real clock.
    */
   clock?: SimClock | undefined;
+  /**
+   * Scheduler this function's handler timers and invocation deadline wait on.
+   * A function built standalone, outside a SimAws instance, has none, and its
+   * handler keeps the host timers and runs for as long as it likes.
+   */
+  background?: BackgroundScheduler | undefined;
   /**
    * Where this function's handler output is recorded. A function built
    * standalone, outside a SimAws instance, has nowhere to record to and writes

--- a/src/util/background/background-clock-waits.iso.test.ts
+++ b/src/util/background/background-clock-waits.iso.test.ts
@@ -1,0 +1,211 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertThrowsErrorAsync,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { BackgroundTasks } from "./background.js";
+import { NonDeterministicBackgroundTasks } from "./non-deterministic-background.js";
+
+describe("work a background scheduler is waiting for", () => {
+  it("waits for work a caller started rather than handed over", async () => {
+    // Given work a caller is holding the promise of.
+    const tasks = new BackgroundTasks();
+    const held = Promise.withResolvers<undefined>();
+    let finished = false;
+    const work = tasks.outstanding(async () => {
+      await held.promise;
+      finished = true;
+
+      return "done";
+    });
+
+    // When the simulation is asked to settle and the work can finish.
+    assertIdentical(tasks.pendingTaskCount, 1);
+    held.resolve(undefined);
+    await tasks.complete();
+
+    // Then it waited for it, and the caller still has what it answered with.
+    assertTrue(finished);
+    assertIdentical(await work, "done");
+  });
+
+  it("leaves a caller's failure to the caller", async () => {
+    // Given work a caller started that fails.
+    const tasks = new BackgroundTasks();
+    const work = tasks.outstanding(async () => {
+      await Promise.resolve();
+
+      throw new Error("the caller's own problem");
+    });
+
+    // When the simulation is asked to settle.
+    // Then nothing failed here: whoever asked for the work is told, and
+    // reporting it twice would fail a caller who never asked.
+    await tasks.complete();
+    await assertThrowsErrorAsync(async () => await work);
+  });
+
+  it("counts work already running as a task where it is", async () => {
+    // Given a scheduled task that starts work of its own.
+    const tasks = new BackgroundTasks();
+    let counted = 0;
+    tasks.schedule(async () => {
+      await tasks.outstanding(async () => {
+        counted = tasks.pendingTaskCount;
+
+        await Promise.resolve();
+      });
+    });
+
+    // When it runs.
+    await tasks.complete();
+
+    // Then the work counts once: it is part of the task, not beside it.
+    assertIdentical(counted, 1);
+  });
+
+  it("leaves out the work asking it to settle", async () => {
+    // Given work that asks the simulation to settle from inside itself, as a
+    // handler moving the clock does.
+    const tasks = new BackgroundTasks();
+    let settled = false;
+
+    // When it asks.
+    await tasks.outstanding(async () => {
+      await tasks.complete();
+      settled = true;
+    });
+
+    // Then it came back rather than waiting for itself to finish.
+    assertTrue(settled);
+  });
+
+  it("stops waiting for a task while it waits on the clock", async () => {
+    // Given a task that goes on to wait for something only the clock brings.
+    const tasks = new BackgroundTasks();
+    const held = Promise.withResolvers<undefined>();
+    let release = (): void => {
+      //
+    };
+    let finished = false;
+    tasks.schedule(async () => {
+      release = tasks.waitingOnClock();
+      await held.promise;
+      finished = true;
+    });
+
+    // When the simulation is asked to settle.
+    await tasks.complete();
+
+    // Then it came back with the task still running: waiting for it would be
+    // waiting for a clock that only moves once this returns.
+    assertFalse(finished);
+
+    // And it waits for the task again once the task is not waiting on the
+    // clock any more.
+    release();
+    held.resolve(undefined);
+    await tasks.complete();
+    assertTrue(finished);
+  });
+
+  it("changes nothing said from outside a task", () => {
+    // Given a scheduler with nothing running.
+    const tasks = new BackgroundTasks();
+
+    // When code that is not part of any task says it is waiting on the clock.
+    const release = tasks.waitingOnClock();
+    release();
+
+    // Then there was nothing to stop waiting for.
+    assertIdentical(tasks.pendingTaskCount, 0);
+  });
+
+  it("runs a task that is already due without waiting for the host", async () => {
+    // Given a scheduler and a task the clock has reached.
+    const tasks = new BackgroundTasks();
+    let ran = false;
+
+    // When it is run as due work.
+    tasks.runDue(async () => {
+      ran = true;
+
+      await Promise.resolve();
+    });
+
+    // Then it started there and then, rather than on the next turn of the
+    // host event loop, which is what keeps a long advance cheap.
+    assertTrue(ran);
+    await tasks.complete();
+  });
+
+  it("surfaces a failure from work that was already due", async () => {
+    // Given a due task that fails.
+    const tasks = new BackgroundTasks();
+    tasks.runDue(async () => {
+      await Promise.resolve();
+
+      throw new Error("due task failed");
+    });
+
+    // When the simulation is asked to settle.
+    // Then the failure comes out here, because nobody else is holding it.
+    await assertThrowsErrorAsync(async () => {
+      await tasks.complete();
+    });
+  });
+
+  it("stops waiting for a task waiting on the clock out of sequence too", async () => {
+    // Given the same, on the scheduler that lets work finish out of order.
+    const tasks = new NonDeterministicBackgroundTasks({ maxJitterMs: 1 });
+    const held = Promise.withResolvers<undefined>();
+    let release = (): void => {
+      //
+    };
+    let finished = false;
+    tasks.schedule(async () => {
+      release = tasks.waitingOnClock();
+      await held.promise;
+      finished = true;
+    });
+
+    // When the simulation is asked to settle, and then asked again once the
+    // task is no longer waiting on the clock.
+    await tasks.complete();
+    assertFalse(finished);
+
+    release();
+    held.resolve(undefined);
+    await tasks.complete();
+
+    // Then it waited the second time and not the first.
+    assertTrue(finished);
+  });
+
+  it("runs due work out of sequence too", async () => {
+    // Given the scheduler that lets work finish out of order.
+    const tasks = new NonDeterministicBackgroundTasks({ maxJitterMs: 1 });
+    let ran = false;
+
+    // When a task the clock has reached is run, and work a caller started
+    // fails beside it.
+    tasks.runDue(async () => {
+      ran = true;
+
+      await Promise.resolve();
+    });
+    const work = tasks.outstanding(async () => {
+      await Promise.resolve();
+
+      throw new Error("the caller's own problem");
+    });
+
+    // Then the due task ran, and the caller's failure stayed the caller's.
+    assertTrue(ran);
+    await tasks.complete();
+    await assertThrowsErrorAsync(async () => await work);
+  });
+});

--- a/src/util/background/background-clock-waits.ts
+++ b/src/util/background/background-clock-waits.ts
@@ -1,0 +1,100 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * How many things one running scheduled task is waiting on the clock for.
+ */
+export interface BackgroundClockWait {
+  count: number;
+}
+
+/**
+ * Which scheduled tasks are waiting for the clock rather than for the host.
+ *
+ * Completing a simulation waits for the work that can still get somewhere on
+ * its own. A task blocked on an instant the clock has not reached is not that
+ * kind of work: only moving the clock releases it, and whatever moves the
+ * clock is what waits for completion. Left in, it would be waiting for itself.
+ *
+ * A task says so for itself, from wherever inside it the wait happens, so a
+ * scheduler needs no way of telling one kind of work from another. Code
+ * running outside a scheduled task has nothing to say, and changes nothing by
+ * saying it, which is what keeps this invisible to a caller who holds the
+ * promise itself.
+ */
+export class BackgroundClockWaits {
+  private readonly storage = new AsyncLocalStorage<BackgroundClockWait>();
+  private started = Promise.withResolvers<undefined>();
+
+  /**
+   * Run outstanding work with a record of what it waits on the clock for.
+   */
+  async around<T>(
+    wait: BackgroundClockWait,
+    work: () => Promise<T>,
+  ): Promise<T> {
+    return await this.storage.run(wait, work);
+  }
+
+  /**
+   * The work in a set that is neither waiting on the clock nor the work asking
+   * about it.
+   */
+  runnable(
+    held: ReadonlyMap<Promise<unknown>, BackgroundClockWait>,
+  ): Promise<unknown>[] {
+    const own = this.storage.getStore();
+
+    return held
+      .entries()
+      .filter(([, wait]) => wait.count === 0 && wait !== own)
+      .map(([promise]) => promise)
+      .toArray();
+  }
+
+  /**
+   * Whether the code running now is already inside outstanding work, and so
+   * already counted.
+   */
+  get inWork(): boolean {
+    return this.storage.getStore() !== undefined;
+  }
+
+  /**
+   * Say that the task running now is waiting for simulated time to reach an
+   * instant, and get back the way to say it no longer is.
+   */
+  begin(): () => void {
+    const wait = this.storage.getStore();
+
+    if (wait === undefined) {
+      return (): void => {
+        // Nothing scheduled is waiting, so nothing stops waiting either.
+      };
+    }
+
+    wait.count += 1;
+    this.wake();
+
+    return (): void => {
+      wait.count -= 1;
+    };
+  }
+
+  /**
+   * Resolves the next time a task starts waiting on the clock.
+   *
+   * Whoever is waiting for the simulation to complete takes this alongside the
+   * tasks it is waiting for, so a task that parks part way through stops the
+   * wait rather than extending it forever.
+   */
+  get next(): Promise<undefined> {
+    return this.started.promise;
+  }
+
+  private wake(): void {
+    const { resolve } = this.started;
+
+    this.started = Promise.withResolvers<undefined>();
+    resolve(undefined);
+  }
+}

--- a/src/util/background/background-jitter.ts
+++ b/src/util/background/background-jitter.ts
@@ -1,3 +1,5 @@
+import { setTimeout } from "node:timers";
+
 /**
  * A short random pause between scheduling a task and running it.
  *

--- a/src/util/background/background-pending-tasks.ts
+++ b/src/util/background/background-pending-tasks.ts
@@ -1,0 +1,140 @@
+import type { BackgroundTask } from "./background.js";
+import { BackgroundSettledTasks } from "./background-settled-tasks.js";
+import {
+  type BackgroundClockWait,
+  BackgroundClockWaits,
+} from "./background-clock-waits.js";
+
+/**
+ * The work one scheduler has outstanding, and how much of it is worth waiting
+ * for.
+ *
+ * Work gets here two ways. A task the scheduler was handed is held here until
+ * it settles, and its failure is kept for whoever waits for the simulation to
+ * complete. Work a caller started is held here too, but answers to that caller
+ * instead, because reporting the same failure twice would fail somebody who
+ * never asked for the work.
+ *
+ * Either way, what completion waits for is what can still get somewhere on its
+ * own. Work waiting on the clock cannot, and neither can the work asking for
+ * the simulation to settle.
+ */
+export class BackgroundPendingTasks {
+  readonly #held = new Map<Promise<unknown>, BackgroundClockWait>();
+  readonly #clockWaits = new BackgroundClockWaits();
+
+  /**
+   * Hold a task until it settles, keeping how it settled for whoever waits.
+   */
+  hold(task: BackgroundTask): void {
+    const wait: BackgroundClockWait = { count: 0 };
+
+    this.#keep(wait, this.#clockWaits.around(wait, task));
+  }
+
+  /**
+   * Hold work a caller started, answering with what it settles with.
+   *
+   * Work already running inside a held task is counted where it is, and simply
+   * runs.
+   */
+  async holdCallers<T>(work: () => Promise<T>): Promise<T> {
+    if (this.#clockWaits.inWork) {
+      return await work();
+    }
+
+    const wait: BackgroundClockWait = { count: 0 };
+    const answer = this.#clockWaits.around(wait, work);
+
+    this.#keep(wait, ignoringFailure(answer));
+
+    return await answer;
+  }
+
+  /**
+   * Say that the held task running now is waiting on the clock.
+   */
+  waitingOnClock(): () => void {
+    return this.#clockWaits.begin();
+  }
+
+  /**
+   * How much work is outstanding, whatever it is waiting for.
+   */
+  get size(): number {
+    return this.#held.size;
+  }
+
+  /**
+   * Wait until nothing is outstanding but work that is waiting on the clock.
+   *
+   * Work that parks part way through ends the wait rather than extending it:
+   * only moving the clock releases it, and moving the clock is what waits
+   * here. The loop then looks again at what is left running, so work that
+   * carries on is waited for again.
+   */
+  async complete(): Promise<void> {
+    let running = this.running();
+
+    while (running.length > 0) {
+      // oxlint-disable-next-line no-await-in-loop
+      const settled = await Promise.race([
+        Promise.allSettled(running),
+        this.#clockWaits.next,
+      ]);
+
+      new BackgroundSettledTasks(settled).throwFirstFailure();
+
+      running = this.running();
+    }
+  }
+
+  /**
+   * The work completion has anything to wait for, which is whatever is
+   * neither waiting on the clock nor waiting for completion itself.
+   *
+   * Work that asks for the simulation to settle from inside itself is left
+   * out. A handler advancing the clock is the ordinary case, and waiting for
+   * the invocation it is part of would be waiting for itself.
+   */
+  running(): Promise<unknown>[] {
+    return this.#clockWaits.runnable(this.#held);
+  }
+
+  /**
+   * Keep work outstanding under its own record until it settles.
+   */
+  #keep(wait: BackgroundClockWait, work: Promise<unknown>): void {
+    const promise = settling(work, () => {
+      this.#held.delete(promise);
+    });
+
+    this.#held.set(promise, wait);
+  }
+}
+
+/**
+ * Answer for work, letting go of it once it has settled either way.
+ */
+async function settling(
+  work: Promise<unknown>,
+  settled: () => void,
+): Promise<unknown> {
+  try {
+    return await work;
+  } finally {
+    settled();
+  }
+}
+
+/**
+ * Wait for work without taking on how it failed, which the caller holding it
+ * is told about instead.
+ */
+async function ignoringFailure(work: Promise<unknown>): Promise<void> {
+  try {
+    await work;
+  } catch {
+    // Reported to the caller, not to whoever waits for completion.
+  }
+}

--- a/src/util/background/background-settled-tasks.ts
+++ b/src/util/background/background-settled-tasks.ts
@@ -5,11 +5,14 @@
  * throws has nowhere to report to. Waiting for tasks to settle is that
  * moment: this is what turns a settled batch back into a thrown error, so a
  * failure in the background surfaces to whoever waited rather than vanishing.
+ *
+ * A wait that ended on something else, such as a task parking on the clock,
+ * settled no batch at all and has no failure to report.
  */
 export class BackgroundSettledTasks {
-  private readonly results: PromiseSettledResult<void>[];
+  private readonly results: readonly PromiseSettledResult<unknown>[];
 
-  constructor(results: PromiseSettledResult<void>[]) {
+  constructor(results: readonly PromiseSettledResult<unknown>[] = []) {
     this.results = results;
   }
 

--- a/src/util/background/background.ts
+++ b/src/util/background/background.ts
@@ -1,6 +1,8 @@
 /* oxlint-disable unicorn-js/prefer-await  */
 
+import { setTimeout } from "node:timers";
 import { type SimClock, SimRealClock } from "../clock/sim-clock.js";
+import { BackgroundPendingTasks } from "./background-pending-tasks.js";
 import {
   type BackgroundDueTask,
   BackgroundDueTasks,
@@ -29,6 +31,29 @@ export interface BackgroundScheduler extends SimClock {
   schedule(task: BackgroundTask): void;
 
   /**
+   * Count work a caller started as outstanding until it settles.
+   *
+   * Completion then waits for it, so a simulation asked to settle takes in
+   * work a caller is holding the promise of as well as work it was handed.
+   * Whoever asked for it still gets what it settles with, failure included.
+   *
+   * Work already running as a scheduled task is counted where it is, and this
+   * simply runs it.
+   */
+  outstanding<T>(work: () => Promise<T>): Promise<T>;
+
+  /**
+   * Run a task that is already due, and keep it outstanding until it settles.
+   *
+   * Started here and now rather than deferred to a host timer, because
+   * advancing the clock steps through every instant work falls due at and a
+   * timer for each of them would cost real time. It is counted as outstanding
+   * work all the same, so a task that goes on to wait for the clock stops
+   * holding up whatever is moving it.
+   */
+  runDue(task: BackgroundTask): void;
+
+  /**
    * Schedule a task to happen once simulated time reaches an instant.
    *
    * Nothing dispatches it until the clock gets there, so scheduled work
@@ -45,6 +70,17 @@ export interface BackgroundScheduler extends SimClock {
    * already run, is nothing to give up on.
    */
   cancelScheduled(task: BackgroundTask): void;
+
+  /**
+   * Say that the scheduled task running now is waiting for simulated time to
+   * reach an instant, and get back the way to say it no longer is.
+   *
+   * Completion stops waiting for the task while it waits here, because moving
+   * the clock is the only thing that releases it and completion is what
+   * moving the clock waits for. Called from outside a scheduled task, such as
+   * from work a caller is holding the promise of, this changes nothing.
+   */
+  waitingOnClock(): () => void;
 }
 
 interface BackgroundTasksProperties {
@@ -83,7 +119,7 @@ export interface BackgroundDueTaskSource {
 export class BackgroundTasks
   implements BackgroundScheduler, BackgroundCompleter, BackgroundDueTaskSource
 {
-  private readonly pending = new Set<Promise<void>>();
+  private readonly pending = new BackgroundPendingTasks();
   private readonly dueTasks = new BackgroundDueTasks();
   private readonly clock: SimClock;
 
@@ -109,26 +145,27 @@ export class BackgroundTasks
    * Schedule a task to happen asynchronously in the background.
    */
   schedule(task: BackgroundTask): void {
-    const promise = new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    })
-
-      .then(task)
-      .then(
-        () => {
-          //
-        },
-        (error: unknown) => {
-          // Keep the promise rejected so complete() can surface failures
-          // deterministically.
-          throw error;
-        },
-      )
-      .finally(() => {
-        this.pending.delete(promise);
+    this.pending.hold(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
       });
 
-    this.pending.add(promise);
+      await task();
+    });
+  }
+
+  /**
+   * Run a task that is already due, keeping it outstanding until it settles.
+   */
+  runDue(task: BackgroundTask): void {
+    this.pending.hold(task);
+  }
+
+  /**
+   * Count work a caller started as outstanding until it settles.
+   */
+  async outstanding<T>(work: () => Promise<T>): Promise<T> {
+    return await this.pending.holdCallers(work);
   }
 
   /**
@@ -143,6 +180,13 @@ export class BackgroundTasks
    */
   cancelScheduled(task: BackgroundTask): void {
     this.dueTasks.cancel(task);
+  }
+
+  /**
+   * Say that the scheduled task running now is waiting on the clock.
+   */
+  waitingOnClock(): () => void {
+    return this.pending.waitingOnClock();
   }
 
   /**
@@ -161,10 +205,7 @@ export class BackgroundTasks
    * clock releases it.
    */
   public async complete(): Promise<void> {
-    while (this.pending.size > 0) {
-      // oxlint-disable-next-line no-await-in-loop
-      await Promise.all(this.pending);
-    }
+    await this.pending.complete();
   }
 
   /**

--- a/src/util/background/non-deterministic-background.ts
+++ b/src/util/background/non-deterministic-background.ts
@@ -5,12 +5,12 @@ import type {
   BackgroundTask,
 } from "./background.js";
 import { type SimClock, SimRealClock } from "../clock/sim-clock.js";
+import { BackgroundPendingTasks } from "./background-pending-tasks.js";
 import {
   type BackgroundDueTask,
   BackgroundDueTasks,
 } from "./background-due-tasks.js";
 import { BackgroundJitter } from "./background-jitter.js";
-import { BackgroundSettledTasks } from "./background-settled-tasks.js";
 
 /* oxlint-disable unicorn-js/prefer-await  */
 
@@ -23,7 +23,7 @@ import { BackgroundSettledTasks } from "./background-settled-tasks.js";
 export class NonDeterministicBackgroundTasks
   implements BackgroundScheduler, BackgroundCompleter, BackgroundDueTaskSource
 {
-  private readonly pending = new Set<Promise<void>>();
+  private readonly pending = new BackgroundPendingTasks();
   private readonly dueTasks = new BackgroundDueTasks();
   private readonly jitter: BackgroundJitter;
   private readonly clock: SimClock;
@@ -52,23 +52,25 @@ export class NonDeterministicBackgroundTasks
    * Schedule a task to happen asynchronously in the background.
    */
   schedule(task: BackgroundTask): void {
-    const promise = this.sequence()
-      .then(task)
-      .then(
-        () => {
-          //
-        },
-        (error: unknown) => {
-          // Keep the promise rejected so complete() can surface failures
-          // deterministically.
-          throw error;
-        },
-      )
-      .finally(() => {
-        this.pending.delete(promise);
-      });
+    this.pending.hold(async () => {
+      await this.sequence();
 
-    this.pending.add(promise);
+      await task();
+    });
+  }
+
+  /**
+   * Run a task that is already due, keeping it outstanding until it settles.
+   */
+  runDue(task: BackgroundTask): void {
+    this.pending.hold(task);
+  }
+
+  /**
+   * Count work a caller started as outstanding until it settles.
+   */
+  async outstanding<T>(work: () => Promise<T>): Promise<T> {
+    return await this.pending.holdCallers(work);
   }
 
   /**
@@ -86,6 +88,13 @@ export class NonDeterministicBackgroundTasks
   }
 
   /**
+   * Say that the scheduled task running now is waiting on the clock.
+   */
+  waitingOnClock(): () => void {
+    return this.pending.waitingOnClock();
+  }
+
+  /**
    * Take the next task due at or before an instant, earliest first.
    */
   takeNextDueBy(instant: Date): BackgroundDueTask | undefined {
@@ -97,13 +106,7 @@ export class NonDeterministicBackgroundTasks
    * If tasks schedule more tasks, this will continue draining until idle.
    */
   public async complete(): Promise<void> {
-    while (this.pending.size > 0) {
-      // oxlint-disable-next-line no-await-in-loop
-      const results = await Promise.allSettled(this.pending);
-
-      // Surface a task that failed in the background to whoever waited here.
-      new BackgroundSettledTasks(results).throwFirstFailure();
-    }
+    await this.pending.complete();
   }
 
   /**

--- a/src/util/clock/sim-clock-control.ts
+++ b/src/util/clock/sim-clock-control.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from "node:timers";
 import type {
   BackgroundCompleter,
   BackgroundDueTaskSource,
@@ -95,6 +96,8 @@ export class SimClockControl implements SimClock {
   async setTo(instant: Date): Promise<void> {
     this.clock.freeze();
 
+    await reachWhatIsWaitedOn();
+
     if (instant.getTime() >= this.now().getTime()) {
       await this.runDueTasksUpTo(instant);
     }
@@ -153,8 +156,7 @@ export class SimClockControl implements SimClock {
     while (due !== undefined) {
       this.clock.setTo(this.laterOfNow(due.dueTime));
 
-      // oxlint-disable-next-line no-await-in-loop
-      await due.task();
+      this.background.runDue(due.task);
 
       // oxlint-disable-next-line no-await-in-loop
       await this.background.complete();
@@ -176,4 +178,25 @@ export class SimClockControl implements SimClock {
 
     return instant;
   }
+}
+
+/**
+ * Let work already under way reach whatever it is waiting for.
+ *
+ * A test that starts something and moves the clock without waiting for it has
+ * a real ordering problem to solve. An invocation asked for on the line above
+ * has not run a line of handler code yet, so the timer the handler is about to
+ * ask for is not on the clock when the clock moves, and moving time past an
+ * instant nothing is waiting on releases nothing.
+ *
+ * One turn of the host event loop settles that. It runs everything already
+ * queued, which carries a promise chain started on the previous line as far as
+ * its first real wait, and the clock then moves past instants that are
+ * actually being waited on. The clock is frozen before this, so the time that
+ * work reads while it gets there is the instant the test moved from.
+ */
+async function reachWhatIsWaitedOn(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
 }


### PR DESCRIPTION
A handler's `setTimeout`, `clearTimeout`, `setInterval` and `clearInterval` measure their delays on the simulation's clock, and the function's `Timeout` is a deadline on that same clock. Advancing time is what releases a sleeping handler. A deadline that arrives first ends the invocation with the `Sandbox.Timedout` error real Lambda reports, through the error, log and metric paths already there, ignores whatever the handler goes on to answer with, and gives up the timers it left running. An `Event` invocation that runs out of time is a failed attempt, and enters the retries and destinations an attempt that threw enters. Sandboxed zip code takes these from its own sandbox globals and a referenced handler from a substituted process global, and code outside an invocation keeps the host timers it already had. The background scheduler now tells work that is waiting on the clock apart from work that can still get somewhere on its own. An advance that leaves an invocation asleep comes back rather than waiting for a clock only that advance can move.
