### PR TITLE
fix: answer Ref with a skipped Resource's name

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1055,8 +1055,15 @@ simulated CloudFront hostname, such as `e123example.cloudfront.net`.
 #### Values from a skipped Resource
 
 A Resource that was skipped, because its type is outside the simulation or because there is no
-simulated Resource to create at all, still answers both intrinsics. `Ref` returns the logical ID, and
-`Fn::GetAtt` returns the string `<logical ID>.<attribute name>`.
+simulated Resource to create at all, still answers both intrinsics.
+
+What `Ref` answers with follows how far the refusal got. A service that had already worked out the
+Resource's name answers with that name. That is the name real CloudFormation would have produced,
+and the simulation holds it whether or not the Resource behind it was created. Sim Lambda declining
+a function on its `Runtime` is the case to know about, and it covers CDK's own Python providers. A
+Resource refused before any name existed answers with the logical ID.
+
+`Fn::GetAtt` answers with the string `<logical ID>.<attribute name>` for either of them.
 
 ```typescript sim-cloudformation-skipped-resource-values
 /**
@@ -1071,28 +1078,31 @@ const stack = await simAws.cloudFormation().deployTemplate({
   stackName: "stand-in-stack",
   template: {
     Resources: {
-      AlarmRule: {
-        Type: "AWS::CloudWatch::Alarm",
+      SearchApi: {
+        Type: "AWS::AppSync::GraphQLApi",
+        Properties: {
+          Name: "search",
+        },
       },
     },
     Outputs: {
-      AlarmRef: { Value: { Ref: "AlarmRule" } },
-      AlarmArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
+      SearchApiRef: { Value: { Ref: "SearchApi" } },
+      SearchApiArn: { Value: { "Fn::GetAtt": ["SearchApi", "Arn"] } },
     },
   },
 });
 
 await stack.waitForDeployComplete();
 
-console.log(stack.output("AlarmRef"));
-// "AlarmRule"
+console.log(stack.output("SearchApiRef"));
+// "SearchApi"
 
-console.log(stack.output("AlarmArn"));
-// "AlarmRule.Arn"
+console.log(stack.output("SearchApiArn"));
+// "SearchApi.Arn"
 
 for (const skipped of stack.skippedResources) {
   console.log(skipped.logicalId, skipped.skippedReason);
-  // "AlarmRule Unsupported sim CloudFormation Resource service CloudWatch"
+  // "SearchApi Unsupported sim CloudFormation Resource service AppSync"
 }
 ```
 
@@ -1101,7 +1111,7 @@ every Resource holding a `Ref` or `Fn::GetAtt` to a skipped Resource would fail 
 every Resource depending on those, until one EventBridge rule took the whole stack down with it. The skip
 stays where it happened.
 
-A stand-in is deliberately shaped unlike an ARN. It fails closed wherever the simulator reads it.
+A logical ID is deliberately shaped unlike an ARN. It fails closed wherever the simulator reads it.
 
 - In an IAM policy `Resource` it matches no ARN, so a caller relying on that statement is denied.
 - In a property that is parsed as an ARN it is refused as malformed, and that Resource fails.
@@ -1112,9 +1122,58 @@ A stand-in is deliberately shaped unlike an ARN. It fails closed wherever the si
   SDK call fails the way a call for a missing resource does. A `PutItem` naming the skipped table
   gets `ResourceNotFoundException: No DynamoDB Table named Orders`.
 
-A stand-in stands in for something absent, and is never a value to rely on. A test asserting against
-one is asserting on a Resource that was never created. `stack.skippedResources` is where to find out
-which Resources those are and why, under
+A generated name behaves differently, and is meant to. It is the name an account would have held, so
+anything reading it reads a well-formed name. CDK writes a function's log group name as
+`/aws/lambda/` joined to a `Ref` of the function, and the log group is created under
+`/aws/lambda/<stack>-<logical ID>-<suffix>` even where the function was declined. A deploy Role
+scoped to `<stack>-*` and `/aws/lambda/<stack>-*` covers the deployment, the way it does on AWS.
+
+```typescript sim-cloudformation-skipped-resource-generated-name
+/**
+ * A function skipped on its Runtime, and the Log Group named after it.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "ReportStack",
+  template: {
+    Resources: {
+      ReportFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          Role: "arn:aws:iam::111111111111:role/ReportRole",
+          Handler: "index.handler",
+          Runtime: "python3.13",
+          Code: { ZipFile: "def handler(event, context): return 'report'" },
+        },
+      },
+      ReportFunctionLogGroup: {
+        Type: "AWS::Logs::LogGroup",
+        Properties: {
+          LogGroupName: {
+            "Fn::Join": ["", ["/aws/lambda/", { Ref: "ReportFunction" }]],
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("ReportFunction")?.refValue);
+// "ReportStack-ReportFunction-42d643ca8338"
+
+console.log(simAws.logs().allLogGroups()[0]?.logGroupName);
+// "/aws/lambda/ReportStack-ReportFunction-42d643ca8338"
+```
+
+The Resource is absent all the same, and the name is no evidence that it is there. Invoking the
+function above fails with `ResourceNotFoundException`. `stack.skippedResources` is where to find out
+which Resources were left out and why, under
 [Inspecting stacks and resources](#inspecting-stacks-and-resources).
 
 ### `Fn::Join`

--- a/docs/services/cloudformation/sim-cloudformation-skipped-resource-generated-name.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-skipped-resource-generated-name.example.ts
@@ -1,0 +1,40 @@
+/**
+ * A function skipped on its Runtime, and the Log Group named after it.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "ReportStack",
+  template: {
+    Resources: {
+      ReportFunction: {
+        Type: "AWS::Lambda::Function",
+        Properties: {
+          Role: "arn:aws:iam::111111111111:role/ReportRole",
+          Handler: "index.handler",
+          Runtime: "python3.13",
+          Code: { ZipFile: "def handler(event, context): return 'report'" },
+        },
+      },
+      ReportFunctionLogGroup: {
+        Type: "AWS::Logs::LogGroup",
+        Properties: {
+          LogGroupName: {
+            "Fn::Join": ["", ["/aws/lambda/", { Ref: "ReportFunction" }]],
+          },
+        },
+      },
+    },
+  },
+});
+
+await stack.waitForDeployComplete();
+
+console.log(stack.getResource("ReportFunction")?.refValue);
+// "ReportStack-ReportFunction-42d643ca8338"
+
+console.log(simAws.logs().allLogGroups()[0]?.logGroupName);
+// "/aws/lambda/ReportStack-ReportFunction-42d643ca8338"

--- a/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-skipped-resource-values.example.ts
@@ -10,26 +10,29 @@ const stack = await simAws.cloudFormation().deployTemplate({
   stackName: "stand-in-stack",
   template: {
     Resources: {
-      AlarmRule: {
-        Type: "AWS::CloudWatch::Alarm",
+      SearchApi: {
+        Type: "AWS::AppSync::GraphQLApi",
+        Properties: {
+          Name: "search",
+        },
       },
     },
     Outputs: {
-      AlarmRef: { Value: { Ref: "AlarmRule" } },
-      AlarmArn: { Value: { "Fn::GetAtt": ["AlarmRule", "Arn"] } },
+      SearchApiRef: { Value: { Ref: "SearchApi" } },
+      SearchApiArn: { Value: { "Fn::GetAtt": ["SearchApi", "Arn"] } },
     },
   },
 });
 
 await stack.waitForDeployComplete();
 
-console.log(stack.output("AlarmRef"));
-// "AlarmRule"
+console.log(stack.output("SearchApiRef"));
+// "SearchApi"
 
-console.log(stack.output("AlarmArn"));
-// "AlarmRule.Arn"
+console.log(stack.output("SearchApiArn"));
+// "SearchApi.Arn"
 
 for (const skipped of stack.skippedResources) {
   console.log(skipped.logicalId, skipped.skippedReason);
-  // "AlarmRule Unsupported sim CloudFormation Resource service CloudWatch"
+  // "SearchApi Unsupported sim CloudFormation Resource service AppSync"
 }

--- a/src/service/cloudformation/README.md
+++ b/src/service/cloudformation/README.md
@@ -814,7 +814,9 @@ Adapters allow simulated service objects to stay focused on service behaviour wh
 controls how those objects appear inside template expressions.
 
 If no specialized adapter exists, the default adapter provides fallback behaviour suitable for
-generic tests and diagnostics.
+generic tests and diagnostics. Its `refValue` answers with the physical name a service worked out
+before refusing to create the resource, where the refusal carried one, and with the logical ID
+otherwise. A service carries a name through by raising `SimCfnNamedSkip`.
 
 ## Property resolution during creation
 

--- a/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-default-resource-value-adapter.ts
@@ -4,6 +4,7 @@ import { simCfnUnansweredAttribute } from "./sim-cfn-unanswered-attribute.js";
 
 interface SimCfnDefaultResourceValueAdapterProperties {
   readonly logicalId: string;
+  readonly uncreatedPhysicalName?: string | undefined;
 }
 
 /**
@@ -12,16 +13,23 @@ interface SimCfnDefaultResourceValueAdapterProperties {
  */
 export class SimCfnDefaultResourceValueAdapter implements SimCfnResourceValueAdapter {
   private readonly logicalId: string;
+  private readonly uncreatedPhysicalName: string | undefined;
 
   constructor(properties: SimCfnDefaultResourceValueAdapterProperties) {
     this.logicalId = properties.logicalId;
+    this.uncreatedPhysicalName = properties.uncreatedPhysicalName;
   }
 
   /**
-   * Default physical-ID stand-in.
+   * The physical ID this Resource would have had, or the logical-ID stand-in.
+   *
+   * A service that worked out the Resource's name before refusing to create it
+   * leaves the simulation holding the name real CloudFormation would have
+   * produced. That is what Ref answers with. The logical ID is left for a
+   * Resource nothing ever named.
    */
   refValue(): SimCfnTemplateValue {
-    return this.logicalId;
+    return this.uncreatedPhysicalName ?? this.logicalId;
   }
 
   /**

--- a/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
+++ b/src/service/cloudformation/resource/cfn/sim-cfn-resource-value-adapter.ts
@@ -12,6 +12,12 @@ export interface SimCfnResourceValueAdapterProperties {
   readonly logicalId: string;
   readonly type: string | undefined;
   readonly simResource: object | undefined;
+
+  /**
+   * The name real CloudFormation would have given the Resource, where the
+   * service knew it before deciding not to create it.
+   */
+  readonly uncreatedPhysicalName?: string | undefined;
 }
 
 /**
@@ -30,7 +36,7 @@ export type SimCfnServiceValueAdapter = SimCfnResourceValueAdapter | undefined;
  * Each service matches its own Resource types, beside that service's adapters,
  * so this registry stays a list of services. A Resource no service claims
  * falls through to the default adapter, which answers a Ref with the logical
- * ID.
+ * ID, or with the name a service worked out before refusing the Resource.
  */
 export function simCfnResourceValueAdapter(
   properties: SimCfnResourceValueAdapterProperties,
@@ -45,5 +51,6 @@ export function simCfnResourceValueAdapter(
 
   return new SimCfnDefaultResourceValueAdapter({
     logicalId: properties.logicalId,
+    uncreatedPhysicalName: properties.uncreatedPhysicalName,
   });
 }

--- a/src/service/cloudformation/resource/create/sim-cfn-resource-create-operation.ts
+++ b/src/service/cloudformation/resource/create/sim-cfn-resource-create-operation.ts
@@ -7,6 +7,7 @@ import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-f
 import { SimCfnResourceCreator } from "./sim-cfn-resource-creator.js";
 import { simCfnInertResourceReason } from "../inert/sim-cfn-inert-resource.js";
 import { isSimCfnUnsupportedResourceError } from "../unsupported/sim-cfn-unsupported-resource.js";
+import { simCfnSkippedPhysicalName } from "../unsupported/sim-cfn-named-skip.js";
 
 interface SimCfnResourceCreateOperationProperties<T extends object> {
   readonly background: BackgroundScheduler;
@@ -83,11 +84,17 @@ export class SimCfnResourceCreateOperation<T extends object = object> {
    * a gap and is skipped, unless nothing this simulator models could have told
    * it apart from one that was created, in which case saying it is missing
    * sends a reader after something that is not lost.
+   *
+   * Either way the Resource keeps whatever name the refusal carried. A
+   * template reading a Ref of it then gets the name real CloudFormation would
+   * have produced.
    */
   private recordUncreated(
     error: unknown,
     context: SimCloudFormationResourceCreateContext,
   ): void {
+    this.resource.recordUncreatedPhysicalName(simCfnSkippedPhysicalName(error));
+
     const inertReason = simCfnInertResourceReason(
       this.resource,
       context.resources,

--- a/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.iso.test.ts
+++ b/src/service/cloudformation/resource/ref/sim-cfn-resource-ref-value.iso.test.ts
@@ -2,6 +2,7 @@ import {
   assertIdentical,
   assertInstanceOf,
   assertNonNullable,
+  assertTrue,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimAws } from "../../../aws/sim-aws.js";
@@ -138,5 +139,39 @@ describe("CloudFormation Resource Ref value", () => {
     assertNonNullable(bucketResource);
     assertIdentical(handleResource.refValue, "handle");
     assertIdentical(bucketResource.simResource, bucket);
+  });
+
+  it("keeps the logical ID for a Resource skipped before anything named it", async () => {
+    // Given a template holding a Resource of a service the simulation does
+    // not model, so nothing works out a name for it before refusing it.
+    const template = {
+      Resources: {
+        SearchApi: {
+          Type: "AWS::AppSync::GraphQLApi",
+          Properties: {
+            Name: "search",
+          },
+        },
+      },
+      Outputs: {
+        SearchApiRef: { Value: { Ref: "SearchApi" } },
+      },
+    };
+
+    // When the template is deployed through sim CloudFormation.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "search-stack",
+      template,
+    });
+
+    // Then the Resource is skipped and Ref answers with the logical-ID
+    // stand-in, since the simulation holds no name to answer with instead.
+    const apiResource = stack.getResource("SearchApi");
+
+    assertNonNullable(apiResource);
+    assertTrue(apiResource.skipped);
+    assertIdentical(apiResource.refValue, "SearchApi");
+    assertIdentical(stack.output("SearchApiRef"), "SearchApi");
   });
 });

--- a/src/service/cloudformation/resource/sim-cfn-resource-record.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource-record.ts
@@ -43,6 +43,8 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
   public readonly stackName: string | undefined;
   public readonly template: SimCfnTemplateValueRecord;
 
+  #uncreatedPhysicalName: string | undefined;
+
   private readonly ignoredPropertyList = new SimCfnIgnoredProperties();
   private readonly resourceTemplateReader: SimCfnResourceTemplateReader;
   private readonly propertyResolver: SimCfnResourcePropertyResolver;
@@ -88,6 +90,17 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
    * The simulated AWS object created for this CloudFormation Resource.
    */
   public abstract get simResource(): object | undefined;
+
+  /**
+   * The name real CloudFormation would have given this Resource, where a
+   * service worked it out before refusing to create it.
+   *
+   * A Resource with a name behind it answers Ref with that name. The
+   * logical-ID stand-in is left for a Resource nothing ever named.
+   */
+  public get uncreatedPhysicalName(): string | undefined {
+    return this.#uncreatedPhysicalName;
+  }
 
   /**
    * The properties this Resource was created without acting on.
@@ -188,6 +201,15 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
   }
 
   /**
+   * Record the name a service worked out for this Resource before refusing to
+   * create it. Called by the creation operation, which is where a refusal
+   * carrying a name is read.
+   */
+  recordUncreatedPhysicalName(physicalName: string | undefined): void {
+    this.#uncreatedPhysicalName = physicalName;
+  }
+
+  /**
    * The value returned when this Resource is referenced via Fn::GetAtt.
    *
    * Mirroring CloudFormation, Resource attributes are Resource-type specific.
@@ -236,11 +258,19 @@ export abstract class SimCfnResourceRecord implements SimCfnPropertyIgnorer {
     this.ignoredPropertyList.clear();
   }
 
+  /**
+   * Forget the name a refusal recorded, for a Resource being created again.
+   */
+  protected clearUncreatedPhysicalName(): void {
+    this.#uncreatedPhysicalName = undefined;
+  }
+
   private cfnValueAdapter(): SimCfnResourceValueAdapter {
     return simCfnResourceValueAdapter({
       logicalId: this.logicalId,
       type: this.type,
       simResource: this.simResource,
+      uncreatedPhysicalName: this.uncreatedPhysicalName,
     });
   }
 }

--- a/src/service/cloudformation/resource/sim-cfn-resource.ts
+++ b/src/service/cloudformation/resource/sim-cfn-resource.ts
@@ -211,6 +211,7 @@ export class SimCfnResource<
    */
   markCreateInProgress(): void {
     this.clearIgnoredProperties();
+    this.clearUncreatedPhysicalName();
     this.creationState.markCreateInProgress();
   }
 

--- a/src/service/cloudformation/resource/unsupported/sim-cfn-named-skip.ts
+++ b/src/service/cloudformation/resource/unsupported/sim-cfn-named-skip.ts
@@ -1,0 +1,34 @@
+/**
+ * A refusal from a service that had already worked out the name real
+ * CloudFormation would give the Resource.
+ *
+ * The logical ID a skipped Resource answers `Ref` with stands in for a value
+ * the simulation does not hold. Where a service names a Resource before
+ * refusing it, the simulation does hold one, so raising this carries the name
+ * through the refusal and the Resource answers `Ref` with it. Sim Lambda
+ * declining a function on its Runtime is the case that needs it: CDK writes a
+ * log group name as `/aws/lambda/` joined to a `Ref` of the function, and a
+ * logical ID there produces a log group under a name no account would hold.
+ *
+ * Nothing else about the refusal changes. The message still decides whether
+ * the Stack records a skip or fails. A service raising this says "Unsupported
+ * sim ... CloudFormation" as it would in an ordinary Error.
+ */
+export class SimCfnNamedSkip extends Error {
+  public override readonly name = "SimCfnNamedSkip";
+
+  constructor(
+    message: string,
+    public readonly physicalName: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * The name a refusal carries, or nothing where the service had not named the
+ * Resource before refusing it.
+ */
+export function simCfnSkippedPhysicalName(error: unknown): string | undefined {
+  return error instanceof SimCfnNamedSkip ? error.physicalName : undefined;
+}

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-runtime-skip.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-runtime-skip.ts
@@ -1,3 +1,4 @@
+import { SimCfnNamedSkip } from "../../../cloudformation/resource/unsupported/sim-cfn-named-skip.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnLambdaFunctionProperties } from "./sim-cfn-lambda-function-properties-parser.js";
 
@@ -33,6 +34,12 @@ const nodeJsRuntimePrefix = "nodejs";
  * CloudFormation carries out itself is recorded as inert instead, because this
  * message would otherwise tell a reader to bind a handler to a function that
  * has nothing left to do.
+ *
+ * The refusal carries the function's name, which the properties parser has
+ * already worked out by the time this gate is asked. CDK writes a function's
+ * log group name as `/aws/lambda/` joined to a Ref of the function. A refusal
+ * carrying no name puts the log group under `/aws/lambda/` and a logical ID,
+ * a name no account would hold.
  */
 export class SimCfnLambdaRuntimeSkip {
   /**
@@ -54,11 +61,12 @@ export class SimCfnLambdaRuntimeSkip {
       return undefined;
     }
 
-    return new Error(
+    return new SimCfnNamedSkip(
       `Unsupported sim Lambda CloudFormation Resource ${resource.logicalId}: ` +
         `sim Lambda simulates Node.js runtimes, and this function declares ` +
         `Runtime ${runtimeName}. Bind a real in-process handler to this ` +
         `function to simulate it.`,
+      functionProperties.functionName,
     );
   }
 }

--- a/src/service/lambda/cfn/function/sim-cfn-lambda-skipped-function-name.iso.test.ts
+++ b/src/service/lambda/cfn/function/sim-cfn-lambda-skipped-function-name.iso.test.ts
@@ -1,0 +1,165 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringStartsWith,
+  assertTrue,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const regionName = "us-east-1";
+
+/**
+ * A stack holding a function sim Lambda declines on its Runtime, beside the
+ * log group CDK writes for a function: `/aws/lambda/` joined to a Ref of it.
+ *
+ * Neither Resource is named by the template, so both names come from
+ * CloudFormation, which is what makes the Ref worth asserting on.
+ */
+const skippedFunctionStack = {
+  Resources: {
+    ReportFunction: {
+      Type: "AWS::Lambda::Function",
+      Properties: {
+        Role: "arn:aws:iam::111111111111:role/ReportRole",
+        Handler: "index.handler",
+        Runtime: "python3.13",
+        Code: { ZipFile: "def handler(event, context): return 'report'" },
+      },
+    },
+    ReportFunctionLogGroup: {
+      Type: "AWS::Logs::LogGroup",
+      Properties: {
+        LogGroupName: {
+          "Fn::Join": ["", ["/aws/lambda/", { Ref: "ReportFunction" }]],
+        },
+      },
+    },
+  },
+};
+
+describe("a Lambda function skipped on its runtime", () => {
+  it("answers Ref with the name CloudFormation generates for it", async () => {
+    // Given the stack with the Python function and its log group.
+    const simAws = new SimAws({ defaultRegionName: regionName });
+
+    // When it is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "ReportStack",
+      template: skippedFunctionStack,
+    });
+
+    // Then the function is skipped, and answers Ref with the name a real
+    // deployment would have given it rather than with its logical ID.
+    const functionResource = stack.getResource("ReportFunction");
+
+    assertNonNullable(functionResource);
+    assertTrue(functionResource.skipped);
+    assertTypeString(functionResource.refValue);
+    assertStringStartsWith(
+      functionResource.refValue,
+      "ReportStack-ReportFunction-",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("names the log group that joins its Ref after the generated name", async () => {
+    // Given the same stack.
+    const simAws = new SimAws({ defaultRegionName: regionName });
+
+    // When it is deployed through sim CloudFormation.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "ReportStack",
+      template: skippedFunctionStack,
+    });
+
+    // Then a log group exists under the name the joined Ref produces, which
+    // carries the stack name the way a real deployment's does.
+    const logGroupResource = stack.getResource("ReportFunctionLogGroup");
+
+    assertNonNullable(logGroupResource);
+    assertIdentical(logGroupResource.status, "CREATE_COMPLETE");
+
+    const [logGroup] = simAws.logs().allLogGroups();
+
+    assertNonNullable(logGroup);
+    assertStringStartsWith(
+      logGroup.logGroupName,
+      "/aws/lambda/ReportStack-ReportFunction-",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+
+  it("deploys as a Role scoped to the stack-name prefixes", async () => {
+    // Given a deploy Role allowed Lambda on the functions of this stack and
+    // CloudWatch Logs on their log groups, and nothing else, as a shared
+    // account tightens a deployment to.
+    const simAws = new SimAws({ defaultRegionName: regionName });
+    const accountId = simAws.defaultAccountId;
+    const deployer = await deployRole(simAws, [
+      `arn:aws:lambda:${regionName}:${accountId}:function:ReportStack-*`,
+      `arn:aws:logs:${regionName}:${accountId}:log-group:/aws/lambda/ReportStack-*`,
+    ]);
+
+    // When the stack is deployed as that Role.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "ReportStack",
+      template: skippedFunctionStack,
+      caller: deployer,
+    });
+
+    // Then the log group was created, because the skipped function's Ref put
+    // it under the prefix an account would have allowed it under.
+    assertIdentical(
+      stack.getResource("ReportFunctionLogGroup")?.status,
+      "CREATE_COMPLETE",
+    );
+
+    await simAws.backgroundTasksComplete();
+  });
+});
+
+/**
+ * A Role a deployment can run as, allowed everything on the resources it names
+ * and nothing anywhere else.
+ */
+async function deployRole(
+  simAws: SimAws,
+  resources: readonly string[],
+): Promise<SimAwsCaller> {
+  const roleName = "DeployRole";
+  const iam = simAws.iam();
+
+  await iam.createRole({
+    input: {
+      RoleName: roleName,
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Action: "sts:AssumeRole",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+        },
+      }),
+    },
+  });
+
+  await iam.putRolePolicy({
+    input: {
+      RoleName: roleName,
+      PolicyName: "DeployPolicy",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: { Action: ["lambda:*", "logs:*"], Resource: resources },
+      }),
+    },
+  });
+
+  return {
+    kind: "arn",
+    arn: `arn:aws:iam::${simAws.defaultAccountId}:role/${roleName}`,
+  };
+}


### PR DESCRIPTION
A skipped Resource answers Ref with its logical ID. That stands in for a value the simulation does not hold, and a service that names a Resource before refusing it leaves the simulation holding one. Sim Lambda declines CDK's own Python provider functions on their Runtime, and CDK writes a function's log group name as `/aws/lambda/` joined to a Ref of the function. The log group was created under `/aws/lambda/<logical ID>`, a name real CloudFormation would never produce, which costs a project any test of a policy scoped by stack-name prefix. A refusal now carries the name the service worked out for the Resource, through `SimCfnNamedSkip`, and the Resource answers Ref with it. Anything refused before a name existed keeps the logical ID.

Resolves #1272