### PR TITLE
docs: rewrite remaining service guides

### DIFF
--- a/docs/services/apigateway/README.md
+++ b/docs/services/apigateway/README.md
@@ -1,16 +1,11 @@
 # Simulated API Gateway REST APIs
 
-Yulin includes a simulated API Gateway v1 service, reachable as `simAws.apiGateway()`. It covers the
-REST API resource tree, the methods declared on it, a Lambda proxy integration behind each method,
-and the deployments and stages that publish them. REST-API-specific types are imported from the
-`@kensio/yulin/apigateway` subpath.
+Yulin simulates API Gateway REST APIs (the v1 API) with Lambda proxy integrations. Use
+`simAws.apiGateway()` directly or intercept an `APIGatewayClient`. REST API types are available from
+`@kensio/yulin/apigateway`.
 
-This is the v1 service. HTTP APIs are v2, on a separate SDK client, and they are documented under
-[API Gateway HTTP APIs](https://yulinsim.dev/services/apigatewayv2/). The two hold separate state. A REST API created here
-stays out of `simAws.apiGatewayV2()`.
-
-A handler behind a REST API can be tested against a real HTTP request, with no hand-built event to
-keep in step.
+HTTP APIs use the separate `simAws.apiGatewayV2()` service. See
+[API Gateway HTTP APIs](https://yulinsim.dev/services/apigatewayv2/).
 
 ## Creating a REST API
 
@@ -48,13 +43,13 @@ console.log(typeof created.rootResourceId);
 // "string"
 ```
 
-A REST API name identifies nothing. Two APIs in one account and region may share a name, and the id
-is what tells them apart. Hold the id the create returns.
+A REST API name is a label. Two APIs in the same account and region may share a name. Use the ID
+returned by `CreateRestApiCommand` to address the API.
 
 ## Building the path tree
 
-A REST API path is a chain of resources, each holding one segment. `CreateResourceCommand` adds a
-segment under a parent and reports the full path its place in the tree gives it.
+A REST API stores its path as a tree of resources. Each resource holds one segment.
+`CreateResourceCommand` adds a segment below a parent and returns its full path.
 
 ```typescript sim-apigateway-resource-tree
 /**
@@ -103,18 +98,17 @@ console.log(listed.items.map((resource) => resource.path));
 // [ "/", "/orders", "/orders/{orderId}" ]
 ```
 
-A segment is a literal such as `orders`, a path parameter such as `{orderId}`, or a greedy path
-parameter such as `{proxy+}`. A greedy segment matches the rest of the request path. A resource
-holding one therefore takes no children, and adding under it is refused.
+A segment may be literal (`orders`), a path parameter (`{orderId}`), or a greedy path parameter
+(`{proxy+}`). A greedy segment matches the rest of the path and cannot have children.
 
 Deleting a resource deletes everything under it, the way real API Gateway does. The root resource
 stays, because every REST API has one.
 
 ## Methods and their integrations
 
-A method is declared on a resource with `PutMethodCommand`, and what it does with a request goes
-behind it with `PutIntegrationCommand`. Both address the same resource id and HTTP method, since a
-REST API method has no id of its own.
+`PutMethodCommand` declares a method on a resource. `PutIntegrationCommand` connects that method to
+a Lambda function. Both commands use the resource ID and HTTP method because a method has no ID of
+its own.
 
 ```typescript sim-apigateway-method-integration
 /**
@@ -184,18 +178,15 @@ console.log(method.methodIntegration?.uri);
 // echoed back as one line, the way it was configured
 ```
 
-The integration URI is written either as the bare function ARN, which CDK emits, or wrapped in the
-API Gateway invoke path above, which CloudFormation templates and OpenAPI documents emit. Both reach
-the same function, and the string is echoed back as it was configured, the way real API Gateway does.
-A version or alias qualifier on the end of the ARN is kept. An integration built on an alias
-therefore follows that alias.
+The integration URI may be a function ARN or the API Gateway invocation URI shown above. CDK emits
+the first form. CloudFormation templates and OpenAPI documents commonly emit the second. A version
+or alias qualifier is preserved. An integration that names an alias follows that alias.
 
 Deleting a method deletes its integration, because a REST API integration is part of the method.
 
 ## Deployments and stages
 
-A REST API has an invocation URL once a stage exists, and every stage is the first path segment of
-that URL. An HTTP API can serve a `$default` stage at the root, and a REST API always carries the
+A REST API gets an invocation URL when it has a stage. The stage name is always the first path
 segment.
 
 ```typescript sim-apigateway-deploy-stage
@@ -249,15 +240,13 @@ console.log(restApi?.invokeUrl("prod"));
 `invokeUrl` is a simulator accessor. Real API Gateway reports no endpoint for a REST API and leaves
 callers to build the URL themselves. CDK's `RestApi.urlForPath` builds the same one.
 
-Real API Gateway freezes the resources and methods into a deployment, and an edit made afterwards
-reaches no client until another deployment is created. Here a stage serves the API's current
-resources. A test that edits a method sees the change straight away, with no redeployment in
-between. That is the one place this departs from AWS.
+Stages serve the API's current resources and methods. Changes take effect immediately. AWS freezes
+the configuration in a deployment and requires another deployment before changes become visible.
 
 ## Serving a request
 
-A request to the stage's invoke URL walks the resource tree to a method and invokes that method's
-integration, and the handler's response becomes the HTTP response.
+A request to a stage selects a resource and method, then invokes its integration. The Lambda result
+becomes the HTTP response.
 
 ```typescript sim-apigateway-serve
 /**
@@ -300,14 +289,13 @@ console.log(await response.text());
 await srv.close();
 ```
 
-`simRestApiLambdaProxyFactory` builds the function, the resources, the method, the integration, the
-invoke permission and the deployment in one call. A test about serving wants all of them and is
-about none of them. A test about the commands themselves sends them one at a time.
+`simRestApiLambdaProxyFactory` creates a ready-to-call REST API in one operation. It creates the
+function, resources, method, integration, invoke permission and deployment.
 
 ### The event a handler receives
 
-A REST API sends payload format 1.0. It carries both a single-value and a multi-value map for the
-headers and the query string, and it sends `null` for an empty map where format 2.0 omits the field:
+A REST API sends a payload format 1.0 event. Headers and query parameters appear in both single-value
+and multi-value maps. Empty values use `null`:
 
 | Field                                                      | Empty case |
 | ---------------------------------------------------------- | ---------- |
@@ -319,18 +307,15 @@ headers and the query string, and it sends `null` for an empty map where format 
 client asked for, stage segment and all. A handler behind a `{proxy+}` reads `resource` to tell which
 template caught its request.
 
-Each format's handler reads the other format's event wrongly. One function behind both an HTTP API
-and a REST API therefore has to pick a side.
+REST API and HTTP API events have different shapes. A handler shared by both must handle both
+formats explicitly.
 
 ### The response a handler returns
 
-A REST API proxy integration takes one shape. A result carrying a numeric `statusCode` becomes the
-response, and `multiValueHeaders` sends a header more than once. Anything else is a 502 with
-`Internal server error`. That is what real API Gateway answers when it cannot read the integration
-response. Payload format 2.0 is the lenient one, wrapping an unrecognised value in a 200, and a
-handler relying on that behaves differently here for the same reason it does on AWS.
+A REST API proxy result must contain a numeric `statusCode`. Use `multiValueHeaders` to send the
+same header more than once. An invalid result produces a 502 response with `Internal server error`.
 
-### Answers when the request matches nothing
+### Responses before an integration runs
 
 | Case                                          | Answer                             |
 | --------------------------------------------- | ---------------------------------- |
@@ -340,8 +325,8 @@ handler relying on that behaves differently here for the same reason it does on 
 | No integration, no function, or no permission | 502 `Internal server error`        |
 | The handler threw                             | 502 `Internal server error`        |
 
-`Missing Authentication Token` is the wording real API Gateway is well known for. It answers a path
-that matched nothing just as much as one that needed credentials.
+API Gateway uses `Missing Authentication Token` for an unmatched path or method, even when the
+request did not require authentication.
 
 ### The invoke permission
 
@@ -467,9 +452,8 @@ is named `ANY`, whatever method the client sent.
 
 Real `CreateStage` carries no method settings. AWS sets them with `UpdateStage` patch operations,
 which are outside this simulation, or from an `AWS::ApiGateway::Stage`. The `methodSettings` input
-above is this simulator's own, so that a test can throttle a stage without a template, and the SDK's
-`CreateStageCommand` declares no such member. `GetStage` reports the settings the way AWS reports
-them.
+above is specific to Yulin and lets a test configure throttling without a template. The SDK's
+`CreateStageCommand` has no such member. `GetStage` reports the settings in the AWS response shape.
 
 ## Authorizing a method
 
@@ -482,8 +466,8 @@ function answers an IAM policy document, evaluated for `execute-api:Invoke` agai
 request being made. Whatever `context` it returns reaches the handler.
 
 A `REQUEST` authorizer sends the whole request to its function (see
-[A REQUEST authorizer](#a-request-authorizer)), so it can identify a caller by several headers
-together or by the query string. It answers the same policy document.
+[A REQUEST authorizer](#a-request-authorizer)). It can identify a caller from several headers or
+query parameters. It answers the same policy document.
 
 ```typescript sim-apigateway-token-authorizer
 /**
@@ -674,9 +658,8 @@ left out.
 | `pathParameters`, `stageVariables`                         | What the resource path captured, and the stage's variables     |
 | `requestContext`                                           | The same block a handler gets, without the `authorizer` member |
 
-The maps are empty objects where the request supplied nothing. An integration event sends `null`
-there, and AWS's own example of the authorizer event sends `{}`, so a function reading
-`event.queryStringParameters.plan` finds nothing rather than throwing.
+The maps are empty objects when the request supplies no values. Integration events use `null` for
+the same fields. AWS's authorizer event examples use `{}`.
 
 ### Answering with a policy
 
@@ -710,8 +693,8 @@ authorizer's own logs, and IAM never sees it.
 ### The context the handler receives
 
 `context` reaches the handler under `requestContext.authorizer`, flattened alongside `principalId`.
-Payload format 2.0 keeps the context in a block of its own, so a handler moved between a REST API and
-an HTTP API reads a different shape.
+Payload format 2.0 keeps the context in its own block. A handler shared with an HTTP API must handle
+both shapes.
 
 An open method has no caller to describe, and leaves `requestContext.authorizer` out of the event
 altogether.
@@ -976,9 +959,8 @@ An admitted caller reaches the handler under `requestContext.identity`.
 | `user`      | The caller's ARN                   |
 | `userArn`   | The caller's ARN                   |
 
-Real API Gateway puts the unique id of the principal in `caller` and `user`, such as `AIDA...` for a
-User. A request carries no such id into the simulation, so the ARN identifying the caller goes in
-every field that can be filled from it.
+Real API Gateway puts the principal's unique ID in `caller` and `user`, such as `AIDA...` for a user.
+The simulation receives only the caller ARN and uses it for each identity field it can populate.
 
 A method of any other authorization type leaves those four `null`, and so does an `AWS_IAM` method
 called by a principal with no ARN behind it. `accessKey`, `apiKey`, `apiKeyId`, `principalOrgId` and
@@ -987,8 +969,8 @@ request itself and are filled for every method.
 
 ## Authorizing a method with a user pool
 
-A `COGNITO_USER_POOLS` authorizer verifies the token itself against the keys the user pools it names
-publish. Nothing is invoked, so there is no function to write and no policy to answer.
+A `COGNITO_USER_POOLS` authorizer verifies the token against the keys published by its user pools.
+It uses no Lambda function or returned policy.
 `CreateAuthorizerCommand` takes the pools as `providerARNs`, and `PutMethodCommand` binds the
 authorizer to a method with `authorizationType: "COGNITO_USER_POOLS"`.
 
@@ -1118,8 +1100,8 @@ two groups arrive as `[Admins Readers]`.
 }
 ```
 
-An HTTP API puts the same claims under `requestContext.authorizer.jwt.claims`, with the scopes
-beside them, so a handler moved between the two reads a different shape.
+An HTTP API puts the same claims under `requestContext.authorizer.jwt.claims`, with scopes beside
+them. A handler shared by both API types must handle both shapes.
 
 ### Scopes
 
@@ -1141,9 +1123,8 @@ token, since an id token carries no `scope` claim at all.
 | A token that has expired, or has no `exp` at all           | 401 `Unauthorized`                                   |
 | A verified token claiming none of the method's scopes      | 403 `User is not authorized to access this resource` |
 
-Every refusal up to and including the claim checks is the same 401, so a client learns that its
-token was not accepted and nothing about which check it failed. An unmet scope is the one 403: the
-token was accepted, and it does not allow this method.
+Token parsing and claim failures return the same 401 response. An unmet scope returns 403 because
+the token was valid but did not allow the method.
 
 The token is taken with or without the `Bearer` scheme in front of it. The identity source is one
 header, as it is for a `TOKEN` authorizer.
@@ -1503,7 +1484,7 @@ AWS sorts what an import finds into three categories, and the third is valid Ope
 leaves unsupported without a request validator. AWS ignores it silently, and so does this:
 `requestBody`, the content schemas under `responses`, `components.schemas`, and an operation's
 `parameters`, `summary`, `description` and `tags`. Request validation is refused at the root of the
-document, so a request whose body contradicts a declared schema still reaches the handler.
+document. A request body is not checked against the declared schema.
 `operationId` is ignored too, since it only supplies the `OperationName` a method carries for
 documentation.
 
@@ -1902,8 +1883,8 @@ and `Stage`, including the template CDK synthesizes from a `RestApi` or a `Lambd
   that is the form the platform's `Headers` hands over. Real API Gateway reports each separately.
 - A Lambda authorizer's `context` reaches the handler as the authorizer returned it. AWS accepts a
   string, a number or a boolean for each value, and how it renders them is not published.
-- A Cognito authorizer reads a `providerARN` for the pool id it names, so a pool in another account
-  is verified against whenever this simulation holds it. `identityValidationExpression`, which real
+- A Cognito authorizer resolves a `providerARN` by pool ID across the simulated accounts.
+  `identityValidationExpression`, which real
   API Gateway matches a token against before verifying it, is outside this.
 - Binary media types negotiated by `Accept`, CORS preflight and gateway responses are outside this.
   A response body is still base64 decoded when the handler says `isBase64Encoded`.

--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -1,11 +1,9 @@
 # Simulated API Gateway HTTP APIs
 
-Yulin includes a simulated API Gateway v2 service, reachable as `simAws.apiGatewayV2()`. It covers
-HTTP APIs with a Lambda proxy integration. A handler that runs behind an HTTP API can be tested
-against a real HTTP request, with no hand-built event to keep in step.
+Yulin simulates API Gateway HTTP APIs with Lambda proxy integrations. Use
+`simAws.apiGatewayV2()` directly or intercept an `ApiGatewayV2Client`.
 
-This is HTTP APIs only. WebSocket APIs and REST APIs (the older API Gateway v1 service, on a
-separate SDK client) are outside it.
+REST APIs use the separate `simAws.apiGateway()` service. WebSocket APIs are unsupported.
 
 ## Creating an API
 
@@ -46,21 +44,19 @@ The endpoint names the API id and the region, as a real one does:
 https://a1b2c3d4e5.execute-api.eu-west-1.amazonaws.com
 ```
 
-A name is a label here, as it is on real AWS. Two APIs in one Account and Region may share a name,
-and only the id tells them apart.
+An API name is a label. Two APIs in the same account and region may share a name. Use the API ID to
+address it.
 
 ## Routing requests to a Lambda function
 
-An API needs three more resources before it serves anything. Those are an integration naming the
-function, a route pointing at that integration, and a stage to serve it from. The function also has to allow API
-Gateway to invoke it. That grant is a permission on the function, not on the API. See
+An API needs an integration, a route and a stage before it can serve requests. The function must
+also grant API Gateway permission to invoke it. See
 [Granting the API permission to invoke the function](#granting-the-api-permission-to-invoke-the-function).
-Once all of that exists, `serveSimAws` answers requests to the generated endpoint by invoking the
-function.
 
-Pass the API endpoint through `srv.localUrl(...)`. It keeps the endpoint's hostname and sends the
-request to the local server, the way it adapts simulated S3 website and Lambda Function URL
-endpoints.
+`serveSimAws` then routes requests from the generated endpoint to the function.
+
+Pass the API endpoint to `srv.localUrl(...)` before making a local HTTP request. The returned URL
+keeps the simulated hostname and points at the local server.
 
 ```typescript sim-apigatewayv2-lambda-proxy
 /**
@@ -152,12 +148,11 @@ Region. It is looked up where its ARN says it is.
 
 ## Granting the API permission to invoke the function
 
-A Lambda proxy integration works once the function's resource policy allows
-`apigateway.amazonaws.com` to invoke it. The console adds that permission for you. An integration
-created through CloudFormation, the CLI or an SDK leaves it to you. That is what
-`AddPermissionCommand` in the example above does. Without it the request is answered with a 500 and
-`{"message":"Internal Server Error"}`, and the handler never runs. CDK's `HttpLambdaIntegration`
-emits the same grant as an `AWS::Lambda::Permission`.
+A Lambda proxy integration requires a resource-based permission for
+`apigateway.amazonaws.com`. Add it with `AddPermissionCommand` or deploy an
+`AWS::Lambda::Permission`. Without the permission, the API returns 500 with
+`{"message":"Internal Server Error"}` and does not invoke the handler. CDK's
+`HttpLambdaIntegration` creates this permission.
 
 Each request is authorized as `lambda:InvokeFunction` on the function ARN, with the caller being the
 service principal `apigateway.amazonaws.com`. The function's own resource policy is the whole
@@ -204,9 +199,8 @@ arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-
 
 A Lambda `REQUEST` authorizer's `AuthorizerUri` takes the same qualifier.
 
-The qualifier is read when the request arrives. A route built on the alias `live` runs whichever
-version `live` points at now, and `UpdateAliasCommand` carries the route to another version with the
-API untouched. (That is how a deployment behind an HTTP API usually moves on AWS.)
+The qualifier is resolved for each request. A route that uses the `live` alias follows changes made
+by `UpdateAliasCommand` without changing the API.
 
 The invoke permission is granted on the qualifier as well. An alias holds a resource policy of its
 own, and a grant made on the function admits an unqualified call and says nothing about `live`. Pass
@@ -336,8 +330,7 @@ was never created does. The endpoint answers 500 and the handler never runs.
 
 ## Route keys
 
-A route key is either the literal `$default` or an upper-case HTTP method and a path separated by one
-space:
+A route key is `$default` or an uppercase HTTP method followed by a path:
 
 ```text
 GET /pets
@@ -370,7 +363,7 @@ Gateway refuses it too is unestablished. This is stricter than AWS is known to b
 
 ## Which route serves a request
 
-More than one route may match a request, and the most specific one takes it. In order:
+When several routes match, Yulin selects one in this order:
 
 1. A route matching the whole path beats a route ending in a greedy parameter, which beats
    `$default`.
@@ -402,9 +395,8 @@ A request whose path matches a route with a different method matches no route at
 
 ## Path parameters and named stages
 
-What a route captured reaches the handler as `event.pathParameters`. A named stage is served under
-its own path segment. Stage selection runs before route selection, and the routes never see the stage
-name.
+Captured route parameters are available as `event.pathParameters`. A named stage uses the first path
+segment. Yulin removes that segment before selecting a route.
 
 ```typescript sim-apigatewayv2-routes
 /**
@@ -529,16 +521,14 @@ left out the same way when the stage has none.
 
 ## Throttling a stage and a route
 
-A stage holds a token bucket for every route it serves. `DefaultRouteSettings` sets the rate and the
-burst those buckets start with, and a `RouteSettings` entry keyed by route key overrides them for the
-route it names. `ThrottlingRateLimit` is requests per second, and `ThrottlingBurstLimit` is how many
-requests a route will take at once.
+Each stage keeps a token bucket per route. `DefaultRouteSettings` sets the default rate and burst.
+`RouteSettings` can override them by route key. `ThrottlingRateLimit` is requests per second and
+`ThrottlingBurstLimit` is the number accepted at once.
 
 A request that finds an empty bucket is answered 429 with `{"message":"Too Many Requests"}`. The
 route's authorizer and its integration are both skipped.
 
-The buckets refill against the simulated clock. Freeze it, spend a route's burst, assert on the 429,
-then move a second on and watch the route serve again.
+Buckets refill against the simulated clock. Advance the clock to test recovery after a 429 response.
 
 ```typescript sim-apigatewayv2-throttling
 /**
@@ -681,8 +671,8 @@ are refused by `CreateStage`. A template carrying one deploys, and the member it
 
 ## Protecting a route with a Cognito user pool
 
-A JWT authorizer verifies a signed token before the integration is invoked. `CreateAuthorizerCommand`
-creates one, and a route asks for it with `AuthorizationType: "JWT"` and the authorizer's id.
+A JWT authorizer verifies a signed token before invoking the integration. Create it with
+`CreateAuthorizerCommand`, then set `AuthorizationType: "JWT"` and `AuthorizerId` on the route.
 
 The issuer is a URL. Point it at a [simulated Cognito user pool](https://yulinsim.dev/services/cognito/ "Simulated Cognito docs")
 and the pool's own signing key verifies the token. A token from `InitiateAuthCommand` or
@@ -852,9 +842,8 @@ console.log(expired.status); // 401
 await srv.close();
 ```
 
-The verification is real. The token is parsed, its `alg` has to be `RS256`, its `kid` has to name a
-key the issuer publishes, and the signature is checked against that key with `node:crypto`. The whole
-check runs in process, with no network fetch and no verification library.
+Yulin parses the token, requires `alg` to be `RS256`, resolves `kid` against the issuer's keys and
+checks the signature with `node:crypto`. Verification runs in process.
 
 ### What a refused request gets back
 
@@ -933,9 +922,8 @@ left out of its events entirely.
 
 ## Protecting a route with IAM
 
-A route declared `AuthorizationType: "AWS_IAM"` reaches its integration only when the caller is
-allowed `execute-api:Invoke` on the ARN of the route being called. IAM itself decides. The route takes
-no authorizer, and naming one is refused.
+A route with `AuthorizationType: "AWS_IAM"` requires `execute-api:Invoke` on the request ARN. The
+route has no separate authorizer.
 
 The caller comes from the request, through either a SigV4 signature or an `x-sim-aws-caller` header
 naming a principal directly. A request offering neither is anonymous, owns no policies, and is
@@ -948,14 +936,13 @@ The ARN a request is authorized against is:
 arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>
 ```
 
-- The Account and Region are the API's own, not the caller's.
+- The account and region identify the API.
 - The stage is the one that served the request, so `$default` for the default stage.
 - The method is the one the client sent, upper case. A `GET` reaching a route keyed `ANY /orders`
   gives `GET`.
-- The path is the request path with the stage segment and the leading slash taken off, so
-  `/dev/orders/42` served from stage `dev` gives `orders/42`. This is the path asked for, not the route
-  key, because a policy is written against it by hand. A request to the API root gives an ARN ending
-  `/GET/`.
+- The path is the request path without the stage segment or leading slash. `/dev/orders/42` on stage
+  `dev` becomes `orders/42`. It uses the requested path, including resolved parameter values. A
+  request to the API root produces an ARN ending in `/GET/`.
 
 An identity policy may wildcard any part of that. `<apiId>/*`, `<apiId>/$default/*` and
 `<apiId>/*/GET/orders/*` all allow a `GET` of `/orders/42` on the default stage.
@@ -1132,13 +1119,13 @@ Account.
 
 ## Protecting a route with a Lambda authorizer
 
-A Lambda `REQUEST` authorizer runs a function of its own before the integration is invoked, and that
-function decides. `CreateAuthorizerCommand` with `AuthorizerType: "REQUEST"` creates one, and a route
-asks for it with `AuthorizationType: "CUSTOM"` and the authorizer's id.
+A Lambda `REQUEST` authorizer invokes a function before the integration. Create it with
+`AuthorizerType: "REQUEST"`, then configure the route with `AuthorizationType: "CUSTOM"` and the
+authorizer ID.
 
-`IdentitySource` is what the request has to carry before the function is invoked at all. Each entry
-is `$request.header.<name>` or `$request.querystring.<name>`, and a request missing any one of them is
-refused without the function running.
+`IdentitySource` lists values required before invoking the authorizer. Each entry is
+`$request.header.<name>` or `$request.querystring.<name>`. A missing value returns 401 without running
+the function.
 
 `EnableSimpleResponses: true` asks the function for `{ isAuthorized, context }`. With it off, the
 function answers a `principalId` and an IAM `policyDocument` instead. Either way, the `context` it
@@ -1357,9 +1344,8 @@ is a different grant from the integration's, and a function used for both needs 
 
 ### Caching the authorizer's decision
 
-`AuthorizerResultTtlInSeconds` holds a decision for that many seconds, and a request presenting the
-same identity source values within it is served from that decision without the function running
-again. AWS accepts up to 3600. The default, 0, holds no decision at all.
+`AuthorizerResultTtlInSeconds` caches a decision by identity source values. AWS accepts values up to
+3,600 seconds. The default of zero disables caching.
 
 The key is the identity source values and nothing else, so one decision covers every route of the API
 that uses the authorizer. Adding `$context.routeKey` as an identity source puts the route in the key.
@@ -1517,8 +1503,7 @@ ran.
 
 ## The event the handler receives
 
-The handler is invoked with the API Gateway HTTP API payload format 2.0 event, exported as
-`SimPayload2Event`:
+The handler receives a payload format 2.0 event, exported as `SimPayload2Event`:
 
 ```json
 {
@@ -1630,9 +1615,8 @@ endpoint, and has
 
 ## The response the handler returns
 
-A handler returning an object with a `statusCode` produces that HTTP response. Its `headers` are
-sent as headers, its `cookies` become `set-cookie` headers, and an empty body is sent as no body,
-leaving a 204 a valid response.
+A result with `statusCode` becomes the HTTP response. `headers` are sent as response headers,
+`cookies` become `set-cookie` headers and an omitted body stays empty.
 
 A handler returning anything else produces a 200 whose body is that value as JSON. That includes an
 object with no `statusCode` in it. A handler returning `{ body: "hi" }` produces a 200 whose body is
@@ -1640,8 +1624,8 @@ the JSON `{"body":"hi"}` with `content-type: application/json`. Real API Gateway
 
 ## Reading an API back
 
-`GetApisCommand`, `GetIntegrationsCommand`, `GetRoutesCommand` and `GetStagesCommand` list what an
-API has. Each answers in full, as paging is outside the simulation.
+`GetApisCommand`, `GetIntegrationsCommand`, `GetRoutesCommand` and `GetStagesCommand` list the API's
+resources. Each command returns all results because pagination is unsupported.
 
 ```typescript sim-apigatewayv2-list-resources
 /**
@@ -1684,10 +1668,9 @@ console.log(stages.Items[0]?.StageVariables);
 
 ## Deleting what an API has
 
-`DeleteRouteCommand`, `DeleteIntegrationCommand` and `DeleteStageCommand` each take one resource off
-an API and leave the rest of it in place. A deleted route stops matching, and a request that used to
-reach it is answered the way any unmatched request is. A deleted stage stops resolving. A request
-addressed to it finds no stage, while the routes it served are still served by the API's other stages.
+`DeleteRouteCommand`, `DeleteIntegrationCommand` and `DeleteStageCommand` remove one resource. A
+deleted route stops matching. Deleting a stage removes its URL while leaving the API's routes
+available through other stages.
 
 An integration a route still points at cannot be deleted. That is a `BadRequestException` naming the
 routes in the way, as it is on real AWS, and an API comes apart routes first and then the integrations
@@ -1761,8 +1744,7 @@ const integrations = await apiGateway.getIntegrations(
 console.log(routes.Items.length, integrations.Items.length);
 ```
 
-`DeleteApiCommand` deletes the API and everything under it, so taking a whole API away needs none of
-these.
+`DeleteApiCommand` deletes the API and all of its resources.
 
 ## Turning the generated endpoint off
 
@@ -1774,9 +1756,8 @@ status nor the body for that case, so both are what a disabled endpoint was obse
 
 ## Serving an API on a custom domain name
 
-`CreateDomainNameCommand` creates a domain that answers on a hostname the project owns.
-`CreateApiMappingCommand` points a base path of that domain at one API and one of its stages. A
-domain with no mapping answers 404 to everything.
+`CreateDomainNameCommand` creates a custom domain. `CreateApiMappingCommand` maps a base path to an
+API stage. A domain with no mapping returns 404.
 
 An empty `ApiMappingKey` maps the root of the domain. Every request reaching the domain goes to that
 API, with the path as the client sent it. A non-empty key is one or more path segments (`orders`,

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1,12 +1,11 @@
 # Simulated CloudFormation
 
-Yulin includes a simulated CloudFormation service for tests and local development. It creates
-simulated AWS resources from CloudFormation templates, and works with hand-written templates, AWS
-SDK-style `CreateStackCommand` calls, or synthesized CDK template files.
+Yulin deploys CloudFormation templates into a simulated AWS environment. It accepts inline
+templates, AWS SDK command inputs, template files and synthesized CDK cloud assemblies.
 
 ## Basic usage
 
-Create a simulated AWS environment, get simulated CloudFormation, and deploy a template.
+Call `deployTemplate(...)` with a template and wait for the stack to finish deploying.
 
 ```typescript sim-cloudformation-basic-template
 /**
@@ -84,7 +83,7 @@ console.log(simAws.s3().getSimBucketByName("typed-site-bucket")?.bucketName);
 
 ## Creating stacks with AWS SDK command shapes
 
-You can also use AWS SDK-style CloudFormation commands.
+Use `createStack(...)` when the code under test works with AWS SDK command shapes.
 
 ```typescript sim-cloudformation-create-stack-command
 /**
@@ -263,11 +262,9 @@ await simAws.backgroundTasksComplete();
 
 ## Updating a stack
 
-`UpdateStackCommand` applies a changed template to a stack that is already deployed. Resources the
-new template adds are created, resources it drops are deleted, and resources it changed are
-replaced. Everything else is left alone, holding whatever it holds in simulated S3, DynamoDB or
-anywhere else. That is what lets a long-running local process pick up an infrastructure change
-without restarting and losing its data.
+`UpdateStackCommand` applies a changed template to an existing stack. It creates added resources,
+deletes removed resources and replaces changed resources. Unchanged resources keep their simulated
+state.
 
 ```typescript sim-cloudformation-update-stack
 /**
@@ -352,11 +349,9 @@ could mean nothing else.
 
 ### What counts as a change
 
-Resources are compared as they resolve, not as they are written. A changed parameter value shows up
-as a changed resource even when the template body is identical, and a template reordered without
-being changed shows up as no change at all. Outputs are compared the same way. The rest of the
-template body is compared as written. A change to a section the simulator ignores, such as
-`Description`, is still an update.
+Yulin compares resolved resources and outputs. Changing a parameter can therefore change a resource
+without changing the template body. Reordering an unchanged template has no effect. Other template
+sections are compared as written, including ignored sections such as `Description`.
 
 A template that changes nothing at all is refused with a `ValidationError` reading
 `No updates are to be performed.`, the same answer CloudFormation gives. So is an update asked for
@@ -436,12 +431,11 @@ An update from the held template with the deployed values changes nothing, and i
 
 ### Changed resources are replaced
 
-A resource whose template entry changed is deleted and created again from the new template. Real
-CloudFormation updates most properties in place and keeps what the resource holds. That makes this a
-divergence worth knowing about. A bucket that gains a property loses its objects here, where in AWS
-it would keep them. In-place update is the obvious next step, still to be built.
+Yulin replaces a resource when its resolved template entry changes. It deletes the old resource and
+creates a new one. AWS updates many properties in place. A simulated bucket therefore loses its
+objects when a property change replaces it.
 
-Three things follow from replacement:
+Replacement also affects dependencies and retention policies:
 
 - A resource naming a replaced resource is replaced too, all the way up the dependency chain, and
   nothing is left pointing at a resource that has gone. Real CloudFormation hands the dependent the
@@ -618,9 +612,8 @@ to create. Name the replacement in the template, as the example above does, to h
 
 ## Deploying through a change set
 
-A change set says what a template would do to a stack before anything happens to it. `cdk deploy`
-goes through one by default, and so does any deployment script that wants to see what an update will
-touch. Simulated CloudFormation serves `CreateChangeSetCommand`, `DescribeChangeSetCommand`,
+A change set describes a proposed stack operation without applying it. Simulated CloudFormation
+serves `CreateChangeSetCommand`, `DescribeChangeSetCommand`,
 `ExecuteChangeSetCommand`, `DeleteChangeSetCommand` and `ListChangeSetsCommand`.
 
 ```typescript sim-cloudformation-change-set
@@ -735,8 +728,7 @@ holds, in the order they were created.
 
 ## Deleting a stack
 
-`DeleteStackCommand` deletes the resources a stack created, in the reverse of the order they were
-created in, and then releases the stack name.
+`DeleteStackCommand` deletes resources in reverse creation order, then releases the stack name.
 
 ```typescript sim-cloudformation-delete-stack
 /**
@@ -801,9 +793,8 @@ Deleting a stack name that was never deployed succeeds, as it does in CloudForma
 
 ### When a resource cannot be deleted
 
-Some resources refuse to go, the same way they do in AWS. An S3 bucket that still holds objects is
-the common one. CloudFormation fails there and never empties the bucket for you. That is why CDK
-ships an `autoDeleteObjects` custom resource.
+Resource deletion can fail. For example, S3 refuses to delete a non-empty bucket. CloudFormation
+leaves the stack in `DELETE_FAILED` and does not empty the bucket automatically.
 
 A refusal leaves the stack in `DELETE_FAILED` with the reason on it, and keeps the stack name in use.
 `waitForStackDeleteComplete(...)` rethrows the error, and `DescribeStacksCommand` reports it as
@@ -896,7 +887,7 @@ takes either.
 
 ## Parameters
 
-Template parameters can be supplied when creating a stack.
+Pass template parameter values when creating or updating a stack.
 
 ```typescript sim-cloudformation-parameters
 /**
@@ -949,7 +940,7 @@ the type.
 
 ## Intrinsic functions
 
-Sim CloudFormation supports common intrinsic functions used by supported resources.
+Yulin resolves the following intrinsic functions in resource properties and outputs.
 
 ### `Ref`
 
@@ -991,8 +982,8 @@ console.log(
 );
 ```
 
-For supported resource types, `Ref` returns the resource-specific CloudFormation value. For example,
-an S3 Bucket `Ref` returns the Bucket name.
+`Ref` returns the CloudFormation value for a resource type. For an S3 bucket, it returns the bucket
+name.
 
 ### `Fn::GetAtt`
 
@@ -1251,8 +1242,8 @@ console.log(simAws.s3().getSimBucketByName("docs-site-bucket")?.bucketName);
 
 ### `Fn::FindInMap`
 
-A template `Mappings` section holds two levels of keys against a value. `Fn::FindInMap` reads one of
-those values, given the map name, the top-level key and the second-level key.
+A template `Mappings` section stores values under two levels of keys. `Fn::FindInMap` reads a value
+using the map name and both keys.
 
 ```typescript sim-cloudformation-fn-find-in-map
 /**
@@ -1330,9 +1321,7 @@ expression. A lookup that finds its value in the map ignores the default.
 
 ### `Fn::Split` and `Fn::Select`
 
-`Fn::Split` cuts a string into a list on a delimiter. `Fn::Select` reads one value out of a list by
-its zero-based index. They are usually written together, to pull one part out of a string another
-resource gave.
+`Fn::Split` divides a string by a delimiter. `Fn::Select` reads a list value by zero-based index.
 
 ```typescript sim-cloudformation-fn-select-split
 /**
@@ -1418,8 +1407,7 @@ resource and the property path the value sat at, for example
 
 ### `Fn::ImportValue`
 
-`Fn::ImportValue` reads a value another Stack exported. A Stack exports one by giving an Output an
-`Export.Name`, and a Stack in the same Account and Region imports it by that name.
+`Fn::ImportValue` reads a named output exported by another stack in the same account and region.
 
 CDK writes both halves on its own. Referencing a resource in another Stack of the same app puts an
 `Export` on the producer and an `Fn::ImportValue` on the consumer, with no opt-in.
@@ -1486,8 +1474,8 @@ exports published in that Region.
 
 ## Dynamic references
 
-A `{{resolve:...}}` dynamic reference reads a value from another service while a resource is being
-created. It is written into the template as ordinary text, so it can sit inside a longer string.
+A `{{resolve:...}}` dynamic reference reads an SSM parameter or Secrets Manager secret while
+creating a resource. A reference can appear inside a longer string.
 
 `Fn::Sub` and `Fn::Join` resolve first, and the reference is read from the string they built. CDK
 writes that shape whenever a secret sits in the same stack as the resource reading it (the secret's
@@ -1506,9 +1494,8 @@ for the segments and for what a reference Secrets Manager cannot answer resolves
 
 ## Conditions
 
-A template `Conditions` section names boolean expressions over the stack's parameter values. A
-condition decides whether a resource is created, and which value `Fn::If` gives a property or an
-output.
+The `Conditions` section defines boolean expressions over parameter and pseudo-parameter values.
+Conditions control resource creation and select `Fn::If` values.
 
 ```typescript sim-cloudformation-conditions
 /**
@@ -1632,7 +1619,7 @@ condition the template leaves undefined fails the deployment.
 
 ## Resource dependencies
 
-Resources can depend on each other explicitly with `DependsOn`.
+Use `DependsOn` to declare an explicit resource dependency.
 
 ```typescript sim-cloudformation-depends-on
 /**
@@ -1765,8 +1752,7 @@ in the assembly, and a Stack named in `stackOptions` carries its own.
 
 ## Deploying synthesized CDK templates
 
-Use `deployTemplateFile(...)` to deploy a template file, including the JSON templates CDK synthesis
-produces.
+Use `deployTemplateFile(...)` to deploy a JSON or YAML template file, including CDK synth output.
 
 ```typescript sim-cloudformation-cdk-template-file
 /**
@@ -1805,8 +1791,7 @@ const stack = await simAws.cloudFormation().deployTemplateFile({
 await stack.waitForDeployComplete();
 ```
 
-This is useful for local integration tests where you want CDK to produce the template, then Yulin to
-create the simulated resources from that synthesized output template.
+This lets an integration test synthesize with CDK and deploy the resulting template through Yulin.
 
 A template path with no file at it is refused with
 `No Sim CloudFormation template file at <path>`, naming the resolved path. A synthesized template
@@ -1814,8 +1799,7 @@ is build output, and a checkout that has yet to synthesize one meets this on the
 
 ## Deploying a template written as YAML
 
-CloudFormation takes a template in JSON or in YAML, and a template written by hand is usually YAML.
-`deployTemplateFile(...)` reads a `.yaml` or `.yml` file as YAML.
+`deployTemplateFile(...)` parses `.yaml` and `.yml` files as YAML.
 
 ```yaml
 Resources:
@@ -3250,10 +3234,10 @@ another function's event put there.
 Two shapes are refused rather than expanded. A bucket writing its `NotificationConfiguration` or its
 `LambdaConfigurations` as an intrinsic such as `Fn::If` is one, because there is no appending to a
 list CloudFormation has not resolved yet, and adding the event's own entries would drop whatever the
-intrinsic resolved to. The other is a function the template conditions out, which real CloudFormation
-refuses for the same reason SAM cannot fix it: the notification belongs to the bucket, the bucket is
-not conditioned, and nothing can condition one entry of somebody else's property. Condition the
-bucket along with the function, or declare the notification on the bucket yourself.
+intrinsic resolved to. The other is a function the template conditions out. Real CloudFormation
+refuses this because the notification belongs to the unconditioned bucket, and one entry of that
+property cannot have its own condition. Condition the bucket along with the function, or declare the
+notification on the bucket yourself.
 
 ### Simple tables
 

--- a/docs/services/cloudfront/README.md
+++ b/docs/services/cloudfront/README.md
@@ -1,18 +1,12 @@
 # Simulated CloudFront
 
-Yulin includes a simulated CloudFront service for tests and local development.
+Yulin simulates CloudFront distributions, origins, cache behaviour and edge functions. Use
+`simAws.cloudFront()` as part of a simulated AWS environment or create a standalone
+`SimCloudFront`. `serveSimAws` exposes distributions over localhost.
 
-Sim CloudFront can be used directly through `SimAws`, and it can also be served on localhost
-alongside other simulated AWS services, so application code can make HTTP requests through a
-CloudFront-like layer without talking to real AWS.
+## Create a distribution
 
-`SimCloudFront` can also be instantiated on its own, in which case it has its own isolated state,
-standing apart from any wider simulated AWS environment.
-
-## Basic Distribution setup
-
-Create a simulated AWS environment, add a sim S3 Bucket, and create a sim CloudFront Distribution
-pointing at that Bucket.
+Create an S3 bucket, then create a distribution whose origin uses the bucket's REST endpoint.
 
 ```typescript sim-cloudfront-distribution-s3-origin
 /**
@@ -95,19 +89,16 @@ console.log(distributionCreation.Distribution?.DomainName);
 
 ## What an S3 Origin can read
 
-An S3 Origin reads its Bucket through the ordinary GetObject command. The Bucket policy decides what
-the Distribution can serve. An Origin with no origin access control reads anonymously, the unsigned
-request real CloudFront sends to the S3 REST endpoint. An Object has to be publicly readable for the
-Distribution to serve it, and a Bucket with no policy answers 403 for every Object.
+An S3 Origin reads its bucket through `GetObject`. The bucket policy decides what the distribution
+can serve. Without an origin access control, CloudFront reads anonymously and the object must be
+publicly readable. A private bucket returns 403.
 
 An Origin that does have an origin access control reads as the CloudFront service principal. The
 Bucket stays private and its policy names the Distribution. See
 [Origin access controls](#origin-access-controls) for the Bucket policy that takes.
 
-That is what the two commands in the example above do. `PutPublicAccessBlockCommand` opts out of the
-block on public Bucket policies, then `PutBucketPolicyCommand` grants `s3:GetObject` to
-`Principal: "*"`. The same pair is what a static website Bucket needs, and it is what CDK's
-`publicReadAccess: true` generates.
+The example disables the block on public bucket policies, then grants `s3:GetObject` to
+`Principal: "*"`. CDK's `publicReadAccess: true` produces the same result.
 
 A denied read reaches the viewer as a 403 from the Origin, and a Distribution's custom error
 response for 403 replaces it. The usual single-page-app setup, rewriting 403 to `/index.html`,
@@ -118,10 +109,8 @@ an Origin that signs nothing.
 
 ## Static sites, default root objects and error pages
 
-A static site behind CloudFront usually leans on two Distribution settings. `DefaultRootObject`
-makes a request for the site root return the home page. `CustomErrorResponses` makes a URL that
-matches no object return the site's own error page in place of the Origin's. Sim CloudFront applies
-both, and a test can assert what a visitor would actually see.
+`DefaultRootObject` maps the distribution root to an object such as `index.html`.
+`CustomErrorResponses` replaces selected Origin errors with another object and status code.
 
 ```typescript sim-cloudfront-static-site
 /**
@@ -242,13 +231,10 @@ try {
 }
 ```
 
-The default root object stands in for a request to the root of the Distribution and nothing else. A
-request for `/blog/` is passed to the Origin as it arrived, even where that folder holds its own
-`index.html`. That is where CloudFront differs from an S3 website index document. The substituted
-path is what the rest of request handling sees, and a Cache Behavior pattern and a `viewer-request`
-CloudFront Function both act on the object being served. The value names an object at the Origin. It may be a
-path such as `public/index.html`, and it must not begin with a forward slash. Sim CloudFront refuses one that does with `InvalidDefaultRootObject`. The alternative would
-be a Distribution that answers its own root with a 403.
+The default root object applies only to `/`. A request for `/blog/` reaches the Origin unchanged,
+even if the Origin contains `/blog/index.html`. Cache Behaviors and viewer-request functions see the
+substituted root path. The value may contain a path such as `public/index.html`, but it must not start
+with `/`. Invalid values raise `InvalidDefaultRootObject`.
 
 A custom error response replaces the Origin's response when its status matches `ErrorCode`. The
 codes CloudFront supports are 400, 403, 404, 405, 414, 416, 500, 501, 502, 503 and 504. The response
@@ -276,7 +262,7 @@ status the Distribution serves no page for. See
 
 ## Serve simulated CloudFront on localhost
 
-Use `serveSimAws` when you want to make real HTTP requests to the simulated system on localhost.
+Use `serveSimAws` to send HTTP requests through the simulated distribution on localhost.
 
 ```typescript serve-sim-cloudfront-localhost
 /**
@@ -390,15 +376,14 @@ the Distribution behind it. See
 
 ## Custom Origins
 
-An Origin with a `CustomOriginConfig` is one CloudFront reaches over HTTP, in place of reading an S3
-Bucket. Sim CloudFront resolves its `DomainName` in the simulated environment and serves the request
-in process. A Distribution can front a simulated HTTP API endpoint
+An Origin with `CustomOriginConfig` routes requests to another simulated HTTP service. CloudFront
+resolves `DomainName` in the simulated environment and serves the request in process. A distribution
+can front a simulated HTTP API endpoint
 (`<api-id>.execute-api.<region>.amazonaws.com`), a simulated Lambda Function URL
 (`<url-id>.lambda-url.<region>.on.aws`), or anything a simulated Route53 record points at one of
 those.
 
-That covers the common arrangement of one Distribution serving static assets from a Bucket and
-sending `/api/*` to an API:
+The following distribution serves static files from S3 and sends `/api/*` to an HTTP API:
 
 ```typescript sim-cloudfront-distribution-custom-origin
 /**
@@ -568,14 +553,13 @@ try {
 }
 ```
 
-The Origin domain is resolved when a request is served, and the Distribution and the service behind
-its Origin can be created in either order, whichever way round a CloudFormation template happens to
-declare them.
+The Origin domain is resolved for each request. The distribution and Origin service may be created
+in either order.
 
 `OriginPath` is prefixed to the request path, as it is for an S3 Origin. An Origin path of `/v1`
 sends a request for `/things` on to `/v1/things`.
 
-Three things follow from the request never leaving the process:
+In-process routing has these limits:
 
 - A domain unknown to the simulation fails with an error naming the Origin and the
   domain. No real request is made to it, and external HTTP Origins are unsupported.
@@ -588,10 +572,9 @@ Three things follow from the request never leaving the process:
 
 ## Custom headers on an Origin
 
-CloudFront adds an Origin's custom headers to every request it sends that Origin. An origin that
-answers only requests carrying a header nothing else knows is how AWS documents
-[restricting a custom origin to CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-overview.html#forward-custom-headers-restrict-access),
-and a sim Distribution sends them the same way.
+CloudFront adds an Origin's custom headers to every request sent to that Origin. A service can use a
+private header value to
+[restrict access to CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-overview.html#forward-custom-headers-restrict-access).
 
 The CloudFront API and CloudFormation name the field differently, and both spellings are accepted
 here. The API has `CustomHeaders` inside an `Origin`, and `AWS::CloudFront::Distribution` has
@@ -741,10 +724,10 @@ An S3 Origin takes the headers and reaches nothing with them. Sim CloudFront rea
 `GetObject` and builds no HTTP request for a header to travel on, and real S3 ignores a header it
 has no use for.
 
-## An Origin declared twice
+## Duplicate Origins
 
-Two Origins over one domain name are ordinary. They differ by `OriginPath`, by their custom headers
-or by how CloudFront connects, and a Behavior points at whichever one it wants.
+Several Origins may use the same domain when their paths, headers, or connection settings differ.
+Each Behavior selects an Origin by ID.
 
 Two Origins that match in every property but the `Id` are one Origin written twice. Copying a
 Behavior and its Origin together, then editing the path pattern, leaves exactly that behind. Sim
@@ -840,9 +823,8 @@ value however they were ordered or cased.
 
 ## Viewer certificates
 
-A Distribution with alternate domain names needs an ACM certificate, and CloudFront accepts only
-certain ones. Sim CloudFront applies the same rules. A Distribution that real CloudFront would
-reject at deploy time is rejected here first, with `InvalidViewerCertificate`:
+A distribution with alternate domain names requires a valid ACM certificate. Yulin raises
+`InvalidViewerCertificate` when:
 
 - the certificate must be in `us-east-1`, wherever the rest of your infrastructure lives
 - the certificate must exist and be `ISSUED`
@@ -912,8 +894,8 @@ as well.
 
 ## Disabling and deleting a Distribution
 
-`DeleteDistributionCommand` removes a Distribution. CloudFront will only delete one that has stopped
-serving. The sequence is `UpdateDistributionCommand` with `Enabled: false` first, then the deletion. Deleting an enabled Distribution answers `DistributionNotDisabled`, as it does in AWS.
+Disable a distribution with `UpdateDistributionCommand` before deleting it. Deleting an enabled
+distribution raises `DistributionNotDisabled`.
 
 `UpdateDistributionCommand` takes a whole `DistributionConfig`, and applies the update as a
 replacement. Anything left out of the new config is dropped, including alternate domain names and
@@ -1012,17 +994,16 @@ Function code.
 
 ## Simulated CloudFront Functions
 
-The sim CloudFront supports `viewer-request` and `viewer-response` CloudFront Functions.
+Yulin supports `viewer-request` and `viewer-response` CloudFront Functions.
 
 A `viewer-response` Function runs for an Origin status below 400. CloudFront skips the
 viewer-response event once the Origin has answered 400 or higher (see
 [Limitations](#limitations)), and so does this simulation.
 
-Use `makeCffFunctionCodeInput` to pass a JavaScript handler function to `CreateFunctionCommand`, or
+Use `makeCffFunctionCodeInput` to pass a JavaScript handler to `CreateFunctionCommand`. Use
 [CloudFormation bindings](https://yulinsim.dev/services/cloudformation/#cloudfront-function-bindings "CloudFront Function bindings usage docs")
-to back a template Resource with one. A handler reference is what to reach for first. It stops on a
-breakpoint and can close over the test's own state. Publish the source itself where the test is
-about the code the Distribution carries, down to the 10 KB it has to fit in. A
+for a function declared in a template. Handler references support breakpoints and local state. Use
+source code when the test covers the deployed function or its 10 KB size limit. A
 [Lambda@Edge](#simulated-lambdaedge) function is an ordinary simulated Lambda function, and the same
 choice covers it.
 
@@ -1851,8 +1832,7 @@ parameter holding the version ARN into a support stack in us-east-1. The stack u
 reads that parameter back through a `Custom::CrossRegionStringParameterReader` resource, and the
 Behavior's `LambdaFunctionARN` is an `Fn::GetAtt` on it. Simulated CloudFormation makes that read
 itself, against the Region the resource names, and the association ends up holding the ARN the
-support stack published. Both stacks have to deploy, which is what deploying the whole cloud
-assembly does:
+support stack published. Deploy the whole cloud assembly to deploy both stacks:
 
 ```typescript
 await simAws.cloudFormation().deployCdkOut("cdk.out");
@@ -2014,8 +1994,8 @@ answered.
 ## Response headers policies
 
 A response headers policy sets headers on everything a cache Behavior serves. Declare one as
-`AWS::CloudFront::ResponseHeadersPolicy` and point a Behavior's `ResponseHeadersPolicyId` at it with
-a `Ref`, which is what CDK's `ResponseHeadersPolicy` construct synthesizes.
+`AWS::CloudFront::ResponseHeadersPolicy` and reference it from the Behavior's
+`ResponseHeadersPolicyId`. CDK's `ResponseHeadersPolicy` construct synthesizes this shape.
 
 ```typescript sim-cloudfront-response-headers-policy
 /**
@@ -2206,9 +2186,9 @@ it.
 
 ## Cache policies
 
-A cache policy decides what a cache Behavior keys its cache on and how long an object stays there.
-Declare one as `AWS::CloudFront::CachePolicy` and point a Behavior's `CachePolicyId` at it with a
-`Ref`, which is what CDK's `CachePolicy` construct synthesizes.
+A cache policy controls the cache key and time to live. Declare one as
+`AWS::CloudFront::CachePolicy` and reference it from the Behavior's `CachePolicyId`. CDK's
+`CachePolicy` construct synthesizes this shape.
 
 ```typescript sim-cloudfront-cache-policy
 /**
@@ -2652,8 +2632,8 @@ try {
 
 The Origin's own headers and the cache policy settle the TTL between them, the way they settle it in
 AWS. `s-maxage` is preferred to `max-age`, and `max-age` to `Expires`. Whatever the Origin asks for
-is held between the policy's `MinTTL` and `MaxTTL`. An Origin that asks for nothing gets the greater
-of `MinTTL` and `DefaultTTL`, which is a day on `CachingOptimized`.
+is held between the policy's `MinTTL` and `MaxTTL`. When the Origin supplies no cache lifetime,
+CloudFront uses the greater of `MinTTL` and `DefaultTTL`. `CachingOptimized` uses one day.
 
 An `Expires` header has to carry one of the three date formats HTTP allows. Anything else, a
 locale-formatted date included, is read as an object that expired already, the way any HTTP cache
@@ -2878,10 +2858,9 @@ different paths is `InvalidationBatchAlreadyExists`.
 
 ## Origin request policies
 
-An origin request policy decides which of the viewer's headers, cookies and query strings a cache
-Behavior carries to its Origin. Declare one as `AWS::CloudFront::OriginRequestPolicy` and point a
-Behavior's `OriginRequestPolicyId` at it with a `Ref`, which is what CDK's `OriginRequestPolicy`
-construct synthesizes.
+An origin request policy selects the viewer headers, cookies and query strings sent to the Origin.
+Declare one as `AWS::CloudFront::OriginRequestPolicy` and reference it from the Behavior's
+`OriginRequestPolicyId`. CDK's `OriginRequestPolicy` construct synthesizes this shape.
 
 ```typescript sim-cloudfront-origin-request-policy
 /**
@@ -3171,9 +3150,9 @@ Behavior names one without a template creating anything. `AllViewer`
 for it. CDK's `OriginRequestPolicy.ALL_VIEWER` and its seven siblings synthesize those IDs. A stack
 reaching for one deploys.
 
-Each also carries the three sections AWS publishes for it. A Behavior on `AllViewer` here sends the
-Origin everything the viewer sent bar its `Host`, which is the Origin's own domain under every
-policy. One on `CORS-CustomOrigin` sends the `Origin` header alone. One on
+Each also carries the three sections AWS publishes for it. A Behavior on `AllViewer` sends every
+viewer value except `Host`. The Origin's domain is used for `Host` under every policy. A Behavior on
+`CORS-CustomOrigin` sends the `Origin` header alone. One on
 `AllViewerExceptHostHeader` sends what `AllViewer` sends, since the `Host` it withholds was never
 the viewer's here.
 
@@ -3189,10 +3168,9 @@ Behavior, the way an absent cache policy does, and the Behavior reports no polic
 
 ## Origin access controls
 
-An origin access control is how a Distribution authenticates to a private Origin. The Origin then
-admits the Distribution and nothing else. Declare one as `AWS::CloudFront::OriginAccessControl` and
-point an Origin's `OriginAccessControlId` at it with a `Ref`, which is what CDK's
-`S3BucketOrigin.withOriginAccessControl` synthesizes.
+An origin access control lets a Distribution authenticate to a private Origin. Declare one as
+`AWS::CloudFront::OriginAccessControl` and reference it from the Origin's `OriginAccessControlId`.
+CDK's `S3BucketOrigin.withOriginAccessControl` synthesizes this shape.
 
 An `OriginAccessControlOriginType` of `s3` signs for an S3 Bucket Origin, and one of `lambda` signs
 for a Lambda Function URL Origin. The origin type has to match the Origin it is attached to. An `s3`
@@ -3635,11 +3613,9 @@ CloudFront. `await simAws.backgroundTasksComplete()` waits for that.
 
 ### ETags
 
-The key value store commands do check `IfMatch`, where the Distribution and Function commands ignore
-it. Both APIs require it on every write and CloudFront refuses a stale one, which is what stops two
-writers overwriting each other. A write carrying a stale ETag is refused with `PreconditionFailed`,
-and a caller has to thread the ETag through the way it does against CloudFront. Each write returns
-the new ETag for the next one.
+Key value store commands check `IfMatch`. Distribution and Function commands ignore it. Both key
+value store APIs require the current ETag for every write. A stale ETag raises
+`PreconditionFailed`, and each successful write returns the ETag for the next one.
 
 A store has two ETags and they are not interchangeable, as in AWS. Each `DescribeKeyValueStore`
 returns its own. The CloudFront client's versions the store's configuration, and the key value store
@@ -3993,8 +3969,8 @@ Where sim CloudFront knowingly behaves differently from AWS:
   response an `origin-request` function generated has no Origin status behind it, and its own status
   stands in.
 - **CloudFront's disallowed and read-only header lists go unchecked.** Real CloudFront answers 502
-  when an edge function adds `Connection` or edits `Content-Length`. Both kinds of function here
-  write what they like, apart from the viewer-request `host`, which is restored.
+  when an edge function adds `Connection` or edits `Content-Length`. Yulin accepts those changes.
+  It restores the `host` after a viewer-request function.
 - **An S3 Origin with no origin access control reads its Bucket anonymously.** That is the unsigned
   request real CloudFront sends to the S3 REST endpoint without one. The Bucket policy has to make
   an Object publicly readable for the Distribution to serve it. A legacy
@@ -4020,9 +3996,9 @@ Where sim CloudFront knowingly behaves differently from AWS:
   are absent, and `AWS::CloudFront::OriginAccessControl` is the only way to make one.
 - **A list's `Quantity` is only checked when it is there.** Every CloudFront list carries a count
   alongside its items, and a `Quantity` that disagrees with `Items` is refused with
-  `InconsistentQuantities`, as CloudFront refuses it. A list arriving as a plain array, which is the
-  CloudFormation shape, has no count to disagree with, and a template goes unchecked this way. So
-  does a hand-written `{ Items: [...] }` with the count left out. The AWS SDK types make omitting
+  `InconsistentQuantities`, as CloudFront refuses it. CloudFormation uses a plain array without a
+  count, so templates skip this validation. A hand-written `{ Items: [...] }` also skips it when the
+  count is absent. The AWS SDK types make omitting
   `Quantity` a compile error, so what arrives without one is a different mistake from the one this
   catches.
 - **A web ACL a Distribution names has to exist here.** `WebACLId` resolves to a web ACL created in
@@ -4075,11 +4051,9 @@ Where sim CloudFront knowingly behaves differently from AWS:
   share of real responses carry `Server-Timing`. This simulation adds it to every response once
   `Enabled` is true. A test asserting on it never depends on chance. The header's value is a
   fixed placeholder, since nothing here measures an Origin fetch the way CloudFront's edge does.
-- **A viewer's `Host` header never reaches an Origin.** Real CloudFront forwards it where a policy
-  names it, which is what `AllViewerExceptHostHeader` exists to stop. Here an Origin request always
-  carries the Origin's own domain as `Host`, since the request has to reach the simulated service
-  its URL names.
-- **CloudFront's own headers are not generated.** `X-Amz-Cf-Id`, `Via`, `X-Forwarded-For` and the
-  `CloudFront-Viewer-*` family are absent from an Origin request, so a policy naming one of them
-  forwards nothing. `Host`, `User-Agent` and the normalized `Accept-Encoding` are the three this
-  simulation sends of its own accord.
+- **Origin requests use the Origin's `Host` header.** Real CloudFront can forward the viewer's value
+  when a policy includes it. Yulin always sends the Origin domain because the request must reach the
+  simulated service named by the URL.
+- **CloudFront-generated headers are absent.** Yulin omits `X-Amz-Cf-Id`, `Via`,
+  `X-Forwarded-For` and the `CloudFront-Viewer-*` family. It generates `Host`, `User-Agent` and a
+  normalized `Accept-Encoding` value.

--- a/docs/services/cognito/README.md
+++ b/docs/services/cognito/README.md
@@ -1,17 +1,14 @@
 # Simulated Cognito IDP
 
-Yulin includes a simulated Cognito user pool directory for tests and local development. Pools and
-their app clients are held in memory, and every operation is authorized by simulated IAM.
+Yulin simulates Cognito user pools, app clients, users, groups, tokens, hosted domains and Lambda
+triggers. Use `simAws.cognitoIdp()` directly or intercept a `CognitoIdentityProviderClient`.
+Cognito types are available from `@kensio/yulin/cognito`.
 
-Only user pools are simulated. Cognito identity pools, which exchange a token for AWS credentials,
-are a different service and are outside the simulation.
-
-Cognito-specific types are imported from the `@kensio/yulin/cognito` subpath.
+Cognito identity pools are unsupported.
 
 ## Creating a pool and an app client
 
-A pool needs a name. Everything else has a default, and the defaults here are the ones real Cognito
-applies.
+A user pool needs a name. Other properties use Cognito's defaults.
 
 ```typescript sim-cognito-create-user-pool
 /**
@@ -46,16 +43,14 @@ const appClient = await cognito.createUserPoolClient(
 console.log(appClient.UserPoolClient?.ClientId); // 26 lowercase characters
 ```
 
-A pool id names the region the pool was created in, as real pool ids do. Application code that
-splits the id on the underscore to find the region works here for the same reason it works on AWS.
+A pool ID contains the region before its underscore, matching Cognito's ID format.
 
 Two pools may share a name. Only the id identifies one.
 
 ## Password policy
 
-A pool created without a `Policies` of its own gets the real default of eight characters, with an
-uppercase letter, a lowercase letter, a number and a symbol each required. A request setting some of
-those keeps the defaults for the rest.
+A pool created without `Policies` requires at least eight characters with uppercase, lowercase,
+numeric and symbol characters. Setting part of the policy keeps the defaults for omitted fields.
 
 ```typescript sim-cognito-password-policy
 /**
@@ -86,10 +81,9 @@ with `InvalidPasswordException`, saying which rule it broke.
 
 ## Users
 
-`AdminCreateUser` creates a user in `FORCE_CHANGE_PASSWORD`, where real Cognito leaves a user an
-admin made. It has a temporary password and cannot sign in with it. Setting a permanent password
-moves the user to `CONFIRMED`. The sign-in flows read that status. A user in
-`FORCE_CHANGE_PASSWORD` gets the `NEW_PASSWORD_REQUIRED` challenge, not tokens.
+`AdminCreateUser` creates a user in `FORCE_CHANGE_PASSWORD` with a temporary password. Sign-in
+returns the `NEW_PASSWORD_REQUIRED` challenge until `AdminSetUserPassword` sets a permanent
+password. A permanent password changes the status to `CONFIRMED`.
 
 ```typescript sim-cognito-create-user
 /**
@@ -145,11 +139,9 @@ console.log(read.UserAttributes?.find((each) => each.Name === "sub")?.Value);
 A password set without `Permanent: true` is temporary, and leaves the user in
 `FORCE_CHANGE_PASSWORD` again.
 
-A user's `sub` is a UUID Cognito allocates, reported among its attributes. It is not the username,
-and code treating the two as interchangeable fails here, and not in a deployment. Admin
-operations here name a user by its username only. Real Cognito also accepts a `sub` where an
-operation asks for a username. That is one thing that works there and not here. The refusal says so
-when the username given is some user's `sub`.
+A user's `sub` is a generated UUID and differs from the username. Yulin's admin operations accept
+the username only. Cognito also accepts a `sub` for some operations, which Yulin reports as an
+unsupported lookup.
 
 Attributes come back under `Attributes` from `AdminCreateUser` and `ListUsers`, and under
 `UserAttributes` from `AdminGetUser`, as the real API names them.
@@ -160,11 +152,9 @@ Attributes come back under `Attributes` from `AdminCreateUser` and `ListUsers`, 
 
 ## Signing in by email or phone number
 
-A pool created with `UsernameAttributes` signs its users in by that attribute, not by a username
-they chose. Cognito generates a UUID as the username for such a user, and the value the
-request called the username goes into the attribute the pool signs in by. That generated username
-is what `AdminGetUser` reports and what the `cognito:username` claim carries. An application reading
-"the username" off such a pool reads a UUID.
+A pool with `UsernameAttributes` signs users in with an email address or phone number. Cognito
+generates a UUID for the stored username. `AdminGetUser` and the `cognito:username` token claim
+report that UUID.
 
 A CDK `UserPool` with `signInAliases: { email: true }` emits `UsernameAttributes: ["email"]`, the
 usual way to build an email sign-in pool.
@@ -384,13 +374,11 @@ outside the simulation.
 
 ## Signing up
 
-`SignUp` is the other way a user gets into a pool. It names an app client rather than a pool, is
-authorized by no IAM policy, and leaves the user in `UNCONFIRMED` with the password it chose.
+`SignUp` creates an `UNCONFIRMED` user through an app client. The operation does not use IAM
+authorization.
 
-Real Cognito emails or texts a confirmation code at that point. Nothing here delivers a message, and
-the code is readable from the pool instead, through `confirmationCode` on the pool object. That is a
-deliberate divergence. Real Cognito never reports a code back to anyone, and reading one is what
-makes a registration flow testable at all.
+Read the confirmation code from `confirmationCode` on the simulated pool. Cognito sends the code by
+email or text and never exposes it through the service API.
 
 The pool also records the message it would have sent, holding the wording and the code a user
 would have read. That is in [Messages a pool would have sent](#messages-a-pool-would-have-sent)
@@ -500,9 +488,8 @@ the deployed pool would give. A pool created without the setting allows sign-up,
 
 ## Resetting a forgotten password
 
-A user that cannot get in asks for a code with `ForgotPassword` and sets a new password with
-`ConfirmForgotPassword`. Both name an app client, and neither is authorized by an IAM policy. They
-are the pair an application calls when it has built its own sign-in screens.
+`ForgotPassword` sends a code and `ConfirmForgotPassword` sets the new password. Both operations use
+an app client and bypass IAM authorization.
 
 The code goes to the same place a sign-up code goes, and is read back the same way, through
 `confirmationCode` on the pool object. `ForgotPassword` answers with `CodeDeliveryDetails` naming
@@ -633,9 +620,8 @@ are refused for one.
 
 ## Messages a pool would have sent
 
-Nothing here delivers an email or a text message. A pool records what it would have sent instead,
-and `sentMessages` on the pool object hands the record over. Each message carries the recipient, the
-medium, the subject, the body and the occasion it was sent on.
+The pool records outgoing email and text messages in `sentMessages`. Each entry contains the
+recipient, medium, subject, body and message type.
 
 A message is recorded on five occasions. Those are a `SignUp`, a `ResendConfirmationCode`, an
 `AdminCreateUser` that did not ask for `MessageAction: SUPPRESS`, an MFA code sent by text message,
@@ -2060,10 +2046,9 @@ own users at the same address, which real Cognito keeps as two accounts until
 `AdminLinkProviderForUser` merges them. That operation is unsimulated.
 
 Posting the page carries on into the sign-in the authorize endpoint already runs, ending in the same
-`<ProviderName>_<subject>` user and the same authorization code. Nothing is kept on the provider
-afterwards: a further authorize request asks again, because real Cognito asks the provider afresh
-every time. A provider that `signInAs` has already put somebody at skips the page, which is what
-leaves a test that says who is signing in seeing none of this.
+`<ProviderName>_<subject>` user and the same authorization code. Provider state is discarded after
+the request. A later authorize request asks again because real Cognito asks the provider afresh each
+time. A provider configured with `signInAs` skips the page and uses the configured identity.
 
 `/signup` is a link from that page. Its form asks for a username, a password and the attributes the
 pool needs, which are the ones its `Schema` made required and the ones its `AutoVerifiedAttributes`
@@ -3704,8 +3689,8 @@ console.log(described.UserPoolClient?.ClientName);
 
 A registered pool behaves like any other. It answers `DescribeUserPoolCommand` and
 `ListUserPoolsCommand`, holds users, groups and app clients, and serves its JWKS and OpenID
-configuration on localhost. Everything written against a pool id follows from the id it was
-registered under: its ARN, its issuer URL, the `iss` claim of its tokens and its `ProviderName`. A
+configuration on localhost. The registered ID determines the pool ARN, issuer URL, token `iss` claim
+and `ProviderName`. A
 policy naming `arn:aws:cognito-idp:eu-west-2:111111111111:userpool/eu-west-2_aBcDeFgHi` authorizes
 the handler that reads the pool, which is what a template carrying the id in two places needs.
 

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -1,18 +1,13 @@
 # Simulated DynamoDB
 
-Yulin includes a simulated DynamoDB for tests and local development. Tables are held in memory, and
-every operation is authorized by simulated IAM.
-
-This page covers creating, describing, listing and deleting tables. What a request says is checked
-the way real DynamoDB checks it. A table that can be created here is one that could be created on
-AWS.
-
-DynamoDB-specific types are imported from the `@kensio/yulin/dynamodb` subpath.
+Yulin simulates DynamoDB tables, indexes, items, streams and time to live in memory. Use
+`simAws.dynamoDb()` directly or intercept a `DynamoDBClient`. DynamoDB types are available from
+`@kensio/yulin/dynamodb`.
 
 ## Creating a table
 
-`CreateTable` needs a `TableName`, a `KeySchema`, and an `AttributeDefinitions` entry for every
-attribute the key schema names.
+`CreateTable` requires a table name, a key schema and an attribute definition for every key
+attribute.
 
 ```typescript sim-dynamodb-create-table
 /**
@@ -45,8 +40,7 @@ await simAws.backgroundTasksComplete();
 A new table is `CREATING`, and activation is scheduled as background work. Call
 `simAws.backgroundTasksComplete()` when a test needs the table to be `ACTIVE`.
 
-The description carries back what the request asked for. That is the key schema, the attribute
-definitions, the table ARN, a table ID, and the billing and capacity the table was created with.
+The response describes the table's keys, attribute definitions, ARN, ID, billing mode and capacity.
 
 ## Key schema and attribute definitions
 
@@ -62,9 +56,8 @@ attribute as the type the table declared for it.
 
 ## Billing modes and throughput
 
-`BillingMode` defaults to `PROVISIONED`, making `ProvisionedThroughput` required with at least one
-read and one write capacity unit. A request that leaves both out asks for a provisioned table with
-no capacity, and is refused.
+`BillingMode` defaults to `PROVISIONED`. A provisioned table requires at least one read and one write
+capacity unit in `ProvisionedThroughput`.
 
 `PAY_PER_REQUEST` refuses `ProvisionedThroughput`, since an on-demand table has no capacity to
 provision.
@@ -111,8 +104,8 @@ reports for one.
 
 ## Global secondary indexes
 
-`GlobalSecondaryIndexes` on `CreateTable` declares indexes with a key of their own over the same
-items. Each index needs an `IndexName`, a `KeySchema` and a `Projection`.
+`GlobalSecondaryIndexes` adds indexes over the table's items. Each index requires an `IndexName`,
+`KeySchema` and `Projection`.
 
 ```typescript sim-dynamodb-global-secondary-index
 /**
@@ -583,9 +576,8 @@ console.log(description.Table?.TableStatus); // "ACTIVE"
 
 ## Tagging tables
 
-A table is tagged by `CreateTable`, or afterwards by `TagResource`. `UntagResource` takes tags off,
-and `ListTagsOfResource` reads them back. The three tag commands name their resource by ARN, in
-`ResourceArn`, where the table commands take a name or an ARN.
+Add tags during `CreateTable` or later with `TagResource`. Remove them with `UntagResource` and read
+them with `ListTagsOfResource`. Tag commands require the table ARN in `ResourceArn`.
 
 ```typescript sim-dynamodb-tag-table
 /**
@@ -683,9 +675,8 @@ calling `Tags.of(stack).add("Environment", "test")` gets a tagged table.
 
 ## Writing items
 
-`PutItem` writes one item, replacing the whole item under its primary key rather than merging into
-it. The item is there by the time the call returns. A write and the read that follows it need no
-step in between.
+`PutItem` replaces the complete item stored under the primary key. The write is visible when the
+command returns.
 
 ```typescript sim-dynamodb-put-item
 /**
@@ -739,10 +730,9 @@ anywhere else in the item.
 
 ## Reading and deleting items
 
-`GetItem` reads one item by its primary key, and `DeleteItem` removes one the same way. The `Key`
-both take is the whole primary key and nothing else. A missing key element, an attribute outside the
-key, or a value whose type fails to match the table's `AttributeDefinitions` is a
-`ValidationException` naming the attribute at fault.
+`GetItem` reads an item by primary key. `DeleteItem` removes it. The `Key` must contain every key
+attribute and no others, using the types declared in `AttributeDefinitions`. Invalid keys raise
+`ValidationException`.
 
 ```typescript sim-dynamodb-get-delete-item
 /**
@@ -822,9 +812,8 @@ Both take the table's name or its ARN, as the table commands do.
 
 ## Updating items
 
-`UpdateItem` changes part of an item, where `PutItem` replaces the whole thing. What to change is
-written as an `UpdateExpression` made of `SET`, `REMOVE`, `ADD` and `DELETE` clauses, in any order.
-Each keyword appears at most once, and the actions inside a clause are separated by commas.
+`UpdateItem` changes selected attributes. Its `UpdateExpression` may contain `SET`, `REMOVE`, `ADD`
+and `DELETE` clauses in any order. Each clause may appear once and contain comma-separated actions.
 
 A `SET` action is `path = operand`, where an operand is a value from `ExpressionAttributeValues`,
 another document path, or a call to `if_not_exists(path, operand)` or `list_append(one, other)`. Two
@@ -1066,12 +1055,11 @@ placeholder used by either counts as used.
 
 ## Conditional writes
 
-`PutItem`, `DeleteItem` and `UpdateItem` take a `ConditionExpression`, checked against whatever is
-stored under the key before anything changes. A condition that fails to hold leaves the item exactly
-as it was and throws `ConditionalCheckFailedException`, with the name and message real DynamoDB
-uses.
+`PutItem`, `DeleteItem` and `UpdateItem` evaluate `ConditionExpression` against the stored item before
+writing. A failed condition leaves the item unchanged and raises
+`ConditionalCheckFailedException`.
 
-That is how a write becomes an insert if absent, and how a version attribute becomes optimistic
+Use `attribute_not_exists` for insert-only writes or compare a version attribute for optimistic
 locking.
 
 ```typescript sim-dynamodb-conditional-write
@@ -1176,9 +1164,8 @@ expression, in both directions. A placeholder the request leaves undefined is a
 
 ## Projecting attributes
 
-`GetItem` takes a `ProjectionExpression`, a comma-separated list of document paths. Only those paths
-come back. A path is an attribute name, then any number of `.attribute` dereferences and `[n]` list
-indexes, such as `address.city` or `lines[0].sku`.
+`ProjectionExpression` is a comma-separated list of document paths returned by `GetItem`. A path can
+contain map attributes and list indexes, such as `address.city` or `lines[0].sku`.
 
 An attribute name that is a DynamoDB reserved word, or that has a character an expression cannot
 carry, is written as a `#name` placeholder and defined in `ExpressionAttributeNames`.
@@ -1259,12 +1246,11 @@ index and a path past that depth are each a `ValidationException` naming the pat
 
 ## Querying an item collection
 
-A table with a sort key holds an item collection under each partition key, holding the items with
-that partition key, ordered by their sort key. `Query` reads one of those collections.
+A table with a sort key keeps one ordered item collection per partition key. `Query` reads one
+collection.
 
-`KeyConditionExpression` says which. It is one equality on the partition key, optionally joined by
-`AND` to one condition on the sort key. The sort key condition is `=`, `<`, `<=`, `>`, `>=`,
-`BETWEEN` or `begins_with`, and both bounds of a `BETWEEN` are inside the range.
+`KeyConditionExpression` requires equality on the partition key. It may add one sort key condition
+with `AND`. Sort key operators are `=`, `<`, `<=`, `>`, `>=`, `BETWEEN` and `begins_with`.
 
 ```typescript sim-dynamodb-query
 /**
@@ -1371,8 +1357,8 @@ in `ExpressionAttributeNames`, as in any other expression.
 
 ### Paging a collection
 
-`Limit` counts the items a query evaluated. `LastEvaluatedKey` is the primary key of the item the
-walk stopped on, and the next request passes it back as `ExclusiveStartKey` to resume after it.
+`Limit` counts evaluated items. Pass `LastEvaluatedKey` back as `ExclusiveStartKey` to continue after
+the last evaluated item.
 
 ```typescript sim-dynamodb-query-paging
 /**
@@ -1447,9 +1433,7 @@ from a different partition key is refused, since it names a collection this quer
 
 ## Reading a global secondary index
 
-`IndexName` on `Query` and `Scan` reads an index in place of the table. The key condition is held to
-the index key schema and not the table's, which is the point. The index is how an access pattern the
-table key cannot serve gets served.
+Set `IndexName` on `Query` or `Scan` to read an index. Key conditions then use the index key schema.
 
 ```typescript sim-dynamodb-query-index
 /**
@@ -1572,9 +1556,8 @@ refused.
 
 ## Scanning a table
 
-`Scan` reads every item in a table. It needs no key knowledge at all. That is what makes it the
-operation test setup and assertions reach for, and the wrong operation for most application access
-patterns, since it reads the whole table however few items the caller wanted.
+`Scan` reads every item in a table without a key condition. It is useful for test assertions but
+usually reads more data than application code needs.
 
 ```typescript sim-dynamodb-scan
 /**

--- a/docs/services/ecs/README.md
+++ b/docs/services/ecs/README.md
@@ -1,31 +1,20 @@
 # Simulated ECS
 
-Yulin includes a simulated Amazon ECS for tests and local development. It holds clusters, task
-definitions and services in memory, runs tasks from handlers you bind to their containers, and
-authorizes every operation with simulated IAM.
+Yulin simulates ECS clusters, task definitions, tasks and services. It runs JavaScript or TypeScript
+handlers bound to container image URIs. Use `simAws.ecs()` directly or intercept an `ECSClient`.
+ECS types are available from `@kensio/yulin/ecs`.
 
-ECS-specific types are imported from the `@kensio/yulin/ecs` subpath.
+## Binding code to a container image
 
-## What Yulin does with a container image
+Yulin uses an image URI as an identifier for an in-process handler. It does not pull or execute the
+image. A container with a matching binding runs the handler. An unbound container is recorded as
+unsimulated while the rest of the task continues.
 
-Yulin never looks inside a container image, and it could not if it tried. An image may hold a Go
-binary, nginx, Redis or anything else, and the only thing Yulin can run is JavaScript or TypeScript
-in its own process.
+A task definition may include application and support containers. Yulin stores and reports every
+container, but only runs containers that have a binding.
 
-So an image URI is only ever an identifier. Nothing here reads it, pulls it, or runs anything from
-it. It is stored as declared, and it is what a container is matched on when a task runs, in the same
-way an image URI identifies a container image Lambda function. The rule that follows is that a
-container matched to a handler runs that handler, and a container with no match is recorded as not
-simulated while the rest of the task carries on.
-
-A realistic task definition holds an application container, a log router and an observability agent.
-Only the first of those is something Yulin could ever run, and all three are stored and reported
-back exactly as declared.
-
-The case this leaves out is a sidecar the application depends on, such as a Redis or a database in
-the same task. Point its connection details, which are ordinary environment variables, at a real one
-you run yourself. See [non-AWS dependencies](https://yulinsim.dev/non-aws-dependencies/) for how that fits
-together.
+Run required sidecars such as Redis separately and pass their connection details through environment
+variables. See [non-AWS dependencies](https://yulinsim.dev/non-aws-dependencies/).
 
 ## Registering a task definition
 
@@ -76,9 +65,7 @@ console.log(described.taskDefinition?.containerDefinitions?.[0]?.image);
 // "example.dkr.ecr.eu-west-2.amazonaws.com/checkout:1"
 ```
 
-Container definitions are stored as declared, whatever the image is and whether or not Yulin could
-ever run it. That covers port mappings, environment variables and secrets. A `valueFrom` naming a
-Secrets Manager secret is held as the identifier it is, and never resolved.
+Container definitions retain their images, port mappings, environment variables and secrets.
 
 A registration that declares something this simulation has no room for is refused outright, and
 never trimmed. That way a declaration cannot go missing from the revision it made.
@@ -132,9 +119,8 @@ a full task definition ARN. The ARN of a revision is
 
 ## Deregistering a revision
 
-`DeregisterTaskDefinition` marks one revision `INACTIVE` without removing it. It stays describable
-by `family:revision` and by ARN, because something already holding either of those still needs to
-find out what it declared. What it stops being is the revision the family resolves to.
+`DeregisterTaskDefinition` marks a revision `INACTIVE` without removing it. The revision remains
+available by `family:revision` or ARN, but the family name no longer resolves to it.
 
 ```typescript sim-ecs-deregister-task-definition
 /**
@@ -234,8 +220,8 @@ A family counts as inactive once every one of its revisions has been deregistere
 
 ## Clusters
 
-A cluster is a named scope for the tasks and services that will run in it. `CreateCluster`,
-`DescribeClusters`, `ListClusters` and `DeleteCluster` hold them.
+A cluster contains tasks and services. Use `CreateCluster`, `DescribeClusters`, `ListClusters` and
+`DeleteCluster` to manage it.
 
 ```typescript sim-ecs-clusters
 /**
@@ -290,13 +276,13 @@ A cluster is named either by its short name or by its full ARN, and the two are 
 ARN belonging to another account or region names a different cluster. `DescribeClusters` reports it
 as a `MISSING` failure, and `DeleteCluster` refuses it.
 
-A cluster has to exist before a task can run in it, including the `default` one. Yulin creates no
-cluster on its own, so create the one the tasks run in.
+Create a cluster before running a task. This includes the `default` cluster, which Yulin does not
+create automatically.
 
 ## Running a task
 
-`bindContainer` says what a container runs. `RunTask` then starts a task in a cluster, and the bound
-handlers run in this process.
+`bindContainer` associates an image with a handler. `RunTask` starts the task and schedules bound
+handlers to run in process.
 
 ```typescript sim-ecs-run-task
 /**
@@ -376,9 +362,7 @@ The task stops with a `stopCode` of `TaskFailedToStart` saying that nothing ran.
 
 ### Binding by image repository
 
-A container built by CDK or by a pipeline has an image tag that changes with every build, so naming
-the container by hand is the wrong way round. A binding can name the repository instead, and the tag
-is ignored on both sides.
+Use a repository binding when image tags change between builds. Repository matching ignores the tag.
 
 ```typescript sim-ecs-bind-image-repository
 /**
@@ -505,9 +489,8 @@ Read inside the handler to get the container's own.
 
 ## The task role
 
-While a container runs, its AWS calls are attributed to the task definition's `taskRoleArn`, in the
-same way a sim Lambda function's are to its execution role. Calls made through an SDK client
-intercepted by `SimSdk` pick this up without the code under test knowing.
+AWS calls made by a container use the task definition's `taskRoleArn`. An SDK client intercepted by
+`SimSdk` picks up the role from the running handler.
 
 ```typescript sim-ecs-task-role
 /**
@@ -600,10 +583,8 @@ alone, since there is no image to pull and no log driver to write to.
 
 ## Container secrets
 
-A container definition's `secrets` are resolved when the task starts, from simulated Secrets Manager
-or simulated SSM Parameter Store according to what each `valueFrom` names, and the values appear in
-the container's environment alongside its declared `environment`. A handler reads them through
-`process.env` like anything else.
+Yulin resolves container `secrets` from simulated Secrets Manager or SSM Parameter Store when the
+task starts. The values appear in `process.env` alongside the declared environment variables.
 
 They are read as the task definition's `executionRoleArn` rather than its `taskRoleArn`. That is the
 split real ECS makes. The execution role is what the task agent pulls secrets with before a
@@ -765,8 +746,7 @@ is reported as it stands, keeping the reason it stopped for.
 
 ## Services
 
-A task runs and stops. A service keeps tasks running, and that is what a deployed application
-usually is. It is a named service in a cluster, running some number of tasks from a task definition.
+An ECS service maintains a desired number of tasks from one task definition in a cluster.
 
 `CreateService` creates one. Its tasks exist as soon as the request is answered and reach `RUNNING`
 on the simulation's background work, as real ECS brings a new service up. The service reports the

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1,7 +1,7 @@
 # Simulated Lambda
 
-Yulin includes a simulated AWS Lambda service for tests and local development. Functions are created
-and invoked in-process and in memory, with no containers and no real AWS infrastructure.
+Yulin creates and invokes Lambda functions in process. A function can use an in-process handler,
+code from a zip archive, code stored in simulated S3, or a handler bound to a container image.
 
 Handlers run with their execution role as the simulated caller, so AWS calls made inside a handler
 are authorized by simulated IAM, as on real Lambda. Creating a function and changing its role are
@@ -9,16 +9,14 @@ authorized as well, both against `lambda:` actions and against `iam:PassRole` on
 the request names. See [passing a Role to a service](https://yulinsim.dev/services/iam/#passing-a-role-to-a-service)
 in the IAM docs.
 
-Lambda-specific helpers are imported from the `@kensio/yulin/lambda` subpath. Real `LambdaClient`
-instances can be routed into sim Lambda with
+Lambda helpers are available from `@kensio/yulin/lambda`. A `LambdaClient` can be routed to Yulin with
 [SDK interception](https://yulinsim.dev/sdk/ "Simulated AWS SDK interception docs").
 
 ## Creating and invoking a function
 
-The quickest way to a working function is to pass a real in-process handler function through the
-SDK-shaped `Code.ZipFile` input with `makeLambdaZipFileInput(...)`. The handler is an ordinary
-function in your Node.js process. It can be stepped through in a debugger and can close over local
-state.
+Use `makeLambdaZipFileInput(...)` to pass an in-process handler through the SDK-shaped `Code.ZipFile`
+input. The handler runs as an ordinary function in the Node.js process. It supports breakpoints and
+access to local state.
 
 ```typescript sim-lambda-create-and-invoke
 /**
@@ -84,18 +82,13 @@ The invoke call itself returns normally.
 
 ## Zip-packaged code and the vm runtime
 
-A real in-process handler is the one to reach for first. `makeLambdaZipFileInput(...)` backs a
-function created through the SDK with one, and an [executable binding](#executable-bindings) backs
-one a template declares. The handler stops on a breakpoint and can close over the test's own state.
-Run the packaged code where the test is about the bundle a deployment ships, its imports and its
-bundling included. Both paths invoke through simulated Lambda, and simulated IAM authorizes the
-handler's own AWS calls under the execution role either way.
+Use an in-process handler for most tests. Use packaged code when the test covers the deployed bundle,
+including its imports. Both forms run through simulated Lambda and make AWS calls as the function's
+execution role.
 
-Real Lambda receives function code as a zip archive. `makeLambdaCodeZip(...)` builds real zip
-bytes from a source string (which becomes a single `index.js` module) or from a files map keyed by
-archive path (like a bundled deployment package). The archive runs in a Node.js `vm` context with
-real cold-start semantics. The module is imported once, on first invocation, and module state stays
-warm across invocations.
+`makeLambdaCodeZip(...)` builds zip bytes from a source string or a map of archive paths to file
+contents. A source string becomes `index.js`. Yulin runs the archive in a Node.js `vm`, loads the
+module on the first invocation and preserves module state for later invocations.
 
 ```typescript sim-lambda-zip-code-vm-runtime
 /**
@@ -171,18 +164,15 @@ package is refused at cold start. A handler file ending in `.mjs` is reported as
 Real Lambda has run ES module packages since nodejs14.x, and `NodejsFunction` in CDK emits one
 under `format: OutputFormat.ESM`.
 
-There are two ways round that. An [executable binding](#executable-bindings) or
-`makeLambdaZipFileInput(...)` backs the function with a real in-process handler. The test's own
-module system loads that handler, and its format is whatever the test file's is. An ESM project
-needs nothing further. Where the archive itself has to be the deployed artefact, compile a CommonJS
-build of the same source and deploy that as the function's code.
+Use an [executable binding](#executable-bindings) or `makeLambdaZipFileInput(...)` for an ESM handler.
+The test's module system loads an in-process handler. To test the archive itself, compile the source
+to CommonJS before creating the zip.
 
 `Code.ZipFile` bytes that fail to unzip are rejected at creation with the AWS-like
 `InvalidParameterValueException: Could not unzip uploaded file`.
 
-The archives are real zip files, and they interoperate with real tooling in both directions. A zip
-built by any other tool works as `Code.ZipFile` input, and `makeLambdaCodeZip` output can be
-unzipped normally.
+`Code.ZipFile` accepts zip archives produced by other tools. Archives from `makeLambdaCodeZip` can
+also be opened with standard zip tools.
 
 ### What a handler prints
 
@@ -408,9 +398,8 @@ writes none of those.
 
 ## Function code from S3
 
-Function code can also be fetched from a zip object stored in sim S3, as SAM and CDK deployments
-do on real AWS. The code object is fetched once at creation time, as the creating caller, so
-simulated IAM applies to the code object read.
+Function code may reference a zip object in simulated S3. Yulin reads the object once during
+function creation as the caller creating the function, so simulated IAM applies to the S3 read.
 
 ```typescript sim-lambda-s3-code
 /**
@@ -944,10 +933,9 @@ the operation header that says so.
 
 ## Invocation types
 
-`InvokeCommand` supports the three AWS invocation types. `RequestResponse` (the default) awaits
-the handler and returns its JSON-serialised result as the response payload. `Event` returns `202`
-immediately and runs the handler in the background. `DryRun` returns `204` without invoking the
-handler at all.
+`InvokeCommand` supports all three invocation types. `RequestResponse` waits for the handler and
+returns its JSON result. `Event` returns 202 and schedules the handler in the background. `DryRun`
+returns 204 without invoking the handler.
 
 ```typescript sim-lambda-invocation-types
 /**
@@ -1007,14 +995,12 @@ covers.
 
 ## Asynchronous retries and destinations
 
-An `Event` invocation whose handler throws is retried twice, as real Lambda retries one. The retries
-wait on the simulated clock, about a minute before the first and two before the second, so a test
-reaches them by advancing time rather than by waiting for it.
+An `Event` invocation retries a failed handler twice by default. Retries use the simulated clock,
+after about one minute and then two minutes. Advance the clock to run them in a test.
 
-`PutFunctionEventInvokeConfigCommand` changes how many retries a function makes and where its
-results go. An invocation that fails its last attempt is sent to the `OnFailure` destination, and
-one whose handler returns is sent to `OnSuccess`. A destination ARN can name a simulated SQS queue,
-SNS topic, EventBridge event bus or Lambda function.
+`PutFunctionEventInvokeConfigCommand` controls retry count and destinations. Lambda sends a final
+failure to `OnFailure` and a successful result to `OnSuccess`. Destinations may be SQS, SNS,
+EventBridge or another Lambda function.
 
 The source function's execution role must allow the operation that writes to the destination:
 
@@ -1154,11 +1140,9 @@ a config of its own, and an invocation of a qualifier with no config of its own 
 
 ### Dead-letter targets
 
-`DeadLetterConfig` is the older way to keep a failed asynchronous invocation, and simulated Lambda
-takes it on `CreateFunction` and `UpdateFunctionConfiguration`. Its `TargetArn` names a simulated
-SQS queue or SNS topic, which receives the event as it was invoked rather than the destination
-record around it. The execution role needs `sqs:SendMessage` for a queue or `sns:Publish` for a
-topic. A denied delivery rejects the background task and leaves the target unchanged.
+`DeadLetterConfig` sends a failed asynchronous event to SQS or SNS. Configure it with
+`CreateFunction` or `UpdateFunctionConfiguration`. The target receives the original event rather
+than a destination record. The execution role needs `sqs:SendMessage` or `sns:Publish`.
 
 ```typescript sim-lambda-dead-letter-queue
 /**
@@ -1249,11 +1233,9 @@ A function carrying both a dead-letter target and an `OnFailure` destination sen
 
 ## Versions and aliases
 
-`PublishVersionCommand` copies a function as it stands and numbers the copy. The first is version
-`1`, and each later one counts up. The copy keeps the code, handler, timeout, memory and
-environment it was published with. `CreateAliasCommand` gives one of those versions a name, and
-`UpdateAliasCommand` moves the name to another version, so a deployment can repoint what callers
-invoke.
+`PublishVersionCommand` creates an immutable numbered copy of the function's code and configuration.
+Versions start at `1`. `CreateAliasCommand` gives a version a name, and `UpdateAliasCommand` moves
+that name to another version.
 
 `InvokeCommand` and `GetFunctionCommand` take a `Qualifier` naming a version number or an alias.
 The same qualifier can travel on the `FunctionName` instead, appended to the name (`orders:live`)
@@ -1366,9 +1348,8 @@ ARN. A `FunctionName` carrying a qualifier (`orders:live`) is refused with an
 
 ## Triggering a function from an SQS queue
 
-An event source mapping connects a [simulated queue](https://yulinsim.dev/services/sqs/ "Simulated SQS docs") to a function.
-Messages sent to the queue are delivered to the handler as an SQS event, with the `Records` shape
-real Lambda uses.
+An event source mapping polls a [simulated queue](https://yulinsim.dev/services/sqs/ "Simulated SQS docs") and invokes the function
+with an SQS `Records` event.
 
 Polling runs on the simulation's background scheduler. A test awaits
 `simAws.backgroundTasksComplete()` and then asserts, without sleeping.
@@ -1600,10 +1581,9 @@ from.
 
 ### When the handler fails
 
-A handler that returns normally has handled the batch, and the messages are deleted from the queue.
-A handler that throws returns the whole batch. The messages stay on the queue, hidden until their
-visibility timeout lapses, and are delivered again after that. Advancing the simulation's clock is
-what brings them back:
+A successful handler deletes the batch from the queue. When the handler throws, every message stays
+in flight until its visibility timeout expires, then becomes available for another delivery. Advance
+the simulated clock to reach that retry:
 
 ```typescript
 await simAws.clock().advanceBy({ seconds: 31 });
@@ -1618,10 +1598,8 @@ the sender sees is the message coming back.
 
 ### Reporting individual message failures
 
-A queue mapping created with `FunctionResponseTypes: ["ReportBatchItemFailures"]` takes the
-`batchItemFailures` list the handler returns. The message ids named in it go back to the queue, and
-the rest of the batch is deleted. A stream mapping takes the same list and does something else with
-it, under [reporting individual record failures](#reporting-individual-record-failures).
+A queue mapping with `FunctionResponseTypes: ["ReportBatchItemFailures"]` reads the handler's
+`batchItemFailures`. Named message IDs return to the queue and the remaining messages are deleted.
 
 ```typescript
 await simAws.lambda().createEventSourceMapping(
@@ -1646,9 +1624,8 @@ or an empty `batchItemFailures` list, has handled the whole batch.
 
 ### Making an SQS event without a queue
 
-A test of the handler on its own, with no queue and no mapping, still has to pass it a whole event.
-`lambdaSqsEventFactory` makes one, and `lambdaSqsEventRecordFactory` makes the records in it. Such a
-test then says what the messages carry and leaves the rest to the factory:
+Use `lambdaSqsEventFactory` and `lambdaSqsEventRecordFactory` to call an SQS handler without creating
+a queue or event source mapping:
 
 ```typescript sim-lambda-sqs-event-factory
 /**
@@ -1708,9 +1685,9 @@ the same records whether it carries them or not. The deploy stands and nothing r
 
 ## Triggering a function from a DynamoDB stream
 
-An event source mapping also connects a [simulated table's stream](https://yulinsim.dev/services/dynamodb/#capturing-changes-with-a-stream "Simulated DynamoDB streams docs")
-to a function. Changes to the table are delivered to the handler as a DynamoDB stream event, with
-the `Records` shape real Lambda uses.
+An event source mapping can also poll a
+[simulated DynamoDB stream](https://yulinsim.dev/services/dynamodb/#capturing-changes-with-a-stream "Simulated DynamoDB streams docs").
+Table changes reach the handler as a DynamoDB `Records` event.
 
 `StartingPosition` is required for a stream and is `TRIM_HORIZON` or `LATEST`. `TRIM_HORIZON` reads
 what the stream still holds, so changes made before the mapping existed are delivered too. `LATEST`
@@ -2058,9 +2035,8 @@ because a message the handler never takes is left to the queue's own redrive pol
 
 ### Reporting individual record failures
 
-A stream mapping created with `FunctionResponseTypes: ["ReportBatchItemFailures"]` takes the
-`batchItemFailures` list the handler returns. For a stream the identifier is the record's
-`SequenceNumber`:
+A stream mapping with `FunctionResponseTypes: ["ReportBatchItemFailures"]` reads the handler's
+`batchItemFailures`. Each item identifies a record by `SequenceNumber`:
 
 ```typescript
 await simAws.lambda().createEventSourceMapping(
@@ -2308,15 +2284,13 @@ Write the grant as an inline policy, as the example above and CDK both do.
 
 ## Triggering a function from a Kinesis stream
 
-An event source mapping also connects a [simulated Kinesis stream](https://yulinsim.dev/services/kinesis/ "Simulated Kinesis Data Streams docs")
-to a function. Records put onto the stream are delivered to the handler as a Kinesis event, with the
-`Records` shape real Lambda uses.
+An event source mapping can poll a
+[simulated Kinesis stream](https://yulinsim.dev/services/kinesis/ "Simulated Kinesis Data Streams docs") and invoke the function
+with a Kinesis `Records` event.
 
-A Kinesis stream has as many shards as it was created with, and every one of them is read. Real
-Lambda runs a processor per shard, and so does this: each shard keeps its own place on the stream,
-delivers its own batches and backs off on its own when a batch fails. One invocation is given
-records from one shard, so a handler that has to see records in order should put them under one
-partition key, which is what puts them on one shard.
+Yulin reads every shard in a Kinesis stream. Each shard tracks its own iterator, delivers its own
+batches and backs off independently after a failure. An invocation receives records from one shard.
+Use one partition key when the handler requires ordered records.
 
 `StartingPosition` is required for a stream. A Kinesis stream takes all three positions.
 `TRIM_HORIZON` reads what the stream still holds, `LATEST` reads only what arrives from the moment

--- a/docs/services/s3/README.md
+++ b/docs/services/s3/README.md
@@ -1,13 +1,12 @@
 # Simulated S3
 
-Yulin includes a simulated S3 service for tests and local development.
+Yulin simulates S3 buckets, objects, policies, notifications and website hosting. Use
+`simAws.s3()` as part of a simulated AWS environment or create a standalone `SimS3`.
+`serveSimAws` exposes the S3 API and website endpoints over localhost.
 
-Sim S3 can be used directly through `SimAws` or instantiated on its own as `SimS3` with isolated
-state. Yulin can serve a simulated S3 service on localhost.
+## Create a bucket and object
 
-## Basic usage
-
-Create a simulated AWS environment, get simulated S3, create a Bucket, and put an Object into it.
+Create a bucket, write an object and read it back.
 
 ```typescript sim-s3-bucket
 /**
@@ -104,15 +103,15 @@ await scopedS3.createBucket(
 );
 ```
 
-Within one `SimAws` instance, Bucket names are globally registered across Accounts and Regions.
-Creating a Bucket with a name already used in another simulated Region or Account throws an error.
+Bucket names are global within a `SimAws` instance. Creating the same name in another simulated
+account or region fails.
 
-Each `SimAws` instance has its own isolated state. Create a fresh one per test or share one across
-all tests, as you prefer.
+Each `SimAws` instance has isolated state.
 
-## Listing Buckets
+## Listing buckets
 
-Use `ListBucketsCommand` to inspect Buckets in the selected simulated S3 scope. Each Bucket reports the instant it was created, taken from [simulated time](https://yulinsim.dev/time/) rather than the host clock.
+`ListBucketsCommand` lists buckets in the selected account and region. Each bucket reports its
+creation time from the [simulated clock](https://yulinsim.dev/time/).
 
 ```typescript sim-s3-list-buckets
 /**
@@ -137,17 +136,20 @@ console.log(listBucketsOutput.Buckets?.map((bucket) => bucket.Name));
 console.log(listBucketsOutput.Buckets?.[0]?.CreationDate);
 ```
 
-## Asking whether something is there
+## Checking whether a bucket or object exists
 
-`HeadObjectCommand` reports what a read would say about an Object without returning the Object, and `HeadBucketCommand` reports whether a Bucket is there and reachable. `HeadBucket` also reports the Region it was found in.
+`HeadObjectCommand` returns object metadata without the body. `HeadBucketCommand` checks that a
+bucket exists and is accessible, and reports its region.
 
-A HEAD response carries no body, so there is no document for an error code to travel in. Real S3 answers a `HeadObject` with `403` or `404`, and a `HeadBucket` with `400`, `403` or `404`, leaving the SDK to name the failure from the status alone. The simulator answers `404` for an absent Bucket and an absent Object alike, which an SDK client raises as `NotFound`, and `403` for a caller the permission is missing for. A read distinguishes `NoSuchBucket` from `NoSuchKey`, because a read has a body to say which.
+A HEAD response has no error document. Yulin returns 404 for a missing bucket or object, which the
+SDK raises as `NotFound`. It returns 403 when the caller lacks permission. `GetObject` can distinguish
+`NoSuchBucket` from `NoSuchKey` because its error response has a body.
 
 `HeadObject` authorizes against `s3:GetObject` and `HeadBucket` against `s3:ListBucket`, as real S3 does, so knowing something is there needs the permission to read it.
 
-## Listing Objects
+## Listing objects
 
-Use `ListObjectsV2Command` to list the Objects in a Bucket. The simulator supports `Prefix`,
+Use `ListObjectsV2Command` to list objects in a bucket. Yulin supports `Prefix`,
 `Delimiter`, `MaxKeys`, `ContinuationToken` and `StartAfter`, and answers with `Contents`,
 `CommonPrefixes`, `KeyCount`, `IsTruncated` and `NextContinuationToken`.
 
@@ -197,18 +199,16 @@ for (const object of listedObjects) {
 }
 ```
 
-Listings are sorted by key, and a page holds at most 1,000 keys, as in real S3. `MaxKeys` above that
-is lowered to it, and the response reports the page size that was actually used. A `MaxKeys` of zero
-returns no keys and completes the listing, and a negative one is refused with `InvalidArgument`.
+Listings sort objects by key and return at most 1,000 entries. Larger `MaxKeys` values are capped at
+1,000. Zero returns an empty complete page, and a negative value raises `InvalidArgument`.
 
 A listing that found no keys has no `Contents` at all, and the example reaches for `Contents ?? []`
 for that reason. `KeyCount` is the count either way.
 
 ### Walking a truncated listing
 
-A truncated response carries `NextContinuationToken`, which the next request passes as
-`ContinuationToken`. The token is opaque, as it is in real S3. Pass it back unchanged, read nothing
-out of it, and simulated S3 refuses one it did not issue.
+A truncated response includes `NextContinuationToken`. Pass it unchanged as `ContinuationToken` in
+the next request. Yulin rejects tokens it did not issue.
 
 ```typescript sim-s3-list-objects-v2-pagination
 /**
@@ -533,9 +533,8 @@ An Object uploaded in parts gets a different form. See
 
 ## Uploading an Object in parts
 
-`aws s3 cp` switches to a multipart upload above eight megabytes, and `@aws-sdk/lib-storage` uploads
-in parts whatever the size. Sim S3 answers the six operations that path is made of, over the SDK and
-over a served endpoint alike.
+Yulin supports multipart upload through the SDK and served S3 endpoint. This covers the operations
+used by `aws s3 cp` for files above eight megabytes and by `@aws-sdk/lib-storage`.
 
 ```bash
 aws s3 cp ./big.bin s3://widgets/big.bin   # 12MB, multipart under the covers
@@ -846,9 +845,8 @@ See [Serve simulated S3 on localhost](#serve-simulated-s3-on-localhost) for sett
 
 ## Deleting Objects
 
-Use `DeleteObjectCommand` to remove one Object, and `DeleteObjectsCommand` to remove several in one
-request. Both are authorized against `s3:DeleteObject` on the Object ARN. A caller allowed to read a
-Bucket cannot empty it.
+Use `DeleteObjectCommand` to remove one object or `DeleteObjectsCommand` to remove several. Each
+object requires `s3:DeleteObject` permission on its ARN.
 
 ```typescript sim-s3-delete-object
 /**
@@ -931,9 +929,9 @@ failures come back.
 
 ## Object versioning
 
-A versioned Bucket keeps every write of a key instead of overwriting it, and answers a delete with a
-marker rather than removing anything. Turn it on with `PutBucketVersioningCommand`, or with
-`VersioningConfiguration` on an `AWS::S3::Bucket` resource.
+A versioned bucket keeps each write as a separate version. Deleting a key adds a delete marker. Enable
+versioning with `PutBucketVersioningCommand` or the `VersioningConfiguration` property of an
+`AWS::S3::Bucket`.
 
 ```typescript sim-s3-object-versioning
 import {
@@ -1096,12 +1094,11 @@ A delete on a versioned Bucket raises `s3:ObjectRemoved:DeleteMarkerCreated` rat
 
 ## Object Lock
 
-Object Lock holds a version of an Object against a delete. A version can be held by a retention
-period, by a legal hold or by both, and a delete naming a held version is answered with
-`AccessDenied`. One way past exists and it is narrow. A `GOVERNANCE` retention period gives way to a
-request carrying `BypassGovernanceRetention` from a caller allowed to use it. A `COMPLIANCE` period
-and a legal hold hold against everyone, the account root included. Turn it on with `PutObjectLockConfigurationCommand`, or with
-`ObjectLockEnabled` on an `AWS::S3::Bucket` resource.
+Object Lock protects an object version with a retention period, a legal hold, or both. Deleting a
+protected version raises `AccessDenied`. A caller with `s3:BypassGovernanceRetention` may bypass
+`GOVERNANCE` retention by setting `BypassGovernanceRetention`. `COMPLIANCE` retention and legal
+holds cannot be bypassed. Enable Object Lock with `PutObjectLockConfigurationCommand` or
+`ObjectLockEnabled` on an `AWS::S3::Bucket`.
 
 Object Lock holds a version, and versioning has to be on underneath it. Turning it on over a Bucket
 with versioning off is refused with `InvalidBucketState`, as real S3 refuses it, and a template
@@ -1256,8 +1253,8 @@ Bucket created around the property would report a default retention it never app
 
 ## Event notifications
 
-A simulated S3 Bucket can notify a simulated Lambda function, a simulated SQS queue or a simulated
-SNS topic when an Object is created or removed. The configuration is applied with
+A simulated bucket can notify Lambda, SQS or SNS when an object is created or removed. Apply the
+configuration with
 `PutBucketNotificationConfigurationCommand` and read back with
 `GetBucketNotificationConfigurationCommand`.
 
@@ -1360,10 +1357,10 @@ can take the `.jpg` files under a prefix while another takes the `.png` files un
 The rule applies across the destination groups. A function and a queue that both want the same
 event are refused as readily as two functions.
 
-`PutBucketNotificationConfigurationCommand` replaces the whole configuration rather than adding to
-it. `GetBucketNotificationConfigurationCommand` answers an empty configuration for a Bucket that has
-none. Note that the response carries the destination groups at the top level, while the request nests
-them under `NotificationConfiguration`:
+`PutBucketNotificationConfigurationCommand` replaces the complete configuration.
+`GetBucketNotificationConfigurationCommand` returns an empty configuration when none is set. The
+request nests destination groups under `NotificationConfiguration`, while the response puts them at
+the top level:
 
 ```typescript
 const read = await simAws
@@ -1476,9 +1473,9 @@ function is.
 
 ### To an SQS queue
 
-A `QueueConfigurations` entry names a queue by ARN. The whole `Records` document arrives as one
-message body, and a consumer parses `record.body` to get at the event. Put a Lambda event source
-mapping on the queue and the chain runs end to end after one `backgroundTasksComplete()`.
+A `QueueConfigurations` entry names a queue by ARN. S3 sends the complete `Records` document as one
+message body. Add a Lambda event source mapping to consume it, then call
+`backgroundTasksComplete()` to finish the delivery chain.
 
 The queue's `Policy` attribute has to allow `sqs:SendMessage` for the `s3.amazonaws.com` service
 principal. S3 supplies `aws:SourceArn` and `aws:SourceAccount`. The `ArnLike` condition CDK's
@@ -1633,10 +1630,9 @@ its own policy and its own Account's IAM are what admit the Bucket. A FIFO queue
 
 ### To an SNS topic
 
-A `TopicConfigurations` entry names a topic by ARN. The whole `Records` document is published as the
-SNS `Message`, with a `Subject` of `Amazon S3 Notification`, as real S3 publishes it. A queue
-subscribed to the topic therefore has two envelopes to reach through. Parse the message body for the
-SNS envelope, then parse its `Message` for the S3 event.
+A `TopicConfigurations` entry names a topic by ARN. S3 publishes the complete `Records` document as
+the SNS `Message` with the subject `Amazon S3 Notification`. A subscribed queue receives an SNS
+envelope whose `Message` contains the S3 event.
 
 The topic's `Policy` attribute has to allow `sns:Publish` for the `s3.amazonaws.com` service
 principal. S3 supplies `aws:SourceArn` and `aws:SourceAccount`. The `ArnLike` condition CDK's


### PR DESCRIPTION
## Summary

- rewrite the nine remaining service guides with shorter introductions and direct capability explanations
- preserve implemented behavior, runnable examples, reference tables and documented limitations

## Testing

- `pnpm run check`
- technical prose checker (0 failures)