### PR TITLE
feat: publish CDK assets as their own principal

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2115,8 +2115,62 @@ const stacks = await simAws.cloudFormation().deployCdkOut({
 console.log(stacks.get("PipelineStack")?.stackName);
 ```
 
-A staged CDK asset is published under the same principal, before CloudFormation reads the template
-that points at it.
+### The principal a CDK asset is published as
+
+A real `cdk deploy` runs in two phases under two Roles. `cdk-assets` publishes every staged file
+asset to the bootstrap staging bucket as the file publishing Role, and CloudFormation then processes
+the template as the execution Role. `assetsCaller` names the first of those, beside the `caller`
+naming the second.
+
+```typescript sim-cloudformation-assets-caller
+/**
+ * Publishing a Stack's CDK file assets as the file publishing Role.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  defaultAccountId: "123456789012",
+  defaultRegionName: "eu-west-2",
+});
+
+const publisher = await simAws.iam().makeDeployRole({
+  roleName: "cdk-file-publishing",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Action: ["s3:GetObject*", "s3:GetBucket*", "s3:List*", "s3:PutObject"],
+      Resource: "arn:aws:s3:::cdk-hnb659fds-assets-*",
+    },
+  },
+});
+
+const executor = await simAws.iam().makeDeployRole({
+  roleName: "cdk-exec",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+  },
+});
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  caller: executor,
+  assetsCaller: publisher,
+});
+
+console.log(stacks.size);
+```
+
+`deployTemplate(...)` and `deployTemplateFile(...)` take the same option, and a Stack in an assembly
+names its own in `stackOptions`. A deployment that names no `assetsCaller` publishes its assets as
+`caller`, the way every deployment did before the two could be told apart.
+
+The CDK bootstrap stack provisions the staging bucket, long before either Role runs. Yulin stands in
+for that and makes the bucket outside IAM when the first asset is published into it. So a Role
+holding only what a scoped execution policy grants on `cdk-hnb659fds-assets-*` deploys a cloud
+assembly with file assets, with no `s3:CreateBucket` or `s3:PutObject` added to it.
 
 ## Editing a synthesized template before deploying it
 

--- a/docs/services/cloudformation/sim-cloudformation-assets-caller.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-assets-caller.example.ts
@@ -1,0 +1,38 @@
+/**
+ * Publishing a Stack's CDK file assets as the file publishing Role.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({
+  defaultAccountId: "123456789012",
+  defaultRegionName: "eu-west-2",
+});
+
+const publisher = await simAws.iam().makeDeployRole({
+  roleName: "cdk-file-publishing",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: {
+      Effect: "Allow",
+      Action: ["s3:GetObject*", "s3:GetBucket*", "s3:List*", "s3:PutObject"],
+      Resource: "arn:aws:s3:::cdk-hnb659fds-assets-*",
+    },
+  },
+});
+
+const executor = await simAws.iam().makeDeployRole({
+  roleName: "cdk-exec",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: { Effect: "Allow", Action: "s3:*", Resource: "*" },
+  },
+});
+
+const stacks = await simAws.cloudFormation().deployCdkOut({
+  directoryPath: "cdk.out",
+  caller: executor,
+  assetsCaller: publisher,
+});
+
+console.log(stacks.size);

--- a/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.iso.test.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.iso.test.ts
@@ -9,7 +9,7 @@ import {
   assertThrowsErrorAsync,
   assertUndefined,
 } from "@kensio/smartass";
-import { describe, it, vi } from "vitest";
+import { describe, it } from "vitest";
 
 import { SimAws } from "../../../aws/sim-aws.js";
 import { SimZipArchive } from "../../../../util/zip/zip-archive.js";
@@ -264,27 +264,16 @@ describe("SimCdkAssetsPublisher", () => {
     assertUndefined(simAws.s3().getSimBucketByName("b"));
   });
 
-  it("publishes into a staging Bucket another Stack created concurrently", async () => {
-    // Given a staging Bucket that appears between the publisher checking for
-    // it and its own CreateBucket landing, as it can when two Stacks sharing
-    // one staging Bucket deploy concurrently.
+  it("publishes into a staging Bucket another Stack already created", async () => {
+    // Given a staging Bucket that is already there, as it is for the second of
+    // two Stacks sharing one.
     const simAws = new SimAws();
     const cdkOutDirectory = new TemporaryDirectory();
     await cdkOutDirectory.writeFile("asset.txt", "content");
 
-    const s3 = simAws.s3();
-    await s3.createBucket({ input: { Bucket: "shared-staging-bucket" } });
-
-    const findBucket = s3.getSimBucketByName.bind(s3);
-    let checkedBeforeCreate = false;
-    vi.spyOn(s3, "getSimBucketByName").mockImplementation((bucketName) => {
-      if (checkedBeforeCreate) {
-        return findBucket(bucketName);
-      }
-      checkedBeforeCreate = true;
-
-      return undefined;
-    });
+    await simAws
+      .s3()
+      .createBucket({ input: { Bucket: "shared-staging-bucket" } });
 
     // When the assets are published.
     await publish(simAws, cdkOutDirectory.path(), {
@@ -298,8 +287,7 @@ describe("SimCdkAssetsPublisher", () => {
       },
     });
 
-    // Then losing the race to create the Bucket is not a failure, and the
-    // asset is published into the Bucket that won.
+    // Then the asset is published into the Bucket that was there.
     const objectBytes = await publishedObjectBytes(
       simAws,
       "shared-staging-bucket",

--- a/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.ts
+++ b/src/service/cloudformation/cdk/assets/sim-cdk-assets-publisher.ts
@@ -8,10 +8,7 @@ import {
   SimCdkAssetPublications,
 } from "./sim-cdk-asset-publications.js";
 import { readSimCdkAssetBytes } from "./sim-cdk-asset-bytes.js";
-import {
-  simCfnResourceCallerOptions,
-  type SimCfnResourceCallerOptions,
-} from "../../resource/caller/sim-cfn-resource-caller-options.js";
+import { simCfnResourceCallerOptions } from "../../resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 
 interface SimCdkAssetsPublisherProperties {
@@ -21,12 +18,16 @@ interface SimCdkAssetsPublisherProperties {
   readonly cdkOutContext?: SimCdkOutContext | undefined;
 
   /**
-   * The principal the deployment runs as, which the staging Bucket is created
-   * and written to as. A real `cdk deploy` publishes assets before
-   * CloudFormation sees the template, and it publishes them as somebody; a
-   * deployment that names a caller is what says who.
+   * The principal the assets are published as.
+   *
+   * A real `cdk deploy` publishes assets before CloudFormation sees the
+   * template, as the file publishing Role the assets manifest names in each
+   * destination's `assumeRoleArn`. CloudFormation then processes the template
+   * as the execution Role. A deployment that names an assets caller is what
+   * tells the two apart here, and one that names none publishes as whoever
+   * deploys.
    */
-  readonly caller?: SimAwsCaller | undefined;
+  readonly assetsCaller?: SimAwsCaller | undefined;
 }
 
 /**
@@ -39,7 +40,7 @@ interface SimCdkAssetsPublisherProperties {
  * Lambda function resolves its code through the ordinary sim S3 fetch with no
  * Lambda-specific asset handling.
  *
- * Publishing is byte movement only; nothing here runs asset code. Functions
+ * Publishing is byte movement only. Nothing here runs asset code. Functions
  * sim Lambda cannot run, such as a CDK BucketDeployment provider written in
  * Python, are declined later by the Lambda resource creator on their Runtime.
  */
@@ -74,7 +75,7 @@ export class SimCdkAssetsPublisher {
     }).resolve(cdkOutContext.assetsManifest);
 
     for (const publication of publications) {
-      // oxlint-disable-next-line no-await-in-loop -- assets sharing a staging Bucket must not race to create it
+      // oxlint-disable-next-line no-await-in-loop -- published in manifest order, as cdk-assets publishes them
       await this.publishAsset(publication);
     }
   }
@@ -88,9 +89,8 @@ export class SimCdkAssetsPublisher {
     }
 
     const s3 = this.stagingS3();
-    const options = simCfnResourceCallerOptions(this.properties.caller);
 
-    await this.ensureBucket(s3, publication.bucketName, options);
+    this.ensureBucket(s3, publication.bucketName);
     await s3.putObject(
       {
         input: {
@@ -99,36 +99,25 @@ export class SimCdkAssetsPublisher {
           Body: assetBytes,
         },
       },
-      options,
+      simCfnResourceCallerOptions(this.properties.assetsCaller),
     );
   }
 
   /**
-   * Create the staging Bucket if this is the first asset published into it,
+   * Make the staging Bucket if this is the first asset published into it,
    * standing in for the CDK bootstrap stack that provisions it for real.
    *
-   * Stacks deployed concurrently share one staging Bucket, and creating it is
-   * not atomic: sim S3 reaches a sequencing point before registering the
-   * Bucket, so both can pass the check above and the loser is refused. A
-   * Bucket that exists by the time the failure lands is the outcome this
-   * wanted, whoever created it. Anything else, such as the name already being
-   * taken in another scope, is a real failure and is reported.
+   * The bootstrap stack runs long before the deployment, and neither the file
+   * publishing Role nor the execution Role creates this Bucket. It comes
+   * through `makeSimBucket` for that reason, which asks IAM nothing. A
+   * deployment scoped to the permissions its real execution Role holds would
+   * otherwise be refused `s3:CreateBucket` before creating a Resource.
+   *
+   * A name already taken in another scope is a real failure, and is reported.
    */
-  private async ensureBucket(
-    s3: SimS3,
-    bucketName: string,
-    options: SimCfnResourceCallerOptions,
-  ): Promise<void> {
-    if (s3.getSimBucketByName(bucketName) !== undefined) {
-      return;
-    }
-
-    try {
-      await s3.createBucket({ input: { Bucket: bucketName } }, options);
-    } catch (error) {
-      if (s3.getSimBucketByName(bucketName) === undefined) {
-        throw error;
-      }
+  private ensureBucket(s3: SimS3, bucketName: string): void {
+    if (s3.getSimBucketByName(bucketName) === undefined) {
+      s3.makeSimBucket(bucketName);
     }
   }
 

--- a/src/service/cloudformation/cdk/sim-cdk-cloud-assembly.factory.ts
+++ b/src/service/cloudformation/cdk/sim-cdk-cloud-assembly.factory.ts
@@ -2,6 +2,7 @@ import { AsyncMappedFactory } from "@kensio/part-factory";
 import { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
 import { jsonStringify } from "../../../util/type-guard/json.js";
 import type { SimCfnTemplateValueRecord } from "../template/value/sim-cfn-template-value.js";
+import type { SimCdkAssetsManifest } from "./sim-cdk-out-context.js";
 
 /**
  * One synthesized Stack in a cloud assembly a test writes.
@@ -32,10 +33,23 @@ export interface SimCdkCloudAssemblyStackInput {
 
   /** The template's Outputs, which a Stack sharing a value needs. */
   readonly outputs?: SimCfnTemplateValueRecord | undefined;
+
+  /**
+   * The assets manifest `cdk synth` writes beside the template, for a Stack
+   * that stages file assets. A Stack given none has no manifest file at all,
+   * which is what a Stack with nothing to stage synthesizes.
+   */
+  readonly assets?: SimCdkAssetsManifest | undefined;
 }
 
 export interface SimCdkCloudAssemblyInput {
   readonly stacks: readonly SimCdkCloudAssemblyStackInput[];
+
+  /**
+   * Staged asset files to write into the assembly, keyed by the path an assets
+   * manifest source names.
+   */
+  readonly assetFiles?: Record<string, string> | undefined;
 }
 
 /** The Bucket a Stack in a written assembly creates, unless it is given others. */
@@ -71,8 +85,8 @@ export const simCdkCloudAssemblyFactory = new AsyncMappedFactory<
       jsonStringify(assemblyManifest(input.stacks)),
     );
 
-    await Promise.all(
-      input.stacks.map(async (stack) =>
+    await Promise.all([
+      ...input.stacks.map(async (stack) =>
         directory.writeFile(
           ["cdk.out", templateFileName(stack)],
           // JSON.stringify drops an undefined value, so a Stack given no
@@ -83,7 +97,19 @@ export const simCdkCloudAssemblyFactory = new AsyncMappedFactory<
           }),
         ),
       ),
-    );
+      ...input.stacks
+        .filter((stack) => stack.assets !== undefined)
+        .map(async (stack) =>
+          directory.writeFile(
+            ["cdk.out", assetsFileName(stack)],
+            jsonStringify(stack.assets),
+          ),
+        ),
+      ...Object.entries(input.assetFiles ?? {}).map(
+        async ([assetPath, content]) =>
+          directory.writeFile(["cdk.out", assetPath], content),
+      ),
+    ]);
 
     return directory;
   },
@@ -117,6 +143,10 @@ function assemblyManifest(
 
 function templateFileName(stack: SimCdkCloudAssemblyStackInput): string {
   return `${stack.artifactId}.template.json`;
+}
+
+function assetsFileName(stack: SimCdkCloudAssemblyStackInput): string {
+  return `${stack.artifactId}.assets.json`;
 }
 
 function stackResources(

--- a/src/service/cloudformation/command/create-stack/create-stack.handler.ts
+++ b/src/service/cloudformation/command/create-stack/create-stack.handler.ts
@@ -34,6 +34,9 @@ interface CreateStackCommandHandlerProperties {
   /** The principal the Stack's Resources are created as. */
   readonly caller?: SimAwsCaller | undefined;
 
+  /** The principal the Stack's CDK file assets are published as. */
+  readonly assetsCaller?: SimAwsCaller | undefined;
+
   /** The order Resources with no dependency between them are started in. */
   readonly resourceOrder?: SimCfnResourceOrder | undefined;
 
@@ -56,6 +59,7 @@ export class CreateStackCommandHandler implements CommandHandler<
   private readonly cdkOutContext: SimCdkOutContext | undefined;
   private readonly bindings: readonly SimCfnBinding[] | undefined;
   private readonly caller: SimAwsCaller | undefined;
+  private readonly assetsCaller: SimAwsCaller | undefined;
   private readonly resourceOrder: SimCfnResourceOrder | undefined;
   private readonly exports: SimCfnExports | undefined;
 
@@ -68,6 +72,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       cdkOutContext,
       bindings,
       caller,
+      assetsCaller,
       resourceOrder,
       exports,
     } = properties;
@@ -79,6 +84,7 @@ export class CreateStackCommandHandler implements CommandHandler<
     this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
     this.caller = caller;
+    this.assetsCaller = assetsCaller;
     this.resourceOrder = resourceOrder;
     this.exports = exports;
   }
@@ -133,6 +139,7 @@ export class CreateStackCommandHandler implements CommandHandler<
       cdkOutContext: this.cdkOutContext,
       bindings: this.bindings,
       caller: this.caller,
+      assetsCaller: this.assetsCaller,
       resourceOrder: this.resourceOrder,
       exports: this.exports,
     });

--- a/src/service/cloudformation/command/update-stack/update-stack.handler.ts
+++ b/src/service/cloudformation/command/update-stack/update-stack.handler.ts
@@ -39,6 +39,12 @@ interface UpdateStackCommandHandlerProperties {
    */
   readonly caller?: SimAwsCaller | undefined;
 
+  /**
+   * The principal to publish the re-synthesized CDK file assets as, for an
+   * update that names one. Left out, they are published as `caller`.
+   */
+  readonly assetsCaller?: SimAwsCaller | undefined;
+
   /** The export names published in this Account and Region. */
   readonly exports?: SimCfnExports | undefined;
 }
@@ -58,6 +64,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
   private readonly background: BackgroundScheduler & BackgroundCompleter;
   private readonly cdkOutContext: SimCdkOutContext | undefined;
   private readonly caller: SimAwsCaller | undefined;
+  private readonly assetsCaller: SimAwsCaller | undefined;
   private readonly exports: SimCfnExports | undefined;
 
   constructor(properties: UpdateStackCommandHandlerProperties) {
@@ -67,6 +74,7 @@ export class UpdateStackCommandHandler implements CommandHandler<
     this.background = properties.background;
     this.cdkOutContext = properties.cdkOutContext;
     this.caller = properties.caller;
+    this.assetsCaller = properties.assetsCaller;
     this.exports = properties.exports;
   }
 
@@ -110,7 +118,11 @@ export class UpdateStackCommandHandler implements CommandHandler<
         input: command.input,
         exports: this.exports,
       }),
-      { cdkOutContext: this.cdkOutContext, caller: this.caller },
+      {
+        cdkOutContext: this.cdkOutContext,
+        caller: this.caller,
+        assetsCaller: this.assetsCaller,
+      },
     );
 
     return {

--- a/src/service/cloudformation/deploy/sim-cfn-assets-caller.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-assets-caller.iso.test.ts
@@ -1,0 +1,269 @@
+import { buffer } from "node:stream/consumers";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimIamPolicyDocument } from "../../iam/policy/sim-iam-policy.js";
+import { simCdkCloudAssemblyFactory } from "../cdk/sim-cdk-cloud-assembly.factory.js";
+import type { SimCdkAssetsManifest } from "../cdk/sim-cdk-out-context.js";
+import type { TemporaryDirectory } from "../../../util/filesystem/temporary-directory.js";
+
+const accountId = "111111111111";
+const regionName = "eu-west-2";
+const stagingBucketName = `cdk-hnb659fds-assets-${accountId}-${regionName}`;
+const reportsBucketName = "reports-bucket";
+
+const assetsManifest: SimCdkAssetsManifest = {
+  files: {
+    abc: {
+      source: { path: "asset.txt", packaging: "file" },
+      destinations: {
+        [`${accountId}-${regionName}`]: {
+          bucketName: stagingBucketName,
+          objectKey: "abc.txt",
+        },
+      },
+    },
+  },
+};
+
+const reportsBucketResources = {
+  ReportsBucket: {
+    Type: "AWS::S3::Bucket",
+    Properties: { BucketName: reportsBucketName },
+  },
+};
+
+/**
+ * What a CDK CloudFormation execution Role holds on the staging Bucket under a
+ * deployment policy scoped away from `AdministratorAccess`. It reads what a
+ * real `cdk deploy` has already published, and writes nothing there.
+ */
+const stagingBucketReadStatement = {
+  Effect: "Allow",
+  Action: ["s3:GetObject*", "s3:GetBucket*", "s3:List*"],
+  Resource: [
+    `arn:aws:s3:::${stagingBucketName}`,
+    `arn:aws:s3:::${stagingBucketName}/*`,
+  ],
+} as const;
+
+/** What the CDK file publishing Role holds on the staging Bucket. */
+const stagingBucketWriteStatement = {
+  Effect: "Allow",
+  Action: ["s3:GetObject*", "s3:GetBucket*", "s3:List*", "s3:PutObject"],
+  Resource: [
+    `arn:aws:s3:::${stagingBucketName}`,
+    `arn:aws:s3:::${stagingBucketName}/*`,
+  ],
+} as const;
+
+/** What the execution Role needs to create the Stack's own Bucket. */
+const reportsBucketStatement = {
+  Effect: "Allow",
+  Action: "s3:CreateBucket",
+  Resource: `arn:aws:s3:::${reportsBucketName}`,
+} as const;
+
+describe("the principal a deployment publishes its CDK assets as", () => {
+  it("publishes as the assets caller rather than the deployment's own", async () => {
+    // Given a publishing Role that may write the staging Bucket, and an
+    // execution Role scoped the way a real one is, which may not.
+    const simAws = simulation();
+    const publisher = await role(simAws, "cdk-file-publishing", [
+      stagingBucketWriteStatement,
+    ]);
+    const executor = await role(simAws, "cdk-exec", [
+      stagingBucketReadStatement,
+      reportsBucketStatement,
+    ]);
+    const directory = await assembly();
+
+    // When the Stack is deployed with the two named apart.
+    const stack = await simAws.cloudFormation().deployTemplateFile({
+      templatePath: templatePath(directory),
+      caller: executor,
+      assetsCaller: publisher,
+    });
+
+    // Then the asset reached the staging Bucket, and the Resource was created
+    // by a Role that could never have put it there.
+    assertIdentical(
+      stack.getResource("ReportsBucket")?.status,
+      "CREATE_COMPLETE",
+    );
+    assertIdentical(await publishedAsset(simAws), "content");
+  });
+
+  it("refuses a publish the assets caller is not allowed to make", async () => {
+    // Given an assets caller allowed only to read, and a deployment caller
+    // allowed everything.
+    const simAws = simulation();
+    const executor = await role(simAws, "cdk-exec", [
+      { Effect: "Allow", Action: "*", Resource: "*" },
+    ]);
+    const reader = await role(simAws, "cdk-reader", [
+      stagingBucketReadStatement,
+    ]);
+    const directory = await assembly();
+
+    // When the Stack is deployed publishing as the Role that may only read.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplateFile({
+        templatePath: templatePath(directory),
+        caller: executor,
+        assetsCaller: reader,
+      });
+    });
+
+    // Then the refusal names the assets caller, and not the caller that would
+    // have been allowed it.
+    assertStringIncludes(
+      error.message,
+      `arn:aws:iam::${accountId}:role/cdk-reader is not authorized to perform: s3:PutObject`,
+    );
+  });
+
+  it("publishes as the deployment's caller when no assets caller is named", async () => {
+    // Given one Role, holding both what publishing takes and what the Stack
+    // takes.
+    const simAws = simulation();
+    const deployer = await role(simAws, "cdk-deploy", [
+      stagingBucketWriteStatement,
+      reportsBucketStatement,
+    ]);
+    const directory = await assembly();
+
+    // When the Stack is deployed naming only that one.
+    const stack = await simAws.cloudFormation().deployTemplateFile({
+      templatePath: templatePath(directory),
+      caller: deployer,
+    });
+
+    // Then it published the asset, as a deployment did before the two could be
+    // named apart.
+    assertIdentical(
+      stack.getResource("ReportsBucket")?.status,
+      "CREATE_COMPLETE",
+    );
+    assertIdentical(await publishedAsset(simAws), "content");
+  });
+
+  it("makes the staging Bucket without authorizing the deployment", async () => {
+    // Given an execution Role holding the real scoped permissions, which allow
+    // it no s3:CreateBucket anywhere, and no staging Bucket yet.
+    const simAws = simulation();
+    const executor = await role(simAws, "cdk-exec", [
+      stagingBucketWriteStatement,
+    ]);
+    const directory = await assembly({ resources: {} });
+    assertUndefined(simAws.s3().getSimBucketByName(stagingBucketName));
+
+    // When the Stack is deployed as it.
+    await simAws.cloudFormation().deployTemplateFile({
+      templatePath: templatePath(directory),
+      caller: executor,
+    });
+
+    // Then the Bucket the bootstrap stack provisions for real is there, and
+    // the deployment was never charged for making it.
+    assertNonNullable(simAws.s3().getSimBucketByName(stagingBucketName));
+    assertIdentical(await publishedAsset(simAws), "content");
+  });
+
+  it("lets a Stack's own assets caller override the assembly's", async () => {
+    // Given an assembly-wide assets caller that may only read the staging
+    // Bucket, and a Stack naming one that may write it.
+    const simAws = simulation();
+    const publisher = await role(simAws, "cdk-file-publishing", [
+      stagingBucketWriteStatement,
+    ]);
+    const reader = await role(simAws, "cdk-reader", [
+      stagingBucketReadStatement,
+    ]);
+    const executor = await role(simAws, "cdk-exec", [reportsBucketStatement]);
+    const directory = await assembly();
+
+    // When the assembly is deployed with the Stack overriding it.
+    const stacks = await simAws.cloudFormation().deployCdkOut({
+      directoryPath: directory.join("cdk.out"),
+      caller: executor,
+      assetsCaller: reader,
+      stackOptions: { AssetStack: { assetsCaller: publisher } },
+    });
+
+    // Then the Stack published as its own, and the assembly's never reached it.
+    assertIdentical(
+      stacks.get("asset-stack")?.getResource("ReportsBucket")?.status,
+      "CREATE_COMPLETE",
+    );
+    assertIdentical(await publishedAsset(simAws), "content");
+  });
+});
+
+function simulation(): SimAws {
+  return new SimAws({
+    defaultAccountId: accountId,
+    defaultRegionName: regionName,
+  });
+}
+
+/**
+ * An assembly holding one Stack that stages a file asset beside its template.
+ */
+async function assembly(
+  overrides: { readonly resources?: object } = {},
+): Promise<TemporaryDirectory> {
+  return await simCdkCloudAssemblyFactory.make({
+    stacks: [
+      {
+        artifactId: "AssetStack",
+        stackName: "asset-stack",
+        regionName,
+        resources: reportsBucketResources,
+        assets: assetsManifest,
+        ...overrides,
+      },
+    ],
+    assetFiles: { "asset.txt": "content" },
+  });
+}
+
+function templatePath(directory: TemporaryDirectory): string {
+  return directory.join("cdk.out", "AssetStack.template.json");
+}
+
+/**
+ * A deploy Role holding the given statements, as its ARN caller.
+ */
+async function role(
+  simAws: SimAws,
+  roleName: string,
+  statements: readonly object[],
+): Promise<SimAwsCaller> {
+  return await simAws.iam().makeDeployRole({
+    roleName,
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: statements,
+    } as SimIamPolicyDocument,
+  });
+}
+
+/**
+ * The staged asset as it was published, read back through simulated S3.
+ */
+async function publishedAsset(simAws: SimAws): Promise<string> {
+  const output = await simAws.s3().getObject({
+    input: { Bucket: stagingBucketName, Key: "abc.txt" },
+  });
+  assertNonNullable(output.Body);
+
+  return Buffer.from(await buffer(output.Body)).toString();
+}

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-deployer.ts
@@ -59,10 +59,8 @@ export class SimCfnCdkOutDeployer {
     deployed: ReadonlyMap<string, SimCfnDeployedStack>,
   ): Promise<SimCfnDeployedStack> {
     const { simAws, accountRegionScope } = this.scope;
-    const { transform, caller, resourceOrder, ...options } = cdkOutOptionsFor(
-      stack,
-      plan.stackOptions,
-    );
+    const { transform, caller, assetsCaller, resourceOrder, ...options } =
+      cdkOutOptionsFor(stack, plan.stackOptions);
 
     return await simAws
       .accountRegionScope(accountRegionScope.accountId, stack.regionName)
@@ -72,6 +70,7 @@ export class SimCfnCdkOutDeployer {
         stackName: stack.stackName,
         ...options,
         caller: caller ?? plan.caller,
+        assetsCaller: assetsCaller ?? plan.assetsCaller,
         resourceOrder: resourceOrder ?? plan.resourceOrder,
         transform: cdkOutBoundTransform(transform, deployed),
       });

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-options-deployed.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-options-deployed.ts
@@ -1,0 +1,27 @@
+import type { SimCdkAssemblyStack } from "../cdk/sim-cdk-assembly-manifest.js";
+import type { SimCfnCdkOutStackOptionsByName } from "./sim-cfn-cdk-out-stack-options.js";
+
+/**
+ * Refuse options keyed against a Stack that is not being deployed.
+ *
+ * A renamed Stack would otherwise take its bindings, its caller and its
+ * transform with it without saying anything, and the deployment that lost them
+ * looks like one that never had them.
+ */
+export function assertCdkOutOptionsAreDeployed(
+  optionsByName: SimCfnCdkOutStackOptionsByName | undefined,
+  deploying: readonly SimCdkAssemblyStack[],
+): void {
+  const names = new Set(
+    deploying.flatMap((stack) => [stack.stackName, stack.artifactId]),
+  );
+  const unmatched = Object.keys(optionsByName ?? {}).filter(
+    (name) => !names.has(name),
+  );
+
+  if (unmatched.length > 0) {
+    throw new Error(
+      `Options were given for ${unmatched.join(", ")}, which no Stack being deployed is named. The Stacks being deployed are ${deploying.map((stack) => stack.stackName).join(", ")}.`,
+    );
+  }
+}

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-plan.ts
@@ -7,10 +7,8 @@ import {
 } from "../cdk/sim-cdk-assembly-manifest.js";
 import { orderCdkAssemblyStacks } from "../cdk/sim-cdk-assembly-order.js";
 import { selectCdkAssemblyStacks } from "../cdk/sim-cdk-assembly-selection.js";
-import {
-  assertCdkOutOptionsAreDeployed,
-  type SimCfnCdkOutStackOptionsByName,
-} from "./sim-cfn-cdk-out-stack-options.js";
+import type { SimCfnCdkOutStackOptionsByName } from "./sim-cfn-cdk-out-stack-options.js";
+import { assertCdkOutOptionsAreDeployed } from "./sim-cfn-cdk-out-options-deployed.js";
 import type { SimCfnResourceOrder } from "../stack/deploy/sim-cfn-resource-order.js";
 
 export interface SimCloudFormationDeployCdkOutProperties {
@@ -37,6 +35,16 @@ export interface SimCloudFormationDeployCdkOutProperties {
   readonly caller?: SimAwsCaller | undefined;
 
   /**
+   * The principal every Stack in the assembly publishes its CDK file assets
+   * as, which one named in `stackOptions` overrides for its own Stack.
+   *
+   * A real `cdk deploy` publishes assets as the file publishing Role and
+   * processes each template as the execution Role. Left out, an assembly
+   * publishes its assets as `caller`.
+   */
+  readonly assetsCaller?: SimAwsCaller | undefined;
+
+  /**
    * The order every Stack in the assembly creates Resources with no dependency
    * between them in, which one named in `stackOptions` overrides for its own
    * Stack. `reversed` deploys each Stack the other way round from the one its
@@ -59,6 +67,7 @@ export interface SimCfnCdkOutPlannedStack extends SimCdkAssemblyStack {
 export interface SimCfnCdkOutPlan {
   readonly stacks: readonly SimCfnCdkOutPlannedStack[];
   readonly caller?: SimAwsCaller | undefined;
+  readonly assetsCaller?: SimAwsCaller | undefined;
   readonly resourceOrder?: SimCfnResourceOrder | undefined;
   readonly stackOptions?: SimCfnCdkOutStackOptionsByName | undefined;
 }
@@ -73,8 +82,14 @@ export async function planCdkOutDeployment(properties: {
   readonly request: SimCloudFormationDeployCdkOutProperties | string;
   readonly defaultRegionName: AwsRegionName;
 }): Promise<SimCfnCdkOutPlan> {
-  const { directoryPath, stackNames, caller, resourceOrder, stackOptions } =
-    cdkOutDeployment(properties.request);
+  const {
+    directoryPath,
+    stackNames,
+    caller,
+    assetsCaller,
+    resourceOrder,
+    stackOptions,
+  } = cdkOutDeployment(properties.request);
 
   const selected = selectCdkAssemblyStacks({
     stacks: await loadCdkAssemblyStacks(directoryPath),
@@ -90,6 +105,7 @@ export async function planCdkOutDeployment(properties: {
       regionName: stack.regionName ?? properties.defaultRegionName,
     })),
     caller,
+    assetsCaller,
     resourceOrder,
     stackOptions,
   };

--- a/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-cdk-out-stack-options.ts
@@ -42,6 +42,12 @@ export interface SimCfnCdkOutStackOptions {
   readonly caller?: SimAwsCaller | undefined;
 
   /**
+   * The principal this Stack publishes its CDK file assets as, where the
+   * assembly's own assets caller is not the right one for it.
+   */
+  readonly assetsCaller?: SimAwsCaller | undefined;
+
+  /**
    * The order this Stack creates Resources with no dependency between them in,
    * where the assembly's own order is not the right one for it.
    */
@@ -84,29 +90,4 @@ export function cdkOutBoundTransform(
   const deployedSoFar = new Map(deployed);
 
   return (template) => transform(template, deployedSoFar);
-}
-
-/**
- * Refuse options keyed against a Stack that is not being deployed.
- *
- * A renamed Stack would otherwise take its bindings, its caller and its
- * transform with it without saying anything, and the deployment that lost them
- * looks like one that never had them.
- */
-export function assertCdkOutOptionsAreDeployed(
-  optionsByName: SimCfnCdkOutStackOptionsByName | undefined,
-  deploying: readonly SimCdkAssemblyStack[],
-): void {
-  const names = new Set(
-    deploying.flatMap((stack) => [stack.stackName, stack.artifactId]),
-  );
-  const unmatched = Object.keys(optionsByName ?? {}).filter(
-    (name) => !names.has(name),
-  );
-
-  if (unmatched.length > 0) {
-    throw new Error(
-      `Options were given for ${unmatched.join(", ")}, which no Stack being deployed is named. The Stacks being deployed are ${deploying.map((stack) => stack.stackName).join(", ")}.`,
-    );
-  }
 }

--- a/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-deployer.ts
@@ -52,6 +52,16 @@ export interface SimCloudFormationCreateStackProperties {
   readonly caller?: SimAwsCaller | undefined;
 
   /**
+   * The principal the CDK file assets staged beside the template are published
+   * as.
+   *
+   * A real `cdk deploy` publishes them as the file publishing Role and only
+   * then processes the template as the execution Role, which is why the two
+   * are named apart. Left out, assets are published as `caller`.
+   */
+  readonly assetsCaller?: SimAwsCaller | undefined;
+
+  /**
    * The order Resources with no dependency between them are created in.
    *
    * CloudFormation is free to create them either way round, and the template's
@@ -138,6 +148,7 @@ export class SimCloudFormationTemplateDeployer {
       parameters: properties.parameters,
       bindings: properties.bindings,
       caller: properties.caller,
+      assetsCaller: properties.assetsCaller,
       resourceOrder: properties.resourceOrder,
       cdkOutContext: await cdkOutContextForTemplatePath(
         properties.templatePath,
@@ -230,6 +241,7 @@ export class SimCloudFormationTemplateDeployer {
       cdkOutContext: deployment.cdkOutContext,
       bindings: deployment.bindings,
       caller: deployment.caller,
+      assetsCaller: deployment.assetsCaller,
       resourceOrder: deployment.resourceOrder,
       exports: this.exports,
     });
@@ -256,6 +268,7 @@ interface SimCfnTemplateDeployment {
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly caller?: SimAwsCaller | undefined;
+  readonly assetsCaller?: SimAwsCaller | undefined;
   readonly resourceOrder?: SimCfnResourceOrder | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
 }

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-loader.ts
@@ -35,6 +35,16 @@ export interface SimCloudFormationDeployTemplateFileProperties {
   readonly caller?: SimAwsCaller | undefined;
 
   /**
+   * The principal the CDK file assets staged beside the template are published
+   * as.
+   *
+   * A real `cdk deploy` publishes them as the file publishing Role and only
+   * then processes the template as the execution Role, which is why the two
+   * are named apart. Left out, assets are published as `caller`.
+   */
+  readonly assetsCaller?: SimAwsCaller | undefined;
+
+  /**
    * The order Resources with no dependency between them are created in.
    *
    * CloudFormation is free to create them either way round, and the template's
@@ -81,6 +91,7 @@ export interface SimCfnLoadedTemplateFile {
   readonly parameters?: Record<string, string> | undefined;
   readonly bindings?: readonly SimCfnBinding[] | undefined;
   readonly caller?: SimAwsCaller | undefined;
+  readonly assetsCaller?: SimAwsCaller | undefined;
   readonly resourceOrder?: SimCfnResourceOrder | undefined;
   readonly cdkOutContext?: SimCdkOutContext | undefined;
 }
@@ -98,8 +109,14 @@ export class SimCfnTemplateFileLoader {
     properties: SimCloudFormationDeployTemplateFileProperties | string,
   ): Promise<SimCfnLoadedTemplateFile> {
     const deployment = simCfnTemplateFileDeployment(properties);
-    const { templatePath, parameters, bindings, caller, resourceOrder } =
-      deployment;
+    const {
+      templatePath,
+      parameters,
+      bindings,
+      caller,
+      assetsCaller,
+      resourceOrder,
+    } = deployment;
     const stackName =
       deployment.stackName ?? stackNameFromTemplatePath(templatePath);
 
@@ -122,6 +139,7 @@ export class SimCfnTemplateFileLoader {
       parameters,
       bindings,
       caller,
+      assetsCaller,
       resourceOrder,
       cdkOutContext,
     };

--- a/src/service/cloudformation/deploy/sim-cfn-template-file-updater.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-template-file-updater.ts
@@ -81,6 +81,7 @@ export class SimCfnTemplateFileUpdater implements SimCfnTemplateFileUpdating {
       background: this.background,
       cdkOutContext: loaded.cdkOutContext,
       caller: loaded.caller,
+      assetsCaller: loaded.assetsCaller,
     });
 
     await handler.handle({

--- a/src/service/cloudformation/stack/sim-cfn-stack-deploy-context.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-deploy-context.ts
@@ -1,0 +1,64 @@
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
+
+/**
+ * What an update can replace on a Stack's deploy context. Anything it leaves
+ * out, the Stack goes on using.
+ */
+export interface SimCfnStackUpdateContext {
+  readonly cdkOutContext?: SimCdkOutContext | undefined;
+  readonly caller?: SimAwsCaller | undefined;
+  readonly assetsCaller?: SimAwsCaller | undefined;
+}
+
+/**
+ * What a Stack is deploying from, and who it is deploying as.
+ *
+ * These three travel together and are the only things an update replaces, so
+ * they are held apart from the rest of a Stack's Resource operations. An
+ * operation reads them here whenever it runs, rather than closing over the
+ * values the deployment started with.
+ */
+export class SimCfnStackDeployContext {
+  /** The CDK cloud assembly the Stack's template was synthesized into. */
+  public cdkOutContext: SimCdkOutContext | undefined;
+
+  /** The principal the Stack's Resource work is authorized as. */
+  public caller: SimAwsCaller | undefined;
+
+  /** The principal the Stack's CDK file assets are published as. */
+  public assetsCaller: SimAwsCaller | undefined;
+
+  constructor(properties: SimCfnStackUpdateContext) {
+    this.cdkOutContext = properties.cdkOutContext;
+    this.caller = properties.caller;
+    this.assetsCaller = properties.assetsCaller;
+  }
+
+  /**
+   * Take on what an update brings with it, for this and every later operation.
+   *
+   * A synthesis writes the template and the assets manifest beside it together,
+   * so a Stack updated from a re-synthesized template needs the manifest that
+   * came with it. Keeping the one the Stack was deployed from would look up the
+   * asset a replaced Resource names in a manifest written before it existed.
+   *
+   * An update naming a caller runs as that one, and the Stack is torn down as
+   * it afterwards. An update that names none keeps the deployment's caller, so
+   * a Stack updated from a plain template path goes on running as whoever
+   * deployed it.
+   */
+  useUpdate(properties: SimCfnStackUpdateContext): void {
+    this.cdkOutContext = properties.cdkOutContext ?? this.cdkOutContext;
+    this.caller = properties.caller ?? this.caller;
+    this.assetsCaller = properties.assetsCaller ?? this.assetsCaller;
+  }
+
+  /**
+   * The principal file assets are published as, which is the deployment's own
+   * caller unless the deployment named one for publishing.
+   */
+  publishingCaller(): SimAwsCaller | undefined {
+    return this.assetsCaller ?? this.caller;
+  }
+}

--- a/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack-resource-operations.ts
@@ -4,6 +4,10 @@ import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
 import type { SimCfnBinding } from "../bind/sim-cfn-binding.js";
 import type { SimCdkOutContext } from "../cdk/sim-cdk-out-context.js";
+import {
+  SimCfnStackDeployContext,
+  type SimCfnStackUpdateContext,
+} from "./sim-cfn-stack-deploy-context.js";
 import { SimCdkAssetsPublisher } from "../cdk/assets/sim-cdk-assets-publisher.js";
 import type { SimCfnResource } from "../resource/sim-cfn-resource.js";
 import { SimCfnResourceRetention } from "../resource/delete/sim-cfn-resource-retention.js";
@@ -38,6 +42,12 @@ interface SimCfnStackResourceOperationsProperties {
   readonly caller?: SimAwsCaller | undefined;
 
   /**
+   * The principal the Stack's CDK file assets are published as, where that is
+   * somebody other than the caller its Resources are created as.
+   */
+  readonly assetsCaller?: SimAwsCaller | undefined;
+
+  /**
    * The order Resources with no dependency between them are started in.
    */
   readonly resourceOrder?: SimCfnResourceOrder | undefined;
@@ -62,8 +72,7 @@ export class SimCfnStackResourceOperations {
   private readonly stackName: SimCloudFormationStackName;
   private readonly bindings: readonly SimCfnBinding[] | undefined;
   private readonly resourceOrder: SimCfnResourceOrder | undefined;
-  private cdkOutContext: SimCdkOutContext | undefined;
-  private caller: SimAwsCaller | undefined;
+  private readonly context: SimCfnStackDeployContext;
 
   /**
    * Resources an update kept in simulated AWS.
@@ -76,44 +85,20 @@ export class SimCfnStackResourceOperations {
   private readonly retainedByUpdates: SimCfnResource[] = [];
 
   constructor(properties: SimCfnStackResourceOperationsProperties) {
-    const {
-      simAws,
-      accountRegionScope,
-      stackName,
-      cdkOutContext,
-      bindings,
-      caller,
-      resourceOrder,
-    } = properties;
+    const { simAws, accountRegionScope, stackName, bindings, resourceOrder } =
+      properties;
 
     this.simAws = simAws;
     this.accountRegionScope = accountRegionScope;
     this.stackName = stackName;
-    this.cdkOutContext = cdkOutContext;
     this.bindings = bindings;
-    this.caller = caller;
     this.resourceOrder = resourceOrder;
+    this.context = new SimCfnStackDeployContext(properties);
   }
 
-  /**
-   * Take on what an update brings with it, for this and every later operation.
-   *
-   * A synthesis writes the template and the assets manifest beside it together,
-   * so a Stack updated from a re-synthesized template needs the manifest that
-   * came with it. Keeping the one the Stack was deployed from would look up the
-   * asset a replaced Resource names in a manifest written before it existed.
-   *
-   * An update naming a caller runs as that one, and the Stack is torn down as
-   * it afterwards. An update that names none keeps the deployment's caller, so
-   * a Stack updated from a plain template path goes on running as whoever
-   * deployed it.
-   */
-  useUpdate(properties: {
-    readonly cdkOutContext?: SimCdkOutContext | undefined;
-    readonly caller?: SimAwsCaller | undefined;
-  }): void {
-    this.cdkOutContext = properties.cdkOutContext ?? this.cdkOutContext;
-    this.caller = properties.caller ?? this.caller;
+  /** Take on what an update brings with it, for every later operation. */
+  useUpdate(properties: SimCfnStackUpdateContext): void {
+    this.context.useUpdate(properties);
   }
 
   /**
@@ -204,7 +189,7 @@ export class SimCfnStackResourceOperations {
           simAws: this.simAws,
           currentResources,
           updatedResources,
-          caller: this.caller,
+          caller: this.context.caller,
         });
       }),
     );
@@ -266,8 +251,8 @@ export class SimCfnStackResourceOperations {
       simAws: this.simAws,
       accountRegionScope: this.accountRegionScope,
       stackName: this.stackName,
-      cdkOutContext: this.cdkOutContext,
-      caller: this.caller,
+      cdkOutContext: this.context.cdkOutContext,
+      assetsCaller: this.context.publishingCaller(),
     }).publish();
   }
 
@@ -278,9 +263,9 @@ export class SimCfnStackResourceOperations {
       simAws: this.simAws,
       resources,
       stackName: this.stackName,
-      cdkOutContext: this.cdkOutContext,
+      cdkOutContext: this.context.cdkOutContext,
       bindings: this.bindings,
-      caller: this.caller,
+      caller: this.context.caller,
       resourceOrder: this.resourceOrder,
     });
   }
@@ -293,7 +278,7 @@ export class SimCfnStackResourceOperations {
       simAws: this.simAws,
       resources,
       stackName: this.stackName,
-      caller: this.caller,
+      caller: this.context.caller,
       retention,
     });
   }

--- a/src/service/cloudformation/stack/sim-cfn-stack.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.ts
@@ -70,6 +70,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
       cdkOutContext,
       bindings,
       caller,
+      assetsCaller,
       resourceOrder,
       exports,
     } = properties;
@@ -96,6 +97,7 @@ export class SimCfnStack implements SimCfnDeployedStack {
       cdkOutContext,
       bindings,
       caller,
+      assetsCaller,
       resourceOrder,
     });
     this.lifecycle = new SimCfnStackDeploymentLifecycle({

--- a/src/service/cloudformation/stack/sim-cfn-stack.type.ts
+++ b/src/service/cloudformation/stack/sim-cfn-stack.type.ts
@@ -44,6 +44,12 @@ export interface SimCfnStackUpdateProperties {
    * The Stack goes on using it, as it does the cloud assembly.
    */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The principal to publish the re-synthesized file assets as, for an update
+   * that names one. The Stack goes on using it too.
+   */
+  readonly assetsCaller?: SimAwsCaller | undefined;
 }
 
 export interface SimCloudFormationStackProperties {
@@ -68,6 +74,16 @@ export interface SimCloudFormationStackProperties {
    * simulation.
    */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The principal the CDK file assets staged beside the template are published
+   * as.
+   *
+   * A real `cdk deploy` publishes them as the file publishing Role and only
+   * then processes the template as the execution Role, which is why the two
+   * are named apart. Left out, assets are published as `caller`.
+   */
+  readonly assetsCaller?: SimAwsCaller | undefined;
 
   /**
    * The order this Stack starts Resources with no dependency between them in.

--- a/src/service/s3/bucket/sim-s3-bucket-maker.ts
+++ b/src/service/s3/bucket/sim-s3-bucket-maker.ts
@@ -1,0 +1,59 @@
+import type { BackgroundScheduler } from "../../../util/background/background.js";
+import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import { SimS3BucketNameAvailability } from "./name-availability/sim-s3-bucket-name-availability.js";
+import { validateS3BucketName } from "./validate/validate-s3-bucket-name.js";
+import { SimS3Bucket, type SimS3BucketName } from "./sim-s3-bucket.js";
+import type { SimS3GlobalRegistry } from "../sim-s3-global-registry.js";
+
+interface SimS3BucketMakerProperties {
+  readonly accountRegionScope: SimAwsAccountRegionScope;
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
+  readonly s3GlobalRegistry: SimS3GlobalRegistry;
+  readonly background: BackgroundScheduler;
+}
+
+/**
+ * Puts a Bucket into a simulated S3 scope, once something has decided it may
+ * be there.
+ *
+ * `CreateBucketCommand` decides that by authorizing the caller. A Bucket real
+ * AWS provisions outside the deployment being simulated, such as the CDK
+ * bootstrap staging Bucket, has no caller to authorize and comes through
+ * `SimS3.makeSimBucket` instead. Both arrive at the same Bucket registered in
+ * the same two places, because the name check and the registration are here
+ * rather than in the command handler.
+ */
+export class SimS3BucketMaker {
+  private readonly properties: SimS3BucketMakerProperties;
+
+  constructor(properties: SimS3BucketMakerProperties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Make a Bucket of the given name, reporting a name this scope cannot take
+   * the way `CreateBucketCommand` reports it.
+   */
+  make(bucketName: string): SimS3Bucket {
+    const { accountRegionScope, buckets, s3GlobalRegistry, background } =
+      this.properties;
+
+    validateS3BucketName(bucketName);
+    new SimS3BucketNameAvailability({
+      accountRegionScope,
+      buckets,
+      s3GlobalRegistry,
+    }).ensureCanCreateBucketNamed(bucketName);
+
+    const bucket = new SimS3Bucket({
+      bucketName,
+      accountRegionScope,
+      clock: background,
+    });
+
+    buckets.set(bucketName, bucket);
+    s3GlobalRegistry.registerBucket(bucketName, accountRegionScope);
+
+    return bucket;
+  }
+}

--- a/src/service/s3/command/create-bucket/create-bucket.handler.ts
+++ b/src/service/s3/command/create-bucket/create-bucket.handler.ts
@@ -3,7 +3,10 @@ import type {
   SimCreateBucketCommand,
   SimCreateBucketCommandOutput,
 } from "./create-bucket.command.js";
-import { SimS3Bucket } from "../../bucket/sim-s3-bucket.js";
+import type {
+  SimS3Bucket,
+  SimS3BucketName,
+} from "../../bucket/sim-s3-bucket.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type { SimS3GlobalRegistry } from "../../sim-s3-global-registry.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
@@ -11,7 +14,7 @@ import {
   type BackgroundScheduler,
   BackgroundTasks,
 } from "../../../../util/background/background.js";
-import { SimS3BucketNameAvailability } from "../../bucket/name-availability/sim-s3-bucket-name-availability.js";
+import { SimS3BucketMaker } from "../../bucket/sim-s3-bucket-maker.js";
 import { validateS3BucketName } from "../../bucket/validate/validate-s3-bucket-name.js";
 import {
   SimIamAllowAllAuth,
@@ -23,7 +26,7 @@ import { simS3ConditionContext } from "../authorize/sim-s3-condition-context.js"
 
 interface CreateBucketCommandHandlerProperties {
   readonly accountRegionScope: SimAwsAccountRegionScope;
-  readonly buckets: Map<string, SimS3Bucket>;
+  readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   readonly s3GlobalRegistry: SimS3GlobalRegistry;
   readonly iam?: SimIamInterServiceAuthZ;
   readonly background?: BackgroundScheduler;
@@ -39,7 +42,7 @@ export class CreateBucketCommandHandler implements CommandHandler<
   SimCreateBucketCommandOutput
 > {
   private readonly accountRegionScope: SimAwsAccountRegionScope;
-  private readonly buckets: Map<string, SimS3Bucket>;
+  private readonly buckets: Map<SimS3BucketName, SimS3Bucket>;
   private readonly s3GlobalRegistry: SimS3GlobalRegistry;
   private readonly iam: SimIamInterServiceAuthZ;
   private readonly background: BackgroundScheduler;
@@ -94,20 +97,12 @@ export class CreateBucketCommandHandler implements CommandHandler<
       });
     }
 
-    const simS3BucketNameAvailability = new SimS3BucketNameAvailability({
+    new SimS3BucketMaker({
       accountRegionScope: this.accountRegionScope,
       buckets: this.buckets,
       s3GlobalRegistry: this.s3GlobalRegistry,
-    });
-    simS3BucketNameAvailability.ensureCanCreateBucketNamed(bucketName);
-
-    const bucket = new SimS3Bucket({
-      bucketName,
-      accountRegionScope: this.accountRegionScope,
-      clock: this.background,
-    });
-    this.buckets.set(bucketName, bucket);
-    this.s3GlobalRegistry.registerBucket(bucketName, this.accountRegionScope);
+      background: this.background,
+    }).make(bucketName);
 
     return {
       BucketArn: resource,

--- a/src/service/s3/sim-s3-commands.ts
+++ b/src/service/s3/sim-s3-commands.ts
@@ -74,11 +74,20 @@ export class SimS3Commands {
   public readonly multipartUploads: SimS3MultipartCommands;
   public readonly objectNotifier: SimS3ObjectNotifier;
 
+  /**
+   * The scheduler and clock every command area here shares, which a
+   * simulator-only control on the service facade needs to hand a Bucket it
+   * makes outside the commands.
+   */
+  public readonly background: BackgroundScheduler;
+
   constructor(properties: SimS3CommandsProperties) {
     const {
       background = new BackgroundTasks(),
       notificationDestinations = new SimS3NoNotificationDestinations(),
     } = properties;
+
+    this.background = background;
 
     const iam = simIamInRegion(
       properties.iam,

--- a/src/service/s3/sim-s3.ts
+++ b/src/service/s3/sim-s3.ts
@@ -2,6 +2,7 @@ import type { SimS3Bucket, SimS3BucketName } from "./bucket/sim-s3-bucket.js";
 import { SimS3GlobalRegistry } from "./sim-s3-global-registry.js";
 import type { SimAwsAccountRegionScope } from "../aws/sim-aws-account-region-scope.js";
 import { SimS3BucketAccess } from "./bucket/sim-s3-bucket-access.js";
+import { SimS3BucketMaker } from "./bucket/sim-s3-bucket-maker.js";
 import { SimS3CloudFormationResourceFactory } from "./cfn/sim-cfn-s3-resource-factory.js";
 import type { SimCfnServiceResourceFactory } from "../cloudformation/resource/factory/sim-cfn-resource-factory.type.js";
 import { simAwsAccountRegionScopeFactory } from "../aws/sim-aws-account-region-scope.factory.js";
@@ -24,6 +25,7 @@ import type { SimS3MountFilesystemOptions } from "./mount/sim-s3-mount.type.js";
  */
 export class SimS3 extends SimS3Operations {
   private readonly bucketAccess: SimS3BucketAccess;
+  private readonly bucketMaker: SimS3BucketMaker;
   private readonly cfnFactory = new SimS3CloudFormationResourceFactory(this);
   private readonly sdkRouter = new SimS3SdkCommandRouter(this);
 
@@ -48,6 +50,30 @@ export class SimS3 extends SimS3Operations {
       accountRegionScope,
       s3GlobalRegistry,
     });
+    this.bucketMaker = new SimS3BucketMaker({
+      accountRegionScope,
+      buckets,
+      s3GlobalRegistry,
+      background: this.commands.background,
+    });
+  }
+
+  /**
+   * Make a Bucket in this scope without a `CreateBucketCommand`, and so
+   * without a principal to authorize.
+   *
+   * This is for a Bucket real AWS has provisioned before the code under test
+   * runs, which nothing in the simulation is deploying. The CDK bootstrap
+   * staging Bucket is the one the simulator makes for itself: `cdk deploy`
+   * publishes assets into a Bucket the bootstrap stack created, and a
+   * deployment that had to create it would be charged permissions no real
+   * deployment needs.
+   *
+   * A name this scope cannot take is reported the way `CreateBucketCommand`
+   * reports it.
+   */
+  makeSimBucket(bucketName: SimS3BucketName | string): SimS3Bucket {
+    return this.bucketMaker.make(bucketName);
   }
 
   /**


### PR DESCRIPTION
A deployment now names the principal its file assets are published as, separately from the one its Resources are created as. `assetsCaller` sits beside `caller` on `deployTemplate`, `deployTemplateFile` and `deployCdkOut`, with a per-Stack override in `stackOptions`, and a deployment naming none publishes as `caller`. The staging Bucket comes through a new simulator-only `SimS3.makeSimBucket`, which asks IAM nothing, because the CDK bootstrap stack provisions it long before either Role runs. A Role holding only what a scoped execution policy grants on `cdk-hnb659fds-assets-*` now deploys a cloud assembly with file assets.

Resolves #1265


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CloudFormation deployments can now use separate credentials for stack execution and CDK asset publishing.
  - Asset-publishing credentials can be configured globally or overridden for individual stacks, with automatic fallback to the deployment credentials.
  - CDK asset manifests and staged asset files are supported in simulated deployments.

- **Documentation**
  - Added guidance and examples for scoped asset-publishing and execution roles, including asset-bucket setup considerations.

- **Bug Fixes**
  - Improved handling of shared staging buckets during asset publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->