### PR TITLE
feat: read Parquet objects in the Athena query engine

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -196,7 +196,8 @@ loads the rows into an in-memory SQLite database, and answers the statement from
 nineteen queries in twenty of the shapes a test writes run this way.
 
 The engine is off until a test turns it on, and it needs `node-sql-parser` in the project. The
-parser is an optional peer dependency, so a project that never runs a query never installs it.
+parser is an optional peer dependency, so a project that never runs a query never installs it. A
+Parquet table needs `hyparquet` on the same terms.
 
 ```bash
 pnpm add -D node-sql-parser
@@ -309,6 +310,8 @@ The SerDe class name in the table's storage descriptor says how its objects are 
   that needs it.
 - `org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe` reads the delimiter `field.delim` names,
   which defaults to the control character Hive uses.
+- `org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe` reads Parquet. So does the older
+  `parquet.hive.serde.ParquetHiveSerDe` that a Hive table carries.
 
 `separatorChar`, `quoteChar` and `escapeChar` in the SerDe's parameters override those defaults, and
 `skip.header.line.count` on the table drops the first lines of every object. An empty field reads as
@@ -335,6 +338,29 @@ A partition column's value comes from the partition the object sits in. A table 
 partitions takes it from the projection, and a table laid out Hive style under its own location
 takes it from the `key=value` segments of the object's key. Either way the column reads on every
 row, though no object holds it.
+
+### Parquet
+
+A Parquet table needs [`hyparquet`](https://github.com/hyparam/hyparquet) in the project, alongside
+the SQL parser. It is an optional peer dependency as well, and a project querying only JSON and CSV
+tables never installs it. The reader loads the first time a query reaches a Parquet table.
+
+```bash
+npm install --save-dev hyparquet
+```
+
+A Parquet file carries its own schema. The table's Glue columns say only what to call each column
+and what type to report it as. A column the table declares and the file has not got reads null, the
+way a JSON record missing a key does. An `int64` column keeps every digit, past what a double holds
+exactly. A `TIMESTAMP`, `DATE` or `INT96` column reads as an instant, and the Glue column type
+decides whether it renders as a day or as a day and a time. A `BYTE_ARRAY` column reads as text.
+
+Parquet compresses per column chunk inside the file, and an object's key says nothing about it. A
+file written with `SNAPPY`, `GZIP`, `ZSTD`, `BROTLI` or no compression at all reads, which covers
+what Athena, Glue and Firehose write. A file written with `LZO`, `LZ4` or `LZ4_RAW` turns the query
+down, and the declaration a test wrote answers it.
+
+ORC has no reader. A table declaring one falls back to its declared result.
 
 ### What it answers with
 
@@ -958,8 +984,15 @@ Current documented limitations:
 - A declaration that fails the query wins from any tier, the engine included. `failsWith` is a
   statement about the query rather than about its rows, so a workgroup rule or a default carrying
   one fails every query it covers whether or not the engine could have answered.
-- Parquet and ORC are absent. A table declaring either falls back to its declared result, and so
-  does a table declaring no SerDe at all.
+- ORC is absent. A table declaring it falls back to its declared result, and so does a table
+  declaring no SerDe at all. The only ORC reader published for Node is AGPL licensed and builds
+  native bindings, which is more than this package asks a test to install.
+- A Parquet table in a project without `hyparquet` falls back the same way, with nothing said. The
+  engine turns down what it cannot do, and a missing install reaches a test through `answeredBy`
+  reading `declaration`.
+- A Parquet query reports every byte of every object it opens as scanned, whatever columns the
+  statement touched. Real Athena bills a columnar read by the columns alone. A cutoff tuned
+  against a real workload therefore refuses a query here that AWS would allow.
 - A null in a result row reads as an empty string. Real Athena leaves the value out of the row.
 - A computed boolean reads as `1` and `0`. The Glue column type is what makes a boolean column read
   as `true` and `false`, and an expression has no column type behind it.

--- a/package.json
+++ b/package.json
@@ -296,6 +296,8 @@
     "eslint-plugin-unicorn": "^72.0.0",
     "execa": "^10.0.0",
     "fta-cli": "^3.0.0",
+    "hyparquet": "^1.29.2",
+    "hyparquet-writer": "^0.16.9",
     "node-sql-parser": "^5.4.0",
     "oxfmt": "^0.65.0",
     "oxlint": "^1.77.0",
@@ -314,11 +316,15 @@
   },
   "peerDependencies": {
     "eslint": "^10.4.1",
+    "hyparquet": "^1.29.2",
     "node-sql-parser": "^5.4.0",
     "typescript-eslint": "^8.60.0"
   },
   "peerDependenciesMeta": {
     "eslint": {
+      "optional": true
+    },
+    "hyparquet": {
       "optional": true
     },
     "node-sql-parser": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,12 @@ importers:
       fta-cli:
         specifier: ^3.0.0
         version: 3.0.1
+      hyparquet:
+        specifier: ^1.29.2
+        version: 1.29.2
+      hyparquet-writer:
+        specifier: ^0.16.9
+        version: 0.16.9
       node-sql-parser:
         specifier: ^5.4.0
         version: 5.4.0
@@ -2354,6 +2360,12 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  hyparquet-writer@0.16.9:
+    resolution: {integrity: sha512-VZvH4Vq9lQwZa/+1y4YrEwF9+FAe5pED+mVN4AHflCoFk5LG2RemMHW9iwVlVqug7fO3ATwEMSG68cr3uZAkjQ==}
+
+  hyparquet@1.29.2:
+    resolution: {integrity: sha512-2LxinZ8X0JqToST+9OXcy9t3t5Q7ZneMTkSqUx/36Hv18pCTk/N71IWZc7APTSNG1Me39l/jjEvzZSZ0R+Knbw==}
 
   identifier-regex@1.1.0:
     resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
@@ -5917,6 +5929,12 @@ snapshots:
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
+
+  hyparquet-writer@0.16.9:
+    dependencies:
+      hyparquet: 1.29.2
+
+  hyparquet@1.29.2: {}
 
   identifier-regex@1.1.0:
     dependencies:

--- a/src/service/athena/engine/sim-athena-column-types.ts
+++ b/src/service/athena/engine/sim-athena-column-types.ts
@@ -74,6 +74,11 @@ export function simAthenaSqliteAffinity(glueType: string | undefined): string {
   return realTypes.has(type) ? "REAL" : "TEXT";
 }
 
+/** Whether a Glue column type holds a day with no time on it. */
+export function simAthenaIsDateType(glueType: string | undefined): boolean {
+  return baseType(glueType) === "date";
+}
+
 /** Whether a Glue column type holds a boolean. */
 export function simAthenaIsBooleanType(glueType: string | undefined): boolean {
   return baseType(glueType) === "boolean";

--- a/src/service/athena/engine/sim-athena-delimited-format.ts
+++ b/src/service/athena/engine/sim-athena-delimited-format.ts
@@ -1,0 +1,71 @@
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
+import type { SimAthenaDelimitedFormat } from "./sim-athena-delimited-records.js";
+
+/** What one delimited SerDe reads before its parameters are applied. */
+interface SimAthenaSerDeDefaults {
+  readonly delimiter: string;
+  readonly quoted: boolean;
+}
+
+/**
+ * The SerDe class names that mean delimited text, and what each one reads
+ * before the table's own parameters are applied.
+ *
+ * `OpenCSVSerde` is comma separated and quoted. `LazySimpleSerDe` is what
+ * `ROW FORMAT DELIMITED` gives: it quotes nothing, and its own default
+ * delimiter is the control character Hive has always used rather than a comma.
+ */
+const delimitedSerDes: ReadonlyMap<string, SimAthenaSerDeDefaults> = new Map([
+  [
+    "org.apache.hadoop.hive.serde2.opencsvserde",
+    { delimiter: ",", quoted: true },
+  ],
+  [
+    "org.apache.hadoop.hive.serde2.lazy.lazysimpleserde",
+    { delimiter: "\u{1}", quoted: false },
+  ],
+]);
+
+/**
+ * How one table's delimited objects are read, or nothing where its SerDe names
+ * no delimited format.
+ */
+export function simAthenaDelimitedFormat(
+  table: SimAthenaCatalogTable,
+  library: string,
+): SimAthenaDelimitedFormat | undefined {
+  const defaults = delimitedSerDes.get(library);
+
+  if (defaults === undefined) {
+    return undefined;
+  }
+
+  const parameters = table.storageDescriptor?.SerdeInfo?.Parameters ?? {};
+  const quoted = defaults.quoted || parameters["quoteChar"] !== undefined;
+
+  return {
+    delimiter:
+      parameters["separatorChar"] ??
+      parameters["field.delim"] ??
+      defaults.delimiter,
+    quote: quoted ? (parameters["quoteChar"] ?? '"') : undefined,
+    escape: quoted ? (parameters["escapeChar"] ?? "\\") : undefined,
+    skipHeaderLines: skippedHeaderLines(table),
+  };
+}
+
+/**
+ * How many lines of every object are a header rather than a row.
+ *
+ * `skip.header.line.count` is a table property on real Athena, and the storage
+ * descriptor's own parameters are read as well because a template can put it
+ * in either place.
+ */
+function skippedHeaderLines(table: SimAthenaCatalogTable): number {
+  const declared =
+    table.parameters["skip.header.line.count"] ??
+    table.storageDescriptor?.Parameters?.["skip.header.line.count"];
+  const count = Math.trunc(Number(declared ?? ""));
+
+  return Number.isFinite(count) && count > 0 ? count : 0;
+}

--- a/src/service/athena/engine/sim-athena-engine-modules.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-engine-modules.iso.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
+import { simAthenaParquetReader } from "./sim-athena-parquet-module.js";
 import { simAthenaSqlParser } from "./sim-athena-parser-module.js";
 import { simAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
 
@@ -31,6 +32,33 @@ describe("loading what the Athena query engine runs on", () => {
 
     // Then it says which module let it down.
     assertStringIncludes(error.message, "node:util carries no Parser");
+  });
+
+  it("says what to add where the Parquet reader is not installed", async () => {
+    // Given a project without hyparquet.
+    // When a query reaches a Parquet table.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAthenaParquetReader("hyparquet-absent-from-this-project"),
+    );
+
+    // Then it names the package to add and the alternative to it.
+    assertIdentical(error.name, "SimAthenaSetUpError");
+    assertStringIncludes(error.message, "hyparquet");
+    assertStringIncludes(error.message, "results()");
+  });
+
+  it("says the same where the package carries no reader", async () => {
+    // Given a module that resolves and is not the reader.
+    // When the engine asks it to read a Parquet file.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAthenaParquetReader("node:util"),
+    );
+
+    // Then it says which module let it down.
+    assertStringIncludes(
+      error.message,
+      "node:util carries no parquetReadObjects",
+    );
   });
 
   it("swallows SQLite's experimental warning and nothing else", async () => {

--- a/src/service/athena/engine/sim-athena-engine-result.ts
+++ b/src/service/athena/engine/sim-athena-engine-result.ts
@@ -24,6 +24,12 @@ export function simAthenaEngineResult(
 
   statement.setReturnArrays(true);
 
+  // A whole number comes back as a BigInt, because SQLite holds a 64 bit
+  // integer and reading one past what a double represents exactly raises
+  // otherwise. A Parquet `bigint` column is what carries values that large.
+  // Every one of them renders the same either way.
+  statement.setReadBigInts(true);
+
   const rows = statement.all() as unknown as readonly SQLOutputValue[][];
   const columns = simAthenaResultColumns(statement.columns(), rows, loaded);
 

--- a/src/service/athena/engine/sim-athena-engine-run.ts
+++ b/src/service/athena/engine/sim-athena-engine-run.ts
@@ -30,7 +30,8 @@ export interface SimAthenaEngineRun {
  * can fail on an object the caller cannot open, building the database can fail
  * on a schema SQLite refuses, and running the statement can fail on anything
  * the parser wrote that SQLite does not have. All three leave the declared
- * result to answer.
+ * result to answer. So does a Parquet table in a project that has not installed
+ * the reader, and `hyparquet` is named in the docs for that reason.
  */
 export async function simAthenaEngineRun(
   run: SimAthenaEngineRun,

--- a/src/service/athena/engine/sim-athena-parquet-module.ts
+++ b/src/service/athena/engine/sim-athena-parquet-module.ts
@@ -1,0 +1,74 @@
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
+
+/** One Parquet file's rows, keyed by the names the file's own schema holds. */
+export type SimAthenaParquetRow = Record<string, unknown>;
+
+/** What one Parquet file is read with. */
+export interface SimAthenaParquetOptions {
+  readonly file: ArrayBuffer;
+  readonly compressors: Readonly<
+    Record<string, (bytes: Uint8Array, size: number) => Uint8Array>
+  >;
+
+  /** Whether a `BYTE_ARRAY` column reads as text, which a Hive string is. */
+  readonly utf8: boolean;
+}
+
+/** The one thing the engine needs out of `hyparquet`. */
+export interface SimAthenaParquetReader {
+  parquetReadObjects(
+    options: SimAthenaParquetOptions,
+  ): Promise<SimAthenaParquetRow[]>;
+}
+
+/**
+ * The package name, held as a variable rather than written into the `import()`
+ * so that building this repository never turns an optional dependency into a
+ * required one.
+ */
+const parquetPackage = "hyparquet";
+
+const missingPackage =
+  `Simulated Athena needs hyparquet to read a Parquet table. Add it to your ` +
+  `project as a dev dependency, or declare what each query over that table ` +
+  `answers with through results().`;
+
+/**
+ * The Parquet reader, loaded the first time a query reaches a Parquet table.
+ *
+ * `hyparquet` is an optional peer dependency, so a project querying only JSON
+ * and CSV tables never installs it. Loading here rather than in `enable()` is
+ * what keeps that true, since the engine has no idea what a test will query
+ * until it does.
+ *
+ * The package name is a parameter so that a test can ask for one that is not
+ * installed and read what a project without the package is told.
+ */
+export async function simAthenaParquetReader(
+  packageName: string = parquetPackage,
+): Promise<SimAthenaParquetReader> {
+  const module = await importedReader(packageName);
+  const { parquetReadObjects } = module;
+
+  if (typeof parquetReadObjects !== "function") {
+    throw new SimAthenaSetUpError(
+      `${packageName} carries no parquetReadObjects. ${missingPackage}`,
+    );
+  }
+
+  return { parquetReadObjects };
+}
+
+async function importedReader(
+  packageName: string,
+): Promise<Partial<SimAthenaParquetReader>> {
+  try {
+    return (await import(packageName)) as Partial<SimAthenaParquetReader>;
+  } catch (error) {
+    const missing = new SimAthenaSetUpError(missingPackage);
+
+    missing.cause = error;
+
+    throw missing;
+  }
+}

--- a/src/service/athena/engine/sim-athena-parquet-records.ts
+++ b/src/service/athena/engine/sim-athena-parquet-records.ts
@@ -1,0 +1,80 @@
+import {
+  brotliDecompressSync,
+  gunzipSync,
+  inflateSync,
+  zstdDecompressSync,
+} from "node:zlib";
+
+import type { SimAthenaEngineRow } from "./sim-athena-engine-row.js";
+import { simAthenaParquetReader } from "./sim-athena-parquet-module.js";
+
+/** One page's bytes, decompressed to the length its header declares. */
+type SimAthenaPageDecompressor = (
+  bytes: Uint8Array,
+  size: number,
+) => Uint8Array;
+
+/**
+ * The Parquet codecs Node's own zlib covers.
+ *
+ * `hyparquet` decompresses `UNCOMPRESSED` and `SNAPPY` itself, and snappy is
+ * what Athena and Glue write by default. The three here are what `node:zlib`
+ * adds for nothing. `LZO`, `LZ4` and `LZ4_RAW` are what is left, and a file in
+ * one of those turns the query down.
+ *
+ * A Parquet file compresses per column chunk inside itself, so none of this
+ * has anything to do with the codec an object's key names.
+ */
+const compressors: Readonly<Record<string, SimAthenaPageDecompressor>> = {
+  GZIP: (bytes, size) => sized(gunzipSync(bytes), size),
+  ZSTD: (bytes, size) => sized(zstdDecompressSync(bytes), size),
+  BROTLI: (bytes, size) => sized(brotliDecompressSync(bytes), size),
+  DEFLATE: (bytes, size) => sized(inflateSync(bytes), size),
+};
+
+/**
+ * One decompressed page, cut to the length the page header declares.
+ *
+ * `hyparquet` checks the length itself and refuses a page that comes back
+ * longer, which a codec padding its output would produce.
+ */
+function sized(buffer: Buffer, size: number): Uint8Array {
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, size);
+}
+
+/**
+ * One Parquet object's rows.
+ *
+ * A Parquet file carries its own schema, so nothing here reads the table's Glue
+ * columns. A column the table declares and the file has not got reads null, the
+ * way a JSON record missing a key already does.
+ *
+ * `utf8` reads a `BYTE_ARRAY` column as text. Hive's `string` is what nearly
+ * every one of them holds, and a Glue `binary` column already arrives as text
+ * everywhere else in this engine.
+ */
+export async function simAthenaParquetRows(
+  bytes: Uint8Array,
+): Promise<readonly SimAthenaEngineRow[]> {
+  const reader = await simAthenaParquetReader();
+
+  return reader.parquetReadObjects({
+    file: arrayBuffer(bytes),
+    compressors,
+    utf8: true,
+  });
+}
+
+/**
+ * One object's bytes as the `ArrayBuffer` the reader takes.
+ *
+ * A `Buffer` read out of simulated S3 is a view onto a larger pool, so the
+ * whole of its own buffer is more than the object and the offsets have to be
+ * carried through.
+ */
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+}

--- a/src/service/athena/engine/sim-athena-record-reader.ts
+++ b/src/service/athena/engine/sim-athena-record-reader.ts
@@ -1,21 +1,37 @@
 import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
-import {
-  simAthenaDelimitedRows,
-  type SimAthenaDelimitedFormat,
-} from "./sim-athena-delimited-records.js";
+import { simAthenaDelimitedFormat } from "./sim-athena-delimited-format.js";
+import { simAthenaDelimitedRows } from "./sim-athena-delimited-records.js";
 import type { SimAthenaEngineRow } from "./sim-athena-engine-row.js";
 import {
   simAthenaJsonRows,
   type SimAthenaJsonFormat,
 } from "./sim-athena-json-records.js";
+import { simAthenaParquetRows } from "./sim-athena-parquet-records.js";
 
-/** One object's bytes, read into the rows it holds. */
+/**
+ * One object's bytes, read into the rows it holds.
+ *
+ * The bytes rather than the text, because Parquet is binary and carries its own
+ * schema. A reader may answer with a promise for the same reason, since reading
+ * one is asynchronous.
+ */
 export type SimAthenaRecordReader = (
-  text: string,
-) => readonly SimAthenaEngineRow[];
+  bytes: Uint8Array,
+) => readonly SimAthenaEngineRow[] | Promise<readonly SimAthenaEngineRow[]>;
 
 /** The SerDe class name that takes `mapping.<column>` parameters. */
 const openXSerDe = "org.openx.data.jsonserde.jsonserde";
+
+/**
+ * The SerDe class names that mean Parquet.
+ *
+ * Glue and the Athena `CREATE TABLE` documentation both name the first. The
+ * second is what an older Hive table carries, and Athena still reads one.
+ */
+const parquetSerDes = new Set([
+  "org.apache.hadoop.hive.ql.io.parquet.serde.parquethiveserde",
+  "parquet.hive.serde.parquethiveserde",
+]);
 
 /** The SerDe class names that mean JSON lines. */
 const jsonSerDes = new Set([
@@ -27,40 +43,15 @@ const jsonSerDes = new Set([
 /** What a `mapping.<column>` parameter is named with. */
 const mappingPrefix = "mapping.";
 
-/** What one delimited SerDe reads before its parameters are applied. */
-interface SimAthenaSerDeDefaults {
-  readonly delimiter: string;
-  readonly quoted: boolean;
-}
-
-/**
- * The SerDe class names that mean delimited text, and what each one reads
- * before the table's own parameters are applied.
- *
- * `OpenCSVSerde` is comma separated and quoted. `LazySimpleSerDe` is what
- * `ROW FORMAT DELIMITED` gives: it quotes nothing, and its own default
- * delimiter is the control character Hive has always used rather than a comma.
- */
-const delimitedSerDes: ReadonlyMap<string, SimAthenaSerDeDefaults> = new Map([
-  [
-    "org.apache.hadoop.hive.serde2.opencsvserde",
-    { delimiter: ",", quoted: true },
-  ],
-  [
-    "org.apache.hadoop.hive.serde2.lazy.lazysimpleserde",
-    { delimiter: "\u{1}", quoted: false },
-  ],
-]);
-
 /**
  * How one table's objects are decoded, or nothing where this simulation has no
  * reader for what the table declares.
  *
  * The SerDe is what says so, the way it says so on real Athena. A table
- * holding Parquet or ORC lands here, and the query falls back to whatever a
- * test declared. A table declaring no SerDe at all lands here too: nothing
- * else in the catalog says what the bytes are, and guessing would answer a
- * Parquet query with nonsense rather than turning it down.
+ * holding ORC lands here, and the query falls back to whatever a test declared.
+ * A table declaring no SerDe at all lands here too. Nothing else in the catalog
+ * says what the bytes are, and guessing would answer with nonsense where
+ * turning the query down is the honest reply.
  */
 export function simAthenaRecordReader(
   table: SimAthenaCatalogTable,
@@ -72,22 +63,30 @@ export function simAthenaRecordReader(
     return undefined;
   }
 
+  if (parquetSerDes.has(library)) {
+    return simAthenaParquetRows;
+  }
+
   if (jsonSerDes.has(library)) {
     const format = jsonFormat(table, library);
 
-    return (text) => simAthenaJsonRows(text, format);
+    return (bytes) => simAthenaJsonRows(decodedText(bytes), format);
   }
 
-  const defaults = delimitedSerDes.get(library);
+  const format = simAthenaDelimitedFormat(table, library);
 
-  if (defaults === undefined) {
+  if (format === undefined) {
     return undefined;
   }
 
-  const format = delimitedFormat(table, defaults);
   const columns = table.columns.map((column) => column.Name);
 
-  return (text) => simAthenaDelimitedRows(text, format, columns);
+  return (bytes) => simAthenaDelimitedRows(decodedText(bytes), format, columns);
+}
+
+/** One object's bytes as the text a JSON or delimited reader wants. */
+function decodedText(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
 }
 
 /**
@@ -117,38 +116,4 @@ function jsonFormat(
     mappings,
     caseInsensitive: parameters["case.insensitive"]?.toLowerCase() !== "false",
   };
-}
-
-function delimitedFormat(
-  table: SimAthenaCatalogTable,
-  defaults: SimAthenaSerDeDefaults,
-): SimAthenaDelimitedFormat {
-  const parameters = table.storageDescriptor?.SerdeInfo?.Parameters ?? {};
-  const quoted = defaults.quoted || parameters["quoteChar"] !== undefined;
-
-  return {
-    delimiter:
-      parameters["separatorChar"] ??
-      parameters["field.delim"] ??
-      defaults.delimiter,
-    quote: quoted ? (parameters["quoteChar"] ?? '"') : undefined,
-    escape: quoted ? (parameters["escapeChar"] ?? "\\") : undefined,
-    skipHeaderLines: skippedHeaderLines(table),
-  };
-}
-
-/**
- * How many lines of every object are a header rather than a row.
- *
- * `skip.header.line.count` is a table property on real Athena, and the storage
- * descriptor's own parameters are read as well because a template can put it
- * in either place.
- */
-function skippedHeaderLines(table: SimAthenaCatalogTable): number {
-  const declared =
-    table.parameters["skip.header.line.count"] ??
-    table.storageDescriptor?.Parameters?.["skip.header.line.count"];
-  const count = Math.trunc(Number(declared ?? ""));
-
-  return Number.isFinite(count) && count > 0 ? count : 0;
 }

--- a/src/service/athena/engine/sim-athena-sqlite-values.ts
+++ b/src/service/athena/engine/sim-athena-sqlite-values.ts
@@ -1,4 +1,27 @@
-import { simAthenaIsBooleanType } from "./sim-athena-column-types.js";
+import {
+  simAthenaIsBooleanType,
+  simAthenaIsDateType,
+} from "./sim-athena-column-types.js";
+
+/**
+ * One instant, as the text a column of its Glue type reads.
+ *
+ * Athena renders a `date` column as a day and a `timestamp` column as a day and
+ * a time, and the Glue column type is the only thing that says which this is.
+ */
+function simAthenaTimestampText(
+  value: Date,
+  glueType: string | undefined,
+): string {
+  const iso = value.toISOString();
+
+  return simAthenaIsDateType(glueType)
+    ? iso.slice(0, 10)
+    : iso
+        .slice(0, 23)
+        .replace("T", " ")
+        .replace(/\.000$/u, "");
+}
 
 /** What SQLite will take as a bound parameter. */
 export type SimAthenaSqliteValue = string | number | bigint | null;
@@ -23,6 +46,11 @@ const booleanText: ReadonlyMap<string, number> = new Map([
  * delimited text carries it as the word `true`, and a column holding the word
  * would otherwise compare against nothing and read back as `true` whichever
  * value it held.
+ *
+ * A `Date` is what a Parquet `TIMESTAMP`, `DATE` or `INT96` column arrives as.
+ * Text formats carry a timestamp as the text the object held, and this writes
+ * one the same way. Left as an object it would reach SQLite as quoted JSON, and
+ * every comparison against it would answer false while the query succeeded.
  */
 export function simAthenaSqliteValue(
   value: unknown,
@@ -44,6 +72,10 @@ export function simAthenaSqliteValue(
 
   if (typeof value === "number") {
     return Number.isFinite(value) ? value : null;
+  }
+
+  if (value instanceof Date) {
+    return simAthenaTimestampText(value, glueType);
   }
 
   return typeof value === "bigint" ? value : JSON.stringify(value);

--- a/src/service/athena/engine/sim-athena-table-objects.ts
+++ b/src/service/athena/engine/sim-athena-table-objects.ts
@@ -30,20 +30,24 @@ export function simAthenaTableObjects(
     : (s3 as SimAthenaTableObjects);
 }
 
-/** One object's bytes, decompressed by its key and read as UTF-8 text. */
-export async function simAthenaObjectText(
+/**
+ * One object's bytes, decompressed by the codec its key names.
+ *
+ * Decoding is left to the reader the table's SerDe picks, because a Parquet
+ * object holds no text to decode.
+ */
+export async function simAthenaObjectBytes(
   objects: SimAthenaTableObjects,
   bucket: string,
   key: string,
   caller: SimAwsCaller | undefined,
-): Promise<string> {
+): Promise<Uint8Array> {
   const got = await objects.getObject(
     { input: { Bucket: bucket, Key: key } },
     caller === undefined ? undefined : { caller },
   );
 
   const chunks = await Array.fromAsync(got.Body ?? []);
-  const bytes = simAthenaDecompressedBytes(key, Buffer.concat(chunks));
 
-  return new TextDecoder().decode(bytes);
+  return simAthenaDecompressedBytes(key, Buffer.concat(chunks));
 }

--- a/src/service/athena/engine/sim-athena-table-rows.ts
+++ b/src/service/athena/engine/sim-athena-table-rows.ts
@@ -12,7 +12,7 @@ import {
   type SimAthenaRecordReader,
 } from "./sim-athena-record-reader.js";
 import {
-  simAthenaObjectText,
+  simAthenaObjectBytes,
   type SimAthenaTableObjects,
 } from "./sim-athena-table-objects.js";
 
@@ -70,7 +70,7 @@ async function objectRows(
   reader: SimAthenaRecordReader,
   one: SimAthenaPartitionedObject,
 ): Promise<readonly SimAthenaEngineRow[]> {
-  const text = await simAthenaObjectText(
+  const bytes = await simAthenaObjectBytes(
     request.objects,
     one.object.bucket,
     one.object.key,
@@ -81,5 +81,7 @@ async function objectRows(
     ...Object.fromEntries(one.values),
   };
 
-  return reader(text).map((row) => ({ ...partition, ...row }));
+  const rows = await reader(bytes);
+
+  return rows.map((row) => ({ ...partition, ...row }));
 }

--- a/src/service/athena/sim-athena-engine-parquet.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-parquet.iso.test.ts
@@ -1,0 +1,360 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededBytes,
+  aSeededParquet,
+  orcSerDe,
+  parquetSerDe,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+/** The columns every orders table in this file declares. */
+const orderColumns = [
+  { Name: "id", Type: "int" },
+  { Name: "customer", Type: "string" },
+  { Name: "total", Type: "bigint" },
+  { Name: "paid", Type: "boolean" },
+  { Name: "placed_at", Type: "timestamp" },
+];
+
+/** Those same columns, as one Parquet file holds them. */
+const orderData = [
+  { name: "id", data: [1, 2, 3], type: "INT32" as const },
+  { name: "customer", data: ["ada", "grace", "ada"], type: "STRING" as const },
+  { name: "total", data: [1200n, 90n, 305n], type: "INT64" as const },
+  { name: "paid", data: [true, false, true], type: "BOOLEAN" as const },
+  {
+    name: "placed_at",
+    data: [
+      new Date("2026-08-01T10:00:00Z"),
+      new Date("2026-08-02T09:00:00Z"),
+      new Date("2026-08-03T11:30:00Z"),
+    ],
+    type: "TIMESTAMP" as const,
+  },
+];
+
+/** A simulation over a Parquet orders table, with the engine on. */
+async function anOrdersSimulation(
+  serDe: string = parquetSerDe,
+): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "orders",
+    columns: orderColumns,
+    serDe,
+  });
+
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["id"], rows: [["declared"]] });
+
+  await simulation.simAws.athena().engine().enable();
+
+  return simulation;
+}
+
+describe("an Athena query over a Parquet table", () => {
+  it("answers from the file the table sits on", async () => {
+    // Given a Parquet table holding three orders.
+    const simulation = await anOrdersSimulation();
+
+    await aSeededParquet(
+      simulation.simAws,
+      "orders/part-00000-c000.snappy.parquet",
+      orderData,
+    );
+
+    // When a query groups them.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT customer, count(*) AS orders, sum(total) AS spent " +
+        "FROM rainlytics.orders GROUP BY 1 ORDER BY spent DESC",
+    );
+
+    // Then the engine answered it from the objects.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["ada", "2", "1505"],
+      ["grace", "1", "90"],
+    ]);
+  });
+
+  it("reads a bigint past what a double holds exactly", async () => {
+    // Given a Parquet table holding a total above 2^53.
+    const simulation = await anOrdersSimulation();
+
+    await aSeededParquet(simulation.simAws, "orders/part-0.parquet", [
+      { name: "id", data: [1], type: "INT32" },
+      { name: "total", data: [9_007_199_254_740_993n], type: "INT64" },
+    ]);
+
+    // When the total is read back.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT total FROM rainlytics.orders",
+    );
+
+    // Then every digit of it survived.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["9007199254740993"]]);
+  });
+
+  it("filters and reads back a timestamp column", async () => {
+    // Given a Parquet table holding orders across three days.
+    const simulation = await anOrdersSimulation();
+
+    await aSeededParquet(simulation.simAws, "orders/part-0.parquet", orderData);
+
+    // When a query filters on the instant each was placed.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id, placed_at FROM rainlytics.orders " +
+        "WHERE placed_at >= timestamp '2026-08-02 00:00:00' ORDER BY id",
+    );
+
+    // Then the filter matched, and the instant reads as Athena writes one.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["2", "2026-08-02 09:00:00"],
+      ["3", "2026-08-03 11:30:00"],
+    ]);
+  });
+
+  it("reads a date column as a day with no time on it", async () => {
+    // Given a table declaring one of its columns a date.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "orders",
+      columns: [{ Name: "placed_on", Type: "date" }],
+      serDe: parquetSerDe,
+    });
+
+    await simulation.simAws.athena().engine().enable();
+    await aSeededParquet(simulation.simAws, "orders/part-0.parquet", [
+      {
+        name: "placed_on",
+        data: [new Date("2026-08-01T00:00:00Z")],
+        type: "TIMESTAMP",
+      },
+    ]);
+
+    // When it is read back.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT placed_on FROM rainlytics.orders",
+    );
+
+    // Then the Glue column type is what dropped the time, as it does on Athena.
+    assertObjectEquals(answered.rows, [["2026-08-01"]]);
+  });
+
+  it("reads a boolean column by what the file holds", async () => {
+    // Given a Parquet table holding paid and unpaid orders.
+    const simulation = await anOrdersSimulation();
+
+    await aSeededParquet(simulation.simAws, "orders/part-0.parquet", orderData);
+
+    // When the unpaid ones are asked for.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id, paid FROM rainlytics.orders WHERE paid = false",
+    );
+
+    // Then the boolean compared and read back as one.
+    assertObjectEquals(answered.rows, [["2", "false"]]);
+  });
+
+  it("reads a nested column as the JSON the shims reach into", async () => {
+    // Given a Parquet table with an array column.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "orders",
+      columns: [
+        { Name: "id", Type: "int" },
+        { Name: "tags", Type: "array<string>" },
+      ],
+      serDe: parquetSerDe,
+    });
+
+    await simulation.simAws.athena().engine().enable();
+    await aSeededParquet(simulation.simAws, "orders/part-0.parquet", [
+      { name: "id", data: [1, 2], type: "INT32" },
+      { name: "tags", data: [["gift", "rush"], ["gift"]] },
+    ]);
+
+    // When a query counts what each row's array holds.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id, cardinality(tags) AS n FROM rainlytics.orders ORDER BY id",
+    );
+
+    // Then the array reached the shim as its JSON.
+    assertObjectEquals(answered.rows, [
+      ["1", "2"],
+      ["2", "1"],
+    ]);
+  });
+
+  it("reads a column the table declares and the file has not got", async () => {
+    // Given a table declaring a column no object was written with.
+    const simulation = await anOrdersSimulation();
+
+    await aSeededParquet(simulation.simAws, "orders/part-0.parquet", [
+      { name: "id", data: [1], type: "INT32" },
+    ]);
+
+    // When that column is selected.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id, customer FROM rainlytics.orders",
+    );
+
+    // Then it reads as nothing, which is how Athena reads a column a file
+    // written before it was added has not got.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["1", ""]]);
+  });
+
+  it("reads each partition of a table laid out Hive style", async () => {
+    // Given a Parquet table partitioned by day.
+    const simulation = await anEngineSimulation();
+
+    aCatalogTable(simulation.simAws, {
+      name: "orders",
+      columns: [{ Name: "id", Type: "int" }],
+      partitionKeys: [{ Name: "day", Type: "string" }],
+      serDe: parquetSerDe,
+    });
+
+    await simulation.simAws.athena().engine().enable();
+
+    await Promise.all(
+      (
+        [
+          ["2026-08-01", [1, 2]],
+          ["2026-08-02", [3]],
+        ] as const
+      ).map(async ([day, ids]) =>
+        aSeededParquet(simulation.simAws, `orders/day=${day}/part-0.parquet`, [
+          { name: "id", data: [...ids], type: "INT32" },
+        ]),
+      ),
+    );
+
+    // When one day is asked for.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders WHERE day = '2026-08-01' ORDER BY id",
+    );
+
+    // Then the partition column came from the key path, as it does for JSON.
+    assertObjectEquals(answered.rows, [["1"], ["2"]]);
+  });
+});
+
+describe("what a Parquet table is compressed with", () => {
+  it.each(["SNAPPY", "GZIP", "ZSTD", "BROTLI", "UNCOMPRESSED"] as const)(
+    "reads a file written with %s",
+    async (codec) => {
+      // Given a Parquet table holding one file in this codec.
+      const simulation = await anOrdersSimulation();
+
+      await aSeededParquet(
+        simulation.simAws,
+        "orders/part-0.parquet",
+        [{ name: "id", data: [7], type: "INT32" }],
+        codec,
+      );
+
+      // When a query reads it.
+      const answered = await anAnsweredQuery(
+        simulation,
+        "SELECT id FROM rainlytics.orders",
+      );
+
+      // Then the engine answered, since Node's own zlib covers all but snappy
+      // and hyparquet covers that one itself.
+      assertIdentical(answered.answeredBy, "engine");
+      assertObjectEquals(answered.rows, [["7"]]);
+    },
+  );
+
+  it("turns the query down for a codec nothing here decompresses", async () => {
+    // Given a Parquet file written with LZ4, which would need a dependency.
+    const simulation = await anOrdersSimulation();
+
+    await aSeededParquet(
+      simulation.simAws,
+      "orders/part-0.parquet",
+      [{ name: "id", data: [7], type: "INT32" }],
+      "LZ4_RAW",
+    );
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders",
+    );
+
+    // Then the declaration answers it, the way an unreadable object already
+    // does.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+});
+
+describe("a Parquet object the engine cannot read", () => {
+  it.each([
+    ["holds something that is not Parquet", '{"id":1}\n'],
+    ["is empty", ""],
+  ])("falls back where the object %s", async (_case, body) => {
+    // Given a Parquet table whose object the reader will refuse.
+    const simulation = await anOrdersSimulation();
+
+    await aSeededBytes(
+      simulation.simAws,
+      "orders/part-0.parquet",
+      new TextEncoder().encode(body),
+    );
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders",
+    );
+
+    // Then the declaration answers it rather than the query failing.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("leaves an ORC table to its declaration", async () => {
+    // Given an ORC table, which nothing here reads.
+    const simulation = await anOrdersSimulation(orcSerDe);
+
+    await aSeededParquet(simulation.simAws, "orders/part-0.parquet", [
+      { name: "id", data: [7], type: "INT32" },
+    ]);
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders",
+    );
+
+    // Then the declaration answers it.
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+});

--- a/src/service/athena/sim-athena-engine.fixture.ts
+++ b/src/service/athena/sim-athena-engine.fixture.ts
@@ -1,4 +1,17 @@
 import { faker } from "@faker-js/faker";
+import {
+  brotliCompressSync,
+  deflateSync,
+  gzipSync,
+  zstdCompressSync,
+} from "node:zlib";
+
+import {
+  parquetWriteBuffer,
+  type BasicType,
+  type ColumnSource,
+} from "hyparquet-writer";
+import type { CompressionCodec } from "hyparquet";
 
 import type { SimClock } from "../../util/clock/sim-clock.js";
 import type { SimGlueColumn } from "../glue/table/sim-glue-table-schema.js";
@@ -9,6 +22,13 @@ export const jsonSerDe = "org.openx.data.jsonserde.JsonSerDe";
 
 /** The SerDe class name a quoted CSV table declares. */
 export const csvSerDe = "org.apache.hadoop.hive.serde2.OpenCSVSerde";
+
+/** The SerDe class name a Parquet table declares. */
+export const parquetSerDe =
+  "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe";
+
+/** The SerDe class name an ORC table declares, which nothing here reads. */
+export const orcSerDe = "org.apache.hadoop.hive.ql.io.orc.OrcSerde";
 
 /** Where every table in these fixtures keeps its data. */
 export const logsBucket = "rainlytics-logs";
@@ -117,4 +137,50 @@ export async function aSeededJson(
   const lines = records.map((record) => JSON.stringify(record));
 
   await aSeededObject(simAws, key, `${lines.join("\n")}\n`);
+}
+
+/** One column of a Parquet fixture, with the values it holds. */
+export interface SimAthenaParquetColumn {
+  readonly name: string;
+  readonly data: readonly unknown[];
+  readonly type?: BasicType;
+}
+
+/**
+ * What the writer compresses a page with, for the codecs it has not got.
+ *
+ * `hyparquet-writer` compresses snappy alone. These are what let a fixture
+ * produce a file in the codecs the reader takes from `node:zlib`, so those
+ * paths are exercised by a real file rather than by a label.
+ */
+const writeCompressors = {
+  GZIP: (bytes: Uint8Array): Uint8Array => new Uint8Array(gzipSync(bytes)),
+  ZSTD: (bytes: Uint8Array): Uint8Array =>
+    new Uint8Array(zstdCompressSync(bytes)),
+  BROTLI: (bytes: Uint8Array): Uint8Array =>
+    new Uint8Array(brotliCompressSync(bytes)),
+  DEFLATE: (bytes: Uint8Array): Uint8Array =>
+    new Uint8Array(deflateSync(bytes)),
+};
+
+/**
+ * Put one Parquet object under the logs Bucket.
+ *
+ * `hyparquet-writer` is a development dependency of this repository alone. A
+ * project testing against a Parquet table brings its own file, or writes one
+ * however its production pipeline does.
+ */
+export async function aSeededParquet(
+  simAws: SimAws,
+  key: string,
+  columns: readonly SimAthenaParquetColumn[],
+  codec: CompressionCodec = "SNAPPY",
+): Promise<void> {
+  const buffer = parquetWriteBuffer({
+    codec,
+    compressors: writeCompressors,
+    columnData: columns as unknown as ColumnSource[],
+  });
+
+  await aSeededBytes(simAws, key, new Uint8Array(buffer));
 }


### PR DESCRIPTION
A table declaring `ParquetHiveSerDe` now answers from its objects rather than falling back to a declared result. The record reader seam takes an object's bytes instead of its decoded text, since Parquet is binary and carries its own schema, and hyparquet reads it. Snappy, gzip, zstd and brotli files all read, which covers what Athena, Glue and Firehose write. hyparquet is an optional peer dependency loaded the first time a query reaches a Parquet table, so a project querying only JSON and CSV tables never installs it. ORC has no reader and still falls back.

Resolves #1253. The spike that measured this is on `spike/hg/athena-parquet`, with its findings in [`spike/parquet/README.md`](https://github.com/KensioSoftware/yulin/blob/spike/hg/athena-parquet/spike/parquet/README.md).

## What changed

`SimAthenaRecordReader` was `(text: string) => rows` and is now `(bytes: Uint8Array) => rows | Promise<rows>`. `simAthenaObjectText` became `simAthenaObjectBytes` and stops decoding, and the JSON and delimited readers decode for themselves. All 412 Athena tests pass across that seam.

Three smaller changes came with it.

A Parquet `TIMESTAMP`, `DATE` or `INT96` column arrives as a `Date`. Left alone it reached SQLite as quoted JSON, where a filter on it answered zero rows while the query still succeeded. It now renders as the text a timestamp already reads as, and the Glue column type decides whether that is a day or a day and a time.

Results read back with `setReadBigInts`. SQLite holds a 64 bit integer and raises reading one past what a double represents exactly, which a Parquet `int64` column is the first format here to carry.

`sim-athena-delimited-format.ts` is a straight extraction, to keep the record reader under the FTA threshold.

## Divergences worth knowing

A Parquet query reports every byte of every object it opens as scanned, whatever columns the statement touched. Real Athena bills a columnar read by the columns alone. The per-column sizes sit in the file footer if that is worth closing later.

A project without hyparquet falls back with nothing said, the way the engine turns down everything it cannot do. #1254 is the general answer to that silence.

ORC stays refused. The only ORC reader published for Node is AGPL licensed and builds native bindings, which is more than this package asks a test to install.
