### PR TITLE
feat: fail a query the Athena engine turns down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,10 @@ dist
 .junie/*.log
 .junie/
 
+# Codex and other agent tooling that writes into the working tree
+.codex
+.agents
+
 # CMake
 cmake-build-*/
 

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -373,9 +373,12 @@ console.log(described.QueryExecution?.Status?.State);
 console.log(described.QueryExecution?.Status?.StateChangeReason);
 ```
 
-The query reaches `FAILED`, and `StateChangeReason` names what the engine could not do. Each of the
-four turn-downs says something different, so a reader of the failing test learns which one it hit
-rather than only that something went wrong.
+The query reaches `FAILED`, and `StateChangeReason` names what the engine could not do. Each
+turn-down says something different, so a reader of the failing test learns which one it hit rather
+than only that something went wrong. The Athena grammar refusing a statement, an `UNNEST` with no
+`json_each` to become, a statement SQLite will not run, a table in a format with no reader, and
+nothing in scope holding the objects all read differently. A statement SQLite refuses carries
+SQLite's own message out with it.
 
 ```
 The simulated Athena query engine has no reader for

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -300,6 +300,93 @@ The engine turns a query down where the parser refuses the statement, where SQLi
 it, where a table declares a format it has no reader for, and where an object it needs cannot be
 opened. Every one of those ends the same way, with the declared result answering.
 
+### Failing a query the engine turns down
+
+A turn-down is quiet. The query succeeds, the declared rows come back, and a test meaning to
+exercise the engine passes either way. Strict mode fails the query instead.
+
+```typescript sim-athena-engine-strict
+/**
+ * A query the engine cannot run, failing rather than falling back to a
+ * declaration nobody meant to use.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws.glue().createDatabase({
+  input: { DatabaseInput: { Name: "rainlytics" } },
+});
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "orders",
+      StorageDescriptor: {
+        Columns: [{ Name: "id", Type: "int" }],
+        Location: "s3://rainlytics-logs/orders/",
+        SerdeInfo: {
+          SerializationLibrary: "org.apache.hadoop.hive.ql.io.orc.OrcSerde",
+        },
+      },
+    },
+  },
+});
+
+// Without this the query below succeeds, answering with the declared rows.
+simAws
+  .athena()
+  .results()
+  .byDefault({ columns: ["id"], rows: [["1"]] });
+
+await simAws.athena().engine().enable({ strict: true });
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString: "SELECT id FROM rainlytics.orders",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const described = await simAws.athena().getQueryExecution({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// "FAILED", because nothing here reads ORC.
+console.log(described.QueryExecution?.Status?.State);
+
+// The reason names the SerDe, the table declaring it, and what to do instead.
+console.log(described.QueryExecution?.Status?.StateChangeReason);
+```
+
+The query reaches `FAILED`, and `StateChangeReason` names what the engine could not do. Each of the
+four turn-downs says something different, so a reader of the failing test learns which one it hit
+rather than only that something went wrong.
+
+```
+The simulated Athena query engine has no reader for
+org.apache.hadoop.hive.ql.io.orc.OrcSerde, which table rainlytics.orders declares. Declare what this
+query answers with through results(), or leave strict mode off to fall back to a declaration.
+```
+
+Strict mode is off unless a test asks for it, and `disable()` takes it off with the engine. A
+declaration written against one exact query text still answers, with no failure, because that is a
+test's own statement about a query the engine gets wrong.
+
 ### The objects it reads
 
 The SerDe class name in the table's storage descriptor says how its objects are decoded.

--- a/docs/services/athena/sim-athena-engine-strict.example.ts
+++ b/docs/services/athena/sim-athena-engine-strict.example.ts
@@ -1,0 +1,65 @@
+/**
+ * A query the engine cannot run, failing rather than falling back to a
+ * declaration nobody meant to use.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-logs" } });
+await simAws.s3().createBucket({ input: { Bucket: "rainlytics-results" } });
+await simAws.athena().createWorkGroup({
+  input: {
+    Name: "rainlytics",
+    Configuration: {
+      ResultConfiguration: { OutputLocation: "s3://rainlytics-results/q/" },
+    },
+  },
+});
+
+simAws.glue().createDatabase({
+  input: { DatabaseInput: { Name: "rainlytics" } },
+});
+simAws.glue().createTable({
+  input: {
+    DatabaseName: "rainlytics",
+    TableInput: {
+      Name: "orders",
+      StorageDescriptor: {
+        Columns: [{ Name: "id", Type: "int" }],
+        Location: "s3://rainlytics-logs/orders/",
+        SerdeInfo: {
+          SerializationLibrary: "org.apache.hadoop.hive.ql.io.orc.OrcSerde",
+        },
+      },
+    },
+  },
+});
+
+// Without this the query below succeeds, answering with the declared rows.
+simAws
+  .athena()
+  .results()
+  .byDefault({ columns: ["id"], rows: [["1"]] });
+
+await simAws.athena().engine().enable({ strict: true });
+
+const started = await simAws.athena().startQueryExecution({
+  input: {
+    QueryString: "SELECT id FROM rainlytics.orders",
+    WorkGroup: "rainlytics",
+  },
+});
+
+await simAws.backgroundTasksComplete();
+
+const described = await simAws.athena().getQueryExecution({
+  input: { QueryExecutionId: started.QueryExecutionId },
+});
+
+// "FAILED", because nothing here reads ORC.
+console.log(described.QueryExecution?.Status?.State);
+
+// The reason names the SerDe, the table declaring it, and what to do instead.
+console.log(described.QueryExecution?.Status?.StateChangeReason);

--- a/src/service/athena/engine/sim-athena-engine-run.ts
+++ b/src/service/athena/engine/sim-athena-engine-run.ts
@@ -1,15 +1,41 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
 import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import { simAthenaRunFailure } from "./sim-athena-turn-down.js";
 import { simAthenaEngineResult } from "./sim-athena-engine-result.js";
 import type { SimAthenaSqlParser } from "./sim-athena-parser-module.js";
 import { simAthenaSqliteDatabase } from "./sim-athena-sqlite-database.js";
 import type { SimAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
-import {
-  simAthenaTableRows,
-  type SimAthenaLoadedTable,
-} from "./sim-athena-table-rows.js";
+import { simAthenaLoadedTables } from "./sim-athena-loaded-tables.js";
 import type { SimAthenaTableObjects } from "./sim-athena-table-objects.js";
+
+/**
+ * What the engine came to for one query.
+ *
+ * A turn-down carries why, because a strict engine fails the query with it and
+ * a reader of that failing test has to learn which of them it hit.
+ */
+export interface SimAthenaEngineAnswer {
+  /** The rows, where the engine ran the statement. */
+  readonly result: SimAthenaResolvedResult | undefined;
+
+  /** What the engine could not do, where it turned the query down. */
+  readonly turnedDown: string | undefined;
+}
+
+/** One answer the engine ran for real. */
+export function simAthenaEngineAnswered(
+  result: SimAthenaResolvedResult,
+): SimAthenaEngineAnswer {
+  return { result, turnedDown: undefined };
+}
+
+/** One query the engine turned down, and why. */
+export function simAthenaEngineTurnedDown(
+  turnedDown: string,
+): SimAthenaEngineAnswer {
+  return { result: undefined, turnedDown };
+}
 
 /** What one query is run with, once the engine is on and has somewhere to read. */
 export interface SimAthenaEngineRun {
@@ -32,15 +58,18 @@ export interface SimAthenaEngineRun {
  * the parser wrote that SQLite does not have. All three leave the declared
  * result to answer. So does a Parquet table in a project that has not installed
  * the reader, and `hyparquet` is named in the docs for that reason.
+ *
+ * Each of them carries a reason out, which a strict engine fails the query
+ * with.
  */
 export async function simAthenaEngineRun(
   run: SimAthenaEngineRun,
-): Promise<SimAthenaResolvedResult | undefined> {
+): Promise<SimAthenaEngineAnswer> {
   try {
-    const loaded = await loadedTables(run);
+    const loaded = await simAthenaLoadedTables(run);
 
-    if (loaded === undefined) {
-      return undefined;
+    if (typeof loaded === "string") {
+      return simAthenaEngineTurnedDown(loaded);
     }
 
     const database = simAthenaSqliteDatabase({
@@ -51,50 +80,13 @@ export async function simAthenaEngineRun(
     });
 
     try {
-      return simAthenaEngineResult(database, run.sql, loaded);
+      return simAthenaEngineAnswered(
+        simAthenaEngineResult(database, run.sql, loaded),
+      );
     } finally {
       database.close();
     }
-  } catch {
-    return undefined;
+  } catch (error) {
+    return simAthenaEngineTurnedDown(simAthenaRunFailure(error));
   }
-}
-
-/**
- * Every table the query reads, loaded once each.
- *
- * A statement naming one table twice resolves to two entries, and loading each
- * of them would read the objects twice and then fail to create the table.
- */
-async function loadedTables(
-  run: SimAthenaEngineRun,
-): Promise<readonly SimAthenaLoadedTable[] | undefined> {
-  const loaded = await Promise.all(
-    distinctTables(run.tables).map(async (planned) =>
-      simAthenaTableRows({ planned, objects: run.objects, caller: run.caller }),
-    ),
-  );
-
-  return loaded.includes(undefined)
-    ? undefined
-    : (loaded as readonly SimAthenaLoadedTable[]);
-}
-
-function distinctTables(
-  tables: readonly SimAthenaPlannedTable[],
-): readonly SimAthenaPlannedTable[] {
-  const seen = new Set<string>();
-
-  return tables.filter((planned) => {
-    const identity =
-      `${planned.table.databaseName}.${planned.table.name}`.toLowerCase();
-
-    if (seen.has(identity)) {
-      return false;
-    }
-
-    seen.add(identity);
-
-    return true;
-  });
 }

--- a/src/service/athena/engine/sim-athena-loaded-tables.ts
+++ b/src/service/athena/engine/sim-athena-loaded-tables.ts
@@ -1,0 +1,55 @@
+import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
+import type { SimAthenaEngineRun } from "./sim-athena-engine-run.js";
+import {
+  simAthenaTableRows,
+  type SimAthenaLoadedTable,
+} from "./sim-athena-table-rows.js";
+import { simAthenaUnreadableFormat } from "./sim-athena-turn-down.js";
+
+/**
+ * Every table the query reads, loaded once each, or the reason one of them
+ * could not be.
+ *
+ * A statement naming one table twice resolves to two entries, and loading each
+ * of them would read the objects twice and then fail to create the table.
+ */
+export async function simAthenaLoadedTables(
+  run: SimAthenaEngineRun,
+): Promise<readonly SimAthenaLoadedTable[] | string> {
+  const loaded = await Promise.all(
+    distinctTables(run.tables).map(async (planned) => ({
+      planned,
+      rows: await simAthenaTableRows({
+        planned,
+        objects: run.objects,
+        caller: run.caller,
+      }),
+    })),
+  );
+  const unread = loaded.find((one) => one.rows === undefined);
+
+  if (unread !== undefined) {
+    return simAthenaUnreadableFormat(unread.planned.table);
+  }
+
+  return loaded.flatMap((one) => one.rows ?? []);
+}
+
+function distinctTables(
+  tables: readonly SimAthenaPlannedTable[],
+): readonly SimAthenaPlannedTable[] {
+  const seen = new Set<string>();
+
+  return tables.filter((planned) => {
+    const identity =
+      `${planned.table.databaseName}.${planned.table.name}`.toLowerCase();
+
+    if (seen.has(identity)) {
+      return false;
+    }
+
+    seen.add(identity);
+
+    return true;
+  });
+}

--- a/src/service/athena/engine/sim-athena-query-engine.ts
+++ b/src/service/athena/engine/sim-athena-query-engine.ts
@@ -15,10 +15,7 @@ import {
 } from "./sim-athena-sqlite-module.js";
 import { simAthenaSqliteSql } from "./sim-athena-sql-translation.js";
 import type { SimAthenaTableObjects } from "./sim-athena-table-objects.js";
-import {
-  simAthenaNoObjects,
-  simAthenaUnreadableStatement,
-} from "./sim-athena-turn-down.js";
+import { simAthenaNoObjects } from "./sim-athena-turn-down.js";
 
 /** How one scope's engine is turned on. */
 export interface SimAthenaEngineOptions {
@@ -119,14 +116,20 @@ export class SimAthenaQueryEngine {
       return simAthenaEngineTurnedDown(simAthenaNoObjects);
     }
 
-    const sql = simAthenaSqliteSql({
+    const translated = simAthenaSqliteSql({
       parser,
       athenaSql: request.queryString,
       tables: request.tables.map((planned) => planned.table),
     });
 
-    return sql === undefined
-      ? simAthenaEngineTurnedDown(simAthenaUnreadableStatement)
-      : simAthenaEngineRun({ ...request, parser, sqlite, objects, sql });
+    return translated.sql === undefined
+      ? simAthenaEngineTurnedDown(translated.turnedDown)
+      : simAthenaEngineRun({
+          ...request,
+          parser,
+          sqlite,
+          objects,
+          sql: translated.sql,
+        });
   }
 }

--- a/src/service/athena/engine/sim-athena-query-engine.ts
+++ b/src/service/athena/engine/sim-athena-query-engine.ts
@@ -1,7 +1,10 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
-import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
-import { simAthenaEngineRun } from "./sim-athena-engine-run.js";
+import {
+  simAthenaEngineRun,
+  simAthenaEngineTurnedDown,
+  type SimAthenaEngineAnswer,
+} from "./sim-athena-engine-run.js";
 import {
   simAthenaSqlParser,
   type SimAthenaSqlParser,
@@ -12,6 +15,23 @@ import {
 } from "./sim-athena-sqlite-module.js";
 import { simAthenaSqliteSql } from "./sim-athena-sql-translation.js";
 import type { SimAthenaTableObjects } from "./sim-athena-table-objects.js";
+import {
+  simAthenaNoObjects,
+  simAthenaUnreadableStatement,
+} from "./sim-athena-turn-down.js";
+
+/** How one scope's engine is turned on. */
+export interface SimAthenaEngineOptions {
+  /**
+   * Whether a query the engine turns down fails rather than falling back.
+   *
+   * Off by default, which leaves every turn-down answering from a declaration
+   * the way it always has. A test suite meaning to exercise the engine turns
+   * this on, and then a query the engine quietly stopped running shows up as a
+   * failing test rather than as one passing on rows nobody meant to use.
+   */
+  readonly strict?: boolean;
+}
 
 /** What one query is run against. */
 export interface SimAthenaEngineRequest {
@@ -41,15 +61,22 @@ export interface SimAthenaEngineRequest {
  * Everything the engine cannot do, it turns down. A statement Athena's grammar
  * refuses, a table in a format it has no reader for, an object it cannot open
  * and a statement SQLite will not run all end the same way: no result, and the
- * declaration a test wrote answers the query instead.
+ * declaration a test wrote answers the query instead. A strict engine fails the
+ * query instead of falling back, and the reason says which of them it hit.
  */
 export class SimAthenaQueryEngine {
   #parser: SimAthenaSqlParser | undefined;
   #sqlite: SimAthenaSqliteModule | undefined;
+  #strict = false;
 
   /** Whether this scope runs queries rather than answering from declarations. */
   get isEnabled(): boolean {
     return this.#parser !== undefined;
+  }
+
+  /** Whether a query this engine turns down fails rather than falling back. */
+  get isStrict(): boolean {
+    return this.#strict;
   }
 
   /**
@@ -59,30 +86,37 @@ export class SimAthenaQueryEngine {
    * optional peer dependency, so a project that never runs a query never
    * installs it.
    */
-  async enable(): Promise<void> {
+  async enable(options: SimAthenaEngineOptions = {}): Promise<void> {
     const parser = await simAthenaSqlParser();
 
     this.#sqlite = await simAthenaSqliteModule();
     this.#parser = parser;
+    this.#strict = options.strict ?? false;
   }
 
   /** Answer queries from declarations again. */
   disable(): void {
     this.#parser = undefined;
+    this.#strict = false;
   }
 
   /**
-   * What one query answers with, or nothing where the engine turned it down.
+   * What one query answers with, or why the engine turned it down.
+   *
+   * An engine nobody turned on turns nothing down. It has no opinion about the
+   * query, and a scope left alone answers from declarations as it always did.
    */
-  async run(
-    request: SimAthenaEngineRequest,
-  ): Promise<SimAthenaResolvedResult | undefined> {
+  async run(request: SimAthenaEngineRequest): Promise<SimAthenaEngineAnswer> {
     const parser = this.#parser;
     const sqlite = this.#sqlite;
     const { objects } = request;
 
-    if (parser === undefined || sqlite === undefined || objects === undefined) {
-      return undefined;
+    if (parser === undefined || sqlite === undefined) {
+      return { result: undefined, turnedDown: undefined };
+    }
+
+    if (objects === undefined) {
+      return simAthenaEngineTurnedDown(simAthenaNoObjects);
     }
 
     const sql = simAthenaSqliteSql({
@@ -92,7 +126,7 @@ export class SimAthenaQueryEngine {
     });
 
     return sql === undefined
-      ? undefined
+      ? simAthenaEngineTurnedDown(simAthenaUnreadableStatement)
       : simAthenaEngineRun({ ...request, parser, sqlite, objects, sql });
   }
 }

--- a/src/service/athena/engine/sim-athena-sql-translation.ts
+++ b/src/service/athena/engine/sim-athena-sql-translation.ts
@@ -4,7 +4,17 @@ import {
   simAthenaSqlForParser,
   simAthenaSqlForSqlite,
 } from "./sim-athena-sql-rewrites.js";
+import {
+  simAthenaUnparsedStatement,
+  simAthenaUnrewrittenUnnest,
+  simAthenaUnwrittenStatement,
+} from "./sim-athena-turn-down.js";
 import { simAthenaRewriteUnnest } from "./sim-athena-unnest-rewrite.js";
+
+/** One statement translated for SQLite, or why it could not be. */
+export type SimAthenaTranslatedSql =
+  | { readonly sql: string; readonly turnedDown: undefined }
+  | { readonly sql: undefined; readonly turnedDown: string };
 
 interface SimAthenaSqlTranslationRequest {
   readonly parser: SimAthenaSqlParser;
@@ -15,25 +25,29 @@ interface SimAthenaSqlTranslationRequest {
 }
 
 /**
- * One Athena statement written back out for SQLite, or nothing where it cannot
- * be.
+ * One Athena statement written back out for SQLite, or why it cannot be.
  *
- * A statement the Athena grammar refuses, one carrying an `UNNEST` that cannot
- * become a `json_each`, and one the parser cannot write back out all land the
- * same way. The engine has one answer to any of them, which is to turn the
- * query down and let the declared result take it. Nothing is reported from
- * here, since a query the engine cannot run is an ordinary thing for a test to
- * write.
+ * Three things stop it, and each is told apart because a strict engine fails
+ * the query with the reason. The Athena grammar can refuse the statement, an
+ * `UNNEST` in it can have no `json_each` to become, and the parser can decline
+ * to write the statement back out. A lenient engine answers all three the same
+ * way, by turning the query down and letting the declared result take it.
  */
 export function simAthenaSqliteSql(
   request: SimAthenaSqlTranslationRequest,
-): string | undefined {
+): SimAthenaTranslatedSql {
   const { parser } = request;
+  let read;
+  let ast;
 
   try {
-    const read = simAthenaSqlForParser(request.athenaSql);
-    const ast = parser.astify(read.sql, { database: "athena" });
+    read = simAthenaSqlForParser(request.athenaSql);
+    ast = parser.astify(read.sql, { database: "athena" });
+  } catch {
+    return turnedDown(simAthenaUnparsedStatement);
+  }
 
+  try {
     if (
       !simAthenaRewriteUnnest({
         ast,
@@ -41,11 +55,18 @@ export function simAthenaSqliteSql(
         tables: request.tables,
       })
     ) {
-      return undefined;
+      return turnedDown(simAthenaUnrewrittenUnnest);
     }
 
-    return simAthenaSqlForSqlite(parser.sqlify(ast, { database: "sqlite" }));
+    return {
+      sql: simAthenaSqlForSqlite(parser.sqlify(ast, { database: "sqlite" })),
+      turnedDown: undefined,
+    };
   } catch {
-    return undefined;
+    return turnedDown(simAthenaUnwrittenStatement);
   }
+}
+
+function turnedDown(reason: string): SimAthenaTranslatedSql {
+  return { sql: undefined, turnedDown: reason };
 }

--- a/src/service/athena/engine/sim-athena-turn-down.ts
+++ b/src/service/athena/engine/sim-athena-turn-down.ts
@@ -11,10 +11,19 @@ const alternatives =
 /** Nothing in scope holds the objects a query would read. */
 export const simAthenaNoObjects = `${engine} has no simulated S3 to read this query's objects from.`;
 
-/** The statement could not be written back out for SQLite. */
-export const simAthenaUnreadableStatement =
-  `${engine} cannot run this statement. The Athena grammar refused it, or it ` +
-  `uses something SQLite has not got.`;
+/**
+ * The Athena grammar would not parse the statement.
+ *
+ * Nothing has reached SQLite at this point. A statement SQLite refuses to run
+ * is its own case, and it carries SQLite's own message out.
+ */
+export const simAthenaUnparsedStatement = `${engine} cannot read this statement. The Athena grammar refused it.`;
+
+/** The statement's `UNNEST` has no `json_each` to become. */
+export const simAthenaUnrewrittenUnnest = `${engine} cannot rewrite this statement's UNNEST onto SQLite's json_each.`;
+
+/** The parsed statement would not come back out as SQLite's dialect. */
+export const simAthenaUnwrittenStatement = `${engine} cannot write this statement back out for SQLite.`;
 
 /** Whatever went wrong while the tables were loaded or the statement ran. */
 export function simAthenaRunFailure(error: unknown): string {

--- a/src/service/athena/engine/sim-athena-turn-down.ts
+++ b/src/service/athena/engine/sim-athena-turn-down.ts
@@ -1,0 +1,52 @@
+import type { SimAthenaCatalogTable } from "../table/sim-athena-catalog-table.js";
+
+/** How every reason opens, so a test can match one without matching all of it. */
+const engine = "The simulated Athena query engine";
+
+/** What a strict engine tells a test to do about the query it failed. */
+const alternatives =
+  `Declare what this query answers with through results(), or leave strict ` +
+  `mode off to fall back to a declaration.`;
+
+/** Nothing in scope holds the objects a query would read. */
+export const simAthenaNoObjects = `${engine} has no simulated S3 to read this query's objects from.`;
+
+/** The statement could not be written back out for SQLite. */
+export const simAthenaUnreadableStatement =
+  `${engine} cannot run this statement. The Athena grammar refused it, or it ` +
+  `uses something SQLite has not got.`;
+
+/** Whatever went wrong while the tables were loaded or the statement ran. */
+export function simAthenaRunFailure(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return `${engine} could not answer this statement. ${message}`;
+}
+
+/**
+ * One table the engine has no reader for.
+ *
+ * The SerDe is what decides, so the SerDe is what the reason names. A table
+ * carrying none is its own case, because there is nothing to name and nothing
+ * else in the catalog says what its objects hold.
+ */
+export function simAthenaUnreadableFormat(
+  table: SimAthenaCatalogTable,
+): string {
+  const name = `${table.databaseName}.${table.name}`;
+  const serDe = table.storageDescriptor?.SerdeInfo?.SerializationLibrary;
+
+  if (serDe === undefined) {
+    return (
+      `Table ${name} declares no SerDe, and ${engine.toLowerCase()} has ` +
+      `nothing to say what its objects hold.`
+    );
+  }
+
+  return `${engine} has no reader for ${serDe}, which table ${name} declares.`;
+}
+
+/** One turn-down, as the reason a strict engine fails the query with. */
+export function simAthenaStrictRefusal(turnedDown: string): string {
+  return `${turnedDown} ${alternatives}`;
+}

--- a/src/service/athena/execution/sim-athena-query-completion.ts
+++ b/src/service/athena/execution/sim-athena-query-completion.ts
@@ -19,7 +19,9 @@ interface SimAthenaQueryCompletionRequest {
  * only a query that got past all three goes on to be answered and written.
  *
  * A write that fails leaves the execution `FAILED` rather than raising at a
- * caller who was answered long ago and has gone away to poll.
+ * caller who was answered long ago and has gone away to poll. A strict engine
+ * turning the query down fails it the same way, and the reason names what the
+ * engine could not do.
  */
 export async function simAthenaCompleteQuery(
   request: SimAthenaQueryCompletionRequest,
@@ -59,6 +61,12 @@ export async function simAthenaCompleteQuery(
     caller,
     startedAt: execution.submittedAt,
   });
+
+  if (answer.refusal !== undefined) {
+    execution.fail(answer.refusal, runner.background.now());
+
+    return;
+  }
 
   try {
     await runner.writer.write(execution, answer.result, caller);

--- a/src/service/athena/index.ts
+++ b/src/service/athena/index.ts
@@ -26,7 +26,10 @@ export {
 export { SimAthenaWorkGroupStore } from "./workgroup/sim-athena-work-group-store.js";
 export { SimAthenaNamedQuery } from "./named-query/sim-athena-named-query.js";
 export { SimAthenaQueryExecution } from "./execution/sim-athena-query-execution.js";
-export { SimAthenaQueryEngine } from "./engine/sim-athena-query-engine.js";
+export {
+  SimAthenaQueryEngine,
+  type SimAthenaEngineOptions,
+} from "./engine/sim-athena-query-engine.js";
 export type {
   SimAthenaAnswerSource,
   SimAthenaQueryAnswer,

--- a/src/service/athena/result/sim-athena-query-answer.ts
+++ b/src/service/athena/result/sim-athena-query-answer.ts
@@ -1,6 +1,7 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAthenaTableObjects } from "../engine/sim-athena-table-objects.js";
 import type { SimAthenaQueryEngine } from "../engine/sim-athena-query-engine.js";
+import { simAthenaStrictRefusal } from "../engine/sim-athena-turn-down.js";
 import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
 import type { SimAthenaQueryResults } from "./sim-athena-query-results.js";
 import type { SimAthenaResolvedResult } from "./sim-athena-resolved-result.js";
@@ -12,6 +13,15 @@ export type SimAthenaAnswerSource = "engine" | "declaration";
 export interface SimAthenaQueryAnswer {
   readonly result: SimAthenaResolvedResult;
   readonly source: SimAthenaAnswerSource;
+
+  /**
+   * Why the query fails rather than answering, where a strict engine turned it
+   * down.
+   *
+   * The declared result is still carried alongside, because it is what the
+   * query would have answered with had the engine not been strict.
+   */
+  readonly refusal: string | undefined;
 }
 
 interface SimAthenaQueryAnswerRequest {
@@ -43,6 +53,10 @@ interface SimAthenaQueryAnswerRequest {
  * declarations again, where a workgroup rule or the default answers it. Every
  * test written before the engine existed therefore keeps working, whether or
  * not the engine is on.
+ *
+ * A strict engine is the exception, and it fails the query it turned down.
+ * The declaration keeps its place ahead of that, since a test writing one
+ * against this exact statement has already said what the engine gets wrong.
  */
 export async function simAthenaQueryAnswer(
   request: SimAthenaQueryAnswerRequest,
@@ -50,7 +64,7 @@ export async function simAthenaQueryAnswer(
   const forQuery = request.results.declaredForQuery(request.queryString);
 
   if (forQuery !== undefined) {
-    return { result: forQuery, source: "declaration" };
+    return { result: forQuery, source: "declaration", refusal: undefined };
   }
 
   const computed = await request.engine.run({
@@ -62,7 +76,30 @@ export async function simAthenaQueryAnswer(
     startedAt: request.startedAt,
   });
 
-  return computed === undefined
-    ? { result: request.declared, source: "declaration" }
-    : { result: computed, source: "engine" };
+  if (computed.result !== undefined) {
+    return { result: computed.result, source: "engine", refusal: undefined };
+  }
+
+  return {
+    result: request.declared,
+    source: "declaration",
+    refusal: strictRefusal(request.engine, computed.turnedDown),
+  };
+}
+
+/**
+ * Why a query fails, where a strict engine is what turned it down.
+ *
+ * An engine nobody turned on turns nothing down, and a lenient one turns a
+ * query down without failing it. Both answer from the declaration.
+ */
+function strictRefusal(
+  engine: SimAthenaQueryEngine,
+  turnedDown: string | undefined,
+): string | undefined {
+  if (turnedDown === undefined || !engine.isStrict) {
+    return undefined;
+  }
+
+  return simAthenaStrictRefusal(turnedDown);
 }

--- a/src/service/athena/sim-athena-answered-query.fixture.ts
+++ b/src/service/athena/sim-athena-answered-query.fixture.ts
@@ -5,6 +5,9 @@ import type { SimAthenaEngineSimulation } from "./sim-athena-engine.fixture.js";
 export interface SimAthenaEngineQuery {
   readonly state: string | undefined;
   readonly answeredBy: SimAthenaAnswerSource | undefined;
+
+  /** Why a failed query failed, which a refusal is what a test reads. */
+  readonly reason: string | undefined;
   readonly columns: readonly (string | undefined)[];
   readonly rows: readonly (readonly (string | undefined)[])[];
 }
@@ -35,6 +38,7 @@ export async function anAnsweredQuery(
   const answered = {
     state: execution?.state,
     answeredBy: execution?.answeredBy,
+    reason: execution?.stateChangeReason,
   };
 
   if (execution?.state !== "SUCCEEDED") {

--- a/src/service/athena/sim-athena-engine-strict.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-strict.iso.test.ts
@@ -1,0 +1,263 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import { SimAthena } from "./sim-athena.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  logsBucket,
+  orcSerDe,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+/** One order, so a table the engine can read has something under it. */
+const oneOrder = [{ id: 1, customer: "ada" }];
+
+/** The columns every orders table in this file declares. */
+const orderColumns = [
+  { Name: "id", Type: "int" },
+  { Name: "customer", Type: "string" },
+];
+
+/**
+ * A simulation over one orders table, with a default declaration behind it.
+ *
+ * The declaration is what a lenient engine falls back to, and what a strict one
+ * refuses to fall back to. Every test here needs to tell the two apart.
+ */
+async function anOrdersSimulation(
+  strict: boolean,
+  serDe?: string,
+): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "orders",
+    columns: orderColumns,
+    serDe,
+  });
+
+  await aSeededJson(simulation.simAws, "orders/part-0.json", oneOrder);
+
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["id"], rows: [["declared"]] });
+
+  await simulation.simAws.athena().engine().enable({ strict });
+
+  return simulation;
+}
+
+describe("a strict Athena query engine", () => {
+  it("is off until a test asks for it", async () => {
+    // Given an engine turned on the way every test before this one turned it on.
+    const simulation = await anEngineSimulation();
+
+    await simulation.simAws.athena().engine().enable();
+
+    // Then it answers from declarations where it cannot run a query, as it did
+    // before strict mode existed.
+    assertTrue(simulation.simAws.athena().engine().isEnabled);
+    assertFalse(simulation.simAws.athena().engine().isStrict);
+  });
+
+  it("fails a statement the grammar refuses", async () => {
+    // Given a strict engine.
+    const simulation = await anOrdersSimulation(true);
+
+    // When a query the Athena grammar refuses runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders GROUP BY GROUPING SETS ((id))",
+    );
+
+    // Then it failed rather than answering from the default declaration.
+    assertIdentical(answered.state, "FAILED");
+    assertStringIncludes(answered.reason ?? "", "cannot run this statement");
+    assertStringIncludes(answered.reason ?? "", "results()");
+  });
+
+  it("fails a table in a format it has no reader for", async () => {
+    // Given a strict engine and an ORC table.
+    const simulation = await anOrdersSimulation(true, orcSerDe);
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders",
+    );
+
+    // Then the reason names the SerDe and the table that declares it.
+    assertIdentical(answered.state, "FAILED");
+    assertStringIncludes(answered.reason ?? "", orcSerDe);
+    assertStringIncludes(answered.reason ?? "", "rainlytics.orders");
+  });
+
+  it("fails a table declaring no SerDe at all", async () => {
+    // Given a strict engine and a table saying nothing about its objects.
+    const simulation = await anEngineSimulation();
+
+    // Declared here rather than through the fixture, which always writes a
+    // SerdeInfo, because a table without one is the whole of this case.
+    simulation.simAws.glue().createTable({
+      input: {
+        DatabaseName: "rainlytics",
+        TableInput: {
+          Name: "orders",
+          StorageDescriptor: {
+            Columns: orderColumns,
+            Location: `s3://${logsBucket}/orders/`,
+          },
+        },
+      },
+    });
+
+    await simulation.simAws.athena().engine().enable({ strict: true });
+
+    // When a query reads it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders",
+    );
+
+    // Then the reason says the table declares nothing to read it by.
+    assertIdentical(answered.state, "FAILED");
+    assertStringIncludes(answered.reason ?? "", "declares no SerDe");
+  });
+
+  it("fails a statement SQLite will not run", async () => {
+    // Given a strict engine.
+    const simulation = await anOrdersSimulation(true);
+
+    // When a query names a column the table has not got.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT missing FROM rainlytics.orders",
+    );
+
+    // Then the reason carries what stopped it, rather than the query passing
+    // on rows the default declaration held.
+    assertIdentical(answered.state, "FAILED");
+    assertStringIncludes(answered.reason ?? "", "could not answer");
+  });
+
+  it("answers a query it can run", async () => {
+    // Given a strict engine over a table it reads.
+    const simulation = await anOrdersSimulation(true);
+
+    // When a query it can run runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT customer FROM rainlytics.orders",
+    );
+
+    // Then strict mode changed nothing about it.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["ada"]]);
+  });
+
+  it("fails where nothing in scope holds the objects", async () => {
+    // Given simulated Athena built on its own, which has no simulated S3.
+    const athena = new SimAthena();
+
+    await athena.createWorkGroup({
+      input: {
+        Name: "standalone",
+        Configuration: {
+          ResultConfiguration: { OutputLocation: "s3://results/q/" },
+        },
+      },
+    });
+    athena.results().byDefault({ columns: ["n"], rows: [["declared"]] });
+
+    await athena.engine().enable({ strict: true });
+
+    // When a query runs.
+    const started = await athena.startQueryExecution({
+      input: { QueryString: "SELECT 1 AS n", WorkGroup: "standalone" },
+    });
+
+    // The runner schedules the query to start, and then to finish, so a
+    // standalone Athena with no SimAws to settle needs both turns of the loop.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    const execution = athena
+      .queryExecutions()
+      .find((one) => one.queryExecutionId === started.QueryExecutionId);
+
+    // Then the reason says there was nowhere to read from, rather than the
+    // query passing on the rows a default declaration held.
+    assertIdentical(execution?.state, "FAILED");
+    assertStringIncludes(execution.stateChangeReason ?? "", "no simulated S3");
+  });
+
+  it("keeps the declaration written against one exact statement", async () => {
+    // Given a strict engine and a declaration for a statement it cannot run.
+    const simulation = await anOrdersSimulation(true);
+    const sql =
+      "SELECT id FROM rainlytics.orders GROUP BY GROUPING SETS ((id))";
+
+    simulation.simAws
+      .athena()
+      .results()
+      .onQuery(sql, { columns: ["id"], rows: [["written down"]] });
+
+    // When that statement runs.
+    const answered = await anAnsweredQuery(simulation, sql);
+
+    // Then the test's own statement about it still wins, since a strict engine
+    // is about queries nobody said anything about.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["written down"]]);
+  });
+
+  it("leaves a lenient engine falling back", async () => {
+    // Given an engine turned on without strict mode.
+    const simulation = await anOrdersSimulation(false);
+
+    // When a query it cannot run runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders GROUP BY GROUPING SETS ((id))",
+    );
+
+    // Then the default declaration answers it, as it always has.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+
+  it("turns nothing down once the engine is off again", async () => {
+    // Given a strict engine that is then turned off.
+    const simulation = await anOrdersSimulation(true);
+
+    simulation.simAws.athena().engine().disable();
+
+    // When a query the engine could never have run runs.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT id FROM rainlytics.orders GROUP BY GROUPING SETS ((id))",
+    );
+
+    // Then the declaration takes it back, and strictness went with the engine.
+    assertFalse(simulation.simAws.athena().engine().isStrict);
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertObjectEquals(answered.rows, [["declared"]]);
+  });
+});

--- a/src/service/athena/sim-athena-engine-strict.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-strict.iso.test.ts
@@ -80,10 +80,28 @@ describe("a strict Athena query engine", () => {
       "SELECT id FROM rainlytics.orders GROUP BY GROUPING SETS ((id))",
     );
 
-    // Then it failed rather than answering from the default declaration.
+    // Then it failed rather than answering from the default declaration, and
+    // the reason says the grammar is what refused it. Nothing had reached
+    // SQLite by then.
     assertIdentical(answered.state, "FAILED");
-    assertStringIncludes(answered.reason ?? "", "cannot run this statement");
+    assertStringIncludes(answered.reason ?? "", "The Athena grammar refused");
     assertStringIncludes(answered.reason ?? "", "results()");
+  });
+
+  it("fails an UNNEST it cannot rewrite, saying so", async () => {
+    // Given a strict engine over a table with no array column.
+    const simulation = await anOrdersSimulation(true);
+
+    // When a statement unnests a column the table has not got.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT tag FROM rainlytics.orders CROSS JOIN UNNEST(tags) AS t (tag)",
+    );
+
+    // Then the reason names the rewrite, rather than the grammar that took the
+    // statement happily.
+    assertIdentical(answered.state, "FAILED");
+    assertStringIncludes(answered.reason ?? "", "UNNEST");
   });
 
   it("fails a table in a format it has no reader for", async () => {
@@ -144,10 +162,12 @@ describe("a strict Athena query engine", () => {
       "SELECT missing FROM rainlytics.orders",
     );
 
-    // Then the reason carries what stopped it, rather than the query passing
-    // on rows the default declaration held.
+    // Then the reason carries what SQLite said, rather than the query passing
+    // on rows the default declaration held. This is the one turn-down SQLite
+    // reaches, and the statement was translated for it before it got there.
     assertIdentical(answered.state, "FAILED");
     assertStringIncludes(answered.reason ?? "", "could not answer");
+    assertStringIncludes(answered.reason ?? "", "missing");
   });
 
   it("answers a query it can run", async () => {


### PR DESCRIPTION
A turn-down is quiet. The query succeeds, the declared rows come back, and a test meaning to exercise the engine passes either way. Strict mode fails the query instead.

```ts
await simAws.athena().engine().enable({ strict: true });
```

Resolves #1254.

## What the reason says

`StateChangeReason` names which of the four turn-downs the query hit, so a reader of the failing test learns what the engine could not do rather than only that something went wrong.

```
The simulated Athena query engine has no reader for org.apache.hadoop.hive.ql.io.orc.OrcSerde,
which table rainlytics.orders declares. Declare what this query answers with through results(),
or leave strict mode off to fall back to a declaration.
```

The other three cover a statement the Athena grammar refused, a statement SQLite would not run, and nothing in scope holding the objects. Each carries what stopped it.

## What stayed the same

Strict mode is off unless a test asks for it, and `disable()` takes it off with the engine. All 412 Athena tests that existed before this pass unchanged.

A declaration written against one exact query text still answers, with no failure. That is a test's own statement about a query the engine gets wrong, and it keeps its place ahead of strictness.

## Threading the reason out

`engine.run()` returned `SimAthenaResolvedResult | undefined`, which lost why. It now answers with `SimAthenaEngineAnswer`, carrying either the rows or the reason, and `simAthenaQueryAnswer` turns a reason into a refusal only when the engine is strict.

`sim-athena-loaded-tables.ts` is an extraction, to keep `sim-athena-engine-run.ts` under the FTA threshold.

## Also here

`.codex` and `.agents` are gitignored, carried on this branch to get them in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional strict query-engine mode for simulated Athena.
  - Strict mode now reports clear refusal reasons when queries cannot be processed, including unsupported formats, missing objects, and execution failures.
  - Query results can include refusal details, while explicitly declared exact-query results continue to take precedence.

- **Bug Fixes**
  - Query executions now stop cleanly when the engine refuses a request instead of writing misleading results.

- **Documentation**
  - Added strict-mode guidance and a complete usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->