### PR TITLE
feat: serve S3 user metadata as headers

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -3305,9 +3305,9 @@ const s3Client = new S3Client({
 An upload keeps the metadata headers it was sent. `cache-control`, `content-disposition`,
 `content-encoding`, `content-language`, `content-type` and `expires` are stored, and a read is
 served every one of them, the way it serves an Object written by a `PutObjectCommand`. See
-[Object system metadata](#object-system-metadata). An `x-amz-meta-` header is stored too, and an
-in-process read reports it in `Metadata`. An `x-amz-tagging` header puts the tags it names on the
-Object, the same way a `PutObjectCommand` does. See [Object tags](#object-tags).
+[Object system metadata](#object-system-metadata). An `x-amz-meta-` header is stored too. An
+`x-amz-tagging` header puts the tags it names on the Object, the same way a `PutObjectCommand`
+does. See [Object tags](#object-tags).
 
 ```typescript
 await fetch(url, {
@@ -3818,7 +3818,9 @@ write attached, and nothing else.
 
 Every path that serves an Object goes through the same mapping. The REST endpoint, the
 [website endpoint](#static-website-hosting) and a CloudFront S3 Origin all report the same headers
-for it. `content-encoding` is the one that matters most. Bytes served without it are bytes no client
+for it. User-defined metadata travels alongside them, one `x-amz-meta-` header per entry. An SDK
+client reading over an endpoint reports the same `Metadata` an in-process read does.
+`content-encoding` is the one that matters most. Bytes served without it are bytes no client
 can decode, and an Object stored as brotli is only usable if the header comes back with it.
 
 `PutObjectCommand` sets them, one request field per header. An upload over a
@@ -3994,6 +3996,3 @@ These apply across the page. The sections above each list what is specific to th
   [Deleting the files under a mount](#deleting-the-files-under-a-mount).
 - Multipart upload parts for a mounted Bucket are held in memory, and only the assembled Object
   reaches the directory.
-- User-defined `x-amz-meta-` metadata is stored by every write and reported in `Metadata` by an
-  in-process read. A response served over an endpoint carries the system metadata headers and leaves
-  the user metadata out.

--- a/src/service/cloudfront/origin/s3/sim-cf-s3-origin-responses.ts
+++ b/src/service/cloudfront/origin/s3/sim-cf-s3-origin-responses.ts
@@ -23,6 +23,7 @@ export class SimCfS3OriginResponses {
   foundObject(object: SimS3Object, request: Request): Response {
     const headers = simS3ObjectResponseHeaders({
       metadata: object.metadata.values,
+      userMetadata: object.metadata.userDefined,
       bodyLength: object.body.length,
       etag: simS3QuotedETag(object.etag),
       lastModified: object.lastModified,

--- a/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.iso.test.ts
+++ b/src/service/cloudfront/origin/s3/sim-cloudfront-s3-origin.iso.test.ts
@@ -81,6 +81,30 @@ describe("sim CloudFront S3 Origin", () => {
     assertIdentical(response.headers.get("content-length"), "10");
   });
 
+  it("serves the metadata a caller attached to an Object", async () => {
+    // Given an Object stored as CSV whose write also attached keys of its own,
+    // one named after a header S3 sets itself.
+    const origin = await originWithObject({
+      "content-type": "text/csv",
+      "x-amz-meta-author": "ada",
+      "x-amz-meta-content-type": "application/vnd.internal",
+    });
+
+    // When CloudFront fetches it from the Origin.
+    const response = await origin.fetch(
+      originRequest(new Request("http://example.test/data/standard.keys")),
+    );
+
+    // Then the Origin serves each entry under its prefix, so a Distribution
+    // sees the same Object an SDK read of the Bucket would.
+    assertIdentical(response.headers.get("x-amz-meta-author"), "ada");
+    assertIdentical(
+      response.headers.get("x-amz-meta-content-type"),
+      "application/vnd.internal",
+    );
+    assertIdentical(response.headers.get("content-type"), "text/csv");
+  });
+
   it("serves the same headers for a HEAD request, without the body", async () => {
     // Given an Object stored as brotli.
     const origin = await originWithObject({ "content-encoding": "br" });

--- a/src/service/s3/bucket/website/s3-bucket-website.loc.test.ts
+++ b/src/service/s3/bucket/website/s3-bucket-website.loc.test.ts
@@ -91,6 +91,44 @@ describe("Serve simulated S3 Bucket static website on localhost", () => {
     assertIdentical(await response.text(), "<h1>Root index</h1>");
   });
 
+  it("serves the metadata a caller attached to a page", async () => {
+    // Given a site whose page was written with a build stamp of its own
+    const simS3 = simAws.region("eu-west-2").s3();
+
+    await simS3.createBucket(
+      new CreateBucketCommand({ Bucket: "annotated-site" }),
+    );
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: "annotated-site",
+        Key: "index.html",
+        Body: "<h1>Annotated</h1>",
+        ContentType: "text/html; charset=utf-8",
+        Metadata: { "build-id": "2026-09-02.7" },
+      }),
+    );
+    await simS3.putBucketWebsite(
+      new PutBucketWebsiteCommand({
+        Bucket: "annotated-site",
+        WebsiteConfiguration: { IndexDocument: { Suffix: "index.html" } },
+      }),
+    );
+    await grantPublicObjectRead(simS3, "annotated-site");
+
+    // When a visitor loads the page
+    const response = await fetch(
+      `http://annotated-site.s3-website.eu-west-2.sim-aws.localhost:${srv.port}/`,
+    );
+
+    // Then the website endpoint serves the stamp alongside the page, the way
+    // the REST and API endpoints do
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(
+      response.headers.get("x-amz-meta-build-id"),
+      "2026-09-02.7",
+    );
+  });
+
   it("serves a configured folder index document", async () => {
     const simS3 = simAws.region("eu-west-2").s3();
 

--- a/src/service/s3/object/s3-object-response-headers.iso.test.ts
+++ b/src/service/s3/object/s3-object-response-headers.iso.test.ts
@@ -52,14 +52,11 @@ describe("simS3ObjectResponseHeaders", () => {
     });
   });
 
-  it("leaves out user metadata and anything else S3 does not return as a header", () => {
-    // Given an Object stored with user metadata alongside its content type.
+  it("leaves out anything else S3 does not return as a header", () => {
+    // Given an Object whose stored metadata holds an entity tag under a header
+    // name, alongside its content type.
     const headers = simS3ObjectResponseHeaders({
-      metadata: {
-        "content-type": "text/plain",
-        "x-amz-meta-author": "hg",
-        etag: "abc",
-      },
+      metadata: { "content-type": "text/plain", etag: "abc" },
       bodyLength: 3,
     });
 
@@ -71,6 +68,41 @@ describe("simS3ObjectResponseHeaders", () => {
       "content-length": "3",
     });
     assertArrayLength(Object.keys(headers), 2);
+  });
+
+  it("serves the metadata a caller attached under the x-amz-meta- prefix", () => {
+    // Given an Object the write attached two of its own keys to.
+    // When its response headers are built.
+    const headers = simS3ObjectResponseHeaders({
+      metadata: { "content-type": "text/plain" },
+      userMetadata: { author: "ada", "review-state": "approved" },
+      bodyLength: 3,
+    });
+
+    // Then each entry travels as its own header, which is what the SDK reads
+    // back into Metadata on the far side of an endpoint.
+    assertObjectMatches(headers, {
+      "x-amz-meta-author": "ada",
+      "x-amz-meta-review-state": "approved",
+    });
+  });
+
+  it("keeps a user metadata key named after a header S3 sets itself apart from it", () => {
+    // Given an Object stored as CSV whose caller also attached a content type
+    // of its own.
+    // When its response headers are built.
+    const headers = simS3ObjectResponseHeaders({
+      metadata: { "content-type": "text/csv" },
+      userMetadata: { "content-type": "application/vnd.internal" },
+      bodyLength: 3,
+    });
+
+    // Then the prefix keeps the two apart, and the Object goes on being served
+    // as the CSV it was written as.
+    assertObjectMatches(headers, {
+      "content-type": "text/csv",
+      "x-amz-meta-content-type": "application/vnd.internal",
+    });
   });
 
   it("reports the length it is given rather than one from metadata", () => {

--- a/src/service/s3/object/s3-object-response-headers.ts
+++ b/src/service/s3/object/s3-object-response-headers.ts
@@ -1,4 +1,7 @@
-import { simS3SystemMetadataHeaders } from "./s3-system-metadata.js";
+import {
+  simS3SystemMetadataHeaders,
+  simS3UserMetadataPrefix,
+} from "./s3-system-metadata.js";
 
 /**
  * What an endpoint knows about the Object it is about to serve.
@@ -6,6 +9,11 @@ import { simS3SystemMetadataHeaders } from "./s3-system-metadata.js";
 export interface SimS3ObjectResponseDescription {
   /** The system metadata S3 was told when the Object was written. */
   readonly metadata?: Readonly<Record<string, string>> | undefined;
+  /**
+   * The metadata the caller attached to the Object, under the keys it used
+   * rather than the prefixed names the headers carry.
+   */
+  readonly userMetadata?: Readonly<Record<string, string>> | undefined;
   /**
    * The headers the read asked to be served in place of the Object's own,
    * under the same names, from its `response-` parameters.
@@ -46,6 +54,12 @@ export interface SimS3ObjectResponseDescription {
  * as real S3 sets it, and the encryption is set for every Object S3 stored
  * itself.
  *
+ * User-defined metadata goes back out under the `x-amz-meta-` prefix S3 sends
+ * it with, one header per entry. The prefix is what keeps a caller's own key
+ * apart from a header S3 sets itself, so an Object holding a `content-type`
+ * key is served an `x-amz-meta-content-type` header alongside its own content
+ * type rather than in place of it.
+ *
  * `ETag` and `Last-Modified` are not metadata but facts about the stored bytes,
  * and are what makes a conditional request or a content-hash comparison
  * possible over HTTP. `Content-Range` is a fact about the response rather than
@@ -71,6 +85,12 @@ export function simS3ObjectResponseHeaders(
     if (value !== undefined) {
       headers[header.name] = value;
     }
+  }
+
+  const userDefined = Object.entries(description.userMetadata ?? {});
+
+  for (const [key, value] of userDefined) {
+    headers[`${simS3UserMetadataPrefix}${key}`] = value;
   }
 
   if (description.etag !== undefined) {

--- a/src/service/s3/serve/api/sim-s3-api-head-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-head-output.ts
@@ -25,6 +25,7 @@ export function simS3HeadObjectResponse(
     status: 200,
     headers: simS3ObjectResponseHeaders({
       metadata: simS3SystemMetadataHeadersFrom(output),
+      userMetadata: output["Metadata"] as Record<string, string> | undefined,
       overrides,
       bodyLength: (output["ContentLength"] as number | undefined) ?? 0,
       etag: output["ETag"] as string | undefined,

--- a/src/service/s3/serve/api/sim-s3-api-object-headers.loc.test.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-headers.loc.test.ts
@@ -6,11 +6,16 @@ import {
 import {
   CreateBucketCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
-import { assertArrayLength, assertIdentical } from "@kensio/smartass";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertObjectMatches,
+} from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
 
 import { SimAwsLocalServer } from "../../../../serve/index.js";
@@ -124,6 +129,61 @@ describe("Serving what a simulated S3 request says about an Object", () => {
       new GetObjectCommand({ Bucket: "reports", Key: "q3.pdf" }),
     );
     assertIdentical(stored.ContentType, "application/pdf");
+  });
+
+  it("reports the metadata a write attached, however the Object is read", async () => {
+    // Given an Object written with metadata of the caller's own
+    await client.send(new CreateBucketCommand({ Bucket: "annotated" }));
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "annotated",
+        Key: "orders.csv",
+        Body: "id,total",
+        ContentType: "text/csv",
+        Metadata: { author: "ada", "review-state": "approved" },
+      }),
+    );
+
+    // When it is read, and asked about without being read
+    const read = await client.send(
+      new GetObjectCommand({ Bucket: "annotated", Key: "orders.csv" }),
+    );
+    const head = await client.send(
+      new HeadObjectCommand({ Bucket: "annotated", Key: "orders.csv" }),
+    );
+
+    // Then both report what the write attached, so a client on the far side of
+    // an endpoint sees the Object it wrote
+    const attached = { author: "ada", "review-state": "approved" };
+    assertObjectMatches(read.Metadata, attached);
+    assertObjectMatches(head.Metadata, attached);
+  });
+
+  it("keeps a metadata key named after a header S3 sets itself out of it", async () => {
+    // Given an Object stored as CSV whose write also attached a content type
+    // of its own
+    await client.send(new CreateBucketCommand({ Bucket: "internal" }));
+    await client.send(
+      new PutObjectCommand({
+        Bucket: "internal",
+        Key: "ledger.csv",
+        Body: "id,total",
+        ContentType: "text/csv",
+        Metadata: { "content-type": "application/vnd.internal" },
+      }),
+    );
+
+    // When it is read back over the endpoint
+    const output = await client.send(
+      new GetObjectCommand({ Bucket: "internal", Key: "ledger.csv" }),
+    );
+
+    // Then the x-amz-meta- prefix keeps the two apart on the wire, and the
+    // Object goes on being served as the CSV it was written as
+    assertObjectMatches(output.Metadata, {
+      "content-type": "application/vnd.internal",
+    });
+    assertIdentical(output.ContentType, "text/csv");
   });
 
   it("encodes the keys of a listing that asked for encoded keys", async () => {

--- a/src/service/s3/serve/api/sim-s3-api-object-output.ts
+++ b/src/service/s3/serve/api/sim-s3-api-object-output.ts
@@ -81,6 +81,7 @@ export async function simS3GetObjectResponse(
     status: contentRange === undefined ? 200 : 206,
     headers: simS3ObjectResponseHeaders({
       metadata: simS3SystemMetadataHeadersFrom(output),
+      userMetadata: output["Metadata"] as Record<string, string> | undefined,
       overrides,
       bodyLength: body.length,
       etag: output["ETag"] as string | undefined,

--- a/src/service/s3/serve/sim-s3-rest-endpoint.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-rest-endpoint.iso.test.ts
@@ -301,6 +301,47 @@ describe("The simulated S3 REST endpoint", () => {
     );
   });
 
+  it("serves the metadata a caller attached to an Object", async () => {
+    // Given an Object a write attached its own keys to, one of them named
+    // after a header S3 sets itself
+    const { simAws, client, http } = await presignSimulation();
+
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: presignBucketName,
+        Key: "annotated.csv",
+        Body: "id,total",
+        ContentType: "text/csv",
+        Metadata: {
+          author: "ada",
+          "content-type": "application/vnd.internal",
+        },
+      }),
+    );
+
+    // When it is read back over the REST endpoint, as a presigned GET is
+    const response = await http.fetch(
+      await getSignedUrl(
+        client,
+        new GetObjectCommand({
+          Bucket: presignBucketName,
+          Key: "annotated.csv",
+        }),
+        { expiresIn: 900 },
+      ),
+    );
+
+    // Then each entry travels under the x-amz-meta- prefix, which keeps the
+    // caller's own content type apart from the Object's
+    assertResponseStatus(response, 200, await describeResponse(response));
+    assertIdentical(response.headers.get("x-amz-meta-author"), "ada");
+    assertIdentical(
+      response.headers.get("x-amz-meta-content-type"),
+      "application/vnd.internal",
+    );
+    assertIdentical(response.headers.get("content-type"), "text/csv");
+  });
+
   it("serves a path style request, as a dotted Bucket name needs", async () => {
     // Given a client addressing the Bucket in the path rather than the
     // hostname, which is what the AWS SDK does for itself when a Bucket name

--- a/src/service/s3/serve/sim-s3-rest-object-reader.ts
+++ b/src/service/s3/serve/sim-s3-rest-object-reader.ts
@@ -48,6 +48,7 @@ export class SimS3RestObjectReader {
     const body = await bodyBytes(output.Body);
     const headers = simS3ObjectResponseHeaders({
       metadata: simS3SystemMetadataHeadersFrom(output),
+      userMetadata: output.Metadata,
       overrides: simS3ResponseHeaderOverrides(
         new URL(request.url).searchParams,
       ),

--- a/src/service/s3/serve/website/sim-s3-website-object-loader.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object-loader.ts
@@ -73,6 +73,7 @@ export class SimS3WebsiteObjectLoader {
       return new SimS3WebsiteObject({
         body: await simS3BodyToBuffer(output.Body as AsyncIterable<Buffer>),
         metadata: simS3SystemMetadataHeadersFrom(output),
+        userMetadata: output.Metadata,
         etag: output.ETag,
         lastModified: output.LastModified,
       });

--- a/src/service/s3/serve/website/sim-s3-website-object.iso.test.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object.iso.test.ts
@@ -31,6 +31,26 @@ describe("SimS3WebsiteObject", () => {
     });
   });
 
+  it("describes an Object by the metadata its caller attached", () => {
+    // Given an Object the website endpoint has read, carrying a key of the
+    // caller's own named after a header S3 sets itself.
+    const object = new SimS3WebsiteObject({
+      body: Buffer.from("<h1>Hello</h1>"),
+      metadata: { "content-type": "text/html" },
+      userMetadata: { "content-type": "application/vnd.internal" },
+    });
+
+    // When the website response headers are built.
+    const headers = object.headers();
+
+    // Then the endpoint serves the attached metadata under its prefix, leaving
+    // the page the content type it is served as.
+    assertObjectMatches(headers, {
+      "content-type": "text/html",
+      "x-amz-meta-content-type": "application/vnd.internal",
+    });
+  });
+
   it("describes an Object stored without metadata by its length alone", () => {
     // Given an Object with no stored metadata.
     const object = new SimS3WebsiteObject({ body: Buffer.from("plain") });

--- a/src/service/s3/serve/website/sim-s3-website-object.ts
+++ b/src/service/s3/serve/website/sim-s3-website-object.ts
@@ -3,6 +3,7 @@ import { simS3ObjectResponseHeaders } from "../../object/s3-object-response-head
 interface SimS3WebsiteObjectProperties {
   readonly body: Buffer;
   readonly metadata?: Readonly<Record<string, string>> | undefined;
+  readonly userMetadata?: Readonly<Record<string, string>> | undefined;
   readonly etag?: string | undefined;
   readonly lastModified?: Date | undefined;
 }
@@ -18,12 +19,14 @@ export class SimS3WebsiteObject {
   public readonly body: Buffer;
 
   private readonly metadata: Readonly<Record<string, string>> | undefined;
+  private readonly userMetadata: Readonly<Record<string, string>> | undefined;
   private readonly etag: string | undefined;
   private readonly lastModified: Date | undefined;
 
   constructor(properties: SimS3WebsiteObjectProperties) {
     this.body = properties.body;
     this.metadata = properties.metadata;
+    this.userMetadata = properties.userMetadata;
     this.etag = properties.etag;
     this.lastModified = properties.lastModified;
   }
@@ -34,6 +37,7 @@ export class SimS3WebsiteObject {
   headers(): Record<string, string> {
     return simS3ObjectResponseHeaders({
       metadata: this.metadata,
+      userMetadata: this.userMetadata,
       bodyLength: this.body.length,
       etag: this.etag,
       lastModified: this.lastModified,


### PR DESCRIPTION
An Object written with `Metadata` kept it, and a read served over HTTP left it
out. A `GetObjectCommand` or `HeadObjectCommand` sent through the served API
endpoint came back with `Metadata` undefined, and a read over the REST endpoint
carried no `x-amz-meta-` headers. `simS3ObjectResponseHeaders` now takes the
metadata a caller attached alongside the system metadata, and emits one
`x-amz-meta-` header per entry. Every path that serves an Object goes through
that function. The API endpoint, the REST endpoint, a presigned GET, the static
website endpoint and a CloudFront S3 Origin all report what the write attached.
The prefix keeps a key named after a header S3 sets itself apart from the
Object's own. A `content-type` entry travels as `x-amz-meta-content-type` and
leaves the Object's content type alone.
Resolves #1249