### PR TITLE
fix: authorize CloudFront policy Resources

### DIFF
--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -3781,6 +3781,110 @@ A CDK stack needs no hand-editing.
 other store. Handing back an empty store would let a Function that lost its association run to
 completion and quietly take every default.
 
+## Permissions
+
+Every CloudFront command goes through simulated IAM. So does every CloudFront Resource a
+CloudFormation Stack creates, decided as the principal the deployment runs as. Stand a project's own
+execution policy up as a deploy Role and the Stack finds out what the policy leaves out. A
+deployment naming no principal is decided as the Account root.
+
+The action is the `cloudfront:` name of the operation. A Distribution action is decided against
+`arn:aws:cloudfront::<account>:distribution/<id>`, a Function action against `function/<name>` and a
+key value store action against `key-value-store/<id>`. A create action has nothing to name until it
+succeeds and is decided against `*`. A policy granting one has to write the wildcard.
+
+These are the actions the simulation asks about:
+
+- `CreateDistribution`, `GetDistribution`, `UpdateDistribution` and `DeleteDistribution`
+- `CreateFunction`, `ListFunctions`, `DescribeFunction`, `GetFunction` and `DeleteFunction`
+- `CreateInvalidation`, `GetInvalidation` and `ListInvalidations`
+- `CreateKeyValueStore`, `ListKeyValueStores`, `DescribeKeyValueStore`, `UpdateKeyValueStore` and
+  `DeleteKeyValueStore`, alongside the data API's own `cloudfront-keyvaluestore:` actions on the
+  keys inside a store
+- `CreateCachePolicy` and `DeleteCachePolicy`
+- `CreateOriginRequestPolicy` and `DeleteOriginRequestPolicy`
+- `CreateResponseHeadersPolicy` and `DeleteResponseHeadersPolicy`
+- `CreateOriginAccessControl` and `DeleteOriginAccessControl`
+
+The last four pairs reach IAM through CloudFormation alone, since a template is the only way to make
+one of those four here. Each delete is decided against the ARN of the thing it names, such as
+`arn:aws:cloudfront::<account>:cache-policy/<id>`.
+
+```typescript sim-cloudfront-deploy-permissions
+/**
+ * A deploy Role refused the cache policy its Stack declares.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// A deploy Role allowed CloudFormation and S3, and no CloudFront action.
+const { Role } = await simAws.iam().createRole({
+  input: {
+    RoleName: "DeployRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  },
+});
+
+await simAws.iam().putRolePolicy({
+  input: {
+    RoleName: "DeployRole",
+    PolicyName: "DeployPolicy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ["cloudformation:*", "s3:*"],
+          Resource: "*",
+        },
+      ],
+    }),
+  },
+});
+
+try {
+  await simAws.cloudFormation().deployTemplate({
+    stackName: "site-stack",
+    caller: { kind: "arn", arn: Role.Arn },
+    template: {
+      Resources: {
+        SiteCachePolicy: {
+          Type: "AWS::CloudFront::CachePolicy",
+          Properties: {
+            CachePolicyConfig: {
+              Name: "site-caching",
+              MinTTL: 0,
+              ParametersInCacheKeyAndForwardedToOrigin: {
+                EnableAcceptEncodingGzip: false,
+                CookiesConfig: { CookieBehavior: "none" },
+                HeadersConfig: { HeaderBehavior: "none" },
+                QueryStringsConfig: { QueryStringBehavior: "none" },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+} catch (error) {
+  // Sim CloudFormation Resource SiteCachePolicy creation failed: User:
+  // arn:aws:iam::...:role/DeployRole is not authorized to perform:
+  // cloudfront:CreateCachePolicy on resource: *
+  console.log((error as Error).message);
+}
+```
+
 ## Available functionality
 
 Sim CloudFront currently supports:

--- a/docs/services/cloudfront/sim-cloudfront-deploy-permissions.example.ts
+++ b/docs/services/cloudfront/sim-cloudfront-deploy-permissions.example.ts
@@ -1,0 +1,72 @@
+/**
+ * A deploy Role refused the cache policy its Stack declares.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+// A deploy Role allowed CloudFormation and S3, and no CloudFront action.
+const { Role } = await simAws.iam().createRole({
+  input: {
+    RoleName: "DeployRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  },
+});
+
+await simAws.iam().putRolePolicy({
+  input: {
+    RoleName: "DeployRole",
+    PolicyName: "DeployPolicy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ["cloudformation:*", "s3:*"],
+          Resource: "*",
+        },
+      ],
+    }),
+  },
+});
+
+try {
+  await simAws.cloudFormation().deployTemplate({
+    stackName: "site-stack",
+    caller: { kind: "arn", arn: Role.Arn },
+    template: {
+      Resources: {
+        SiteCachePolicy: {
+          Type: "AWS::CloudFront::CachePolicy",
+          Properties: {
+            CachePolicyConfig: {
+              Name: "site-caching",
+              MinTTL: 0,
+              ParametersInCacheKeyAndForwardedToOrigin: {
+                EnableAcceptEncodingGzip: false,
+                CookiesConfig: { CookieBehavior: "none" },
+                HeadersConfig: { HeaderBehavior: "none" },
+                QueryStringsConfig: { QueryStringBehavior: "none" },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+} catch (error) {
+  // Sim CloudFormation Resource SiteCachePolicy creation failed: User:
+  // arn:aws:iam::...:role/DeployRole is not authorized to perform:
+  // cloudfront:CreateCachePolicy on resource: *
+  console.log((error as Error).message);
+}

--- a/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-creator.ts
+++ b/src/service/cloudfront/cfn/cache-policy/sim-cfn-cf-cache-policy-creator.ts
@@ -1,3 +1,4 @@
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
@@ -13,6 +14,9 @@ interface SimCfnCfCachePolicyCreatorProperties {
  * Resources.
  */
 export class SimCfnCfCachePolicyCreator {
+  private static readonly createAction = "cloudfront:CreateCachePolicy";
+  private static readonly deleteAction = "cloudfront:DeleteCachePolicy";
+
   private readonly cloudFront: SimCloudFront;
 
   constructor(properties: SimCfnCfCachePolicyCreatorProperties) {
@@ -25,7 +29,12 @@ export class SimCfnCfCachePolicyCreator {
   create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): SimCloudFrontCachePolicy {
+    this.cloudFront
+      .cfnAuthorizer()
+      .authorizeAny(SimCfnCfCachePolicyCreator.createAction, options);
+
     const policy = new SimCfnCfCachePolicyConfig({
       resource,
       properties,
@@ -39,12 +48,23 @@ export class SimCfnCfCachePolicyCreator {
   /**
    * Remove a policy created from a Resource.
    */
-  delete(resource: SimCfnResource): void {
+  delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): void {
     const policy = resource.simResource as SimCloudFrontCachePolicy | undefined;
 
     if (policy === undefined) {
       return;
     }
+
+    this.cloudFront
+      .cfnAuthorizer()
+      .authorizeResource(
+        SimCfnCfCachePolicyCreator.deleteAction,
+        `cache-policy/${policy.id}`,
+        options,
+      );
 
     this.cloudFront.removeCachePolicy(policy.id);
   }

--- a/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-creator.ts
+++ b/src/service/cloudfront/cfn/origin-access-control/sim-cfn-cf-oac-creator.ts
@@ -1,3 +1,4 @@
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
@@ -13,6 +14,9 @@ interface SimCfnCfOriginAccessControlCreatorProperties {
  * AWS::CloudFront::OriginAccessControl Resources.
  */
 export class SimCfnCfOriginAccessControlCreator {
+  private static readonly createAction = "cloudfront:CreateOriginAccessControl";
+  private static readonly deleteAction = "cloudfront:DeleteOriginAccessControl";
+
   private readonly cloudFront: SimCloudFront;
 
   constructor(properties: SimCfnCfOriginAccessControlCreatorProperties) {
@@ -25,7 +29,12 @@ export class SimCfnCfOriginAccessControlCreator {
   create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): SimCloudFrontOriginAccessControl {
+    this.cloudFront
+      .cfnAuthorizer()
+      .authorizeAny(SimCfnCfOriginAccessControlCreator.createAction, options);
+
     const originAccessControl = new SimCfnCfOriginAccessControlConfig({
       resource,
       properties,
@@ -39,7 +48,10 @@ export class SimCfnCfOriginAccessControlCreator {
   /**
    * Remove an origin access control created from a Resource.
    */
-  delete(resource: SimCfnResource): void {
+  delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): void {
     const originAccessControl = resource.simResource as
       | SimCloudFrontOriginAccessControl
       | undefined;
@@ -47,6 +59,14 @@ export class SimCfnCfOriginAccessControlCreator {
     if (originAccessControl === undefined) {
       return;
     }
+
+    this.cloudFront
+      .cfnAuthorizer()
+      .authorizeResource(
+        SimCfnCfOriginAccessControlCreator.deleteAction,
+        `origin-access-control/${originAccessControl.id}`,
+        options,
+      );
 
     this.cloudFront.removeOriginAccessControl(originAccessControl.id);
   }

--- a/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-creator.ts
+++ b/src/service/cloudfront/cfn/origin-request-policy/sim-cfn-cf-orp-creator.ts
@@ -1,3 +1,4 @@
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
@@ -13,6 +14,9 @@ interface SimCfnCfOriginRequestPolicyCreatorProperties {
  * AWS::CloudFront::OriginRequestPolicy Resources.
  */
 export class SimCfnCfOriginRequestPolicyCreator {
+  private static readonly createAction = "cloudfront:CreateOriginRequestPolicy";
+  private static readonly deleteAction = "cloudfront:DeleteOriginRequestPolicy";
+
   private readonly cloudFront: SimCloudFront;
 
   constructor(properties: SimCfnCfOriginRequestPolicyCreatorProperties) {
@@ -25,7 +29,12 @@ export class SimCfnCfOriginRequestPolicyCreator {
   create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): SimCloudFrontOriginRequestPolicy {
+    this.cloudFront
+      .cfnAuthorizer()
+      .authorizeAny(SimCfnCfOriginRequestPolicyCreator.createAction, options);
+
     const policy = new SimCfnCfOriginRequestPolicyConfig({
       resource,
       properties,
@@ -39,7 +48,10 @@ export class SimCfnCfOriginRequestPolicyCreator {
   /**
    * Remove a policy created from a Resource.
    */
-  delete(resource: SimCfnResource): void {
+  delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): void {
     const policy = resource.simResource as
       | SimCloudFrontOriginRequestPolicy
       | undefined;
@@ -47,6 +59,14 @@ export class SimCfnCfOriginRequestPolicyCreator {
     if (policy === undefined) {
       return;
     }
+
+    this.cloudFront
+      .cfnAuthorizer()
+      .authorizeResource(
+        SimCfnCfOriginRequestPolicyCreator.deleteAction,
+        `origin-request-policy/${policy.id}`,
+        options,
+      );
 
     this.cloudFront.removeOriginRequestPolicy(policy.id);
   }

--- a/src/service/cloudfront/cfn/policy/sim-cfn-cf-policy-creators.ts
+++ b/src/service/cloudfront/cfn/policy/sim-cfn-cf-policy-creators.ts
@@ -1,0 +1,62 @@
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimCloudFront } from "../../sim-cloudfront.js";
+import { SimCfnCfCachePolicyCreator } from "../cache-policy/sim-cfn-cf-cache-policy-creator.js";
+import { SimCfnCfOriginAccessControlCreator } from "../origin-access-control/sim-cfn-cf-oac-creator.js";
+import { SimCfnCfOriginRequestPolicyCreator } from "../origin-request-policy/sim-cfn-cf-orp-creator.js";
+import { SimCfnCfResponseHeadersPolicyCreator } from "../response-headers-policy/sim-cfn-cf-rh-policy-creator.js";
+
+/**
+ * What the four creators in here have in common.
+ *
+ * Each builds its own kind of policy from a Resource's properties and stores
+ * it on the simulated CloudFront, and each authorizes the deployment's caller
+ * for its own pair of actions.
+ */
+interface SimCfnCfPolicyCreator {
+  create(
+    resource: SimCfnResource,
+    properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
+  ): object;
+  delete(resource: SimCfnResource, options?: SimCfnResourceCallerOptions): void;
+}
+
+/**
+ * The CloudFront Resource types a template is the only way to make.
+ *
+ * A cache policy, an origin request policy, a response headers policy and an
+ * origin access control have no SDK command here. The Resource factory hands
+ * all four to this one lookup, and its own switch stays about the Resource
+ * types a command creates.
+ */
+export class SimCfnCfPolicyCreators {
+  private readonly creators: ReadonlyMap<string, SimCfnCfPolicyCreator>;
+
+  constructor(cloudFront: SimCloudFront) {
+    this.creators = new Map<string, SimCfnCfPolicyCreator>([
+      [
+        "ResponseHeadersPolicy",
+        new SimCfnCfResponseHeadersPolicyCreator({ cloudFront }),
+      ],
+      ["CachePolicy", new SimCfnCfCachePolicyCreator({ cloudFront })],
+      [
+        "OriginRequestPolicy",
+        new SimCfnCfOriginRequestPolicyCreator({ cloudFront }),
+      ],
+      [
+        "OriginAccessControl",
+        new SimCfnCfOriginAccessControlCreator({ cloudFront }),
+      ],
+    ]);
+  }
+
+  /**
+   * The creator owning one Resource type, or nothing where another part of
+   * the factory owns it.
+   */
+  creatorFor(resourceTypeName: string): SimCfnCfPolicyCreator | undefined {
+    return this.creators.get(resourceTypeName);
+  }
+}

--- a/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-creator.ts
+++ b/src/service/cloudfront/cfn/response-headers-policy/sim-cfn-cf-rh-policy-creator.ts
@@ -1,3 +1,4 @@
+import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCloudFront } from "../../sim-cloudfront.js";
@@ -13,6 +14,11 @@ interface SimCfnCfResponseHeadersPolicyCreatorProperties {
  * AWS::CloudFront::ResponseHeadersPolicy Resources.
  */
 export class SimCfnCfResponseHeadersPolicyCreator {
+  private static readonly createAction =
+    "cloudfront:CreateResponseHeadersPolicy";
+  private static readonly deleteAction =
+    "cloudfront:DeleteResponseHeadersPolicy";
+
   private readonly cloudFront: SimCloudFront;
 
   constructor(properties: SimCfnCfResponseHeadersPolicyCreatorProperties) {
@@ -25,7 +31,12 @@ export class SimCfnCfResponseHeadersPolicyCreator {
   create(
     resource: SimCfnResource,
     properties: SimCfnTemplateValueRecord,
+    options?: SimCfnResourceCallerOptions,
   ): SimCloudFrontResponseHeadersPolicy {
+    this.cloudFront
+      .cfnAuthorizer()
+      .authorizeAny(SimCfnCfResponseHeadersPolicyCreator.createAction, options);
+
     const policy = new SimCfnCfResponseHeadersPolicyConfig({
       resource,
       properties,
@@ -39,7 +50,10 @@ export class SimCfnCfResponseHeadersPolicyCreator {
   /**
    * Remove a policy created from a Resource.
    */
-  delete(resource: SimCfnResource): void {
+  delete(
+    resource: SimCfnResource,
+    options?: SimCfnResourceCallerOptions,
+  ): void {
     const policy = resource.simResource as
       | SimCloudFrontResponseHeadersPolicy
       | undefined;
@@ -47,6 +61,14 @@ export class SimCfnCfResponseHeadersPolicyCreator {
     if (policy === undefined) {
       return;
     }
+
+    this.cloudFront
+      .cfnAuthorizer()
+      .authorizeResource(
+        SimCfnCfResponseHeadersPolicyCreator.deleteAction,
+        `response-headers-policy/${policy.id}`,
+        options,
+      );
 
     this.cloudFront.removeResponseHeadersPolicy(policy.id);
   }

--- a/src/service/cloudfront/cfn/sim-cfn-cf-authorizer.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cf-authorizer.ts
@@ -1,0 +1,66 @@
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimCfnResourceCallerOptions } from "../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
+import type { SimIamInterServiceAuthZ } from "../../iam/authorize/sim-iam-inter-service-auth-z.js";
+import { simCfAuthorize } from "../sim-cf-authorize.js";
+
+interface SimCfnCfAuthorizerProperties {
+  readonly accountId: SimAwsAccountId;
+  readonly iam: SimIamInterServiceAuthZ;
+}
+
+/**
+ * Authorizes the CloudFront Resources a template is the only way to make.
+ *
+ * A cache policy, an origin request policy, a response headers policy and an
+ * origin access control have no SDK command here, so their CloudFormation
+ * creators reach the stored policy directly rather than through a command that
+ * would ask IAM on the way. This is where those creators ask instead, so a
+ * deploy Role holding no CloudFront permission is refused the way real
+ * CloudFormation refuses it.
+ */
+export class SimCfnCfAuthorizer {
+  private readonly accountId: SimAwsAccountId;
+  private readonly iam: SimIamInterServiceAuthZ;
+
+  constructor(properties: SimCfnCfAuthorizerProperties) {
+    this.accountId = properties.accountId;
+    this.iam = properties.iam;
+  }
+
+  /**
+   * Ensure the caller may take an action that names nothing yet.
+   *
+   * A create action has no ID to authorize against until it succeeds, and
+   * CloudFront offers no resource-level permission for one, so a policy
+   * granting it writes `*` and that is what it is decided against.
+   */
+  authorizeAny(action: string, options?: SimCfnResourceCallerOptions): void {
+    simCfAuthorize({
+      iam: this.iam,
+      action,
+      resource: "*",
+      caller: options?.caller,
+    });
+  }
+
+  /**
+   * Ensure the caller may take an action on the CloudFront resource a path
+   * names, such as `cache-policy/8f1a2b3c`.
+   *
+   * A delete names the thing it is deleting, so a policy can grant deleting
+   * one cache policy without granting deleting every cache policy in the
+   * Account.
+   */
+  authorizeResource(
+    action: string,
+    resourcePath: string,
+    options?: SimCfnResourceCallerOptions,
+  ): void {
+    simCfAuthorize({
+      iam: this.iam,
+      action,
+      resource: `arn:aws:cloudfront::${this.accountId}:${resourcePath}`,
+      caller: options?.caller,
+    });
+  }
+}

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-authorization.iso.test.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-authorization.iso.test.ts
@@ -1,0 +1,278 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { CfnTemplateBodyRecord } from "../../cloudformation/template/sim-cfn-template.js";
+import type { SimCfnTemplateValueRecord } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-policy.factory.js";
+import { SimCloudFrontCachePolicy } from "../cache-policy/sim-cf-cache-policy.js";
+
+/**
+ * One of the four CloudFront Resource types a template is the only way to
+ * make, and the two actions a deployment creating and deleting it needs.
+ */
+interface CloudFrontResourceType {
+  readonly logicalId: string;
+  readonly createAction: string;
+  readonly deleteAction: string;
+  readonly resource: SimCfnTemplateValueRecord;
+}
+
+const cachePolicyType: CloudFrontResourceType = {
+  logicalId: "SiteCachePolicy",
+  createAction: "cloudfront:CreateCachePolicy",
+  deleteAction: "cloudfront:DeleteCachePolicy",
+  resource: {
+    Type: "AWS::CloudFront::CachePolicy",
+    Properties: {
+      CachePolicyConfig: {
+        Name: "site-caching",
+        MinTTL: 0,
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          EnableAcceptEncodingGzip: false,
+          CookiesConfig: { CookieBehavior: "none" },
+          HeadersConfig: { HeaderBehavior: "none" },
+          QueryStringsConfig: { QueryStringBehavior: "none" },
+        },
+      },
+    },
+  },
+};
+
+const originRequestPolicyType: CloudFrontResourceType = {
+  logicalId: "SiteOriginRequestPolicy",
+  createAction: "cloudfront:CreateOriginRequestPolicy",
+  deleteAction: "cloudfront:DeleteOriginRequestPolicy",
+  resource: {
+    Type: "AWS::CloudFront::OriginRequestPolicy",
+    Properties: {
+      OriginRequestPolicyConfig: {
+        Name: "site-origin-requests",
+        CookiesConfig: { CookieBehavior: "none" },
+        HeadersConfig: { HeaderBehavior: "none" },
+        QueryStringsConfig: { QueryStringBehavior: "none" },
+      },
+    },
+  },
+};
+
+const responseHeadersPolicyType: CloudFrontResourceType = {
+  logicalId: "SiteResponseHeadersPolicy",
+  createAction: "cloudfront:CreateResponseHeadersPolicy",
+  deleteAction: "cloudfront:DeleteResponseHeadersPolicy",
+  resource: {
+    Type: "AWS::CloudFront::ResponseHeadersPolicy",
+    Properties: {
+      ResponseHeadersPolicyConfig: { Name: "site-response-headers" },
+    },
+  },
+};
+
+const originAccessControlType: CloudFrontResourceType = {
+  logicalId: "SiteOriginAccessControl",
+  createAction: "cloudfront:CreateOriginAccessControl",
+  deleteAction: "cloudfront:DeleteOriginAccessControl",
+  resource: {
+    Type: "AWS::CloudFront::OriginAccessControl",
+    Properties: {
+      OriginAccessControlConfig: {
+        Name: "site-oac",
+        OriginAccessControlOriginType: "s3",
+        SigningBehavior: "always",
+        SigningProtocol: "sigv4",
+      },
+    },
+  },
+};
+
+const resourceTypes: readonly CloudFrontResourceType[] = [
+  cachePolicyType,
+  originRequestPolicyType,
+  responseHeadersPolicyType,
+  originAccessControlType,
+];
+
+/**
+ * The actions a deployment creating all four of them needs.
+ */
+const createActions = resourceTypes.map(
+  (resourceType) => resourceType.createAction,
+);
+
+/**
+ * A template holding one of the four on its own, so a refusal names the
+ * Resource the test is about rather than whichever one the deployment reached
+ * first.
+ */
+function templateFor(
+  resourceType: CloudFrontResourceType,
+): CfnTemplateBodyRecord {
+  return { Resources: { [resourceType.logicalId]: resourceType.resource } };
+}
+
+/**
+ * A template holding all four.
+ */
+function everyResourceTemplate(): CfnTemplateBodyRecord {
+  return {
+    Resources: Object.fromEntries(
+      resourceTypes.map((resourceType) => [
+        resourceType.logicalId,
+        resourceType.resource,
+      ]),
+    ),
+  };
+}
+
+/**
+ * A deploy Role allowed the CloudFront actions it is given, and nothing else.
+ */
+async function deployRole(
+  simAws: SimAws,
+  roleName: string,
+  actions: readonly string[],
+): Promise<SimAwsCaller> {
+  const role = await simIamRoleWithPolicyFactory.make(
+    { roleName, policyName: `${roleName}-policy`, actions },
+    simAws,
+  );
+
+  return { kind: "arn", arn: role.Arn };
+}
+
+describe("the caller a CloudFront CloudFormation Resource is created as", () => {
+  it.each(resourceTypes)(
+    "refuses $logicalId under $createAction",
+    async (resourceType) => {
+      // Given a deploy Role holding a CloudFront permission that does not
+      // cover this Resource type.
+      const simAws = new SimAws();
+      const deployer = await deployRole(simAws, "distro-deployer", [
+        "cloudfront:CreateDistribution",
+      ]);
+
+      // When a Stack declaring the Resource is deployed as that Role.
+      const error = await assertThrowsErrorAsync(async () => {
+        await simAws.cloudFormation().deployTemplate({
+          stackName: "site-stack",
+          template: templateFor(resourceType),
+          caller: deployer,
+        });
+      });
+
+      // Then the deployment is refused, naming the action the policy is
+      // missing, as real CloudFormation refuses the same template.
+      assertStringIncludes(error.message, resourceType.createAction);
+      assertStringIncludes(error.message, "role/distro-deployer");
+      assertIdentical(
+        simAws
+          .cloudFormation()
+          .getStackByName("site-stack")
+          ?.getResource(resourceType.logicalId)?.status,
+        "CREATE_FAILED",
+      );
+    },
+  );
+
+  it("creates a cache policy the deploy Role is allowed to create", async () => {
+    // Given a deploy Role allowed to create cache policies.
+    const simAws = new SimAws();
+    const deployer = await deployRole(simAws, "policy-deployer", [
+      "cloudfront:CreateCachePolicy",
+    ]);
+
+    // When a Stack declaring one is deployed as that Role.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "site-stack",
+      template: templateFor(cachePolicyType),
+      caller: deployer,
+    });
+
+    // Then the policy was created and stored under its ID.
+    const resource = stack.getResource("SiteCachePolicy");
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+    assertInstanceOf(resource.simResource, SimCloudFrontCachePolicy);
+    assertIdentical(
+      simAws.cloudFront().getCachePolicyById(resource.simResource.id),
+      resource.simResource,
+    );
+  });
+
+  it("creates all four for a deployment naming no caller", async () => {
+    // Given a deployment that names no principal, which is decided as the
+    // Account root.
+    const simAws = new SimAws();
+
+    // When a Stack declaring all four is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "site-stack",
+      template: everyResourceTemplate(),
+    });
+
+    // Then each of them was created, as it was before any of this asked IAM.
+    for (const resourceType of resourceTypes) {
+      assertIdentical(
+        stack.getResource(resourceType.logicalId)?.status,
+        "CREATE_COMPLETE",
+      );
+    }
+  });
+
+  it.each(resourceTypes)(
+    "refuses tearing $logicalId down without $deleteAction",
+    async (resourceType) => {
+      // Given a Stack deployed as a Role allowed to create all four and to
+      // delete none of them.
+      const simAws = new SimAws();
+      const deployer = await deployRole(
+        simAws,
+        "create-only-deployer",
+        createActions,
+      );
+      const stack = await simAws.cloudFormation().deployTemplate({
+        stackName: "site-stack",
+        template: templateFor(resourceType),
+        caller: deployer,
+      });
+
+      // When the Stack is torn down.
+      const error = await assertThrowsErrorAsync(async () => {
+        await stack.teardown();
+      });
+
+      // Then the teardown is refused, naming the delete action.
+      assertStringIncludes(error.message, resourceType.deleteAction);
+    },
+  );
+
+  it("deletes a cache policy the deploy Role is allowed to delete", async () => {
+    // Given a Stack deployed as a Role allowed both cache policy actions.
+    const simAws = new SimAws();
+    const deployer = await deployRole(simAws, "policy-deployer", [
+      "cloudfront:CreateCachePolicy",
+      "cloudfront:DeleteCachePolicy",
+    ]);
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "site-stack",
+      template: templateFor(cachePolicyType),
+      caller: deployer,
+    });
+    const created = stack.getResource("SiteCachePolicy")?.simResource;
+    assertInstanceOf(created, SimCloudFrontCachePolicy);
+
+    // When the Stack is torn down.
+    await stack.teardown();
+
+    // Then the policy has gone with it.
+    assertUndefined(simAws.cloudFront().getCachePolicyById(created.id));
+  });
+});

--- a/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
+++ b/src/service/cloudfront/cfn/sim-cfn-cloudfront-resource-factory.ts
@@ -9,10 +9,7 @@ import { simCfnResourceCallerOptions } from "../../cloudformation/resource/calle
 import { SimCfnCfDistroCreator } from "./distro/sim-cfn-cf-distro-creator.js";
 import { SimCfnCffCreator } from "./cff/sim-cfn-cff-creator.js";
 import { SimCfnCfDistroDeleter } from "./distro/sim-cfn-cf-distro-deleter.js";
-import { SimCfnCfResponseHeadersPolicyCreator } from "./response-headers-policy/sim-cfn-cf-rh-policy-creator.js";
-import { SimCfnCfCachePolicyCreator } from "./cache-policy/sim-cfn-cf-cache-policy-creator.js";
-import { SimCfnCfOriginRequestPolicyCreator } from "./origin-request-policy/sim-cfn-cf-orp-creator.js";
-import { SimCfnCfOriginAccessControlCreator } from "./origin-access-control/sim-cfn-cf-oac-creator.js";
+import { SimCfnCfPolicyCreators } from "./policy/sim-cfn-cf-policy-creators.js";
 import { SimCfnCfKeyValueStoreCreator } from "./key-value-store/sim-cfn-cf-kvs-creator.js";
 
 /**
@@ -22,25 +19,14 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
   private readonly distroCreator: SimCfnCfDistroCreator;
   private readonly functionCreator: SimCfnCffCreator;
   private readonly distroDeleter: SimCfnCfDistroDeleter;
-  private readonly responseHeadersPolicyCreator: SimCfnCfResponseHeadersPolicyCreator;
-  private readonly cachePolicyCreator: SimCfnCfCachePolicyCreator;
-  private readonly originRequestPolicyCreator: SimCfnCfOriginRequestPolicyCreator;
-  private readonly originAccessControlCreator: SimCfnCfOriginAccessControlCreator;
+  private readonly policyCreators: SimCfnCfPolicyCreators;
   private readonly keyValueStoreCreator: SimCfnCfKeyValueStoreCreator;
 
   constructor(cloudFront: SimCloudFront) {
     this.distroCreator = new SimCfnCfDistroCreator({ cloudFront });
     this.functionCreator = new SimCfnCffCreator({ cloudFront });
     this.distroDeleter = new SimCfnCfDistroDeleter({ cloudFront });
-    this.responseHeadersPolicyCreator =
-      new SimCfnCfResponseHeadersPolicyCreator({ cloudFront });
-    this.cachePolicyCreator = new SimCfnCfCachePolicyCreator({ cloudFront });
-    this.originRequestPolicyCreator = new SimCfnCfOriginRequestPolicyCreator({
-      cloudFront,
-    });
-    this.originAccessControlCreator = new SimCfnCfOriginAccessControlCreator({
-      cloudFront,
-    });
+    this.policyCreators = new SimCfnCfPolicyCreators(cloudFront);
     this.keyValueStoreCreator = new SimCfnCfKeyValueStoreCreator({
       cloudFront,
     });
@@ -55,6 +41,12 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
     context: SimCloudFormationResourceCreateContext,
   ): Promise<object | undefined> {
     const properties = context.resolvedProperties ?? resource.properties;
+    const options = simCfnResourceCallerOptions(context.caller);
+    const policyCreator = this.policyCreators.creatorFor(resourceTypeName);
+
+    if (policyCreator !== undefined) {
+      return policyCreator.create(resource, properties, options);
+    }
 
     switch (resourceTypeName) {
       case "Distribution": {
@@ -63,23 +55,11 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       case "Function": {
         return await this.functionCreator.create(resource, properties, context);
       }
-      case "ResponseHeadersPolicy": {
-        return this.responseHeadersPolicyCreator.create(resource, properties);
-      }
-      case "CachePolicy": {
-        return this.cachePolicyCreator.create(resource, properties);
-      }
-      case "OriginRequestPolicy": {
-        return this.originRequestPolicyCreator.create(resource, properties);
-      }
-      case "OriginAccessControl": {
-        return this.originAccessControlCreator.create(resource, properties);
-      }
       case "KeyValueStore": {
         return await this.keyValueStoreCreator.create(
           resource,
           properties,
-          simCfnResourceCallerOptions(context.caller),
+          options,
         );
       }
       default: {
@@ -100,6 +80,12 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
     context: SimCloudFormationResourceDeleteContext,
   ): Promise<void> {
     const options = simCfnResourceCallerOptions(context.caller);
+    const policyCreator = this.policyCreators.creatorFor(resourceTypeName);
+
+    if (policyCreator !== undefined) {
+      policyCreator.delete(resource, options);
+      return;
+    }
 
     switch (resourceTypeName) {
       case "Distribution": {
@@ -108,22 +94,6 @@ export class SimCloudFrontCloudFormationResourceFactory implements SimCfnService
       }
       case "Function": {
         await this.functionCreator.delete(resource, options);
-        return;
-      }
-      case "ResponseHeadersPolicy": {
-        this.responseHeadersPolicyCreator.delete(resource);
-        return;
-      }
-      case "CachePolicy": {
-        this.cachePolicyCreator.delete(resource);
-        return;
-      }
-      case "OriginRequestPolicy": {
-        this.originRequestPolicyCreator.delete(resource);
-        return;
-      }
-      case "OriginAccessControl": {
-        this.originAccessControlCreator.delete(resource);
         return;
       }
       case "KeyValueStore": {

--- a/src/service/cloudfront/sim-cloudfront-commands.ts
+++ b/src/service/cloudfront/sim-cloudfront-commands.ts
@@ -56,6 +56,7 @@ import { SimCloudFrontKeyValueStoreApi } from "./sim-cloudfront-key-value-store.
 import { SimCffKeyValueStoreUsers } from "./cff/kvs/sim-cff-key-value-store-users.js";
 import { SimCfFunctionCommands } from "./cff/sim-cf-function-commands.js";
 import { SimCfInvalidationCommands } from "./command/invalidation/sim-cf-invalidation-commands.js";
+import { SimCfnCfAuthorizer } from "./cfn/sim-cfn-cf-authorizer.js";
 
 /**
  * How one simulated CloudFront is put together.
@@ -153,6 +154,12 @@ export class SimCloudFrontCommands {
    */
   public readonly invalidations: SimCfInvalidationCommands;
 
+  /**
+   * How the CloudFormation Resource factory authorizes the Resources it
+   * creates without a command of their own.
+   */
+  public readonly cfnAuthorizer: SimCfnCfAuthorizer;
+
   private readonly distributionState: SimCloudFrontDistributionState;
   private readonly configurationState: SimCfDistributionConfigurationState;
 
@@ -196,6 +203,7 @@ export class SimCloudFrontCommands {
       iam,
       background,
     });
+    this.cfnAuthorizer = new SimCfnCfAuthorizer({ accountId, iam });
     this.configurationState = {
       s3OriginResolver,
       customOriginDispatcher,

--- a/src/service/cloudfront/sim-cloudfront.ts
+++ b/src/service/cloudfront/sim-cloudfront.ts
@@ -7,6 +7,7 @@ import type {
   SimCloudFrontFunction,
   SimCloudFrontFunctionName,
 } from "./cff/sim-cloudfront-function.js";
+import type { SimCfnCfAuthorizer } from "./cfn/sim-cfn-cf-authorizer.js";
 import { SimCloudFrontCloudFormationResourceFactory } from "./cfn/sim-cfn-cloudfront-resource-factory.js";
 import type {
   SimCreateDistributionCommand,
@@ -261,6 +262,14 @@ export class SimCloudFront extends SimCloudFrontDistributions {
     return this.cloudFrontFunctions.get(
       cloudFrontFunctionName as SimCloudFrontFunctionName,
     );
+  }
+
+  /**
+   * How the CloudFormation Resource factory authorizes a deployment's caller
+   * for the Resources it creates without a command of their own.
+   */
+  cfnAuthorizer(): SimCfnCfAuthorizer {
+    return this.commands.cfnAuthorizer;
   }
 
   /**


### PR DESCRIPTION
A cache policy, an origin request policy, a response headers policy and an origin access control
were stored straight on the simulated CloudFront, skipping the IAM question every other Resource
asks. A deploy Role holding no CloudFront permission created all four and the Stack reached
CREATE_COMPLETE, where real CloudFormation refuses the same template with an access denial. Each of
the four CloudFormation creators now authorizes the deployment's caller for its own create and
delete actions, decided against the wildcard on create and against the resource ARN on delete. A
deployment naming no caller is still decided as the Account root, and the CloudFront docs gained a
Permissions section listing every action the simulation asks IAM about.

Resolves #1270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added IAM authorization checks for CloudFront CloudFormation resources, including creation and deletion of policies and origin access controls.
  - Added support for resource-specific and wildcard permission validation.
  - Added access to the CloudFront CloudFormation authorizer.
  - Added an example deployment demonstrating permission failures.

- **Documentation**
  - Documented CloudFront permission requirements, supported operations, resource mappings, and authorization examples.

- **Tests**
  - Added coverage for authorized and unauthorized CloudFront resource operations, caller roles, error reporting, and root-account behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->