### PR TITLE
docs: rewrite service guides for clarity

### DIFF
--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -1,8 +1,8 @@
 # Simulated ACM
 
-Yulin includes a simulated AWS Certificate Manager (ACM) for tests and local development. In this
-guide, you'll request certificates, configure DNS validation, filter certificate lists, and use ACM
-with simulated CloudFormation.
+Yulin simulates AWS Certificate Manager (ACM) in memory. You can request and inspect certificates,
+exercise DNS validation against simulated Route53, and deploy certificate resources through
+simulated CloudFormation.
 
 ## Prerequisites
 
@@ -12,9 +12,8 @@ with simulated CloudFormation.
 
 ## Request a certificate
 
-1. Create a `SimAws` instance and get a simulated ACM client.
-2. Call `requestCertificate` with a `RequestCertificateCommand`.
-3. Call `listCertificates` with a `ListCertificatesCommand` to confirm the certificate exists.
+Create a `SimAws` instance, request a certificate, then list the certificates in that account and
+region:
 
 ```typescript sim-acm-request-certificate
 /**
@@ -145,9 +144,8 @@ for (const validation of domainValidationOptions) {
 }
 ```
 
-For DNS validation, simulated ACM returns CNAME validation records for the primary domain and each
-subject alternative name. The records are deterministic, which makes them suitable for assertions in
-tests.
+For DNS validation, ACM returns a deterministic CNAME record for the primary domain and each subject
+alternative name. Tests can assert on these records directly.
 
 For EMAIL validation, the validation method is recorded but no DNS resource record is returned.
 
@@ -187,11 +185,8 @@ console.log(validation?.ResourceRecord);
 
 ## Wait for certificate issuance
 
-Requested certificates start in `PENDING_VALIDATION` status. Simulated ACM schedules background work
-to move them to `ISSUED`.
-
-If your test needs the issued state, wait for background tasks to complete before describing the
-certificate.
+Requested certificates start as `PENDING_VALIDATION`. Wait for background tasks before asserting
+that a certificate is `ISSUED`.
 
 > **Note:** Where a simulated Route53 hosted zone covers the certificate domain, issuance waits for
 > DNS validation first.
@@ -233,19 +228,14 @@ console.log(describeOutput.Certificate?.IssuedAt);
 
 ## Validate a certificate against simulated Route53
 
-Real ACM issues a DNS-validated certificate only once the CNAME it requests is resolvable. Simulated
-ACM does the same, but only where the simulation can answer for the domain.
-
-By default, the rules are:
+ACM requires the validation CNAME when simulated Route53 is authoritative for the domain. The
+default rules are:
 
 - If a simulated Route53 hosted zone covers the certificate domain, the certificate waits for its validation record.
 - If no hosted zone covers the domain, the certificate is issued as soon as background tasks drain.
 
-Templates commonly reference hosted zones managed by another team or another tool. Those
-certificates keep working here because the simulation holds no zone for their domain.
-
-[Two methods override that default](#override-when-validation-is-required) where it doesn't suit
-your test.
+This lets templates refer to externally managed hosted zones without leaving certificates pending.
+[Two methods override the default](#override-when-validation-is-required).
 
 ```typescript sim-acm-dns-validation
 /**
@@ -322,11 +312,9 @@ const issuedOutput = await simAws.acm().describeCertificate(
 console.log(issuedOutput.Certificate?.Status); // ISSUED
 ```
 
-Each domain on a certificate is validated separately. A certificate with subject alternative names
-is issued only once every domain that needs DNS validation has its record. Domains that are not
-covered by any hosted zone don't need anything published for them. Until all domains are validated,
-`DescribeCertificateCommand` reports `SUCCESS` for validated domains and `PENDING_VALIDATION` for
-the rest.
+Each domain is validated separately. A certificate is issued when every domain covered by a
+simulated hosted zone has its validation record. `DescribeCertificateCommand` reports `SUCCESS` for
+validated domains and `PENDING_VALIDATION` for the rest.
 
 Hosted zones are looked up across every simulated account, matching real ACM validating against
 public DNS. A certificate in one account can be validated by a hosted zone in another.
@@ -558,14 +546,10 @@ Each `SimAws` instance has its own isolated state. Create a fresh instance per t
 
 ## Register a certificate with a chosen ARN
 
-`RequestCertificateCommand` allocates its own certificate ARN, as real ACM does, and takes none from
-you. When something else already decided the ARN, register the certificate as part of your test setup
-instead.
-
-The usual reason is a CDK app that creates its certificate in one stack and uses it in another. The
-ARN crosses between the two as a plain string, and the stack using it carries that ARN into its
-synthesized template. Simulated CloudFront checks the certificate before it creates a Distribution,
-so registering the certificate first lets the template deploy as it is, with no rewriting.
+`RequestCertificateCommand` allocates the ARN. If a fixture or another stack already provides the
+ARN, register that certificate during test setup. This is useful when one CDK stack creates a
+certificate and another uses its ARN. Simulated CloudFront can then resolve the certificate without
+changing the synthesized template.
 
 ```typescript sim-acm-register-certificate
 /**
@@ -791,9 +775,7 @@ A `HostedZoneId` that names a hosted zone the simulator doesn't hold is skipped 
 
 If a hosted zone covers the domain but the validation record never appears, the stack fails rather than hanging. Real CloudFormation sits in `CREATE_IN_PROGRESS` for hours before timing out, which is of little use in a test. The resource fails immediately and names the record it waited for.
 
-## Available functionality
-
-Simulated ACM supports:
+## Supported operations
 
 - `RequestCertificateCommand`, `DescribeCertificateCommand`, and `ListCertificatesCommand`
 - DNS validation against records in simulated Route53

--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -1,22 +1,15 @@
 # Simulated Athena
 
-Yulin includes a simulated Amazon Athena for tests and local development. It holds workgroups and
-named queries, and hands both back through the SDK.
+Yulin simulates Amazon Athena workgroups, named queries and query execution for tests and local
+development. Tests can supply a result for a particular SQL statement, or enable the optional
+[query engine](#running-a-query-for-real) to run SQL against objects in simulated S3.
 
-A query is answered one of two ways. A test declares what it answers with, and the simulation
-matches that declaration on the query text. Or the
-[query engine](#running-a-query-for-real) runs the SQL for real over the objects a test seeded into
-simulated S3. The engine is off until a test turns it on, and it needs one package added to the
-project.
+Both paths use the same query lifecycle. Athena checks tables in the simulated
+[Glue Data Catalog](https://yulinsim.dev/services/glue/ "Simulated Glue usage docs"), applies the
+workgroup's bytes-scanned limit and writes results to the configured S3 location. This lets client
+code start a query, poll its status and read its results through the AWS SDK.
 
-Either way the lifecycle around the query is real. A test can prove its bytes-scanned cutoff
-refuses a query, that results land where the workgroup says, and that a client polls the lifecycle
-correctly. The tables a query names are looked for in the simulated
-[Glue Data Catalog](https://yulinsim.dev/services/glue/ "Simulated Glue usage docs"), and a query
-naming one that is absent fails the way real Athena fails it. The
-[Limitations](#limitations) at the end say what this leaves out.
-
-Athena-specific types are imported from the `@kensio/yulin/athena` subpath.
+Import Athena-specific types from `@kensio/yulin/athena`.
 
 ## Workgroups from a template
 
@@ -177,23 +170,21 @@ const results = await simAws.athena().getQueryResults({
 console.log(results.ResultSet?.Rows?.[1]?.Data?.[1]?.VarCharValue);
 ```
 
-A rule for an exact query wins, then a rule for a workgroup, then the default. `onWorkGroup` covers
-every query a stack's rollups run, and `byDefault` covers everything else. Matching is exact, on the
-query text as it was sent, so two queries differing only in whitespace are two different keys.
+A result declared for an exact query takes precedence over a workgroup result, which takes
+precedence over the default result. Use `onWorkGroup` to cover every query in one workgroup and
+`byDefault` as the fallback. Exact matching includes whitespace.
 
 The query engine sits between the two tiers. A rule for an exact query is ahead of it and the
 workgroup rule and the default are behind it.
 
-`failsWith` fails a query instead of answering it. Nothing here reads SQL, so a query that should
-fail cannot be discovered on its own. Saying so is what makes a client's failure handling
-reachable.
+Use `failsWith` to declare a failed query and test the client's error handling. Declared results do
+not parse the SQL, so failures must be configured explicitly.
 
 ## Running a query for real
 
-The query engine answers a `SELECT` from the objects a test seeded into simulated S3. It reads the
-table's schema out of the Glue Data Catalog, decodes each object with the SerDe the table declares,
-loads the rows into an in-memory SQLite database, and answers the statement from them. Roughly
-nineteen queries in twenty of the shapes a test writes run this way.
+The query engine runs a `SELECT` against objects seeded into simulated S3. It reads the table schema
+from the Glue Data Catalog, decodes each object with the table's SerDe, loads the rows into an
+in-memory SQLite database and executes the statement.
 
 The engine is off until a test turns it on, and it needs `node-sql-parser` in the project. The
 parser is an optional peer dependency, so a project that never runs a query never installs it. A
@@ -965,7 +956,7 @@ Every command is authorized against the workgroup ARN,
 own and authorizes work on one against the workgroup it belongs to. This asks the same question.
 `ListWorkGroups` names no workgroup, so IAM evaluates it against `*`.
 
-## Available functionality
+## Supported operations
 
 - Query executions, moving through `QUEUED` and `RUNNING` to `SUCCEEDED`, `FAILED` or `CANCELLED`
 - `StartQueryExecution`, `GetQueryExecution`, `GetQueryResults` and `StopQueryExecution`

--- a/docs/services/backup/README.md
+++ b/docs/services/backup/README.md
@@ -1,12 +1,12 @@
 # Simulated AWS Backup
 
-Yulin includes simulated AWS Backup vaults, plans, selections, backup jobs and recovery points for
-tests and local development. AWS Backup types are imported from the `@kensio/yulin/backup` subpath.
+Yulin simulates AWS Backup vaults, plans, selections, jobs and recovery points. Import Backup types
+from `@kensio/yulin/backup`.
 
 ## Creating a vault, plan and selection
 
-`simAws.backup()` gives the AWS Backup service for the default account and Region. A plan rule names
-an existing vault. A selection belongs to one plan and records the resource ARNs assigned to it.
+Use `simAws.backup()` for the default account and Region. Each plan rule names an existing vault. A
+selection assigns resource ARNs to a plan.
 
 ```typescript sim-backup-create-plan-selection
 /**
@@ -78,19 +78,17 @@ console.log(selection.BackupSelection?.Resources);
 // ["arn:aws:dynamodb:us-east-1:888888888888:table/orders"]
 ```
 
-A plan needs at least one rule. Every rule needs a name and a target vault. An omitted schedule uses
-`cron(0 5 ? * * *)`, the AWS Backup default. Six-field AWS cron expressions and rate expressions
-are validated when the plan is created. A one-time `at(...)` expression is refused.
+A plan needs at least one named rule and target vault. The default schedule is
+`cron(0 5 ? * * *)`. Yulin accepts six-field AWS cron expressions and rate expressions. It rejects
+`at(...)` expressions.
 
-`MoveToColdStorageAfterDays` can be combined with `DeleteAfterDays`. The deletion must be at least
-90 days after the move to cold storage. A shorter lifecycle raises
-`InvalidParameterValueException`. Set both values to `-1` to retain recovery points indefinitely.
+When both lifecycle values are set, `DeleteAfterDays` must be at least 90 days after
+`MoveToColdStorageAfterDays`. Use `-1` for both values to keep recovery points indefinitely.
 
 ## Running scheduled backups
 
-Each plan rule runs on the simulated clock. A due rule creates one recovery point for each distinct
-resource ARN in the plan's selections. The recovery point records the rule, resource ARN, lifecycle
-and creation time. The simulation completes backup jobs at the scheduled instant.
+Plan rules run on the simulated clock. A due rule creates one completed job and recovery point for
+each distinct resource ARN in its selections.
 
 ```typescript sim-backup-run-schedule
 /**
@@ -161,19 +159,16 @@ console.log(points.RecoveryPoints?.[0]?.ResourceArn);
 console.log(jobs.BackupJobs?.[0]?.State); // "COMPLETED"
 ```
 
-`DeleteAfterDays` removes a recovery point when the clock reaches its deletion time. Vault reads,
-`ListRecoveryPointsByBackupVault` and `DescribeRecoveryPoint` apply the expiry before returning.
-Repeated schedules keep every unexpired recovery point.
+`DeleteAfterDays` removes a recovery point when simulated time reaches its expiry. Recovery point
+reads apply expiry before returning.
 
-Vault Lock bounds apply when a backup starts. A lifecycle shorter than `MinRetentionDays`, longer
-than `MaxRetentionDays` or indefinite under a finite maximum produces a `FAILED` backup job. The
-vault receives no recovery point for that job. Use `ListBackupJobs` or `DescribeBackupJob` to read
-the failure and its `StatusMessage`.
+Vault Lock bounds are checked when a backup starts. An invalid lifecycle produces a `FAILED` job and
+no recovery point. Read the reason from the job's `StatusMessage`.
 
 ## Starting an on-demand backup
 
-`StartBackupJob` completes an on-demand job at the current simulated time. It applies the same
-lifecycle validation and Vault Lock bounds as a scheduled rule.
+`StartBackupJob` completes at the current simulated time. It applies the same lifecycle and Vault
+Lock checks as a scheduled job.
 
 ```typescript sim-backup-start-job
 /**
@@ -219,9 +214,8 @@ console.log(point.CreationDate?.toISOString());
 
 ## Vault Lock
 
-`PutBackupVaultLockConfiguration` records minimum and maximum retention periods on a vault. Adding
-`ChangeableForDays` creates a compliance lock. The configuration stays changeable until the grace
-period ends, then becomes immutable.
+`PutBackupVaultLockConfiguration` sets minimum and maximum retention. `ChangeableForDays` adds a
+grace period. The configuration becomes immutable when that period ends.
 
 ```typescript sim-backup-vault-lock
 /**
@@ -284,8 +278,7 @@ exceed the maximum, and the maximum cannot exceed 36,500 days. A lock without
 ## Deploying from CloudFormation
 
 Simulated CloudFormation deploys `AWS::Backup::BackupVault`, `AWS::Backup::BackupPlan` and
-`AWS::Backup::BackupSelection`. References between the resources resolve before AWS Backup creates
-them.
+`AWS::Backup::BackupSelection`.
 
 ```typescript sim-backup-cloudformation
 /**
@@ -376,10 +369,9 @@ Stack teardown removes all three resource types from the simulation.
 
 ## Permissions
 
-Every supported operation is authorized by simulated IAM. Vault operations use the vault ARN. Plan
-and selection operations use the plan ARN. `ListBackupVaults` has no resource in its request and is
-authorized against `*`. `StartBackupJob` and `ListRecoveryPointsByBackupVault` use the vault ARN.
-`DescribeRecoveryPoint` uses the recovery point ARN. Backup job reads use `*`.
+Every supported operation uses simulated IAM. Vault operations authorize against the vault ARN.
+Plan and selection operations use the plan ARN. `DescribeRecoveryPoint` uses the recovery point ARN.
+List and backup job read operations that name no resource use `*`.
 
 ```typescript sim-backup-iam-policy
 /**
@@ -432,13 +424,12 @@ const created = await simAws.backup().createBackupVault(
 console.log(created.BackupVaultName); // "application-backups"
 ```
 
-Authorization runs before resource lookup. An unauthorized request for a missing vault or plan
-raises `AccessDeniedException`, without revealing whether the resource exists.
+Authorization runs before resource lookup. An unauthorized request for a missing resource raises
+`AccessDeniedException`.
 
 ## SDK interception
 
-`SimSdk` routes commands from an AWS `BackupClient` to the simulation. Intercept the client instance
-when a test owns it, or intercept the class when application code creates the client.
+Intercept a `BackupClient` instance or the client class to route SDK commands to Yulin.
 
 ```typescript sim-backup-sdk-interception
 /**
@@ -466,13 +457,12 @@ console.log(listed.BackupVaultList?.[0]?.BackupVaultName);
 // "application-backups"
 ```
 
-The client's configured Region selects the simulated Region. Credentials select the account and
-caller when the intercepted client has them. See the [SDK interception docs](https://yulinsim.dev/sdk/)
-for class interception and credential handling.
+Client Region and credentials select the simulated scope and caller. See
+[SDK interception](https://yulinsim.dev/sdk/) for details.
 
 ## Account and Region scoping
 
-AWS Backup state belongs to one account and Region. The same vault name can exist in another scope.
+Backup state is scoped by account and Region. The same vault name can exist in another scope.
 
 ```typescript sim-backup-account-region-scoping
 /**

--- a/docs/services/bedrock/README.md
+++ b/docs/services/bedrock/README.md
@@ -1,14 +1,14 @@
 # Simulated Bedrock
 
-Simulated Bedrock answers model invocations from responses declared against a prompt or a model. A
-test says what the model says, and no model runs.
+Yulin answers Bedrock Runtime requests from response rules declared by the test. Model responses
+come entirely from those rules.
 
 Bedrock-specific types are imported from the `@kensio/yulin/bedrock` subpath.
 
 ## Answering a conversation
 
-`Converse` answers with the response declared for the prompt it carries. The prompt is the text of
-the last user message.
+Declare a response with `onPrompt`, then call `converse`. The prompt is the text of the last user
+message.
 
 ```typescript sim-bedrock-converse
 /**
@@ -37,13 +37,12 @@ console.log(answered.output.message.content.at(0)?.text);
 console.log(answered.stopReason); // "end_turn"
 ```
 
-A conversation with several turns matches on its last user message, so a rule keeps matching as the
-conversation grows.
+A multi-turn conversation also matches its last user message.
 
 ## Answering every call to one model
 
-`onModel` covers every invocation of a model that no prompt rule matched first. This is the rule for
-a test that cares about the code around the call rather than about one exchange.
+Use `onModel` when every call to one model should receive the same response. Prompt rules take
+precedence over model rules.
 
 ```typescript sim-bedrock-model-rule
 /**
@@ -71,13 +70,13 @@ const answered = await simAws.bedrock().converse(
 console.log(answered.output.message.content.at(0)?.text); // "A short summary."
 ```
 
-`byDefault` covers everything else again. An invocation matching no rule at all answers with a
-built-in line of text that says it is simulated.
+`byDefault` handles calls that match no prompt or model rule. With no matching declaration, Yulin
+returns a built-in simulated response for `Converse`.
 
 ## Answering with a tool call
 
-A declared response carries content blocks as they were written, so a tool call reaches the code
-that handles one. The response stops for `tool_use` unless the declaration names another reason.
+Declare a `toolUse` content block to test code that handles model tool calls. The default stop reason
+for this response is `tool_use`.
 
 ```typescript sim-bedrock-tool-use
 /**
@@ -119,8 +118,8 @@ console.log(answered.output.message.content.at(0)?.toolUse?.name);
 
 ## Streaming a conversation
 
-`ConverseStream` answers from the same rules, and sends the response as the events real Bedrock
-sends. Declaring `chunks` says where the deltas fall.
+`ConverseStream` uses the same rules as `Converse`. Declare `chunks` to control the text in each
+stream event.
 
 ```typescript sim-bedrock-converse-stream
 /**
@@ -156,14 +155,11 @@ for await (const event of answered.stream) {
 console.log(accumulated); // "Entry 1042 covers the tone sandhi rules."
 ```
 
-The events arrive in the order real Bedrock sends them. `messageStart`, then one
-`contentBlockDelta` per chunk, then `contentBlockStop`, `messageStop` carrying the stop reason, and
-`metadata` carrying the token counts. A tool call adds a `contentBlockStart` before its delta,
-carrying the tool use id and name.
+The stream contains `messageStart`, content block events, `messageStop` and `metadata`. Tool calls
+also include `contentBlockStart` with the tool use ID and name.
 
-The same declaration serves both APIs. `Converse` answers with the chunks joined, and a response
-declared as `text` streams as a single delta. A stream is readable once, and reading it again
-raises.
+The same declaration serves both APIs. `Converse` joins declared chunks. Plain `text` becomes one
+stream delta. A stream can be read once.
 
 `InvokeModelWithResponseStream` streams the declared body as a single `chunk`:
 
@@ -175,8 +171,8 @@ for await (const event of answered.body) {
 
 ## Invoking a model directly
 
-`InvokeModel` answers with the body declared for the request, serialized as JSON. The body is the
-shape the model behind the id uses, which is why there is no built-in default for it.
+`InvokeModel` returns the declared `body` as JSON. The response shape depends on the model, so this
+operation has no built-in body.
 
 ```typescript sim-bedrock-invoke-model
 /**
@@ -207,12 +203,11 @@ console.log(JSON.parse(new TextDecoder().decode(answered.body)));
 // { results: [ { outputText: "Entry 1042 covers tone sandhi." } ] }
 ```
 
-An `InvokeModel` request matches a prompt rule on its request body decoded as UTF-8. A model rule is
-usually the one to reach for.
+Prompt rules match the UTF-8 request body. Model rules are usually simpler for this API.
 
 ## Reporting token counts
 
-`usage` comes from the declaration, and a response that declares none reports fixed counts.
+Set `usage` on a response rule to control token counts. Yulin uses fixed counts when it is omitted.
 
 ```typescript sim-bedrock-usage
 /**
@@ -245,14 +240,13 @@ console.log(answered.usage.totalTokens); // 1620
 
 ## Authorizing an invocation
 
-An invocation authorizes `bedrock:InvokeModel` against the model it names. A base model id becomes a
-foundation model ARN for the Region the call was made in, and an inference profile ARN or a
-provisioned model ARN is authorized against as it was written.
+Every invocation authorizes `bedrock:InvokeModel` against the requested model. A base model ID is
+converted to a foundation model ARN in the request Region. Model ARNs are used unchanged.
 
 ## SDK interception
 
-An intercepted `BedrockRuntimeClient` reaches the simulated Bedrock of the Account and Region the
-client is configured for.
+Intercept a `BedrockRuntimeClient` when application code constructs the client itself. Client
+credentials and Region select the simulated scope.
 
 ```typescript sim-bedrock-sdk-interception
 /**
@@ -296,32 +290,26 @@ simSdk.restoreAll();
 
 - `Converse`, `ConverseStream`, `InvokeModel` and `InvokeModelWithResponseStream`, through
   `simAws.bedrock()` and through an intercepted `BedrockRuntimeClient`.
-- Responses declared with `onPrompt`, `onModel` and `byDefault`. A prompt rule wins, then a model
-  rule, then the default.
+- Responses declared with `onPrompt`, `onModel` and `byDefault`, in that precedence order.
 - A declared response carries `text`, `chunks` or `content` blocks for `Converse`, a `body` for
   `InvokeModel`, and optionally a `stopReason` and a `usage`.
-- Streamed responses, with `chunks` deciding where the deltas fall and one declaration serving the
-  streaming and non-streaming APIs alike.
+- Streamed responses with caller-controlled chunks.
 - Tool calls, as a declared `toolUse` content block.
 - IAM authorization of `bedrock:InvokeModel` against the foundation model, inference profile or
   provisioned model ARN the request names.
-- Rules held per Account and Region, so two Regions answer the same prompt differently.
+- Rules scoped by account and Region.
 
 ## Limitations
 
-- No model runs. A response is whatever the matching rule declared, and the prompt is read only as
-  a key to match on.
+- No model runs. Yulin returns the matching declared response.
 - Every event of a stream is ready as soon as the call returns. Real Bedrock sends them as the model
   generates them. No simulated clock advance separates them here.
-- A response is split into deltas only where the declaration says so. Text declared any other way
-  arrives in one delta. The split a real model streams comes from its own tokenizer.
+- A response is split only at declared chunk boundaries. Other text arrives in one delta.
 - A streamed tool call sends its arguments in one delta. Real `ConverseStream` sends them as
   fragments of JSON to be concatenated. A tool call with no declared arguments sends `{}`.
 - `InvokeModelWithResponseStream` sends the declared body as a single chunk. Real Bedrock sends a
   chunk per generated fragment, in the shape the model behind the id uses.
-- A serialized Bedrock request is refused. Bedrock speaks REST-JSON, and the wire path answers only
-  the AWS JSON protocol services. A function bundling its own SDK reaches Bedrock through module
-  interception. S3 and every other non-JSON-protocol service are reached the same way.
+- Serialized Bedrock requests are unsupported. Use SDK interception.
 - The Bedrock control plane is unsimulated. `ListFoundationModels`, guardrail management, inference
   profile management and provisioned throughput all belong to `BedrockClient`.
 - Bedrock Agents and knowledge bases are unsimulated. `InvokeAgent`, `Retrieve` and
@@ -329,22 +317,20 @@ simSdk.restoreAll();
 - `ApplyGuardrail` is unsimulated, and a `guardrailConfig` or a `guardrailIdentifier` on an
   invocation is refused outright. Answering without the guardrail would make one look applied here
   and be applied in production.
-- `system`, `inferenceConfig`, `toolConfig` and `additionalModelRequestFields` are accepted and
-  decide nothing. `maxTokens` truncates no declared response, and a `toolConfig` naming no tools
+- `system`, `inferenceConfig`, `toolConfig` and `additionalModelRequestFields` are accepted and have
+  no effect. `maxTokens` truncates no declared response, and a `toolConfig` naming no tools
   still gets a declared tool call.
 - Token counts are fixed unless the declaration carries them. Counting them needs the tokenizer of
   the model the request names. Declare a `usage` where the code under test meters spend.
 - `metrics.latencyMs` is always zero. No time passes during an invocation.
 - A `Converse` with no messages is refused. Real Bedrock accepts one where the `modelId` names a
   prompt version from Prompt management, which is unsimulated.
-- The model id goes unchecked. AWS publishes no enumerable table of model ids, so refusing one would
-  be failing closed against Yulin's own gaps.
+- Any model ID is accepted.
 - `InvokeModel` has no built-in default response body, and an invocation matching a rule that
   declares none is refused. A response body is model-specific, and one family's shape served for
   every other one would parse into something the caller cannot read.
-- An `InvokeModel` body that arrives as a stream or a Blob matches no prompt rule. Reading it would
-  consume the caller's own request body, so such a request falls through to a model rule or to the
-  default.
-- A `Converse` call matching a response declared only as a body is refused for the same reason. It
-  does not fall back to the default.
+- An `InvokeModel` body supplied as a stream or `Blob` cannot match a prompt rule. It may still match
+  a model or default rule.
+- A `Converse` call matching a response declared only as a body is refused for the same reason. The
+  matching rule prevents the default rule from being selected.
 - There are no CloudFormation resource types for Bedrock, and Bedrock is absent from `serveSimAws`.

--- a/docs/services/cloudwatch/README.md
+++ b/docs/services/cloudwatch/README.md
@@ -1,20 +1,11 @@
 # Simulated CloudWatch Metrics
 
-Yulin includes a simulated Amazon CloudWatch for tests and local development. It holds custom
-metrics. Those are the datapoints `PutMetricData` publishes, and the statistics
-`GetMetricStatistics` and `GetMetricData` read back from them, without an AWS account. It also holds alarms over those
-metrics, which evaluate on the simulation's clock and notify an SNS topic when they change state.
+Yulin simulates CloudWatch metrics and alarms in memory. Application code can publish datapoints and
+read their statistics through the normal CloudWatch commands. Alarms evaluate on simulated time and
+can notify simulated SNS topics.
 
-Code that publishes a business metric is code teams already have, and until now the only way to test
-it was to assert that the SDK client had been called. That proves the call was made. What it
-measured goes untested.
-
-Most of what lives here is custom metrics. Simulated Lambda publishes its own `AWS/Lambda`
-`Invocations`, `Errors`, `Duration` and `IteratorAge`, simulated Cognito publishes a pool's
-`AWS/Cognito` counts, and no other simulated service publishes into an `AWS/` namespace yet. A
-query for one nothing measures comes back empty, in place of a number that was never taken. A test
-can stand a datapoint up for one of those itself, which is what drives an alarm on a service metric
-to a state change.
+Simulated Lambda publishes `AWS/Lambda` metrics, and simulated Cognito publishes `AWS/Cognito`
+metrics. Tests can seed other AWS-managed metrics through the service writer described below.
 
 A custom metric's datapoints arrive either from `PutMetricData` or from a CloudWatch Logs metric
 filter counting matching log events. See the [CloudWatch Logs docs](../logs/README.md) for the
@@ -24,8 +15,8 @@ CloudWatch specific types are imported from the `@kensio/yulin/cloudwatch` subpa
 
 ## Publishing and reading back a metric
 
-A metric is identified by its namespace, its name and its dimensions together. Publishing a value
-and asking for it back at a period is the whole loop:
+A metric is identified by its namespace, name, and exact set of dimensions. Publish a value and
+read it back over a period:
 
 ```typescript sim-cloudwatch-publish-and-read
 /**
@@ -84,18 +75,14 @@ the way out. A query naming a unit CloudWatch lacks fails here as it would in an
 
 ## Metrics are identified by their dimensions
 
-Real CloudWatch leaves a custom metric unrolled across its dimensions, and so does this. The same
-metric name published under two channels is two metrics. A read naming no dimensions reaches only the
-metric that was published with none, and never aggregates across the others.
-
-That is the behaviour teams most often get wrong, and it is worth a test of its own. A dashboard
-query written against a metric name alone finds nothing at all if every publish carried a dimension.
+CloudWatch treats each exact set of dimensions as a separate metric. Publishing the same metric name
+with two dimension values creates two metrics. A query without dimensions reads only datapoints
+published without dimensions.
 
 ## Metrics and simulated time
 
-A datum carrying no `Timestamp` is stamped from the simulation's clock. A test with
-a frozen clock therefore gets timestamps it can assert on exactly, and one that moves time on gets
-datapoints in the period it moved to:
+A datum without a `Timestamp` uses the simulation's clock. Set or advance the clock to place
+datapoints in exact periods:
 
 ```typescript sim-cloudwatch-simulated-time
 /**
@@ -153,11 +140,14 @@ window drops a metric out of the listing without anything having to expire it.
 
 ## Metrics a simulated service publishes
 
-Real CloudWatch holds two kinds of metric. A caller publishes a custom one through `PutMetricData`, and AWS publishes its own under a namespace beginning `AWS/` that no caller may write into. Both kinds are read the same way.
+Callers publish custom metrics through `PutMetricData`. AWS-managed metrics use namespaces beginning
+with `AWS/`, which callers cannot publish into.
 
-Two services publish their own. Simulated Cognito counts what a user pool was asked to do, under `AWS/Cognito` and dimensioned by `UserPool` and `UserPoolClient`, which the [Cognito docs](../cognito/README.md) cover.
+Simulated Cognito publishes counts under `AWS/Cognito`, dimensioned by `UserPool` and
+`UserPoolClient`. See the [Cognito docs](../cognito/README.md).
 
-Simulated Lambda publishes three of its own. Every invocation counts `Invocations` and a `Duration`, and one whose handler threw counts an `Errors` alongside them, all under `AWS/Lambda` and dimensioned by `FunctionName`. Nothing has to be turned on, and no execution Role needs a permission for it, which is how real Lambda behaves.
+Simulated Lambda publishes `Invocations`, `Duration`, and `Errors` under `AWS/Lambda`, dimensioned by
+`FunctionName`. These metrics require no extra configuration or execution-role permission.
 
 ```typescript sim-cloudwatch-lambda-errors
 /**
@@ -217,13 +207,15 @@ const { MetricAlarms } = await simAws
 console.log(MetricAlarms?.[0]?.StateValue);
 ```
 
-`Duration` is measured on the simulation's clock rather than the host's, so it is a number a test can assert on. A handler that moves the clock reports the time it moved, and one that returns without touching it reports nothing spent. `IteratorAge` is measured the same way, and the Lambda documentation covers what a stream event source mapping reports.
+`Duration` uses the simulation's clock rather than the host's. A handler that advances the clock
+reports that elapsed time, while a handler that leaves it unchanged reports zero duration.
+`IteratorAge` uses the same clock. The Lambda documentation describes the value reported by a stream
+event source mapping.
 
 ## Seeding a metric AWS publishes
 
-`PutMetricData` refuses a namespace beginning `AWS/`, exactly as an account does. An alarm watching a metric no simulated service publishes therefore sits in `INSUFFICIENT_DATA`, and its arithmetic goes untested however carefully the alarm itself is declared.
-
-The service writer is the way in. It is the same route simulated Lambda's own metrics take, reached from a test through `cloudWatch().serviceWriter()`, and it stands a datapoint up in any namespace.
+`PutMetricData` refuses namespaces beginning with `AWS/`. To test an alarm for another AWS-managed
+metric, add the datapoint through `cloudWatch().serviceWriter()`.
 
 ```typescript sim-cloudwatch-seed-service-metric
 /**
@@ -286,14 +278,13 @@ console.log(MetricAlarms?.[0]?.StateValue);
 
 A datapoint arriving without a `timestamp` is stamped with the simulation's clock. One carrying its own lands where it says, which fills a window without the clock having to be walked through it.
 
-`PutMetricData` is untouched by any of this. A caller naming a reserved namespace is refused exactly as before, and only the account's own machinery and a test reach the store this way.
+The service writer is a test setup API. `PutMetricData` keeps its reserved-namespace validation.
 
 ## Alarms
 
-An alarm watches one metric and changes state on the simulation's clock, with no real timer behind
-it. Each evaluation is scheduled at the next period boundary. A frozen clock evaluates nothing, and
-advancing time by twenty minutes walks twenty one-minute evaluations and settles before the next
-line of the test runs.
+An alarm watches one metric and changes state on the simulation's clock. Each evaluation is scheduled
+at the next period boundary. Advancing time by twenty minutes runs twenty one-minute evaluations and
+settles before the next line of the test.
 
 ```typescript sim-cloudwatch-alarm
 /**
@@ -353,8 +344,8 @@ console.log(described.MetricAlarms?.at(0)?.StateValue);
 ```
 
 A new alarm is in `INSUFFICIENT_DATA` until it has evaluated a period, as on real CloudWatch. The
-window it looks back over reaches behind the moment the alarm was created. An alarm over a metric
-nothing publishes into, with `TreatMissingData: "breaching"`, therefore fires on its first
+window it looks back over reaches behind the moment the alarm was created. An alarm over an empty
+metric, with `TreatMissingData: "breaching"`, therefore fires on its first
 evaluation, without waiting for the periods to accumulate. That is what an account does too.
 
 ### Reaching a subscriber
@@ -458,10 +449,9 @@ had never named them.
 
 ## Permissions
 
-CloudWatch metrics have no ARN, leaving a policy nothing to name. Every metric action here is
-granted on `*`. A policy written against something like
-`arn:aws:cloudwatch:eu-west-2:111111111111:metric/Orders/Failed` reaches nothing, here and in an
-account.
+CloudWatch metrics have no ARN, so every metric action uses a resource of `*`. A policy written
+against a fabricated metric ARN such as
+`arn:aws:cloudwatch:eu-west-2:111111111111:metric/Orders/Failed` is invalid in Yulin and AWS.
 
 Alarms are the exception, and do have an ARN. `PutMetricAlarm`, `DeleteAlarms` and `SetAlarmState`
 authorize against `arn:aws:cloudwatch:<region>:<account>:alarm:<name>`, while `DescribeAlarms` and
@@ -525,7 +515,7 @@ await simAws.cloudWatch().putMetricData(
 // Publishing into any other namespace as this Role is denied.
 ```
 
-## What is simulated
+## Supported operations
 
 - `PutMetricData`, with `Value`, `StatisticValues` and `Values`/`Counts`.
 - `ListMetrics`, filtered by namespace, metric name and dimensions, with `RecentlyActive` and
@@ -546,11 +536,9 @@ await simAws.cloudWatch().putMetricData(
 - `AWS::CloudWatch::Alarm` in simulated CloudFormation, deployed through `PutMetricAlarm` and taken
   down with the stack.
 
-## What is refused, and how it says so
+## Unsupported operations and options
 
-Anything real CloudWatch would accept and this leaves undone is refused with a message saying so,
-rather than accepted and ignored. A silently dropped filter is worse than a failure, because the
-test still passes and no longer means what it says.
+Yulin rejects unsupported CloudWatch behavior instead of ignoring it:
 
 - **Composite and anomaly detection alarms.** `Metrics` and `ThresholdMetricId` on `PutMetricAlarm`
   are refused. There is no trained model here for an anomaly band to come from.
@@ -571,8 +559,6 @@ test still passes and no longer means what it says.
   through the service writer. A CloudWatch Logs metric filter naming a reserved namespace is refused
   when it publishes, as `PutMetricData` refuses a caller naming one.
 
-Two divergences are deliberate, and not refusals. Real CloudWatch rejects a datapoint more than two
-weeks old or more than two hours in the future, and this accepts any timestamp, letting a test seed
-a window without arranging the clock around it. And datapoints come back earliest first, which real
-CloudWatch's contract permits without promising, because a test reading the third period of five
-needs an order it can rely on.
+Two behaviors differ from AWS. Yulin accepts datapoints more than two weeks old or more than two
+hours in the future, which makes it easier to seed a test window. It also returns datapoints in
+ascending timestamp order so tests receive deterministic results.

--- a/docs/services/ecr/README.md
+++ b/docs/services/ecr/README.md
@@ -1,31 +1,20 @@
 # Simulated ECR
 
-Yulin includes a simulated Amazon ECR for tests and local development. It holds repositories, and
-each repository holds images by tag, where a simulated image is a real in-process handler.
-
-That is what this service is for. A container image Lambda function cannot run here, because Yulin
-never reads an image, so something has to say what the code inside that image actually is. A
-repository is the natural place to say it. It is the stable name for the thing that holds the code,
-outliving any tag and any CDK construct ID, and a repository holding a registered handler outlives
-the stack that declared it too.
+Yulin represents an ECR image with an in-process Lambda handler. Register the handler against a
+repository and tag, then deploy or create a container image function that uses the image URI.
 
 ECR-specific types are imported from the `@kensio/yulin/ecr` subpath.
 
 ## What a simulated image is
 
-An image URI is only ever an identifier here. No image is pulled or inspected, and no layer,
-manifest, digest or scan finding exists. A simulated image is a handler function, registered against
-a repository and a tag.
+An image URI identifies a registered handler. Image content remains outside the simulation.
 
-Registering one is a Yulin-native operation, named `simulateImage` to keep it clear of a simulated
-`PutImage`. Real `PutImage` takes an image manifest for layers that were pushed over the Docker
-registry protocol. None of that happens in this process, and a simulated `PutImage` would be a
-command taking an argument nothing could produce.
+Use the Yulin-specific `simulateImage` method to register a handler. The simulated surface has no
+ECR SDK or Docker registry operations.
 
 ## Registering a handler as an image
 
-Register the handler once, in test setup, and every function that runs an image from that repository
-is created from it.
+Register the handler during test setup. Lambda resolves image functions from the same repository.
 
 ```typescript sim-ecr-register-image
 /**
@@ -82,36 +71,22 @@ console.log(Buffer.from(output.Payload).toString());
 await simAws.backgroundTasksComplete();
 ```
 
-Naming a repository is what creates it. A repository holds only its images. There is no prior
-declaration to make, and a test can name the repository its templates already point at.
+Calling `repository(name)` creates the repository if it is absent.
 
-The repository takes a bare name such as `orders` or `platform/orders`, and never a full image URI.
-The account, the region and the registry host around it come from the simulated ECR the repository
-belongs to. A name real ECR would refuse is refused here too.
+Pass a repository name such as `orders` or `platform/orders`. The selected simulated account and
+Region supply the registry host.
 
 ## How an image URI is matched
 
-Resolving an image URI happens in two steps, and the tag means something different in each.
+Yulin first matches the registry host and repository name. It then looks for the requested tag. A
+registered tag selects that handler. An unknown tag, a digest or no tag selects the most recently
+registered handler. This fallback lets content-hash and build-number tags resolve without copying
+those generated values into the test.
 
-Finding the repository ignores the tag. A function's `Code.ImageUri` is matched on the registry host
-and the repository name, with any tag or digest dropped, because no tag is stable enough to write
-into a test. A CDK image asset is tagged with the asset content hash, which changes whenever the
-image source does, and a pipeline-built image is usually tagged with a git sha or a build number
-passed in as a stack parameter. An `ImageUri` built by `Fn::Sub` or from a stack parameter is
-matched on what it resolves to.
+The registry host determines the account and Region. Repositories with the same name in different
+scopes remain separate. Cross-account image references are supported.
 
-Choosing the image in that repository does read the tag. A tag the repository holds selects exactly
-that image, and any other tag, or none at all, falls back to the image registered most recently.
-
-The registry host is part of the match, and the account and the region have to agree. A function can
-run an image from another account's repository, as it can on real AWS, and a same-named repository
-in another account is a different repository.
-
-So `orders:blue` runs the handler registered under `blue` where the repository holds one, and the
-handler registered most recently otherwise. That is how a blue/green pair of images in one
-repository can back two functions differently, while a content hash tag nobody registered still
-finds something to run. Registering a tag again both replaces what it held and makes it the most
-recent registration.
+Registering a tag again replaces its handler and makes that handler the most recent registration.
 
 ```typescript sim-ecr-image-tags
 /**
@@ -152,18 +127,15 @@ console.log(Buffer.from(output.Payload).toString()); // "blue handler"
 await simAws.backgroundTasksComplete();
 ```
 
-A function created directly through `CreateFunction` resolves its image the same way a template
-function does, as the example above shows. A function whose image resolves to no handler is refused,
-the way real Lambda refuses a function whose image it cannot pull.
+Direct `CreateFunction` calls and CloudFormation deployments use the same resolution rules. Lambda
+refuses an image URI that resolves to no handler.
 
 ## Repositories in CloudFormation
 
-`AWS::ECR::Repository` creates a simulated repository. A template declares a repository and never an
-image, as real CloudFormation does. A deployed repository starts empty unless a handler has already
-been registered in it.
+Simulated CloudFormation creates `AWS::ECR::Repository`. The repository starts empty unless a
+handler was already registered under its name.
 
-`Ref` returns the repository name, and `Fn::GetAtt` exposes `Arn` and `RepositoryUri`. An
-application stack can build its function's `ImageUri` from the repository a platform stack declared.
+`Ref` returns the repository name. `Fn::GetAtt` supports `Arn` and `RepositoryUri`.
 
 ```typescript sim-ecr-cloudformation-repository
 /**
@@ -236,34 +208,23 @@ console.log(Buffer.from(output.Payload).toString());
 await simAws.backgroundTasksComplete();
 ```
 
-A repository a handler is already registered in is adopted, and the order these happen in makes no
-difference. The image can exist before the stack that declares the repository, as it does in real
-life.
+A deployment adopts a repository that already contains a registered handler.
 
-Tearing the stack down removes the repository only where it holds no simulated image. One that does
-is left where it is, and the deletion is recorded as skipped, because the handler in it was
-registered outside any stack and is what every later deploy resolves to. Real ECR also refuses to
-delete a repository that still holds images, which fails the stack unless the template says
-`EmptyOnDelete`. Here the refusal is recorded and the teardown carries on, since what is being
-protected is a test's own registration.
+Stack teardown removes an empty repository. A repository containing a handler remains in place and
+its deletion is recorded as skipped. Teardown continues after the skipped deletion.
 
-Every other property a repository can declare is recorded as an ignored property, and the repository
-is created without it. That covers `ImageScanningConfiguration`, `ImageTagMutability`,
+Other repository properties are recorded as ignored. These include `ImageScanningConfiguration`, `ImageTagMutability`,
 `LifecyclePolicy`, `RepositoryPolicyText`, `EncryptionConfiguration`, `EmptyOnDelete` and `Tags`.
 
 ## Where a function's handler comes from
 
-Two things can back a container image function, and a deploy is looked at in this order:
+Yulin resolves a container image function in this order:
 
-1. An [executable binding](https://yulinsim.dev/services/lambda/#executable-bindings) given to that deploy, including one
-   naming the image repository. A binding is the more specific thing to have said, since it is about
-   one deploy.
-2. The simulated ECR repository the function's `Code.ImageUri` names. That is a standing statement
-   about what the image is, made once and good for every stack that runs it.
+1. An [executable binding](https://yulinsim.dev/services/lambda/#executable-bindings) supplied for the deployment.
+2. The handler registered in the ECR repository named by `Code.ImageUri`.
 
-A function with no binding and no registered image is skipped with a diagnostic, and the rest of the
-stack deploys. The reason separates a missing repository from an empty one, since those send you to
-different places. One is a wrong name, and the other is a handler that was never registered.
+A function with no binding or registered image is skipped. The diagnostic distinguishes a missing
+repository from a repository with no handlers.
 
 ## Available functionality
 
@@ -278,16 +239,14 @@ different places. One is a wrong name, and the other is a handler that was never
 
 ## Limitations
 
-Current documented limitations:
-
 - No image content, layer, digest, manifest or scan behaviour is simulated. A repository holds
   handlers, and no image is ever pulled or inspected.
 - There are no ECR SDK commands. `CreateRepository`, `DescribeRepositories`, `PutImage`,
   `DescribeImages`, `BatchDeleteImage` and `GetAuthorizationToken` are all absent. Registering an
   image is a Yulin-native operation because real `PutImage` takes a manifest for layers pushed over
   the Docker registry protocol, and that protocol never runs in this process.
-- Nothing authorizes against a repository. With no requests to authorize, a repository policy goes
-  unread and simulated IAM stays out of it.
+- CloudFormation authorizes `ecr:CreateRepository` and `ecr:DeleteRepository`. Handler registration
+  has no caller and skips authorization. Repository policies are ignored.
 - Lifecycle policies go unevaluated, and no simulated image ever expires. Tag mutability goes
   unenforced, and registering the same tag again replaces what it held.
 - Naming a repository creates it. There is no `CreateRepository` to fail for a name already taken,
@@ -295,8 +254,8 @@ Current documented limitations:
 - A stack teardown records the deletion of a repository holding a simulated image and carries on,
   where real CloudFormation fails the stack unless the template says `EmptyOnDelete`. The repository
   and its handler are left in place, and `EmptyOnDelete` itself goes unread.
-- Nothing tracks which stack created a repository. A repository holding no simulated image is
-  removed by the teardown of any stack that declared it, and made again by the next deploy.
+- The repository model records no owning stack. Teardown of any declaring stack removes an empty
+  repository.
 - Repository tags, registry policies, pull through cache rules, replication configuration and ECR
-  Public are not simulated.
-- ECR has no HTTP API under `serveSimAws`, and nothing for a Docker client to talk to.
+  Public are absent.
+- `serveSimAws` exposes no ECR HTTP API or Docker registry endpoint.

--- a/docs/services/elbv2/README.md
+++ b/docs/services/elbv2/README.md
@@ -1,24 +1,16 @@
 # Simulated Elastic Load Balancing
 
-Yulin includes a simulated Application Load Balancer for tests and local development. Load
-balancers, target groups, listeners and listener rules are held in memory and every operation is
-authorized by simulated IAM. ELBv2-specific types are imported from the `@kensio/yulin/elbv2`
-subpath.
+Yulin simulates Application Load Balancers, target groups, listeners and listener rules for tests
+and local development. Requests pass through the listener and rule configuration before reaching a
+registered Lambda function or simulated ECS service. Simulated IAM authorizes every operation.
 
-A load balancer created here has a DNS name of the shape real ELB issues, and a
-[Route53](https://yulinsim.dev/services/route53/) record pointing at that name resolves to it. A request made to your own
-hostname reaches the load balancer as it would deployed. A request is matched to a listener by port
-and then to one of that listener's rules, and a `forward` action sends it to a target group, where a
-registered [Lambda](https://yulinsim.dev/services/lambda/) function is invoked with the request and its response becomes the
-HTTP response.
+Each load balancer receives an AWS-shaped DNS name. A simulated
+[Route 53](https://yulinsim.dev/services/route53/) record can point a local hostname at that name, so
+an HTTP request follows the same routing path as the deployed application.
 
-Only the application load balancer is simulated. A network or gateway load balancer routes below
-HTTP, which nothing here speaks, and `Type: "network"` is refused outright.
-
-No TLS is performed anywhere in this. An HTTPS listener holds a certificate and is checked against
-simulated ACM, and everything travels in the clear. See
-[HTTPS listeners and certificates](#https-listeners-and-certificates) for what that leaves a test
-able to conclude.
+Network and Gateway Load Balancers are not simulated. HTTPS listeners validate their certificates
+against simulated ACM, but Yulin does not perform TLS. Import ELBv2-specific types from
+`@kensio/yulin/elbv2`.
 
 ## Creating a load balancer
 
@@ -73,9 +65,8 @@ why a load balancer cannot be named starting with `internal-`.
 
 ## Target groups hold functions or addresses
 
-A target group names what it holds through its `TargetType`, and that decides the rest. It sets how
-many targets the group takes, what a target's `Id` has to look like, and whether the group carries a
-protocol and port at all.
+`TargetType` determines what a target group can contain. It controls the number and shape of target
+IDs, and whether the group requires a protocol and port.
 
 ```typescript sim-elbv2-lambda-target-group
 /**
@@ -178,15 +169,14 @@ console.log(health.TargetHealthDescriptions?.length); // 1
 console.log(health.TargetHealthDescriptions?.[0]?.Target.Port); // 8080
 ```
 
-`TargetType: "instance"` is refused outright, because there are no EC2 instances here for it to mean
-anything about. A group created as one would look configured and route nowhere. A request naming no
-target type at all is refused for the same reason, since real ELB defaults it to `instance`.
+`TargetType: "instance"` is unsupported because Yulin does not simulate EC2 instances. Omitting
+`TargetType` is also rejected because AWS would default it to `instance`.
 
 ## Listeners and the rules on them
 
-A listener answers on a port and holds the default actions for a request no rule claims. Rules carry
-a priority, and that is what decides which of several matching rules claims a request. Two rules on
-one listener cannot hold the same priority.
+A listener handles one port and provides the default action when no rule matches. When several
+rules match, the lowest priority number wins. Two rules on the same listener cannot use the same
+priority.
 
 ```typescript sim-elbv2-listener-rules
 /**
@@ -1761,7 +1751,7 @@ console.log(created.LoadBalancers?.[0]?.DNSName);
 // "shop-alb-0000000001.eu-west-2.elb.amazonaws.com"
 ```
 
-## Available functionality
+## Supported operations
 
 - `CreateLoadBalancer`, `DescribeLoadBalancers` and `DeleteLoadBalancer`, with a DNS name, ARN,
   canonical hosted zone id, scheme and state on every load balancer.

--- a/docs/services/eventbridge/README.md
+++ b/docs/services/eventbridge/README.md
@@ -1,12 +1,12 @@
 # Simulated EventBridge
 
-Yulin includes a simulated Amazon EventBridge for tests and local development. Event buses are held
-in memory and every operation is authorized by simulated IAM.
+Yulin simulates Amazon EventBridge event buses, rules, targets and `PutEvents` for tests and local
+development. Rules can match events, run on a simulated schedule, and deliver to simulated Lambda,
+SQS, SNS or ECS. Event buses and rules are stored in memory, and simulated IAM authorizes every
+operation.
 
-Event buses, rules, targets and `PutEvents`. A rule can send matched events to a simulated Lambda
-function, SQS queue or SNS topic, run a simulated ECS task, or fire on a schedule when a test
-advances simulated time. [EventBridge Scheduler](https://yulinsim.dev/services/scheduler/) is a separate service with its own
-docs. EventBridge-specific types are imported from the `@kensio/yulin/eventbridge` subpath.
+[EventBridge Scheduler](https://yulinsim.dev/services/scheduler/) is simulated separately. Import
+EventBridge-specific types from `@kensio/yulin/eventbridge`.
 
 ## Putting an event onto a bus
 
@@ -142,10 +142,8 @@ console.log(output.FailedEntryCount); // 0
 console.log(output.Entries?.[0]?.EventId !== undefined); // true
 ```
 
-This is real EventBridge behaviour, and not a gap here. AWS answers 200, finds no rule to match the
-event against, and drops it, without counting the entry as failed. A mistyped bus name therefore
-looks exactly like a working call. That is worth knowing before it costs an afternoon, and the
-simulation reproduces it faithfully.
+AWS also accepts and drops an event sent to a bus that does not exist. The entry is not counted as a
+failure, so check the bus name when `PutEvents` succeeds but no rule runs.
 
 ## Inspecting what a bus received
 
@@ -250,9 +248,8 @@ within the account. A rule ARN on the default bus is
 `arn:aws:events:<region>:<account>:rule/<name>`, and a rule on a custom bus carries the bus as well,
 as `rule/<bus>/<name>`.
 
-`PutRule` creates and updates alike, and an update **replaces** the rule rather than merging into
-it. A second request that leaves out the description clears the description. That is real behaviour
-and a common surprise.
+`PutRule` creates or updates a rule. An update replaces the stored rule instead of merging fields,
+so omitting the description clears it.
 
 `DisableRule` stops a rule matching, and `EnableRule` starts it again. A rule that was off picks up
 from the next event and leaves what it missed behind. `DeleteRule` on a rule that was never there
@@ -285,10 +282,9 @@ field, the pattern matches when the two lists overlap, and a pattern naming one 
 event whose `resources` names several. `exists` is about the field and not its members, and a field
 carrying an empty list still exists.
 
-Anything else is refused at `PutRule`. The `cidr`, `equals-ignore-case`, `wildcard` and `$or`
-operators are all refused by name, as are the nested forms of `anything-but` and the
-case-insensitive forms of `prefix` and `suffix`. A pattern that silently matched nothing would look
-like a pattern that was simply too specific, and the rule would go unnoticed until the deployment.
+`PutRule` rejects unsupported operators instead of storing a pattern that can never match. These
+include `cidr`, `equals-ignore-case`, `wildcard`, `$or`, nested `anything-but`, and the
+case-insensitive forms of `prefix` and `suffix`.
 
 ## Testing a pattern without a rule
 
@@ -1049,7 +1045,7 @@ events across accounts that way, but nothing here can reach another simulation's
 treating a foreign ARN as local would let a test pass while the real call crossed a boundary it has
 no permission for.
 
-## Available functionality
+## Supported operations
 
 - `CreateEventBus`, `DeleteEventBus`, `DescribeEventBus`, `ListEventBuses` and `PutEvents`.
 - `PutRule`, `DeleteRule`, `DescribeRule`, `ListRules`, `EnableRule`, `DisableRule` and

--- a/docs/services/firehose/README.md
+++ b/docs/services/firehose/README.md
@@ -1,18 +1,16 @@
 # Simulated Kinesis Data Firehose
 
-Yulin includes a simulated Kinesis Data Firehose for tests and local development. A delivery stream
-takes records, buffers them, and writes them into a simulated S3 Bucket under the key format real
-Firehose uses. The records come from `PutRecord` or off a simulated Kinesis stream. A test can put an
-event and assert on the Object it landed in, without an AWS account and without waiting five minutes
-for a buffer to flush.
+Yulin simulates Kinesis Data Firehose delivery streams in memory. A stream accepts records directly
+or reads them from simulated Kinesis, buffers them, and writes each completed buffer to simulated S3.
+Advance simulated time to flush interval-based buffers without waiting in real time.
 
 Firehose specific types are imported from the `@kensio/yulin/firehose` subpath.
 
 ## Putting a record and finding the Object
 
-`simAws.firehose()` gives the service for the default account and region. A delivery stream needs a
-Bucket to write into and a Role to write as, so both exist before it does. Advancing the clock past
-the buffering interval is what delivers the buffer.
+`simAws.firehose()` returns Firehose for the default account and region. Create the destination
+bucket and delivery role before the delivery stream. Advance the clock past the buffering interval
+to write the buffered records.
 
 ```typescript sim-firehose-put-and-deliver
 /**
@@ -93,15 +91,13 @@ const { Contents } = await simAws
 console.log(Contents?.[0]?.Key);
 ```
 
-The put is answered straight away with a record id. The Bucket stays empty until the buffer is
-delivered. That delay is what a Firehose pipeline is built around.
+`PutRecord` returns a record ID immediately. The bucket remains empty until the buffer is delivered.
 
 ## Buffering
 
-A delivery stream holds its records until the buffer passes `SizeInMBs` or `IntervalInSeconds`,
-whichever comes first. Everything in one buffer arrives as one Object, with the records concatenated
-end to end. A producer that wants lines puts the newline on the end of each record. The example
-below does exactly that.
+A delivery stream flushes when it reaches `SizeInMBs` or `IntervalInSeconds`, whichever comes first.
+Firehose concatenates all records in the buffer into one S3 object. Add a newline to each record if
+the object should contain separate lines.
 
 `IntervalInSeconds` runs from the first record of a buffer. The default is 300 seconds and the
 default size is 5 MB, as they are on real Firehose.
@@ -224,8 +220,8 @@ the background scheduler, the way real Firehose answers the producer before it w
 
 ## The Object key
 
-The key is the `Prefix`, then the UTC date path, then the delivery stream name, its version, the
-delivery time and a random string:
+Object keys contain the configured `Prefix`, UTC date path, delivery stream name, version, delivery
+time, and a random suffix:
 
 ```
 <Prefix>YYYY/MM/DD/HH/<delivery-stream-name>-<version>-YYYY-MM-DD-HH-MM-SS-<random>
@@ -234,15 +230,15 @@ delivery time and a random string:
 A delivery stream with no `Prefix` gets the bare date path. The version is `1` and stays there,
 since a delivery stream's configuration is fixed once it is created.
 
-Simulated time is what the date path and the timestamp come from. A test that sets the clock to a
-known instant knows the prefix its Objects are under, and can list them.
+The date path and timestamp use simulated time. Set the clock before delivery to make the prefix
+predictable.
 
 ## Reading from a Kinesis stream
 
-A delivery stream can take its records off a simulated Kinesis stream instead. Create it with a
+A delivery stream can read records from simulated Kinesis. Create it with a
 `DeliveryStreamType` of `KinesisStreamAsSource` and a `KinesisStreamSourceConfiguration` naming the
-stream and the Role to read it as. Records put on the stream from then on are buffered and delivered
-the way put records are.
+stream and its read role. Records added after the delivery stream is created are buffered and sent
+to S3.
 
 ```typescript sim-firehose-kinesis-source
 /**
@@ -382,11 +378,8 @@ Creating a delivery stream hands Firehose the destination `RoleARN`, and the sou
 where it reads a Kinesis stream. `CreateDeliveryStream` authorizes `iam:PassRole` against each of
 them. See [passing a Role to a service](https://yulinsim.dev/services/iam/#passing-a-role-to-a-service) in the IAM docs.
 
-The delivery itself is a separate request, made as the delivery stream's `RoleARN`. The caller who
-put the record needs no S3 permission at all, and a Role that cannot write to the Bucket fails the
-delivery. Real
-Firehose answered that `PutRecord` minutes earlier, and what became of the buffer reaches the
-producer through CloudWatch. The simulator keeps the failure for a test to read instead.
+Delivery uses the delivery stream's `RoleARN`, not the identity that called `PutRecord`. The role
+needs `s3:PutObject` on the destination. Failed writes appear in `getDeliveryFailures()`.
 
 ```typescript sim-firehose-permissions
 /**
@@ -507,9 +500,8 @@ what a test checking the denial does. Anything else is also warned about on the 
 `KinesisStreamSourceConfiguration` and `Tags` are read. A `Ref` gives the delivery stream name and
 `Fn::GetAtt` on `Arn` gives the ARN, the way real CloudFormation publishes them.
 
-A CDK `DeliveryStream` with an `S3Bucket` destination synthesizes that resource, along with the
-delivery Role and its policy. A CDK project reaches a simulated delivery stream by deploying its
-synthesized template, and nothing here has to be written by hand.
+A CDK `DeliveryStream` with an `S3Bucket` destination synthesizes this resource, its delivery role,
+and the role policy. Deploy that synthesized template directly into simulated CloudFormation.
 
 ```typescript sim-firehose-cloudformation
 /**
@@ -627,9 +619,9 @@ A `DeliveryStreamType` of `KinesisStreamAsSource` deploys as well. The
 `KinesisStreamSourceConfiguration` names the stream by ARN and the Role to read it as, and a stack
 declaring the stream beside the delivery stream archives what a producer puts on it.
 
-A delivery stream this simulation cannot deliver for is skipped and recorded in
-`stack.skippedResources`, and the rest of the stack deploys. That covers a destination other than
-S3, and a source property naming somewhere the records cannot come from, such as
+A delivery stream with an unsupported source or destination is recorded in
+`stack.skippedResources`, while the rest of the stack deploys. This includes destinations other than
+S3 and unsupported source properties such as
 `MSKSourceConfiguration` or `DatabaseSourceConfiguration`. The source property is what the skip is
 decided on, because a template that leaves `DeliveryStreamType` out gets `DirectPut` by default.
 

--- a/docs/services/glue/README.md
+++ b/docs/services/glue/README.md
@@ -1,26 +1,17 @@
 # Simulated Glue
 
-Yulin includes a simulated Glue Data Catalog for tests and local development. It holds databases,
-tables and the partitions registered against them, deploys databases and tables from
-`AWS::Glue::Database` and `AWS::Glue::Table`, and hands them back through `GetDatabase` and
-`GetTable`. A test can assert that a stack declared the table definition it meant to, including the
-Athena partition projection its parameters configure.
+Yulin simulates Glue Data Catalog databases, tables and partitions. The catalog stores metadata. It
+does not read the data in S3.
 
-A table here is a definition. The data it describes stays in S3, unread, and the catalog answers
-with what it was told to hold.
-
-Simulated [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") reads this
-catalog. A query naming a table no database here holds fails the way real Athena fails it, and a
-table's partition projection is evaluated when a query runs against it. All four projection types
-are covered, `enum`, `integer`, `date` and `injected`. A projection with a mistake in its parameters
-fails the query that reads it.
+Simulated [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") reads the
+catalog and evaluates partition projection when it runs a query.
 
 Glue-specific types are imported from the `@kensio/yulin/glue` subpath.
 
 ## Deploying a database and a table
 
-A stack declares the database, and the table names it through `Ref`. Both read back through the SDK
-once the deploy finishes.
+Simulated CloudFormation deploys `AWS::Glue::Database` and `AWS::Glue::Table`. A table can name its
+database through `Ref`.
 
 ```typescript sim-glue-cloudformation
 /**
@@ -84,18 +75,15 @@ const { Table } = simAws
 console.log(Table.Parameters["projection.enabled"]);
 ```
 
-Partition projection lives entirely in `TableInput.Parameters`. Those parameters are read into the
-table, and never recorded as ignored. A table whose parameters were dropped on the way in deploys
-green while projecting none of them. Simulated Athena reads those same parameters when a query runs.
-A broken projection fails that query.
+Partition projection configuration is stored in `TableInput.Parameters`. Athena reads these
+parameters when a query runs and rejects invalid projection configuration.
 
 `Ref` answers with the database name and with the table name.
 
 ## Names are folded to lower case
 
-A database name and a table name are both folded to lower case when they are stored. Real Glue folds
-them the same way, for compatibility with Apache Hive. A database created as `Rainlytics` is stored,
-reported and queried as `rainlytics`.
+Database and table names are stored in lower case. A database created as `Rainlytics` is reported as
+`rainlytics`.
 
 ```typescript sim-glue-name-folding
 /**
@@ -123,36 +111,27 @@ const { Database } = glue.getDatabase(
 console.log(Database.Name);
 ```
 
-Two names differing only by case are one name. A second `CreateDatabase` for `Rainlytics` after one
-for `rainlytics` is an `AlreadyExistsException`, and a `GetTable` finds the table under whichever
-spelling it is asked for.
+Names that differ only by case refer to the same database or table. Creating the second one raises
+`AlreadyExistsException`.
 
-Column names keep the case they were given, including partition keys. Real Glue leaves those alone,
-and simulated [Athena](https://yulinsim.dev/services/athena/ "Simulated Athena usage docs") folds a
-column name only when it runs a query.
+Column and partition key names keep their original case.
 
-A database or a table the template leaves unnamed is named from the stack name, the logical ID and a
-tail derived from both, folded the same way. A `LogTable` in `analytics-stack` becomes
-`analytics-stack-logtable-` and twelve more characters, where real CloudFormation ends the name in
-twelve random ones. The name is trimmed to the 255 bytes the catalog allows, and [the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
-cover how the stack name and the logical ID share what is left.
+CloudFormation generates a lower-case name when the template omits one. See
+[generated resource names](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates").
 
 ## Reading the catalog back
 
-`GetDatabase`, `GetDatabases`, `GetTable` and `GetTables` answer through the SDK. A `SimGlue` also
-carries `findDatabase`, `findTable`, `allDatabases`, `tablesInDatabase`, `findPartition` and
-`partitionsInTable`. Those read the same state without going through a Command or its
-authorization.
+Use the SDK commands to read the catalog through IAM authorization. The `findDatabase`, `findTable`,
+`allDatabases`, `tablesInDatabase`, `findPartition` and `partitionsInTable` accessors read the same
+state directly.
 
-The storage descriptor keeps its columns in the order they were declared, and the partition keys
-keep theirs. The two stay apart, the way real Glue keeps them. A partition key repeated among the
-storage descriptor's columns gives a table Athena refuses to query.
+Storage descriptor columns and partition keys keep their declared order. Athena rejects a table
+that repeats a partition key in the storage descriptor columns.
 
 ## Registering partitions
 
-A crawler, `MSCK REPAIR TABLE` or `ALTER TABLE ADD PARTITION` fills a real catalog's partition list.
-Here the six partition commands do it. A partition is keyed by its values in the order the table's
-`PartitionKeys` declares them, and carries a storage descriptor saying where its own data sits.
+Register partitions with the Glue partition commands. Values follow the order of the table's
+`PartitionKeys`. Each partition may provide its own storage descriptor.
 
 ```typescript sim-glue-partitions
 /**
@@ -219,24 +198,19 @@ console.log(Errors.length);
 console.log(Partitions[1]?.StorageDescriptor?.Location);
 ```
 
-`CreatePartition` registers one partition and `BatchCreatePartition` registers a list of them.
-`GetPartition` reads one back by its values, and `GetPartitions` answers with a table's partitions in
-registration order. `DeletePartition` and `BatchDeletePartition` remove them.
+`CreatePartition` and `BatchCreatePartition` register partitions. `GetPartition` reads one by its
+values. `GetPartitions` returns them in registration order. The delete commands remove them.
 
-A batch reports what it could not do in `Errors` and carries on with the rest, the way real Glue
-does. Each entry there carries the values it was given and an `ErrorCode` naming the refusal, so a
-job re-run over a week of days learns which days were already registered and registers the others.
+A batch continues after an individual partition fails. Its `Errors` list contains the supplied
+values and an `ErrorCode` for each failure.
 
-Values are positional. A `Values` list of a different length from the table's `PartitionKeys` lines
-up with the wrong keys, and is refused with `InvalidInputException` naming both counts. Registering
-one day twice is an `AlreadyExistsException`, since registration is not idempotent on real Glue.
-Deleting a table removes the partitions registered against it, the way deleting a database removes
-its tables.
+The number of values must match the number of partition keys. A mismatch raises
+`InvalidInputException`. Registering the same values twice raises `AlreadyExistsException`. Deleting
+a table removes its partitions, and deleting a database removes its tables.
 
 ## Filtering partitions
 
-`GetPartitions` takes an `Expression` and answers with the partitions it matches. A request carrying
-none reads them all.
+Pass `Expression` to `GetPartitions` to filter the result. Omitting it returns every partition.
 
 ```typescript sim-glue-partition-expressions
 /**
@@ -295,28 +269,19 @@ const { Partitions } = glue.getPartitions(
 console.log(JSON.stringify(Partitions.map((partition) => partition.Values)));
 ```
 
-A term names a partition key, an operator, and whatever the operator takes. The operators are `=`,
-`<>` and `!=`, `>`, `<`, `>=`, `<=`, `LIKE`, `IN` and `BETWEEN`, and `BETWEEN` takes both of its
-ends. `AND`, `OR` and `NOT` combine terms and brackets group them, with the precedence SQL gives
-them (`NOT` binds tightest, then `AND`, then `OR`). `NOT` also sits in front of `LIKE`, `IN` and
-`BETWEEN` to reverse that one term.
+Expressions support `=`, `<>`, `!=`, `>`, `<`, `>=`, `<=`, `LIKE`, `IN` and `BETWEEN`. Combine terms
+with `AND`, `OR`, `NOT` and parentheses. Operator precedence is `NOT`, then `AND`, then `OR`.
 
-Comparison follows the type the table declares for the key. `tinyint`, `smallint`, `int`, `integer`,
-`bigint`, `float`, `double` and `decimal` compare as numbers, so `10` sorts above `9` rather than
-below it. Every other declared type compares as text, which is the order a date written the ISO way
-already has. A key declared as a number is held to a numeric literal, and `hour = 'noon'` is refused
-rather than matching nothing.
+Numeric partition key types use numeric comparison. Other types use text comparison. A numeric key
+requires a numeric literal.
 
-`LIKE` matches the value's text whatever type the key is declared with, since that is what `LIKE`
-does. `%` stands for any run of characters and `_` for exactly one.
+`LIKE` treats the value as text. `%` matches any sequence and `_` matches one character.
 
-An expression naming a column the table does not partition by is refused, naming the column and the
-keys the table does have. So is one that cannot be read, and the message says where reading stopped.
+An unknown partition key or invalid expression is rejected with a position-aware error.
 
 ## Intercepting a GlueClient
 
-An intercepted `GlueClient` reaches the simulated catalog, so code under test builds its own client
-and sends its own Commands.
+Intercept a `GlueClient` when application code constructs the client itself.
 
 ```typescript sim-glue-sdk-interception
 /**
@@ -357,11 +322,9 @@ console.log(TableList?.[0]?.Name);
 
 ## Permissions
 
-Every Command authorizes through simulated IAM. Data Catalog resources are a hierarchy with the
-catalog at the root, and an operation on one needs permission on that resource and on every ancestor
-of it. Reading a table needs the table, the database and the catalog, and a policy naming only the
-table ARN is denied. Deleting a database needs permission on every table in it as well, since the
-tables go with it.
+Every command uses simulated IAM. Catalog resources form a hierarchy. A table operation needs
+permission on the table, database and catalog. Deleting a database also needs permission on its
+tables.
 
 ```typescript sim-glue-permissions
 /**
@@ -441,7 +404,7 @@ const { Table } = glue.getTable(
 console.log(Table.Name);
 ```
 
-A policy listing only the table ARN is refused here, and refused by real Glue for the same reason.
+A policy that grants only the table ARN is insufficient.
 
 ## Available functionality
 

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -1,11 +1,11 @@
 # Simulated IAM
 
-Yulin includes a simulated IAM service for tests and local development.
+Yulin simulates IAM users, roles, policies and authorization decisions for tests and local
+development. Other simulated services use IAM to authorize requests, simulated STS uses it to issue
+temporary role sessions, and simulated CloudFormation can create IAM resources from templates.
 
-Sim IAM stores simulated Roles, Users and Policies, and evaluates allow/deny authorization decisions
-for them. Other simulated services use it to authorize their own actions, simulated STS uses it to
-issue temporary Role sessions, and sim CloudFormation can create IAM resources from templates. It can
-also be instantiated on its own as `SimIam` with isolated state.
+Use IAM through `SimAws` when it should share state with other services. Use `SimIam` directly when
+you need an isolated policy evaluator.
 
 ## Basic usage
 
@@ -70,9 +70,8 @@ denied for every action.
 
 ## Authorization decisions
 
-`authorize(...)` returns a decision object. A denied request comes back as a decision too, and a
-test can assert on exactly why it was allowed or denied. The decision models the common IAM
-evaluation rules:
+`authorize(...)` returns an authorization decision without throwing when access is denied. Tests
+can inspect why the request was allowed or denied. The evaluator applies these rules:
 
 - A matching explicit `Deny` statement in any evaluated policy wins
 - Otherwise, within one Account, a matching `Allow` in an identity policy or resource policy allows
@@ -81,12 +80,11 @@ evaluation rules:
   [Cross-Account requests](#cross-account-requests)
 - Otherwise the request is implicitly denied
 
-The decision exposes `value` (`"Allow"`, `"ExplicitDeny"`, or `"ImplicitDeny"`), the convenience
-flags `isAllowed`, `isDenied`, `isExplicitDeny`, and `isImplicitDeny`, the matching
-`allowStatements` and `explicitDenyStatements`, and the resolved `caller` for diagnostics. The
-matching Allows are also available per side as `identityAllowStatements` and
-`resourceAllowStatements`. A cross-Account denial is best read from those. Statements the simulator
-could not evaluate are reported by `unevaluatedStatements`, covered under
+The decision's `value` is `"Allow"`, `"ExplicitDeny"` or `"ImplicitDeny"`. Convenience flags expose
+the same result as `isAllowed`, `isDenied`, `isExplicitDeny` and `isImplicitDeny`. The decision also
+contains the resolved `caller` and the matching allow and deny statements. For cross-account
+requests, inspect `identityAllowStatements` and `resourceAllowStatements` to see which side did not
+grant access. Unsupported statements appear in `unevaluatedStatements`, covered under
 [Statements left unevaluated](#statements-left-unevaluated).
 
 If the caller is omitted, authorization defaults to the simulation's own
@@ -1634,7 +1632,7 @@ stands apart from any wider `SimAws` environment. Other services instantiated st
 `new SimRoute53()`, fall back to allow-all authorization. Connect services through a shared `SimAws`
 instance when a test should exercise real IAM enforcement.
 
-## Available functionality
+## Supported operations
 
 Sim IAM currently supports:
 

--- a/docs/services/kinesis/README.md
+++ b/docs/services/kinesis/README.md
@@ -1,16 +1,14 @@
 # Simulated Kinesis Data Streams
 
-Yulin includes a simulated Kinesis Data Streams for tests and local development. It creates streams,
-places records on shards the way real Kinesis does, and hands them back through shard iterators. A
-test can put an event and assert that the consumer read it, without an AWS account and without
-waiting on a real stream.
+Yulin simulates Kinesis streams, shards, records and shard iterators in memory. Use
+`simAws.kinesis()` directly or intercept a `KinesisClient`.
 
 Kinesis specific types are imported from the `@kensio/yulin/kinesis` subpath.
 
 ## Putting a record and reading it back
 
-`simAws.kinesis()` gives the service for the default account and region. Records go on with
-`PutRecord`, and come off through a shard iterator, which is the walk every Kinesis consumer makes.
+Create a stream, put a record, then read it through a shard iterator. This is the same sequence used
+by an AWS SDK consumer.
 
 ```typescript sim-kinesis-put-and-read
 /**
@@ -59,17 +57,15 @@ const { Records } = await kinesis.getRecords(
 console.log(new TextDecoder().decode(Records[0]?.Data));
 ```
 
-A record keeps the bytes it was given. Whatever the producer encoded is what the consumer decodes.
+Kinesis stores the bytes supplied by the producer. The consumer is responsible for decoding them.
 
 ## Shards and partition keys
 
-A stream is created with the shard count it asks for, and each shard owns a slice of a 128 bit hash
-key space. A record goes to the shard whose slice covers the MD5 hash of its partition key, which is
-the placement real Kinesis makes. Two records sharing a partition key therefore land on one shard,
-in the order they were put, and that per-key ordering is what most Kinesis consumers depend on.
+A stream divides the 128-bit hash key space evenly across its shards. Kinesis uses the MD5 hash of
+the partition key to select a shard. Records with the same partition key reach the same shard in
+write order.
 
-Records under different partition keys can land anywhere. A consumer that has to see every record
-reads every shard.
+Different partition keys may select different shards. Read every shard to consume the whole stream.
 
 ```typescript sim-kinesis-shards
 /**
@@ -121,12 +117,10 @@ console.log(
 );
 ```
 
-An `ExplicitHashKey` on a record overrides the partition key for placement, and the record still
-carries the partition key the producer gave it. That is how a producer pins a record to a shard it
-picked.
+`ExplicitHashKey` overrides the hash used for placement. The stored record still contains the
+original partition key.
 
-A stream created with `StreamModeDetails` of `ON_DEMAND` gets four shards, which is what real
-Kinesis starts an on-demand stream with. Nothing here grows or shrinks that count.
+An `ON_DEMAND` stream starts with four shards. Its shard count remains fixed.
 
 ## Where a read starts
 
@@ -140,24 +134,20 @@ Every shard iterator type resolves to a place on the shard.
 | `AFTER_SEQUENCE_NUMBER` | The record following that sequence number.                    |
 | `AT_TIMESTAMP`          | The first record that arrived at or after the instant given.  |
 
-`GetRecords` hands back a `NextShardIterator` pointing at where the read finished, which is what a
-polling consumer passes to its next call. A read that has caught up comes back empty with an
-iterator standing where it was.
+Pass `NextShardIterator` to the next `GetRecords` call. A reader at the end of the shard receives an
+empty record list and another iterator at the same position.
 
-`MillisBehindLatest` reports how far behind the tip the reader is. Zero means caught up. Otherwise
-it is the age of the last record handed back, measured against simulated time.
+`MillisBehindLatest` is zero for a reader at the end of the shard. Otherwise it reports the age of
+the last returned record, measured against simulated time.
 
 ## Retention
 
-A stream keeps a record for 24 hours. Records older than that are gone from a read, and trimming is
-applied at the instant of the read rather than on a timer, so moving simulated time forward is all a
-test needs.
+A stream retains records for 24 hours by default. Retention is applied when records are read. Move
+simulated time forward to test expiration.
 
-`IncreaseStreamRetentionPeriod` and `DecreaseStreamRetentionPeriod` move it, up to the 8760 hours
-Kinesis keeps at most. Each refuses a request that goes the other way, including one asking for what
-the stream already keeps, which is what real Kinesis does with a caller that has the wrong idea of
-what the stream is set to. Shortening the window drops whatever it has already outlived from the
-next read.
+Use `IncreaseStreamRetentionPeriod` or `DecreaseStreamRetentionPeriod` to change the period. Values
+must stay between 24 and 8,760 hours. Each command rejects a value pointing in the wrong direction.
+Shortening the period affects the next read.
 
 ```typescript sim-kinesis-retention
 /**
@@ -209,26 +199,21 @@ console.log(Records.length);
 ## Triggering a Lambda function
 
 A [Lambda event source mapping](https://yulinsim.dev/services/lambda/#triggering-a-function-from-a-kinesis-stream "Simulated Lambda Kinesis event source docs")
-polls a stream and invokes a function with the records it reads. Every shard is read by a processor
-of its own, as real Lambda reads one, and the function's execution role is what the polling is done
-as.
+polls each shard and invokes the function with batches of records. Reads use the function's
+execution role.
 
 ## Feeding a Firehose delivery stream
 
 A [Firehose delivery stream](https://yulinsim.dev/services/firehose/#reading-from-a-kinesis-stream "Simulated Firehose Kinesis source docs")
-can read a stream and buffer what it reads into an S3 Bucket. It reads every shard as its source
-`RoleARN`, starting at the end of the stream when the delivery stream is created.
+can read every shard and buffer the records into S3. It starts at the end of the stream and reads as
+its source `RoleARN`.
 
 ## Deploying a stream
 
-`AWS::Kinesis::Stream` creates a simulated stream, which is what a CDK `Stream` synthesizes. The
-stream goes through the ordinary `CreateStream` command, so a stream a template deployed is the same
-thing an SDK caller would have got, and a template asking for something Kinesis will not take is
-refused in the words `CreateStream` refuses it in.
+Simulated CloudFormation deploys `AWS::Kinesis::Stream` through `CreateStream`. A CDK `Stream`
+synthesizes this resource type.
 
-`Ref` gives the stream name and `Fn::GetAtt` on `Arn` gives the stream ARN, which is the way round
-real CloudFormation publishes them. Every Kinesis API and every grant names the ARN, so a template
-wiring a stream into a Lambda event source mapping or an IAM policy reads the attribute.
+`Ref` returns the stream name. `Fn::GetAtt Arn` returns its ARN.
 
 ```typescript sim-kinesis-cloudformation
 /**
@@ -274,32 +259,24 @@ await simAws.kinesis().putRecord(
 );
 ```
 
-`Name`, `ShardCount`, `RetentionPeriodHours`, `StreamModeDetails` and `Tags` are read. A stream the
-template does not name is named after the stack, the logical ID and a tail derived from both, as
-[the CloudFormation docs](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates")
-describe.
+Yulin reads `Name`, `ShardCount`, `RetentionPeriodHours`, `StreamModeDetails` and `Tags`. It generates
+a name when `Name` is absent. See [generated resource names](https://yulinsim.dev/services/cloudformation/#names-cloudformation-generates "Names CloudFormation generates").
 
-`RetentionPeriodHours` is applied after the stream is created, because `CreateStream` takes no
-retention on real Kinesis either. It only ever goes up: a new stream keeps records for 24 hours,
-which is also the least Kinesis accepts, so a template can ask for more or for the same and never
-for less.
+`RetentionPeriodHours` is applied after creation. A new stream already has the minimum 24-hour
+period, so a template may keep it or increase it.
 
-`StreamEncryption` and `DesiredShardLevelMetrics` are recorded against the resource as unsimulated
-and the stream is created anyway, so a template that encrypts its streams still deploys and the
-omission is somewhere a test can find it. Deleting the stack deletes the stream.
+`StreamEncryption` and `DesiredShardLevelMetrics` are recorded as ignored properties. The stream is
+still created. Deleting the stack deletes it.
 
-`AWS::Kinesis::StreamConsumer` and `AWS::Kinesis::ResourcePolicy` are reported as unsupported and
-skipped. One registers an enhanced fan-out consumer and the other admits a caller from another
-account, and neither has anything to act on here.
+`AWS::Kinesis::StreamConsumer` and `AWS::Kinesis::ResourcePolicy` are skipped. Enhanced fan-out and
+resource policies are absent.
 
 ## Permissions
 
-Every operation goes through simulated IAM. The action is the `kinesis:` name of the operation, and
-the resource is the stream ARN, `arn:aws:kinesis:<region>:<account>:stream/<name>`. `ListStreams`
-names no stream and authorizes against `*`.
+Every operation uses simulated IAM. Stream operations authorize the corresponding `kinesis:` action
+against the stream ARN. `ListStreams` authorizes against `*`.
 
-`GetRecords` authorizes against the stream the iterator was made on, which the iterator carries. A
-caller cannot reach a stream it lacks permission for by holding someone else's iterator.
+`GetRecords` authorizes against the stream stored in the iterator.
 
 ```typescript sim-kinesis-permissions
 /**
@@ -362,8 +339,7 @@ try {
 
 ## SDK interception
 
-A `KinesisClient` handed to `SimSdk` reaches the simulated service, so application code that builds
-its own client needs no change.
+Intercept a `KinesisClient` when application code creates and uses the client itself.
 
 ```typescript sim-kinesis-sdk-interception
 /**
@@ -418,38 +394,22 @@ console.log(put.ShardId);
 
 Every operation takes `StreamName` or `StreamARN`, and reads the ARN when a request carries both.
 
-Anything else refuses on send with `SimSdkUnsupportedCommandError`.
+Any other command raises `SimSdkUnsupportedCommandError`.
 
 ## Divergences and limitations
 
-- **A stream is `ACTIVE` as soon as it exists.** Real Kinesis reports `CREATING` while it brings the
-  shards up, and a status a test has to poll through earns nothing when there are no shards to bring
-  up. `DELETING` and `UPDATING` are absent for the same reason.
-- **Nothing reshards.** `UpdateShardCount`, `SplitShard` and `MergeShards` move the shard map
-  underneath consumers holding iterators, and they are left out. A shard is opened when the stream
-  is created and never closes, so no shard reports an ending sequence number and no read reports a
-  child shard.
-- **Enhanced fan-out is absent.** `RegisterStreamConsumer`, `DeregisterStreamConsumer`,
-  `ListStreamConsumers`, `DescribeStreamConsumer` and `SubscribeToShard` need an HTTP/2 event stream
-  that nothing here delivers. Every consumer reads through `GetRecords`.
+- Streams become `ACTIVE` immediately. `CREATING`, `DELETING` and `UPDATING` states are absent.
+- Resharding is absent. `UpdateShardCount`, `SplitShard` and `MergeShards` are unsupported. Shards
+  have no ending sequence number or child shards.
+- Enhanced fan-out is absent. Consumers read through `GetRecords`.
 - **A shard iterator never expires.** Real Kinesis expires one after five minutes. An iterator this
   simulation never issued is still refused, with the `ExpiredIteratorException` real Kinesis uses.
-- **Throughput is unlimited.** Real Kinesis takes 1 MB or 1,000 records a second per shard for
-  writes and 2 MB a second for reads, and refuses past that with
-  `ProvisionedThroughputExceededException`. Nothing here counts. That is why `FailedRecordCount` on
-  `PutRecords` is always zero: the reasons real Kinesis fails one record of a batch are throughput
-  limits and internal faults, and neither is simulated. The per-record result shape is still what a
-  consumer of the response reads.
+- Throughput is unlimited. Yulin never raises `ProvisionedThroughputExceededException`, and
+  `PutRecords` reports zero failed records.
 - **Sequence numbers are 56 digit counters.** They are unique within a stream and increase within a
-  shard, as real Kinesis promises. They also increase across shards here, which real Kinesis does
-  not promise, so a consumer ordering two records from different shards would be relying on
-  something AWS does not offer.
-- **Server-side encryption is absent.** `StartStreamEncryption` and `StopStreamEncryption` are left
-  out, and no response carries an `EncryptionType`.
-- **Tags are kept and never listed.** A stream created with `Tags` holds them, readable through
-  `findStream`. `AddTagsToStream`, `ListTagsForStream` and `RemoveTagsFromStream` are absent.
-- **Kinesis Data Firehose is a separate service.** It has a simulation of its own under
-  `simAws.firehose()`, and a delivery stream there can read a stream here. Kinesis Video Streams is
-  absent.
-- **`AWS::DynamoDB::Table` `KinesisStreamSpecification` stays unsimulated.** A table does not publish
-  its changes into a stream here.
+  shard, as real Kinesis promises. Yulin also increments them across shards. AWS promises ordering
+  within a shard only.
+- Server-side encryption is absent. Responses contain no `EncryptionType`.
+- Stream tags are stored and available through `findStream`. Tagging commands are unsupported.
+- Kinesis Video Streams is absent.
+- The DynamoDB `KinesisStreamSpecification` integration is absent.

--- a/docs/services/kms/README.md
+++ b/docs/services/kms/README.md
@@ -1,17 +1,15 @@
 # Simulated KMS
 
-Yulin includes a simulated AWS Key Management Service (KMS) for tests and local development.
-
-Encryption is real. Each simulated key holds AES-256 key material and the operations run through
-Node.js's own `crypto`. A ciphertext can only be read with its key, and a decryption with the wrong
-encryption context fails.
+Yulin simulates AWS Key Management Service (KMS) in memory. Symmetric keys use AES-256 key material,
+and asymmetric keys use real key pairs. Cryptographic operations run through Node.js `crypto`, so
+the wrong key or encryption context cannot decrypt a ciphertext.
 
 KMS-specific types are imported from the `@kensio/yulin/kms` subpath.
 
 ## Encrypting and decrypting
 
-Create a key and use it. `Decrypt` needs no `KeyId` for a symmetric key, because the ciphertext
-already names the key that produced it.
+Create a key, encrypt a value, then decrypt it. `Decrypt` does not need a `KeyId` for symmetric
+ciphertext because the ciphertext identifies its key.
 
 ```typescript sim-kms-encrypt-decrypt
 /**
@@ -52,8 +50,8 @@ any second `SimAws` instance both reject it.
 
 ## Encryption context
 
-An encryption context is non-secret key/value data bound to a ciphertext. Decryption with a
-different context fails. That ties a ciphertext to the thing it belongs to.
+An encryption context binds non-secret key/value data to a ciphertext. Decryption requires the same
+context.
 
 ```typescript sim-kms-encryption-context
 /**
@@ -100,9 +98,8 @@ The context is an unordered map. The same pairs written in a different order sti
 
 ## Envelope encryption
 
-`Encrypt` takes at most 4096 bytes. That limit is what makes envelope encryption necessary.
-`GenerateDataKey` returns a data key twice, once in the clear to encrypt your data with, and once
-encrypted under the KMS key to store alongside it.
+`Encrypt` accepts at most 4,096 bytes. For larger values, use `GenerateDataKey`. It returns a
+plaintext data key for encryption and an encrypted copy to store with the data.
 
 ```typescript sim-kms-generate-data-key
 /**
@@ -141,8 +138,8 @@ console.log(recovered.Plaintext?.length); // 32
 
 ## Signing and verifying
 
-A key created with `KeyUsage: SIGN_VERIFY` holds a real key pair, and the signatures are real
-signatures. A key spec is required, because the default `SYMMETRIC_DEFAULT` spec cannot sign.
+A key with `KeyUsage: SIGN_VERIFY` holds a real key pair. Set a signing key spec because the default
+`SYMMETRIC_DEFAULT` key cannot sign.
 
 ```typescript sim-kms-sign-verify
 /**
@@ -261,9 +258,8 @@ both matching what KMS produces. `GetPublicKey` against a symmetric key is
 
 ## Key policies and IAM
 
-Every KMS key has a policy, and it cannot be removed. An IAM policy granting `kms:Decrypt` only
-takes effect where the key's own policy admits the caller. How it admits them decides what else is
-needed:
+Every key has a key policy. An identity policy granting `kms:Decrypt` works only when the key policy
+also permits the caller:
 
 - A statement naming the caller grants access outright. A role with no permissions of its own can
   still use the key.
@@ -342,16 +338,15 @@ on real KMS.
 
 ## AWS managed keys and `kms:ViaService`
 
-An alias beginning `alias/aws/` names an AWS managed key, and the key is created the first time
-something references it. Such a key gets the policy real AWS gives it, which differs from the
-customer default:
+An alias beginning with `alias/aws/` names an AWS managed key. Yulin creates that key when it is
+first referenced and applies AWS-managed-key policy behavior:
 
 - Use of the key is allowed to any principal in the owning account, but only when `kms:ViaService`
   names the service that owns the key, such as `ssm.us-east-1.amazonaws.com` for `aws/ssm`.
-- The account root is allowed to read the key's metadata. That is the whole of what this policy
-  delegates to IAM.
+- The account root can read the key's metadata.
 
-That is why a role holding `kms:Decrypt` on such a key cannot use it by calling KMS itself.
+A role cannot use an AWS managed key by calling KMS directly, even when its identity policy grants
+`kms:Decrypt`.
 
 `kms:ViaService` is set by the service making the call on the caller's behalf. Sim SSM does this for
 `SecureString` parameters. Code calling simulated KMS directly sets it with the `viaService` request
@@ -417,8 +412,7 @@ and a condition on it stays unmatched.
 
 ## Naming a key
 
-Every operation takes its target as a `KeyId`, in any of the four forms real KMS accepts. Those are
-a key ID, a key ARN, an alias name such as `alias/app-key`, and an alias ARN.
+`KeyId` accepts a key ID, key ARN, alias name such as `alias/app-key`, or alias ARN.
 
 A key ARN or alias ARN naming another account or region resolves to no key at all. Its identifier is
 never read out and looked up locally. A foreign ARN cannot reach a key that happens to share an
@@ -473,8 +467,8 @@ console.log(managed.KeyMetadata?.KeyManager); // "AWS"
 
 A key can be disabled and re-enabled later. A disabled key stays present, and refuses to be used.
 
-Deletion is never immediate. `ScheduleKeyDeletion` sets a recovery window of 7 to 30 days, defaulting
-to 30. During that window the key refuses to be used but can still be recovered with
+`ScheduleKeyDeletion` sets a recovery window from 7 to 30 days, defaulting to 30. During that window
+the key cannot be used but can be recovered with
 `CancelKeyDeletion`. Cancelling leaves the key disabled. Re-enabling it is a separate step.
 
 A disabled key fails cryptographic operations with `DisabledException`. A key pending deletion fails
@@ -600,9 +594,7 @@ the function's execution role as the caller. A handler that decrypts a value the
 allowed to, by both the key policy and the role's identity policy, the same as on real AWS. See
 [simulated Lambda](https://yulinsim.dev/services/lambda/) for how function code and execution roles work.
 
-## Available functionality
-
-Sim KMS currently supports:
+## Supported operations
 
 - `CreateKeyCommand`, for symmetric encryption keys and asymmetric signing keys
 - `DescribeKeyCommand` and `ListKeysCommand`
@@ -618,8 +610,6 @@ Sim KMS currently supports:
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
 ## Limitations
-
-Current documented limitations:
 
 - Only encryption with a symmetric key and signing with an asymmetric key are simulated. Left out
   are asymmetric encryption (`RSAES_OAEP_SHA_1` and `RSAES_OAEP_SHA_256`), HMAC keys and

--- a/docs/services/logs/README.md
+++ b/docs/services/logs/README.md
@@ -1,20 +1,15 @@
 # Simulated CloudWatch Logs
 
-Yulin includes a simulated Amazon CloudWatch Logs for tests and local development. It holds log
-groups, the streams inside them and the events written to those streams. A test can put log events
-and read them back with `GetLogEvents`, or search them with `FilterLogEvents`, without an AWS
-account.
-
-The point of it is to make log data addressable. Code that writes to CloudWatch Logs is code teams
-already have, and the alternative for a test is capturing process output.
+Yulin simulates CloudWatch Logs in memory. It stores log groups, streams, and events. Application
+code can write events through the normal SDK commands, and tests can read one stream with
+`GetLogEvents` or search a group with `FilterLogEvents`.
 
 CloudWatch Logs specific types are imported from the `@kensio/yulin/logs` subpath.
 
 ## Writing and searching log events
 
-A log group holds streams, a stream holds events, and `FilterLogEvents` searches across every
-stream in a group. A test can therefore name the group and leave the stream out, without knowing
-which execution environment wrote the line.
+`FilterLogEvents` searches every stream in a group. A test can find an event without knowing which
+execution environment wrote it.
 
 ```typescript sim-logs-write-and-search
 /**
@@ -86,11 +81,9 @@ set of alternatives, and a quoted phrase matches with its spaces intact.
 
 An omitted or empty pattern matches everything.
 
-The structured pattern syntaxes are refused. A JSON property pattern (`{ $.level = "ERROR" }`), a
+Yulin refuses structured pattern syntaxes. A JSON property pattern (`{ $.level = "ERROR" }`), a
 space delimited field pattern (`[level=ERROR, message]`) and a regular expression term
-(`%ERROR|WARN%`) each raise `SimLogsUnsupportedOperationException`. Approximating one would be
-worse. A pattern quietly treated as matching everything would turn an assertion about one log line
-into an assertion about any log line at all, and the test would keep passing while testing nothing.
+(`%ERROR|WARN%`) each raise `SimLogsUnsupportedOperationException`.
 
 ## Reading one stream
 
@@ -166,10 +159,8 @@ console.log(read);
 
 ## Retention
 
-Retention is held as a property to assert on. Events stay where they are, and seeing one go would
-mean moving the clock by months. What teams get wrong about retention is the value they deployed,
-ahead of the deletion that eventually follows from it. A log group with no retention keeps its
-events forever, the AWS default.
+Retention is stored and reported but leaves events in place. A log group without a retention setting
+keeps events forever, matching the AWS default.
 
 The accepted values are a fixed set. A reasonable-looking `retentionInDays: 10` is refused here
 exactly as it is by an account.
@@ -210,9 +201,8 @@ console.log(
 
 ## Lambda handler output
 
-A Lambda function's output is recorded into `/aws/lambda/<function name>` as it runs, whether its
-code is a zip archive or a real in-process handler. A test can then assert on what a handler logged
-by searching its log group.
+A simulated Lambda function writes its output to `/aws/lambda/<function name>`, whether it runs from
+a zip archive or an in-process handler. Search that group to assert on handler output.
 
 ```typescript sim-logs-lambda-output
 /**
@@ -256,11 +246,9 @@ const found = await simAws.logs().filterLogEvents(
 console.log(found.events?.[0]?.message);
 ```
 
-The output still reaches the terminal as well. Real Lambda sends it to CloudWatch Logs and nowhere
-else, but a test tool that swallowed it would make a failing test harder to debug. Recording is a
-tee.
+Output also remains visible in the terminal to help diagnose failing tests.
 
-An invocation that ends in an error nothing caught leaves an `ERROR Invoke Error` line in the group
+An invocation that ends in an uncaught error leaves an `ERROR Invoke Error` line in the group
 after whatever it printed, carrying the error's type, its message and its stack. The
 [simulated Lambda docs](https://yulinsim.dev/services/lambda/ "Simulated Lambda usage docs") show
 one.
@@ -272,8 +260,8 @@ shape in a test, and leave the value alone.
 
 Writing on this path is unconditional. A real function needs `logs:CreateLogGroup` and
 `logs:PutLogEvents` on its execution Role, and one without them produces no logs at all, in silence.
-Simulating that would leave nearly every function in a test logging nothing, with no failure to
-explain why.
+Yulin always captures this output so missing log permissions do not hide diagnostic messages in
+tests.
 
 ## Declaring a log group in a template
 
@@ -308,12 +296,11 @@ Two divergences to know about:
 
 ## Delivering logs from another service
 
-CloudWatch Logs delivery carries the logs of another service somewhere. CloudFront standard logging
-v2 is the clearest case. A distribution has no logging property of its own, and turning logging on
-means three CloudWatch Logs resources.
+CloudWatch Logs delivery connects a service's log source to a destination. CloudFront standard
+logging v2 uses a delivery source, a delivery destination, and a delivery.
 
-A delivery source names what is being logged and which of its logs. A delivery destination names
-where they land and in what form. A delivery joins one to the other.
+The source identifies the resource and log type. The destination identifies where logs would go and
+their output format. The delivery joins them.
 
 ```typescript sim-logs-delivery
 /**
@@ -418,7 +405,7 @@ rules from real AWS are modelled here, each of them a deploy that looks fine unt
 - **A delivery holds both its ends.** Deleting the source or the destination while a delivery joins
   them fails with `ConflictException`. The delivery goes first, and CloudFormation orders that
   itself when a stack is deleted.
-- **CloudFront delivers `ACCESS_LOGS` and nothing else.** Any other `logType` over a distribution is
+- **CloudFront supports only `ACCESS_LOGS`.** Any other `logType` over a distribution is
   refused.
 - **CloudFront delivery is set up from `us-east-1`**, whatever region the destination bucket is in.
   A CloudFront delivery source put from anywhere else is refused.
@@ -441,10 +428,9 @@ bare variables and let delivery name them.
 
 ### Declaring delivery in a template
 
-The same three resources in a template, which is the whole of what a CDK construct for CloudFront
-logging synthesises, alongside the distribution they are for. The source's `ResourceArn` is built
-around a `Ref` to that distribution, the way CDK builds it. A pinned distribution id fails the
-deploy (see [the rules above](#delivering-logs-from-another-service)).
+A CloudFormation template can declare the same three resources alongside the CloudFront distribution.
+The source's `ResourceArn` can use `Ref` to include the generated distribution ID. A hard-coded ID
+for a missing distribution fails deployment (see [the rules above](#delivering-logs-from-another-service)).
 
 ```yaml
 SiteDistribution:
@@ -501,9 +487,9 @@ The template carries the S3 layout as two flat properties, and the API takes the
 delivery. CloudWatch Logs issues that ID. A template cannot predict it.
 
 `Fn::GetAtt` gives `Arn` on all three. The source also publishes `Service` and `ResourceArns`, and
-the delivery publishes `DeliveryId` and `DeliveryDestinationType`. The destination publishes nothing
-else, and `DeliveryDestinationType` is a property of it rather than an attribute, so read that one
-off the delivery. Anything outside this set is refused here, as CloudFormation refuses it.
+the delivery publishes `DeliveryId` and `DeliveryDestinationType`. The destination publishes only
+`Arn`. Read `DeliveryDestinationType` from the delivery rather than the destination. CloudFormation
+refuses attributes outside this set.
 
 `Tags` and `DeliveryDestinationPolicy` are recorded as ignored properties, and the stack still
 deploys.
@@ -732,7 +718,8 @@ function is. `UpdateAlias` moves what the filter reaches, and the filter stays a
 
 ## Metric filters
 
-A metric filter turns matching log events into CloudWatch metric datapoints. It is how a log line becomes something an alarm can watch, with no handler publishing a metric of its own.
+A metric filter converts matching log events into CloudWatch metric datapoints. An alarm can then
+watch the metric without application code calling `PutMetricData`.
 
 ```typescript sim-logs-metric-filter
 /**
@@ -916,7 +903,9 @@ console.log(MetricAlarms?.[0]?.StateValue);
 
 ## Embedded Metric Format
 
-A log event that is itself an Embedded Metric Format document publishes the metrics it declares. This is how AWS Lambda Powertools counts anything. Its `Metrics` writes an EMF document to the handler's stdout and calls no CloudWatch API at all, and a CDK `NodejsFunction` bundling Powertools does the same in a deployed account.
+A log event containing an Embedded Metric Format (EMF) document publishes its declared metrics.
+AWS Lambda Powertools uses this path. It writes EMF to standard output instead of calling the
+CloudWatch API.
 
 ```typescript sim-logs-embedded-metric-format
 /**
@@ -997,7 +986,9 @@ A log event is read as a document only where it parses as JSON, comes out as an 
 
 Three things go on `simAws.logs().metricPublicationFailures` rather than passing quietly. A metric the metadata declares and the document body carries no number under, a metric asking for `StorageResolution: 1`, which simulated CloudWatch has no period short enough for, and a directive that asked for dimensions and got no usable set of them.
 
-A dimension set is taken whole or dropped whole. One naming a key the body lacks, and one carrying anything but strings, are both dropped, because publishing part of a set would put the datapoint under a narrower identity than the document declared. A directive left with no usable set publishes nothing at all. Falling back to no dimensions would land the datapoint on the undimensioned metric, and that is one an alarm may well be watching.
+A dimension set is accepted or dropped as a whole. Yulin drops a set when the body lacks one of its
+keys or a value has a type other than string. Publishing only part of the set would create the wrong
+metric identity. A directive without a usable set produces no datapoint.
 
 Each entry on the ledger names its `source`, which is `{ kind: "metricFilter", filterName }` or `{ kind: "embeddedMetricFormat" }`. The two are told apart by kind rather than by name, because a metric filter may be called anything.
 
@@ -1132,7 +1123,7 @@ console.log(described.logGroups?.[0]?.logGroupArn);
 - **Events never expire.** Retention is stored and reported, never acted on.
 - **A metric filter reading a field of the log event.** A `metricValue` or a dimension value
   beginning `$` is refused where the filter is put. Both need a structured filter pattern, and
-  neither structured syntax is simulated.
+  both require a structured syntax, which Yulin refuses.
 - **How far back a `defaultValue` looks.** A filter remembers the most recent minute it matched
   something in. A later write into that same minute publishes no default over the top, and a write
   landing in an earlier minute a match was already seen in does publish one. Events
@@ -1143,21 +1134,21 @@ console.log(described.logGroups?.[0]?.logGroupArn);
   read, which is how it reaches CloudWatch in an account.
 - **`AWS::Logs::SubscriptionFilter`.** Recorded as a gap. The log group, the metric filter and the
   three delivery resource types are what simulated CloudFormation deploys here.
-- **`ApplyOnTransformedLogs` and `EmitSystemFieldDimensions` on a metric filter.** Recorded and
-  acted on by nothing. Log transformers are absent, so there is no transformed event to read.
-- **Nothing is actually delivered.** A delivery records that a source was joined to a destination
+- **`ApplyOnTransformedLogs` and `EmitSystemFieldDimensions` on a metric filter.** Recorded as
+  ignored properties. Log transformers are absent.
+- **Delivery resources store configuration only.** A delivery records that a source was joined to a destination
   and how the records would be written. No access log file ever reaches the bucket.
 - **`GetDeliverySource`, `GetDeliveryDestination` and `GetDelivery`.** Absent as SDK operations. The
   three `Describe` operations report the same resources. The three action names are authorized where
   CloudFormation reads a delivery Resource back.
 - **Delivery resource tags and cross-account delivery.** `PutDeliverySource`,
   `PutDeliveryDestination` and `CreateDelivery` refuse tags outright. `DeliveryDestinationPolicy` in
-  a template is recorded and acted on by nothing.
+  a template is recorded as an ignored property.
 - **An `=` in a suffix path with Hive compatible paths off.** Taken. Whether real CloudWatch Logs
   takes one is unverified. A path hand-rolling its own partition keys without the option is left
   alone here, and refused with the option on.
-- **Log types for services other than CloudFront.** Any `logType` is taken over a resource that is
-  not a distribution, because the valid set varies by service and this simulation does not carry it.
+- **Log types for services other than CloudFront.** Yulin accepts any `logType` for resources other
+  than distributions because the valid set varies by service.
 - **Logs Insights, export tasks, tags, encryption and data protection policies.** Absent. Tags and
   `kmsKeyId` on `CreateLogGroup` are refused outright. A property cannot look set here and behave
   differently in an account.

--- a/docs/services/organizations/README.md
+++ b/docs/services/organizations/README.md
@@ -1,18 +1,14 @@
 # Simulated Organizations
 
-Yulin simulates AWS Organizations service control policies. A test can find out that the
-organization around an account forbids something before a deployment does.
+Yulin simulates AWS Organizations service control policies (SCPs) and organization structure.
 
-A service control policy filters what an account's principals may do and grants nothing. Policies
-attach to the organization root, to an organizational unit, or to one account, and an account
-inherits every policy on the path down to it. Sim IAM evaluates them ahead of that account's
-identity and resource policies. An SCP therefore applies to a CloudFormation deployment, an
-intercepted SDK client, and a direct service call alike.
+An SCP limits permissions granted by identity and resource policies. Attach one to the organization
+root, an organizational unit or an account. An account inherits policies from every node on its path
+from the root. Simulated IAM applies them to direct calls, intercepted clients and CloudFormation.
 
 ## Attach a policy to an organizational unit
 
-A policy is usually attached to an organizational unit rather than to one account, and every account
-under that unit inherits it. Units nest, and the root sits above all of them.
+Create an organizational unit and attach an SCP to it. Accounts below the unit inherit the policy.
 
 ```typescript sim-organizations-organizational-unit
 /**
@@ -44,16 +40,13 @@ const decision = simAws.account("123456789012").iam().authorize({
 console.log(decision.value); // "ExplicitDeny"
 ```
 
-The policy hangs two levels above the account and still reaches it. `createOrganizationalUnit` takes
-a parent unit as its second argument, and leaves the unit under the root without one.
-`organizations.root()` is the node above everything, and a policy attached there covers every
-account in the organization.
+Pass a parent as the second argument to `createOrganizationalUnit` to nest units. With no parent, the
+new unit sits below `organizations.root()`.
 
 ## Every level has to allow the action
 
-An account is filtered by each node on the path from the root down to it, and each one has to allow
-an action on its own. A root allowing S3 and a unit allowing DynamoDB leave an account beneath them
-able to do neither.
+Every node on the path must allow the action. An allow at one level cannot supply an allow missing
+at another. A deny at any level rejects the request.
 
 ```typescript sim-organizations-every-level-allows
 /**
@@ -89,15 +82,12 @@ console.log(decision.value); // "ImplicitDeny"
 console.log(decision.serviceControlPolicy.unallowedLevels); // [ "Workloads" ]
 ```
 
-`unallowedLevels` names the nodes that allowed nothing matching. That is the part of a real SCP
-denial that takes longest to track down.
-
-A `Deny` at any level ends the request whatever another level allows.
+`unallowedLevels` identifies the nodes with no matching allow.
 
 ## The management account
 
-`setManagementAccount` names the account AWS exempts from every service control policy. That account
-is decided by its identity and resource policies alone, whatever is attached above it.
+Use `setManagementAccount` to exempt one account from SCP evaluation. Its identity and resource
+policies still apply.
 
 ```typescript sim-organizations-management-account
 /**
@@ -126,9 +116,8 @@ console.log(decision.serviceControlPolicy.isApplied); // false
 
 ## Attach a service control policy to an Account
 
-A policy attached straight to an account applies to that account alone. An organization spans
-accounts, so it belongs to the whole simulated environment and is reached as
-`simAws.organizations()`, not from an account scope.
+An SCP attached directly to an account applies only to that account. Organization state belongs to
+the whole `SimAws` instance and is available through `simAws.organizations()`.
 
 ```typescript sim-organizations-attach-scp
 /**
@@ -159,17 +148,15 @@ console.log(decision.serviceControlPolicy.isDenied); // true
 console.log(decision.serviceControlPolicy.denyStatements[0]?.Sid); // "DenyBucketCreation"
 ```
 
-The account also gets AWS's own `FullAWSAccess` policy, as it would in a real organization. One
-`Deny` statement therefore denies that one action and leaves the rest of the account working.
+New organization nodes receive the AWS-managed `FullAWSAccess` policy. A deny-list SCP can then
+block one action while leaving other actions allowed.
 
-An account with no policy attached to it stays outside the organization's reach, and its identity
-and resource policies decide its requests as they did before.
+An account outside the organization is unaffected by SCPs.
 
 ## Catch a deployment the policy denies
 
-Sim CloudFormation creates each resource through the owning service's command handler, and that
-handler authorizes. A deployment that names no principal is decided as the account root. An SCP
-applies to a member account's root the same way AWS does.
+CloudFormation creates resources through each service's authorized command path. A deployment with
+no caller runs as the account root, and SCPs apply to that root.
 
 ```typescript sim-organizations-scp-deployment
 /**
@@ -213,14 +200,13 @@ const failed = simAws
 console.log(failed?.status); // "CREATE_FAILED"
 ```
 
-The resource is left `CREATE_FAILED` and the deployment rejects. A test asserting that a stack
-deploys then fails on the policy, with the policy named in the message.
+When an SCP denies creation, the resource enters `CREATE_FAILED` and the deployment rejects. The
+error names the policy.
 
 ## Name the principal a deployment runs as
 
-An organization that denies its accounts' root principals is ordinary, and a deployment decided as
-the root fails under one. `caller` says which principal the resources are created as, and a
-statement conditioned on `aws:PrincipalArn` then has a deploy role to match against.
+Pass `caller` when the deployment should run as a role. SCP conditions on `aws:PrincipalArn` then
+evaluate against that role.
 
 ```typescript sim-organizations-scp-deploy-role
 /**
@@ -285,17 +271,15 @@ const stack = await simAws.cloudFormation().deployTemplate({
 console.log(stack.getResource("ReportsBucket")?.status); // "CREATE_COMPLETE"
 ```
 
-The Role is created before the policy is attached. Creating it afterwards is a call the policy
-denies the root, and the account root is who a bare `createRole` runs as.
+Create the role before attaching a policy that would deny the setup call.
 
 ## Name the caller the rest of a test reads as
 
-A deployment names its own principal. Every other call in the test still names none, and each one is
-the account root. Under a policy denying that root, a test reading back what a stack made is denied
-on every read.
+A deployment caller applies only to that deployment. Other calls still use the account root unless
+the simulation has a default caller.
 
-`defaultCaller` on `SimAws` says who those calls are. A test then reads the account as the person or
-role that would really be looking at it, and an explicit `caller` still wins wherever one is given.
+Set `defaultCaller` on `SimAws` to choose the principal for unattributed calls. An explicit `caller`
+still takes precedence.
 
 ```typescript sim-organizations-scp-default-caller
 /**
@@ -369,17 +353,13 @@ console.log(read.Parameter?.Value); // "reports-bucket"
 console.log(identity.Arn); // "arn:aws:iam::123456789012:role/Administrator"
 ```
 
-Setup runs before the policy is attached, for the same reason the deploy Role above does. The Role a
-simulation reads as has to exist and hold a policy, and creating it is itself a call.
-
-Naming a default caller says who an unattributed call comes from, and leaves the root's own identity
-access where it was. A test about root behaviour names `simAws.account().rootPrincipal` and gets the
-root. Under the policy above that call is denied, which is what the statement is written to do.
+Create and configure the default caller before attaching policies that would deny those setup calls.
+Pass `simAws.account().rootPrincipal` explicitly when a test needs to make a request as root.
 
 ## Write an allow list instead of a deny list
 
-`detachFullAwsAccess` takes AWS's own policy off an account. What remains has to allow an action
-for the account to be allowed it. That is an organization run as an allow list.
+Call `detachFullAwsAccess` to use an allow-list SCP. The remaining policies must explicitly allow an
+action.
 
 ```typescript sim-organizations-scp-allow-list
 /**
@@ -407,16 +387,13 @@ console.log(decision.denialReason);
 // "because no service control policy allows the s3:GetObject action"
 ```
 
-An account root holds unrestricted access in sim IAM, and this denies it anyway. That is what an
-SCP does in AWS, and it is why an allow list is worth writing in a test at all.
-
-Detaching `FullAWSAccess` on its own leaves the account holding no policy, and every action is then
-denied. AWS behaves the same way, and warns about it.
+SCPs still limit an account root. Removing `FullAWSAccess` without adding another allow policy denies
+every action.
 
 ## Deploy an organization from CloudFormation
 
-A template's `AWS::Organizations::*` resources build the organization they describe, so a stack
-already managing the org chart is the same one a test deploys.
+Simulated CloudFormation supports the organization, organizational unit, account and policy
+resource types.
 
 ```typescript sim-organizations-cloudformation
 /**
@@ -470,17 +447,13 @@ const decision = simAws.account("123456789012").iam().authorize({
 console.log(decision.value); // "ExplicitDeny"
 ```
 
-`Content` takes the policy document inline or as JSON text. `TargetIds` takes a list or a single
-value, and each entry names the root, a unit, or an Account. A policy reaches every target it names
-or none of them. A target this organization has never heard of fails the resource before anything is
-attached.
+`Content` accepts an object or JSON text. `TargetIds` accepts one target or a list of roots, units and
+accounts. An unknown target fails the resource before the policy is attached anywhere.
 
-A simulated environment has one organization from the start, so
-`AWS::Organizations::Organization` records the one already there rather than making another. It is
-worth declaring for `RootId`, which is what a unit hangs off.
+A `SimAws` instance starts with one organization. `AWS::Organizations::Organization` adopts it and
+exposes its `RootId`.
 
-`AWS::Organizations::Account` creates an Account with an id nobody chose, as AWS does. Read that id
-back with `Ref` or `Fn::GetAtt AccountId`.
+`AWS::Organizations::Account` generates an account ID. Read it with `Ref` or `Fn::GetAtt AccountId`.
 
 These are the properties read from each resource:
 
@@ -491,10 +464,8 @@ These are the properties read from each resource:
 | `AWS::Organizations::Account`            | `AccountName`, `Email`, `ParentIds`    | `Tags`, `RoleName`    |
 | `AWS::Organizations::Policy`             | `Name`, `Type`, `Content`, `TargetIds` | `Tags`, `Description` |
 
-Tearing the stack down takes its own policies off the nodes they were attached to, removes the
-units, and takes any Account the stack created back out of the organization. A node holding
-policies from more than one stack keeps the others. A unit that still holds something when it goes
-hands what it holds to its parent, so every Account keeps a path to the root.
+Stack teardown removes resources created by that stack. Policies from other stacks remain attached.
+Accounts and child units move to the deleted unit's parent.
 
 ## Reading a denial
 
@@ -510,21 +481,16 @@ sides, through `decision.serviceControlPolicy`:
 | `denyStatements`  | The matching `Deny` statements.                             |
 | `allowStatements` | The matching `Allow` statements.                            |
 
-`decision.denialReason` carries the wording AWS puts on the `AccessDenied` message, and every
-simulated service passes it through to the error it throws.
+`decision.denialReason` contains the text used by service access-denied errors.
 
-`simAws.organizations().serviceControlPoliciesFor(accountId)` returns the policies in force for an
-account, in the order they were evaluated, including `FullAWSAccess` where it is still attached.
+`serviceControlPoliciesFor(accountId)` returns the policies in evaluation order.
 
-`serviceControlPolicySetFor(accountId).levels` keeps the policies grouped by the node they hang on,
-root first. That grouping is what sim IAM evaluates.
+`serviceControlPolicySetFor(accountId).levels` groups policies by node, starting at the root.
 
-The flattened list is empty in three cases that behave differently. An account that was never named
-sits outside the organization and stays unrestricted. The management account is exempt and equally
-unrestricted. An account left holding no policy is denied everything. `applies` separates the last
-of those from the other two.
-`serviceControlPolicySetFor(accountId).applies` tells the two apart, and so does
-`decision.serviceControlPolicy.isApplied`.
+An empty policy list can mean that the account is outside the organization, is the management
+account or has no policies. The first two are exempt. The last is denied every action. Check
+`serviceControlPolicySetFor(accountId).applies` or `decision.serviceControlPolicy.isApplied` to
+distinguish them.
 
 ## Available functionality
 
@@ -567,7 +533,6 @@ Simulated Organizations supports:
 | Service-linked roles        | Evaluated like any other principal. AWS exempts a service-linked role from SCPs.                                                    |
 | Other policy types          | Resource control policies, declarative policies, tag policies, backup policies and AI services opt-out policies are not simulated.  |
 | The Organizations SDK       | `CreatePolicy`, `AttachPolicy`, `ListAccounts` and the rest of the API are not handled. Policies are attached through the accessor. |
-| CloudFormation              | `AWS::Organizations::Organization`, `::OrganizationalUnit`, `::Account` and `::Policy` are not created from a template.             |
 | Organization condition keys | `aws:PrincipalOrgID` and `aws:PrincipalOrgPaths` are not populated. A condition naming either fails to match.                       |
 | Service principals          | A request whose caller is a service principal or anonymous belongs to no Account and is subject to no policy.                       |
 | Condition operator coverage | The operators above are evaluated. Anything else fails closed and the statement holding it matches nothing.                         |

--- a/docs/services/personalize/README.md
+++ b/docs/services/personalize/README.md
@@ -1,17 +1,15 @@
 # Simulated Personalize
 
-Simulated Personalize holds the resources a recommendation is served from. No model is trained and
-no data is read, in the way simulated ACM issues certificates without producing real TLS
-certificates. A dataset group, a solution, a solution version and a campaign all exist, carry what
-the request gave them, and reach `ACTIVE` straight away.
+Yulin simulates the Personalize resources and API calls used to serve recommendations. It does not
+train a model or derive results from datasets. Tests declare the recommendations that a campaign or
+recommender should return. Created resources become `ACTIVE` immediately.
 
 Personalize-specific types are imported from the `@kensio/yulin/personalize` subpath.
 
 ## Building the chain to a campaign
 
-Every runtime recommendation names a campaign, and a campaign is the far end of a chain. The dataset
-group holds the data, the solution picks a recipe, the solution version is the trained model, and
-the campaign serves it.
+A campaign is built from a resource chain. A dataset group contains the datasets, a solution selects
+a recipe, a solution version represents the trained model, and a campaign serves that version.
 
 ```typescript sim-personalize-campaign-chain
 /**
@@ -73,9 +71,8 @@ expects.
 
 ## Recommendations from a campaign
 
-A campaign answers the runtime API from results declared against it. No model is fitted and no
-interaction history is held. A test says what one campaign recommends for one item, and the code
-under test makes the calls it would make against AWS.
+A campaign returns results declared during test setup. Application code still sends the same
+Personalize Runtime commands it sends to AWS.
 
 The two runtime operations live on `simAws.personalizeRuntime()`, and an intercepted
 `PersonalizeRuntimeClient` reaches the same place. They arrive from a separate SDK package
@@ -140,9 +137,8 @@ const recommended = await simAws.personalizeRuntime().getRecommendations(
 console.log(recommended.itemList?.map((item) => item.itemId).join(" "));
 ```
 
-Results are declared per campaign, through `recommendations()` and `rankings()`. A campaign serves
-one solution version trained on one recipe, and two campaigns in a dataset group answer the same
-entry differently.
+Declare results per campaign through `recommendations()` and `rankings()`. Two campaigns in the same
+dataset group can return different results for the same input.
 
 An item rule is read first where the request carries an item, then a user rule, then the default.
 That order follows the recipes. `aws-similar-items` requires an `itemId` and looks at no user, and
@@ -152,9 +148,8 @@ would have used. Matching is exact, with no pattern syntax.
 `numResults` cuts a declared list to length. A request no rule matches gets the campaign's default,
 and an empty `itemList` where no default is declared.
 
-An item is declared as an id on its own, or as an id with a score for a test to assert on. The
-number comes from the declaration, and a rule that leaves it out answers with an item carrying no
-score.
+Declare an item as an ID or as an ID with a score. An item declared without a score is returned
+without one.
 
 ```typescript sim-personalize-recommendation-scores
 /**
@@ -228,10 +223,8 @@ Runtime does.
 
 ## Datasets and schemas
 
-A dataset belongs to a dataset group and has one of five types. The dataset ARN carries the group
-and the type rather than the name the request gave, which is how real Personalize builds it. One
-dataset group therefore holds one dataset of each type, and two dataset groups can each hold an
-`INTERACTIONS` dataset without colliding.
+A dataset belongs to a dataset group and has one of five types. Its ARN contains the group and type,
+not the requested name. Each group can contain one dataset of each type.
 
 ```typescript sim-personalize-dataset
 /**
@@ -289,8 +282,8 @@ domain dataset group refuses them here too.
 
 ## Recording events
 
-An event tracker is where `PutEvents` sends item interactions. It is created against a dataset
-group and reports a tracking ID back, and every `PutEvents` names that ID.
+An event tracker records the item interactions sent through `PutEvents`. Create it for a dataset
+group, then pass its tracking ID to each request.
 
 ```typescript sim-personalize-event-tracker
 /**
@@ -464,10 +457,9 @@ console.log(group.domain);
 
 ## Recommenders and their use cases
 
-A recommender goes straight onto a Domain dataset group, for one of the ten use cases AWS trained.
-There is no solution and no solution version in between. `GetRecommendations` then names a
-`recommenderArn` where the custom path names a `campaignArn`, and results are declared against it
-through the same `recommendations()` rules.
+A recommender belongs directly to a domain dataset group and selects one of ten AWS use cases. It
+does not use a solution or solution version. Pass its ARN to `GetRecommendations` and declare its
+results with the same `recommendations()` API used for campaigns.
 
 ```typescript sim-personalize-recommender
 /**
@@ -525,9 +517,8 @@ Real Personalize trains for hours and retrains every seven days.
 
 ### The ten use cases
 
-The recipe ARN picks the use case, and the use case decides what a request has to carry. A request
-leaving out a parameter its use case requires is refused, which is what real Personalize does with
-it. That refusal is the part of the domain path worth simulating, and everything else here is state.
+The recipe ARN selects the use case. Each use case defines whether `itemId` and `userId` are
+required, optional, or unused. Requests missing a required parameter are rejected.
 
 | Use case                           | Recipe ARN suffix                              | `itemId` | `userId` |
 | ---------------------------------- | ---------------------------------------------- | -------- | -------- |
@@ -554,9 +545,6 @@ already watched or bought and that filtering is keyed on the user. `Trending now
 A parameter marked unused is ignored rather than matched on. A `Top picks for you` request carrying
 an `itemId` as well as its `userId` is answered from the user rule, since that is the tier real
 Personalize would have used. An optional one is matched where the request carries it.
-
-These are the requirements AWS documents against each use case. Both pages are worth reading before
-writing a request, since two of them differ from the e-commerce use case they otherwise mirror.
 
 ### Starting and stopping
 
@@ -602,8 +590,7 @@ and solutions gone. A group still holding one is reported as `ResourceInUseExcep
 
 `AWS::Personalize::DatasetGroup`, `AWS::Personalize::Schema`, `AWS::Personalize::Dataset`,
 `AWS::Personalize::Solution` and `AWS::Personalize::EventTracker` deploy into simulated Personalize.
-A project that declares them in CDK or CloudFormation can deploy the same template its application
-deploys, with no hand-written test setup.
+A project can deploy its synthesized template without hand-written Personalize setup.
 
 Each one goes through the ordinary create command. A template and an SDK caller get the same
 validation, the same refusals and the same ARN.
@@ -710,19 +697,16 @@ wiring one resource into another reads `Fn::GetAtt`. An event tracker publishes 
 does not publish fails the deploy, since answering one would let a template deploy here and fail on
 AWS.
 
-### A stack stops at the solution
+### Resources without CloudFormation types
 
-CloudFormation has no `AWS::Personalize::Campaign` type and no `AWS::Personalize::Recommender` type.
-A campaign is what every runtime call names, and it is always created out of band through the SDK,
-the CLI or the console. A deployed stack gets as far as a solution and stops there. A test creates
-the solution version and the campaign itself, as the example above does. This is real Personalize
-behaviour and worth knowing before reading it as a gap in the simulation.
+CloudFormation has no `AWS::Personalize::Campaign` or `AWS::Personalize::Recommender` type. Create
+these resources through the SDK after deploying the stack, as the example above does.
 
 The domain path stops in the same place. `Domain` is a property of `AWS::Personalize::DatasetGroup`,
 and a template can declare a Domain dataset group. No `AWS::Personalize::Recommender` type exists to
 put a recommender on it.
 
-### Types a stack steps over
+### Skipped resource types
 
 `AWS::Personalize::BatchInferenceJob`, `AWS::Personalize::BatchSegmentJob`,
 `AWS::Personalize::DataDeletionJob`, `AWS::Personalize::MetricAttribution` and
@@ -763,9 +747,9 @@ console.log(group?.name, group?.status);
 
 ## Deleting resources
 
-Deletion follows real Personalize. A dataset group holding datasets, solutions or an event tracker
-is reported as `ResourceInUseException`, and so is a solution a campaign still deploys. Tear a chain
-down from the campaign end.
+Delete resources from the campaign end of the chain. A dataset group that still contains datasets,
+solutions, or an event tracker raises `ResourceInUseException`. A solution still used by a campaign
+raises the same error.
 
 Deleting an event tracker leaves the events it accepted recorded, as real Personalize leaves the
 interactions it wrote in the dataset behind it.

--- a/docs/services/rekognition/README.md
+++ b/docs/services/rekognition/README.md
@@ -1,8 +1,8 @@
 # Simulated Rekognition
 
-Simulated Rekognition answers detection calls from results declared against images. A test can say
-which image fails moderation or holds a cat, with no image analysis happening. The bytes are never
-looked at.
+Yulin simulates Rekognition by returning results declared for an image name or content hash. It does
+not analyze the image. Tests can define labels, moderation results, faces, and face matches while
+application code uses the normal Rekognition commands.
 
 Rekognition-specific types are imported from the `@kensio/yulin/rekognition` subpath.
 
@@ -67,9 +67,8 @@ const detected = await simAws
 
 ## Detecting labels in an image
 
-`DetectLabels` answers with the objects, scenes and concepts an image is declared to hold. Each
-label carries the parents, aliases, categories and instances it was declared with, and no more. A
-label is reported as written.
+`DetectLabels` returns the objects, scenes, and concepts declared for an image. Each label contains
+only the parents, aliases, categories, and instances in its declaration.
 
 ```typescript sim-rekognition-detect-labels
 /**
@@ -131,19 +130,16 @@ console.log(detected.LabelModelVersion); // "3.0"
 Labels come back in descending order of confidence, which is the order real Rekognition reports them
 in. A declared instance with no confidence of its own takes its label's.
 
-An image no rule matches gets the built-in default result. That is the one `Mobile Phone` label from
-the example response in the AWS `DetectLabels` documentation, with the parent, alias, category and
-bounding box AWS documents it with. It is a real Rekognition response, though which labels an
-unconfigured image gets is a simulator convention rather than what AWS would return for it.
+An image that matches no rule gets a built-in `Mobile Phone` result based on the AWS
+`DetectLabels` example response. This default is a Yulin convention. AWS results depend on the image.
 
-A label name fills in nothing of its own. Declaring `Cat` with no parents reports `Cat` with no
-parents, and declaring a `Pizza` nobody has heard of reports `Pizza`. Yulin ships no general label
-ontology to check a name against or to expand one from.
+Yulin does not validate or expand general detection labels. Declaring `Cat` without parents returns
+`Cat` without parents.
 
 ## Detecting faces in an image
 
-`DetectFaces` answers with the faces an image is declared to hold. A face says where it is and what
-it looks like, and the response carries the attributes the request asked for.
+`DetectFaces` returns the faces declared for an image, including their positions and requested
+attributes.
 
 ```typescript sim-rekognition-detect-faces
 /**
@@ -204,8 +200,7 @@ Faces come back in the order they were declared. An attribute with no confidence
 the face's, and a face detected at 99.4 is reported as smiling at 99.4. A face declared with no
 confidence at all is detected at the built-in one.
 
-An image with nobody in it is `{ faces: [] }`. Two built-in results cover the counting a test
-usually does:
+Use `{ faces: [] }` for an image with no faces. Two built-in results cover common face-count tests:
 
 ```typescript
 import {
@@ -219,10 +214,8 @@ faces.onName("incoming/landscape.png", simRekognitionNoFaces);
 faces.onName("incoming/crowd.png", simRekognitionSeveralFaces);
 ```
 
-An image no rule matches gets the built-in default result. That is the one face from the example
-response in the AWS `DetectFaces` documentation, with the attributes and all thirty landmarks AWS
-documents it with. It is a real Rekognition response, though which face an unconfigured image gets is
-a simulator convention rather than what AWS would return for it.
+An image that matches no rule gets the face from the AWS `DetectFaces` example response, including
+its attributes and 30 landmarks. This default is a Yulin convention.
 
 ## Choosing the facial attributes
 
@@ -305,11 +298,10 @@ excludes the chin.
 
 ## Declaring results
 
-Results are declared per operation. `moderation()` holds the rules `DetectModerationLabels` answers
-from, `labels()` holds the rules `DetectLabels` answers from, `faces()` holds the rules
-`DetectFaces` answers from, and `faceMatches()` holds the rules `SearchFacesByImage` answers from.
-All four take the same three kinds of rule, being an exact S3 object name, an exact content hash, or
-anything at all.
+Declare results separately for each operation. Use `moderation()` for `DetectModerationLabels`,
+`labels()` for `DetectLabels`, `faces()` for `DetectFaces`, and `faceMatches()` for
+`SearchFacesByImage`. Each API accepts rules for an exact S3 object name, an exact content hash, or a
+default result.
 
 ```typescript sim-rekognition-moderation-rules
 /**
@@ -340,8 +332,8 @@ moderation.onHash(simRekognitionImageHash(fixture), {
 });
 ```
 
-A hash rule wins, then a name rule, then the default. Matching is exact, with no pattern syntax.
-Which rule applies never depends on how specific a pattern looks.
+Rules use exact matching. Hash rules take precedence over name rules, which take precedence over the
+default.
 
 A name is the `Name` in the request, the S3 object key. It is matched on its own, with the Bucket
 left out, so a rule for a key applies to that key in whichever Bucket the request names. An image
@@ -412,9 +404,8 @@ refused where the rule is written.
 
 ## Sample images
 
-Simulated Rekognition ships with five images whose hashes are already declared. A test uploads one
-through its own code and gets a known answer without registering anything. That is what makes an
-application generating its own object keys testable, since the test never has to know the key.
+Yulin includes five small images with predeclared hash rules. Application code can upload one under
+any object key and receive a known result without registering another rule.
 
 | Image                                              | Format | Detected as                                       |
 | -------------------------------------------------- | ------ | ------------------------------------------------- |
@@ -477,9 +468,8 @@ simAws
   .onHash(simRekognitionImageHash(sample), { labels: [] });
 ```
 
-The images are real 16 by 16 PNG and JPEG files, 1,909 bytes in total. The format check reads their
-magic bytes as it does for any other image. What they are pictures of decides nothing, since no
-image is looked at.
+The images are valid 16 by 16 PNG and JPEG files. Rekognition checks their file signatures but does
+not inspect their visual content.
 
 ## Moderation labels come back with their parents
 
@@ -772,7 +762,7 @@ ever. Filter the notification configuration by prefix or suffix, as this one doe
 
 ## Face collections
 
-A collection is what lets an application recognise the same person twice, where a detection answers what is in one image.
+A collection stores indexed faces so an application can search for the same person later.
 
 ```typescript sim-rekognition-collections
 /**
@@ -970,9 +960,7 @@ An image is read from a Bucket in another Account when that Bucket's policy allo
 real Rekognition reads across Accounts. A Bucket in another Region is refused, as real Rekognition
 reads only Buckets in its own Region.
 
-## Available functionality
-
-Simulated Rekognition currently supports:
+## Supported operations
 
 - `DetectModerationLabelsCommand`, `DetectLabelsCommand` and `DetectFacesCommand`, for an image
   supplied as `Image.Bytes` or as `Image.S3Object`

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -1,11 +1,12 @@
 # Simulated Route53
 
-Yulin includes a simulated Route53 service for tests and local development.
+Yulin simulates Amazon Route 53 hosted zones, records and DNSSEC configuration for tests and local
+development. You can manage them through the AWS SDK or deploy them from CloudFormation and CDK
+templates. When Yulin serves the simulation on localhost, Route 53 records can route local hostnames
+to simulated services such as CloudFront distributions and S3 bucket websites.
 
-Sim Route53 can be used directly through `SimAws`, instantiated on its own as `SimRoute53`, and used
-by sim CloudFormation when deploying Route53 resources from CloudFormation or CDK templates. When
-served on localhost, Route53 records can route custom local hostnames to other simulated AWS
-services, such as simulated CloudFront distributions or simulated S3 bucket websites.
+Use Route 53 through `SimAws` when it should share state with other services. Use `SimRoute53`
+directly when you need an isolated Route 53 simulation.
 
 ## Basic Hosted Zone usage
 
@@ -54,8 +55,8 @@ console.log(hostedZoneOut.HostedZone?.ResourceRecordSetCount);
 Hosted Zone names are normalised with a trailing dot in Route53-style outputs, so `example.test`
 becomes `example.test.`.
 
-Hosted Zone creation uses background tasks to move the zone to `INSYNC`. If your test needs final
-state, call `await simAws.backgroundTasksComplete()` before continuing.
+Hosted zone creation moves the zone to `INSYNC` in a background task. Call
+`await simAws.backgroundTasksComplete()` before asserting on the final state.
 
 Hosted Zone IDs are accepted in any real Route53 shape, being a `Z` prefix followed by uppercase
 alphanumerics, up to 32 characters. A real Hosted Zone ID copied out of an AWS account, such as
@@ -65,14 +66,12 @@ alphanumerics, up to 32 characters. A real Hosted Zone ID copied out of an AWS a
 
 ## Registering a Hosted Zone with a chosen ID
 
-`CreateHostedZoneCommand` allocates its own Hosted Zone ID, as real Route53 does, and takes none
-from you. When something else already decided the ID, register the Hosted Zone as part of your test
-setup instead.
+`CreateHostedZoneCommand` allocates the hosted zone ID. When a synthesized template already contains
+an ID, register that hosted zone during test setup instead.
 
-The usual reason is a CDK app that looks its zone up with `HostedZone.fromLookup` instead of
-creating it. That bakes the real Hosted Zone ID into the synthesized template, and every
-`AWS::Route53::RecordSet` in the template names that ID. Registering the zone first lets the
-template deploy as it is, with no rewriting.
+For example, `HostedZone.fromLookup` writes the resolved hosted zone ID into the synthesized
+template. Registering that ID before deployment lets its `AWS::Route53::RecordSet` resources deploy
+without changing the template.
 
 ```typescript sim-route53-register-hosted-zone
 /**
@@ -1732,7 +1731,7 @@ console.log(hostedZoneCreation.HostedZone?.Id);
 A standalone `SimRoute53` instance has its own isolated state, standing apart from any wider
 `SimAws` environment. Use `SimAws` when Route53 needs to resolve names to other simulated services.
 
-## Available functionality
+## Supported operations
 
 Sim Route53 currently supports:
 

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -1,14 +1,12 @@
 # Simulated EventBridge Scheduler
 
-Yulin includes a simulated Amazon EventBridge Scheduler for tests and local development. Schedules
-are held in memory and every operation is authorized by simulated IAM. Scheduler-specific types are
-imported from the `@kensio/yulin/scheduler` subpath.
+Yulin simulates Amazon EventBridge Scheduler in memory. Schedules run when simulated time advances,
+and every management operation is authorized by simulated IAM. Import Scheduler-specific types from
+`@kensio/yulin/scheduler`.
 
-Scheduler is a separate service from [EventBridge](https://yulinsim.dev/services/eventbridge/), not a corner of it. It has its
-own SDK client, its own ARN shape, and its own way of reaching a target. A schedule assumes an IAM
-execution role, where an EventBridge rule relies on a resource policy admitting a service principal.
-A project using Scheduler cannot be tested against simulated EventBridge rules. That is why this
-exists separately.
+Scheduler is separate from [EventBridge](https://yulinsim.dev/services/eventbridge/). It uses its own
+SDK client and ARN format. It also assumes an execution role to invoke a target, while EventBridge
+rules use the target's resource policy.
 
 ## Creating a schedule
 
@@ -56,8 +54,7 @@ IAM policy naming a schedule needs the group in it, or it matches no schedule.
 
 ## Writing the schedule expression
 
-Three forms, and the same parser as an [EventBridge scheduled
-rule](https://yulinsim.dev/services/eventbridge/#rules-that-fire-on-a-schedule) with two differences:
+Scheduler accepts three expression forms:
 
 - `at(yyyy-mm-ddThh:mm:ss)` runs once, at that instant. The timezone is a separate setting on the
   schedule, outside the expression, and a trailing `Z` is refused.
@@ -71,9 +68,7 @@ rule](https://yulinsim.dev/services/eventbridge/#rules-that-fire-on-a-schedule) 
 
 ## Firing a schedule
 
-A schedule fires on the simulation's clock. Advancing simulated time past a due
-instant invokes the target. Leave time alone and the target is never invoked. A nightly job takes no
-time at all to test.
+A schedule fires on the simulation's clock. Advance time past a due instant to invoke the target.
 
 ```typescript sim-scheduler-firing
 /**
@@ -163,12 +158,11 @@ own to describe.
 
 ### The execution role
 
-This is the part that differs most from an [EventBridge rule](https://yulinsim.dev/services/eventbridge/), and the part that
-most often goes wrong in a real account. A rule reaches its target as the `events.amazonaws.com`
-service principal, and the target's own resource policy decides. A schedule assumes the `RoleArn` on
-its target, and that role's policies decide. No resource policy on the target is involved at all.
+A schedule assumes the target's `RoleArn`, and that role's policies authorize delivery. An
+[EventBridge rule](https://yulinsim.dev/services/eventbridge/) instead invokes as
+`events.amazonaws.com` and depends on the target's resource policy.
 
-Two things therefore have to be right, and they are fixed in different places:
+The execution role needs both:
 
 - The role's **trust policy** has to let `scheduler.amazonaws.com` assume it. A role copied from an
   EventBridge rule trusts `events.amazonaws.com` and fails here.
@@ -176,14 +170,13 @@ Two things therefore have to be right, and they are fixed in different places:
   `sqs:SendMessage`, `sns:Publish` or `ecs:RunTask`.
 
 A trust policy may also carry the condition AWS recommends against the confused deputy problem. The
-schedule's group ARN is supplied as `aws:SourceArn`, and the Account the schedule is in as
-`aws:SourceAccount`. A role scoped to one schedule group is assumable by schedules in that group and
-by nothing else. CDK writes that condition into the execution roles it generates for a schedule
-target, so a role taken from a synthesized template works here unchanged.
+schedule's group ARN is supplied as `aws:SourceArn`, and the account is supplied as
+`aws:SourceAccount`. A role scoped to one schedule group is assumable only by schedules in that
+group. CDK writes that condition into the execution roles it generates for a schedule target, so a
+role from a synthesized template works unchanged.
 
-When either is missing the target goes uninvoked and no error is thrown, exactly as on AWS, where the
-failure goes to CloudWatch and nowhere the caller can see. `advanceBy(...)` still returns normally. A
-test asserting on a failed invocation reads `deliveryFailures`:
+If either permission is missing, `advanceBy(...)` still returns normally and the target is not
+invoked. Read `deliveryFailures` to assert on the failed delivery:
 
 ```typescript sim-scheduler-delivery-failures
 /**
@@ -256,9 +249,8 @@ following delay doubles to 2, 4, 8 seconds and so on. A retry does not run while
 still. `advanceBy(...)` runs every retry that becomes due in the interval and settles their work
 before it returns.
 
-Scheduler does not retry a failure that cannot clear by trying the same request. A missing target,
-a missing execution role, an execution role that does not trust Scheduler and an IAM denial are
-permanent failures. They are abandoned after the initial attempt.
+Scheduler retries only failures that may clear. A missing target, missing execution role, invalid
+trust policy, or IAM denial is permanent and is abandoned after the initial attempt.
 
 Set `Target.DeadLetterConfig.Arn` to a standard SQS queue ARN to keep an input that Scheduler abandons.
 The execution role needs `sqs:SendMessage` on this queue as well as permission to invoke the target.
@@ -267,19 +259,17 @@ shape and include the error, schedule ARN, target ARN, scheduled time and retry 
 `EXHAUSTED_RETRY_CONDITION` is `MaximumRetryAttempts` or `MaximumEventAgeInSeconds` for an exhausted
 retryable failure. A permanent failure leaves that attribute out.
 
-A successful DLQ send does not add an entry to `deliveryFailures`, since the configured destination
-received the input. A missing queue or denied `sqs:SendMessage` is recorded there instead. This keeps
-a misconfigured DLQ visible to a test.
+A successful DLQ send leaves `deliveryFailures` empty because the configured destination received the
+input. A missing queue or denied `sqs:SendMessage` is recorded there instead.
 
 ### One-time schedules and what happens after
 
-An `at(...)` schedule fires once and then stops. By default it stays in the Account afterwards, which
-surprises people who expected it to clean up. It keeps counting against the schedule quota and keeps
-turning up in listings. `ActionAfterCompletion: "DELETE"` is what removes it, and after that
-`GetSchedule` reports it gone.
+An `at(...)` schedule fires once. It remains in the account unless
+`ActionAfterCompletion: "DELETE"` removes it. A retained schedule continues to appear in listings
+and count against the schedule quota.
 
-A schedule that is disabled when its only instant passes has not completed, since nothing was
-invoked. It is still there afterwards whatever `ActionAfterCompletion` says.
+A disabled schedule remains incomplete when its only instant passes. It stays in the account
+regardless of `ActionAfterCompletion`.
 
 `State: "DISABLED"` stops a recurring schedule firing while it is off, and an `UpdateSchedule`
 enabling it picks up from the next due instant. What it missed is never replayed. An update that
@@ -287,9 +277,8 @@ changes the expression reschedules from the new one.
 
 ## Running an ECS task on a schedule
 
-A target whose ARN names an ECS cluster runs a [simulated ECS](https://yulinsim.dev/services/ecs/) task, in place of being
-invoked with a payload. That is the shape a nightly batch job usually has. A container runs, does
-its work and stops.
+A target whose ARN names an ECS cluster runs a [simulated ECS](https://yulinsim.dev/services/ecs/)
+task. Use `EcsParameters` to select the task definition and use `Input` for task overrides.
 
 ```typescript sim-scheduler-ecs-target
 /**
@@ -404,8 +393,8 @@ target with no `Input` runs the task with no overrides.
 
 [Simulated ECS](https://yulinsim.dev/services/ecs/) decides which containers actually run. A container
 with a binding runs its handler, and a container without one is recorded as not simulated.
-A target naming a task definition with nothing bound therefore records a task that never started,
-and the schedule counts as invoked.
+A target naming a task definition without a bound container records a task that never started, and
+the schedule counts as invoked.
 
 ## Updating and deleting
 
@@ -457,8 +446,8 @@ console.log(described.ScheduleExpression); // "rate(30 minutes)"
 console.log(described.Description); // undefined, and not by accident
 ```
 
-`UpdateSchedule` carries the whole of a schedule, and anything an earlier request set and this one
-leaves out is gone. That is real behaviour and a common surprise. The schedule has to exist.
+`UpdateSchedule` replaces the full schedule definition. Any optional value omitted from the update
+is removed. The schedule must already exist.
 Updating one that is absent raises `ResourceNotFoundException`. EventBridge's `PutRule` creates it.
 
 `CreateSchedule` for a name that already exists raises `ConflictException`. A deployment running it
@@ -618,10 +607,10 @@ against the `RoleArn` on the target.
 
 ## Deploying from a CloudFormation template
 
-`AWS::Scheduler::Schedule` deploys through [simulated CloudFormation](https://yulinsim.dev/services/cloudformation/). A stack
-that declares its schedules can be exercised end to end, with no SDK calls of its own. Everything the
-Resource carries lines up with `CreateSchedule`, and a target ARN or execution role resolved by
-`Fn::GetAtt` from the same template works as it would in a real deployment.
+`AWS::Scheduler::Schedule` deploys through [simulated
+CloudFormation](https://yulinsim.dev/services/cloudformation/). Its properties follow
+`CreateSchedule`, and the target ARN or execution role can use `Fn::GetAtt` references to resources
+in the same template.
 
 ```typescript sim-scheduler-cloudformation
 /**
@@ -786,7 +775,7 @@ anyway. Read the record back from `stack.getResource("<logicalId>")?.ignoredProp
 Tearing the stack down removes the group. Its schedules go with it, whether or not they are
 Resources of the same stack.
 
-## Available functionality
+## Supported operations
 
 - `CreateSchedule`, `GetSchedule`, `UpdateSchedule`, `DeleteSchedule` and `ListSchedules`.
 - `at(...)`, `rate(...)` and six-field `cron(...)` expressions, fired by advancing the simulation's
@@ -839,7 +828,7 @@ Resources of the same stack.
 - A target `EventBridgeParameters`, `KinesisParameters`, `SageMakerPipelineParameters` and
   `SqsParameters` are refused outright, as is `EcsParameters` on a target whose ARN names something
   other than an ECS cluster. A `DeadLetterConfig` must name a standard SQS queue because simulated
-  SQS does not support FIFO queues.
+  SQS supports only standard queues.
 - An ECS target's `EcsParameters` takes `TaskDefinitionArn` and `TaskCount`, and takes and ignores
   `LaunchType`, `PlatformVersion`, `NetworkConfiguration` and `CapacityProviderStrategy`, since
   there is no placement and no network here for them to apply to. Anything else it can carry, such
@@ -849,5 +838,5 @@ Resources of the same stack.
   on an ECS target, where every other target type takes any text.
 - A `TaskCount` above one runs that many simulated tasks, and a bound container handler runs once
   for each of them, in this process and one after another.
-- `KmsKeyArn` is refused, and `ClientToken` is accepted and ignored. Schedule management requests
-  are not retried, so the token has no request to make idempotent.
+- `KmsKeyArn` is refused, and `ClientToken` is accepted and ignored. Yulin makes each schedule
+  management request once, so the token has no retry to make idempotent.

--- a/docs/services/secretsmanager/README.md
+++ b/docs/services/secretsmanager/README.md
@@ -1,7 +1,7 @@
 # Simulated Secrets Manager
 
-Yulin includes a simulated AWS Secrets Manager for tests and local development. Secrets are stored
-in memory, versioned by staging label, and every operation is authorized by simulated IAM.
+Yulin simulates AWS Secrets Manager in memory. Secrets have encrypted versions and staging labels,
+and simulated IAM authorizes every operation.
 
 Secrets Manager-specific types are imported from the `@kensio/yulin/secretsmanager` subpath.
 
@@ -45,19 +45,14 @@ on read.
 
 ## Encryption and KMS permissions
 
-Every version is encrypted through simulated KMS when it is written and decrypted when
-`GetSecretValue` reads it. There is no flag for reading a secret without decrypting it. The read
-either returns the plaintext or fails.
+Every secret version is encrypted through simulated KMS. `GetSecretValue` decrypts the version and
+either returns its plaintext or fails.
 
-A secret naming no `KmsKeyId` uses the `aws/secretsmanager` AWS managed key, which asks the caller
-for no KMS permission at all. Secrets Manager supplies `kms:ViaService`, and that key's policy allows
-the account's principals to use it through Secrets Manager. A Lambda role granted only
-`secretsmanager:GetSecretValue` therefore reads the secret, as it does on real AWS.
+A secret without `KmsKeyId` uses the `aws/secretsmanager` AWS managed key. Its policy permits use
+through Secrets Manager, so callers do not need a separate KMS permission.
 
-Pass `KmsKeyId` to encrypt under a customer managed key instead, and the caller's own permissions on
-that key start to matter. Secrets Manager uses envelope encryption, asking KMS for a data key per
-version. A write needs `kms:GenerateDataKey` and a read needs `kms:Decrypt`. A role granted the
-secret but not the key fails here, ahead of a deployment.
+Pass `KmsKeyId` to use a customer managed key. Writing a version requires `kms:GenerateDataKey`, and
+reading it requires `kms:Decrypt`, in addition to the relevant Secrets Manager permission.
 
 ```typescript sim-secrets-manager-customer-key
 /**
@@ -141,10 +136,9 @@ they were made with and stay readable, as they do on real AWS.
 
 ## Secret ARNs and IAM policies
 
-Real Secrets Manager appends a hyphen and six random characters to the secret name in its ARN. A
-secret named `db-creds` gets an ARN ending `:secret:db-creds-AbCdEf`, and sim Secrets Manager does
-the same. A policy naming the bare ARN therefore matches nothing, and a policy has to end in
-`-??????` or a wildcard.
+Secret ARNs end with a hyphen and six random characters. A secret named `db-creds`, for example,
+gets an ARN ending in `:secret:db-creds-AbCdEf`. An IAM resource pattern for the secret must include
+that suffix, such as `-??????` or `-*`.
 
 ```typescript sim-secrets-manager-iam-policy
 /**
@@ -214,17 +208,16 @@ nothing, here as there.
 
 ## Naming a secret
 
-Every operation takes its target as a `SecretId`, in any of the three forms real Secrets Manager
-accepts. Those are the friendly name, the full ARN including the suffix, and the partial ARN without
-it.
+`SecretId` accepts the friendly name, the full ARN with its random suffix, or the partial ARN without
+the suffix.
 
 An ARN naming another account or region resolves to no secret at all. Its name is never read out and
 looked up locally, and a foreign ARN cannot reach a secret that happens to share a name.
 
 ## Versions and staging labels
 
-Every write creates a version, leaving the earlier ones in place. `AWSCURRENT` names the version a
-plain read returns, and writing a new current version demotes the previous one to `AWSPREVIOUS`.
+Every write creates a version. `AWSCURRENT` marks the version returned by a plain read. Writing a new
+current version moves `AWSPREVIOUS` to the former current version.
 
 ```typescript sim-secrets-manager-staging-labels
 /**
@@ -273,12 +266,9 @@ label. A version that has lost every label is on its way out of existence, and i
 
 ## Deletion and the recovery window
 
-`DeleteSecret` schedules deletion for later. The recovery window is 7 to 30 days, defaulting to 30.
-During that window the secret is still there. It can be described and restored, it refuses to be
-read or written, and it still holds its name.
-
-Holding the name is what a redeployed stack hits. Advancing the simulated clock past the window frees
-it.
+`DeleteSecret` schedules deletion after a recovery window of 7 to 30 days, defaulting to 30. During
+that window the secret can be described or restored, but it cannot be read or changed. Its name also
+remains reserved. Advance simulated time past the window to complete deletion.
 
 ```typescript sim-secrets-manager-deletion
 /**
@@ -435,14 +425,14 @@ console.log(credentials.username); // "app"
 console.log(credentials.password?.length); // 24
 ```
 
-Generated passwords are random. A test reads the value back out of the simulation the way a deployed
-application does.
+Generated passwords are random. Read the deployed value through Secrets Manager instead of asserting
+on an exact password.
 
 ## Reading a secret with a dynamic reference
 
-A template reads a secret that already exists through a `{{resolve:secretsmanager:...}}` dynamic
-reference. The reference is replaced with the secret's value as the resource holding it is created.
-CDK emits one from `SecretValue.secretsManager`.
+A `{{resolve:secretsmanager:...}}` dynamic reference reads an existing secret while CloudFormation
+creates the resource containing the reference. CDK emits this form for
+`SecretValue.secretsManager`.
 
 The whole form is
 `{{resolve:secretsmanager:secret-id:secret-string:json-key:version-stage:version-id}}`. Only the
@@ -554,11 +544,10 @@ another resource of the same stack creates is only there in time when the templa
 Resource properties are reported as they resolved, including this one. Real CloudFormation keeps a
 resolved secret out of its own logs and events, and sim CloudFormation has no such protection.
 
-### A reference the simulation cannot answer
+### Unresolved references
 
-Simulated CloudFormation deploys what it can. A reference naming a secret that was never created
-resolves to `dummy-value-for-<secret-id>`, and the stack carries on deploying. A template reading a
-secret a test does not care about is still worth deploying for everything else in it.
+If Yulin cannot resolve a reference, it substitutes `dummy-value-for-<secret-id>` and continues the
+deployment.
 
 The substitution is recorded on
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without),
@@ -596,9 +585,7 @@ The same applies to `SimSdk` interception. Intercepting `SecretsManagerClient` r
 code into the simulation, served in process. See
 [AWS SDK interception](https://yulinsim.dev/sdk/ "Simulated AWS SDK docs").
 
-## Available functionality
-
-Sim Secrets Manager currently supports:
+## Supported operations
 
 - `CreateSecretCommand`, holding either a string or binary
 - `GetSecretValueCommand`, by staging label or by version id
@@ -618,8 +605,6 @@ Sim Secrets Manager currently supports:
 - A dynamic reference carrying a full ARN reading the account that ARN names
 
 ## Limitations
-
-Current documented limitations:
 
 - A `KmsKeyId` is checked when a version is written under it, not when it is set on its own. An
   `UpdateSecret` changing only the key accepts a key that is absent, and the next write of a value

--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -1,20 +1,14 @@
 # Simulated SES
 
-Yulin includes a simulated Amazon SES for tests and local development, through the SES v2 API. It
-holds email identities, applies the sandbox rules, and keeps a record of every message it would have
-sent. A test can assert that signing someone up produced a welcome email addressed to them, without
-an AWS account and without a mailbox to read.
-
-There is no delivery to simulate. A message SES accepts leaves AWS for a mail system. The whole of
-the observable AWS behaviour is whether SES would have accepted the message and what it would have
-sent. That is what makes this service small and what makes it useful.
+Yulin simulates the Amazon SES v2 API in memory. It stores email identities, applies sandbox and
+suppression rules, renders templates, and records accepted messages. It does not deliver email.
 
 SES specific types are imported from the `@kensio/yulin/ses` subpath.
 
 ## Asserting on a message that was sent
 
-`sentEmails()` hands over the record. Each message carries who it was from, the three recipient
-lists, the subject, the body, its attachments and the message id SES answered with.
+Use `sentEmails()` to inspect accepted messages. Each record contains the sender, To/Cc/Bcc lists,
+subject, body, attachments, and message ID.
 
 ```typescript sim-ses-send-and-assert
 /**
@@ -115,9 +109,8 @@ console.log(
 
 ## Verifying identities
 
-Real SES verifies an email address by emailing it a link and a domain by looking for DNS records.
-Neither can happen inside a test process, so verification here is the simulator's own operation
-instead of an API call. `verifyIdentity` performs it, creating the identity where one is absent.
+SES normally verifies an address by email and a domain through DNS. In tests, call `verifyIdentity`
+instead. It creates the identity if necessary and marks it verified.
 
 Everything else about identities is the ordinary SES API. `CreateEmailIdentity` starts one, and it
 starts unverified, exactly as a real one does:
@@ -631,13 +624,10 @@ one answer whoever asked.
 
 ## The sandbox
 
-An account starts in the SES sandbox, where **both** the sender and every recipient have to be
-verified. That is the state most tests should be written against. It is the configuration that
-refuses to mail an address nobody verified, and catching that refusal in a test is much better than
-catching it in an account.
+An account starts in the SES sandbox. Both the sender and every recipient must be verified. Outside
+the sandbox, only the sender must be verified.
 
-Outside the sandbox only the sender is checked. `PutAccountDetails` with `ProductionAccessEnabled`
-is how an account gets there:
+Call `PutAccountDetails` with `ProductionAccessEnabled` to leave the sandbox:
 
 ```typescript sim-ses-sandbox
 /**
@@ -696,17 +686,12 @@ caller finds out everything it has to verify from one failure:
 Email address is not verified. The following identities failed the check in region US-EAST-1: someone@example.org
 ```
 
-Real SES treats `ProductionAccessEnabled` as a request that a human at AWS then reviews, and an
-account stays in the sandbox until that review lands. Granting it immediately is a deliberate
-divergence. The alternative is a simulator no test can get out of the sandbox in, and waiting for a
-review is beyond what a test can assert on anyway.
+Unlike AWS, Yulin grants production access immediately instead of waiting for a manual review.
 
 ## The suppression list
 
-Real SES holds an account-level suppression list and fills it from hard bounces and complaints.
-Tests supply that feedback explicitly with `recordFeedback`. Suppression commands manage the same
-list. The support tool that lists suppressed addresses, the form that removes one and the script
-that seeds the list all have somewhere to run.
+SES maintains an account suppression list for hard bounces and complaints. Tests add feedback with
+`recordFeedback`, and the suppression commands read and change the same list.
 
 `PutSuppressedDestination`, `GetSuppressedDestination`, `ListSuppressedDestinations` and
 `DeleteSuppressedDestination` manage it.
@@ -870,8 +855,7 @@ recorded.
 
 ## Messages on the console
 
-`sentEmails()` is test code. A dev server has the same messages going past and nothing to read them
-with, so `serveSimAws` prints a summary of each one as SES accepts it:
+For local development, `serveSimAws` prints a summary whenever SES accepts a message:
 
 ```
 sim SES: hello@example.com to alice@example.com, bcc audit@example.com
@@ -899,9 +883,8 @@ pool kept. Both services recorded it, and each block says what that service hold
 
 ## Permissions
 
-Every command authorizes through simulated IAM. A send authorizes against the identity being sent
-**from**, and recipients never enter into it. That is worth knowing when a policy looks like it
-should cover a send and fails to.
+Every command uses simulated IAM. A send authorizes against the sender identity, not the recipient
+addresses.
 
 ```typescript sim-ses-permissions
 /**

--- a/docs/services/sns/README.md
+++ b/docs/services/sns/README.md
@@ -1,14 +1,11 @@
 # Simulated SNS
 
-Yulin includes a simulated Amazon SNS for tests and local development. Topics are held in memory and
-every operation is authorized by simulated IAM.
+Yulin simulates Amazon SNS standard topics for tests and local development. A published message can
+reach simulated SQS queues, invoke simulated Lambda functions or create SMS records that tests can
+inspect. Direct SMS publishes are recorded in the same way.
 
-Standard topics only. SNS-specific types are imported from the `@kensio/yulin/sns` subpath.
-
-A message published to a topic is delivered to every queue subscribed to it, invokes every Lambda
-function subscribed to it, and is recorded as an SMS for every phone number subscribed to it. Only
-those three protocols are simulated. A message published straight to a phone number is recorded
-as an SMS a test can assert on.
+Topics are stored in memory, and simulated IAM authorizes every operation. FIFO topics and other
+subscription protocols are not simulated. Import SNS-specific types from `@kensio/yulin/sns`.
 
 ## Creating a topic and publishing to it
 
@@ -103,11 +100,10 @@ console.log(read.Attributes?.["SubscriptionsConfirmed"]); // "0"
 reports it. The three subscription counts are reported as zero, the counts a topic with no
 subscriptions has.
 
-An attribute real SNS has and this simulation gives no behaviour to is refused by name rather than
-taken and ignored. That covers `FifoTopic`, `KmsMasterKeyId`, `SignatureVersion`, `TracingConfig`,
-`ArchivePolicy`, `DeliveryPolicy`, `ContentBasedDeduplication` and the delivery status logging
-attributes such as `SQSSuccessFeedbackRoleArn`. A topic that appeared to accept `KmsMasterKeyId`
-would look encrypted to the request that set it and be plain to everything else.
+Unsupported topic attributes are rejected instead of being stored without effect. These include
+`FifoTopic`, `KmsMasterKeyId`, `SignatureVersion`, `TracingConfig`, `ArchivePolicy`, `DeliveryPolicy`,
+`ContentBasedDeduplication` and delivery status logging attributes such as
+`SQSSuccessFeedbackRoleArn`.
 
 ## Publishing
 
@@ -148,12 +144,11 @@ const published = await sns.publish(
 console.log(published.MessageId !== undefined); // true
 ```
 
-The name and data type rules are the real ones. A data type is `String`, `String.Array`, `Number` or
-`Binary`, and each takes a custom label after a dot, so `Number.int` is a number as far as the rules
-go. A reserved `AWS.` or `Amazon.` prefix on a name, a data type built on none of the four, or a
-value that disagrees with its data type is refused. A test finds any of those without going near AWS. The two reserved names real
-SNS defines for SMS, `AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType`, are the exception.
-[Sending an SMS](#sending-an-sms) covers those.
+Message attributes use the AWS name and type rules. A type starts with `String`, `String.Array`,
+`Number` or `Binary` and may add a custom label after a dot, such as `Number.int`. SNS rejects
+reserved `AWS.` and `Amazon.` name prefixes, unknown base types and values that do not match their
+type. The SMS attributes `AWS.SNS.SMS.SenderID` and `AWS.SNS.SMS.SMSType` are exceptions. See
+[Sending an SMS](#sending-an-sms).
 
 A `Subject` is UTF-8 text with no line breaks or control characters, of fewer than 100 characters.
 That is the contract real SNS states. A subject of exactly 100 characters is already too long. A
@@ -164,9 +159,8 @@ publish with no `Message`, or with one over the size limit, is refused with
 the rest of the batch goes through, as real SNS reports it. An empty batch, more than ten entries, a
 malformed entry id or two entries sharing an id fail the whole request.
 
-The size limit is the one thing a batch is held to as a whole. Ten entries each just inside it are
-one batch far outside it, and a single entry over it fails the whole batch with
-`BatchRequestTooLongException`. The response singles out no entry.
+The size limit applies to the whole batch. A batch over the limit fails with
+`BatchRequestTooLongException`, without identifying one entry as the cause.
 
 ```typescript sim-sns-publish-batch
 /**
@@ -1762,9 +1756,9 @@ synthesises an `AWS::SNS::Subscription` alongside the `AWS::SQS::QueuePolicy` th
 delivery, and both deploy. `new subscriptions.LambdaSubscription(fn)` does the same with the
 `AWS::Lambda::Permission` beside it.
 
-## Available functionality
+## Supported operations
 
-Sim SNS currently supports:
+Simulated SNS supports:
 
 - `CreateTopicCommand`, idempotent for a name already taken, and `DeleteTopicCommand`
 - `ListTopicsCommand`, paged at a hundred topics with a `NextToken`
@@ -1806,8 +1800,6 @@ Sim SNS currently supports:
   `Subscription` property on a topic and `Ref` and `Fn::GetAtt` over the deployed resources
 
 ## Limitations
-
-Current documented limitations:
 
 - Only the `sqs`, `lambda` and `sms` subscription protocols are simulated. A queue, a function and a
   phone number are the only things a topic can deliver to. `http`, `https`, `email`, `email-json`,

--- a/docs/services/sqs/README.md
+++ b/docs/services/sqs/README.md
@@ -1,9 +1,11 @@
 # Simulated SQS
 
-Yulin includes a simulated Amazon SQS for tests and local development. Messages are held in memory,
-hidden and released on the simulation's own clock, and every operation is authorized by simulated IAM.
+Yulin simulates Amazon SQS standard queues for tests and local development. You can create queues,
+send and receive messages, test visibility timeouts and redrive messages to dead-letter queues.
+Messages are stored in memory, time-based behavior uses the simulation's clock, and simulated IAM
+authorizes every operation.
 
-Standard queues only. SQS-specific types are imported from the `@kensio/yulin/sqs` subpath.
+FIFO queues are not simulated. Import SQS-specific types from `@kensio/yulin/sqs`.
 
 ## Creating a queue and sending a message
 
@@ -57,10 +59,9 @@ differ. A request naming no attributes always matches.
 
 ## Visibility timeouts
 
-A received message is hidden from other consumers for the queue's visibility timeout, 30 seconds by
-default. The message records the instant it is hidden until. It becomes receivable again once
-simulated time reaches that instant. Advancing the clock is all a test needs to watch an undeleted
-message come back.
+A received message is hidden from other consumers for the queue's visibility timeout, which is 30
+seconds by default. If the consumer does not delete it, the message becomes available again when the
+simulated clock reaches the end of that timeout.
 
 ```typescript sim-sqs-visibility-timeout
 /**
@@ -127,8 +128,8 @@ Every receive issues a fresh receipt handle, and a delete has to use the handle 
 receive of that message. A handle from an earlier receive is accepted and deletes nothing. Real SQS
 accepts one too, and promises only that the message might not be deleted.
 
-That is the failure a consumer slower than its visibility timeout hits. Its message went back on the
-queue, someone else took it, and its own delete quietly does nothing.
+This can happen when a consumer runs past the visibility timeout and another consumer receives the
+same message. The first consumer's later delete succeeds without deleting the message.
 
 ```typescript sim-sqs-stale-receipt-handle
 /**
@@ -187,10 +188,9 @@ still the most recent one, so deleting with it works. A handle the queue never i
 
 ## Dead-letter queues
 
-A `RedrivePolicy` says where a message goes once a consumer has had enough attempts at it. Once a
-message has been received `maxReceiveCount` times without being deleted, the next lapse of its
-visibility timeout moves it to the queue named by `deadLetterTargetArn`. Advancing the clock drives
-the move, as it drives the timeout itself.
+A `RedrivePolicy` sends repeatedly received messages to a dead-letter queue. After a message reaches
+`maxReceiveCount` without being deleted, the next visibility timeout moves it to the queue named by
+`deadLetterTargetArn`. Advance the simulated clock to trigger the timeout and move.
 
 ```typescript sim-sqs-dead-letter-queue
 /**
@@ -1137,7 +1137,7 @@ that deploys here, with the queue URL reaching the function through its environm
 policy naming the queue by the ARN `Fn::GetAtt` gives. A grant to a service principal synthesises an
 `AWS::SQS::QueuePolicy` alongside it, which deploys too.
 
-## Available functionality
+## Supported operations
 
 Sim SQS currently supports:
 

--- a/docs/services/ssm/README.md
+++ b/docs/services/ssm/README.md
@@ -1,12 +1,11 @@
 # Simulated SSM Parameter Store
 
-Yulin includes a simulated AWS Systems Manager Parameter Store for tests and local development.
-Parameters are stored in memory, versioned on every write, and every operation is authorized by
-simulated IAM.
+Yulin simulates AWS Systems Manager Parameter Store for tests and local development. You can create,
+read, update and delete parameters through the AWS SDK or a CloudFormation template. Parameters are
+stored in memory, each write creates a version, and simulated IAM authorizes every operation.
 
-Only Parameter Store is simulated.
-
-SSM-specific types are imported from the `@kensio/yulin/ssm` subpath.
+Other Systems Manager features, such as Run Command and Session Manager, are not simulated. Import
+SSM-specific types from `@kensio/yulin/ssm`.
 
 ## Writing and reading a parameter
 
@@ -292,8 +291,7 @@ console.log(origins.length); // 2
 
 ## Parameter names
 
-Name validation matches real Parameter Store, because a name it accepts and AWS refuses is a
-deployment failure a passing test would have hidden. A name:
+Parameter names use the same validation rules as AWS. A name:
 
 - may contain letters, digits, `_`, `.`, `-` and `/`
 - must start with `/` if it contains a hierarchy at all
@@ -302,8 +300,8 @@ deployment failure a passing test would have hidden. A name:
 - may not contain spaces between characters, though surrounding spaces are stripped
 - may not make an ARN longer than 1011 characters, counting the ARN prefix for the account and region
 
-A `String` or `StringList` value holds at most 4KB, the standard tier limit. This is the one people
-hit, usually by putting a whole JSON configuration blob in one parameter.
+A `String` or `StringList` value holds at most 4 KB, the standard tier limit. Larger configuration
+documents must be split across parameters or stored elsewhere.
 
 ## Deploying a parameter from CloudFormation
 
@@ -455,9 +453,9 @@ covers that one.
 
 ### A reference the simulation cannot answer
 
-Simulated CloudFormation deploys what it can. A reference naming a parameter that was never created
-resolves to `dummy-value-for-<name>`, and the stack carries on deploying. A template reading
-configuration a test does not care about is still worth deploying for everything else in it.
+When a reference names a parameter that does not exist, simulated CloudFormation substitutes
+`dummy-value-for-<name>` and continues the deployment. This lets a test deploy the rest of a
+template without setting up unrelated configuration.
 
 The substitution is recorded on
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without),
@@ -998,9 +996,9 @@ console.log(read.Parameter?.Value); // "hunter2"
 
 `DescribeParameters` reports the key each `SecureString` is encrypted under as `KeyId`.
 
-## Available functionality
+## Supported operations
 
-Sim SSM currently supports:
+Simulated Parameter Store supports:
 
 - `PutParameterCommand`, creating a parameter or overwriting one
 - `GetParameterCommand`, by name, by `name:version` or by `name:label`
@@ -1025,8 +1023,6 @@ Sim SSM currently supports:
 - Calls made from inside a simulated Lambda handler, authorized as the function's execution role
 
 ## Limitations
-
-Current documented limitations:
 
 - Only standard tier `SecureString` encryption is simulated, which encrypts under the KMS key
   directly. The advanced tier's envelope encryption through the AWS Encryption SDK is left out, and

--- a/docs/services/stepfunctions/README.md
+++ b/docs/services/stepfunctions/README.md
@@ -1,18 +1,18 @@
 # Simulated Step Functions
 
-Simulated Step Functions interprets Amazon States Language and runs a state machine in the same
-process as the code under test. A workflow held in a template as data becomes something a test can
-run and assert on.
+Yulin interprets Amazon States Language and runs Step Functions state machines in the same process
+as the code under test. Tests can start executions, invoke simulated services, advance waits and
+inspect execution history without deploying a workflow.
 
-Types for simulated Step Functions are imported from the `@kensio/yulin/stepfunctions` subpath.
+Import Step Functions-specific types from `@kensio/yulin/stepfunctions`.
 
-## What runs today
+## Supported state machine features
 
-Every state type Amazon States Language defines runs. `Pass`, `Task`, `Succeed`, `Fail`, `Choice`,
-`Wait`, `Parallel` and `Map`.
+All eight state types are supported: `Pass`, `Task`, `Succeed`, `Fail`, `Choice`, `Wait`, `Parallel`
+and `Map`.
 
-The data-flow fields run in full. `InputPath`, `Parameters`, `ResultSelector`, `ResultPath` and
-`OutputPath` apply in that order, reading Reference Paths and the intrinsic functions.
+The data-flow fields `InputPath`, `Parameters`, `ResultSelector`, `ResultPath` and `OutputPath` run in
+that order. They support Reference Paths and intrinsic functions.
 
 A `Task` state invokes a simulated Lambda function, calls an operation on any other simulated
 service, or starts another state machine. A `Resource` this simulator has no answer for is refused
@@ -114,23 +114,21 @@ console.log(described.status); // FAILED
 console.log(described.error); // NotEligible
 ```
 
-A failing execution is recorded on the execution, and the call returns as it would for one that
-succeeded. Simulated EventBridge treats an undeliverable event the same way. An execution failing is
-as often the thing under test as it is a fault, and raising it would fail an unrelated `advanceBy`
-elsewhere in the same test.
+A failed execution records its status and error instead of throwing from `StartExecution`. Read it
+with `DescribeExecution` or the inspection API. This keeps workflow failure available for
+assertions.
 
 ## Invoking a Lambda function
 
 A `Task` state invokes a simulated Lambda function, through either of the two `Resource` forms CDK's
 `LambdaInvoke` emits.
 
-`arn:aws:states:::lambda:invoke` is the integration Step Functions optimises. The state is talking to
-the Lambda API, so its `Parameters` are an `Invoke` request (`FunctionName` names the function and
-`Payload` carries what it is sent) and its result is an `Invoke` response, with the handler's answer
-under `Payload`.
+With `arn:aws:states:::lambda:invoke`, `Parameters` has the shape of a Lambda `Invoke` request.
+`FunctionName` selects the function, `Payload` contains its input, and the handler result appears
+under `Payload` in the task output.
 
-A function ARN sends the state's own input to the handler and answers with what the handler
-returned. CDK writes this form for `payloadResponseOnly`.
+A function ARN sends the state input directly to the handler and uses the handler result as the task
+output. CDK emits this form when `payloadResponseOnly` is enabled.
 
 ```typescript sim-step-functions-task
 /**
@@ -1334,7 +1332,7 @@ reference contradicts itself here, listing a differing role ARN under `StateMach
 while the operation's own note says the difference is ignored. The note is the more specific of the
 two and is what this follows.
 
-## Still to come
+## Limitations
 
 - Distributed Map, with `ItemReader`, `ResultWriter` and the `ToleratedFailure` fields.
 - The `.sync` pattern, task tokens and activities.

--- a/docs/services/sts/README.md
+++ b/docs/services/sts/README.md
@@ -1,16 +1,12 @@
 # Simulated STS
 
-Yulin includes a simulated STS (Security Token Service) for tests and local development.
-
-Sim STS is used through `SimAws` as `simAws.sts()`, scoped to the Account making the assume request.
-It simulates assuming IAM Roles. An assume request is evaluated against
-[simulated IAM](https://yulinsim.dev/services/iam/) policies, and a request that passes issues temporary session credentials
-that the rest of the simulated environment authenticates like real AWS credentials.
+Yulin simulates `AssumeRole` and `GetCallerIdentity`. Access the service through `simAws.sts()` or an
+intercepted `STSClient`.
 
 ## Basic usage
 
-Create a Role whose trust policy allows the Account to assume it, then assume it through STS. An
-omitted caller defaults to the Account root principal.
+Create a role with a trust policy, then call `assumeRole`. A request with no caller runs as the
+account root.
 
 ```typescript sim-sts-assume-role
 /**
@@ -50,23 +46,28 @@ console.log(assumeRoleOutput.Credentials?.AccessKeyId);
 console.log(assumeRoleOutput.Credentials?.Expiration);
 ```
 
-The output matches the AWS shape. `AssumedRoleUser.Arn` is the session ARN, such as
+`AssumedRoleUser.Arn` is the session ARN, such as
 `arn:aws:sts::123456789012:assumed-role/TargetRole/test-session`, and `Credentials` carries the
 temporary `AccessKeyId`, `SecretAccessKey`, `SessionToken`, and `Expiration`.
 
-The issued credentials are registered with the target Account's sim IAM. They authenticate later
-simulated requests, for example as the `caller` of an IAM authorization attempt, where identity
-policies come from the underlying Role. See [the sim IAM docs](https://yulinsim.dev/services/iam/#sts-assumerole-sessions) for a
-full example. Credentials missing their session token, or used after `Expiration`, are rejected with
-an AWS-like invalid-credentials error.
+Yulin registers the credentials with simulated IAM in the target account. Later requests use the
+role's identity policies. See [STS sessions in simulated IAM](https://yulinsim.dev/services/iam/#sts-assumerole-sessions).
+Credentials fail after `Expiration` or when the session token is missing.
 
-`DurationSeconds` controls the session lifetime and defaults to 3600 seconds (one hour). It must be
-a positive integer.
+`DurationSeconds` defaults to 3,600 seconds and must be a positive integer.
+
+## Reading the current identity
+
+`getCallerIdentity` reports the caller's ARN, account ID and user ID. It handles account roots, IAM
+users and assumed-role sessions. The intercepted and served STS APIs also support
+`GetCallerIdentityCommand`.
+
+An unattributed request reports the configured default caller, or the account root when no default
+caller is configured. An anonymous caller receives `AccessDenied`.
 
 ## Role-to-Role assumption
 
-Pass a caller to assume a Role as a specific principal. As in real AWS, both sides of the request
-are then evaluated:
+Pass `caller` to assume a role as a specific principal. STS checks both sides of the request:
 
 - The target Role's trust policy must allow the caller to perform `sts:AssumeRole`
 - A non-root caller also needs an identity policy allowing `sts:AssumeRole` on the target Role's
@@ -144,33 +145,25 @@ const assumeRoleOutput = await account.sts().assumeRole(
 console.log(assumeRoleOutput.AssumedRoleUser?.Arn);
 ```
 
-STS throws an AWS-like access-denied error if either side denies the request, which happens when the
-trust policy does not cover the caller, the caller has no identity policy allowing `sts:AssumeRole`,
-or an explicit `Deny` matches. The error has a `403` status code and names the `sts:AssumeRole`
-action and the target Role ARN. No session is created.
+If either check fails, STS raises a 403 access-denied error naming `sts:AssumeRole` and the target
+role ARN. No session is created.
 
-Cross-Account assumption works the same way. Create the source and target Roles in different
-simulated Accounts of the same `SimAws` instance, and call `assumeRole` on the source Account's
-`sts()`. The issued session belongs to the target Role's Account.
+Cross-account assumption uses the same checks. Call `assumeRole` through the source account. The
+session belongs to the target role's account.
 
 ## Role chaining
 
-A process that assumes a Role and then assumes a second one from that session is chaining Roles. The
-caller of the second request is the session, and the Role it holds the permissions of is what both
-sides of the decision are written against. The trust policy of the target names that Role, and the
-identity policy allowing `sts:AssumeRole` belongs to it.
+For role chaining, use the first session as the caller of the second `assumeRole` request. The target
+trust policy names the first role, and that role needs identity permission to assume the target.
 
-Both ARNs of a session are matched against a `Principal`, so a trust policy naming either the Role
-or one particular session admits it. AWS recommends naming the Role, and a session name is often
-decided at run time rather than written into a policy.
+A trust policy may name the role ARN or one assumed-role session ARN. Prefer the role ARN when the
+session name is chosen at run time.
 
-Chaining over a served endpoint works the same way. Credentials from the first request sign the
-second, and the caller they resolve to carries the Role along with the session.
+The served endpoint resolves session credentials in the same way.
 
 ## ExternalId
 
-A trust policy can require an external ID through the `sts:ExternalId` condition key. The
-`ExternalId` supplied to `AssumeRoleCommand` is matched against it.
+A trust policy can require `sts:ExternalId`. Pass the matching `ExternalId` to `AssumeRoleCommand`.
 
 ```typescript sim-sts-external-id
 /**
@@ -214,14 +207,14 @@ const assumeRoleOutput = await account.sts().assumeRole(
 console.log(assumeRoleOutput.AssumedRoleUser?.Arn);
 ```
 
-An omitted or mismatched `ExternalId` leaves the trust-policy condition unmatched. The assume
-request is denied.
+An omitted or mismatched value denies the request.
 
 ## Available functionality
 
 Sim STS currently supports:
 
 - `AssumeRoleCommand`
+- `GetCallerIdentityCommand`
 - Trust-policy evaluation against the target Role's assume-role policy document
 - Identity-policy evaluation of the source caller, requiring `sts:AssumeRole` permission on the
   target Role
@@ -231,15 +224,9 @@ Sim STS currently supports:
 - Temporary credentials registered with the target Account's sim IAM, including session-token and
   expiry validation
 
-Unsupported STS options may be ignored or may throw errors depending on whether the simulator needs
-them to model the requested behaviour.
-
 ## Limitations
 
-Sim STS models Role assumption. Notable gaps:
-
-- `AssumeRoleCommand` is the only supported command. There is no `GetCallerIdentity`, federation, or
-  web-identity support
+- Federation, web identity and session-token commands are unsupported.
 - Session policies (`Policy` / `PolicyArns`), tags, and `SourceIdentity` requests are not evaluated
 - Condition support in trust policies is limited to the operators supported by
   [sim IAM](https://yulinsim.dev/services/iam/#policy-conditions)

--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -1,16 +1,11 @@
 # Simulated WAFv2
 
-Yulin includes a simulated AWS WAFv2 for tests and local development. It holds web ACLs, IP sets and
-regex pattern sets, and it evaluates a request against a web ACL's rules to reach a decision. A test
-can assert that a request to `/admin` is blocked and one to `/` is allowed, without an AWS account
-and without a distribution in front of anything.
+Yulin simulates AWS WAFv2 web ACLs, IP sets and regex pattern sets for tests and local development.
+You can evaluate a `Request` directly or associate a web ACL with a simulated API Gateway REST API,
+Cognito user pool or CloudFront distribution. Each request is checked against the web ACL before
+the protected service handles it.
 
-A web ACL can also go in front of what serves the requests. A simulated API Gateway REST API stage
-and a simulated Cognito user pool each take one through `AssociateWebACL`, and a simulated
-CloudFront distribution takes one through its own `WebACLId`. The requests that stage, pool or
-distribution serves are then put through the web ACL's rules.
-
-WAFv2 specific types are imported from the `@kensio/yulin/wafv2` subpath.
+Import WAFv2-specific types from `@kensio/yulin/wafv2`.
 
 ## Deciding what happens to a request
 
@@ -91,11 +86,11 @@ carrying the status, the body and any headers the rule named.
 
 ## Rules run in priority order
 
-Rules are evaluated in ascending `Priority` and not in the order the list was written. The first
-rule that matches and carries a terminating action (`Allow` or `Block`) decides the request.
+Rules are evaluated by ascending `Priority`, regardless of their order in the input list. The first
+matching rule with an `Allow` or `Block` action decides the request.
 
-A `Count` action records the match and lets the next rule have a look. That is how a rule is staged
-before it is turned on, and `countedRuleNames` is what a test asserts against.
+A `Count` action records the match and continues to the next rule. Tests can inspect
+`countedRuleNames` before changing a rule to `Allow` or `Block`.
 
 ```typescript sim-wafv2-count
 /**
@@ -154,8 +149,8 @@ whatever serves the request has usually read it by the time WAF gets a look.
 
 ## What a statement can inspect
 
-A statement reads one part of the request, applies the rule's text transformations to it, and tests
-what comes out.
+A statement selects part of the request, applies its text transformations, and then tests the
+result.
 
 The parts a statement can be pointed at are `UriPath`, `QueryString`, `SingleQueryArgument`,
 `AllQueryArguments`, `SingleHeader`, `Headers`, `Cookies`, `Method` and `Body`. `Headers` and
@@ -1371,7 +1366,7 @@ Tags, logging, sampled requests and CloudWatch metrics for a web ACL are not sim
 `AssociationConfig`, `DataProtectionConfig`, `OnSourceDDoSProtectionConfig` and `ApplicationConfig`
 are refused for the same reason, each naming what it would have configured.
 
-## Simulated commands
+## Supported operations
 
 `CreateWebACL`, `GetWebACL`, `UpdateWebACL`, `ListWebACLs`, `DeleteWebACL`, `CreateIPSet`,
 `GetIPSet`, `UpdateIPSet`, `ListIPSets`, `DeleteIPSet`, `CreateRegexPatternSet`,


### PR DESCRIPTION
## Summary

- rewrite 27 service guides with shorter introductions and direct explanations
- organize each guide around supported behavior, practical usage and known limitations
- preserve executable examples, reference tables and implementation details

## Testing

- `pnpm run check`