### PR TITLE
feat: project simulated Query and Scan reads

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1899,6 +1899,84 @@ The key condition and the filter share one set of placeholders. A `#name` or `:v
 uses counts as used, and one that goes unused by both is refused the way an unused placeholder
 always is.
 
+### Projecting a read
+
+`ProjectionExpression` names the attributes a `Query` or a `Scan` answers with, the way it does on
+[a GetItem](#projecting-attributes). Only the paths it names come back. The key attributes the read
+walked by are left out along with everything else. That is what makes a projection usable as an
+allow-list over what leaves the table.
+
+The projection runs after the filter, and an attribute the filter tested can be left out of the
+answer.
+
+```typescript sim-dynamodb-scan-projection
+/**
+ * Scanning a table without reading the attributes the caller has no use for.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "ReadersTable",
+    KeySchema: [{ AttributeName: "readerId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "readerId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "ReadersTable",
+    Item: {
+      readerId: { S: "reader-1" },
+      email: { S: "reader@example.com" },
+      status: { S: "active" },
+      lastReadAt: { S: "2026-01-31" },
+    },
+  }),
+);
+
+const output = await dynamoDb.scan(
+  new ScanCommand({
+    TableName: "ReadersTable",
+    // `status` is a DynamoDB reserved word, so it is named by a placeholder.
+    ProjectionExpression: "#status, lastReadAt",
+    ExpressionAttributeNames: { "#status": "status" },
+  }),
+);
+
+// The key the scan walked by is left out along with the email address.
+console.log(Object.keys(output.Items?.[0] ?? {}));
+// [ "status", "lastReadAt" ]
+
+console.log(output.Items?.[0]?.["lastReadAt"]?.S);
+// 2026-01-31
+```
+
+`Count` and `ScannedCount` count items. A projection cuts each item down and moves neither figure.
+
+`LastEvaluatedKey` names the item a page stopped on by its key, whether or not the projection asked
+for those attributes. A paged read resumes from a token the items it answered with do not carry.
+
+The key condition, the filter and the projection share one set of placeholders. A `#name` or
+`:value` any of them uses counts as used, and one none of them uses is refused the way an unused
+placeholder always is.
+
+On a global secondary index a projection may name only the attributes the index projects. Anything
+else is a `ValidationException`, the refusal a filter naming the same attribute gets. A local
+secondary index fetches from the base table, and any attribute of the item is nameable there.
+
 ### Counting and projecting with Select
 
 `Select` says which attributes a read answers with. A table read defaults to `ALL_ATTRIBUTES`,
@@ -1916,8 +1994,8 @@ The other two values are held to the rules AWS holds them to, each a `Validation
 - `ALL_PROJECTED_ATTRIBUTES` without an `IndexName`. It asks for the attributes an index projects,
   and a table read has no index to project from.
 
-Projecting a `Query` or a `Scan` is absent, so `SPECIFIC_ATTRIBUTES` gets as far as the
-`ProjectionExpression` refusal rather than being accepted with no attribute to project.
+`SPECIFIC_ATTRIBUTES` alongside a `ProjectionExpression` answers with the attributes that
+projection names. See [projecting a read](#projecting-a-read).
 
 ## Reading and writing items in batches
 
@@ -3485,7 +3563,7 @@ is written.
   ARN and authorizes before the lookup.
 - `GetItem`, answering with the item under a primary key, and with no `Item` at all when the key
   holds nothing.
-- `ProjectionExpression` on `GetItem`, with document paths, list indexing and
+- `ProjectionExpression` on `GetItem`, `Query` and `Scan`, with document paths, list indexing and
   `ExpressionAttributeNames` placeholders.
 - `DeleteItem`, removing the item under a primary key and answering with it for `ALL_OLD`.
 - `UpdateItem`, with `SET`, `REMOVE`, `ADD` and `DELETE` update expressions, `if_not_exists`,
@@ -3560,9 +3638,9 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
 - A read of a global secondary index answers with the attributes the index projects, and no fetch
   fills in the rest. Real DynamoDB behaves the same way. It never reads the base table for an
   attribute a global secondary index omits. That is why `Select: ALL_ATTRIBUTES` against a partial
-  projection is refused outright. A local secondary index does fetch from the base table, and that
-  is simulated. `ProjectionExpression` is absent on `Query` or `Scan` either way, so naming a
-  non-projected attribute that way never arises.
+  projection is refused outright, and so is a `ProjectionExpression` naming an attribute the index
+  omits. A local secondary index does fetch from the base table, and that is simulated, so a
+  `ProjectionExpression` there may name any attribute of the item.
 - The 10 GB limit on one item collection is left out, along with
   `ItemCollectionSizeLimitExceededException`. A table with a local secondary index can hold as much
   under one partition key here as memory allows. A write real DynamoDB would refuse for the size of
@@ -3705,9 +3783,6 @@ SimDynamoDb()` has no clock control at all. No item there ever expires.
   real DynamoDB accepts it. The shape of a key condition is fixed. There is no sub-expression for
   brackets to group, and being stricter is the direction that fails safely. It is a puzzling refusal
   here rather than a query that means something different on AWS.
-- `ProjectionExpression` is refused on `Query` and on `Scan`, since it changes which parts of an
-  item the operation answers with. `Select` covers the counted and the projected read in the
-  meantime.
 - `UnprocessedItems` and `UnprocessedKeys` are always empty. No request here is throttled and no
   response stops at a size, and the branch of a batch retry loop that resends what did not go
   through is never taken against the simulator.
@@ -3740,8 +3815,8 @@ SimDynamoDb()` has no clock control at all. No item there ever expires.
 - A CloudFormation stack update replaces a changed table rather than updating it in place. The items
   in it are lost where real CloudFormation would keep them for a property it can change without
   replacement.
-- `ProjectionExpression` is simulated on `GetItem`, `BatchGetItem` and `TransactGetItems`. On
-  `Query` and `Scan` it is refused, never ignored.
+- `ProjectionExpression` is simulated on every read that takes one, which is `GetItem`,
+  `BatchGetItem`, `TransactGetItems`, `Query` and `Scan`.
 - The legacy `AttributesToGet` is refused outright, since an item that came back whole where part of
   it was asked for would hide an application reading an attribute it never requested.
   `ProjectionExpression` replaced it, and real DynamoDB has built no feature on it since.

--- a/docs/services/dynamodb/sim-dynamodb-scan-projection.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-scan-projection.example.ts
@@ -1,0 +1,52 @@
+/**
+ * Scanning a table without reading the attributes the caller has no use for.
+ */
+
+import {
+  CreateTableCommand,
+  PutItemCommand,
+  ScanCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const dynamoDb = simAws.dynamoDb();
+
+await dynamoDb.createTable(
+  new CreateTableCommand({
+    TableName: "ReadersTable",
+    KeySchema: [{ AttributeName: "readerId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "readerId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simAws.backgroundTasksComplete();
+
+await dynamoDb.putItem(
+  new PutItemCommand({
+    TableName: "ReadersTable",
+    Item: {
+      readerId: { S: "reader-1" },
+      email: { S: "reader@example.com" },
+      status: { S: "active" },
+      lastReadAt: { S: "2026-01-31" },
+    },
+  }),
+);
+
+const output = await dynamoDb.scan(
+  new ScanCommand({
+    TableName: "ReadersTable",
+    // `status` is a DynamoDB reserved word, so it is named by a placeholder.
+    ProjectionExpression: "#status, lastReadAt",
+    ExpressionAttributeNames: { "#status": "status" },
+  }),
+);
+
+// The key the scan walked by is left out along with the email address.
+console.log(Object.keys(output.Items?.[0] ?? {}));
+// [ "status", "lastReadAt" ]
+
+console.log(output.Items?.[0]?.["lastReadAt"]?.S);
+// 2026-01-31

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -252,15 +252,19 @@ the same walking a table gets and the same walking whichever kind of index it is
 
 `SimDynamoDbProjectedIndexAttributes` is the global secondary index half. `assertCarriesWholeItem`
 and `assertCarriesPaths` refuse a `Select` of `ALL_ATTRIBUTES` against a projection that is not ALL,
-and a filter naming an attribute the index does not project. Both fail closed. The alternative to
-the second is an empty page, which reads as a collection that happens to hold nothing.
+and a filter or a `ProjectionExpression` naming an attribute the index does not project. Both fail
+closed. The alternative to the second is an empty page for a filter, or an attribute quietly missing
+from every item for a projection.
 
 `SimDynamoDbFetchedIndexAttributes` is the local secondary index half, and refuses neither. The index
 entry is in the same partition as the item, so DynamoDB reads the base table for what the index does
 not project and charges the extra capacity for it. Cutting an item down to the projection is still
 the same job, so it is delegated to the projected implementation rather than written twice. What the
-read then answers with is decided by `SimDynamoDbSelect.wholeItems` in `SimDynamoDbReadAnswer`: a
-read asking for whole items gets the item, and anything else gets the view's projection of it.
+read then answers with is decided in `SimDynamoDbReadAnswer`. A request carrying a
+`ProjectionExpression` has that applied to the whole item, which is what fetches an unprojected
+attribute here and changes nothing on a global secondary index, where every projected path has been
+checked already. Otherwise `SimDynamoDbSelect.wholeItems` decides: a read asking for whole items gets
+the item, and anything else gets the view's projection of it.
 
 The other place the kinds differ is `assertAnswersConsistentRead`, reached through
 `SimDynamoDbReadView.assertConsistentRead` and applied by
@@ -572,10 +576,10 @@ The order it works in is the order the other commands follow, with one addition:
 1. `SimDynamoDbSelect.from` reads which attributes the request asks for. It comes first because it
    decides whether the projection the request carries is one it could have asked for at all.
 2. `refuseUnsimulatedQueryInput` refuses the inputs this simulation does not model.
-3. `readSimDynamoDbQueryExpressions` reads the `KeyConditionExpression` and the `FilterExpression`,
-   before the table is reached, so an expression DynamoDB would refuse is refused whether or not the
-   table is there. Both draw on one `SimDynamoDbExpressionParameters`, the way UpdateItem's two
-   expressions do.
+3. `readSimDynamoDbQueryExpressions` reads the `KeyConditionExpression`, the `FilterExpression` and
+   the `ProjectionExpression`, before the table is reached, so an expression DynamoDB would refuse is
+   refused whether or not the table is there. All three draw on one
+   `SimDynamoDbExpressionParameters`, the way UpdateItem's two expressions do.
 4. The table is found and the caller authorized.
 5. `SimDynamoDbKeyConditionTerms.forTable` reads the terms against the table's key schema, which is
    the part that could not be checked without it: which attribute is the partition key, and what type
@@ -634,9 +638,10 @@ and no key knowledge. It takes the same steps a query does, minus the key condit
 
 1. `SimDynamoDbSelect.from` reads which attributes the request asks for.
 2. `refuseUnsimulatedScanInput` refuses the inputs this simulation does not model.
-3. `readSimDynamoDbScanSegment` reads `Segment` and `TotalSegments`, and `readSimDynamoDbFilter` the
-   `FilterExpression`, before the table is reached, so input DynamoDB would refuse is refused whether
-   or not the table is there. A scan filter needs nothing from the table, unlike a query's.
+3. `readSimDynamoDbScanSegment` reads `Segment` and `TotalSegments`, and
+   `readSimDynamoDbScanExpressions` the `FilterExpression` and the `ProjectionExpression` against one
+   set of placeholders, before the table is reached, so input DynamoDB would refuse is refused
+   whether or not the table is there. A scan filter needs nothing from the table, unlike a query's.
 4. The table is found and the caller authorized.
 5. The table is put in scan order, walked from the `ExclusiveStartKey`, and cut to a page by the same
    `SimDynamoDbItemPage` a query uses, then filtered by the same `SimDynamoDbReadAnswer`.
@@ -916,7 +921,9 @@ parser reads one and refuses a second. That is a grammar rule rather than a simu
 DynamoDB refuses `:a + :b + :c` as a syntax error too.
 
 `expression/projection/` is the other consumer. `readSimDynamoDbProjection` reads a
-`ProjectionExpression` and its names into a `SimDynamoDbProjection`, and `SimDynamoDbProjectionNode`
+`ProjectionExpression` and its names into a `SimDynamoDbProjection` for a read whose projection is
+its only expression, and `parseSimDynamoDbProjection` does the same against placeholders a query or a
+scan has already gathered for its other expressions. `SimDynamoDbProjectionNode`
 merges the paths into a tree before anything is read, so `address.city` and `address.postcode` become
 one `address` holding two attributes. Two paths where one contains the other are refused there, as
 real DynamoDB refuses them.

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.ts
@@ -78,6 +78,7 @@ export class SimDynamoDbQuery {
     // waits for the view the same way the key condition does.
     expressions.filter?.assertNamesNoKeyAttribute(view.keySchema);
     expressions.filter?.assertNamesOnlyCarried(view);
+    expressions.projection?.assertNamesOnlyCarried(view);
 
     // The token names an item of the collection being read, so it can only be
     // checked once that collection is known.
@@ -100,6 +101,7 @@ export class SimDynamoDbQuery {
       ...new SimDynamoDbReadAnswer({
         page,
         filter: expressions.filter,
+        projection: expressions.projection,
         select,
         view,
       }).fields(),

--- a/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.iso.test.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.iso.test.ts
@@ -36,10 +36,6 @@ const keyCondition = {
 
 describe("DynamoDB QueryCommand unsimulated input", () => {
   it.each([
-    {
-      name: "ProjectionExpression",
-      input: { ProjectionExpression: "orderId" },
-    },
     { name: "AttributesToGet", input: { AttributesToGet: ["orderId"] } },
     {
       name: "KeyConditions",

--- a/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-unsimulated-query-input.ts
@@ -13,11 +13,6 @@ export function refuseUnsimulatedQueryInput(input: SimQueryCommandInput): void {
   const unsimulated = new SimDynamoDbUnsimulatedInput("Query");
 
   unsimulated.refuse(
-    input.ProjectionExpression !== undefined,
-    "ProjectionExpression",
-    "answering with whole items where part of them was asked for",
-  );
-  unsimulated.refuse(
     (input.AttributesToGet ?? []).length > 0,
     "AttributesToGet",
     "answering with whole items where part of them was asked for",

--- a/src/service/dynamodb/command/read/sim-dynamodb-read-answer.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-read-answer.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter.js";
+import type { SimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 import type { SimDynamoDbAttributeValue } from "../item/item.types.js";
@@ -22,6 +23,7 @@ export interface SimDynamoDbReadFields {
 interface SimDynamoDbReadAnswerProperties {
   readonly page: SimDynamoDbItemPage;
   readonly filter: SimDynamoDbFilter | undefined;
+  readonly projection: SimDynamoDbProjection | undefined;
   readonly select: SimDynamoDbSelect;
   readonly view: SimDynamoDbReadView;
 }
@@ -45,6 +47,7 @@ export class SimDynamoDbReadAnswer {
   private readonly lastEvaluatedKey:
     | Record<string, SimDynamoDbAttributeValue>
     | undefined;
+  private readonly projection: SimDynamoDbProjection | undefined;
   private readonly select: SimDynamoDbSelect;
   private readonly view: SimDynamoDbReadView;
 
@@ -54,6 +57,7 @@ export class SimDynamoDbReadAnswer {
     this.scannedCount = evaluated.length;
     this.kept = properties.filter?.applyTo(evaluated) ?? evaluated;
     this.lastEvaluatedKey = properties.page.lastEvaluatedKey;
+    this.projection = properties.projection;
     this.select = properties.select;
     this.view = properties.view;
   }
@@ -86,12 +90,23 @@ export class SimDynamoDbReadAnswer {
   /**
    * One item as the read answers with it.
    *
-   * A read asking for whole items answers with the whole item. Anything else is
-   * cut to what the view carries, so a read of an index answers with the
-   * attributes that index projects rather than with everything. A read of the
-   * table cuts nothing either way.
+   * A `ProjectionExpression` names the attributes it wants, so it is applied to
+   * the whole item and the view is not asked to cut one first. On a global
+   * secondary index that changes nothing, since every path the projection names
+   * has already been checked against what the index projects. On a local
+   * secondary index it is what fetches an unprojected attribute from the base
+   * table, which is what real DynamoDB does for the same read.
+   *
+   * Without a projection, a read asking for whole items answers with the whole
+   * item, and anything else is cut to what the view carries. That is how a read
+   * of an index answers with the attributes that index projects rather than
+   * with everything. A read of the table cuts nothing either way.
    */
   private answered(item: SimDynamoDbItem): SimDynamoDbItem {
+    if (this.projection !== undefined) {
+      return this.projection.apply(item);
+    }
+
     if (this.select.wholeItems) {
       return item;
     }

--- a/src/service/dynamodb/command/read/sim-dynamodb-read-projection.iso.test.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-read-projection.iso.test.ts
@@ -1,0 +1,193 @@
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import { simDynamoDbCollectionTableFactory } from "../../table/sim-dynamodb-collection-table.factory.js";
+import { simDynamoDbStockedTableFactory } from "../../table/sim-dynamodb-stocked-table.factory.js";
+import { simDynamoDbTableReads as reads } from "./sim-dynamodb-table-read.fixture.js";
+
+/**
+ * One customer's two orders, which is enough for a page with more than one item
+ * in it and few enough to write every attribute of both out.
+ */
+const oneCustomer = { customerCount: 1, orderCount: 2 };
+
+describe("DynamoDB read projections", () => {
+  it.each(reads)(
+    "answers with the projected attributes alone on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(oneCustomer, simAws);
+
+      // When a read names two of the four attributes an order carries.
+      const output = await read(simDynamoDb, {
+        ProjectionExpression: "orderId, #t",
+        ExpressionAttributeNames: { "#t": "total" },
+      });
+
+      // Then those two come back and the rest stay behind, including the key
+      // attributes the read found the items by. A projection used as an
+      // allow-list is only worth writing if what it leaves out never arrives.
+      const items = output.Items ?? [];
+
+      assertArrayLength(items, 2);
+      assertObjectEquals(items[0], {
+        orderId: { S: "2026-01" },
+        total: { N: "1" },
+      });
+      assertObjectEquals(items[1], {
+        orderId: { S: "2026-02" },
+        total: { N: "2" },
+      });
+    },
+  );
+
+  it.each(reads)(
+    "keeps the nested shape of what it projects on $operation",
+    async ({ read }) => {
+      // Given a table holding one order with a map and a list in it.
+      const simAws = new SimAws();
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbCollectionTableFactory.make({}, simAws);
+      await simDynamoDb.putItem({
+        input: {
+          TableName: "OrdersTable",
+          Item: {
+            customerId: { S: "c-1" },
+            orderId: { S: "2026-01" },
+            address: { M: { city: { S: "Leeds" }, postcode: { S: "LS1" } } },
+            lines: { L: [{ S: "first" }, { S: "second" }] },
+          },
+        },
+      });
+
+      // When a read names one attribute of the map and one place in the list.
+      const output = await read(simDynamoDb, {
+        ProjectionExpression: "address.city, lines[0]",
+      });
+
+      // Then the map and the list come back holding only what was named,
+      // rather than flattened into the paths that named them.
+      const items = output.Items ?? [];
+
+      assertArrayLength(items, 1);
+      assertObjectEquals(items[0], {
+        address: { M: { city: { S: "Leeds" } } },
+        lines: { L: [{ S: "first" }] },
+      });
+    },
+  );
+
+  it.each(reads)(
+    "reads a filter and a projection off one set of placeholders on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders, one of them shipped.
+      const simAws = new SimAws();
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(oneCustomer, simAws);
+
+      // When a read filters by one attribute and projects another, with a
+      // placeholder defined for each.
+      const output = await read(simDynamoDb, {
+        FilterExpression: "#s = :shipped",
+        ProjectionExpression: "#t",
+        ExpressionAttributeNames: { "#s": "status", "#t": "total" },
+        ExpressionAttributeValues: { ":shipped": { S: "SHIPPED" } },
+      });
+
+      // Then both expressions were read, and neither placeholder counted as
+      // unused because the other expression is the one using it.
+      const items = output.Items ?? [];
+
+      assertArrayLength(items, 1);
+      assertObjectEquals(items[0], { total: { N: "2" } });
+    },
+  );
+
+  it.each(reads)(
+    "refuses a placeholder the projection and the filter both leave alone on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(oneCustomer, simAws);
+
+      // When a read projects one attribute and defines a name for another.
+      const error = await assertThrowsErrorAsync(async () =>
+        read(simDynamoDb, {
+          ProjectionExpression: "#t",
+          ExpressionAttributeNames: { "#t": "total", "#s": "status" },
+        }),
+      );
+
+      // Then the one no expression reached is refused by name, the way an
+      // expression left half edited is caught on AWS.
+      assertInstanceOf(error, SimDynamoDbValidationException);
+      assertStringIncludes(error.message, "#s");
+    },
+  );
+
+  it.each(reads)(
+    "counts the items it read rather than the attributes on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(oneCustomer, simAws);
+
+      // When a read projects one attribute of every item.
+      const output = await read(simDynamoDb, {
+        ProjectionExpression: "orderId",
+      });
+
+      // Then both counts are of items, and a projection cutting each item down
+      // moves neither of them.
+      assertIdentical(output.Count, 2);
+      assertIdentical(output.ScannedCount, 2);
+    },
+  );
+
+  it.each(reads)(
+    "names the item it stopped on by its key, whatever it projected, on $operation",
+    async ({ read }) => {
+      // Given a table holding a customer's orders.
+      const simAws = new SimAws();
+      const simDynamoDb = simAws.dynamoDb();
+
+      await simDynamoDbStockedTableFactory.make(oneCustomer, simAws);
+
+      // When a read stops at a limit while projecting away the key.
+      const output = await read(simDynamoDb, {
+        Limit: 1,
+        ProjectionExpression: "#t",
+        ExpressionAttributeNames: { "#t": "total" },
+      });
+
+      // Then the item carries only what was projected, and the token still
+      // carries the key. A token cut down to the projection would page no
+      // further, which is the read that quietly stops early.
+      const items = output.Items ?? [];
+
+      assertArrayLength(items, 1);
+      assertObjectEquals(items[0], { total: { N: "1" } });
+      assertObjectEquals(output.LastEvaluatedKey ?? {}, {
+        customerId: { S: "c-1" },
+        orderId: { S: "2026-01" },
+      });
+    },
+  );
+});

--- a/src/service/dynamodb/command/read/sim-dynamodb-select.iso.test.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-select.iso.test.ts
@@ -1,6 +1,7 @@
 import {
   assertArrayLength,
   assertIdentical,
+  assertObjectEquals,
   assertInstanceOf,
   assertStringIncludes,
   assertThrowsErrorAsync,
@@ -12,56 +13,8 @@ import {
   SimDynamoDbUnsupportedOperation,
   SimDynamoDbValidationException,
 } from "../../error/dynamodb.error.js";
-import type { SimDynamoDb } from "../../sim-dynamodb.js";
 import { simDynamoDbStockedTableFactory } from "../../table/sim-dynamodb-stocked-table.factory.js";
-import type {
-  SimQueryCommandInput,
-  SimQueryCommandOutput,
-} from "../query/query.command.js";
-import type { SimScanCommandInput } from "../scan/scan.command.js";
-
-/**
- * The values a query's own key condition needs, whatever the test adds.
- */
-const keyConditionValues = { ":customer": { S: "c-1" } };
-
-/**
- * One way of reading a table, so a rule about `Select` is checked on both of
- * the operations that take it.
- *
- * A query carries a key condition of its own, so what a test writes is added to
- * that rather than replacing it.
- */
-interface SimDynamoDbTableRead {
-  readonly operation: string;
-  readonly read: (
-    simDynamoDb: SimDynamoDb,
-    input: SimQueryCommandInput & SimScanCommandInput,
-  ) => Promise<SimQueryCommandOutput>;
-}
-
-const reads: readonly SimDynamoDbTableRead[] = [
-  {
-    operation: "Query",
-    read: async (simDynamoDb, input) =>
-      simDynamoDb.query({
-        input: {
-          TableName: "OrdersTable",
-          KeyConditionExpression: "customerId = :customer",
-          ...input,
-          ExpressionAttributeValues: {
-            ...keyConditionValues,
-            ...input.ExpressionAttributeValues,
-          },
-        },
-      }),
-  },
-  {
-    operation: "Scan",
-    read: async (simDynamoDb, input) =>
-      simDynamoDb.scan({ input: { TableName: "OrdersTable", ...input } }),
-  },
-];
+import { simDynamoDbTableReads as reads } from "./sim-dynamodb-table-read.fixture.js";
 
 describe("DynamoDB Select", () => {
   it.each(reads)(
@@ -231,7 +184,7 @@ describe("DynamoDB Select", () => {
   );
 
   it.each(reads)(
-    "refuses SPECIFIC_ATTRIBUTES with a projection as unsimulated on $operation",
+    "answers SPECIFIC_ATTRIBUTES with the projected attributes on $operation",
     async ({ read }) => {
       // Given a table holding a customer's orders.
       const simAws = new SimAws();
@@ -243,17 +196,18 @@ describe("DynamoDB Select", () => {
       );
 
       // When a read asks for specific attributes and names them.
-      const error = await assertThrowsErrorAsync(async () =>
-        read(simDynamoDb, {
-          Select: "SPECIFIC_ATTRIBUTES",
-          ProjectionExpression: "orderId",
-        }),
-      );
+      const output = await read(simDynamoDb, {
+        Select: "SPECIFIC_ATTRIBUTES",
+        ProjectionExpression: "orderId",
+      });
 
-      // Then the pair is allowed and the projection itself is what is refused,
-      // since projecting a query or a scan is not simulated yet.
-      assertInstanceOf(error, SimDynamoDbUnsupportedOperation);
-      assertStringIncludes(error.message, "ProjectionExpression");
+      // Then every item carries the one attribute the projection named, and
+      // the key it was found by is left out along with everything else.
+      const items = output.Items ?? [];
+
+      assertArrayLength(items, 2);
+      assertObjectEquals(items[0], { orderId: { S: "2026-01" } });
+      assertObjectEquals(items[1], { orderId: { S: "2026-02" } });
     },
   );
 

--- a/src/service/dynamodb/command/read/sim-dynamodb-table-read.fixture.ts
+++ b/src/service/dynamodb/command/read/sim-dynamodb-table-read.fixture.ts
@@ -1,0 +1,64 @@
+import type { SimDynamoDb } from "../../sim-dynamodb.js";
+import type {
+  SimQueryCommandInput,
+  SimQueryCommandOutput,
+} from "../query/query.command.js";
+import type { SimScanCommandInput } from "../scan/scan.command.js";
+
+/**
+ * Test support for checking one rule on both of the operations it governs.
+ *
+ * `Select`, `ProjectionExpression` and the rest of the read parameters mean the
+ * same thing to a Query and to a Scan, and a rule proved on one of them says
+ * nothing about the other. Tests of those iterate this rather than being
+ * written twice.
+ *
+ * These helpers drive the simulator through structural command shapes rather
+ * than real SDK command objects, because this is source rather than a test
+ * file. The colocated tests cover SDK-shaped input.
+ */
+
+/**
+ * The values a query's own key condition needs, whatever the test adds.
+ */
+const keyConditionValues = { ":customer": { S: "c-1" } };
+
+/**
+ * One way of reading a table, against `simDynamoDbStockedTableFactory`.
+ *
+ * A query carries a key condition of its own, so what a test writes is added to
+ * that rather than replacing it.
+ */
+export interface SimDynamoDbTableRead {
+  readonly operation: string;
+  readonly read: (
+    simDynamoDb: SimDynamoDb,
+    input: SimQueryCommandInput & SimScanCommandInput,
+  ) => Promise<SimQueryCommandOutput>;
+}
+
+/**
+ * Every way of reading a table, for a test that iterates them.
+ */
+export const simDynamoDbTableReads: readonly SimDynamoDbTableRead[] = [
+  {
+    operation: "Query",
+    read: async (simDynamoDb, input) =>
+      simDynamoDb.query({
+        input: {
+          TableName: "OrdersTable",
+          KeyConditionExpression: "customerId = :customer",
+          ...input,
+          ExpressionAttributeValues: {
+            ...keyConditionValues,
+            ...input.ExpressionAttributeValues,
+          },
+        },
+      }),
+  },
+  {
+    operation: "Scan",
+    read: async (simDynamoDb, input) =>
+      simDynamoDb.scan({ input: { TableName: "OrdersTable", ...input } }),
+  },
+];

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-expressions.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-expressions.ts
@@ -1,49 +1,58 @@
 import { parseSimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter-expression.js";
 import type { SimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter.js";
-import { readSimDynamoDbKeyCondition } from "../../expression/key-condition/sim-dynamodb-key-condition-expression.js";
-import type { SimDynamoDbKeyConditionTerms } from "../../expression/key-condition/sim-dynamodb-key-condition-terms.js";
 import { parseSimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection-expression.js";
 import type { SimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection.js";
 import { SimDynamoDbExpressionParameters } from "../../expression/sim-dynamodb-expression-parameters.js";
-import type { SimQueryCommandInput } from "./query.command.js";
+import type { SimScanCommandInput } from "./scan.command.js";
 
 /**
- * What a query's expressions say, once all three have been read.
+ * What a scan's expressions say, once both have been read.
  */
-export interface SimDynamoDbQueryExpressions {
-  readonly terms: SimDynamoDbKeyConditionTerms;
+export interface SimDynamoDbScanExpressions {
   readonly filter: SimDynamoDbFilter | undefined;
   readonly projection: SimDynamoDbProjection | undefined;
 }
 
 /**
- * Read every expression of a query against one set of placeholders.
+ * Read both expressions of a scan against one set of placeholders.
  *
  * `ExpressionAttributeNames` and `ExpressionAttributeValues` are shared between
- * the key condition, the filter and the projection, so they are checked once
- * all three have been read. A placeholder used by any one of them counts as
- * used, and one used by none is refused.
+ * the filter and the projection, so they are checked once both have been read.
+ * A placeholder used by either counts as used, and one used by neither is
+ * refused.
  *
- * All three are read before the table is reached, so an expression DynamoDB
- * would refuse is refused whether or not the table is there. What is left is
- * the part that needs the key schema, which each of them is held to once the
- * table has been found.
+ * A scan that names neither expression is a different refusal. There is nothing
+ * for a placeholder to be unused in, which is the wording real DynamoDB uses
+ * for a request carrying parameters and no expression at all.
+ *
+ * Both are read before the table is reached, so an expression DynamoDB would
+ * refuse is refused whether or not the table is there. What is left is which
+ * attributes the view being read carries, which each of them is held to once
+ * the table has been found.
  */
-export function readSimDynamoDbQueryExpressions(
-  input: SimQueryCommandInput,
-): SimDynamoDbQueryExpressions {
+export function readSimDynamoDbScanExpressions(
+  input: SimScanCommandInput,
+): SimDynamoDbScanExpressions {
+  if (
+    input.FilterExpression === undefined &&
+    input.ProjectionExpression === undefined
+  ) {
+    SimDynamoDbExpressionParameters.assertNoneWithout(input);
+
+    return { filter: undefined, projection: undefined };
+  }
+
   const parameters = new SimDynamoDbExpressionParameters(input);
-  const terms = readSimDynamoDbKeyCondition(input, parameters);
   const filter = filterIn(input.FilterExpression, parameters);
   const projection = projectionIn(input.ProjectionExpression, parameters);
 
   parameters.assertAllUsed();
 
-  return { terms, filter, projection };
+  return { filter, projection };
 }
 
 /**
- * Read the filter a query drops read items by, if it names one.
+ * Read the filter a scan drops read items by, if it names one.
  */
 function filterIn(
   expression: string | undefined,
@@ -57,7 +66,7 @@ function filterIn(
 }
 
 /**
- * Read the parts of an item a query answers with, if it names them.
+ * Read the parts of an item a scan answers with, if it names them.
  */
 function projectionIn(
   expression: string | undefined,

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
@@ -1,11 +1,11 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
-import { readSimDynamoDbFilter } from "../../expression/filter/sim-dynamodb-filter-expression.js";
 import { SimDynamoDbItemPage } from "../item/sim-dynamodb-item-page.js";
 import { SimDynamoDbReadAnswer } from "../read/sim-dynamodb-read-answer.js";
 import { assertSimDynamoDbConsistentReadAnswerable } from "../read/sim-dynamodb-consistent-read.js";
 import { SimDynamoDbSelect } from "../read/sim-dynamodb-select.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import type { SimScanCommand, SimScanCommandOutput } from "./scan.command.js";
+import { readSimDynamoDbScanExpressions } from "./sim-dynamodb-scan-expressions.js";
 import { readSimDynamoDbScanSegment } from "./sim-dynamodb-scan-segment-input.js";
 import { readSimDynamoDbScanStartKey } from "./sim-dynamodb-scan-start-key.js";
 import { refuseUnsimulatedScanInput } from "./sim-dynamodb-unsimulated-scan-input.js";
@@ -53,12 +53,12 @@ export class SimDynamoDbScan {
 
     refuseUnsimulatedScanInput(input);
 
-    // The segment and the filter are read before the table is reached, so
+    // The segment and the expressions are read before the table is reached, so
     // input DynamoDB would refuse is refused whether or not the table is
     // there. A scan narrows nothing, so unlike a query its filter may name any
     // attribute, including a key attribute, and needs no key schema to check.
     const segment = readSimDynamoDbScanSegment(input);
-    const filter = readSimDynamoDbFilter(input);
+    const expressions = readSimDynamoDbScanExpressions(input);
     const table = this.access.required(
       "dynamodb:Scan",
       input.TableName,
@@ -73,7 +73,8 @@ export class SimDynamoDbScan {
     // two index kinds is being read, so it waits for the view.
     assertSimDynamoDbConsistentReadAnswerable(input, view);
     select.assertAnswerableBy(view);
-    filter?.assertNamesOnlyCarried(view);
+    expressions.filter?.assertNamesOnlyCarried(view);
+    expressions.projection?.assertNamesOnlyCarried(view);
 
     // The token names a place in this view's scan order, so it can only be
     // checked once that order is known.
@@ -91,7 +92,13 @@ export class SimDynamoDbScan {
     });
 
     return {
-      ...new SimDynamoDbReadAnswer({ page, filter, select, view }).fields(),
+      ...new SimDynamoDbReadAnswer({
+        page,
+        filter: expressions.filter,
+        projection: expressions.projection,
+        select,
+        view,
+      }).fields(),
       $metadata: {},
     };
   }

--- a/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.iso.test.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.iso.test.ts
@@ -27,10 +27,6 @@ async function ordersTable(simAws: SimAws): Promise<SimDynamoDb> {
 
 describe("DynamoDB ScanCommand unsimulated input", () => {
   it.each([
-    {
-      name: "ProjectionExpression",
-      input: { ProjectionExpression: "orderId" },
-    },
     { name: "AttributesToGet", input: { AttributesToGet: ["orderId"] } },
     {
       name: "ScanFilter",

--- a/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-unsimulated-scan-input.ts
@@ -10,18 +10,13 @@ import type { SimScanCommandInput } from "./scan.command.js";
  * application reading the page.
  *
  * `ExpressionAttributeNames` and `ExpressionAttributeValues` are not among
- * them. They are the placeholders of the `FilterExpression`, and a request
- * carrying them with no expression to use them in is a ValidationException the
- * way it is on AWS.
+ * them. They are the placeholders of the `FilterExpression` and the
+ * `ProjectionExpression`, and a request carrying them with neither expression
+ * to use them in is a ValidationException the way it is on AWS.
  */
 export function refuseUnsimulatedScanInput(input: SimScanCommandInput): void {
   const unsimulated = new SimDynamoDbUnsimulatedInput("Scan");
 
-  unsimulated.refuse(
-    input.ProjectionExpression !== undefined,
-    "ProjectionExpression",
-    "answering with whole items where part of them was asked for",
-  );
   unsimulated.refuse(
     (input.AttributesToGet ?? []).length > 0,
     "AttributesToGet",

--- a/src/service/dynamodb/expression/filter/sim-dynamodb-filter-expression.ts
+++ b/src/service/dynamodb/expression/filter/sim-dynamodb-filter-expression.ts
@@ -1,46 +1,17 @@
 import { simDynamoDbConditionParser } from "../condition/sim-dynamodb-condition-grammar.js";
-import type { SimDynamoDbExpressionParameterInput } from "../sim-dynamodb-expression-parameters.js";
-import { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
+import type { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
 import { SimDynamoDbFilter } from "./sim-dynamodb-filter.js";
 
 const expressionName = "FilterExpression";
-
-interface SimDynamoDbFilterRequest extends SimDynamoDbExpressionParameterInput {
-  readonly FilterExpression?: string | undefined;
-}
-
-/**
- * Read the filter a read drops items by, if it names one.
- *
- * A request with no FilterExpression answers with every item it read, so there
- * is nothing to drop by.
- */
-export function readSimDynamoDbFilter(
-  request: SimDynamoDbFilterRequest,
-): SimDynamoDbFilter | undefined {
-  const expression = request.FilterExpression;
-
-  if (expression === undefined) {
-    SimDynamoDbExpressionParameters.assertNoneWithout(request);
-
-    return undefined;
-  }
-
-  const parameters = new SimDynamoDbExpressionParameters(request);
-  const filter = parseSimDynamoDbFilter(expression, parameters);
-
-  parameters.assertAllUsed();
-
-  return filter;
-}
 
 /**
  * Read one FilterExpression against placeholders that have already been
  * gathered.
  *
- * A query carries a key condition alongside its filter, and both draw on the
- * same `ExpressionAttributeNames` and `ExpressionAttributeValues`, so the
- * placeholders are checked once both expressions have been read.
+ * Every read that can carry a filter can carry another expression alongside it,
+ * and they draw on the same `ExpressionAttributeNames` and
+ * `ExpressionAttributeValues`, so the placeholders are gathered by the caller
+ * and checked once every expression has been read.
  */
 export function parseSimDynamoDbFilter(
   expression: string,

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
@@ -18,6 +18,11 @@ interface SimDynamoDbProjectionRequest extends SimDynamoDbExpressionParameterInp
  *
  * A request with no ProjectionExpression asks for the whole item, so there is
  * nothing to project.
+ *
+ * This is the form for a request whose projection is its only expression, which
+ * is every read that names one item or a list of them. A query or a scan can
+ * carry a filter alongside its projection, and reads both against one set of
+ * placeholders through `parseSimDynamoDbProjection`.
  */
 export function readSimDynamoDbProjection(
   request: SimDynamoDbProjectionRequest,
@@ -31,6 +36,25 @@ export function readSimDynamoDbProjection(
   }
 
   const parameters = new SimDynamoDbExpressionParameters(request);
+  const projection = parseSimDynamoDbProjection(expression, parameters);
+
+  parameters.assertAllUsed();
+
+  return projection;
+}
+
+/**
+ * Read one ProjectionExpression against placeholders that have already been
+ * gathered.
+ *
+ * A query carries a key condition and may carry a filter alongside its
+ * projection, and all three draw on the same `ExpressionAttributeNames`, so the
+ * placeholders are checked once every expression has been read.
+ */
+export function parseSimDynamoDbProjection(
+  expression: string,
+  parameters: SimDynamoDbExpressionParameters,
+): SimDynamoDbProjection {
   const paths = projectedPaths(
     SimDynamoDbExpressionTokens.of(
       expressionName,
@@ -39,8 +63,6 @@ export function readSimDynamoDbProjection(
     ),
     parameters.names,
   );
-
-  parameters.assertAllUsed();
 
   return new SimDynamoDbProjection({ expressionName, paths });
 }

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection.ts
@@ -1,4 +1,5 @@
 import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbReadView } from "../../table/sim-dynamodb-read-view.js";
 import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
 import { SimDynamoDbProjectionNode } from "./sim-dynamodb-projection-node.js";
 
@@ -15,13 +16,29 @@ interface SimDynamoDbProjectionProperties {
  */
 export class SimDynamoDbProjection {
   private readonly root: SimDynamoDbProjectionNode;
+  private readonly paths: readonly SimDynamoDbDocumentPath[];
 
   constructor(properties: SimDynamoDbProjectionProperties) {
     this.root = new SimDynamoDbProjectionNode(properties.expressionName);
+    this.paths = properties.paths;
 
     for (const path of properties.paths) {
       this.root.add(path);
     }
+  }
+
+  /**
+   * Refuse a projection naming an attribute the view being read does not carry.
+   *
+   * A global secondary index holds only what it projects, so a path outside
+   * that would leave the attribute out of every item it answers with. An
+   * attribute quietly missing reads as an item that happens not to have it,
+   * which is the answer a projection used as an allow-list must never give. A
+   * local secondary index fetches from the base table, so any path is nameable
+   * there.
+   */
+  assertNamesOnlyCarried(view: SimDynamoDbReadView): void {
+    view.assertCarriesPaths(this.paths);
   }
 
   /**

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-index-projected-read.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-index-projected-read.iso.test.ts
@@ -1,6 +1,7 @@
 import {
   assertIdentical,
   assertInstanceOf,
+  assertObjectEquals,
   assertStringIncludes,
   assertThrowsErrorAsync,
   assertUndefined,
@@ -186,5 +187,42 @@ describe("DynamoDB reads of what an index projects", () => {
     // Then the filter runs, keeping the one item it names.
     assertIdentical(page.Count, 1);
     assertIdentical(page.ScannedCount, 2);
+  });
+
+  it("refuses a projection naming an attribute the index does not project", async () => {
+    // Given a table whose index carries only its keys.
+    const simAws = new SimAws();
+    await simDynamoDbIndexedTableFactory.make(
+      { projectionType: "KEYS_ONLY" },
+      simAws,
+    );
+
+    // When a read of it projects an attribute outside the projection.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().query({
+        input: { ...openOrders, ProjectionExpression: "title" },
+      }),
+    );
+
+    // Then it is refused, the way a filter naming the same attribute is. The
+    // index does not hold it, so it would be missing from every item, and an
+    // attribute quietly missing reads as an item that never had one.
+    assertInstanceOf(error, SimDynamoDbValidationException);
+    assertStringIncludes(
+      error.message,
+      "title is not projected into the global secondary index byStatus",
+    );
+  });
+
+  it("takes a projection naming an attribute the index does project", async () => {
+    // When an index including one attribute is read for that attribute.
+    const item = await firstOpenOrder(
+      { projectionType: "INCLUDE", nonKeyAttributes: ["title"] },
+      { ProjectionExpression: "title" },
+    );
+
+    // Then the projection runs against what the index carries, cutting the
+    // index keys the read walked by out of the answer.
+    assertObjectEquals(item, { title: { S: "Order order-01" } });
   });
 });

--- a/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-fetched-read.iso.test.ts
+++ b/src/service/dynamodb/secondary-index/sim-dynamodb-local-index-fetched-read.iso.test.ts
@@ -1,4 +1,8 @@
-import { assertIdentical, assertUndefined } from "@kensio/smartass";
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertUndefined,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import type { SimQueryCommandInput } from "../command/query/query.command.js";
@@ -121,5 +125,18 @@ describe("DynamoDB reads beyond what a local secondary index projects", () => {
     // Then the count is of the index entries, with no Items at all.
     assertIdentical(page.Count, 3);
     assertUndefined(page.Items);
+  });
+
+  it("projects an attribute the index does not carry", async () => {
+    // When a read of a KEYS_ONLY index names an unprojected attribute.
+    const item = await firstOrder(
+      { projectionType: "KEYS_ONLY" },
+      { ProjectionExpression: "title" },
+    );
+
+    // Then it comes back, fetched from the base table the way Select
+    // ALL_ATTRIBUTES fetches it. A global secondary index refuses the same
+    // read, since it has no base table entry to reach for.
+    assertObjectEquals(item, { title: { S: "Order order-02" } });
   });
 });


### PR DESCRIPTION
Query and Scan refused a `ProjectionExpression`, leaving a projection used as an allow-list impossible to exercise against the simulation. Both now apply one through the parser `GetItem` already uses, and a read answers with the paths it named and nothing else. The projection is applied to the whole item ahead of the view's own cut. That is what fetches an unprojected attribute on a local secondary index, and it changes nothing on a global one, where a path outside the index projection is refused up front. Each of the two commands reads its expressions against one set of placeholders. A name the filter or the key condition uses counts as used by the request.

`Select: SPECIFIC_ATTRIBUTES` alongside a projection is now accepted and projects, where it previously reached the refusal instead. `Count`, `ScannedCount` and `LastEvaluatedKey` are unchanged by a projection, so a paged read still resumes from a key the items it answered with no longer carry.

The standalone `readSimDynamoDbFilter` went with the change. Scan was its only caller, and a scan now reads its filter and its projection together.

Resolves #1258
