### PR TITLE
feat: name CDK's unresolved zone lookup

### DIFF
--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -139,6 +139,17 @@ Register the zone yourself when a test depends on its name, such as one listing 
 when its name is a suffix of no record the stack holds. A registered zone keeps the name it was
 given, and its records are stored under the name you chose.
 
+### A lookup that never resolved
+
+`HostedZone.fromLookup` needs credentials for the account holding the zone, or a `cdk.context.json`
+holding a previous lookup's answer. With neither, CDK synthesizes the literal `DUMMY` as the Hosted
+Zone ID and writes it into every `AWS::Route53::RecordSet` in the template. Deploying that template
+gives `InvalidInput`, naming `DUMMY` as the stand-in and pointing back at the synth.
+
+Run `cdk synth` with credentials for that account, or commit the `cdk.context.json` a resolved
+lookup writes. Either one puts the real Hosted Zone ID in the template, and the zone is then
+registered on demand like any other looked-up zone.
+
 ## Creating records
 
 Use `ChangeResourceRecordSetsCommand` to add records to a Hosted Zone.

--- a/src/service/route53/command/create-hosted-zone/sim-route53-zone-id.iso.test.ts
+++ b/src/service/route53/command/create-hosted-zone/sim-route53-zone-id.iso.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "vitest";
 import {
   assertIdentical,
   assertInstanceOf,
+  assertStringIncludes,
   assertThrowsError,
 } from "@kensio/smartass";
 import { SimRoute53InvalidInput } from "../../error/sim-route53.error.js";
@@ -98,6 +99,61 @@ describe("sim Route53 Hosted Zone ID", () => {
 
       // Then InvalidInput is reported.
       assertInstanceOf(error, SimRoute53InvalidInput);
+    });
+
+    it("names CDK's unresolved lookup stand-in", () => {
+      // Given the Hosted Zone ID CDK synthesizes for an unresolved
+      // HostedZone.fromLookup.
+      const value = "DUMMY";
+
+      // When the Hosted Zone ID is normalized.
+      const error = assertThrowsError(() =>
+        normalizeSimRoute53HostedZoneId(value),
+      );
+
+      // Then InvalidInput names the stand-in and how to resolve the lookup.
+      assertInstanceOf(error, SimRoute53InvalidInput);
+      assertIdentical(
+        error.message,
+        "Invalid Route53 Hosted Zone ID: DUMMY. CDK fills an unresolved " +
+          "`HostedZone.fromLookup` with this stand-in. Run `cdk synth` with " +
+          "credentials for the account holding the zone, or commit the " +
+          "`cdk.context.json` a resolved lookup writes.",
+      );
+    });
+
+    it("names the stand-in behind a /hostedzone/ prefix", () => {
+      // Given the stand-in in its resource path form.
+      const value = "/hostedzone/DUMMY";
+
+      // When the Hosted Zone ID is normalized.
+      const error = assertThrowsError(() =>
+        normalizeSimRoute53HostedZoneId(value),
+      );
+
+      // Then InvalidInput still points at the unresolved lookup.
+      assertInstanceOf(error, SimRoute53InvalidInput);
+      assertStringIncludes(
+        error.message,
+        "CDK fills an unresolved `HostedZone.fromLookup` with this stand-in.",
+      );
+    });
+
+    it("rejects an ID merely containing DUMMY with the plain message", () => {
+      // Given a malformed ID that holds the stand-in as a substring.
+      const value = "DUMMYZONE!";
+
+      // When the Hosted Zone ID is normalized.
+      const error = assertThrowsError(() =>
+        normalizeSimRoute53HostedZoneId(value),
+      );
+
+      // Then InvalidInput reports the value and nothing about CDK.
+      assertInstanceOf(error, SimRoute53InvalidInput);
+      assertIdentical(
+        error.message,
+        "Invalid Route53 Hosted Zone ID: DUMMYZONE!",
+      );
     });
 
     it("rejects a missing Hosted Zone ID", () => {

--- a/src/service/route53/command/create-hosted-zone/sim-route53-zone-id.ts
+++ b/src/service/route53/command/create-hosted-zone/sim-route53-zone-id.ts
@@ -48,11 +48,42 @@ export function normalizeSimRoute53HostedZoneId(
 
   if (!isSimRoute53HostedZoneId(hostedZoneId)) {
     throw new SimRoute53InvalidInput(
-      `Invalid Route53 Hosted Zone ID: ${value ?? "(missing)"}`,
+      rejectedSimRoute53HostedZoneId(value, hostedZoneId),
     );
   }
 
   return hostedZoneId;
+}
+
+/**
+ * The literal CDK writes into a synthesized template when
+ * `HostedZone.fromLookup` runs against no credentials and no cached context.
+ */
+const cdkUnresolvedLookupHostedZoneId = "DUMMY";
+
+/**
+ * The message for a Hosted Zone ID that fails the shape check.
+ *
+ * CDK writes its unresolved lookup stand-in into every RecordSet of the
+ * synthesized template, and that value arrives here looking like any other
+ * malformed ID. Reporting it as one sends the reader to check an ID they never
+ * wrote, so the stand-in is named and the synth that produced it is pointed at.
+ */
+function rejectedSimRoute53HostedZoneId(
+  value: string | undefined,
+  hostedZoneId: string | undefined,
+): string {
+  const reported = `Invalid Route53 Hosted Zone ID: ${value ?? "(missing)"}`;
+
+  if (hostedZoneId !== cdkUnresolvedLookupHostedZoneId) {
+    return reported;
+  }
+
+  return (
+    `${reported}. CDK fills an unresolved \`HostedZone.fromLookup\` with this ` +
+    "stand-in. Run `cdk synth` with credentials for the account holding the " +
+    "zone, or commit the `cdk.context.json` a resolved lookup writes."
+  );
 }
 
 /**

--- a/src/service/route53/command/get-hosted-zone/get-hosted-zone.iso.test.ts
+++ b/src/service/route53/command/get-hosted-zone/get-hosted-zone.iso.test.ts
@@ -9,7 +9,10 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
-import { SimRoute53NoSuchHostedZone } from "../../error/sim-route53.error.js";
+import {
+  SimRoute53InvalidInput,
+  SimRoute53NoSuchHostedZone,
+} from "../../error/sim-route53.error.js";
 import { makeSimRoute53HostedZoneId } from "../create-hosted-zone/sim-route53-zone-id.js";
 import {
   ChangeResourceRecordSetsCommand,
@@ -126,5 +129,31 @@ describe("Route53 GetHostedZoneCommand", () => {
     // Then Route53 reports that the Hosted Zone does not exist.
     assertInstanceOf(error, SimRoute53NoSuchHostedZone);
     assertStringIncludes(error.message, "No sim Route53 Hosted Zone with ID");
+  });
+
+  it("points at the synth when CDK's lookup stand-in is used as an ID", async () => {
+    // Given an empty simulated Route53 service.
+    const simAws = new SimAws();
+    const simRoute53 = simAws.route53();
+
+    // When a Hosted Zone is requested under the ID CDK synthesizes for an
+    // unresolved HostedZone.fromLookup.
+    const error = await assertThrowsErrorAsync(async () =>
+      simRoute53.getHostedZone(
+        new GetHostedZoneCommand({
+          Id: "DUMMY",
+        }),
+      ),
+    );
+
+    // Then Route53 names the stand-in and how to resolve the lookup.
+    assertInstanceOf(error, SimRoute53InvalidInput);
+    assertIdentical(
+      error.message,
+      "Invalid Route53 Hosted Zone ID: DUMMY. CDK fills an unresolved " +
+        "`HostedZone.fromLookup` with this stand-in. Run `cdk synth` with " +
+        "credentials for the account holding the zone, or commit the " +
+        "`cdk.context.json` a resolved lookup writes.",
+    );
   });
 });


### PR DESCRIPTION
`HostedZone.fromLookup` synthesizes the literal `DUMMY` as a Hosted Zone ID when it runs with no credentials and no cached context, and a Route53 command reported that value as a malformed ID like any other. The message now names `DUMMY` as CDK's stand-in for a lookup that did not resolve, and says to run `cdk synth` with credentials for the account holding the zone or to commit the `cdk.context.json` a resolved lookup writes. Every other malformed ID keeps the message it had.

Resolves #1273