### PR TITLE
fix: supply SES FromAddress to IAM

### DIFF
--- a/docs/services/ses/README.md
+++ b/docs/services/ses/README.md
@@ -888,7 +888,7 @@ addresses.
 
 ```typescript sim-ses-permissions
 /**
- * A Role that may only send from one domain.
+ * A Role that may only send from one address at a verified domain.
  */
 
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
@@ -928,6 +928,9 @@ await simAws.iam().putRolePolicy(
           Effect: "Allow",
           Action: "ses:SendEmail",
           Resource: "arn:aws:ses:us-east-1:111111111111:identity/example.com",
+          Condition: {
+            StringEquals: { "ses:FromAddress": "hello@example.com" },
+          },
         },
       ],
     }),
@@ -936,7 +939,7 @@ await simAws.iam().putRolePolicy(
 
 await ses.sendEmail(
   new SendEmailCommand({
-    FromEmailAddress: "anything@example.com",
+    FromEmailAddress: "hello@example.com",
     Destination: { ToAddresses: ["someone@example.com"] },
     Content: {
       Simple: {
@@ -960,6 +963,10 @@ console.log(ses.sentEmails().length);
 The more specific identity wins when both exist. A policy naming `identity/example.com` covers a
 send from any address at the domain, unless that address is an identity in its own right, in which
 case the send authorizes against `identity/hello@example.com` instead.
+
+`ses:FromAddress` carries the bare `FromEmailAddress`. A policy can use it to allow one address at a
+verified domain. A display name does not change the value. For example, `Welcome team
+<hello@example.com>` supplies `hello@example.com` to IAM.
 
 `ses:ListEmailIdentities`, `ses:GetAccount` and `ses:PutAccountDetails` have no resource type at all
 on real SES, and only a policy written against `*` allows them. A policy scoped to identity ARNs

--- a/docs/services/ses/sim-ses-permissions.example.ts
+++ b/docs/services/ses/sim-ses-permissions.example.ts
@@ -1,5 +1,5 @@
 /**
- * A Role that may only send from one domain.
+ * A Role that may only send from one address at a verified domain.
  */
 
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
@@ -39,6 +39,9 @@ await simAws.iam().putRolePolicy(
           Effect: "Allow",
           Action: "ses:SendEmail",
           Resource: "arn:aws:ses:us-east-1:111111111111:identity/example.com",
+          Condition: {
+            StringEquals: { "ses:FromAddress": "hello@example.com" },
+          },
         },
       ],
     }),
@@ -47,7 +50,7 @@ await simAws.iam().putRolePolicy(
 
 await ses.sendEmail(
   new SendEmailCommand({
-    FromEmailAddress: "anything@example.com",
+    FromEmailAddress: "hello@example.com",
     Destination: { ToAddresses: ["someone@example.com"] },
     Content: {
       Simple: {

--- a/src/service/ses/command/authorize/sim-ses-authorizer.ts
+++ b/src/service/ses/command/authorize/sim-ses-authorizer.ts
@@ -67,6 +67,27 @@ export class SimSesAuthorizer {
   }
 
   /**
+   * Ensure the caller may send from one email identity and address.
+   *
+   * SES supplies the bare sender address as `ses:FromAddress`. A policy can
+   * use this key to grant one address under a verified domain identity.
+   *
+   * https://docs.aws.amazon.com/ses/latest/dg/sending-authorization-policy-examples.html#sending-authorization-policy-example-from
+   */
+  authorizeSendEmail(
+    emailIdentity: string,
+    fromAddress: string,
+    caller?: SimAwsCaller,
+  ): SimAwsResolvedCaller {
+    return this.authorizeResource(
+      "ses:SendEmail",
+      simSesIdentityArn(this.#accountRegionScope, emailIdentity),
+      caller,
+      { "ses:FromAddress": fromAddress },
+    );
+  }
+
+  /**
    * Ensure the caller may perform an action on one email template.
    *
    * The template need not exist, for the same reason an identity need not:
@@ -125,8 +146,14 @@ export class SimSesAuthorizer {
     action: string,
     resource: string,
     caller: SimAwsCaller | undefined,
+    conditionContext?: Readonly<Record<string, string>>,
   ): SimAwsResolvedCaller {
-    const decision = this.#iam.authorize({ action, resource, caller });
+    const decision = this.#iam.authorize({
+      action,
+      resource,
+      caller,
+      conditionContext,
+    });
 
     if (decision.isDenied) {
       throw new SimIamAccessDenied({

--- a/src/service/ses/command/authorize/sim-ses-iam.iso.test.ts
+++ b/src/service/ses/command/authorize/sim-ses-iam.iso.test.ts
@@ -96,6 +96,57 @@ describe("SES IAM authorization", () => {
     assertArrayLength(ses.sentEmails(), 1);
   });
 
+  it("allows a send whose From address matches the policy condition", async () => {
+    // Given a Role allowed to send from one address at a verified domain.
+    const simAws = await simAwsWithRole({
+      Action: "ses:SendEmail",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+      Condition: {
+        StringEquals: { "ses:FromAddress": "hello@example.com" },
+      },
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+
+    // When it sends with a display name around that address.
+    await ses.sendEmail(
+      new SendEmailCommand({
+        ...welcome,
+        FromEmailAddress: "Welcome team <hello@example.com>",
+      }),
+      asRole,
+    );
+
+    // Then IAM compares the condition with the bare From address and allows it.
+    assertArrayLength(ses.sentEmails(), 1);
+  });
+
+  it("refuses a send whose From address does not match the condition", async () => {
+    // Given a Role allowed to send from one address at a verified domain.
+    const simAws = await simAwsWithRole({
+      Action: "ses:SendEmail",
+      Resource: `arn:aws:ses:us-east-1:${accountIdOneOnes}:identity/example.com`,
+      Condition: {
+        StringEquals: { "ses:FromAddress": "orders@example.com" },
+      },
+    });
+    const ses = simAws.sesV2();
+
+    ses.verifyIdentity("example.com");
+    ses.verifyIdentity("example.org");
+
+    // When it sends from another address at that domain.
+    const error = await assertThrowsErrorAsync(async () => {
+      await ses.sendEmail(new SendEmailCommand(welcome), asRole);
+    });
+
+    // Then the resource still matches, but the condition denies the send.
+    assertInstanceOf(error, SimIamAccessDenied);
+    assertArrayEmpty(ses.sentEmails());
+  });
+
   it("refuses a send from an identity the policy does not name", async () => {
     // Given a Role allowed to send from one domain only.
     const simAws = await simAwsWithRole({

--- a/src/service/ses/command/send/sim-ses-send-email.ts
+++ b/src/service/ses/command/send/sim-ses-send-email.ts
@@ -78,12 +78,13 @@ export class SimSesSendEmail {
   ): SimSendEmailCommandOutput {
     const input = command.input;
     const fromEmailAddress = requiredSimSesFromAddress(input.FromEmailAddress);
+    const bareFromAddress = simSesBareAddress(fromEmailAddress);
 
     refuseUnsimulatedSendInput(input);
 
-    this.#authorizer.authorizeIdentity(
-      "ses:SendEmail",
-      this.#identities.covering(simSesBareAddress(fromEmailAddress)),
+    this.#authorizer.authorizeSendEmail(
+      this.#identities.covering(bareFromAddress),
+      bareFromAddress,
       options?.caller,
     );
 


### PR DESCRIPTION
## Changes

- Supply the bare sender address to simulated IAM as `ses:FromAddress` when authorizing `SendEmail`.
- Cover matching and mismatched conditions, including a sender with a display name, and update the SES permissions example.

## Verification

- `pnpm run check`

Resolves #1289

@coderabbitai ignore