### PR TITLE
feat: read iam:PermissionsBoundary on CreateRole

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -260,6 +260,11 @@ from the resolved caller and `aws:RequestedRegion` from the Region the request w
 service supplies under either name is overwritten by the derived one. Context-key names are matched
 case-insensitively, while string values remain case-sensitive.
 
+IAM's own requests carry two service keys. A Role handed to a service carries
+[`iam:PassedToService`](#passing-a-role-to-a-service), and a `CreateRole` request carries the
+boundary it declares as
+[`iam:PermissionsBoundary`](#creating-a-role-under-a-permissions-boundary).
+
 Every simulated service supplies its own Region. A policy conditioned on `aws:RequestedRegion`
 therefore sees the Region of the service that handled the request, whichever Region the caller was
 in, and a CloudFormation deployment carries the Region of the Stack it is deploying. IAM, CloudFront
@@ -1045,6 +1050,104 @@ await simAws.backgroundTasksComplete();
 A request naming no caller is decided as the Account root, which may pass any Role. A test that never
 mentions IAM keeps working.
 
+## Creating a Role under a permissions boundary
+
+An account that requires every Role to carry a permissions boundary allows `iam:CreateRole` only
+under `StringEquals` on `iam:PermissionsBoundary`. Its CloudFormation execution policy is written
+that way, and the CDK `PermissionsBoundary.fromName(...)` aspect puts the boundary ARN on every Role
+the app synthesizes. Both halves meet here. A `CreateRoleCommand` carrying `PermissionsBoundary`
+supplies the key, and `AWS::IAM::Role` supplies it from the template property of the same name.
+
+A request that leaves the property out leaves the key unset, and a positive operator over an unset
+key matches nothing, so the guard refuses the Role. A request naming some other policy is refused
+too. A test can assert both, which is what makes the policy worth standing up as a deploy Role in
+the first place.
+
+The boundary is recorded on the Role the request created. It is not yet evaluated as a policy source
+of its own, so it does not narrow what that Role may then do (see [Limitations](#limitations)).
+
+```typescript sim-iam-permissions-boundary
+/**
+ * Deploying into an account that requires a permissions boundary.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const boundaryArn = "arn:aws:iam::123456789012:policy/DeveloperBoundary";
+
+const deployer = await simAws.iam().makeDeployRole({
+  roleName: "cfn-exec",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: "iam:CreateRole",
+        Resource: "*",
+        Condition: {
+          StringEquals: { "iam:PermissionsBoundary": boundaryArn },
+        },
+      },
+      {
+        Effect: "Allow",
+        Action: ["cloudformation:*", "iam:PutRolePolicy", "iam:PassRole"],
+        Resource: "*",
+      },
+    ],
+  },
+});
+
+const jobRoleTrust = {
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Action: "sts:AssumeRole",
+    Principal: { Service: "lambda.amazonaws.com" },
+  },
+};
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "guarded-stack",
+  template: {
+    Resources: {
+      JobRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "JobRole",
+          PermissionsBoundary: boundaryArn,
+          AssumeRolePolicyDocument: jobRoleTrust,
+        },
+      },
+    },
+  },
+  caller: deployer,
+});
+
+// CREATE_COMPLETE
+console.log(stack.getResource("JobRole")?.status);
+
+try {
+  await simAws.cloudFormation().deployTemplate({
+    stackName: "unguarded-stack",
+    template: {
+      Resources: {
+        BareRole: {
+          Type: "AWS::IAM::Role",
+          Properties: {
+            RoleName: "BareRole",
+            AssumeRolePolicyDocument: jobRoleTrust,
+          },
+        },
+      },
+    },
+    caller: deployer,
+  });
+} catch (error) {
+  console.error("A Role declaring no boundary was refused", error);
+}
+```
+
 ## A Role for a CloudFormation deployment
 
 `makeDeployRole(...)` creates a Role from a policy document and hands back a caller. Pass it as
@@ -1240,6 +1343,11 @@ For `AWS::IAM::Role`, `Ref` returns the Role name and `Fn::GetAtt` supports `Arn
 the logical ID when it is omitted, and inline `Policies` declared on a Role are stored as the
 Role's inline policies. The `ReadOnlyAccess` policy above is attached to `LambdaExecutionRole`.
 Authorization for that Role reads the policy document the template gave it.
+
+A Role's `PermissionsBoundary` reaches the authorization decision the deployment is made under, and
+is recorded on the Role it names.
+[Creating a Role under a permissions boundary](#creating-a-role-under-a-permissions-boundary) covers
+the guard it exists for.
 
 ### Users
 
@@ -1534,6 +1642,8 @@ Sim IAM currently supports:
 - IAM authorization at simulated service boundaries, such as Route53 actions
 - `iam:PassRole` authorization of a Role handed to simulated Lambda, Scheduler, EventBridge, Step
   Functions, ECS or Firehose, with `iam:PassedToService` supplied
+- `iam:CreateRole` authorization against `iam:PermissionsBoundary`, from the `PermissionsBoundary`
+  a request or an `AWS::IAM::Role` declares
 - Resolving the caller of an HTTP request, from an `x-sim-aws-caller` header or a verified SigV4
   signature, defaulting to anonymous, and the resource it is made on behalf of from
   `x-sim-aws-source-arn` and `x-sim-aws-source-account`
@@ -1551,8 +1661,10 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
 
 - Groups are absent. An `AWS::IAM::User` naming one fails, and an `AWS::IAM::Policy` naming one
   fails too
-- Permissions boundaries and session policies are not evaluated. Service control policies are, and
-  are attached through [simulated Organizations](https://yulinsim.dev/services/organizations/ "Simulated Organizations service control policies usage docs")
+- Permissions boundaries and session policies are not evaluated. A boundary a `CreateRole` request
+  declares is authorized against `iam:PermissionsBoundary` and recorded on the Role, and stops
+  there. Service control policies are evaluated, and are attached through
+  [simulated Organizations](https://yulinsim.dev/services/organizations/ "Simulated Organizations service control policies usage docs")
 - Managed Policies have a single version, and the policy version commands are absent
 - A policy document is measured against IAM's character limit one document at a time. The
   20,480-character cap on the sum of a User's inline policies is absent, and so is the cap on how

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -1055,22 +1055,26 @@ mentions IAM keeps working.
 An account that requires every Role to carry a permissions boundary allows `iam:CreateRole` only
 under `StringEquals` on `iam:PermissionsBoundary`. Its CloudFormation execution policy is written
 that way, and the CDK `PermissionsBoundary.fromName(...)` aspect puts the boundary ARN on every Role
-the app synthesizes. Both halves meet here. A `CreateRoleCommand` carrying `PermissionsBoundary`
-supplies the key, and `AWS::IAM::Role` supplies it from the template property of the same name.
+the app synthesizes. A `CreateRoleCommand` carrying `PermissionsBoundary` supplies the key, and
+`AWS::IAM::Role` supplies it from the template property of the same name.
 
-A request that leaves the property out leaves the key unset, and a positive operator over an unset
-key matches nothing, so the guard refuses the Role. A request naming some other policy is refused
-too. A test can assert both, which is what makes the policy worth standing up as a deploy Role in
-the first place.
+A request that leaves the property out leaves the key unset. A positive operator over an unset key
+matches nothing, and the guard refuses the Role. A request naming some other policy is refused the
+same way. A test can assert both refusals, and that is what makes the policy worth standing up as a
+deploy Role.
 
-The boundary is recorded on the Role the request created. It is not yet evaluated as a policy source
-of its own, so it does not narrow what that Role may then do (see [Limitations](#limitations)).
+`CreateRole` and `GetRole` then describe the boundary the Role carries, in the attachment shape IAM
+answers with (`PermissionsBoundaryType` and `PermissionsBoundaryArn`). `ListRoles` leaves the field
+out, as IAM does, and points a caller at `GetRole`. The boundary is not yet evaluated as a policy
+source of its own, and does not narrow what the Role may then do
+(see [Limitations](#limitations)).
 
 ```typescript sim-iam-permissions-boundary
 /**
  * Deploying into an account that requires a permissions boundary.
  */
 
+import { GetRoleCommand } from "@aws-sdk/client-iam";
 import { SimAws } from "@kensio/yulin";
 
 const simAws = new SimAws({ defaultAccountId: "123456789012" });
@@ -1126,6 +1130,13 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 // CREATE_COMPLETE
 console.log(stack.getResource("JobRole")?.status);
+
+const roleRead = await simAws
+  .iam()
+  .getRole(new GetRoleCommand({ RoleName: "JobRole" }));
+
+// arn:aws:iam::123456789012:policy/DeveloperBoundary
+console.log(roleRead.Role.PermissionsBoundary?.PermissionsBoundaryArn);
 
 try {
   await simAws.cloudFormation().deployTemplate({
@@ -1662,7 +1673,7 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
 - Groups are absent. An `AWS::IAM::User` naming one fails, and an `AWS::IAM::Policy` naming one
   fails too
 - Permissions boundaries and session policies are not evaluated. A boundary a `CreateRole` request
-  declares is authorized against `iam:PermissionsBoundary` and recorded on the Role, and stops
+  declares is authorized against `iam:PermissionsBoundary` and described by `GetRole`, and stops
   there. Service control policies are evaluated, and are attached through
   [simulated Organizations](https://yulinsim.dev/services/organizations/ "Simulated Organizations service control policies usage docs")
 - Managed Policies have a single version, and the policy version commands are absent

--- a/docs/services/iam/sim-iam-permissions-boundary.example.ts
+++ b/docs/services/iam/sim-iam-permissions-boundary.example.ts
@@ -1,0 +1,79 @@
+/**
+ * Deploying into an account that requires a permissions boundary.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws({ defaultAccountId: "123456789012" });
+const boundaryArn = "arn:aws:iam::123456789012:policy/DeveloperBoundary";
+
+const deployer = await simAws.iam().makeDeployRole({
+  roleName: "cfn-exec",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: "iam:CreateRole",
+        Resource: "*",
+        Condition: {
+          StringEquals: { "iam:PermissionsBoundary": boundaryArn },
+        },
+      },
+      {
+        Effect: "Allow",
+        Action: ["cloudformation:*", "iam:PutRolePolicy", "iam:PassRole"],
+        Resource: "*",
+      },
+    ],
+  },
+});
+
+const jobRoleTrust = {
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Action: "sts:AssumeRole",
+    Principal: { Service: "lambda.amazonaws.com" },
+  },
+};
+
+const stack = await simAws.cloudFormation().deployTemplate({
+  stackName: "guarded-stack",
+  template: {
+    Resources: {
+      JobRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "JobRole",
+          PermissionsBoundary: boundaryArn,
+          AssumeRolePolicyDocument: jobRoleTrust,
+        },
+      },
+    },
+  },
+  caller: deployer,
+});
+
+// CREATE_COMPLETE
+console.log(stack.getResource("JobRole")?.status);
+
+try {
+  await simAws.cloudFormation().deployTemplate({
+    stackName: "unguarded-stack",
+    template: {
+      Resources: {
+        BareRole: {
+          Type: "AWS::IAM::Role",
+          Properties: {
+            RoleName: "BareRole",
+            AssumeRolePolicyDocument: jobRoleTrust,
+          },
+        },
+      },
+    },
+    caller: deployer,
+  });
+} catch (error) {
+  console.error("A Role declaring no boundary was refused", error);
+}

--- a/docs/services/iam/sim-iam-permissions-boundary.example.ts
+++ b/docs/services/iam/sim-iam-permissions-boundary.example.ts
@@ -2,6 +2,7 @@
  * Deploying into an account that requires a permissions boundary.
  */
 
+import { GetRoleCommand } from "@aws-sdk/client-iam";
 import { SimAws } from "@kensio/yulin";
 
 const simAws = new SimAws({ defaultAccountId: "123456789012" });
@@ -57,6 +58,13 @@ const stack = await simAws.cloudFormation().deployTemplate({
 
 // CREATE_COMPLETE
 console.log(stack.getResource("JobRole")?.status);
+
+const roleRead = await simAws
+  .iam()
+  .getRole(new GetRoleCommand({ RoleName: "JobRole" }));
+
+// arn:aws:iam::123456789012:policy/DeveloperBoundary
+console.log(roleRead.Role.PermissionsBoundary?.PermissionsBoundaryArn);
 
 try {
   await simAws.cloudFormation().deployTemplate({

--- a/src/service/cloudformation/deploy/sim-cfn-deployment-permissions-boundary.iso.test.ts
+++ b/src/service/cloudformation/deploy/sim-cfn-deployment-permissions-boundary.iso.test.ts
@@ -1,0 +1,152 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import { makeSimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import type { SimIamRole } from "../../iam/role/sim-iam-role.js";
+import type { CfnTemplateBodyRecord } from "../template/sim-cfn-template.js";
+
+/**
+ * A deployment into an account that requires a permissions boundary.
+ *
+ * The execution policy allows iam:CreateRole only under the boundary, and the
+ * CDK `PermissionsBoundary.fromName(...)` aspect writes the ARN onto every
+ * Role the app synthesizes. A Stack the aspect has not been applied to fails
+ * on its first Role, which is what the guard exists to do.
+ */
+describe("a deployment into an account requiring a permissions boundary", () => {
+  it("creates the Role its template declares the boundary on", async () => {
+    // Given a deploy Role allowed iam:CreateRole only under the account's
+    // boundary.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await deployRole(simAws, accountId);
+
+    // When it deploys a Stack whose Role declares that boundary, as the CDK
+    // aspect writes it.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "reports-stack",
+      template: jobStackTemplate(boundaryArn(accountId)),
+      caller: deployer,
+    });
+
+    // Then the Role was created carrying the boundary the template named.
+    assertIdentical(stack.getResource("JobRole")?.status, "CREATE_COMPLETE");
+
+    const role = stack.getResource("JobRole")?.simResource as
+      | SimIamRole
+      | undefined;
+
+    assertNonNullable(role);
+    assertIdentical(role.permissionsBoundaryArn, boundaryArn(accountId));
+  });
+
+  it("fails the Role its template leaves the boundary off", async () => {
+    // Given the same deploy Role.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const deployer = await deployRole(simAws, accountId);
+
+    // When it deploys a Stack whose Role declares no boundary.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName: "reports-stack",
+        template: jobStackTemplate(undefined),
+        caller: deployer,
+      });
+    });
+
+    // Then the deployment stopped at the Role, naming the deploy Role that
+    // was refused.
+    assertStringIncludes(
+      error.message,
+      `arn:aws:iam::${accountId}:role/deployer is not authorized to ` +
+        `perform: iam:CreateRole on resource: ` +
+        `arn:aws:iam::${accountId}:role/JobRole`,
+    );
+
+    const stack = simAws.cloudFormation().getStackByName("reports-stack");
+
+    assertNonNullable(stack);
+    assertIdentical(stack.getResource("JobRole")?.status, "CREATE_FAILED");
+  });
+});
+
+/**
+ * The boundary policy the account requires every Role to carry.
+ */
+function boundaryArn(accountId: SimAwsAccountId): string {
+  return `arn:aws:iam::${accountId}:policy/DeveloperBoundary`;
+}
+
+/**
+ * A Stack declaring one Role, with or without a boundary on it.
+ */
+function jobStackTemplate(
+  permissionsBoundary: string | undefined,
+): CfnTemplateBodyRecord {
+  return {
+    Resources: {
+      JobRole: {
+        Type: "AWS::IAM::Role",
+        Properties: {
+          RoleName: "JobRole",
+          ...(permissionsBoundary !== undefined && {
+            PermissionsBoundary: permissionsBoundary,
+          }),
+          AssumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: {
+              Effect: "Allow",
+              Action: "sts:AssumeRole",
+              Principal: { Service: "lambda.amazonaws.com" },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * A Role a deployment can run as, allowed to create Roles only under the
+ * account's boundary.
+ */
+async function deployRole(
+  simAws: SimAws,
+  accountId: SimAwsAccountId,
+): Promise<SimAwsCaller> {
+  return await simAws
+    .account(accountId)
+    .iam()
+    .makeDeployRole({
+      roleName: "deployer",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: "iam:CreateRole",
+            Resource: "*",
+            Condition: {
+              StringEquals: {
+                "iam:PermissionsBoundary": boundaryArn(accountId),
+              },
+            },
+          },
+          {
+            Effect: "Allow",
+            Action: ["cloudformation:*", "iam:PutRolePolicy", "iam:PassRole"],
+            Resource: "*",
+          },
+        ],
+      },
+    });
+}

--- a/src/service/iam/authorize/sim-iam-action-authorizer.ts
+++ b/src/service/iam/authorize/sim-iam-action-authorizer.ts
@@ -1,5 +1,6 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import { SimIamAccessDenied } from "../error/sim-iam.error.js";
+import type { SimIamConditionValue } from "../policy/sim-iam-policy.js";
 import type { SimIamInterServiceAuthZ } from "./sim-iam-inter-service-auth-z.js";
 
 interface SimIamActionAuthorizerProperties {
@@ -12,8 +13,9 @@ interface SimIamActionAuthorizerProperties {
  *
  * This shared authorizer suits services whose commands map one-to-one onto an
  * IAM action and resource ARN, such as the IAM and CloudFormation control
- * planes. Commands needing richer context, such as condition values, use
- * their own per-command authorizers instead.
+ * planes. A command carrying a condition value of its own passes it here.
+ * Commands needing more than that, such as a service that hands a Role over,
+ * use their own per-command authorizers instead.
  */
 export class SimIamActionAuthorizer {
   private readonly iam: SimIamInterServiceAuthZ;
@@ -28,9 +30,22 @@ export class SimIamActionAuthorizer {
    * The caller is passed through unchanged so sim IAM can distinguish an
    * omitted caller, which defaults to Account root, from an explicit
    * anonymous caller, which has no identity policy permissions.
+   *
+   * Condition values the request itself carries are supplied last, since most
+   * commands carry none and read better without an empty record.
    */
-  authorize(action: string, resource: string, caller?: SimAwsCaller): void {
-    const decision = this.iam.authorize({ action, resource, caller });
+  authorize(
+    action: string,
+    resource: string,
+    caller?: SimAwsCaller,
+    conditionContext?: Readonly<Record<string, SimIamConditionValue>>,
+  ): void {
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller,
+      conditionContext,
+    });
 
     if (decision.isDenied) {
       throw new SimIamAccessDenied({

--- a/src/service/iam/cfn/role/sim-cfn-iam-role-creator.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role-creator.ts
@@ -41,6 +41,7 @@ export class SimCfnIamRoleCreator {
           Path: roleProperties.path,
           Description: roleProperties.description,
           AssumeRolePolicyDocument: roleProperties.assumeRolePolicyDocument,
+          PermissionsBoundary: roleProperties.permissionsBoundary,
         },
       },
       options,

--- a/src/service/iam/cfn/role/sim-cfn-iam-role-properties-parser.ts
+++ b/src/service/iam/cfn/role/sim-cfn-iam-role-properties-parser.ts
@@ -1,7 +1,13 @@
+/* oxlint-disable security/detect-object-injection -- each lookup here reads a
+   template property under the name this parser asks for by literal. */
+
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { simCfnIamPrincipalGeneratedName } from "../name/sim-cfn-iam-generated-name.js";
-import { simCfnIamOptionalString } from "../sim-cfn-iam-optional-string.js";
+import {
+  simCfnIamJsonObject,
+  simCfnIamOptionalString,
+} from "../sim-cfn-iam-property.js";
 import {
   SimCfnIamPoliciesParser,
   type SimCfnIamInlinePolicy,
@@ -12,9 +18,12 @@ export interface SimCfnIamRoleProperties {
   readonly path: string | undefined;
   readonly description: string | undefined;
   readonly assumeRolePolicyDocument: string;
+  readonly permissionsBoundary: string | undefined;
   readonly inlinePolicies: readonly SimCfnIamInlinePolicy[];
   readonly managedPolicyArns: readonly string[];
 }
+
+const resourceType = "AWS::IAM::Role";
 
 /**
  * Parses and validates AWS::IAM::Role CloudFormation properties into the shape
@@ -25,7 +34,7 @@ export interface SimCfnIamRoleProperties {
  */
 export class SimCfnIamRolePropertiesParser {
   private readonly policiesParser = new SimCfnIamPoliciesParser({
-    resourceType: "AWS::IAM::Role",
+    resourceType,
   });
 
   /**
@@ -37,18 +46,15 @@ export class SimCfnIamRolePropertiesParser {
   ): SimCfnIamRoleProperties {
     return {
       roleName:
-        this.optionalString(resource, properties["RoleName"], "RoleName") ??
+        this.optionalString(resource, properties, "RoleName") ??
         simCfnIamPrincipalGeneratedName(resource),
-      path: this.optionalString(resource, properties["Path"], "Path"),
-      description: this.optionalString(
+      path: this.optionalString(resource, properties, "Path"),
+      description: this.optionalString(resource, properties, "Description"),
+      assumeRolePolicyDocument: this.jsonObject(resource, properties),
+      permissionsBoundary: this.optionalString(
         resource,
-        properties["Description"],
-        "Description",
-      ),
-      assumeRolePolicyDocument: this.jsonObject(
-        resource,
-        properties["AssumeRolePolicyDocument"],
-        "AssumeRolePolicyDocument",
+        properties,
+        "PermissionsBoundary",
       ),
       inlinePolicies: this.policiesParser.inlinePolicies(resource, properties),
       managedPolicyArns: this.policiesParser.managedPolicyArns(
@@ -60,28 +66,28 @@ export class SimCfnIamRolePropertiesParser {
 
   private optionalString(
     resource: SimCfnResource,
-    value: SimCfnTemplateValueRecord[string] | undefined,
+    properties: SimCfnTemplateValueRecord,
     label: string,
   ): string | undefined {
     return simCfnIamOptionalString({
-      resourceType: "AWS::IAM::Role",
+      resourceType,
       resource,
-      value,
+      value: properties[label],
       label,
     });
   }
 
   private jsonObject(
     resource: SimCfnResource,
-    value: SimCfnTemplateValueRecord[string] | undefined,
-    label: string,
+    properties: SimCfnTemplateValueRecord,
   ): string {
-    if (typeof value !== "object" || value === null || Array.isArray(value)) {
-      throw new TypeError(
-        `Invalid AWS::IAM::Role ${resource.logicalId}: ${label} must be an object`,
-      );
-    }
+    const label = "AssumeRolePolicyDocument";
 
-    return JSON.stringify(value);
+    return simCfnIamJsonObject({
+      resourceType,
+      resource,
+      value: properties[label],
+      label,
+    });
   }
 }

--- a/src/service/iam/cfn/sim-cfn-iam-property.ts
+++ b/src/service/iam/cfn/sim-cfn-iam-property.ts
@@ -1,7 +1,7 @@
 import type { SimCfnResource } from "../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
 
-interface SimCfnIamOptionalStringProperties {
+interface SimCfnIamPropertyInput {
   readonly resourceType: string;
   readonly resource: SimCfnResource;
   readonly value: SimCfnTemplateValueRecord[string] | undefined;
@@ -16,7 +16,7 @@ interface SimCfnIamOptionalStringProperties {
  * declared.
  */
 export function simCfnIamOptionalString(
-  properties: SimCfnIamOptionalStringProperties,
+  properties: SimCfnIamPropertyInput,
 ): string | undefined {
   const { resourceType, resource, value, label } = properties;
 
@@ -31,4 +31,25 @@ export function simCfnIamOptionalString(
   }
 
   return value;
+}
+
+/**
+ * Read a JSON-object property an IAM Resource requires.
+ *
+ * A Role's trust policy arrives as the object the template wrote, and IAM
+ * takes its policy documents as JSON text. A value of any other shape fails
+ * the Resource, naming the Resource type the template declared.
+ */
+export function simCfnIamJsonObject(
+  properties: SimCfnIamPropertyInput,
+): string {
+  const { resourceType, resource, value, label } = properties;
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(
+      `Invalid ${resourceType} ${resource.logicalId}: ${label} must be an object`,
+    );
+  }
+
+  return JSON.stringify(value);
 }

--- a/src/service/iam/cfn/user/sim-cfn-iam-user-properties-parser.ts
+++ b/src/service/iam/cfn/user/sim-cfn-iam-user-properties-parser.ts
@@ -1,7 +1,7 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import { simCfnIamPrincipalGeneratedName } from "../name/sim-cfn-iam-generated-name.js";
-import { simCfnIamOptionalString } from "../sim-cfn-iam-optional-string.js";
+import { simCfnIamOptionalString } from "../sim-cfn-iam-property.js";
 import {
   SimCfnIamPoliciesParser,
   type SimCfnIamInlinePolicy,

--- a/src/service/iam/command/role/create-role/create-role-permissions-boundary.iso.test.ts
+++ b/src/service/iam/command/role/create-role/create-role-permissions-boundary.iso.test.ts
@@ -1,0 +1,199 @@
+import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import {
+  assertIdentical,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { makeSimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import type { SimAwsAccountId } from "../../../../aws/sim-aws-account.js";
+import type { SimAwsCaller } from "../../../../aws/caller/sim-aws-caller.js";
+import type { SimIam } from "../../../sim-iam.js";
+import type { SimIamRoleName } from "../../../role/sim-iam-role.js";
+import { jsonStringify } from "../../../../../util/type-guard/json.js";
+
+/**
+ * The permissions-boundary guard on iam:CreateRole.
+ *
+ * An account that requires every Role to carry a boundary writes its
+ * CloudFormation execution policy this way, and the CDK
+ * `PermissionsBoundary.fromName(...)` aspect puts the ARN on each Role it
+ * synthesizes. The condition is what makes the two halves meet.
+ */
+describe("IAM CreateRole under an iam:PermissionsBoundary condition", () => {
+  it("creates the Role a request declares the named boundary on", async () => {
+    // Given a deploy Role allowed iam:CreateRole only under the boundary its
+    // account requires.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const deployer = await deployRole(simIam, accountId);
+
+    // When it creates a Role declaring that boundary.
+    const roleCreation = await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "ReportsRole",
+        AssumeRolePolicyDocument: lambdaTrustPolicy,
+        PermissionsBoundary: boundaryArn(accountId),
+      }),
+      { caller: deployer },
+    );
+
+    // Then the condition matched and the Role carries the boundary.
+    assertIdentical(roleCreation.Role.RoleName, "ReportsRole");
+    assertIdentical(
+      simIam.roles.get("ReportsRole" as SimIamRoleName)?.permissionsBoundaryArn,
+      boundaryArn(accountId),
+    );
+  });
+
+  it("refuses a Role declaring a boundary the condition does not name", async () => {
+    // Given the same deploy Role.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const deployer = await deployRole(simIam, accountId);
+
+    // When it creates a Role declaring some other policy as its boundary.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simIam.createRole(
+        new CreateRoleCommand({
+          RoleName: "UnguardedRole",
+          AssumeRolePolicyDocument: lambdaTrustPolicy,
+          PermissionsBoundary: `arn:aws:iam::${accountId}:policy/Anything`,
+        }),
+        { caller: deployer },
+      );
+    });
+
+    // Then the request was refused and no Role was created.
+    assertStringIncludes(
+      error.message,
+      `arn:aws:iam::${accountId}:role/deployer is not authorized to ` +
+        `perform: iam:CreateRole on resource: ` +
+        `arn:aws:iam::${accountId}:role/UnguardedRole`,
+    );
+    assertUndefined(simIam.roles.get("UnguardedRole" as SimIamRoleName));
+  });
+
+  it("refuses a Role declaring no boundary at all", async () => {
+    // Given the same deploy Role.
+    const accountId = makeSimAwsAccountId();
+    const simAws = new SimAws({ defaultAccountId: accountId });
+    const simIam = simAws.iam();
+    const deployer = await deployRole(simIam, accountId);
+
+    // When it creates a Role that leaves PermissionsBoundary out, which
+    // leaves the condition key unset.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simIam.createRole(
+        new CreateRoleCommand({
+          RoleName: "BareRole",
+          AssumeRolePolicyDocument: lambdaTrustPolicy,
+        }),
+        { caller: deployer },
+      );
+    });
+
+    // Then the statement matched nothing, which is the guard doing its job.
+    assertStringIncludes(error.message, "iam:CreateRole");
+    assertUndefined(simIam.roles.get("BareRole" as SimIamRoleName));
+  });
+
+  it("leaves the boundary off a Role created without one", async () => {
+    // Given an IAM service whose Account root may create any Role.
+    const simAws = new SimAws({ defaultAccountId: makeSimAwsAccountId() });
+    const simIam = simAws.iam();
+
+    // When a Role is created with no boundary.
+    await simIam.createRole(
+      new CreateRoleCommand({
+        RoleName: "PlainRole",
+        AssumeRolePolicyDocument: lambdaTrustPolicy,
+      }),
+    );
+
+    // Then the Role records none, rather than an empty one.
+    assertUndefined(
+      simIam.roles.get("PlainRole" as SimIamRoleName)?.permissionsBoundaryArn,
+    );
+  });
+});
+
+/**
+ * The trust a Role a function runs as needs.
+ */
+const lambdaTrustPolicy = jsonStringify({
+  Version: "2012-10-17",
+  Statement: {
+    Effect: "Allow",
+    Action: "sts:AssumeRole",
+    Principal: { Service: "lambda.amazonaws.com" },
+  },
+});
+
+/**
+ * The boundary policy the account requires every Role to carry.
+ */
+function boundaryArn(accountId: SimAwsAccountId): string {
+  return `arn:aws:iam::${accountId}:policy/DeveloperBoundary`;
+}
+
+/**
+ * A Role allowed to create Roles only under the account's boundary, which is
+ * how the CDK permissions-boundary guard is written.
+ */
+async function deployRole(
+  simIam: SimIam,
+  accountId: SimAwsAccountId,
+): Promise<SimAwsCaller> {
+  const creation = await simIam.createRole({
+    input: {
+      RoleName: "deployer",
+      AssumeRolePolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "sts:AssumeRole",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+        },
+      }),
+    },
+  });
+
+  await simIam.putRolePolicy({
+    input: {
+      RoleName: "deployer",
+      PolicyName: "deployer-policy",
+      PolicyDocument: jsonStringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: "iam:CreateRole",
+            Resource: "*",
+            Condition: {
+              StringEquals: {
+                "iam:PermissionsBoundary": boundaryArn(accountId),
+              },
+            },
+          },
+          {
+            Effect: "Allow",
+            Action: [
+              "iam:PutRolePolicy",
+              "iam:AttachRolePolicy",
+              "iam:PassRole",
+            ],
+            Resource: "*",
+          },
+        ],
+      }),
+    },
+  });
+
+  return { kind: "arn", arn: creation.Role.Arn };
+}

--- a/src/service/iam/command/role/create-role/create-role-permissions-boundary.iso.test.ts
+++ b/src/service/iam/command/role/create-role/create-role-permissions-boundary.iso.test.ts
@@ -1,4 +1,4 @@
-import { CreateRoleCommand } from "@aws-sdk/client-iam";
+import { CreateRoleCommand, GetRoleCommand } from "@aws-sdk/client-iam";
 import {
   assertIdentical,
   assertStringIncludes,
@@ -116,7 +116,13 @@ describe("IAM CreateRole under an iam:PermissionsBoundary condition", () => {
       }),
     );
 
-    // Then the Role records none, rather than an empty one.
+    // Then the Role has no attachment to describe, and IAM leaves the field
+    // out rather than answering an empty one.
+    const roleRead = await simIam.getRole(
+      new GetRoleCommand({ RoleName: "PlainRole" }),
+    );
+
+    assertUndefined(roleRead.Role.PermissionsBoundary);
     assertUndefined(
       simIam.roles.get("PlainRole" as SimIamRoleName)?.permissionsBoundaryArn,
     );

--- a/src/service/iam/command/role/create-role/create-role-record-factory.ts
+++ b/src/service/iam/command/role/create-role/create-role-record-factory.ts
@@ -42,6 +42,9 @@ export class CreateRoleRecordFactory {
         | undefined,
       description: cmd.input.Description,
       creationDate,
+      permissionsBoundaryArn: cmd.input.PermissionsBoundary as
+        | SimArn
+        | undefined,
       inlinePolicies: new Map(),
       attachedPolicyArns: new Set(),
     };

--- a/src/service/iam/command/role/create-role/create-role-record-factory.ts
+++ b/src/service/iam/command/role/create-role/create-role-record-factory.ts
@@ -9,6 +9,7 @@ import type { SimIamPolicyDocument } from "../../../policy/sim-iam-policy.js";
 import type { JSONString } from "../../../../../util/type-guard/json.js";
 import type { SimIamRole, SimIamRoleName } from "../../../role/sim-iam-role.js";
 import { makeSimIamRoleId } from "../../../role/sim-iam-role-id.js";
+import { simIamAttachedPermissionsBoundary } from "../../../role/sim-iam-role-boundary.js";
 
 interface MakeRoleProperties {
   readonly accountId: SimAwsAccountId;
@@ -63,6 +64,7 @@ export class CreateRoleRecordFactory {
         CreateDate: role.creationDate,
         AssumeRolePolicyDocument: role.assumeRolePolicyDocument,
         Description: role.description,
+        PermissionsBoundary: simIamAttachedPermissionsBoundary(role),
       },
     };
   }

--- a/src/service/iam/command/role/create-role/create-role.command.ts
+++ b/src/service/iam/command/role/create-role/create-role.command.ts
@@ -5,6 +5,15 @@ export interface SimCreateRoleCommandInput {
   readonly Path?: string | undefined;
   readonly AssumeRolePolicyDocument?: string | undefined;
   readonly Description?: string | undefined;
+
+  /**
+   * ARN of the managed policy to attach to the new Role as its permissions
+   * boundary.
+   *
+   * The request carries this ARN as `iam:PermissionsBoundary`, which is the
+   * key an account requiring a boundary conditions `iam:CreateRole` on.
+   */
+  readonly PermissionsBoundary?: string | undefined;
 }
 
 export interface SimCreateRoleCommand {

--- a/src/service/iam/command/role/create-role/create-role.command.ts
+++ b/src/service/iam/command/role/create-role/create-role.command.ts
@@ -1,4 +1,5 @@
 import type { SimArn } from "../../../../aws/arn.js";
+import type { SimIamAttachedPermissionsBoundary } from "../../../role/sim-iam-role-boundary.js";
 
 export interface SimCreateRoleCommandInput {
   readonly RoleName?: string | undefined;
@@ -29,5 +30,8 @@ export interface SimCreateRoleCommandOutput {
     readonly CreateDate: Date;
     readonly AssumeRolePolicyDocument?: string | undefined;
     readonly Description?: string | undefined;
+    readonly PermissionsBoundary?:
+      | SimIamAttachedPermissionsBoundary
+      | undefined;
   };
 }

--- a/src/service/iam/command/role/get-role/get-role.command.ts
+++ b/src/service/iam/command/role/get-role/get-role.command.ts
@@ -1,5 +1,6 @@
 import type { SimArn } from "../../../../aws/arn.js";
 import type { SimIamRoleName } from "../../../role/sim-iam-role.js";
+import type { SimIamAttachedPermissionsBoundary } from "../../../role/sim-iam-role-boundary.js";
 
 export interface SimGetRoleCommandInput {
   readonly RoleName?: string | undefined;
@@ -18,5 +19,8 @@ export interface SimGetRoleCommandOutput {
     readonly CreateDate: Date;
     readonly AssumeRolePolicyDocument?: string | undefined;
     readonly Description?: string | undefined;
+    readonly PermissionsBoundary?:
+      | SimIamAttachedPermissionsBoundary
+      | undefined;
   };
 }

--- a/src/service/iam/command/role/get-role/get-role.handler.ts
+++ b/src/service/iam/command/role/get-role/get-role.handler.ts
@@ -10,6 +10,7 @@ import type {
   SimGetRoleCommandOutput,
 } from "./get-role.command.js";
 import type { SimIamRole, SimIamRoleName } from "../../../role/sim-iam-role.js";
+import { simIamAttachedPermissionsBoundary } from "../../../role/sim-iam-role-boundary.js";
 
 interface GetRoleCommandHandlerProperties {
   readonly roles: Map<SimIamRoleName, SimIamRole>;
@@ -63,6 +64,7 @@ export class GetRoleCommandHandler implements CommandHandler<
         CreateDate: role.creationDate,
         AssumeRolePolicyDocument: role.assumeRolePolicyDocument,
         Description: role.description,
+        PermissionsBoundary: simIamAttachedPermissionsBoundary(role),
       },
     };
   }

--- a/src/service/iam/command/role/sim-iam-role-command-handlers.ts
+++ b/src/service/iam/command/role/sim-iam-role-command-handlers.ts
@@ -3,6 +3,7 @@ import type { SimIamActionAuthorizer } from "../../authorize/sim-iam-action-auth
 import type { SimIamRequestOptions } from "../sim-iam-request-options.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimIamRole, SimIamRoleName } from "../../role/sim-iam-role.js";
+import type { SimIamConditionValue } from "../../policy/sim-iam-policy.js";
 import { CreateRoleCommandHandler } from "./create-role/create-role.handler.js";
 import type {
   SimCreateRoleCommand,
@@ -86,6 +87,7 @@ export class SimIamRoleCommandHandlers {
       "iam:CreateRole",
       this.roleArn(command.input.RoleName),
       options?.caller,
+      permissionsBoundaryCondition(command.input.PermissionsBoundary),
     );
     const handler = new CreateRoleCommandHandler({
       accountId: this.accountId,
@@ -230,4 +232,21 @@ export class SimIamRoleCommandHandlers {
   private roleArn(roleName: string | undefined): string {
     return `arn:aws:iam::${this.accountId}:role/${roleName ?? "*"}`;
   }
+}
+
+/**
+ * What a Role-creating request says about the boundary it declares.
+ *
+ * An account that requires a permissions boundary allows `iam:CreateRole`
+ * only under `StringEquals` on `iam:PermissionsBoundary`, and the CDK
+ * permissions-boundary guard is written that way. A request declaring no
+ * boundary leaves the key out, which is what refuses it: a positive operator
+ * over an absent key matches nothing.
+ */
+function permissionsBoundaryCondition(
+  permissionsBoundary: string | undefined,
+): Readonly<Record<string, SimIamConditionValue>> | undefined {
+  return permissionsBoundary === undefined
+    ? undefined
+    : { "iam:PermissionsBoundary": permissionsBoundary };
 }

--- a/src/service/iam/role/sim-iam-role-boundary.ts
+++ b/src/service/iam/role/sim-iam-role-boundary.ts
@@ -1,0 +1,43 @@
+import type { SimArn } from "../../aws/arn.js";
+import type { SimIamRole } from "./sim-iam-role.js";
+
+/**
+ * A permissions boundary attached to a Role, as IAM describes one.
+ *
+ * IAM answers with the attachment rather than the bare ARN, and the type has
+ * only ever taken one value.
+ */
+export interface SimIamAttachedPermissionsBoundary {
+  readonly PermissionsBoundaryType: "PermissionsBoundaryPolicy";
+  readonly PermissionsBoundaryArn: SimArn;
+}
+
+/**
+ * The member names IAM describes an attached boundary with.
+ */
+export const simIamAttachedBoundaryMembers = [
+  "PermissionsBoundaryType",
+  "PermissionsBoundaryArn",
+];
+
+/**
+ * How a Role's boundary appears in a CreateRole or GetRole answer.
+ *
+ * A Role created without one has no attachment to describe, and IAM leaves
+ * the field out. `ListRoles` leaves it out whatever the Role carries, along
+ * with the Role's tags and last use, and points the caller at `GetRole`.
+ */
+export function simIamAttachedPermissionsBoundary(
+  role: SimIamRole,
+): SimIamAttachedPermissionsBoundary | undefined {
+  const permissionsBoundaryArn = role.permissionsBoundaryArn;
+
+  if (permissionsBoundaryArn === undefined) {
+    return undefined;
+  }
+
+  return {
+    PermissionsBoundaryType: "PermissionsBoundaryPolicy",
+    PermissionsBoundaryArn: permissionsBoundaryArn,
+  };
+}

--- a/src/service/iam/role/sim-iam-role.ts
+++ b/src/service/iam/role/sim-iam-role.ts
@@ -27,6 +27,17 @@ export interface SimIamRole extends SimIamPrincipal {
   readonly creationDate: Date;
 
   /**
+   * ARN of the managed policy attached to this Role as its permissions
+   * boundary, where the request creating it declared one.
+   *
+   * This records what the Role was created with, so that a policy conditioned
+   * on `iam:PermissionsBoundary` can be tested against the Roles a deployment
+   * makes. The boundary is not yet evaluated as a policy source, so it does
+   * not narrow what the Role itself may do.
+   */
+  readonly permissionsBoundaryArn?: SimArn | undefined;
+
+  /**
    * Inline identity-based permissions policies stored directly on this role.
    */
   readonly inlinePolicies: Map<string, JSONString<SimIamPolicyDocument>>;

--- a/src/service/iam/serve/sim-iam-api.loc.test.ts
+++ b/src/service/iam/serve/sim-iam-api.loc.test.ts
@@ -25,6 +25,7 @@ import {
   assertStringIncludes,
   assertThrowsErrorAsync,
   assertTrue,
+  assertUndefined,
 } from "@kensio/smartass";
 import { afterAll, beforeAll, describe, it } from "vitest";
 
@@ -129,13 +130,16 @@ describe("Serving simulated IAM on an endpoint URL", () => {
   });
 
   it("makes a Role, reads it back and lists it", async () => {
-    // Given a Role created over the endpoint with a trust policy
+    // Given a Role created over the endpoint with a trust policy and a
+    // permissions boundary
+    const boundaryArn = `arn:aws:iam::${simAws.defaultAccountId}:policy/Boundary`;
     const created = await client.send(
       new CreateRoleCommand({
         RoleName: "Checkout",
         Path: "/service-role/",
         AssumeRolePolicyDocument: lambdaTrustPolicy,
         Description: "The checkout function's Role",
+        PermissionsBoundary: boundaryArn,
       }),
     );
     const role = created.Role;
@@ -164,6 +168,26 @@ describe("Serving simulated IAM on an endpoint URL", () => {
     assertArrayIncludes(
       (listed.Roles ?? []).map((listedRole) => listedRole.RoleName),
       "Checkout",
+    );
+
+    // And the boundary travelled as the structure IAM answers with, on the
+    // create and the get, while the listing left it out as IAM does
+    const attachedBoundary = role.PermissionsBoundary;
+
+    assertNonNullable(attachedBoundary, "CreateRole described the boundary");
+    assertIdentical(
+      attachedBoundary.PermissionsBoundaryType,
+      "PermissionsBoundaryPolicy",
+    );
+    assertIdentical(attachedBoundary.PermissionsBoundaryArn, boundaryArn);
+    assertIdentical(
+      read.PermissionsBoundary?.PermissionsBoundaryArn,
+      boundaryArn,
+    );
+    assertUndefined(
+      (listed.Roles ?? []).find(
+        (listedRole) => listedRole.RoleName === "Checkout",
+      )?.PermissionsBoundary,
     );
   });
 

--- a/src/service/iam/serve/sim-iam-query-entity.ts
+++ b/src/service/iam/serve/sim-iam-query-entity.ts
@@ -15,15 +15,26 @@ import { xmlElement } from "../../../util/xml/xml-writer.js";
  * same structures are what a listing repeats. The Query layer writes the
  * members of a structure and the items of a list, and this is the one shape
  * left between them.
+ *
+ * An entity carrying a member of its own that is a structure passes `nested`,
+ * which writes whatever a scalar member cannot. A Role's permissions boundary
+ * is the case that exists for, and a listing that leaves it out passes
+ * nothing.
  */
 export function iamQueryEntity(
   output: SimQueryOutput,
   name: string,
   members: readonly string[],
+  nested?: (entity: SimQueryOutput) => string,
 ): string {
   const entity = output[name];
 
-  return isRecord(entity)
-    ? xmlElement(name, queryMembers(entity, members))
-    : "";
+  if (!isRecord(entity)) {
+    return "";
+  }
+
+  return xmlElement(
+    name,
+    queryMembers(entity, members) + (nested?.(entity) ?? ""),
+  );
 }

--- a/src/service/iam/serve/sim-iam-query-role-operations.ts
+++ b/src/service/iam/serve/sim-iam-query-role-operations.ts
@@ -2,7 +2,10 @@ import type { SimQueryOperations } from "../../../serve/http/api/query/sim-query
 import {
   queryList,
   queryMembers,
+  queryStructure,
 } from "../../../serve/http/api/query/sim-query-result.js";
+import type { SimQueryOutput } from "../../../serve/http/api/query/sim-query-result.js";
+import { simIamAttachedBoundaryMembers } from "../role/sim-iam-role-boundary.js";
 import { iamQueryEntity } from "./sim-iam-query-entity.js";
 import {
   iamQueryListingInput,
@@ -23,6 +26,19 @@ const roleMembers = [
 ];
 
 /**
+ * Write the permissions boundary a Role carries, where it carries one.
+ *
+ * A boundary is a structure of its own, and `queryMembers` would write it as
+ * the JSON text of an object. `ListRoles` leaves the field out altogether, as
+ * IAM does, so only the create and the get pass this.
+ */
+function roleBoundary(role: SimQueryOutput): string {
+  return queryStructure(role, "PermissionsBoundary", (boundary) =>
+    queryMembers(boundary, simIamAttachedBoundaryMembers),
+  );
+}
+
+/**
  * The Role operations simulated IAM serves over the Query protocol.
  *
  * The policy operations that name a Role are here rather than with the managed
@@ -41,7 +57,8 @@ export function simIamQueryRoleOperations(): SimQueryOperations {
           Description: fields.text("Description"),
           PermissionsBoundary: fields.text("PermissionsBoundary"),
         }),
-        result: (output): string => iamQueryEntity(output, "Role", roleMembers),
+        result: (output): string =>
+          iamQueryEntity(output, "Role", roleMembers, roleBoundary),
       },
     ],
     [
@@ -50,7 +67,8 @@ export function simIamQueryRoleOperations(): SimQueryOperations {
         input: (fields): Record<string, unknown> => ({
           RoleName: fields.text("RoleName"),
         }),
-        result: (output): string => iamQueryEntity(output, "Role", roleMembers),
+        result: (output): string =>
+          iamQueryEntity(output, "Role", roleMembers, roleBoundary),
       },
     ],
     [

--- a/src/service/iam/serve/sim-iam-query-role-operations.ts
+++ b/src/service/iam/serve/sim-iam-query-role-operations.ts
@@ -39,6 +39,7 @@ export function simIamQueryRoleOperations(): SimQueryOperations {
           Path: fields.text("Path"),
           AssumeRolePolicyDocument: fields.text("AssumeRolePolicyDocument"),
           Description: fields.text("Description"),
+          PermissionsBoundary: fields.text("PermissionsBoundary"),
         }),
         result: (output): string => iamQueryEntity(output, "Role", roleMembers),
       },


### PR DESCRIPTION
The standard permissions-boundary guard allows `iam:CreateRole` only under `StringEquals` on `iam:PermissionsBoundary`. Nothing populated that key, and a positive operator over an unset key matches nothing, leaving the statement to allow no Role at all. A stack using `cdk.PermissionsBoundary.fromName(...)` failed on its first Role, and the way past it was to delete the condition from the copy of the policy the test used. `CreateRole` now takes `PermissionsBoundary` and supplies the ARN as the condition value, `AWS::IAM::Role` carries the template property of the same name through to it, and `CreateRole` and `GetRole` answer with the boundary the Role carries in the attachment shape IAM describes one with. `ListRoles` leaves the field out, as IAM does. Evaluating that stored boundary as a policy source of its own is a separate change.

Resolves #1271