### PR TITLE
docs: recommend shared Yulin test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ npm i -D @kensio/yulin
 - [Non-AWS dependencies](https://yulinsim.dev/non-aws-dependencies/ "Dependencies Yulin does not simulate docs")
 - [Serving on localhost](https://yulinsim.dev/serve/ "Serving simulated AWS on localhost docs")
 - [Simulated time](https://yulinsim.dev/time/ "Simulated time docs")
+- [Test suite setup](https://yulinsim.dev/testing/ "Sharing one Yulin environment across a test suite")
 - [Terraform](https://yulinsim.dev/terraform/ "Deploying Terraform into simulated AWS docs")
 
 Every page listed above also ships inside the package as markdown, documenting the version
@@ -73,6 +74,24 @@ installed. `node_modules/@kensio/yulin/llms.txt` indexes them, and a coding agen
 reach can read them from there.
 
 ## Usage
+
+### Set up Yulin once for the test suite
+
+An application test suite should normally create one Yulin environment in its Vitest setup. Install
+SDK interception and deploy the application's simulated infrastructure there, then let every test
+use that state. Treat the environment like an AWS account or a LocalStack container that belongs to
+the suite.
+
+Keep tests independent by giving their records and resources unique names. A fresh `SimAws` or
+`SimSdk` for every test or test file is supported, but it is intended for cases that specifically
+need an empty simulated account.
+
+The simulated clock is shared too. Most tests should leave it alone and use the suite environment.
+Put tests that call `freeze()`, `setTo(...)`, `advanceBy(...)`, or `resume()` in a separate group with
+a fresh Yulin environment for each test.
+
+The [test suite setup guide](https://yulinsim.dev/testing/ "Sharing one Yulin environment across a test suite")
+shows the Vitest configuration, shared deployment, and SDK interception.
 
 ### Intercept AWS SDK clients
 
@@ -166,8 +185,9 @@ const accountId = simAwsAccountId("111111111111");
 const someOtherAccountId = makeSimAwsAccountId();
 ```
 
-Each instance of `SimAws` is cheap and encapsulated. Make one wherever you need it, in every test
-case or in shared test setup, whichever suits.
+Each instance of `SimAws` is encapsulated. Application tests should usually share one instance from
+suite setup. Create another instance when a test needs a separate simulated account with no shared
+state.
 
 If you prefer, you can also instantiate simulated services individually:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,12 @@ npm install --save-dev @kensio/yulin
 
 ## Choose how to use Yulin
 
+Start with [test suite setup](https://yulinsim.dev/testing/) when adding Yulin to an application's
+tests. Create one simulated environment, deploy the application's infrastructure, and install SDK
+interception for the whole suite. Tests then use that shared environment as they would use an AWS
+account or a container-based simulator. Put the smaller set of tests that control simulated time in
+an isolated group because the clock belongs to the environment too.
+
 Start with [AWS SDK interception](https://yulinsim.dev/sdk/) when the code under test already uses an
 AWS SDK client. Yulin intercepts the client's `send` calls and returns responses from a simulated
 service. The application code continues to use the AWS SDK normally.
@@ -81,4 +87,5 @@ credential, or run other work that depends on time passing.
 - [Non-AWS dependencies](https://yulinsim.dev/non-aws-dependencies/ "Dependencies Yulin does not simulate usage docs")
 - [Serving on localhost](https://yulinsim.dev/serve/ "Serving simulated AWS on localhost usage docs")
 - [Simulated time](https://yulinsim.dev/time/ "Simulated time usage docs")
+- [Test suite setup](https://yulinsim.dev/testing/ "Sharing one Yulin environment across a test suite")
 - [Terraform](https://yulinsim.dev/terraform/ "Deploying Terraform into simulated AWS usage docs")

--- a/docs/ai-skill/README.md
+++ b/docs/ai-skill/README.md
@@ -37,9 +37,14 @@ The skill tells an agent how to:
 - control simulated time
 - inspect simulated state in assertions
 - match simulated service errors by `name`
-- share an expensive deployment across tests in one file
+- share one simulated deployment and SDK interception across a whole test suite
+- give tests that control simulated time their own isolated Yulin environment
 - invoke code through a simulated Lambda function with its configured role and environment
 - treat unsupported behaviour as a gap to report, not behaviour to guess
+
+The [test suite setup guide](https://yulinsim.dev/testing/) states the default explicitly. An agent
+should set Yulin up once for the suite and let tests share it as they would share an AWS account or a
+container-based simulator. Tests that move the shared simulated clock are the main exception.
 
 ## Give the agent access to the API docs
 

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -3,6 +3,18 @@
 `SimSdk` routes AWS SDK for JavaScript v3 commands to Yulin. Use it to test code that already sends
 commands through AWS SDK clients.
 
+## Install interception in suite setup
+
+Application tests should normally create one `SimSdk` in Vitest suite setup and keep its class
+interceptions installed for the whole suite. Every SDK client then reaches the same simulated state,
+including clients created in different test files.
+
+The [test suite setup guide](https://yulinsim.dev/testing/) shows how to share one in-process
+environment across Vitest files. It also covers the worker and isolation settings this requires.
+A separate `SimSdk` for each test or file remains supported when a case needs an empty environment.
+Tests that control the simulation's clock should use a separate `SimSdk` so their time changes cannot
+affect the shared suite.
+
 ## Intercept a client
 
 Create a `SimSdk`, intercept a client class, and run the code under test:
@@ -146,6 +158,9 @@ Restore an interception before later code needs the client's original `send` met
 - Save the result of `simSdk.intercept(...)` and call its `restore()` method to restore one client.
 - Call `simSdk.restoreAll()` to restore every client intercepted by that `SimSdk`.
 - Declare `SimSdk` or an interception handle with `using` to restore it when the scope ends.
+
+A suite-wide interception stays installed until the test worker exits. Do not restore it in a
+per-file `afterAll`, since later files use the same interception and simulated state.
 
 ## Limit the intercepted commands
 

--- a/docs/services/acm/README.md
+++ b/docs/services/acm/README.md
@@ -542,7 +542,9 @@ await scopedAcm.requestCertificate(
 );
 ```
 
-Each `SimAws` instance has its own isolated state. Create a fresh instance per test or share one across related local setup.
+Each `SimAws` instance has its own isolated state. Application tests should normally use the instance
+from their shared [test suite setup](https://yulinsim.dev/testing/). A fresh instance remains useful
+when a test specifically needs an empty simulated account.
 
 ## Register a certificate with a chosen ARN
 

--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -1901,6 +1901,10 @@ it.
 environment names. The assembly's `manifest.json` is where that comes from, so an app synthesizing
 several Stacks across several regions needs no loop of its own and no region constants beside it.
 
+An application test suite should normally call `deployCdkOut(...)` once from its shared Yulin setup.
+Every test then uses the same deployed Stacks. The [test suite setup guide](https://yulinsim.dev/testing/)
+shows this arrangement with Vitest and SDK interception.
+
 ```typescript sim-cloudformation-cdk-out-assembly
 /**
  * Deploying every Stack a synthesized CDK cloud assembly holds.

--- a/docs/services/route53/README.md
+++ b/docs/services/route53/README.md
@@ -1700,8 +1700,9 @@ await scopedRoute53.createHostedZone(
 );
 ```
 
-Each `SimAws` instance has its own isolated state. Create a fresh instance per test, or share one
-across related local setup.
+Each `SimAws` instance has its own isolated state. Application tests should normally use the instance
+from their shared [test suite setup](https://yulinsim.dev/testing/). A fresh instance remains useful
+when a test specifically needs an empty simulated account.
 
 ## Standalone SimRoute53
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,228 @@
+# Test suite setup
+
+Run one Yulin environment for an application's test suite. Create the simulation, deploy the
+application's infrastructure, and install AWS SDK interception once. Every test then interacts with
+the same simulated account and resources.
+
+This is the recommended setup. It matches the way a suite uses a shared AWS account or a
+container-based simulator such as LocalStack. Creating a new Yulin environment for every test or
+test file is supported, but it should be reserved for cases that need a blank simulated account.
+
+The simulated clock is the main exception. A suite-wide `SimAws` has one clock, so a test that moves
+it changes time for every resource in that environment. Keep the majority of tests in the shared
+environment without changing its clock. Put clock-controlling tests in a smaller isolated group.
+
+## Split the Vitest suite
+
+Yulin holds state in the process that created it. Vitest must run the Yulin tests in one worker for
+all shared files to reach the same environment. Give that project disabled file parallelism and file
+isolation, then load a setup module before each test file.
+
+The second project below matches files ending in `.clock.test.ts`. Those tests do not load the shared
+setup and can create isolated Yulin environments:
+
+```typescript testing-vitest-config
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "shared Yulin",
+          include: ["test/**/*.test.ts"],
+          exclude: ["test/**/*.clock.test.ts"],
+          fileParallelism: false,
+          isolate: false,
+          setupFiles: ["./test/setup-yulin.ts"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "isolated Yulin clock",
+          include: ["test/**/*.clock.test.ts"],
+        },
+      },
+    ],
+  },
+});
+```
+
+Vitest executes a `setupFiles` entry before every test file. With isolation disabled, modules
+imported by that entry stay cached in the worker. Put the Yulin initialization in an imported module
+to make it run once.
+
+See Vitest's documentation for [`setupFiles`](https://vitest.dev/config/setupfiles),
+[`fileParallelism`](https://vitest.dev/config/fileparallelism), and
+[`isolate`](https://vitest.dev/config/isolate).
+
+## Create and deploy the shared environment
+
+Put the suite environment in a module such as `test/yulin-environment.ts`. Intercept client classes
+used by the application and deploy its synthesized CDK cloud assembly:
+
+```typescript testing-shared-yulin-environment
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { S3Client } from "@aws-sdk/client-s3";
+import type { SimAws } from "@kensio/yulin";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+interface YulinTestEnvironment {
+  readonly simAws: SimAws;
+  readonly simSdk: SimSdk;
+  readonly uploadsBucketName: string;
+}
+
+type YulinTestGlobal = typeof globalThis & {
+  yulinEnvironment?: Promise<YulinTestEnvironment>;
+};
+
+const testGlobal = globalThis as YulinTestGlobal;
+
+// oxlint-disable-next-line unicorn-js/prefer-top-level-await -- The shared promise prevents setup from running again before another test file.
+export const yulin = await (testGlobal.yulinEnvironment ??= startYulin());
+
+async function startYulin(): Promise<YulinTestEnvironment> {
+  const simSdk = new SimSdk();
+  simSdk.intercept(DynamoDBClient);
+  simSdk.intercept(S3Client);
+
+  const stacks = await simSdk.simAws.cloudFormation().deployCdkOut({
+    directoryPath: "cdk.out",
+    stackNames: ["ApplicationStack"],
+  });
+  const appStack = stacks.get("ApplicationStack");
+
+  if (appStack === undefined) {
+    throw new Error("ApplicationStack was not deployed");
+  }
+
+  process.once("exit", () => {
+    simSdk.restoreAll();
+  });
+
+  return {
+    simAws: simSdk.simAws,
+    simSdk,
+    uploadsBucketName: appStack.output("UploadsBucketName"),
+  };
+}
+```
+
+Use the same templates that the application deploys. `deployCdkOut(...)` can deploy the whole cloud
+assembly or the named application Stacks. Read generated resource names from stack outputs or
+resource accessors after deployment.
+
+The configured setup entry only needs to import that module:
+
+```typescript
+// test/setup-yulin.ts
+import "./yulin-environment.js";
+```
+
+Do not put the initialization directly in `setup-yulin.ts`. Vitest executes that file for every test
+file, even when isolation is disabled.
+
+## Use the environment from every test
+
+Application code continues to construct and send through ordinary AWS SDK clients. Class-level
+interception routes all of them to the suite's Yulin environment.
+
+A test that needs direct access can import the shared environment:
+
+```typescript
+import { randomUUID } from "node:crypto";
+
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { expect, it } from "vitest";
+
+import { yulin } from "../yulin-environment.js";
+
+it("stores an upload", async () => {
+  const key = `test-uploads/${randomUUID()}.txt`;
+  const s3 = new S3Client({ region: "eu-west-2" });
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: yulin.uploadsBucketName,
+      Key: key,
+      Body: "an upload",
+    }),
+  );
+
+  const stored = await yulin.simAws
+    .region("eu-west-2")
+    .s3()
+    .getObject(
+      new GetObjectCommand({
+        Bucket: yulin.uploadsBucketName,
+        Key: key,
+      }),
+    );
+
+  expect(await stored?.Body?.transformToString()).toBe("an upload");
+});
+```
+
+The `SimAws` object is mainly useful for preparing input state and reading state back in assertions.
+Exercise the application through its normal interfaces whenever possible.
+
+## Keep tests independent in shared state
+
+Shared infrastructure does not require tests to depend on one another. Give each test's records,
+object keys, user names, and other mutable data unique values. Read CloudFormation-generated names
+from the deployed stack. Avoid assertions that assume the simulated account contains no other data.
+
+Keep `beforeEach` for the records a test needs. A per-file `beforeAll` can prepare data used by every
+test in that file. Leave the suite's stacks and SDK interception in place until the worker exits.
+
+Tests run sequentially with `fileParallelism: false`. If a test uses `it.concurrent`, its data still
+needs unique identifiers because those cases share the same environment at the same time.
+
+## Give clock-controlling tests their own environment
+
+Every service in a `SimAws` reads the same simulated clock. Calling `advanceBy(...)` can expire
+credentials, delete resources whose retention period has passed, and run scheduled work anywhere in
+the environment. Resetting the clock afterwards cannot reverse those changes.
+
+Tests in the shared project should treat the clock as read-only. Put a test that calls `freeze()`,
+`setTo(...)`, `advanceBy(...)`, or `resume()` in a `.clock.test.ts` file and create a fresh environment
+inside the test:
+
+```typescript
+import { SimAws, SimFixedClock } from "@kensio/yulin";
+import { it } from "vitest";
+
+it("expires a session", async () => {
+  const simAws = new SimAws({
+    clock: new SimFixedClock(new Date("2026-09-04T09:00:00.000Z")),
+  });
+
+  // Deploy only the infrastructure this clock-controlling test needs.
+
+  await simAws.clock().advanceBy({ minutes: 20 });
+
+  // Assert the behaviour after the time change.
+});
+```
+
+Create a `SimSdk` around that `SimAws` when application code uses SDK clients. Restore its
+interceptions at the end of the test. The [simulated time guide](https://yulinsim.dev/time/) describes
+what moving the clock runs and changes.
+
+## When to create another environment
+
+A fresh `SimAws` or `SimSdk` is useful when the empty environment is part of the behaviour under
+test, or when the test needs to control simulated time. Yulin's own service unit tests are another
+example because they test resource creation and account isolation directly.
+
+Vitest workers cannot share an in-memory `SimAws`. A suite that keeps file parallelism creates one
+environment per worker. Put Yulin-based application tests in a Vitest project with
+`fileParallelism: false` when the rest of the unit suite should remain parallel.

--- a/docs/testing/testing-shared-yulin-environment.example.ts
+++ b/docs/testing/testing-shared-yulin-environment.example.ts
@@ -1,0 +1,45 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { S3Client } from "@aws-sdk/client-s3";
+import type { SimAws } from "@kensio/yulin";
+import { SimSdk } from "@kensio/yulin/sdk";
+
+interface YulinTestEnvironment {
+  readonly simAws: SimAws;
+  readonly simSdk: SimSdk;
+  readonly uploadsBucketName: string;
+}
+
+type YulinTestGlobal = typeof globalThis & {
+  yulinEnvironment?: Promise<YulinTestEnvironment>;
+};
+
+const testGlobal = globalThis as YulinTestGlobal;
+
+// oxlint-disable-next-line unicorn-js/prefer-top-level-await -- The shared promise prevents setup from running again before another test file.
+export const yulin = await (testGlobal.yulinEnvironment ??= startYulin());
+
+async function startYulin(): Promise<YulinTestEnvironment> {
+  const simSdk = new SimSdk();
+  simSdk.intercept(DynamoDBClient);
+  simSdk.intercept(S3Client);
+
+  const stacks = await simSdk.simAws.cloudFormation().deployCdkOut({
+    directoryPath: "cdk.out",
+    stackNames: ["ApplicationStack"],
+  });
+  const appStack = stacks.get("ApplicationStack");
+
+  if (appStack === undefined) {
+    throw new Error("ApplicationStack was not deployed");
+  }
+
+  process.once("exit", () => {
+    simSdk.restoreAll();
+  });
+
+  return {
+    simAws: simSdk.simAws,
+    simSdk,
+    uploadsBucketName: appStack.output("UploadsBucketName"),
+  };
+}

--- a/docs/testing/testing-vitest-config.example.ts
+++ b/docs/testing/testing-vitest-config.example.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "shared Yulin",
+          include: ["test/**/*.test.ts"],
+          exclude: ["test/**/*.clock.test.ts"],
+          fileParallelism: false,
+          isolate: false,
+          setupFiles: ["./test/setup-yulin.ts"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "isolated Yulin clock",
+          include: ["test/**/*.clock.test.ts"],
+        },
+      },
+    ],
+  },
+});

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -3,6 +3,16 @@
 Each `SimAws` has its own clock. Yulin uses that clock for resource timestamps, expiry checks, and
 scheduled work.
 
+## Isolate tests that control time
+
+A shared [test suite environment](https://yulinsim.dev/testing/) also has one shared clock. Most
+tests should use that environment without calling `freeze()`, `setTo(...)`, `advanceBy(...)`, or
+`resume()`.
+
+Put tests that control simulated time in a separate test group. Give each of those tests its own
+`SimAws` or `SimSdk`, along with the infrastructure it needs. A clock change then affects only that
+test's environment. The rest of the suite can keep sharing one deployment and SDK interception.
+
 ## Start at a known time
 
 A new simulation follows the system clock by default. Pass a `SimFixedClock` when a test needs an


### PR DESCRIPTION
## Summary

- recommend one shared Yulin deployment and SDK interception for an application test suite
- document isolated environments for tests that control the simulated clock
- add checked Vitest setup examples and link the guidance from related documentation

## Testing

- `pnpm run check`
- technical prose audit (0 files over the fail threshold)