### PR TITLE
fix: refuse a missing key without s3:ListBucket

### DIFF
--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -2238,6 +2238,111 @@ matching S3's idempotent behaviour.
 A Bucket policy granting `Principal: "*"` is refused by default. See
 [Block Public Access](#block-public-access) below.
 
+### Missing keys and `s3:ListBucket`
+
+What S3 answers for a missing Object depends on a second permission. A caller holding
+`s3:GetObject` alone is answered `403 AccessDenied` for a key the Bucket does not hold, the same
+answer it gets for a key it may not read. `s3:ListBucket` on the Bucket ARN is what buys
+`404 NoSuchKey`.
+
+Which keys a Bucket holds is what a listing tells you, and real S3 admits the absence only to a
+caller that may list. A test written against a simulator that always answered `NoSuchKey` would
+handle the absence on a path the deployed code never reaches.
+
+```typescript sim-s3-missing-key-permission
+/**
+ * What simulated S3 answers for an Object that is not there.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateBucketCommand, GetObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simIam = simAws.iam();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "reports" }));
+
+const readerCreation = await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "ReportReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ReportReader",
+    PolicyName: "ReadReports",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:GetObject",
+        Resource: "arn:aws:s3:::reports/*",
+      },
+    }),
+  }),
+);
+
+const asReader = {
+  caller: { kind: "arn", arn: readerCreation.Role.Arn },
+} as const;
+
+try {
+  await simS3.getObject(
+    new GetObjectCommand({ Bucket: "reports", Key: "q4/report.txt" }),
+    asReader,
+  );
+} catch (error) {
+  // AccessDenied, with a 403 status. This caller may not list the Bucket, and
+  // S3 will not tell it whether the key is there.
+  console.error("Read refused", error);
+}
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ReportReader",
+    PolicyName: "ListReports",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:ListBucket",
+        Resource: "arn:aws:s3:::reports",
+      },
+    }),
+  }),
+);
+
+try {
+  await simS3.getObject(
+    new GetObjectCommand({ Bucket: "reports", Key: "q4/report.txt" }),
+    asReader,
+  );
+} catch (error) {
+  // NoSuchKey, with a 404 status.
+  console.error("Object missing", error);
+}
+```
+
+An Object that is there is served on `s3:GetObject` alone. The listing permission only decides what
+a caller is told about a key the Bucket does not hold.
+
+Everything that reads through GetObject follows the same rule, including the served S3 endpoint, the
+static website endpoint and a CloudFront S3 Origin. A site whose Bucket policy grants only
+`s3:GetObject` answers 403 for a page it does not hold, and serves its custom error document with
+that status. Adding `s3:ListBucket` on the Bucket ARN gives it the 404 an error document is usually
+written for.
+
 ### Where a request came from
 
 A request can say what it is being made for, and a simulated service supplies that when it reaches a

--- a/docs/services/s3/sim-s3-missing-key-permission.example.ts
+++ b/docs/services/s3/sim-s3-missing-key-permission.example.ts
@@ -1,0 +1,82 @@
+/**
+ * What simulated S3 answers for an Object that is not there.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { CreateBucketCommand, GetObjectCommand } from "@aws-sdk/client-s3";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const simIam = simAws.iam();
+const simS3 = simAws.s3();
+
+await simS3.createBucket(new CreateBucketCommand({ Bucket: "reports" }));
+
+const readerCreation = await simIam.createRole(
+  new CreateRoleCommand({
+    RoleName: "ReportReader",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ReportReader",
+    PolicyName: "ReadReports",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:GetObject",
+        Resource: "arn:aws:s3:::reports/*",
+      },
+    }),
+  }),
+);
+
+const asReader = {
+  caller: { kind: "arn", arn: readerCreation.Role.Arn },
+} as const;
+
+try {
+  await simS3.getObject(
+    new GetObjectCommand({ Bucket: "reports", Key: "q4/report.txt" }),
+    asReader,
+  );
+} catch (error) {
+  // AccessDenied, with a 403 status. This caller may not list the Bucket, and
+  // S3 will not tell it whether the key is there.
+  console.error("Read refused", error);
+}
+
+await simIam.putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ReportReader",
+    PolicyName: "ListReports",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "s3:ListBucket",
+        Resource: "arn:aws:s3:::reports",
+      },
+    }),
+  }),
+);
+
+try {
+  await simS3.getObject(
+    new GetObjectCommand({ Bucket: "reports", Key: "q4/report.txt" }),
+    asReader,
+  );
+} catch (error) {
+  // NoSuchKey, with a 404 status.
+  console.error("Object missing", error);
+}

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -516,9 +516,10 @@ never the thing caching holds on to.
 
 The second decision is what real S3 makes for a key that is not there. Admitting the absence tells
 the caller something a listing would have told it. A caller holding no `s3:ListBucket` is answered
-`AccessDenied` whether the key is there or not. `GetObjectLoader` raises the missing-key error and
-`GetObjectCommandHandler` catches it. The listing permission then stays out of the path a read of an
-Object that is there takes.
+`AccessDenied` for a missing key, and one holding it is answered `NoSuchKey`. `GetObjectLoader`
+answers `undefined` for a key that holds nothing, the way `simS3ReadObjectVersion` answers it, and
+`GetObjectCommandHandler` takes the decision from there. An Object that is there comes back before
+any of that, on `s3:GetObject` alone.
 
 Everything reading an Object through the GetObject command inherits this, including the served REST
 endpoint, the static website endpoint and a CloudFront S3 Origin. `grantPublicObjectRead` in

--- a/src/service/s3/README.md
+++ b/src/service/s3/README.md
@@ -506,11 +506,23 @@ never the thing caching holds on to.
 2. looks up the Bucket locally
 3. throws `SimS3NoSuchBucket` if absent
 4. sequences background work
-5. gets the object from Bucket storage
-6. throws `SimS3NoSuchKey` if absent
-7. resolves any stated `Range` against the size of the stored body
-8. returns a readable body stream, metadata, `ETag`, `LastModified`, `ContentLength` and
+5. authorizes `s3:GetObject` against the Object ARN through `GetObjectAuthorizer`
+6. gets the object from Bucket storage
+7. authorizes `s3:ListBucket` against the Bucket ARN if the key holds nothing, and throws
+   `SimS3NoSuchKey` once that passes
+8. resolves any stated `Range` against the size of the stored body
+9. returns a readable body stream, metadata, `ETag`, `LastModified`, `ContentLength` and
    `$metadata`, with a `ContentRange` for a read that asked for part of the Object
+
+The second decision is what real S3 makes for a key that is not there. Admitting the absence tells
+the caller something a listing would have told it. A caller holding no `s3:ListBucket` is answered
+`AccessDenied` whether the key is there or not. `GetObjectLoader` raises the missing-key error and
+`GetObjectCommandHandler` catches it. The listing permission then stays out of the path a read of an
+Object that is there takes.
+
+Everything reading an Object through the GetObject command inherits this, including the served REST
+endpoint, the static website endpoint and a CloudFront S3 Origin. `grantPublicObjectRead` in
+`bucket/sim-s3-public-read.fixture.ts` grants the listing alongside the read for that reason.
 
 `simS3ReadObjectRange` in `object/s3-object-range.ts` reads the header. The three forms are
 `bytes=<start>-<end>`, `bytes=<start>-` and `bytes=-<suffix>`, and an end past the last byte is

--- a/src/service/s3/bucket/sim-s3-public-read.fixture.ts
+++ b/src/service/s3/bucket/sim-s3-public-read.fixture.ts
@@ -13,6 +13,12 @@ import type { SimS3 } from "../sim-s3.js";
  * issues exactly the two commands a real deployment issues rather than reaching
  * around them, so a test using it exercises the same path a user's own setup
  * would.
+ *
+ * The policy grants listing alongside the read. Real S3 admits that a key is
+ * missing only to a reader holding `s3:ListBucket`, and answers 403 to a
+ * reader holding the Object read alone. A site with its own error document, a
+ * folder redirect or a custom 404 error response grants both permissions for
+ * that reason.
  */
 export async function grantPublicObjectRead(
   simS3: SimS3,
@@ -33,12 +39,20 @@ export async function grantPublicObjectRead(
       Bucket: bucketName,
       Policy: JSON.stringify({
         Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Principal: "*",
-          Action: "s3:GetObject",
-          Resource: `arn:aws:s3:::${bucketName}/*`,
-        },
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:GetObject",
+            Resource: `arn:aws:s3:::${bucketName}/*`,
+          },
+          {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "s3:ListBucket",
+            Resource: `arn:aws:s3:::${bucketName}`,
+          },
+        ],
       }),
     },
   });

--- a/src/service/s3/command/get-object/get-object-authorizer.ts
+++ b/src/service/s3/command/get-object/get-object-authorizer.ts
@@ -1,7 +1,6 @@
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
-import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
-import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js";
+import { simS3AuthorizeAction } from "../authorize/sim-s3-authorize-action.js";
 import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 
 interface GetObjectAuthorizerProperties {
@@ -11,17 +10,11 @@ interface GetObjectAuthorizerProperties {
 /**
  * Applies IAM authorization to an S3 GetObject request.
  *
- * GetObject is authorized against the target Object ARN rather than the Bucket
- * ARN. An omitted caller is passed through to sim IAM so Account root fallback
- * behavior remains owned by IAM.
- *
- * The request's source ARN and source Account go in as condition keys, which is
- * what a Bucket policy written for a CloudFront origin access control is
- * conditioned on.
+ * A read is authorized against the target Object ARN. A read that finds
+ * nothing is authorized a second time, against the Bucket ARN, because real S3
+ * decides between AccessDenied and NoSuchKey on `s3:ListBucket`.
  */
 export class GetObjectAuthorizer {
-  private static readonly action = "s3:GetObject";
-
   private readonly iam: SimIamInterServiceAuthZ;
 
   constructor(properties: GetObjectAuthorizerProperties) {
@@ -36,32 +29,32 @@ export class GetObjectAuthorizer {
     key: string,
     options?: SimS3RequestOptions,
   ): void {
-    const resource = `arn:aws:s3:::${bucket.bucketName}/${key}`;
-    const policy = bucket.getPolicy();
-    const decision = this.iam.authorize({
-      action: GetObjectAuthorizer.action,
-      resource,
-      caller: options?.caller,
-      conditionContext: simS3ConditionContext(options),
-      resourcePolicies:
-        policy === undefined
-          ? []
-          : [
-              {
-                document: policy,
-                policyName: "BucketPolicy",
-                resourceArn: `arn:aws:s3:::${bucket.bucketName}`,
-              },
-            ],
+    simS3AuthorizeAction({
+      iam: this.iam,
+      action: "s3:GetObject",
+      resource: `arn:aws:s3:::${bucket.bucketName}/${key}`,
+      bucket,
+      options,
     });
+  }
 
-    if (decision.isDenied) {
-      throw new SimIamAccessDenied({
-        principal: decision.caller.principal,
-        reason: decision.denialReason,
-        action: GetObjectAuthorizer.action,
-        resource,
-      });
-    }
+  /**
+   * Ensure the caller may be told that the Bucket holds no such key.
+   *
+   * Which keys a Bucket holds is what a listing tells you. Real S3 admits the
+   * absence only to a caller holding `s3:ListBucket` on the Bucket. Everyone
+   * else gets the same AccessDenied whether the key is there or not.
+   */
+  authorizeMissingKey(
+    bucket: SimS3Bucket,
+    options?: SimS3RequestOptions,
+  ): void {
+    simS3AuthorizeAction({
+      iam: this.iam,
+      action: "s3:ListBucket",
+      resource: `arn:aws:s3:::${bucket.bucketName}`,
+      bucket,
+      options,
+    });
   }
 }

--- a/src/service/s3/command/get-object/get-object-loader.ts
+++ b/src/service/s3/command/get-object/get-object-loader.ts
@@ -1,6 +1,5 @@
 import { Readable } from "node:stream";
 import type { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
-import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
 import { simS3QuotedETag } from "../../object/s3-object-etag.js";
 import { simS3ObjectStorageReport } from "../../object/s3-object-storage-report.js";
 import {
@@ -20,8 +19,8 @@ import type { SimGetObjectCommandOutput } from "./get-object.command.js";
  * This class owns both storage lookup and response conversion because the SDK
  * response is a representation of the stored Object:
  *
- * - a missing storage entry becomes the S3 NoSuchKey error, and a `VersionId`
- *   naming a version the Bucket never issued becomes NoSuchVersion;
+ * - a `VersionId` naming a version the Bucket never issued becomes
+ *   NoSuchVersion;
  * - the stored Buffer, or the part of it the read asked for, becomes the
  *   readable response body;
  * - what S3 was told about the Object becomes the response's own fields, and
@@ -35,16 +34,20 @@ export class GetObjectLoader {
   /**
    * Read an Object, or the range of it that was asked for, from the resolved
    * Bucket, and build its SDK command output.
+   *
+   * Answering `undefined` means the key holds nothing. The command handler
+   * turns that into the error the caller's permissions allow, which for a
+   * missing key is a decision of its own.
    */
   async load(
     bucket: SimS3Bucket,
     key: string,
     rangeHeader?: string,
     versionId?: string,
-  ): Promise<SimGetObjectCommandOutput> {
+  ): Promise<SimGetObjectCommandOutput | undefined> {
     const read = await simS3ReadObjectVersion(bucket, key, versionId);
     if (read === undefined) {
-      throw new SimS3NoSuchKey(`No S3 Object named ${key}`);
+      return undefined;
     }
 
     const object = read.object;

--- a/src/service/s3/command/get-object/get-object-missing-key-iam.iso.test.ts
+++ b/src/service/s3/command/get-object/get-object-missing-key-iam.iso.test.ts
@@ -1,0 +1,179 @@
+import { PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import {
+  assertBufferEqual,
+  assertIdentical,
+  assertInstanceOf,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { SimSdk } from "../../../../sdk/sim-sdk.js";
+import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
+import type { SimS3 } from "../../sim-s3.js";
+import { simS3BodyToBuffer } from "../../storage/s3-body-buffer.js";
+
+/**
+ * What S3 answers for a key that is not there depends on a second permission.
+ *
+ * A caller allowed `s3:GetObject` and nothing else is told the same thing
+ * whether or not the Object exists, because admitting the absence would tell
+ * it something a listing would have told it. `s3:ListBucket` on the Bucket is
+ * what buys the difference.
+ */
+describe("S3 GetObject on a key that is not there", () => {
+  const bucketName = "quarterly-reports";
+
+  it("refuses a reader that may not list the Bucket", async () => {
+    // Given a reader allowed to get Objects from a Bucket and nothing else.
+    const simAws = new SimAws();
+    const simS3 = await bucketFor(simAws);
+    const readerArn = await objectReaderArn(simAws);
+
+    // When it asks for a key the Bucket does not hold.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({ Bucket: bucketName, Key: "q4/report.pdf" }),
+        { caller: { kind: "arn", arn: readerArn } },
+      ),
+    );
+
+    // Then S3 refuses rather than saying the key is missing, and names the
+    // listing permission that would have let it say so.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertIdentical(error.$metadata.httpStatusCode, 403);
+    assertIdentical(error.action, "s3:ListBucket");
+    assertIdentical(error.resource, `arn:aws:s3:::${bucketName}`);
+  });
+
+  it("admits the key is missing once the reader may list the Bucket", async () => {
+    // Given the same reader, now also allowed to list the Bucket.
+    const simAws = new SimAws();
+    const simS3 = await bucketFor(simAws);
+    const readerArn = await objectReaderArn(simAws);
+    await allowBucketListing(simAws);
+
+    // When it asks for a key the Bucket does not hold.
+    const error = await assertThrowsErrorAsync(async () =>
+      simS3.getObject(
+        new GetObjectCommand({ Bucket: bucketName, Key: "q4/report.pdf" }),
+        { caller: { kind: "arn", arn: readerArn } },
+      ),
+    );
+
+    // Then the absence is what comes back, which is the error a caller
+    // handling an optional Object catches.
+    assertInstanceOf(error, SimS3NoSuchKey);
+    assertIdentical(error.$metadata.httpStatusCode, 404);
+  });
+
+  it("serves an Object that is there to a reader holding no listing permission", async () => {
+    // Given an Object in the Bucket and a reader allowed only to get Objects.
+    const simAws = new SimAws();
+    const simS3 = await bucketFor(simAws);
+    const readerArn = await objectReaderArn(simAws);
+    await simS3.putObject(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: "q3/report.pdf",
+        Body: "quarterly numbers",
+      }),
+    );
+
+    // When it asks for that Object.
+    const output = await simS3.getObject(
+      new GetObjectCommand({ Bucket: bucketName, Key: "q3/report.pdf" }),
+      { caller: { kind: "arn", arn: readerArn } },
+    );
+
+    // Then reading an Object it can already name takes `s3:GetObject` alone.
+    assertBufferEqual(
+      await simS3BodyToBuffer(output.Body as AsyncIterable<Buffer>),
+      Buffer.from("quarterly numbers"),
+    );
+  });
+
+  it("answers an intercepted SDK client the same way", async () => {
+    // Given an AWS SDK client whose commands go to the simulation, sending as
+    // a reader that may not list the Bucket.
+    const simAws = new SimAws();
+    using simSdk = new SimSdk({ simAws });
+    await bucketFor(simAws);
+    const readerArn = await objectReaderArn(simAws);
+
+    const client = new S3Client({ region: simAws.defaultRegionName });
+    simSdk.intercept(client);
+
+    // When it asks for a key the Bucket does not hold.
+    const error = await simAws.runAs(
+      { kind: "arn", arn: readerArn },
+      async () =>
+        await assertThrowsErrorAsync(async () =>
+          client.send(
+            new GetObjectCommand({ Bucket: bucketName, Key: "q4/report.pdf" }),
+          ),
+        ),
+    );
+
+    // Then the code under test sees the name and status a deployed client
+    // would see rather than a missing-key error it never gets in AWS.
+    assertIdentical(error.name, "AccessDenied");
+    assertIdentical(
+      (error as SimIamAccessDenied).$metadata.httpStatusCode,
+      403,
+    );
+  });
+
+  /**
+   * A Bucket in its own simulated AWS, in the Region the tests read from.
+   */
+  async function bucketFor(simAws: SimAws): Promise<SimS3> {
+    const simS3 = simAws.s3();
+    await simS3.createBucket(new CreateBucketCommand({ Bucket: bucketName }));
+
+    return simS3;
+  }
+
+  /**
+   * A Role allowed to read the Bucket's Objects and to do nothing else.
+   */
+  async function objectReaderArn(simAws: SimAws): Promise<string> {
+    const role = await simIamRoleWithPolicyFactory.make(
+      {
+        roleName: "ReportReader",
+        actions: ["s3:GetObject"],
+        resource: `arn:aws:s3:::${bucketName}/*`,
+      },
+      simAws,
+    );
+
+    return role.Arn;
+  }
+
+  /**
+   * Grant that Role the Bucket listing its Objects sit under.
+   */
+  async function allowBucketListing(simAws: SimAws): Promise<void> {
+    await simAws.iam().putRolePolicy(
+      new PutRolePolicyCommand({
+        RoleName: "ReportReader",
+        PolicyName: "ListReports",
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: {
+            Action: "s3:ListBucket",
+            Resource: `arn:aws:s3:::${bucketName}`,
+          },
+        }),
+      }),
+    );
+  }
+});

--- a/src/service/s3/command/get-object/get-object.handler.ts
+++ b/src/service/s3/command/get-object/get-object.handler.ts
@@ -8,7 +8,7 @@ import type {
   SimS3BucketName,
 } from "../../bucket/sim-s3-bucket.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
-import { SimS3NoSuchBucket } from "../../error/sim-s3.error.js";
+import { SimS3NoSuchKey } from "../../error/sim-s3.error.js";
 import {
   type BackgroundScheduler,
   BackgroundTasks,
@@ -17,6 +17,7 @@ import {
   SimIamAllowAllAuth,
   type SimIamInterServiceAuthZ,
 } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { requireSimS3Bucket } from "../require-sim-s3-bucket.js";
 import type { SimS3RequestOptions } from "../sim-s3-request-options.js";
 import { GetObjectAuthorizer } from "./get-object-authorizer.js";
 import { GetObjectLoader } from "./get-object-loader.js";
@@ -65,6 +66,10 @@ export class GetObjectCommandHandler implements CommandHandler<
    *
    * A stated `Range` reaches the loader with the key, since which bytes of an
    * Object a caller may read is not something IAM decides.
+   *
+   * A key holding nothing goes back to authorization before the absence is
+   * reported. Real S3 tells a caller that a key is missing only where it may
+   * list the Bucket, and answers AccessDenied otherwise.
    */
   async handle(
     command: SimGetObjectCommand,
@@ -73,22 +78,29 @@ export class GetObjectCommandHandler implements CommandHandler<
     assertDefined(command.input.Bucket, "GetObjectCommand.input.Bucket");
     assertDefined(command.input.Key, "GetObjectCommand.input.Key");
 
-    const bucketName = command.input.Bucket as SimS3BucketName;
-    const bucket = this.buckets.get(bucketName);
-    if (bucket === undefined) {
-      throw new SimS3NoSuchBucket(`No S3 Bucket named ${bucketName}`);
-    }
+    const bucket = requireSimS3Bucket(
+      this.buckets,
+      command.input.Bucket as SimS3BucketName,
+    );
 
     // Complete request sequencing before authorization and storage access.
     await this.background.sequence();
 
     this.authorizer.authorize(bucket, command.input.Key, options);
 
-    return await this.loader.load(
+    const output = await this.loader.load(
       bucket,
       command.input.Key,
       command.input.Range,
       command.input.VersionId,
     );
+
+    if (output !== undefined) {
+      return output;
+    }
+
+    this.authorizer.authorizeMissingKey(bucket, options);
+
+    throw new SimS3NoSuchKey(`No S3 Object named ${command.input.Key}`);
   }
 }

--- a/src/service/s3/serve/sim-s3-rest-endpoint.iso.test.ts
+++ b/src/service/s3/serve/sim-s3-rest-endpoint.iso.test.ts
@@ -75,6 +75,27 @@ describe("The simulated S3 REST endpoint", () => {
     expect(await response.text()).toMatch(/<Code>NoSuchKey<\/Code>/);
   });
 
+  it("refuses a missing Object to a signer that may not list the Bucket", async () => {
+    // Given a presigned URL from a user allowed to read Objects and nothing
+    // else, for an Object that is not there
+    const { client, http } = await presignSimulation({
+      allowsBucketListing: false,
+    });
+    const url = await getSignedUrl(
+      client,
+      new GetObjectCommand({ Bucket: presignBucketName, Key: "missing.pdf" }),
+      { expiresIn: 900 },
+    );
+
+    // When it is fetched
+    const response = await http.fetch(url);
+
+    // Then the endpoint refuses rather than admitting the key is absent, which
+    // is what a deployed client holding the same permissions is answered
+    assertResponseStatus(response, 403, await describeResponse(response));
+    expect(await response.text()).toMatch(/<Code>AccessDenied<\/Code>/);
+  });
+
   it("serves a HEAD request without a body", async () => {
     // Given a URL presigned for HEAD, since the method is signed and a URL
     // presigned for GET cannot be used with another

--- a/test/s3/presign-simulation.ts
+++ b/test/s3/presign-simulation.ts
@@ -86,6 +86,12 @@ interface PresignSimulationProperties {
    */
   readonly allowedActions?: string[];
   /**
+   * Whether the signing user may list the Bucket, which is what lets S3 tell
+   * it that a key is missing. A user without it is answered AccessDenied for
+   * an Object that is not there, as real S3 answers one.
+   */
+  readonly allowsBucketListing?: boolean;
+  /**
    * Passed to the S3 client, so a test can build URLs the way a client with a
    * different checksum setting would.
    */
@@ -106,6 +112,7 @@ export async function presignSimulation(
 ): Promise<PresignSimulation> {
   const {
     allowedActions = ["s3:GetObject", "s3:PutObject"],
+    allowsBucketListing = true,
     requestChecksumCalculation = "WHEN_REQUIRED",
     forcePathStyle = false,
   } = properties;
@@ -135,11 +142,22 @@ export async function presignSimulation(
       PolicyName: "PresignedObjectAccess",
       PolicyDocument: JSON.stringify({
         Version: "2012-10-17",
-        Statement: {
-          Effect: "Allow",
-          Action: allowedActions,
-          Resource: `arn:aws:s3:::${presignBucketName}/*`,
-        },
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: allowedActions,
+            Resource: `arn:aws:s3:::${presignBucketName}/*`,
+          },
+          ...(allowsBucketListing
+            ? [
+                {
+                  Effect: "Allow",
+                  Action: "s3:ListBucket",
+                  Resource: `arn:aws:s3:::${presignBucketName}`,
+                },
+              ]
+            : []),
+        ],
       }),
     }),
   );


### PR DESCRIPTION
GetObject answered NoSuchKey for a key the Bucket does not hold whoever asked. Real S3 answers that only to a caller holding `s3:ListBucket` on the Bucket, and refuses everyone else whether the key is there or not, which left a test handling an absence the deployed code never reports. A read that finds nothing now goes back to authorization for that permission, and a caller allowed `s3:GetObject` alone gets AccessDenied with a 403 through the in-process command, an intercepted SDK client and the served REST endpoint alike. Reading an Object that is there still takes `s3:GetObject` on its own. The static website endpoint and a CloudFront S3 Origin read through the same command and follow the rule, and the shared public-read test fixture now grants the Bucket listing a public site needs for its 404s.

Resolves #1252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 missing-object responses now reflect bucket permissions: requests return `403 AccessDenied` without listing access and `404 NoSuchKey` when listing access is granted.
  * This behavior is consistent across SDK, REST, static website, and CloudFront S3 access.
  * Existing objects remain accessible with `s3:GetObject` alone.

* **Documentation**
  * Added guidance and examples explaining missing-object authorization and custom error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->