### PR TITLE
feat: sim DynamoDB document transactions

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2473,7 +2473,7 @@ simSdk.intercept(documents);
 for (const [tableName, keyName] of [
   ["OrdersTable", "orderId"],
   ["ClaimsTable", "code"],
-]) {
+] as const) {
   await documents.send(
     new CreateTableCommand({
       TableName: tableName,

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -2443,6 +2443,123 @@ console.log(output.Responses[1]); // {}
 That is the difference from `BatchGetItem`, which leaves a missing item out of its answer
 altogether. Here the answers stay lined up with the Gets that asked for them.
 
+### Transactions through the document client
+
+`TransactWriteCommand` and `TransactGetCommand` from `@aws-sdk/lib-dynamodb` reach the same two
+operations. Every action's `Item`, `Key` and `ExpressionAttributeValues` are converted on the way in,
+and the `Item` of each `Responses` entry on the way out.
+
+```typescript sim-dynamodb-document-transactions
+/**
+ * Writing an order and the claim on its code together, in plain JavaScript.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  TransactGetCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+);
+simSdk.intercept(documents);
+
+for (const [tableName, keyName] of [
+  ["OrdersTable", "orderId"],
+  ["ClaimsTable", "code"],
+]) {
+  await documents.send(
+    new CreateTableCommand({
+      TableName: tableName,
+      KeySchema: [{ AttributeName: keyName, KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: keyName, AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+}
+await simSdk.simAws.backgroundTasksComplete();
+
+const claim = {
+  TableName: "ClaimsTable",
+  ConditionExpression: "attribute_not_exists(code)",
+};
+
+// The order and the claim on its code go in together.
+await documents.send(
+  new TransactWriteCommand({
+    TransactItems: [
+      {
+        Put: {
+          TableName: "OrdersTable",
+          Item: { orderId: "order-1", total: 42, lines: [{ sku: "widget" }] },
+        },
+      },
+      { Put: { ...claim, Item: { code: "ABC123", orderId: "order-1" } } },
+    ],
+  }),
+);
+
+const read = await documents.send(
+  new TransactGetCommand({
+    TransactItems: [
+      { Get: { TableName: "OrdersTable", Key: { orderId: "order-1" } } },
+      { Get: { TableName: "ClaimsTable", Key: { code: "ABC123" } } },
+    ],
+  }),
+);
+
+const lines = read.Responses?.[0]?.Item?.["lines"] as { sku: string }[];
+console.log(lines[0]?.sku); // widget
+console.log(read.Responses?.[1]?.Item?.["orderId"]); // order-1
+
+// A second order wanting the same code loses the claim, and loses the order
+// with it.
+try {
+  await documents.send(
+    new TransactWriteCommand({
+      TransactItems: [
+        {
+          Put: {
+            TableName: "OrdersTable",
+            Item: { orderId: "order-2", total: 7 },
+          },
+        },
+        { Put: { ...claim, Item: { code: "ABC123", orderId: "order-2" } } },
+      ],
+    }),
+  );
+} catch (error) {
+  const cancelled = error as {
+    name: string;
+    CancellationReasons?: { Code: string }[];
+  };
+
+  console.log(cancelled.name); // "TransactionCanceledException"
+  console.log(cancelled.CancellationReasons?.map((reason) => reason.Code));
+  // ["None", "ConditionalCheckFailed"]
+}
+
+const second = await documents.send(
+  new TransactGetCommand({
+    TransactItems: [
+      { Get: { TableName: "OrdersTable", Key: { orderId: "order-2" } } },
+    ],
+  }),
+);
+
+console.log(second.Responses?.[0]); // {}
+```
+
+`CancellationReasons` arrive as the low-level Command reports them. There is one per action, in
+`TransactItems` order. A reason's `Item` holds AttributeValues, because a cancelled transaction is
+thrown, and the real document client converts nothing on the way out of a transactional write.
+
 ## Expiring items with time to live
 
 `UpdateTimeToLive` names the attribute a table expires items by, and `DescribeTimeToLive` reports
@@ -2930,8 +3047,11 @@ console.log(tags.has("priority")); // true
 ```
 
 `PutCommand`, `GetCommand`, `DeleteCommand`, `UpdateCommand`, `QueryCommand`, `ScanCommand`,
-`BatchWriteCommand` and `BatchGetCommand` are converted. A document Command with no route here, such
-as `TransactWriteCommand`, is refused by name before anything tries to convert its values.
+`BatchWriteCommand`, `BatchGetCommand`, `TransactWriteCommand` and `TransactGetCommand` are
+converted. The two transactional ones have
+[a section of their own](#transactions-through-the-document-client). A document Command with no route
+here, such as the PartiQL `ExecuteStatementCommand`, is refused by name before anything tries to
+convert its values.
 
 Intercept the document client itself. `DynamoDBDocumentClient.from(client)` builds a separate object
 outside the `DynamoDBClient` class, so intercepting the base client leaves Commands sent through the
@@ -3621,15 +3741,15 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
 - SDK interception, and an intercepted `DynamoDBClient` or `DynamoDBStreamsClient` reaches the
   simulation.
 - The `@aws-sdk/lib-dynamodb` document client, with `PutCommand`, `GetCommand`, `DeleteCommand`,
-  `UpdateCommand`, `QueryCommand`, `ScanCommand`, `BatchWriteCommand` and `BatchGetCommand`
-  converting native JavaScript values on the way in and out, and `paginateQuery` and `paginateScan`
-  paging through a simulated table.
+  `UpdateCommand`, `QueryCommand`, `ScanCommand`, `BatchWriteCommand`, `BatchGetCommand`,
+  `TransactWriteCommand` and `TransactGetCommand` converting native JavaScript values on the way in
+  and out, and `paginateQuery` and `paginateScan` paging through a simulated table.
 
 ## Limitations
 
-- The document client's transaction and PartiQL Commands go unconverted. PartiQL is an operation
-  this simulation lacks yet. The transactions are simulated as operations, so only the document form
-  of them is missing. Both are refused by name, never half converted.
+- The document client's PartiQL Commands go unconverted, because PartiQL is an operation this
+  simulation lacks yet. `ExecuteStatementCommand`, `BatchExecuteStatementCommand` and
+  `ExecuteTransactionCommand` are refused by name, never half converted.
 - A document client's translate config goes unread. The marshalling options it was built with do not
   apply. See [the SDK docs](https://yulinsim.dev/sdk/#limitations).
 - `Expected`, `ConditionalOperator`, `AttributeUpdates`, `KeyConditions`, `QueryFilter` and

--- a/docs/services/dynamodb/sim-dynamodb-document-transactions.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-document-transactions.example.ts
@@ -21,7 +21,7 @@ simSdk.intercept(documents);
 for (const [tableName, keyName] of [
   ["OrdersTable", "orderId"],
   ["ClaimsTable", "code"],
-]) {
+] as const) {
   await documents.send(
     new CreateTableCommand({
       TableName: tableName,

--- a/docs/services/dynamodb/sim-dynamodb-document-transactions.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-document-transactions.example.ts
@@ -1,0 +1,104 @@
+/**
+ * Writing an order and the claim on its code together, in plain JavaScript.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  TransactGetCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+);
+simSdk.intercept(documents);
+
+for (const [tableName, keyName] of [
+  ["OrdersTable", "orderId"],
+  ["ClaimsTable", "code"],
+]) {
+  await documents.send(
+    new CreateTableCommand({
+      TableName: tableName,
+      KeySchema: [{ AttributeName: keyName, KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: keyName, AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+}
+await simSdk.simAws.backgroundTasksComplete();
+
+const claim = {
+  TableName: "ClaimsTable",
+  ConditionExpression: "attribute_not_exists(code)",
+};
+
+// The order and the claim on its code go in together.
+await documents.send(
+  new TransactWriteCommand({
+    TransactItems: [
+      {
+        Put: {
+          TableName: "OrdersTable",
+          Item: { orderId: "order-1", total: 42, lines: [{ sku: "widget" }] },
+        },
+      },
+      { Put: { ...claim, Item: { code: "ABC123", orderId: "order-1" } } },
+    ],
+  }),
+);
+
+const read = await documents.send(
+  new TransactGetCommand({
+    TransactItems: [
+      { Get: { TableName: "OrdersTable", Key: { orderId: "order-1" } } },
+      { Get: { TableName: "ClaimsTable", Key: { code: "ABC123" } } },
+    ],
+  }),
+);
+
+const lines = read.Responses?.[0]?.Item?.["lines"] as { sku: string }[];
+console.log(lines[0]?.sku); // widget
+console.log(read.Responses?.[1]?.Item?.["orderId"]); // order-1
+
+// A second order wanting the same code loses the claim, and loses the order
+// with it.
+try {
+  await documents.send(
+    new TransactWriteCommand({
+      TransactItems: [
+        {
+          Put: {
+            TableName: "OrdersTable",
+            Item: { orderId: "order-2", total: 7 },
+          },
+        },
+        { Put: { ...claim, Item: { code: "ABC123", orderId: "order-2" } } },
+      ],
+    }),
+  );
+} catch (error) {
+  const cancelled = error as {
+    name: string;
+    CancellationReasons?: { Code: string }[];
+  };
+
+  console.log(cancelled.name); // "TransactionCanceledException"
+  console.log(cancelled.CancellationReasons?.map((reason) => reason.Code));
+  // ["None", "ConditionalCheckFailed"]
+}
+
+const second = await documents.send(
+  new TransactGetCommand({
+    TransactItems: [
+      { Get: { TableName: "OrdersTable", Key: { orderId: "order-2" } } },
+    ],
+  }),
+);
+
+console.log(second.Responses?.[0]); // {}

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -1111,8 +1111,8 @@ intercepted send never runs it and the conversion happens at the interception bo
   `-routes.ts` builds one per Command for the SDK router to merge in.
 
 Most document Commands are named differently to the Command they stand for, so `PutCommand` and
-`PutItemCommand` route separately. One with no route, such as `TransactWriteCommand`, is refused by
-name before anything tries to convert its values.
+`PutItemCommand` route separately. One with no route, such as the PartiQL `ExecuteStatementCommand`,
+is refused by name before anything tries to convert its values.
 
 `QueryCommand` and `ScanCommand` are named the same in both packages, so the SDK router cannot key on
 the name alone. `sim-dynamodb-document-shared-name-route.ts` holds the document route and the client

--- a/src/service/dynamodb/document/sim-dynamodb-document-command-paths.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-command-paths.ts
@@ -73,6 +73,68 @@ const batchGetKeys = simDynamoDbDocumentEach(
 );
 
 /**
+ * One action of a transactional write that names an item by its key, which a
+ * ConditionCheck, a Delete and an Update all do.
+ */
+const transactWriteKeyed = simDynamoDbDocumentFields({
+  Key: simDynamoDbDocumentValues(),
+  ExpressionAttributeValues: simDynamoDbDocumentValues(),
+});
+
+/**
+ * The Put of a transactional write, which carries a whole item.
+ */
+const transactWritePut = simDynamoDbDocumentFields({
+  Item: simDynamoDbDocumentValues(),
+  ExpressionAttributeValues: simDynamoDbDocumentValues(),
+});
+
+/**
+ * The actions a transactional write applies.
+ *
+ * An entry carries exactly one of the four, so each is named here and the
+ * three the entry left out are left out of the conversion with it. Every
+ * action carries its own condition, so its expression values are converted
+ * alongside the item they compare against.
+ */
+const transactWriteActions = simDynamoDbDocumentEach(
+  simDynamoDbDocumentFields({
+    ConditionCheck: transactWriteKeyed,
+    Put: transactWritePut,
+    Delete: transactWriteKeyed,
+    Update: transactWriteKeyed,
+  }),
+);
+
+/**
+ * One Get of a transactional read, which names an item by its key.
+ */
+const transactGet = simDynamoDbDocumentFields({
+  Get: simDynamoDbDocumentFields({ Key: simDynamoDbDocumentValues() }),
+});
+
+/**
+ * What a transactional read answers with, one entry per Get.
+ */
+const transactGetResponses = simDynamoDbDocumentEach(
+  simDynamoDbDocumentFields({ Item: simDynamoDbDocumentValues() }),
+);
+
+/**
+ * What a transactional write answers with, which is nothing to convert.
+ *
+ * `ItemCollectionMetrics` is the one place the real document client converts
+ * this output, and it is only reported when a request asks for it with
+ * `ReturnItemCollectionMetrics`, which simulated DynamoDB refuses.
+ *
+ * A cancelled transaction is not converted either. `CancellationReasons` reach
+ * a caller on a thrown `TransactionCanceledException` rather than in an
+ * answer, and the real document client leaves the `Item` of a reason as the
+ * descriptors the low-level Command reports.
+ */
+const transactWritten = simDynamoDbDocumentFields({});
+
+/**
  * Where each supported document Command carries native values.
  *
  * These mirror the key nodes the real document client declares on its own
@@ -132,5 +194,15 @@ export const simDynamoDbDocumentCommandPaths = {
       Responses: simDynamoDbDocumentEach(valueRecords),
       UnprocessedKeys: batchGetKeys,
     }),
+  },
+  transactWrite: {
+    input: simDynamoDbDocumentFields({ TransactItems: transactWriteActions }),
+    output: transactWritten,
+  },
+  transactGet: {
+    input: simDynamoDbDocumentFields({
+      TransactItems: simDynamoDbDocumentEach(transactGet),
+    }),
+    output: simDynamoDbDocumentFields({ Responses: transactGetResponses }),
   },
 } as const satisfies Readonly<Record<string, SimDynamoDbDocumentCommandPaths>>;

--- a/src/service/dynamodb/document/sim-dynamodb-document-interception.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-interception.iso.test.ts
@@ -5,10 +5,10 @@ import {
 } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
+  ExecuteStatementCommand,
   GetCommand,
   PutCommand,
   QueryCommand,
-  TransactWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
 import {
   assertArrayEquals,
@@ -119,22 +119,15 @@ describe("simulated DynamoDB document client interception", () => {
     // When a document Command with no route is sent.
     const error = await assertThrowsErrorAsync(async () => {
       await documents.send(
-        new TransactWriteCommand({
-          TransactItems: [
-            {
-              Put: {
-                TableName: "OrdersTable",
-                Item: { orderId: "order-1" },
-              },
-            },
-          ],
+        new ExecuteStatementCommand({
+          Statement: `SELECT * FROM "OrdersTable"`,
         }),
       );
     });
 
     // Then it is refused by name, before anything tries to convert its values.
     assertInstanceOf(error, SimSdkUnsupportedCommandError);
-    assertStringIncludes(error.message, "TransactWriteCommand");
+    assertStringIncludes(error.message, "ExecuteStatementCommand");
     assertStringIncludes(error.message, "PutCommand");
   });
 

--- a/src/service/dynamodb/document/sim-dynamodb-document-routes.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-routes.ts
@@ -80,7 +80,7 @@ export function simDynamoDbDocumentSharedNameRoutes(dynamoDb: SimDynamoDb): {
  * so are routed by `simDynamoDbDocumentSharedNameRoutes` instead.
  *
  * An operation with no document route at all, such as a document
- * `TransactWriteCommand`, is refused by name like any other unsupported
+ * `ExecuteStatementCommand`, is refused by name like any other unsupported
  * Command, rather than failing part way through a conversion.
  */
 export function simDynamoDbDocumentRoutes(
@@ -124,6 +124,22 @@ export function simDynamoDbDocumentRoutes(
       paths.batchGet,
       async (input: simDynamoDbCommands.SimBatchGetItemCommandInput, options) =>
         await dynamoDb.batchGetItem({ input }, options),
+    ),
+    namedDocumentRoute(
+      "TransactWriteCommand",
+      paths.transactWrite,
+      async (
+        input: simDynamoDbCommands.SimTransactWriteItemsCommandInput,
+        options,
+      ) => await dynamoDb.transactWriteItems({ input }, options),
+    ),
+    namedDocumentRoute(
+      "TransactGetCommand",
+      paths.transactGet,
+      async (
+        input: simDynamoDbCommands.SimTransactGetItemsCommandInput,
+        options,
+      ) => await dynamoDb.transactGetItems({ input }, options),
     ),
   ];
 }

--- a/src/service/dynamodb/document/sim-dynamodb-document-transact.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-transact.iso.test.ts
@@ -1,0 +1,299 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  TransactGetCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertObjectEquals,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimDynamoDbTransactionCanceledException } from "../error/dynamodb.error.js";
+import { simDynamoDbCreatedTableFactory } from "../table/sim-dynamodb-created-table.factory.js";
+
+/**
+ * An intercepted document client, and the two tables one transaction spans.
+ *
+ * A transaction is worth showing across two tables, since that is the thing a
+ * batch cannot do.
+ */
+async function interceptedDocuments(
+  simSdk: SimSdk,
+): Promise<DynamoDBDocumentClient> {
+  await simDynamoDbCreatedTableFactory.make(
+    { tableName: "AccountsTable", partitionKeyName: "accountId" },
+    simSdk.simAws,
+  );
+  await simDynamoDbCreatedTableFactory.make(
+    { tableName: "LedgerTable", partitionKeyName: "entryId" },
+    simSdk.simAws,
+  );
+
+  // The tables the factory made are in the simulated default Region, so the
+  // client works there too.
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: simSdk.simAws.defaultRegionName }),
+  );
+  simSdk.intercept(documents);
+
+  return documents;
+}
+
+/**
+ * Read one account back as plain JavaScript.
+ */
+async function readAccount(
+  documents: DynamoDBDocumentClient,
+  accountId: string,
+): Promise<Record<string, unknown> | undefined> {
+  const read = await documents.send(
+    new GetCommand({ TableName: "AccountsTable", Key: { accountId } }),
+  );
+
+  return read.Item;
+}
+
+describe("simulated DynamoDB document client transactions", () => {
+  it("applies a put, an update, a delete and a condition check together", async () => {
+    // Given an open account, another account to move, and a ledger entry to
+    // replace.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: "account-1", balance: 100, status: "open" },
+      }),
+    );
+    await documents.send(
+      new PutCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: "account-2", status: "open" },
+      }),
+    );
+    await documents.send(
+      new PutCommand({
+        TableName: "LedgerTable",
+        Item: { entryId: "entry-1", amount: 25 },
+      }),
+    );
+
+    // When one transaction writes an entry, moves a balance, removes the old
+    // entry and checks the account it is leaving alone, all in plain
+    // JavaScript.
+    await documents.send(
+      new TransactWriteCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: "LedgerTable",
+              Item: { entryId: "entry-2", amount: 75, lines: [{ sku: "a" }] },
+            },
+          },
+          {
+            Update: {
+              TableName: "AccountsTable",
+              Key: { accountId: "account-1" },
+              UpdateExpression: "SET balance = :balance",
+              ConditionExpression: "#status = :open",
+              ExpressionAttributeNames: { "#status": "status" },
+              ExpressionAttributeValues: { ":balance": 75, ":open": "open" },
+            },
+          },
+          {
+            Delete: {
+              TableName: "LedgerTable",
+              Key: { entryId: "entry-1" },
+            },
+          },
+          {
+            ConditionCheck: {
+              TableName: "AccountsTable",
+              Key: { accountId: "account-2" },
+              ConditionExpression: "#status = :open",
+              ExpressionAttributeNames: { "#status": "status" },
+              ExpressionAttributeValues: { ":open": "open" },
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then every action happened, and what each wrote reads back native.
+    assertObjectEquals(await readAccount(documents, "account-1"), {
+      accountId: "account-1",
+      balance: 75,
+      status: "open",
+    });
+
+    const entries = await documents.send(
+      new TransactGetCommand({
+        TransactItems: [
+          { Get: { TableName: "LedgerTable", Key: { entryId: "entry-1" } } },
+          { Get: { TableName: "LedgerTable", Key: { entryId: "entry-2" } } },
+        ],
+      }),
+    );
+    const responses = entries.Responses;
+    assertNonNullable(responses);
+    assertArrayLength(responses, 2);
+    assertObjectEquals(responses[0], {});
+    assertObjectEquals(responses[1].Item, {
+      entryId: "entry-2",
+      amount: 75,
+      lines: [{ sku: "a" }],
+    });
+  });
+
+  it("cancels the whole transaction when one condition is refused", async () => {
+    // Given a closed account.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: "account-1", balance: 100, status: "closed" },
+      }),
+    );
+
+    // When a transaction writes a ledger entry and moves the balance of it.
+    const cancelled = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new TransactWriteCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: "LedgerTable",
+                Item: { entryId: "entry-1", amount: 25 },
+              },
+            },
+            {
+              Update: {
+                TableName: "AccountsTable",
+                Key: { accountId: "account-1" },
+                UpdateExpression: "SET balance = :balance",
+                ConditionExpression: "#status = :open",
+                ExpressionAttributeNames: { "#status": "status" },
+                ExpressionAttributeValues: { ":balance": 75, ":open": "open" },
+              },
+            },
+          ],
+        }),
+      );
+    });
+
+    // Then the reasons line up with the actions the request named, the same
+    // way the low-level Command reports them.
+    assertInstanceOf(cancelled, SimDynamoDbTransactionCanceledException);
+    assertArrayLength(cancelled.CancellationReasons, 2);
+    assertObjectEquals(cancelled.CancellationReasons[0], { Code: "None" });
+    assertIdentical(
+      cancelled.CancellationReasons[1].Code,
+      "ConditionalCheckFailed",
+    );
+
+    // And neither action was applied.
+    const entry = await documents.send(
+      new GetCommand({ TableName: "LedgerTable", Key: { entryId: "entry-1" } }),
+    );
+    assertUndefined(entry.Item);
+    assertObjectEquals(await readAccount(documents, "account-1"), {
+      accountId: "account-1",
+      balance: 100,
+      status: "closed",
+    });
+  });
+
+  it("reports the item of a cancellation reason as the low-level Command does", async () => {
+    // Given a closed account the transaction asks to see on failure.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "AccountsTable",
+        Item: { accountId: "account-1", balance: 100, status: "closed" },
+      }),
+    );
+
+    // When its condition is refused.
+    const cancelled = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new TransactWriteCommand({
+          TransactItems: [
+            {
+              ConditionCheck: {
+                TableName: "AccountsTable",
+                Key: { accountId: "account-1" },
+                ConditionExpression: "#status = :open",
+                ExpressionAttributeNames: { "#status": "status" },
+                ExpressionAttributeValues: { ":open": "open" },
+                ReturnValuesOnConditionCheckFailure: "ALL_OLD",
+              },
+            },
+          ],
+        }),
+      );
+    });
+
+    // Then the item on the reason carries descriptors. A cancelled transaction
+    // is thrown, and the real document client converts nothing on the way out
+    // of a transactional write.
+    assertInstanceOf(cancelled, SimDynamoDbTransactionCanceledException);
+    assertArrayLength(cancelled.CancellationReasons, 1);
+    assertObjectEquals(cancelled.CancellationReasons[0].Item, {
+      accountId: { S: "account-1" },
+      balance: { N: "100" },
+      status: { S: "closed" },
+    });
+  });
+
+  it("projects a transactional read and answers with native values", async () => {
+    // Given an account holding more than the read asks for.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    await documents.send(
+      new PutCommand({
+        TableName: "AccountsTable",
+        Item: {
+          accountId: "account-1",
+          balance: 100,
+          tags: new Set(["priority"]),
+        },
+      }),
+    );
+
+    // When only one attribute is projected.
+    const read = await documents.send(
+      new TransactGetCommand({
+        TransactItems: [
+          {
+            Get: {
+              TableName: "AccountsTable",
+              Key: { accountId: "account-1" },
+              ProjectionExpression: "balance",
+            },
+          },
+        ],
+      }),
+    );
+
+    // Then that attribute comes back native.
+    const responses = read.Responses;
+    assertNonNullable(responses);
+    assertArrayLength(responses, 1);
+    assertObjectEquals(responses[0].Item, { balance: 100 });
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-transact.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-transact.iso.test.ts
@@ -21,10 +21,10 @@ import { SimDynamoDbTransactionCanceledException } from "../error/dynamodb.error
 import { simDynamoDbCreatedTableFactory } from "../table/sim-dynamodb-created-table.factory.js";
 
 /**
- * An intercepted document client, and the two tables one transaction spans.
+ * An intercepted document client, and the two tables these transactions span.
  *
- * A transaction is worth showing across two tables, since that is the thing a
- * batch cannot do.
+ * A transaction is usually reached for when two items have to agree with each
+ * other, and those two items are often in different tables.
  */
 async function interceptedDocuments(
   simSdk: SimSdk,


### PR DESCRIPTION
`SimSdk` refused `TransactWriteCommand` and `TransactGetCommand` from `@aws-sdk/lib-dynamodb`, even though both low-level transaction operations were already simulated. The two document Commands now route like the rest of them, converting each action's `Item`, `Key` and `ExpressionAttributeValues` on the way in and each `Responses` entry's `Item` on the way out. A cancelled transaction reports `CancellationReasons` as the low-level Command does, since the reasons arrive on a thrown exception and the real document client converts nothing there. The DynamoDB docs gain a section on the document-client form beside the low-level one, and the example that showed an unroutable document Command now uses the PartiQL `ExecuteStatementCommand`.

Resolves #1269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for transactional DynamoDB document-client writes and reads.
  * Transactions now support native JavaScript values, conditional cancellation, atomic rollback, and projection expressions.
  * Added examples demonstrating cross-table transactional workflows and rollback behavior.

* **Documentation**
  * Updated DynamoDB documentation to describe transactional document commands and clarify unsupported PartiQL commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->