### PR TITLE
test: pin the error page an OAC Bucket serves

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -259,6 +259,11 @@ with a 200 for a URL the Bucket has no object for. It is one of the same error c
 CloudFront allows. Where the response page is itself missing, the viewer gets the status from
 fetching it, as in CloudFront.
 
+Behind an origin access control, a response page the Bucket does not hold answers 403 where a public
+Bucket answers 404. The Bucket policy an origin access control is written with grants `s3:GetObject`
+and no `s3:ListBucket`, and S3 refuses a key whose absence it may not report. A test whose Bucket
+was never loaded with the site's error page sees that refusal in place of the page.
+
 A viewer-response function never sees a custom error page. CloudFront runs no viewer-response
 function once the Origin has answered 400 or higher, and simulated CloudFront does the same, for a
 CloudFront Function and a Lambda@Edge function alike. The status the Origin returned is what decides

--- a/src/service/cloudfront/README.md
+++ b/src/service/cloudfront/README.md
@@ -142,6 +142,18 @@ accepted and left out of the internal model. `DefaultRootObject` beginning with 
 refused for the same reason: in real CloudFront it answers the Distribution root with a 403, so a
 Distribution carrying one is not worth creating.
 
+`SimCfCustomErrorResponder` under `controller/error/` puts the rule's page in place of the Origin's
+error. The page is fetched as a request of its own, through the Behavior its own path matches. A
+Distribution can keep its error pages on an Origin of their own, away from the content that failed,
+as CloudFront does.
+
+An S3 Origin reads that page through `SimCfS3OriginSigner` like any other Object. A page behind an
+origin access control is read as the CloudFront service principal for that Distribution, and the
+Bucket policy CDK writes for one covers it. A page the Bucket does not hold is a different matter.
+That policy grants `s3:GetObject` and no `s3:ListBucket`. The read is refused, and the refusal
+reaches the viewer as a 403 in place of the Origin's own error. A Bucket the site's build was never
+loaded into answers exactly this way.
+
 ### Viewer certificates
 
 `distribution/viewer-certificate/` holds the checks CloudFront applies to a Distribution's ACM

--- a/src/service/cloudfront/controller/error/sim-cf-custom-error-oac.iso.test.ts
+++ b/src/service/cloudfront/controller/error/sim-cf-custom-error-oac.iso.test.ts
@@ -1,0 +1,87 @@
+import {
+  assertIdentical,
+  assertResponseStatus,
+  assertStringIncludes,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  simCfOacCloudFrontReadStatement,
+  simCfOacSiteDistributionArn,
+  simCfOacSiteStack,
+} from "../../../../../test/cloudfront/oac-site-fixture.js";
+import { simCfSiteRequest } from "../../../../../test/cloudfront/site-fixture.js";
+
+const errorPage = "<h1>Not found</h1>";
+
+/**
+ * The rule a site behind an origin access control needs, and the reason it
+ * needs it: the Bucket policy an origin access control is written with grants
+ * `s3:GetObject` and nothing else, so a key the Bucket does not hold comes back
+ * as 403 rather than 404. Mapping only 404 would leave a mistyped URL on
+ * CloudFront's own error page.
+ */
+const mapForbiddenToErrorPage = [
+  { ErrorCode: 403, ResponseCode: 404, ResponsePagePath: "/404.html" },
+];
+
+/**
+ * Serving a custom error page from a Bucket reached through an origin access
+ * control.
+ *
+ * The error page is fetched as a request of its own, and it is fetched through
+ * the Behavior that matches its path, so it is read as the same CloudFront
+ * service principal an ordinary page is. Anything else would serve every page
+ * of a private site and 403 on the one a mistyped URL reaches.
+ */
+describe("Sim CloudFront custom error responses behind an origin access control", () => {
+  it("reads the error page as the Distribution the Bucket policy names", async () => {
+    // Given a private site holding an error page, mapping the 403 a missing key
+    // behind an origin access control comes back as onto it.
+    const { simAws, distributionId } = await simCfOacSiteStack({
+      signingBehavior: "always",
+      statement: simCfOacCloudFrontReadStatement(simCfOacSiteDistributionArn),
+      customErrorResponses: mapForbiddenToErrorPage,
+      additionalObjects: { "404.html": errorPage },
+    });
+
+    // When a viewer asks for a page the Bucket does not hold, which the Origin
+    // refuses rather than reporting absent.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/mistyped.html",
+    );
+
+    // Then the error page is served under the rule's status, which means the
+    // read of it was signed for this Distribution as the ordinary read is.
+    assertResponseStatus(response, 404, await describeResponse(response));
+    assertIdentical(await response.text(), errorPage);
+  });
+
+  it("answers with the refusal where the Bucket holds no error page", async () => {
+    // Given the same site with nothing at the error page's path.
+    const { simAws, distributionId } = await simCfOacSiteStack({
+      signingBehavior: "always",
+      statement: simCfOacCloudFrontReadStatement(simCfOacSiteDistributionArn),
+      customErrorResponses: mapForbiddenToErrorPage,
+    });
+
+    // When a viewer asks for a page the Bucket does not hold.
+    const response = await simCfSiteRequest(
+      simAws,
+      distributionId,
+      "/mistyped.html",
+    );
+
+    // Then fetching the error page is refused in its turn, and that refusal is
+    // what reaches the viewer, as it does in CloudFront. A Bucket the site's
+    // build was never loaded into looks exactly like this.
+    assertResponseStatus(response, 403, await describeResponse(response));
+    assertStringIncludes(
+      await response.text(),
+      "Access denied reading Object 404.html",
+    );
+  });
+});

--- a/test/cloudfront/oac-site-fixture.ts
+++ b/test/cloudfront/oac-site-fixture.ts
@@ -76,6 +76,17 @@ export interface SimCfOacSiteStackProperties {
    * access control does not.
    */
   readonly publicPolicyAllowed?: boolean;
+
+  /**
+   * The Distribution's custom error responses, for a test about the page one
+   * serves.
+   */
+  readonly customErrorResponses?: SimCfnTemplateValue;
+
+  /**
+   * Objects the Bucket holds besides its home page, keyed by object key.
+   */
+  readonly additionalObjects?: Readonly<Record<string, string>>;
 }
 
 export interface SimCfOacSite {
@@ -142,6 +153,9 @@ export async function simCfOacSiteStack(
                 TargetOriginId: "SiteOrigin",
                 ViewerProtocolPolicy: "allow-all",
               },
+              ...(properties.customErrorResponses !== undefined && {
+                CustomErrorResponses: properties.customErrorResponses,
+              }),
             },
           },
         },
@@ -169,6 +183,20 @@ export async function simCfOacSiteStack(
       ContentType: "text/html",
       Body: simCfOacSitePage,
     }),
+  );
+
+  await Promise.all(
+    Object.entries(properties.additionalObjects ?? {}).map(
+      async ([key, body]) =>
+        await simAws.s3().putObject(
+          new PutObjectCommand({
+            Bucket: simCfOacSiteBucketName,
+            Key: key,
+            ContentType: "text/html",
+            Body: body,
+          }),
+        ),
+    ),
   );
 
   const distributionId = stack.outputs.get("DistributionId")?.value;


### PR DESCRIPTION
A Distribution serving a private Bucket was reported to fetch its custom error page anonymously and to get a 403 back. The fetch already carries the origin access control's identity. It goes through the Behavior the page's path matches and is read as the CloudFront service principal for that Distribution, and the first test here holds it to that against the shape CDK synthesizes. The reported 403 comes from an error page the Bucket does not hold. An origin access control's Bucket policy grants `s3:GetObject` and no `s3:ListBucket`, and since 1.21.4 a read that finds nothing is refused for want of the listing permission, as real S3 refuses it. The second test pins that refusal, and both READMEs now say where it comes from.

Resolves #1268
