### PR TITLE
fix: record template Tags instead of refusing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,36 @@
-# Simulated AWS usage documentation
+# Yulin documentation
 
-This directory contains area-specific documentation for Yulin. Each page explains the simulated
-behaviour and includes example code that can be copied into tests or local development scripts.
+Yulin runs simulated AWS services inside a Node.js process. Tests can use AWS SDK clients,
+CloudFormation templates, or direct service calls without connecting to AWS. Each `SimAws` instance
+holds its own state in memory.
+
+Yulin implements selected AWS behaviour. The service pages describe what each simulation supports
+and where it differs from AWS.
+
+## Install Yulin
+
+```bash
+npm install --save-dev @kensio/yulin
+```
+
+## Choose how to use Yulin
+
+Start with [AWS SDK interception](https://yulinsim.dev/sdk/) when the code under test already uses an
+AWS SDK client. Yulin intercepts the client's `send` calls and returns responses from a simulated
+service. The application code continues to use the AWS SDK normally.
+
+Use [event factories](https://yulinsim.dev/factories/) when a test calls a handler directly and only
+needs an AWS event object. The factories fill in fields that the test does not care about.
+
+Use [CloudFormation](https://yulinsim.dev/services/cloudformation/) to build a simulation from a
+template. This also works with templates synthesized by AWS CDK and AWS SAM.
+
+Use the [localhost server](https://yulinsim.dev/serve/) when the code runs in another process or
+sends HTTP requests. The [AWS CLI guide](https://yulinsim.dev/cli/) explains how to point AWS CLI
+commands at the same endpoint.
+
+Read [simulated time](https://yulinsim.dev/time/) when a test needs to advance a schedule, expire a
+credential, or run other work that depends on time passing.
 
 ## Service documentation
 
@@ -42,7 +71,7 @@ behaviour and includes example code that can be copied into tests or local devel
 - [STS](https://yulinsim.dev/services/sts/ "Simulated STS usage docs")
 - [WAFv2](https://yulinsim.dev/services/wafv2/ "Simulated WAFv2 usage docs")
 
-## Feature documentation
+## Feature guides
 
 - [AI skill](https://yulinsim.dev/ai-skill/ "Yulin AI skill usage docs")
 - [The AWS CLI](https://yulinsim.dev/cli/ "The AWS CLI against simulated AWS usage docs")

--- a/docs/factories/README.md
+++ b/docs/factories/README.md
@@ -1,36 +1,11 @@
 # Event factories
 
-A handler is invoked with an event, and a test of a handler has to produce one. The events AWS
-delivers are large, most of each one is fields the handler never reads, and the two or three the
-test is about are buried in them. Written out by hand, that literal is copied between files and
-drifts.
+Yulin's event factories create complete AWS event objects for tests that call a handler directly.
+They use [`@kensio/part-factory`](https://partfactory.dev/) and do not need a `SimAws` instance.
 
-Yulin exports [`@kensio/part-factory`](https://partfactory.dev/) factories for those event shapes. A
-test made with one says what the request or the message was and leaves the rest of the event alone.
-They are ordinary factories, made in-process, and they need no `SimAws` instance and no simulated
-service running. A handler test that runs without a simulator is who they are for. A test that does want
-one (a Function URL served over HTTP, a queue with a real event source mapping) gets its events from
-the simulator, and these factories make the same shapes that simulator delivers.
+## Make a record or an event
 
-## What is exported
-
-| Factory                                                                       | Import                       | Event                               |
-| ----------------------------------------------------------------------------- | ---------------------------- | ----------------------------------- |
-| `lambdaFunctionUrlEventFactory`                                               | `@kensio/yulin/lambda`       | A Lambda Function URL invocation    |
-| `lambdaSqsEventFactory`, `lambdaSqsEventRecordFactory`                        | `@kensio/yulin/lambda`       | An SQS event source mapping's batch |
-| `lambdaDynamoDbStreamEventFactory`, `lambdaDynamoDbStreamEventRecordFactory`  | `@kensio/yulin/lambda`       | A DynamoDB stream mapping's batch   |
-| `httpApiProxyEventFactory`                                                    | `@kensio/yulin/apigatewayv2` | An HTTP API `AWS_PROXY` invocation  |
-| `s3NotificationEventFactory`, `s3NotificationEventRecordFactory`              | `@kensio/yulin/s3`           | An S3 event notification            |
-| `cloudFrontViewerRequestEventFactory`, `cloudFrontViewerResponseEventFactory` | `@kensio/yulin/cloudfront`   | A CloudFront Functions event        |
-
-Each service's own documentation covers what its events mean. This page is about how the factories
-are shaped and what they have in common.
-
-## One factory per shape, and one per record
-
-An event that carries a list of records has two factories, one for a record and one for the event
-around it. The record factory makes one record, and the event factory completes as many records as
-the test asks for.
+Pass the fields that matter to the test. The factory supplies the remaining fields:
 
 ```typescript factories-records-and-events
 /**
@@ -68,17 +43,14 @@ const event = lambdaSqsEventFactory.make({
 console.log(ordersHandler(event));
 ```
 
-The event factory exists so a test can pass partial records like that. A `DynamicFactory` whose
-defaults hold one record would not manage it. Overrides are merged onto defaults, and merging
-replaces a list whole rather than element by element. A partial record passed that way would reach
-the handler as the only thing in those records, typed as a complete one and missing every field the
-handler reads.
+Factories whose names end in `RecordFactory` create one record. Their matching event factories
+create the object that contains a `Records` array. The event factory makes one record by default and
+completes every partial record passed in `Records`.
 
-## Named variations
+## Reuse a named event shape
 
-Every factory here is an `ItemFactory`. A variation with a name is a `VariantFactory` around it, the
-same as for any other `part-factory` factory. That is usually the tidiest way to describe the kind
-of request or message one application receives:
+Every exported event factory implements `ItemFactory`. Wrap one in a `VariantFactory` to keep a
+common event shape in one place:
 
 ```typescript factories-variants
 /**
@@ -118,23 +90,39 @@ console.log(
 );
 ```
 
-## Events that agree with themselves
+## Keep related fields consistent
 
-A real AWS event says the same thing in more than one field, and those copies are where a
-hand-written literal goes wrong. It asks for `/user/status` and leaves the request context saying
-`/`, or gives an SQS record the digest of some other body, or reports a DynamoDB insert on a record
-that carries an old image.
+AWS events often repeat the same value in several fields. The factories calculate those fields from
+the overrides. For example, an SQS record's `md5OfBody` follows its `body`, and an S3 notification's
+bucket ARN follows its bucket name.
 
-Each factory's defaults are computed from the overrides, so supplying either copy settles the other.
-What that covers is listed in each factory's own documentation, and in outline it is:
+The factories keep these groups consistent:
 
-- **Function URL and HTTP API events** — the path, the query, the route key, the endpoint's id,
-  hostname and `host` header, the caller's user agent and address, and the invocation time
-- **SQS records** — the digest of the body, and the Region of the queue ARN
-- **DynamoDB stream records** — the images the reported change would carry, the view type naming
-  the images that are there, and the Region of the stream ARN
-- **S3 notification records** — the ARN of the Bucket named, and whether the Object still exists to
-  have a size and an eTag
+- Function URL and HTTP API request paths, route keys, query strings, endpoint details, caller
+  details, and invocation times
+- SQS message bodies, body digests, queue ARNs, and regions
+- DynamoDB stream images, event names, view types, stream ARNs, and regions
+- S3 bucket names, bucket ARNs, event names, and object metadata
 
-Overriding both copies of one of those with different values is still allowed. A test that wants an
-event no real invocation would produce is entitled to one. It just has to ask for it twice.
+You can still override both copies with different values. The factory preserves explicit overrides,
+even when AWS would not produce that combination.
+
+## Available factories
+
+| Factory                                                                       | Import                       | Event                               |
+| ----------------------------------------------------------------------------- | ---------------------------- | ----------------------------------- |
+| `lambdaFunctionUrlEventFactory`                                               | `@kensio/yulin/lambda`       | A Lambda Function URL invocation    |
+| `lambdaSqsEventFactory`, `lambdaSqsEventRecordFactory`                        | `@kensio/yulin/lambda`       | An SQS event source mapping's batch |
+| `lambdaDynamoDbStreamEventFactory`, `lambdaDynamoDbStreamEventRecordFactory`  | `@kensio/yulin/lambda`       | A DynamoDB stream mapping's batch   |
+| `httpApiProxyEventFactory`                                                    | `@kensio/yulin/apigatewayv2` | An HTTP API `AWS_PROXY` invocation  |
+| `s3NotificationEventFactory`, `s3NotificationEventRecordFactory`              | `@kensio/yulin/s3`           | An S3 event notification            |
+| `cloudFrontViewerRequestEventFactory`, `cloudFrontViewerResponseEventFactory` | `@kensio/yulin/cloudfront`   | A CloudFront Functions event        |
+
+Each service page describes the fields and defaults for its own factories.
+
+## Limitations
+
+- Event factories create data only. They do not invoke a Lambda function, apply IAM permissions, or
+  run another simulated service.
+- A factory accepts explicit overrides that disagree with each other. It does not validate that the
+  final event could have come from AWS.

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,27 +1,11 @@
-# Simulated AWS SDK
+# AWS SDK interception
 
-Yulin can intercept AWS SDK clients and route their Commands to simulated AWS services. The code
-under test uses the AWS SDK as it would in production, and needs no knowledge of the simulator.
+`SimSdk` routes AWS SDK for JavaScript v3 commands to Yulin. Use it to test code that already sends
+commands through AWS SDK clients.
 
-This is the recommended way to test implementation code that already uses the AWS SDK. Direct
-interaction with `SimAws` remains useful for seeding and inspecting simulated state from within
-tests.
+## Intercept a client
 
-## How it works
-
-`SimSdk` replaces the `send` method of an intercepted SDK client. Each sent Command is routed by
-name to the matching operation of a simulated AWS service, and the result comes back to the caller
-as a normal SDK response. Every Command is served in process.
-
-Every `SimSdk` owns a simulated AWS environment. You can let it create its own, or give it an
-existing one to share:
-
-- `new SimSdk()` creates an isolated `SimAws` internally, available as `simSdk.simAws`.
-- `new SimSdk({ simAws })` wraps a `SimAws` you already have.
-
-## Basic usage
-
-Intercept an SDK client class, then use the SDK as normal:
+Create a `SimSdk`, intercept a client class, and run the code under test:
 
 ```typescript sim-sdk-intercept-s3
 /**
@@ -58,36 +42,33 @@ console.log(await output.Body?.transformToString()); // "Hello, world!"
 simSdk.restoreAll();
 ```
 
-You can intercept a client class or a client instance:
+Intercepting a class affects every instance of that class. This includes clients created after the
+call to `intercept`. Intercepting an object affects that client only.
 
-- **A class** (`simSdk.intercept(S3Client)`) intercepts every instance of it, including instances
-  the code under test constructs later. This is the most common choice.
-- **An instance** (`simSdk.intercept(s3Client)`) intercepts only that instance. Use it when one
-  client should hit the simulator and the others are handled some other way.
+`SimSdk` replaces the intercepted client's `send` method. It routes each command to the matching
+Yulin service and returns an SDK-shaped response. The request stays inside the process.
 
-A client can only have one interception at a time. Intercepting an already-intercepted client
-throws a diagnostic error, and the existing interception stays in place.
+A client can have one active interception. A second interception throws
+`SimSdkAlreadyInterceptedError` and leaves the first one in place.
 
-## Account and Region scope
+## Access simulated state
 
-Each sent Command resolves its own simulated Account and Region scope:
+`new SimSdk()` creates a `SimAws` instance and exposes it as `simSdk.simAws`. Use that instance to
+prepare state before running the application, or to inspect state afterwards.
 
-1. The **Region** comes from the sending client's own configuration, such as
-   `new S3Client({ region: "eu-west-2" })`, falling back to the simulation default.
-2. The **Account** comes from the ambient `simAws.runAs(...)` caller when one is set, falling back
-   to the simulation default Account.
+Pass an existing instance as `new SimSdk({ simAws })` when several parts of a test need to share the
+same simulation.
 
-The resolved caller reaches the simulated service, and simulated [IAM](https://yulinsim.dev/services/iam/)
-authorization applies to it exactly as it does for direct sim service use. A caller without
-permission for a Command is denied, as on real AWS. Where no caller can be identified, Commands run
-as the simulation's `defaultCaller`, and as the default Account root where the simulation was given
-none. See
-[Name the caller a simulation uses by default](https://yulinsim.dev/services/iam/#name-the-caller-a-simulation-uses-by-default).
+## Account and region
 
-`runAs` runs a function with an ambient simulated caller, such as an IAM Role. Commands sent during
-the run are attributed to that caller, with no changes to the client or the code under test. A
-direct sim service call inside the run is attributed to it too, covered in
-[Run a block of calls as one caller](https://yulinsim.dev/services/iam/#run-a-block-of-calls-as-one-caller):
+Yulin resolves the account and region for every `send` call. The client's `region` configuration
+selects the simulated region. Yulin uses its default region when the client has none.
+
+The current `simAws.runAs(...)` caller selects the account. Without a `runAs` caller, Yulin uses the
+simulation's default account and caller. Simulated [IAM](https://yulinsim.dev/services/iam/)
+authorization applies to intercepted commands.
+
+Use `runAs` to send commands as a role without changing the client or the application code:
 
 ```typescript sim-sdk-run-as
 /**
@@ -155,31 +136,31 @@ await simAws.runAs(
 simSdk.restoreAll();
 ```
 
-The ambient caller belongs to its own `SimAws` instance. Separate simulations in the same process
-each keep their own.
+`runAs` applies only to the `SimAws` instance on which it was called. A caller set on another
+simulation does not affect these commands.
 
-## Restoring interception
+## Restore the client
 
-Restoring puts back the client's real SDK `send`:
+Restore an interception before later code needs the client's original `send` method:
 
-- `interception.restore()` restores one interception. `simSdk.intercept(...)` returns the handle.
-- `simSdk.restoreAll()` restores everything intercepted through that `SimSdk`.
-- `SimSdk` and interception handles are disposable. `using simSdk = new SimSdk();` restores
-  automatically at the end of the scope.
+- Save the result of `simSdk.intercept(...)` and call its `restore()` method to restore one client.
+- Call `simSdk.restoreAll()` to restore every client intercepted by that `SimSdk`.
+- Declare `SimSdk` or an interception handle with `using` to restore it when the scope ends.
 
-## Choosing Commands to intercept
+## Limit the intercepted commands
 
-By default every Command sent through an intercepted client is routed to the simulator. To
-intercept only specific Commands, pass an allow list of Command classes or names:
-`simSdk.intercept(s3Client, { commands: [GetObjectCommand] })`. Commands outside the allow list
-throw a diagnostic error.
+An interception handles every command by default. Pass an allow list when a test should accept only
+specific commands:
 
-## The DynamoDB document client
+`simSdk.intercept(s3Client, { commands: [GetObjectCommand] })`
 
-`@aws-sdk/lib-dynamodb` takes plain JavaScript values. Application code writes
-`{ id: "a", count: 1 }` where the base client wants `{ id: { S: "a" }, count: { N: "1" } }`.
-Intercept the document client and its Commands reach simulated DynamoDB with the values already
-converted. Code written against the document client runs against the simulator unchanged.
+The list accepts command classes or command names. Sending another command throws
+`SimSdkCommandNotInterceptedError`.
+
+## Intercept the DynamoDB document client
+
+The DynamoDB document client accepts plain JavaScript values. Intercept the document client object,
+then send `@aws-sdk/lib-dynamodb` commands through it:
 
 ```typescript sim-sdk-document-client
 /**
@@ -232,43 +213,61 @@ console.log(read.Item?.["total"]); // 42
 console.log(read.Item?.["paid"]); // true
 ```
 
-`DynamoDBDocumentClient.from(client)` builds a separate object of its own class. Intercepting the
-base client therefore leaves Commands sent through the document client alone. Intercept the
-document client. Both can be intercepted at once, and they reach
-the same simulated tables, since the document client shares the base client's config and so
-resolves the same Account and Region.
+`DynamoDBDocumentClient.from(client)` returns a separate client object. Intercept that object, not
+the base `DynamoDBClient`. You may intercept both clients. They use the same simulated tables when
+their account and region match.
 
-The real document client converts values in middleware, which runs inside the `send` that
-interception replaces. So the conversion happens at the interception boundary instead, using the
-option defaults `lib-dynamodb` sets (not the `util-dynamodb` ones). Which native types map to which
-descriptors is in [the sim DynamoDB docs](https://yulinsim.dev/services/dynamodb/#the-document-client).
+Yulin converts document values at the interception boundary. It uses the default translation
+options from `@aws-sdk/lib-dynamodb`. The [DynamoDB documentation](https://yulinsim.dev/services/dynamodb/#the-document-client)
+lists the supported value conversions.
 
-## Supported services and Commands
+## Available functionality
 
-These simulated services support SDK interception: ACM, API Gateway v2, CloudFormation, CloudFront,
-CloudWatch, CloudWatch Logs, Cognito, DynamoDB, DynamoDB Streams, ECS, Elastic Load Balancing v2,
-EventBridge, EventBridge Scheduler, IAM, KMS, Lambda, Rekognition, Route53, S3, Secrets Manager,
-SES, SNS, SQS, SSM, STS and WAFv2. Each service's own docs list the Commands it
-simulates.
+SDK interception supports these service clients:
 
-A gap in that coverage is refused on send, with a different error for each kind:
+- ACM
+- API Gateway REST APIs and HTTP APIs
+- Athena
+- AWS Backup
+- Bedrock Runtime
+- CloudFormation
+- CloudFront and CloudFront KeyValueStore
+- CloudWatch metrics and CloudWatch Logs
+- Cognito Identity Provider
+- DynamoDB and DynamoDB Streams
+- ECS and Elastic Load Balancing v2
+- EventBridge and EventBridge Scheduler
+- Glue
+- IAM
+- Kinesis Data Firehose and Kinesis Data Streams
+- KMS
+- Lambda
+- Personalize, Personalize Events, and Personalize Runtime
+- Rekognition
+- Route 53
+- S3
+- Secrets Manager
+- SESv2
+- SNS and SQS
+- SSM
+- Step Functions
+- STS
+- WAFv2
 
-- A Command the simulated service doesn't support throws `SimSdkUnsupportedCommandError`, naming the
-  Command and listing the Commands that service does support.
-- A client for an AWS service Yulin doesn't simulate at all throws `SimSdkUnknownServiceError`,
-  naming the service. There is no Command list to report, since no simulated service was resolved.
+Each service page lists the commands that service accepts. An unsupported command throws
+`SimSdkUnsupportedCommandError` and includes the supported command names. A client for an unknown
+service throws `SimSdkUnknownServiceError`.
 
 ## Limitations
 
-- Only `client.send(command)` is intercepted. SDK utilities that bypass `send`, such as
-  `getSignedUrl`, run against real AWS. Paginators and waiters go through `send`, so they work. Presigning works without interception. Point the client at the simulated endpoint, as
-  [the sim S3 presigned URL docs](https://yulinsim.dev/services/s3/#presigned-urls) show.
-- Simulated errors carry SDK-shaped `name` and `$metadata`, but are not instances of the real SDK
-  exception classes. Match an error by its `error.name`. An `instanceof` check against the SDK class
-  fails.
+- Yulin intercepts `client.send(command)`. SDK utilities that bypass `send`, including
+  `getSignedUrl`, bypass interception. Paginators and waiters use `send` and can be intercepted. To
+  use a presigned URL with Yulin, point the client at a served endpoint as shown in the
+  [S3 documentation](https://yulinsim.dev/services/s3/#presigned-urls).
+- Simulated errors have SDK-shaped `name` and `$metadata` fields. They are separate classes from the
+  SDK exceptions, so match them by `error.name` instead of `instanceof`.
 - The callback form of `send(command, callback)` is not supported. Use the promise form.
-- The translate config a document client is built with,
-  `DynamoDBDocumentClient.from(client, { marshallOptions, unmarshallOptions })`, is ignored. The
-  conversion always uses the defaults. `removeUndefinedValues: true` in particular has no effect
-  here, and an `undefined` attribute is refused where AWS would have dropped it. The refusal names
-  the attribute and says so.
+- Yulin ignores the translation options in
+  `DynamoDBDocumentClient.from(client, { marshallOptions, unmarshallOptions })`. The conversion uses
+  the defaults. `removeUndefinedValues: true` has no effect. Yulin refuses an `undefined` attribute
+  that the configured document client would otherwise remove.

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -919,6 +919,12 @@ at deploy time naming the property and the Resource. The alternative is a rule t
 event where one field was asked for. Tearing the stack down removes the buses, rules and targets it
 created.
 
+`Tags` is the one difference from the commands, which refuse it outright. A template's tags are
+usually the whole stack's (a CDK app calling `Tags.of(app).add(...)` tags every rule and bus in it),
+and a rule routes the same events whether it carries them or not. They are recorded as an ignored
+property and the deploy stands. Nothing reads them back. A rule or a bus deployed with tags behaves
+as though the template had never named them.
+
 ## Reading back a failed delivery
 
 Real EventBridge tells the caller nothing about a failed delivery. A `PutEvents` that matched a rule
@@ -1101,7 +1107,8 @@ no permission for.
 - EventBridge Scheduler is a separate service, simulated separately. See
   [simulated Scheduler](https://yulinsim.dev/services/scheduler/).
 - Rule tags, a rule `RoleArn`, managed rules and the `ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS`
-  state are all refused.
+  state are all refused at `PutRule`. An `AWS::Events::Rule` carrying `Tags` deploys with the tags
+  dropped and the property recorded.
 - Deleting an event bus deletes its rules, and deleting a rule deletes its targets. Real EventBridge
   refuses to delete either while it still has what hangs off it.
 - `AWS::Events::EventBusPolicy`, `AWS::Events::Archive`, `AWS::Events::Connection` and
@@ -1113,6 +1120,7 @@ no permission for.
   stricter than real AWS.
 - Putting an event onto another account's or region's bus is refused.
 - Partner event buses and partner event sources are refused, as are event bus tags, encryption with
-  a customer managed key, dead letter queues, logging configuration and global endpoints.
+  a customer managed key, dead letter queues, logging configuration and global endpoints. An
+  `AWS::Events::EventBus` carrying `Tags` deploys with the tags dropped and the property recorded.
 - Archives, replay, schema registry and discovery, API destinations and connections are not
   simulated.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1702,6 +1702,10 @@ Reporting individual failures can be tested against a made event too. The handle
 a template naming one is refused. The same Resource deploys a
 [stream mapping](#stream-mappings-in-templates), which has to have one.
 
+`Tags` is the one property recorded rather than refused. A template's tags are usually the whole
+stack's (a CDK app calling `Tags.of(app).add(...)` tags every mapping in it), and a mapping delivers
+the same records whether it carries them or not. The deploy stands and nothing reads them back.
+
 ## Triggering a function from a DynamoDB stream
 
 An event source mapping also connects a [simulated table's stream](https://yulinsim.dev/services/dynamodb/#capturing-changes-with-a-stream "Simulated DynamoDB streams docs")
@@ -4268,7 +4272,9 @@ Current documented limitations:
 - SQS queues, DynamoDB streams and Kinesis streams are the only event sources. Kafka, DocumentDB and
   Kinesis enhanced fan-out consumers are refused outright, and so are `FilterCriteria`,
   `ScalingConfig`, `DestinationConfig`, `BisectBatchOnFunctionError`, `ParallelizationFactor`,
-  `TumblingWindowInSeconds` and the other mapping inputs this simulation has no behaviour for.
+  `TumblingWindowInSeconds` and the other mapping inputs this simulation has no behaviour for. An
+  `AWS::Lambda::EventSourceMapping` carrying `Tags` is the exception, and deploys with the tags
+  dropped and the property recorded.
 - A failed stream batch waits 1, 2, 4, 8 and 16 seconds between attempts, where AWS documents no
   delay. That is deliberate. A delay of zero falls due at the instant the clock already reads, and a
   handler that always throws would leave `advanceBy` with work falling due forever. A mapping that

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -1742,15 +1742,20 @@ ARNs, and `Ref` on an `AWS::SNS::Topic` gives one.
 
 A property with no simulated behaviour fails the resource rather than being dropped. That covers
 `FifoTopic`, `ContentBasedDeduplication`, `FifoThroughputScope`, `KmsMasterKeyId`,
-`SignatureVersion`, `TracingConfig`, `ArchivePolicy`, `DeliveryStatusLogging`, `DataProtectionPolicy`
-and `Tags` on a topic, and `DeliveryPolicy`, `RedrivePolicy`, `ReplayPolicy`, `SubscriptionRoleArn`
-and `Region` on a subscription. Most of them are refused by simulated SNS itself, since they are
-topic or subscription attributes of the same name, and the reason is the same one an SDK caller gets.
-A property the resource type never had is refused too. The failure is worded as an invalid resource,
-which fails the resource where an unsupported one would be
+`SignatureVersion`, `TracingConfig`, `ArchivePolicy`, `DeliveryStatusLogging` and
+`DataProtectionPolicy` on a topic, and `DeliveryPolicy`, `RedrivePolicy`, `ReplayPolicy`,
+`SubscriptionRoleArn` and `Region` on a subscription. Most of them are refused by simulated SNS
+itself, since they are topic or subscription attributes of the same name, and the reason is the same
+one an SDK caller gets. A property the resource type never had is refused too. The failure is worded
+as an invalid resource, which fails the resource where an unsupported one would be
 [skipped](https://yulinsim.dev/services/cloudformation/#values-from-a-skipped-resource). A topic that cannot be created
 as the template asked for it would otherwise leave a stack that looks deployed with no publisher
 behind it.
+
+`Tags` is the one difference from `CreateTopic`, which refuses it outright. A template's tags are
+usually the whole stack's (a CDK app calling `Tags.of(app).add(...)` tags every topic in it), and a
+topic delivers the same messages whether it carries them or not. They are recorded as an ignored
+property and the deploy stands. Nothing reads them back either.
 
 CDK works without hand-editing. `topic.addSubscription(new subscriptions.SqsSubscription(queue))`
 synthesises an `AWS::SNS::Subscription` alongside the `AWS::SQS::QueuePolicy` that authorizes the
@@ -1880,7 +1885,8 @@ Current documented limitations:
 - Encryption is left out. `KmsMasterKeyId` is refused, and message bodies are held in process memory
   as they were published. Anything sharing the process can read them.
 - Tags are left out. `TagResource`, `UntagResource` and `ListTagsForResource` are absent, and
-  `CreateTopic` refuses a `Tags` parameter rather than dropping it.
+  `CreateTopic` refuses a `Tags` parameter rather than dropping it. An `AWS::SNS::Topic` carrying
+  `Tags` deploys with the tags dropped and the property recorded.
 - Data protection policies are left out. `PutDataProtectionPolicy` and `GetDataProtectionPolicy` are
   absent, and `CreateTopic` refuses a `DataProtectionPolicy` rather than creating a topic that
   redacts nothing.

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -1039,7 +1039,8 @@ Current documented limitations:
 - Parameter policies (expiration and notification) are left out. `Policies` is refused, and
   `DescribeParameters` always reports an empty `Policies` list.
 - Tags are left out. `Tags` on `PutParameter` is refused, and `AddTagsToResource`,
-  `RemoveTagsFromResource` and `ListTagsForResource` are absent.
+  `RemoveTagsFromResource` and `ListTagsForResource` are absent. An `AWS::SSM::Parameter` carrying
+  `Tags` deploys with the tags dropped and the property recorded.
 - `AllowedPattern` is refused outright. Ignoring it would store a value it was meant to reject,
   without complaint.
 - `KeyId` on a `String` or `StringList` parameter is refused, since nothing would encrypt a value
@@ -1060,9 +1061,10 @@ Current documented limitations:
 - Deletion is immediate. Real Parameter Store asks for thirty seconds before a deleted name is
   reused, where here the name is free straight away.
 - `AWS::SSM::Parameter` supports `Name`, `Type`, `Value`, `Description` and `Tier`. `AllowedPattern`,
-  `DataType`, `Policies` and `Tags` reach `PutParameter`, which refuses them for the reasons above.
-  `Type: SecureString` is refused, as real CloudFormation refuses it for this resource type. The
-  plaintext value would sit in the template.
+  `DataType` and `Policies` reach `PutParameter`, which refuses them for the reasons above. `Tags`
+  is the one difference from the command, and is recorded as an ignored property so a stack that
+  tags every Resource in it still deploys. `Type: SecureString` is refused, as real CloudFormation
+  refuses it for this resource type. The plaintext value would sit in the template.
 - The other `AWS::SSM::*` resource types (`Document`, `Association`, `MaintenanceWindow`,
   `PatchBaseline`, `ResourceDataSync` and the rest) are reported as unsupported and skipped.
 - Every deployment of an `AWS::SSM::Parameter` is a create. A name another stack already used is

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -1,24 +1,12 @@
 # Simulated time
 
-Every timestamp a simulated AWS service produces comes from that simulation's own clock, and that
-clock can be moved. Time can be frozen, set to an instant, or advanced by a duration. Behaviour that
-depends on time passing, such as a temporary session expiring, can be tested without waiting for it.
+Each `SimAws` has its own clock. Yulin uses that clock for resource timestamps, expiry checks, and
+scheduled work.
 
-Time belongs to a `SimAws` instance. Moving it affects that instance only. The host clock, another
-simulation running in the same test file, and any other code in the process all carry on unchanged.
+## Start at a known time
 
-## Reading the time
-
-`simAws.now()` is what the simulation means by "now". The host clock may say something different. It
-also stamps simulated resources, such as an IAM User's `CreateDate` and an `AssumeRole` session's
-`Expiration`.
-
-By default a new `SimAws` runs in step with the real system clock.
-
-## Starting at a known instant
-
-Pass a clock to start somewhere specific. `SimFixedClock` is the usual choice, since it reports one
-instant and stays there:
+A new simulation follows the system clock by default. Pass a `SimFixedClock` when a test needs an
+exact starting time:
 
 ```typescript sim-clock-freeze-and-advance
 /**
@@ -47,41 +35,33 @@ console.log(simAws.now()); // 2026-07-26T11:30:00.000Z
 simAws.clock().resume();
 ```
 
-Simulated time is layered over whatever clock is supplied. A simulation started at a fixed instant
-is still free to move from there, and it stays measured against that clock. Resuming a simulation
-built on a `SimFixedClock` puts it back in running mode, and its time then moves whenever the clock
-underneath moves. A fixed clock stays where it is. Leave the default real clock in place for a
-simulation whose time should pass by itself.
+`simAws.now()` returns the current simulated time. Services use the same value when they create
+timestamps such as an IAM user's `CreateDate`.
+
+The controllable clock sits on top of the clock passed to `SimAws`. Calling `resume()` makes time
+follow that underlying clock again. A `SimFixedClock` never moves, so resuming it still reports a
+fixed time. Keep the default system clock when resumed time should move normally.
 
 ## Frozen and running
 
-There are two modes:
+Call `freeze()` to stop the clock at its current time. Both `setTo(...)` and `advanceBy(...)` also
+leave the clock frozen at the resulting time. This keeps timestamps stable while the test makes its
+assertions.
 
-- **Frozen**: simulated time only moves when something moves it. A frozen clock reports the same
-  instant however long the host takes, and a slow test holds the state it set up. This is what a
-  deterministic assertion wants.
-- **Running**: simulated time tracks the clock underneath, offset from it. On the default real clock
-  time passes by itself. Use it to jump forward an hour and carry on.
+Call `resume()` to let the underlying clock move time again. Any offset remains in place. For
+example, a simulation advanced by one hour continues to run one hour ahead of the system clock.
 
-Moving time deliberately freezes it. `setTo(...)` and `advanceBy(...)` both leave the clock stopped
-where they put it. A test that asked for a specific instant then asserts on that instant, however
-long the assertion takes. `resume()` is the way back to running, and it carries on from where the
-clock stopped.
-
-`simAws.clock().isFrozen` reports which mode the clock is in.
+Read `simAws.clock().isFrozen` to check the current mode.
 
 ## Advancing time
 
-`advanceBy(...)` takes a duration written as any combination of `days`, `hours`, `minutes`,
-`seconds` and `milliseconds`, which add together. A bare number counts milliseconds, as it does for
-`setTimeout`, and `advanceBy(3_600_000)` moves an hour. Durations are never negative, since time
-passing only runs forwards. `setTo(...)` is the explicit way to move a clock back.
+`advanceBy(...)` accepts days, hours, minutes, seconds, and milliseconds. The values are added
+together. A number means milliseconds, so `advanceBy(3_600_000)` advances by one hour. Durations
+must be zero or greater. Use `setTo(...)` to move to an earlier time.
 
-Advancing moves the clock, and it runs whatever the passage of time should have caused. Work
-scheduled for an instant inside the interval is dispatched in due order, each task running with the
-clock reading its own due time. Further work it schedules settles before `advanceBy` returns where
-that work is itself due by the new time, and stays queued where it falls later. So a test can
-advance and then assert, with no additional waiting:
+Advancing the clock also runs scheduled work due within the interval. Yulin runs each task at its
+due time and waits for the simulation to settle before returning. The test can assert on the result
+immediately:
 
 ```typescript sim-clock-session-expiry
 /**
@@ -138,31 +118,16 @@ try {
 }
 ```
 
-Work triggered by advancing that fails throws from `advanceBy(...)`, where the caller can see it.
-The clock is left at the point it failed, and anything still queued stays queued.
+If scheduled work throws, `advanceBy(...)` throws the same failure. The clock stops at the failed
+task's due time, and later work remains queued.
 
-Delivery to a target is the exception, and deliberately so. An EventBridge rule or a Scheduler
-schedule that cannot reach its target records the failure instead of throwing. Real AWS reports a
-failed delivery to nobody, and one rejected delivery would otherwise fail an unrelated
-`advanceBy(...)` elsewhere in the same test. Read the failures from `eventBridge().deliveryFailures`
-and `scheduler().deliveryFailures`.
+EventBridge and EventBridge Scheduler delivery failures are recorded instead. Read them from
+`eventBridge().deliveryFailures` or `scheduler().deliveryFailures`. Step Functions also records a
+failed state on the execution for `DescribeExecution` to return.
 
-A Step Functions execution works the same way. A state that fails while the clock is being advanced
-is recorded on the execution, and `DescribeExecution` reports it once the advance has returned.
+## Read simulated time in a Lambda handler
 
-Several parts of the simulator schedule work on the clock. Advancing time does more than change what
-timestamps and expiry checks see. A scheduled EventBridge rule fires, an EventBridge Scheduler
-schedule invokes its target, a DynamoDB item passes its time to live, a Secrets Manager deletion
-falls due, a Step Functions execution moves on from a `Wait` state, and a Lambda event source
-mapping polls again. Each of those runs at its own due instant inside the interval, in the order
-they fall due.
-
-## Time inside a simulated Lambda handler
-
-A simulated Lambda function runs on its simulation's clock, and that reaches the JavaScript clock
-the function code itself reads. `Date.now()` and `new Date()` inside a handler report simulated
-time. Code stamping an expiry or building a date-partitioned key can be tested against a clock the
-test controls:
+Inside a simulated Lambda invocation, `Date.now()` and `new Date()` read the simulation's clock:
 
 ```typescript sim-clock-lambda-handler
 /**
@@ -203,30 +168,22 @@ const second = await lambda.invoke(
 console.log(Buffer.from(second.Payload!).toString()); // {"at":"2026-07-26T11:00:00.000Z"}
 ```
 
-How that is arranged depends on where the function code runs. One of the two touches a process
-global:
+Zip code runs in a VM with a `Date` constructor connected to the simulation. An in-process handler
+uses the same simulated time during its invocation. Code outside the invocation continues to read
+the system clock, including code running concurrently in another simulation.
 
-- **Zip code** runs in a vm sandbox owning its own globals, and is handed a `Date` bound to the
-  simulation's clock. The globals outside the sandbox are left alone.
-- **A real in-process handler function** is a closure over the module scope it was written in, and
-  reads the global `Date` like everything else in the test run. So the global is substituted for one
-  reporting the invocation's clock while an invocation is running, and the host clock otherwise,
-  tracked with `AsyncLocalStorage` so concurrent invocations of different simulations stay apart. It
-  is installed on the first in-process invocation and never removed, and with no invocation running
-  it behaves exactly as the host's own `Date` does.
+Only calls that ask for the current time are changed. `new Date("2020-03-12")`, `Date.parse(...)`,
+`Date.UTC(...)`, and `instanceof Date` keep their usual behaviour.
 
-Only the current time comes from the clock. `new Date("2020-03-12")`, `Date.parse(...)`,
-`Date.UTC(...)` and `instanceof Date` all behave as they always did.
-
-Under a frozen clock `Date.now()` returns the same number for the whole invocation, and handler code
-that waits for it to change never finishes. Call `resume()` before invoking if the code under test
-polls the clock.
+The global `setTimeout`, `clearTimeout`, `setInterval`, and `clearInterval` functions also use the
+simulation's clock during an invocation. Start an invocation without awaiting it, advance the
+clock past the timer delay, then await the invocation. Lambda's configured timeout and
+`context.getRemainingTimeInMillis()` use the same clock.
 
 ### Where real AWS gets the time
 
-Real Lambda has no current-time API. The context object carries no timestamp, only
-`getRemainingTimeInMillis()`, and no environment variable holds one. Handler code reading `new
-Date()` is reading the machine clock. AWS does provide the time on the event:
+Real Lambda has no current-time API. A production handler gets the current time from the machine
+clock or from a timestamp in its event:
 
 | Event source              | Field                                             |
 | ------------------------- | ------------------------------------------------- |
@@ -236,49 +193,52 @@ Date()` is reading the machine clock. AWS does provide the time on the event:
 | SNS                       | `Records[].Sns.Timestamp`                         |
 | SQS                       | `Records[].attributes.SentTimestamp`              |
 
-For a scheduled invocation AWS advises reading the event's `time` in preference to the system clock,
-because a retry or a delayed delivery runs later than the time the work was for. Simulated Lambda
-follows the same rule where it builds events. A Function URL request carries simulated time in
-`requestContext.time` and `requestContext.timeEpoch`.
+Yulin puts simulated time into the events it builds. Function URL events include
+`requestContext.time` and `requestContext.timeEpoch`. SQS records include simulated
+`SentTimestamp` and `ApproximateFirstReceiveTimestamp` values. The
+[Lambda documentation](https://yulinsim.dev/services/lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda event source mapping docs")
+describes the event source mapping behaviour.
 
-An SQS event source mapping does the same. The `SentTimestamp` and
-`ApproximateFirstReceiveTimestamp` attributes on a delivered record are simulated time, and a
-handler reading the event's time reads the clock the test controls. See
-[simulated Lambda](https://yulinsim.dev/services/lambda/#triggering-a-function-from-an-sqs-queue "Simulated Lambda event source mapping docs").
-
-Handler code that takes a clock as a dependency stays the most testable option, on real AWS and
-here, and needs none of the machinery above.
+A handler can also accept a clock as a dependency. That approach works without Lambda-specific
+clock handling.
 
 ## Time over HTTP
 
-A simulation served over HTTP, through `serveSimAws` or `SimAwsHttp.fetch(...)`, stamps every
-response with simulated time in its `Date` header, as real AWS stamps every API response with server
-time. Advancing the clock changes what that header reports. A client talking to the simulation sees
-the same "now" the simulation does, with no need to know it is talking to a simulator.
+A simulation served through `serveSimAws` or `SimAwsHttp.fetch(...)` uses simulated time in each
+response's `Date` header. Advancing the clock changes the header on later responses.
 
 ## Time and SDK interception
 
-A `SimSdk` owns a simulated AWS environment, available as `simSdk.simAws`. Intercepted SDK code runs
-on a clock a test can control with `await simSdk.simAws.clock().advanceBy({ hours: 1 })`.
+A `SimSdk` exposes its simulation as `simSdk.simAws`. Advance its clock with
+`await simSdk.simAws.clock().advanceBy({ hours: 1 })`.
+
+## Uses of simulated time
+
+Yulin uses the clock for:
+
+- Resource timestamps and expiry checks
+- EventBridge rules and EventBridge Scheduler schedules
+- DynamoDB time to live and scheduled Secrets Manager deletion
+- Step Functions `Wait` states
+- Lambda event source polling and event timestamps
+- `Date`, global timers, and invocation deadlines inside a simulated Lambda invocation
+- HTTP response `Date` headers
 
 ## Limitations
 
-- Advancing the clock is the only thing that fires a scheduled
-  [EventBridge rule](https://yulinsim.dev/services/eventbridge/#rules-that-fire-on-a-schedule). Nothing runs on the
-  host's clock. A simulation left alone in real time fires nothing however long it is left.
-- Advancing the clock is also the only thing that fires an
-  [EventBridge Scheduler schedule](https://yulinsim.dev/services/scheduler/#firing-a-schedule), including a one-time
-  `at(...)` one.
-- Only `SimAws` exposes time control. Services constructed standalone, such as `new SimS3()`, get
-  their own real clock and no way to move it.
-- A `SimAws` constructed with a `background` scheduler of its own cannot control time, because that
-  scheduler brings its own clock. `simAws.clock()` throws a diagnostic error saying so.
-- Simulated time reaches JavaScript's own clock inside a simulated Lambda invocation, and nowhere
-  else. `Date.now()` and `new Date()` in code under test that is not running as a simulated Lambda
-  function still report real time.
-- Timers are not simulated. `setTimeout` inside a handler is a host timer. A sleeping handler waits
-  in real time, and advancing the clock leaves it asleep.
-- A time already read cannot be reached. A handler module doing `const startedAt = Date.now()` at
-  module scope read it when the test file imported the module, long before any invocation.
-- Advancing time does not re-evaluate simulated state that was already computed, such as an ACM
-  certificate that has finished validating. It changes what is read from the clock next.
+- Scheduled [EventBridge rules](https://yulinsim.dev/services/eventbridge/#rules-that-fire-on-a-schedule)
+  and [EventBridge Scheduler schedules](https://yulinsim.dev/services/scheduler/#firing-a-schedule)
+  run when `advanceBy(...)` or a forward `setTo(...)` reaches their due time. Elapsed system time
+  does not run them.
+- Time control is available through `SimAws`. A standalone service such as `new SimS3()` uses the
+  system clock and has no clock controls.
+- A `SimAws` created with a custom `background` scheduler cannot control time because the scheduler
+  owns its clock. Calling `simAws.clock()` throws `SimAwsTimeNotControllable`.
+- JavaScript's `Date` and global timer functions use simulated time only during a simulated Lambda
+  invocation. Other application code continues to use system time.
+- Lambda code imported from `node:timers` or `node:timers/promises` uses system time. The same is
+  true of `util.promisify(setTimeout)`.
+- A module-level `Date.now()` runs when the module is imported, before the Lambda invocation begins.
+  It reads system time.
+- Moving the clock does not recalculate state that has already been computed. For example, it does
+  not restart validation for an ACM certificate that is already issued.

--- a/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-creator.ts
+++ b/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-creator.ts
@@ -41,6 +41,7 @@ export class SimCfnEventBusCreator {
     });
 
     busProperties.refuseUnsimulated();
+    busProperties.recordIgnoredProperties();
 
     const name = busProperties.name();
     const description = busProperties.description();

--- a/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-properties.ts
+++ b/src/service/eventbridge/cfn/bus/sim-cfn-event-bus-properties.ts
@@ -25,8 +25,24 @@ const unsimulatedProperties: readonly (readonly [string, string])[] = [
   ["EventSourceName", "partner event buses are not simulated"],
   ["KmsKeyIdentifier", "events are not encrypted with a customer managed key"],
   ["LogConfig", "event bus logging is not simulated"],
-  ["Tags", "event bus tags are not simulated"],
 ];
+
+/**
+ * What a template can say about an event bus that this simulation has nothing
+ * to act on, and why.
+ *
+ * `Tags` is the whole list, and it is recorded rather than refused. A bus
+ * behaves the same way with a tag and without one, and a CDK app calling
+ * `Tags.of(app).add(...)` tags every bus in it.
+ */
+const ignoredPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "Tags",
+    `${eventBusResourceType} property Tags is not simulated, so the bus is ` +
+      "created without them. Nothing reads them back and nothing is grouped " +
+      "or billed by them.",
+  ],
+]);
 
 interface SimCfnEventBusPropertiesProperties {
   readonly resource: SimCfnResource;
@@ -91,6 +107,17 @@ export class SimCfnEventBusProperties {
           `${property} is not simulated, so the Resource is refused rather ` +
             `than deployed without it: ${reason}`,
         );
+      }
+    }
+  }
+
+  /**
+   * Record the properties the bus is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    for (const [property, reason] of ignoredPropertyReasons) {
+      if (this.properties.has(property)) {
+        this.resource.ignoreProperty(property, reason);
       }
     }
   }

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-creator.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-creator.ts
@@ -6,6 +6,10 @@ import type { SimEventBridge } from "../../sim-event-bridge.js";
 import { simCfnEventBridgeResourceCreation } from "../sim-cfn-event-bridge-resource-error.js";
 import { eventRuleResourceType } from "../sim-cfn-event-bridge-resource-types.js";
 import { SimCfnEventRuleProperties } from "./sim-cfn-event-rule-properties.js";
+import {
+  recordIgnoredEventRuleProperties,
+  refuseUnsimulatedEventRuleProperties,
+} from "./sim-cfn-event-rule-unsimulated-properties.js";
 import type { SimCfnEventRuleTarget } from "./sim-cfn-event-rule-targets.js";
 import type { SimCfnResourceCallerOptions } from "../../../cloudformation/resource/caller/sim-cfn-resource-caller-options.js";
 
@@ -45,7 +49,8 @@ export class SimCfnEventRuleCreator {
       properties,
     });
 
-    ruleProperties.refuseUnsimulated();
+    refuseUnsimulatedEventRuleProperties(resource, properties);
+    recordIgnoredEventRuleProperties(resource, properties);
 
     const name = ruleProperties.name();
     const busName = ruleProperties.busName();

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-properties.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-properties.ts
@@ -122,32 +122,6 @@ export class SimCfnEventRuleProperties {
     );
   }
 
-  /**
-   * Refuse what this simulation does not model, naming the property.
-   *
-   * Both are asked by key rather than by value, so a template writing `null`
-   * for one is refused rather than read as having left it out.
-   */
-  refuseUnsimulated(): void {
-    if (this.properties.has("RoleArn")) {
-      throw this.propertyError(
-        "RoleArn is not simulated, so the Resource is refused rather than " +
-          "deployed without it: a rule reaches its target as the EventBridge " +
-          "service principal, admitted by the target's own resource policy",
-      );
-    }
-
-    // Rule tags never reach PutRule, which is the one place that would
-    // otherwise refuse them, so a tagged rule would deploy and quietly lose
-    // its tags.
-    if (this.properties.has("Tags")) {
-      throw this.propertyError(
-        "Tags are not simulated, so the Resource is refused rather than " +
-          "deployed without them",
-      );
-    }
-  }
-
   private stringProperty(name: string): string | undefined {
     const value = this.properties.get(name);
 

--- a/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-unsimulated-properties.ts
+++ b/src/service/eventbridge/cfn/rule/sim-cfn-event-rule-unsimulated-properties.ts
@@ -1,0 +1,75 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simCfnEventBridgeResourceError } from "../sim-cfn-event-bridge-resource-error.js";
+import { eventRuleResourceType } from "../sim-cfn-event-bridge-resource-types.js";
+
+/**
+ * What a template can say about a rule that this simulation does not model,
+ * and why each one fails the Resource.
+ *
+ * `RoleArn` is the whole list. A rule reaches its target as the EventBridge
+ * service principal, admitted by the target's own resource policy, so a rule
+ * deployed with a role would sit in a test looking as though the role decided
+ * something.
+ */
+const refusedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "RoleArn",
+    "RoleArn is not simulated, so the Resource is refused rather than " +
+      "deployed without it: a rule reaches its target as the EventBridge " +
+      "service principal, admitted by the target's own resource policy",
+  ],
+]);
+
+/**
+ * What a template can say about a rule that this simulation has nothing to act
+ * on, and why each one is recorded rather than refused.
+ *
+ * `Tags` is the whole list. Rule tags never reach `PutRule`, so the record is
+ * the only place a tagged rule says it lost them. A rule routes the same
+ * events with a tag and without one, and a CDK app calling
+ * `Tags.of(app).add(...)` tags every rule in it.
+ */
+const ignoredPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "Tags",
+    `${eventRuleResourceType} property Tags is not simulated, so the rule is ` +
+      "created without them. Nothing reads them back and nothing is grouped " +
+      "or billed by them.",
+  ],
+]);
+
+/**
+ * Refuse what this simulation does not model, naming the property.
+ *
+ * Asked by key rather than by value, so a template writing `null` for one of
+ * these is refused rather than read as having left it out.
+ */
+export function refuseUnsimulatedEventRuleProperties(
+  resource: SimCfnResource,
+  properties: SimCfnTemplateValueRecord,
+): void {
+  for (const [property, reason] of refusedPropertyReasons) {
+    if (Object.hasOwn(properties, property)) {
+      throw simCfnEventBridgeResourceError(
+        eventRuleResourceType,
+        resource.logicalId,
+        reason,
+      );
+    }
+  }
+}
+
+/**
+ * Record the properties the rule is created without acting on.
+ */
+export function recordIgnoredEventRuleProperties(
+  resource: SimCfnResource,
+  properties: SimCfnTemplateValueRecord,
+): void {
+  for (const [property, reason] of ignoredPropertyReasons) {
+    if (Object.hasOwn(properties, property)) {
+      resource.ignoreProperty(property, reason);
+    }
+  }
+}

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-error.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-resource-error.ts
@@ -27,7 +27,7 @@ export function simCfnEventBridgeResourceError(
  * Every Resource type here goes through the ordinary EventBridge commands, so
  * what a template may ask for is decided once, by simulated EventBridge, rather
  * than again in the CloudFormation layer. What that leaves out is where the
- * request came from: a deployment failing with `Rule tags are not simulated`
+ * request came from: a deployment failing with `Rule pattern is not valid`
  * says nothing about which Resource asked for it. Only EventBridge's own errors
  * are renamed, so a refusal the CloudFormation layer decided keeps the wording
  * it was written with.

--- a/src/service/eventbridge/cfn/sim-cfn-event-bridge-rule.iso.test.ts
+++ b/src/service/eventbridge/cfn/sim-cfn-event-bridge-rule.iso.test.ts
@@ -246,32 +246,37 @@ describe("EventBridge CloudFormation Rule deployment", () => {
     assertStringIncludes(error.message, "OrdersRule");
   });
 
-  it("refuses rule tags rather than deploying without them", async () => {
-    // Given a tagged rule. Tags reach no EventBridge command, so nothing else
-    // would notice them going missing.
+  it("records rule tags rather than failing the stack over them", async () => {
+    // Given a tagged rule, as a CDK app tagging its whole app deploys.
     const simAws = new SimAws();
 
-    const error = await assertThrowsErrorAsync(async () => {
-      const stack = await simAws.cloudFormation().deployTemplate({
-        stackName: "orders-stack",
-        template: {
-          Resources: {
-            OrdersRule: {
-              Type: "AWS::Events::Rule",
-              Properties: {
-                Name: "orders",
-                EventPattern: orderPattern,
-                Tags: [{ Key: "team", Value: "orders" }],
-              },
+    // When the stack is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersRule: {
+            Type: "AWS::Events::Rule",
+            Properties: {
+              Name: "orders",
+              EventPattern: orderPattern,
+              Tags: [{ Key: "team", Value: "orders" }],
             },
           },
         },
-      });
-
-      await stack.waitForDeployComplete();
+      },
     });
 
-    assertStringIncludes(error.message, "Tags");
+    await stack.waitForDeployComplete();
+
+    // Then the rule is there, and the tags it lost are recorded against it.
+    assertNonNullable(simAws.eventBridge().findRule("orders"));
+
+    const ignored = stack.getResource("OrdersRule")?.ignoredProperties ?? [];
+
+    assertArrayLength(ignored, 1);
+    assertIdentical(ignored[0].path, "Tags");
+    assertStringIncludes(ignored[0].reason, "not simulated");
   });
 
   it("refuses a bus property written as null", async () => {
@@ -297,6 +302,38 @@ describe("EventBridge CloudFormation Rule deployment", () => {
 
     // Then it is refused, rather than read as having left the policy out.
     assertStringIncludes(error.message, "Policy");
+  });
+
+  it("records bus tags rather than failing the stack over them", async () => {
+    // Given a tagged bus, as a CDK app tagging its whole app deploys.
+    const simAws = new SimAws();
+
+    // When the stack is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersBus: {
+            Type: "AWS::Events::EventBus",
+            Properties: {
+              Name: "orders",
+              Tags: [{ Key: "team", Value: "orders" }],
+            },
+          },
+        },
+      },
+    });
+
+    await stack.waitForDeployComplete();
+
+    // Then the bus is there, and the tags it lost are recorded against it.
+    assertNonNullable(simAws.eventBridge().findEventBus("orders"));
+
+    const ignored = stack.getResource("OrdersBus")?.ignoredProperties ?? [];
+
+    assertArrayLength(ignored, 1);
+    assertIdentical(ignored[0].path, "Tags");
+    assertStringIncludes(ignored[0].reason, "not simulated");
   });
 
   it("removes the rules and targets a stack created", async () => {

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
@@ -49,10 +49,7 @@ export class SimCfnLambdaEventSourceMappingProperties {
       "EventSourceArn",
     );
 
-    assertSimulatedEventSourceMappingProperties(
-      this.resource.logicalId,
-      this.properties,
-    );
+    assertSimulatedEventSourceMappingProperties(this.resource, this.properties);
 
     return {
       EventSourceArn: eventSourceArn,

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
@@ -1,3 +1,4 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 
 /**
@@ -47,9 +48,26 @@ const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "SelfManagedEventSource",
   "SelfManagedKafkaEventSourceConfig",
   "SourceAccessConfigurations",
-  "Tags",
   "Topics",
   "TumblingWindowInSeconds",
+]);
+
+/**
+ * Real AWS::Lambda::EventSourceMapping properties this simulation has nothing
+ * to act on and no reason to fail a stack over.
+ *
+ * `Tags` is the whole list. The mapping is created without them and the
+ * omission is recorded against the Resource. A mapping delivers the same
+ * records with a tag and without one, and a CDK app calling
+ * `Tags.of(app).add(...)` tags every mapping in it.
+ */
+const ignoredPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "Tags",
+    "AWS::Lambda::EventSourceMapping property Tags is not simulated, so the " +
+      "mapping is created without them. Nothing reads them back and nothing " +
+      "is grouped or billed by them.",
+  ],
 ]);
 
 /**
@@ -72,13 +90,23 @@ export function eventSourceMappingPropertyError(
 
 /**
  * Refuse everything about an AWS::Lambda::EventSourceMapping Resource that is
- * not simulated.
+ * not simulated, and record what the mapping is created without.
  */
 export function assertSimulatedEventSourceMappingProperties(
-  logicalId: string,
+  resource: SimCfnResource,
   properties: SimCfnTemplateValueRecord,
 ): void {
+  const logicalId = resource.logicalId;
+
   for (const name of Object.keys(properties)) {
+    const ignoredReason = ignoredPropertyReasons.get(name);
+
+    if (ignoredReason !== undefined) {
+      resource.ignoreProperty(name, ignoredReason);
+
+      continue;
+    }
+
     if (unsimulatedPropertyNames.has(name)) {
       throw eventSourceMappingPropertyError(
         logicalId,

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
@@ -209,6 +209,34 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
     assertIdentical(events[0].Records[0]?.body, "order-1");
   });
 
+  it("records mapping tags rather than failing the stack over them", async () => {
+    // Given a tagged mapping, as a CDK app tagging its whole app deploys.
+    const simAws = new SimAws();
+
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: consumerTemplate({
+        ...mappingProperties,
+        Tags: [{ Key: "team", Value: "orders" }],
+      }),
+      bindings: [
+        { logicalId: "ConsumerFunction", handler: (): undefined => undefined },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the mapping is there, and the tags it lost are recorded against it.
+    const resource = stack.getResource("OrderConsumerMapping");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimLambdaEventSourceMapping);
+
+    assertArrayLength(resource.ignoredProperties, 1);
+    assertIdentical(resource.ignoredProperties[0].path, "Tags");
+    assertStringIncludes(resource.ignoredProperties[0].reason, "not simulated");
+  });
+
   it("refuses an attribute AWS::Lambda::EventSourceMapping does not have", () => {
     // Given the CloudFormation-facing adapter for a mapping.
     const adapter = new SimLambdaEventSourceMappingCfn({

--- a/src/service/sns/README.md
+++ b/src/service/sns/README.md
@@ -364,11 +364,13 @@ got, and a template asking for something this simulation will not do is refused 
 refuses an SDK caller.
 
 That is why `sim-cfn-sns-topic-property-names.ts` is short. Most AWS::SNS::Topic properties are topic
-attributes of the same name, so they are handed to `CreateTopic` and SNS decides. Only the three that
-have no single attribute behind them are refused in the CloudFormation layer: `Tags` and
-`DataProtectionPolicy` are inputs of their own on a `CreateTopic` request, and `DeliveryStatusLogging`
-is a list that would become fifteen separate attributes. `AWS::SNS::Subscription` works the same way
-against `Subscribe`, with only `Region` refused here.
+attributes of the same name, so they are handed to `CreateTopic` and SNS decides. Three of them have
+no single attribute behind them, so the CloudFormation layer answers for those. `DataProtectionPolicy`
+is an input of its own on a `CreateTopic` request and `DeliveryStatusLogging` is a list that would
+become fifteen separate attributes, and both are refused. `Tags` is recorded as an ignored property
+instead, since a topic delivers the same messages whether it carries them or not and a CDK app tags
+every topic in it. `AWS::SNS::Subscription` works the same way against `Subscribe`, with only
+`Region` refused here.
 
 `sim-cfn-sns-resource-error.ts` is where a refusal gets its wording, and the wording is the point.
 Sim CloudFormation reads an error saying a Resource is unsupported as one to record and step over,
@@ -480,7 +482,8 @@ here, it does not make another Account's topics reachable through this one.
   delivery retry policies are not simulated. `SubscriptionsPending` is always zero, because no
   protocol simulated needs a confirmation.
 - Tags, data protection policies and encryption are refused rather than ignored, whether by
-  `CreateTopic` or by `SetTopicAttributes`.
+  `CreateTopic` or by `SetTopicAttributes`. An `AWS::SNS::Topic` carrying `Tags` is the exception,
+  and records them as an ignored property.
 - `MessageStructure` is refused, because a `json` structure picks a different body per protocol and
   picking one is not simulated.
 - Publishing to a `TargetArn` is refused, since mobile application endpoints are not simulated. A

--- a/src/service/sns/cfn/sim-cfn-sns-validation.iso.test.ts
+++ b/src/service/sns/cfn/sim-cfn-sns-validation.iso.test.ts
@@ -1,4 +1,10 @@
-import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import {
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
@@ -88,19 +94,36 @@ describe("AWS::SNS::Topic validation", () => {
     );
   });
 
-  it("fails a topic carrying tags", async () => {
-    // Given a template tagging the topic.
-    const error = await deployTopic({
-      TopicName: "orders",
-      Tags: [{ Key: "team", Value: "orders" }],
+  it("records topic tags rather than failing the stack over them", async () => {
+    // Given a tagged topic, as a CDK app tagging its whole app deploys.
+    const simAws = new SimAws();
+
+    // When the stack is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: {
+        Resources: {
+          OrdersTopic: {
+            Type: "AWS::SNS::Topic",
+            Properties: {
+              TopicName: "orders",
+              Tags: [{ Key: "team", Value: "orders" }],
+            },
+          },
+        },
+      },
     });
 
-    // Then it fails, since a dropped tag would leave the topic looking tagged
-    // to the template that wrote it.
-    assertStringIncludes(
-      error.message,
-      "Tags is a real AWS::SNS::Topic property simulated SNS does not act on",
-    );
+    await stack.waitForDeployComplete();
+
+    // Then the topic is there, and the tags it lost are recorded against it.
+    assertNonNullable(simAws.sns().findTopic("orders"));
+
+    const ignored = stack.getResource("OrdersTopic")?.ignoredProperties ?? [];
+
+    assertArrayLength(ignored, 1);
+    assertIdentical(ignored[0].path, "Tags");
+    assertStringIncludes(ignored[0].reason, "not simulated");
   });
 
   it("fails a topic asking for delivery status logging", async () => {

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-creator.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-creator.ts
@@ -40,6 +40,8 @@ export class SimCfnSnsTopicCreator {
       resource,
       properties,
     });
+    topicProperties.recordIgnoredProperties();
+
     const name = topicProperties.name();
     const attributes = topicProperties.attributes();
     const inline = topicProperties.inlineSubscriptions();

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-properties.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-properties.ts
@@ -14,6 +14,7 @@ import {
 import { SimCfnSnsTopicName } from "./sim-cfn-sns-topic-name.js";
 import {
   attributePropertyNames,
+  ignoredPropertyReasons,
   topicNamePropertyName,
   topicSubscriptionPropertyName,
   unsimulatedPropertyReasons,
@@ -97,17 +98,30 @@ export class SimCfnSnsTopicProperties {
   }
 
   /**
+   * Record the properties the topic is created without acting on.
+   */
+  recordIgnoredProperties(): void {
+    for (const [property, reason] of ignoredPropertyReasons) {
+      if (this.properties.has(property)) {
+        this.resource.ignoreProperty(property, reason);
+      }
+    }
+  }
+
+  /**
    * Whether a property is handed to CreateTopic as an attribute.
    *
-   * The two properties the CloudFormation layer reads itself are not. The rest
-   * are refused as they are reached: the ones with a reason of their own with
-   * that reason, and anything else as a property AWS::SNS::Topic does not have,
-   * which is how real CloudFormation answers one too.
+   * The two properties the CloudFormation layer reads itself are not, and
+   * neither are the ones recorded as ignored. The rest are refused as they are
+   * reached: the ones with a reason of their own with that reason, and
+   * anything else as a property AWS::SNS::Topic does not have, which is how
+   * real CloudFormation answers one too.
    */
   private isAttributeProperty(name: string): boolean {
     if (
       name === topicNamePropertyName ||
-      name === topicSubscriptionPropertyName
+      name === topicSubscriptionPropertyName ||
+      ignoredPropertyReasons.has(name)
     ) {
       return false;
     }

--- a/src/service/sns/cfn/topic/sim-cfn-sns-topic-property-names.ts
+++ b/src/service/sns/cfn/topic/sim-cfn-sns-topic-property-names.ts
@@ -50,5 +50,21 @@ export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
     "DeliveryStatusLogging",
     "delivery status logging writes to CloudWatch Logs, which is not simulated",
   ],
-  ["Tags", "no simulated service reads a topic tag"],
+]);
+
+/**
+ * The real AWS::SNS::Topic properties this simulation has nothing to act on
+ * and no reason to fail a stack over.
+ *
+ * `Tags` is the whole list. The topic is created without them and the omission
+ * is recorded against the Resource. A topic behaves the same way with a tag
+ * and without one, and a CDK app calling `Tags.of(app).add(...)` tags every
+ * topic in it.
+ */
+export const ignoredPropertyReasons: ReadonlyMap<string, string> = new Map([
+  [
+    "Tags",
+    "AWS::SNS::Topic property Tags is not simulated, so the topic is created " +
+      "without them. No simulated service reads a topic tag.",
+  ],
 ]);

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-creator.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-creator.ts
@@ -45,6 +45,8 @@ export class SimCfnSsmParameterCreator {
     });
     const name = parameterProperties.name();
 
+    parameterProperties.recordIgnoredTags();
+
     await this.ssm.putParameter(
       {
         input: {
@@ -56,7 +58,6 @@ export class SimCfnSsmParameterCreator {
           AllowedPattern: parameterProperties.allowedPattern(),
           DataType: parameterProperties.dataType(),
           Policies: parameterProperties.policies(),
-          Tags: parameterProperties.tags(),
         },
       },
       options,

--- a/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-properties.ts
+++ b/src/service/ssm/cfn/parameter/sim-cfn-ssm-parameter-properties.ts
@@ -3,7 +3,6 @@ import type {
   SimCfnTemplateValue,
   SimCfnTemplateValueRecord,
 } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
-import type { SimSsmTag } from "../../command/parameter/parameter.command.js";
 import { simCfnSsmGeneratedParameterName } from "./sim-cfn-ssm-generated-parameter-name.js";
 
 interface SimCfnSsmParameterPropertiesProperties {
@@ -119,26 +118,39 @@ export class SimCfnSsmParameterProperties {
   }
 
   /**
-   * The parameter Tags, which PutParameter refuses.
+   * Record the tags the parameter is written without.
    *
-   * CloudFormation carries these as a map of names to values for this
-   * Resource type, rather than the list of Key/Value pairs most Resource
-   * types use, so they are turned into the list shape PutParameter takes.
+   * `Tags` is the one difference from `PutParameter`, which refuses it
+   * outright. A template's tags are usually the whole stack's, and a CDK app
+   * calling `Tags.of(app).add(...)` tags every parameter in it. The parameter
+   * holds the same value either way, so the deploy stands and the omission is
+   * recorded.
+   *
+   * The shape is still read, because CloudFormation carries these as a map of
+   * names to values for this Resource type and a template AWS refuses should
+   * not deploy here.
    */
-  tags(): readonly SimSsmTag[] | undefined {
+  recordIgnoredTags(): void {
     const tags = this.properties["Tags"];
 
     if (tags === undefined) {
-      return undefined;
+      return;
     }
 
     if (typeof tags !== "object" || tags === null || Array.isArray(tags)) {
       throw this.propertyError("Tags must be an object");
     }
 
-    return Object.entries(tags).map(([key, value]) => {
-      return { Key: key, Value: this.stringValue(value, `Tags.${key}`) };
-    });
+    for (const [key, value] of Object.entries(tags)) {
+      this.stringValue(value, `Tags.${key}`);
+    }
+
+    this.resource.ignoreProperty(
+      "Tags",
+      "AWS::SSM::Parameter property Tags is not simulated, so the parameter " +
+        "is written without them. Nothing reads them back and no " +
+        "aws:ResourceTag condition key matches them.",
+    );
   }
 
   private string(

--- a/src/service/ssm/cfn/sim-cfn-ssm-parameter-validation.iso.test.ts
+++ b/src/service/ssm/cfn/sim-cfn-ssm-parameter-validation.iso.test.ts
@@ -169,17 +169,44 @@ describe("SSM CloudFormation Parameter validation", () => {
       allowedPattern.message,
       "PutParameter AllowedPattern is not simulated",
     );
+  });
 
-    const parameterTags = await createParameterResource({
-      Name: "/myapp/prod/db-host",
-      Type: "String",
-      Value: "db.internal",
-      Tags: { component: "database" },
+  it("records parameter tags rather than failing the stack over them", async () => {
+    // Given a tagged parameter, as a CDK app tagging its whole app deploys.
+    const simAws = new SimAws();
+
+    // When the stack is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "myapp",
+      template: {
+        Resources: {
+          DbHost: {
+            Type: "AWS::SSM::Parameter",
+            Properties: {
+              Name: "/myapp/prod/db-host",
+              Type: "String",
+              Value: "db.internal",
+              Tags: { component: "database" },
+            },
+          },
+        },
+      },
     });
-    assertStringIncludes(
-      parameterTags.message,
-      "PutParameter Tags is not simulated",
+
+    await stack.waitForDeployComplete();
+
+    // Then the parameter holds its value, and the tags it lost are recorded.
+    assertIdentical(
+      simAws.ssm().findParameter("/myapp/prod/db-host")?.currentVersion.value
+        .value,
+      "db.internal",
     );
+
+    const ignored = stack.getResource("DbHost")?.ignoredProperties ?? [];
+
+    assertArrayLength(ignored, 1);
+    assertIdentical(ignored[0].path, "Tags");
+    assertStringIncludes(ignored[0].reason, "not simulated");
   });
 
   it("refuses a name another stack already used", async () => {


### PR DESCRIPTION
Five CloudFormation Resource types failed a whole stack over a tag they would have carried without behaving any differently: `AWS::Events::Rule`, `AWS::Events::EventBus`, `AWS::SNS::Topic`, `AWS::Lambda::EventSourceMapping` and `AWS::SSM::Parameter`. A CDK app calling `Tags.of(app).add(...)` tags everything in it, so one scheduled rule was enough to take down every test that deployed the stack. Each of the five now creates the Resource without the tags and records the omission against it, the way API Gateway and CloudWatch alarms already do. A property that changes behaviour is still refused, so a rule `RoleArn` and a topic `DataProtectionPolicy` fail as before, and the SDK commands still refuse `Tags` where they always did.

Resolves #1282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CloudFormation deployments now succeed for tags on EventBridge buses and rules, Lambda event source mappings, SNS topics, and SSM parameters.
  * These tags are recorded as ignored properties and do not affect runtime behavior or become readable resource tags.
  * Other unsupported properties continue to be rejected, and direct SDK tag restrictions remain unchanged.

* **Documentation**
  * Expanded guidance for installation, event factories, AWS SDK interception, CloudFormation, simulated time, and localhost usage.
  * Clarified supported features, limitations, error handling, and tag behavior across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->