### PR TITLE
docs: fix skip examples that no longer skip

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -4035,8 +4035,11 @@ const stack = await simAws.cloudFormation().deployTemplate({
           BucketName: "skipped-site-bucket",
         },
       },
-      AlarmRule: {
-        Type: "AWS::CloudWatch::Alarm",
+      SearchApi: {
+        Type: "AWS::AppSync::GraphQLApi",
+        Properties: {
+          Name: "search",
+        },
       },
     },
   },
@@ -4045,10 +4048,10 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 console.log(stack.skippedResources.map((resource) => resource.logicalId));
-// ["AlarmRule"]
+// ["SearchApi"]
 
-console.log(stack.getResource("AlarmRule")?.skippedReason);
-// "Unsupported sim CloudFormation Resource service CloudWatch"
+console.log(stack.getResource("SearchApi")?.skippedReason);
+// "Unsupported sim CloudFormation Resource service AppSync"
 ```
 
 A skipped Resource is still there for `stack.getResource(...)`, and still answers `Ref` and `Fn::GetAtt` with
@@ -4092,8 +4095,11 @@ const stack = await simAws.cloudFormation().deployTemplate({
           Description: "/opt/awscli/aws",
         },
       },
-      AlarmRule: {
-        Type: "AWS::CloudWatch::Alarm",
+      SearchApi: {
+        Type: "AWS::AppSync::GraphQLApi",
+        Properties: {
+          Name: "search",
+        },
       },
     },
   },
@@ -4102,7 +4108,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 console.log(stack.skippedResources.map((resource) => resource.logicalId));
-// ["AlarmRule"]
+// ["SearchApi"]
 
 console.log(stack.inertResources.map((resource) => resource.logicalId));
 // ["AwsCliLayer"]

--- a/docs/services/cloudformation/sim-cloudformation-inert-resources.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-inert-resources.example.ts
@@ -16,8 +16,11 @@ const stack = await simAws.cloudFormation().deployTemplate({
           Description: "/opt/awscli/aws",
         },
       },
-      AlarmRule: {
-        Type: "AWS::CloudWatch::Alarm",
+      SearchApi: {
+        Type: "AWS::AppSync::GraphQLApi",
+        Properties: {
+          Name: "search",
+        },
       },
     },
   },
@@ -26,7 +29,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 console.log(stack.skippedResources.map((resource) => resource.logicalId));
-// ["AlarmRule"]
+// ["SearchApi"]
 
 console.log(stack.inertResources.map((resource) => resource.logicalId));
 // ["AwsCliLayer"]

--- a/docs/services/cloudformation/sim-cloudformation-inspect-skipped.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-inspect-skipped.example.ts
@@ -16,8 +16,11 @@ const stack = await simAws.cloudFormation().deployTemplate({
           BucketName: "skipped-site-bucket",
         },
       },
-      AlarmRule: {
-        Type: "AWS::CloudWatch::Alarm",
+      SearchApi: {
+        Type: "AWS::AppSync::GraphQLApi",
+        Properties: {
+          Name: "search",
+        },
       },
     },
   },
@@ -26,7 +29,7 @@ const stack = await simAws.cloudFormation().deployTemplate({
 await stack.waitForDeployComplete();
 
 console.log(stack.skippedResources.map((resource) => resource.logicalId));
-// ["AlarmRule"]
+// ["SearchApi"]
 
-console.log(stack.getResource("AlarmRule")?.skippedReason);
-// "Unsupported sim CloudFormation Resource service CloudWatch"
+console.log(stack.getResource("SearchApi")?.skippedReason);
+// "Unsupported sim CloudFormation Resource service AppSync"


### PR DESCRIPTION
The `sim-cloudformation-inspect-skipped` and `sim-cloudformation-inert-resources` examples stood an `AWS::CloudWatch::Alarm` with no `Properties` in for a Resource the deployment would skip. Sim CloudWatch creates alarms now. An alarm declared without `Properties` fails validation in `SimCfnAlarmCreator`, and both templates failed the stack rather than reaching the output the examples print. Both now use the `AWS::AppSync::GraphQLApi` the stand-in section further up the page already uses, and each was run against `src/index.ts` to confirm the printed comments match. The other examples asserting a skip (`sim-cloudformation-skipped-resource-values`, `sim-route53-skipped-record-type` and `sim-lambda-container-image-function`) were run the same way and still print what they claim.