### PR TITLE
feat: deliver exhausted Lambda stream batches to failure destinations

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1904,7 +1904,7 @@ with more steps.
 `MaximumRetryAttempts` and `MaximumRecordAgeInSeconds` govern the same failed-batch lifecycle, and a
 stream mapping keeps both. `MaximumRetryAttempts: 0` makes one delivery and no retries, and a
 positive value allows that many retries after the first delivery. `MaximumRecordAgeInSeconds`
-discards a record once the next attempt would fall past that age. Lambda's `-1` means no limit
+discards expired records before each invocation, including the first poll. Lambda's `-1` means no limit
 (that is what a mapping naming neither reports back).
 
 ```typescript sim-lambda-stream-retry-limits
@@ -2032,6 +2032,58 @@ discarded, and the mapping reads on from behind it.
 `AWS::Lambda::EventSourceMapping` takes both in a template. A value outside Lambda's range (`-1` to
 10,000 retries, `-1` to 604,800 seconds) is a `ValidationException`. A queue mapping takes neither,
 because a message the handler never takes is left to the queue's own redrive policy.
+
+### Sending discarded stream batches to a destination
+
+DynamoDB Streams and Kinesis mappings accept `DestinationConfig.OnFailure` with a standard SQS
+queue or SNS topic ARN. Supply it to `CreateEventSourceMapping` or the
+`AWS::Lambda::EventSourceMapping` resource alongside the retry and record-age limits:
+
+```json
+{
+  "MaximumRetryAttempts": 10,
+  "MaximumRecordAgeInSeconds": 3600,
+  "DestinationConfig": {
+    "OnFailure": {
+      "Destination": "arn:aws:sqs:eu-west-2:111111111111:stream-failures"
+    }
+  }
+}
+```
+
+CDK's `DynamoEventSource` and `KinesisEventSource` accept `onFailure: new SqsDlq(queue)` or
+`onFailure: new SnsDlq(topic)`. Their synthesized destination configuration is passed through to
+the simulated mapping. Create, Get, List and Delete responses preserve that configuration.
+
+The function's execution role needs `sqs:SendMessage` on the queue or `sns:Publish` on the topic.
+Delivery goes through the simulated destination service, so its IAM checks and SNS subscriptions
+apply. An IAM denial or a missing destination rejects `backgroundTasksComplete()` or the clock
+advance that exhausted the batch. The discarded records have already advanced the checkpoint.
+Yulin attempts destination delivery once and does not retry a failed send.
+
+The JSON message follows the AWS
+[DynamoDB Streams](https://docs.aws.amazon.com/lambda/latest/dg/services-dynamodb-errors.html) and
+[Kinesis](https://docs.aws.amazon.com/lambda/latest/dg/kinesis-on-failure-destination.html)
+notification formats. Import `SimLambdaStreamFailureRecord` from `@kensio/yulin/lambda` to type it.
+
+- `version` is `"1.0"` and `timestamp` is the simulated discard time in ISO 8601 format.
+- `requestContext` contains a generated `requestId`, the mapping's `functionArn`,
+  `approximateInvokeCount`, and either `RetryAttemptsExhausted` or `RecordAgeExceeded` as `condition`.
+- `responseContext` reports `statusCode: 200` and `executedVersion`. A handler error adds
+  `functionError: "Unhandled"`. A valid partial-batch failure response leaves that field out.
+  Records discarded before any invocation omit `responseContext`.
+- `DDBStreamBatchInfo` or `KinesisBatchInfo` identifies the stream ARN, shard ID, first and last
+  sequence numbers, first and last arrival times, and batch size. Arrival times are ISO 8601 strings.
+
+The original record payloads are absent. A successful batch produces no notification. After a
+partial-batch response, the notification covers the discarded suffix starting at the failed
+checkpoint. When only an older prefix expires, its notification excludes the younger records.
+Records already expired on their first poll report zero invocations. Request IDs are generated for
+the notification and are not correlated with the handler's invocation context.
+
+S3 destinations, FIFO queues or topics, and `OnSuccess` are refused. SQS source mappings cannot
+have this destination configuration. The simulator's existing five-retry cap for mappings with
+neither limit also produces a failure notification when it discards a batch.
 
 ### Reporting individual record failures
 
@@ -2273,8 +2325,7 @@ the three stream actions on the stream ARN and `dynamodb:ListStreams` on every s
 the mapping's execution-role check is looking for.
 
 The properties a non-default `DynamoEventSource` adds are refused by name. Those are
-`FilterCriteria`, `ParallelizationFactor`, `BisectBatchOnFunctionError`, `TumblingWindowInSeconds`
-and `DestinationConfig`.
+`FilterCriteria`, `ParallelizationFactor`, `BisectBatchOnFunctionError` and `TumblingWindowInSeconds`.
 
 A hand-written template or a SAM application usually gives the function the AWS managed policy
 `AWSLambdaDynamoDBExecutionRole` instead. Simulated IAM has no model for managed policy ARNs, so
@@ -4154,8 +4205,10 @@ Current documented limitations:
 - Throttling does not drive a retry. A retry follows a handler that threw or ran out of time, and
   the `MaximumEventAgeInSeconds` a config carries is measured from when the invocation was
   accepted.
-- `DestinationConfig` on an event source mapping is left out. It is a different mechanism from the
-  asynchronous invocation destinations above.
+- Stream mappings support standard SQS and SNS `DestinationConfig.OnFailure` destinations.
+  S3 destinations and `OnSuccess` are refused. Destination delivery is attempted once. A delivery
+  failure rejects the background task after the discarded records have advanced the checkpoint.
+  Destination delivery retries and `DestinationDeliveryFailures` metrics are not simulated.
 - A settings change takes effect at once. Real Lambda reports `LastUpdateStatus: "InProgress"` while
   it rolls the change out, and neither that member nor the wait it implies is simulated.
 - A cross-account grant is only half of what admits a call. The caller's own Account has to allow
@@ -4245,7 +4298,7 @@ Current documented limitations:
   it stands.
 - SQS queues, DynamoDB streams and Kinesis streams are the only event sources. Kafka, DocumentDB and
   Kinesis enhanced fan-out consumers are refused outright, and so are `FilterCriteria`,
-  `ScalingConfig`, `DestinationConfig`, `BisectBatchOnFunctionError`, `ParallelizationFactor`,
+  `ScalingConfig`, `BisectBatchOnFunctionError`, `ParallelizationFactor`,
   `TumblingWindowInSeconds` and the other mapping inputs this simulation has no behaviour for. An
   `AWS::Lambda::EventSourceMapping` carrying `Tags` is the exception, and deploys with the tags
   dropped and the property recorded.

--- a/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-stream-destinations.loc.test.ts
+++ b/src/service/cloudformation/cdk/lambda/sim-cdk-lambda-stream-destinations.loc.test.ts
@@ -1,0 +1,117 @@
+import { assertTypeString } from "@kensio/smartass";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { TestCdkProject } from "../../../../util/filesystem/test-cdk-project.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import type { SimLambdaStreamFailureRecord } from "../../../lambda/event-source/poll/sim-lambda-stream-failure-record.js";
+
+describe("CDK stream failure destinations", () => {
+  it.each(["dynamodb", "kinesis"])(
+    "deploys and delivers a %s failure destination",
+    async (source) => {
+      // Given a CDK stream subscription with an on-failure destination and generated grants.
+      const project = new TestCdkProject();
+      await project.writeCdkAppFile(`
+import * as cdk from "aws-cdk-lib/core";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as kinesis from "aws-cdk-lib/aws-kinesis";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as sources from "aws-cdk-lib/aws-lambda-event-sources";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+const app = new cdk.App();
+const stack = new cdk.Stack(app, "StreamFailures", { env: { account: "111111111111", region: "eu-west-2" } });
+const queue = new sqs.Queue(stack, "Failures");
+const fn = new lambda.Function(stack, "Consumer", {
+  runtime: lambda.Runtime.NODEJS_24_X,
+  handler: "index.handler",
+  code: lambda.Code.fromInline('exports.handler = async () => { throw new Error("Failed stream batch"); };'),
+});
+if (${JSON.stringify(source)} === "dynamodb") {
+  const table = new dynamodb.Table(stack, "Orders", {
+    partitionKey: { name: "orderId", type: dynamodb.AttributeType.STRING },
+    stream: dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,
+  });
+  fn.addEventSource(new sources.DynamoEventSource(table, {
+    startingPosition: lambda.StartingPosition.TRIM_HORIZON,
+    retryAttempts: 10,
+    maxRecordAge: cdk.Duration.hours(1),
+    onFailure: new sources.SqsDlq(queue),
+  }));
+  new cdk.CfnOutput(stack, "SourceName", { value: table.tableName });
+} else {
+  const stream = new kinesis.Stream(stack, "Orders");
+  fn.addToRolePolicy(new iam.PolicyStatement({ actions: ["kinesis:ListStreams"], resources: ["*"] }));
+  const topic = new sns.Topic(stack, "FailureTopic");
+  topic.addSubscription(new SqsSubscription(queue, { rawMessageDelivery: true }));
+  fn.addEventSource(new sources.KinesisEventSource(stream, {
+    startingPosition: lambda.StartingPosition.TRIM_HORIZON,
+    retryAttempts: 10,
+    maxRecordAge: cdk.Duration.hours(1),
+    onFailure: new sources.SnsDlq(topic),
+  }));
+  new cdk.CfnOutput(stack, "SourceName", { value: stream.streamName });
+}
+new cdk.CfnOutput(stack, "QueueUrl", { value: queue.queueUrl });
+app.synth();
+`);
+      const output = await project.synth();
+      const simAws = new SimAws();
+      const scope = simAws.account("111111111111").region("eu-west-2");
+
+      // When the unmodified template is deployed locally and a record exhausts ten retries.
+      const stack = await scope
+        .cloudFormation()
+        .deployTemplateFile(path.join(output, "StreamFailures.template.json"));
+      await simAws.backgroundTasksComplete();
+      const sourceName = stack.outputs.get("SourceName")?.value;
+      const queueUrl = stack.outputs.get("QueueUrl")?.value;
+      assertTypeString(sourceName);
+      assertTypeString(queueUrl);
+      if (source === "dynamodb") {
+        await scope.dynamoDb().putItem({
+          input: {
+            TableName: sourceName,
+            Item: { orderId: { S: "order-1" } },
+          },
+        });
+      } else {
+        await scope.kinesis().putRecord({
+          input: {
+            StreamName: sourceName,
+            PartitionKey: "order-1",
+            Data: new TextEncoder().encode("order-1"),
+          },
+        });
+      }
+      await simAws.backgroundTasksComplete();
+      await simAws.clock().advanceBy({ hours: 1 });
+
+      // Then the destination receives the batch metadata through the permissions CDK granted.
+      const messages = await scope
+        .sqs()
+        .receiveMessage({ input: { QueueUrl: queueUrl } });
+      expect(messages.Messages).toHaveLength(1);
+      const record = JSON.parse(
+        messages.Messages?.[0]?.Body ?? "null",
+      ) as SimLambdaStreamFailureRecord;
+      expect(record.requestContext).toMatchObject({
+        condition: "RetryAttemptsExhausted",
+        approximateInvokeCount: 11,
+      });
+      const mapping = await scope
+        .lambda()
+        .listEventSourceMappings({ input: {} });
+      expect(mapping.EventSourceMappings[0]).toMatchObject({
+        MaximumRetryAttempts: 10,
+        MaximumRecordAgeInSeconds: 3600,
+      });
+      expect(
+        mapping.EventSourceMappings[0]?.DestinationConfig?.OnFailure
+          ?.Destination,
+      ).toMatch(/^arn:aws:(sqs|sns):/u);
+    },
+  );
+});

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -552,6 +552,17 @@ enough. The five-attempt cap applies to a mapping that named neither limit
 ([issue 1219](https://github.com/KensioSoftware/yulin/issues/1219)). One that named a record age has
 an end of its own, and retries until the records reach it.
 
+`SimLambdaStreamProgress.before` checks record age before invoking a batch. Expired records are
+removed from the front, including when the mapping has never invoked them. `after` accounts for
+the handler response and the retry quota. Both paths advance the checkpoint before attempting a
+failure notification, so a destination error cannot cause a discarded batch to be invoked again.
+
+Stream mappings preserve `DestinationConfig.OnFailure` and deliver through
+`SimLambdaDestinationTargets` using the execution role. `sim-lambda-stream-failure-record.ts`
+builds the SQS/SNS metadata envelope with shard and sequence-number bounds. The stream readers
+supply their shard IDs. Destination delivery is attempted once and failures reject the background
+task. The usage guide lists the supported fields and delivery limitations.
+
 Two polls must never overlap, which a queue mapping does not have to care about: a received message
 is hidden and a read record is not, so a second poll from the same checkpoint would deliver the same
 records twice. `SimLambdaEventSourcePollTurn` is the one-at-a-time guard, and it reschedules from

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
@@ -1,3 +1,4 @@
+import { simLambdaStreamDestinationConfig } from "../../event-source/sim-lambda-stream-destination-config.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCreateEventSourceMappingCommandInput } from "../../command/event-source-mapping/event-source-mapping.command.js";
@@ -53,6 +54,9 @@ export class SimCfnLambdaEventSourceMappingProperties {
 
     return {
       EventSourceArn: eventSourceArn,
+      DestinationConfig: simLambdaStreamDestinationConfig(
+        this.properties["DestinationConfig"],
+      ),
       FunctionName: simCfnLambdaTargetFunctionName(
         this.parser.requiredString(
           this.resource,

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
@@ -21,6 +21,7 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "MaximumBatchingWindowInSeconds",
   "MaximumRecordAgeInSeconds",
   "MaximumRetryAttempts",
+  "DestinationConfig",
   "StartingPosition",
   "StartingPositionTimestamp",
 ]);
@@ -36,7 +37,6 @@ const simulatedPropertyNames: ReadonlySet<string> = new Set([
 const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
   "AmazonManagedKafkaEventSourceConfig",
   "BisectBatchOnFunctionError",
-  "DestinationConfig",
   "DocumentDBEventSourceConfig",
   "FilterCriteria",
   "KmsKeyArn",

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -1,3 +1,7 @@
+import {
+  simLambdaStreamDestinationConfig,
+  type SimLambdaStreamDestinationConfiguration,
+} from "../../event-source/sim-lambda-stream-destination-config.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
 import {
   type SimLambdaEventSourceArn,
@@ -26,6 +30,9 @@ interface SimLambdaEventSourceMappingInputProperties {
   readonly start: SimLambdaEventSourceStart | undefined;
   readonly enabled: boolean;
   readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
+  readonly destinationConfig:
+    | SimLambdaStreamDestinationConfiguration
+    | undefined;
   readonly streamRetryLimits: SimLambdaStreamRetryLimits | undefined;
 }
 
@@ -56,6 +63,10 @@ export class SimLambdaEventSourceMappingInput {
   public readonly enabled: boolean;
   public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 
+  public readonly destinationConfig:
+    | SimLambdaStreamDestinationConfiguration
+    | undefined;
+
   /**
    * When a failed batch stops being delivered again, for a source that leaves
    * the counting to the mapping.
@@ -70,6 +81,7 @@ export class SimLambdaEventSourceMappingInput {
     this.start = properties.start;
     this.enabled = properties.enabled;
     this.functionResponseTypes = properties.functionResponseTypes;
+    this.destinationConfig = properties.destinationConfig;
     this.streamRetryLimits = properties.streamRetryLimits;
   }
 
@@ -88,6 +100,10 @@ export class SimLambdaEventSourceMappingInput {
 
     return new this({
       eventSourceArn,
+      destinationConfig: simLambdaStreamDestinationConfig(
+        input.DestinationConfig,
+        eventSourceArn.kind,
+      ),
       ...simLambdaFunctionReferenceOf(
         requiredString(input.FunctionName, "functionName"),
       ),

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -15,11 +15,6 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
   ["ScalingConfig", "polling concurrency is not simulated"],
   ["ProvisionedPollerConfig", "polling concurrency is not simulated"],
   [
-    "DestinationConfig",
-    "failure destinations are not simulated, so a stream batch that runs out " +
-      "of attempts is discarded rather than sent anywhere",
-  ],
-  [
     "BisectBatchOnFunctionError",
     "batch bisection is not simulated, so a failing stream batch is retried " +
       "whole",

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -1,3 +1,4 @@
+import type { SimLambdaDestinationTargets } from "../../destination/sim-lambda-destination-targets.js";
 import type { CommandHandler } from "../../../../command/command-handler.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
@@ -31,6 +32,7 @@ interface CreateEventSourceMappingCommandHandlerProperties {
   readonly kinesisStreams: SimLambdaKinesisStreams;
   readonly functions: SimLambdaFunctionLookup;
   readonly iam: SimIamInterServiceAuthZ;
+  readonly destinations?: SimLambdaDestinationTargets;
   readonly background: BackgroundScheduler;
 }
 
@@ -145,6 +147,8 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
       enabled: input.enabled,
       functionResponseTypes: input.functionResponseTypes,
       streamRetryLimits: input.streamRetryLimits,
+      destinationConfig: input.destinationConfig,
+      destinations: this.properties.destinations,
       createdAt: this.properties.background.now(),
     });
 

--- a/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.ts
+++ b/src/service/lambda/command/event-source-mapping/sim-lambda-event-source-mapping-commands.ts
@@ -1,3 +1,4 @@
+import type { SimLambdaDestinationTargets } from "../../destination/sim-lambda-destination-targets.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-region-scope.js";
@@ -34,6 +35,7 @@ interface SimLambdaEventSourceMappingCommandsProperties {
   readonly kinesisStreams: SimLambdaKinesisStreams;
   readonly functions: SimLambdaFunctionLookup;
   readonly iam: SimIamInterServiceAuthZ;
+  readonly destinations?: SimLambdaDestinationTargets;
   readonly background: BackgroundScheduler;
 }
 

--- a/src/service/lambda/destination/sim-lambda-destination-targets.ts
+++ b/src/service/lambda/destination/sim-lambda-destination-targets.ts
@@ -1,3 +1,4 @@
+import type { SimLambdaStreamFailureRecord } from "../event-source/poll/sim-lambda-stream-failure-record.js";
 import { SimLambdaError } from "../error/sim-lambda.error.js";
 import type { SimLambdaDestinationArn } from "./sim-lambda-destination-arn.js";
 import type { SimLambdaDestinationRecord } from "./sim-lambda-destination-record.js";
@@ -7,7 +8,7 @@ import type { SimLambdaDestinationRecord } from "./sim-lambda-destination-record
  */
 export interface SimLambdaDestinationDeliveryRequest {
   readonly destinationArn: SimLambdaDestinationArn;
-  readonly record: SimLambdaDestinationRecord;
+  readonly record: SimLambdaDestinationRecord | SimLambdaStreamFailureRecord;
 
   /**
    * The function whose invocation produced this record, which is what the

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-poller.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-poller.ts
@@ -1,5 +1,6 @@
+import { processSimLambdaStreamBatch } from "../sim-lambda-stream-batch-processing.js";
+import { simLambdaKinesisStreamRecordTimes } from "../sim-lambda-stream-record-times.js";
 import type { BackgroundScheduler } from "../../../../../util/background/background.js";
-import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionLookup } from "../../../function/url/sim-lambda-function-lookup.js";
 import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-mapping.js";
 import { simLambdaEventSourceFunction } from "../sim-lambda-event-source-function.js";
@@ -81,7 +82,11 @@ export class SimLambdaKinesisShardPoller implements SimLambdaEventSourcePolls {
    * reading the same records.
    */
   async poll(): Promise<void> {
-    const simFunction = this.pollingFunction();
+    const simFunction = simLambdaEventSourceFunction(
+      this.functions,
+      this.mapping,
+      this.stopped,
+    );
 
     if (simFunction === undefined) {
       return;
@@ -95,23 +100,12 @@ export class SimLambdaKinesisShardPoller implements SimLambdaEventSourcePolls {
       this.mapping.batchSize,
     );
 
-    if (batch.records.length === 0) {
-      progress.caughtUp(batch);
-
-      return;
-    }
-
-    progress.after(await this.delivery.to(simFunction, batch.records), batch);
-  }
-
-  /**
-   * The function this mapping delivers to, while it should be delivering.
-   */
-  private pollingFunction(): SimLambdaFunction | undefined {
-    if (this.stopped || !this.mapping.isPolling) {
-      return undefined;
-    }
-
-    return simLambdaEventSourceFunction(this.functions, this.mapping);
+    await processSimLambdaStreamBatch({
+      batch,
+      progress,
+      simFunction,
+      times: simLambdaKinesisStreamRecordTimes,
+      deliver: async (records) => await this.delivery.to(simFunction, records),
+    });
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event-source-poller.ts
@@ -1,8 +1,7 @@
+import { SimLambdaDynamoDbStreamPolling } from "./sim-lambda-dynamodb-stream-polling.js";
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
-import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
-import { simLambdaEventSourceFunction } from "./sim-lambda-event-source-function.js";
 import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
 import type { SimLambdaEventSourceStreams } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaDynamoDbPolledStream } from "./sim-lambda-dynamodb-polled-stream.js";
@@ -38,10 +37,9 @@ interface SimLambdaDynamoDbStreamEventSourcePollerProperties {
 export class SimLambdaDynamoDbStreamEventSourcePoller
   implements SimLambdaEventSourcePoller, SimLambdaEventSourcePolls
 {
-  private readonly mapping: SimLambdaEventSourceMapping;
-  private readonly functions: SimLambdaFunctionLookup;
   private readonly stream: SimLambdaDynamoDbPolledStream;
   private readonly delivery: SimLambdaDynamoDbStreamDelivery;
+  private readonly polling: SimLambdaDynamoDbStreamPolling;
   private readonly progress: SimLambdaStreamProgress;
   private readonly turn = new SimLambdaEventSourcePollTurn(this);
 
@@ -50,8 +48,6 @@ export class SimLambdaDynamoDbStreamEventSourcePoller
   constructor(properties: SimLambdaDynamoDbStreamEventSourcePollerProperties) {
     const { eventSourceArn, mapping } = properties;
 
-    this.mapping = mapping;
-    this.functions = properties.functions;
     this.stream = new SimLambdaDynamoDbPolledStream(
       properties.streams,
       eventSourceArn.value,
@@ -66,6 +62,12 @@ export class SimLambdaDynamoDbStreamEventSourcePoller
       poll: async (): Promise<void> => {
         await this.turn.take();
       },
+    });
+    this.polling = new SimLambdaDynamoDbStreamPolling({
+      ...properties,
+      stream: this.stream,
+      progress: this.progress,
+      delivery: this.delivery,
     });
   }
 
@@ -122,38 +124,6 @@ export class SimLambdaDynamoDbStreamEventSourcePoller
    * reading the same records.
    */
   async poll(): Promise<void> {
-    const simFunction = this.pollingFunction();
-
-    if (simFunction === undefined) {
-      return;
-    }
-
-    const { progress } = this;
-    // Reading is done as the function's execution role, as on real Lambda, so
-    // simulated IAM decides whether this mapping may read its stream.
-    const batch = await this.stream.read(
-      simFunction.roleArn,
-      progress.position,
-      this.mapping.batchSize,
-    );
-
-    if (batch.records.length === 0) {
-      progress.caughtUp(batch);
-
-      return;
-    }
-
-    progress.after(await this.delivery.to(simFunction, batch.records), batch);
-  }
-
-  /**
-   * The function this mapping delivers to, while it should be delivering.
-   */
-  private pollingFunction(): SimLambdaFunction | undefined {
-    if (this.stopped || !this.mapping.isPolling) {
-      return undefined;
-    }
-
-    return simLambdaEventSourceFunction(this.functions, this.mapping);
+    await this.polling.poll(this.stopped);
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-polling.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-polling.ts
@@ -1,0 +1,47 @@
+import { simLambdaDynamoDbStreamRecordTimes } from "./sim-lambda-stream-record-times.js";
+import { processSimLambdaStreamBatch } from "./sim-lambda-stream-batch-processing.js";
+import { simLambdaEventSourceFunction } from "./sim-lambda-event-source-function.js";
+import type { SimLambdaFunctionLookup } from "../../function/url/sim-lambda-function-lookup.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaDynamoDbPolledStream } from "./sim-lambda-dynamodb-polled-stream.js";
+import type { SimLambdaDynamoDbStreamDelivery } from "./sim-lambda-dynamodb-stream-delivery.js";
+import type { SimLambdaStreamProgress } from "./sim-lambda-stream-progress.js";
+interface DynamoDbStreamPollingProperties {
+  readonly functions: SimLambdaFunctionLookup;
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly stream: SimLambdaDynamoDbPolledStream;
+  readonly delivery: SimLambdaDynamoDbStreamDelivery;
+  readonly progress: SimLambdaStreamProgress;
+}
+/** Read and process DynamoDB batches as the function execution role. */
+export class SimLambdaDynamoDbStreamPolling {
+  constructor(private readonly properties: DynamoDbStreamPollingProperties) {}
+  async poll(stopped: boolean): Promise<void> {
+    const simFunction = simLambdaEventSourceFunction(
+      this.properties.functions,
+      this.properties.mapping,
+      stopped,
+    );
+
+    if (simFunction === undefined) {
+      return;
+    }
+
+    const { progress, stream, mapping, delivery } = this.properties;
+    // Reading is done as the function's execution role, as on real Lambda, so
+    // simulated IAM decides whether this mapping may read its stream.
+    const batch = await stream.read(
+      simFunction.roleArn,
+      progress.position,
+      mapping.batchSize,
+    );
+
+    await processSimLambdaStreamBatch({
+      batch,
+      progress,
+      simFunction,
+      times: simLambdaDynamoDbStreamRecordTimes,
+      deliver: async (records) => await delivery.to(simFunction, records),
+    });
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-function.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-function.ts
@@ -13,7 +13,9 @@ import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-map
 export function simLambdaEventSourceFunction(
   functions: SimLambdaFunctionLookup,
   mapping: SimLambdaEventSourceMapping,
+  stopped = false,
 ): SimLambdaFunction | undefined {
+  if (stopped || !mapping.isPolling) return undefined;
   return functions.findTarget(mapping.functionName, mapping.qualifier)
     ?.simFunction;
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-age.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-age.ts
@@ -1,0 +1,39 @@
+import type { SimClock } from "../../../../util/clock/sim-clock.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimLambdaStreamRetryLimits } from "../sim-lambda-stream-retry-limits.js";
+import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaStreamDiscard } from "./sim-lambda-stream-failure-record.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+
+/** Identifies the expired prefix at the time a batch is polled. */
+export class SimLambdaStreamBatchAge {
+  constructor(
+    private readonly limits: SimLambdaStreamRetryLimits,
+    private readonly clock: SimClock,
+  ) {}
+
+  discarded(
+    records: readonly SimLambdaStreamRecordTime[],
+  ): SimLambdaStreamDiscard | undefined {
+    const at = this.clock.now();
+    const firstLive = records.findIndex(
+      (record) => !this.limits.hasAgedOut(record.at, at),
+    );
+    const count = firstLive === -1 ? records.length : firstLive;
+    if (count === 0) return undefined;
+    return {
+      records: records.slice(0, count),
+      condition: "RecordAgeExceeded",
+      at,
+    };
+  }
+
+  firstLivePosition(
+    records: readonly SimLambdaStreamRecordTime[],
+    count: number,
+  ): SimLambdaEventSourceStreamPosition {
+    const sequenceNumber = records.at(count)?.sequenceNumber;
+    assertDefined(sequenceNumber, "live stream record sequence number");
+    return { kind: "sequence", sequenceNumber };
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-info.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-info.ts
@@ -1,0 +1,48 @@
+import type { SimLambdaStreamFailureRecord } from "./sim-lambda-stream-failure-record.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+export interface SimLambdaStreamBatchInfo {
+  readonly shardId: string;
+  readonly streamArn: string;
+  readonly startSequenceNumber: string;
+  readonly endSequenceNumber: string;
+  readonly approximateArrivalOfFirstRecord: string;
+  readonly approximateArrivalOfLastRecord: string;
+  readonly batchSize: number;
+}
+
+/** Identify the discarded records by shard and sequence-number bounds. */
+export function simLambdaStreamBatchInfo(
+  records: readonly SimLambdaStreamRecordTime[],
+  streamArn: string,
+  shardId: string | undefined,
+): SimLambdaStreamBatchInfo {
+  const first = records.at(0);
+  const last = records.at(-1);
+  assertDefined(shardId, "discarded stream batch shard ID");
+  assertDefined(first?.sequenceNumber, "discarded batch start sequence number");
+  assertDefined(last?.sequenceNumber, "discarded batch end sequence number");
+  assertDefined(first.at, "discarded batch first arrival time");
+  assertDefined(last.at, "discarded batch last arrival time");
+  return {
+    shardId,
+    streamArn,
+    startSequenceNumber: first.sequenceNumber,
+    endSequenceNumber: last.sequenceNumber,
+    approximateArrivalOfFirstRecord: first.at.toISOString(),
+    approximateArrivalOfLastRecord: last.at.toISOString(),
+    batchSize: records.length,
+  };
+}
+
+/** Identify the discarded records by shard and sequence-number bounds. */
+export function streamFailureBatchInfo(
+  arn: string,
+  info: SimLambdaStreamBatchInfo,
+): Pick<
+  SimLambdaStreamFailureRecord,
+  "DDBStreamBatchInfo" | "KinesisBatchInfo"
+> {
+  if (arn.startsWith("arn:aws:dynamodb:")) return { DDBStreamBatchInfo: info };
+  return { KinesisBatchInfo: info };
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-outcome.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-outcome.ts
@@ -4,6 +4,7 @@ import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times
 interface SimLambdaStreamBatchOutcomeProperties {
   readonly isHandled: boolean;
   readonly records: readonly SimLambdaStreamRecordTime[];
+  readonly functionError?: boolean;
   readonly rewindTo?: string | undefined;
 }
 
@@ -21,6 +22,7 @@ interface SimLambdaStreamBatchOutcomeProperties {
  * to and the instants its records are aged from.
  */
 export class SimLambdaStreamBatchOutcome {
+  public readonly functionError: boolean;
   public readonly isHandled: boolean;
 
   /**
@@ -31,6 +33,7 @@ export class SimLambdaStreamBatchOutcome {
   private readonly rewindTo: string | undefined;
 
   private constructor(properties: SimLambdaStreamBatchOutcomeProperties) {
+    this.functionError = properties.functionError ?? false;
     this.isHandled = properties.isHandled;
     this.records = properties.records;
     this.rewindTo = properties.rewindTo;
@@ -51,7 +54,11 @@ export class SimLambdaStreamBatchOutcome {
   static failed(
     records: readonly SimLambdaStreamRecordTime[],
   ): SimLambdaStreamBatchOutcome {
-    return new SimLambdaStreamBatchOutcome({ isHandled: false, records });
+    return new SimLambdaStreamBatchOutcome({
+      isHandled: false,
+      records,
+      functionError: true,
+    });
   }
 
   /**

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-batch-processing.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-batch-processing.ts
@@ -1,0 +1,41 @@
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaEventSourceStreamProgressBatch } from "../stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
+import type { SimLambdaStreamProgress } from "./sim-lambda-stream-progress.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+
+interface StreamBatchProcessing<RecordType> {
+  readonly batch: SimLambdaEventSourceStreamProgressBatch & {
+    readonly records: readonly RecordType[];
+  };
+  readonly simFunction: SimLambdaFunction;
+  readonly progress: SimLambdaStreamProgress;
+  readonly times: (
+    records: readonly RecordType[],
+  ) => readonly SimLambdaStreamRecordTime[];
+  readonly deliver: (
+    records: readonly RecordType[],
+  ) => Promise<SimLambdaStreamBatchOutcome>;
+}
+
+/** Check record age, invoke live records, and apply the batch outcome. */
+export async function processSimLambdaStreamBatch<RecordType>(
+  properties: StreamBatchProcessing<RecordType>,
+): Promise<void> {
+  const { batch, progress, simFunction } = properties;
+  if (batch.records.length === 0) {
+    progress.caughtUp(batch);
+    return;
+  }
+  const firstLive = await progress.before(
+    properties.times(batch.records),
+    batch,
+    simFunction,
+  );
+  if (firstLive === batch.records.length) return;
+  await progress.after(
+    await properties.deliver(batch.records.slice(firstLive)),
+    batch,
+    simFunction,
+  );
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-cursor.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-cursor.ts
@@ -1,0 +1,36 @@
+import type { PollSchedule } from "../../../../util/background/poll-schedule.js";
+import type { SimLambdaEventSourceStart } from "../sim-lambda-event-source-starting-position.js";
+import type {
+  SimLambdaEventSourceStreamPosition,
+  SimLambdaEventSourceStreamProgressBatch,
+} from "../stream/sim-lambda-event-source-streams.js";
+import { SimLambdaStreamCheckpoint } from "./sim-lambda-stream-checkpoint.js";
+import type { SimLambdaStreamRetryAttempt } from "./sim-lambda-stream-retry.js";
+
+/** Keep the next read position and schedule consistent when a batch finishes or retries. */
+export class SimLambdaStreamCursor {
+  private readonly checkpoint: SimLambdaStreamCheckpoint;
+  constructor(
+    start: SimLambdaEventSourceStart,
+    private readonly schedule: PollSchedule,
+  ) {
+    this.checkpoint = new SimLambdaStreamCheckpoint(start);
+  }
+  get position(): SimLambdaEventSourceStreamPosition {
+    return this.checkpoint.position;
+  }
+  advanceTo(position: SimLambdaEventSourceStreamPosition): void {
+    this.checkpoint.advanceTo(position);
+  }
+  pollNow(): void {
+    this.schedule.now();
+  }
+  handled(batch: SimLambdaEventSourceStreamProgressBatch): void {
+    this.advanceTo(batch.next);
+    if (!batch.drained) this.pollNow();
+  }
+  resume(attempt: SimLambdaStreamRetryAttempt): void {
+    this.advanceTo(attempt.position);
+    this.schedule.afterSeconds(attempt.afterSeconds);
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-expiry.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-expiry.ts
@@ -1,0 +1,34 @@
+import type { SimLambdaStreamBatchAge } from "./sim-lambda-stream-batch-age.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaStreamFailureDestination } from "./sim-lambda-stream-failure-destination.js";
+import type { SimLambdaEventSourceStreamProgressBatch } from "../stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaStreamCursor } from "./sim-lambda-stream-cursor.js";
+interface StreamExpiryProperties {
+  readonly age: SimLambdaStreamBatchAge;
+  readonly cursor: SimLambdaStreamCursor;
+  readonly failures: SimLambdaStreamFailureDestination;
+  readonly handled: (batch: SimLambdaEventSourceStreamProgressBatch) => void;
+}
+/** Advance past expired records and notify their destination before processing live records. */
+export class SimLambdaStreamExpiry {
+  constructor(private readonly properties: StreamExpiryProperties) {}
+  async before(
+    records: readonly SimLambdaStreamRecordTime[],
+    batch: SimLambdaEventSourceStreamProgressBatch,
+    simFunction: SimLambdaFunction,
+  ): Promise<number> {
+    const { age, cursor, failures, handled } = this.properties;
+    const discard = age.discarded(records);
+    if (discard === undefined) return 0;
+    const discardedCount = discard.records.length;
+    const notification = failures.deliver(discard, batch, simFunction);
+    if (discardedCount === records.length) {
+      handled(batch);
+    } else {
+      cursor.advanceTo(age.firstLivePosition(records, discardedCount));
+    }
+    await notification;
+    return discardedCount;
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-failure-context.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-failure-context.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from "node:crypto";
+import type {
+  SimLambdaStreamFailureRecord,
+  StreamFailureRecordProperties,
+} from "./sim-lambda-stream-failure-record.js";
+
+/** Build invocation metadata for a stream failure notification. */
+export function streamFailureContext(
+  properties: StreamFailureRecordProperties,
+): Pick<SimLambdaStreamFailureRecord, "requestContext" | "responseContext"> {
+  return {
+    requestContext: {
+      requestId: randomUUID(),
+      functionArn: properties.mapping.functionArn,
+      condition: properties.discard.condition,
+      approximateInvokeCount: properties.invokeCount,
+    },
+    ...(properties.invokeCount > 0 && {
+      responseContext: {
+        statusCode: 200,
+        executedVersion: properties.simFunction.version,
+        ...(properties.functionError && { functionError: "Unhandled" }),
+      },
+    }),
+  };
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-failure-destination.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-failure-destination.ts
@@ -1,0 +1,50 @@
+import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
+import { SimLambdaDestinationArn } from "../../destination/sim-lambda-destination-arn.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceStreamProgressBatch } from "../stream/sim-lambda-event-source-streams.js";
+import {
+  simLambdaStreamFailureRecord,
+  type SimLambdaStreamDiscard,
+} from "./sim-lambda-stream-failure-record.js";
+
+/** Count invocations and send discarded batch metadata through the destination service. */
+export class SimLambdaStreamFailureDestination {
+  private invokeCount = 0;
+  private functionError = false;
+
+  constructor(private readonly mapping: SimLambdaEventSourceMapping) {}
+
+  invoked(outcome: SimLambdaStreamBatchOutcome): void {
+    this.invokeCount += 1;
+    this.functionError = outcome.functionError;
+  }
+
+  reset(): void {
+    this.invokeCount = 0;
+  }
+
+  async deliver(
+    discard: SimLambdaStreamDiscard | undefined,
+    batch: SimLambdaEventSourceStreamProgressBatch,
+    simFunction: SimLambdaFunction,
+  ): Promise<void> {
+    const mapping = this.mapping;
+    const arn = mapping.failureDestinationArn;
+    if (discard === undefined || arn === undefined || arn === "") return;
+    const record = simLambdaStreamFailureRecord({
+      mapping,
+      simFunction,
+      discard,
+      invokeCount: this.invokeCount,
+      shardId: batch.shardId,
+      functionError: this.functionError,
+    });
+    await mapping.destinations.deliver({
+      destinationArn: SimLambdaDestinationArn.of(arn),
+      sourceFunctionArn: mapping.functionArn,
+      sourceFunctionRoleArn: simFunction.roleArn,
+      record,
+    });
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-failure-record.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-failure-record.ts
@@ -1,0 +1,68 @@
+import { streamFailureContext } from "./sim-lambda-stream-failure-context.js";
+import {
+  simLambdaStreamBatchInfo,
+  streamFailureBatchInfo,
+  type SimLambdaStreamBatchInfo,
+} from "./sim-lambda-stream-batch-info.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+
+export type SimLambdaStreamFailureCondition =
+  | "RetryAttemptsExhausted"
+  | "RecordAgeExceeded";
+
+export interface SimLambdaStreamDiscard {
+  readonly records: readonly SimLambdaStreamRecordTime[];
+  readonly condition: SimLambdaStreamFailureCondition;
+  readonly at: Date;
+}
+
+export interface SimLambdaStreamFailureRecord {
+  readonly version: string;
+  readonly timestamp: string;
+  readonly requestContext: {
+    readonly requestId: string;
+    readonly functionArn: string;
+    readonly condition: SimLambdaStreamFailureCondition;
+    readonly approximateInvokeCount: number;
+  };
+  readonly responseContext?: {
+    readonly statusCode: number;
+    readonly executedVersion: string;
+    readonly functionError?: string;
+  };
+  readonly DDBStreamBatchInfo?: SimLambdaStreamBatchInfo;
+  readonly KinesisBatchInfo?: SimLambdaStreamBatchInfo;
+}
+
+export interface StreamFailureRecordProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly simFunction: SimLambdaFunction;
+  readonly shardId: string | undefined;
+  readonly discard: SimLambdaStreamDiscard;
+  readonly invokeCount: number;
+  readonly functionError: boolean;
+}
+
+/**
+ * SQS and SNS receive metadata identifying the discarded records.
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/services-dynamodb-errors.html
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/kinesis-on-failure-destination.html
+ */
+export function simLambdaStreamFailureRecord(
+  properties: StreamFailureRecordProperties,
+): SimLambdaStreamFailureRecord {
+  const { mapping, discard, shardId } = properties;
+  const info = simLambdaStreamBatchInfo(
+    discard.records,
+    mapping.eventSourceArn,
+    shardId,
+  );
+  return {
+    version: "1.0",
+    timestamp: discard.at.toISOString(),
+    ...streamFailureContext(properties),
+    ...streamFailureBatchInfo(mapping.eventSourceArn, info),
+  };
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress-state.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress-state.ts
@@ -1,0 +1,55 @@
+import { SimLambdaStreamExpiry } from "./sim-lambda-stream-expiry.js";
+import { SimLambdaStreamBatchAge } from "./sim-lambda-stream-batch-age.js";
+import { SimLambdaStreamFailureDestination } from "./sim-lambda-stream-failure-destination.js";
+import { SimLambdaStreamCursor } from "./sim-lambda-stream-cursor.js";
+import { SimLambdaStreamRetry } from "./sim-lambda-stream-retry.js";
+import { PollSchedule } from "../../../../util/background/poll-schedule.js";
+import { assertDefined } from "../../../../util/type-guard/defined.js";
+import type {
+  BackgroundScheduler,
+  BackgroundTask,
+} from "../../../../util/background/background.js";
+import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import type { SimLambdaEventSourceStreamProgressBatch } from "../stream/sim-lambda-event-source-streams.js";
+export interface SimLambdaStreamProgressProperties {
+  readonly mapping: SimLambdaEventSourceMapping;
+  readonly background: BackgroundScheduler;
+  readonly poll: BackgroundTask;
+}
+
+/** Own the per-shard retry state and its expiry and destination collaborators. */
+export class SimLambdaStreamProgressState {
+  readonly expiry: SimLambdaStreamExpiry;
+  readonly failures: SimLambdaStreamFailureDestination;
+  readonly cursor: SimLambdaStreamCursor;
+  readonly retry: SimLambdaStreamRetry;
+  constructor(properties: SimLambdaStreamProgressProperties) {
+    const { mapping, background } = properties;
+    this.failures = new SimLambdaStreamFailureDestination(mapping);
+    // A stream mapping is refused at creation unless it names a starting
+    // position, so one that has got this far without one is the simulator
+    // having gone wrong rather than a request having been wrong.
+    const { start, streamRetryLimits } = mapping;
+    assertDefined(start, "stream mapping start position");
+    assertDefined(streamRetryLimits, "stream mapping retry limits");
+
+    this.cursor = new SimLambdaStreamCursor(
+      start,
+      new PollSchedule(properties),
+    );
+    this.retry = new SimLambdaStreamRetry(streamRetryLimits, background);
+    this.expiry = new SimLambdaStreamExpiry({
+      age: new SimLambdaStreamBatchAge(streamRetryLimits, background),
+      cursor: this.cursor,
+      failures: this.failures,
+      handled: (batch): void => {
+        this.handled(batch);
+      },
+    });
+  }
+  handled(batch: SimLambdaEventSourceStreamProgressBatch): void {
+    this.failures.reset();
+    this.retry.reset();
+    this.cursor.handled(batch);
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
@@ -1,68 +1,33 @@
-import type {
-  BackgroundScheduler,
-  BackgroundTask,
-} from "../../../../util/background/background.js";
-import { assertDefined } from "../../../../util/type-guard/defined.js";
-import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
+import {
+  SimLambdaStreamProgressState,
+  type SimLambdaStreamProgressProperties,
+} from "./sim-lambda-stream-progress-state.js";
+import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
+import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type {
   SimLambdaEventSourceStreamPosition,
   SimLambdaEventSourceStreamProgressBatch,
 } from "../stream/sim-lambda-event-source-streams.js";
-import { PollSchedule } from "../../../../util/background/poll-schedule.js";
 import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
-import { SimLambdaStreamCheckpoint } from "./sim-lambda-stream-checkpoint.js";
-import { SimLambdaStreamRetry } from "./sim-lambda-stream-retry.js";
 
-interface SimLambdaStreamProgressProperties {
-  readonly mapping: SimLambdaEventSourceMapping;
-  readonly background: BackgroundScheduler;
-  readonly poll: BackgroundTask;
-}
-
-/**
- * How far along its stream one mapping has got, and what it does next.
- *
- * The two belong together because they are the same decision. A batch the
- * function took moves the checkpoint and the mapping reads on; a batch it threw
- * on leaves the checkpoint where it is and the mapping tries the same records
- * again after a wait; a batch it reported failing partway through moves the
- * checkpoint back to the record it named. Nothing behind a failing batch is
- * read until it is through, which is what it means for a stream mapping to
- * block its shard.
- */
+/** Apply a stream batch outcome to its checkpoint and retry schedule. */
 export class SimLambdaStreamProgress {
-  private readonly checkpoint: SimLambdaStreamCheckpoint;
-  private readonly retry: SimLambdaStreamRetry;
-  private readonly schedule: PollSchedule;
-
+  private readonly state: SimLambdaStreamProgressState;
   constructor(properties: SimLambdaStreamProgressProperties) {
-    // A stream mapping is refused at creation unless it names a starting
-    // position, so one that has got this far without one is the simulator
-    // having gone wrong rather than a request having been wrong.
-    const { start, streamRetryLimits } = properties.mapping;
-    assertDefined(start, "stream mapping start position");
-    assertDefined(streamRetryLimits, "stream mapping retry limits");
-
-    this.checkpoint = new SimLambdaStreamCheckpoint(start);
-    this.retry = new SimLambdaStreamRetry({
-      limits: streamRetryLimits,
-      clock: properties.background,
-    });
-    this.schedule = new PollSchedule(properties);
+    this.state = new SimLambdaStreamProgressState(properties);
   }
-
   /**
    * Poll as soon as the simulation gets to it.
    */
   pollNow(): void {
-    this.schedule.now();
+    this.state.cursor.pollNow();
   }
 
   /**
    * Where the next read starts.
    */
   get position(): SimLambdaEventSourceStreamPosition {
-    return this.checkpoint.position;
+    return this.state.cursor.position;
   }
 
   /**
@@ -73,23 +38,46 @@ export class SimLambdaStreamProgress {
    * than working out a new one each time.
    */
   caughtUp(batch: SimLambdaEventSourceStreamProgressBatch): void {
-    this.checkpoint.advanceTo(batch.next);
+    this.state.cursor.advanceTo(batch.next);
+  }
+
+  async before(
+    records: readonly SimLambdaStreamRecordTime[],
+    batch: SimLambdaEventSourceStreamProgressBatch,
+    simFunction: SimLambdaFunction,
+  ): Promise<number> {
+    return await this.state.expiry.before(records, batch, simFunction);
   }
 
   /**
    * Take what became of a batch: move past it, or wait and try it again.
    */
-  after(
+  async after(
     outcome: SimLambdaStreamBatchOutcome,
     batch: SimLambdaEventSourceStreamProgressBatch,
-  ): void {
+    simFunction: SimLambdaFunction,
+  ): Promise<void> {
+    this.state.failures.invoked(outcome);
     if (outcome.isHandled) {
       this.handled(batch);
 
       return;
     }
 
-    this.failed(outcome, batch);
+    const again = this.state.retry.after(outcome, this.position);
+
+    const notification = this.state.failures.deliver(
+      this.state.retry.discarded,
+      batch,
+      simFunction,
+    );
+    if (again === undefined) {
+      this.handled(batch);
+    } else {
+      this.state.cursor.resume(again);
+    }
+
+    await notification;
   }
 
   /**
@@ -99,40 +87,6 @@ export class SimLambdaStreamProgress {
    * given up on.
    */
   handled(batch: SimLambdaEventSourceStreamProgressBatch): void {
-    this.retry.reset();
-    this.checkpoint.advanceTo(batch.next);
-
-    if (!batch.drained) {
-      this.schedule.now();
-    }
-  }
-
-  /**
-   * Wait and hand a failed batch over again, or give up on it.
-   *
-   * Giving up discards the records and carries on with the stream, which is
-   * what AWS does when a stream mapping's error handling runs out. Parking the
-   * shard instead would be a simulator invention.
-   *
-   * A batch runs out either by having had its retries or by every record left
-   * in it being older than the mapping will carry. Records that aged out of the
-   * front of a batch are left behind, and the ones behind them go over again,
-   * so a mapping given a record age keeps working through its shard rather than
-   * stalling on the oldest record on it.
-   */
-  failed(
-    outcome: SimLambdaStreamBatchOutcome,
-    batch: SimLambdaEventSourceStreamProgressBatch,
-  ): void {
-    const again = this.retry.after(outcome, this.checkpoint.position);
-
-    if (again === undefined) {
-      this.handled(batch);
-
-      return;
-    }
-
-    this.checkpoint.advanceTo(again.position);
-    this.schedule.afterSeconds(again.afterSeconds);
+    this.state.handled(batch);
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-retry.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-retry.ts
@@ -1,16 +1,9 @@
+import type { SimLambdaStreamDiscard } from "./sim-lambda-stream-failure-record.js";
 import type { SimClock } from "../../../../util/clock/sim-clock.js";
 import type { SimLambdaStreamRetryLimits } from "../sim-lambda-stream-retry-limits.js";
 import type { SimLambdaEventSourceStreamPosition } from "../stream/sim-lambda-event-source-streams.js";
 import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
-import type { SimLambdaStreamRecordTime } from "./sim-lambda-stream-record-times.js";
 import { SimLambdaStreamRetryBackoff } from "./sim-lambda-stream-retry-backoff.js";
-
-const millisecondsPerSecond = 1000;
-
-interface SimLambdaStreamRetryProperties {
-  readonly limits: SimLambdaStreamRetryLimits;
-  readonly clock: SimClock;
-}
 
 /**
  * One more delivery of a failed batch: where it starts, and how long the
@@ -21,32 +14,15 @@ export interface SimLambdaStreamRetryAttempt {
   readonly afterSeconds: number;
 }
 
-/**
- * Whether a failed batch is handed over again, and from which record.
- *
- * Both of Lambda's failed-batch limits end here because they end the same
- * thing. A batch stops being delivered when it has had its retries, and a
- * record stops being delivered when it is older than the mapping will carry;
- * whichever comes first, what is left of the batch is discarded and the mapping
- * reads on. Records age out of the front of a batch, because a batch is in
- * stream order, so the answer is one record to start from rather than a list of
- * survivors.
- *
- * Ages are read at the instant the next delivery falls due rather than now,
- * because the wait before it is what ages the records out. A record judged now
- * would be handed to the function and only then found to be too old.
- */
+/** Tracks the retry quota and checkpoint of one failed stream batch. */
 export class SimLambdaStreamRetry {
-  private readonly limits: SimLambdaStreamRetryLimits;
+  public discarded: SimLambdaStreamDiscard | undefined;
   private readonly clock: SimClock;
   private readonly backoff: SimLambdaStreamRetryBackoff;
 
-  constructor(properties: SimLambdaStreamRetryProperties) {
-    this.limits = properties.limits;
-    this.clock = properties.clock;
-    this.backoff = new SimLambdaStreamRetryBackoff(
-      properties.limits.attemptLimit,
-    );
+  constructor(limits: SimLambdaStreamRetryLimits, clock: SimClock) {
+    this.clock = clock;
+    this.backoff = new SimLambdaStreamRetryBackoff(limits.attemptLimit);
   }
 
   /**
@@ -57,19 +33,18 @@ export class SimLambdaStreamRetry {
     outcome: SimLambdaStreamBatchOutcome,
     readFrom: SimLambdaEventSourceStreamPosition,
   ): SimLambdaStreamRetryAttempt | undefined {
+    this.discarded = undefined;
     if (this.backoff.isExhausted) {
+      this.discarded = {
+        records: outcome.records.slice(outcome.retryIndex),
+        condition: "RetryAttemptsExhausted",
+        at: this.clock.now(),
+      };
       return undefined;
     }
 
     const afterSeconds = this.backoff.nextSeconds();
-    const deliveryAt = this.deliveryAt(afterSeconds);
-    const position = this.retryPosition(outcome, readFrom, deliveryAt);
-
-    if (position === undefined) {
-      return undefined;
-    }
-
-    return { position, afterSeconds };
+    return { position: outcome.retryPosition(readFrom), afterSeconds };
   }
 
   /**
@@ -77,63 +52,5 @@ export class SimLambdaStreamRetry {
    */
   reset(): void {
     this.backoff.reset();
-  }
-
-  /**
-   * Where the next delivery starts, or nothing when every record left in the
-   * batch has aged out.
-   */
-  private retryPosition(
-    outcome: SimLambdaStreamBatchOutcome,
-    readFrom: SimLambdaEventSourceStreamPosition,
-    deliveryAt: Date,
-  ): SimLambdaEventSourceStreamPosition | undefined {
-    const { records, retryIndex } = outcome;
-    const live = this.firstLiveIndex(records, retryIndex, deliveryAt);
-
-    if (live === undefined) {
-      return undefined;
-    }
-
-    const sequenceNumber = records.at(live)?.sequenceNumber;
-
-    // Nothing aged out of the front, so the batch goes back exactly where the
-    // report left it. A record that aged out but cannot be named leaves the
-    // batch where it was too, since skipping past a record the mapping cannot
-    // name would skip the records after it as well.
-    if (live === retryIndex || sequenceNumber === undefined) {
-      return outcome.retryPosition(readFrom);
-    }
-
-    return { kind: "sequence", sequenceNumber };
-  }
-
-  /**
-   * The first record from `from` on that is still young enough to deliver.
-   */
-  private firstLiveIndex(
-    records: readonly SimLambdaStreamRecordTime[],
-    from: number,
-    deliveryAt: Date,
-  ): number | undefined {
-    const index = records.findIndex(
-      (record, position) =>
-        position >= from && !this.limits.hasAgedOut(record.at, deliveryAt),
-    );
-
-    return index === -1 ? undefined : index;
-  }
-
-  /**
-   * When the next delivery falls due, which is what a record's age is judged
-   * against.
-   *
-   * Judging it now would hand a record over and only then notice that it was
-   * too old to be worth handing over, since the wait is what makes it too old.
-   */
-  private deliveryAt(afterSeconds: number): Date {
-    return new Date(
-      this.clock.now().getTime() + afterSeconds * millisecondsPerSecond,
-    );
   }
 }

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -1,3 +1,6 @@
+import type { SimLambdaStreamDestinationConfiguration } from "./sim-lambda-stream-destination-config.js";
+import type { SimLambdaDestinationTargets } from "../destination/sim-lambda-destination-targets.js";
+import { SimLambdaNoDestinationTargets } from "../destination/sim-lambda-destination-targets.js";
 import { randomUUID } from "node:crypto";
 
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
@@ -49,6 +52,10 @@ interface SimLambdaEventSourceMappingProperties {
     | readonly SimLambdaFunctionResponseType[]
     | undefined;
   readonly streamRetryLimits?: SimLambdaStreamRetryLimits | undefined;
+  readonly destinationConfig?:
+    | SimLambdaStreamDestinationConfiguration
+    | undefined;
+  readonly destinations?: SimLambdaDestinationTargets | undefined;
   readonly createdAt: Date;
 }
 
@@ -58,6 +65,9 @@ interface SimLambdaEventSourceMappingProperties {
  * DeleteEventSourceMapping responses all report it.
  */
 export interface SimLambdaEventSourceMappingConfiguration extends Partial<SimLambdaStreamRetryLimitsConfiguration> {
+  readonly DestinationConfig?:
+    | SimLambdaStreamDestinationConfiguration
+    | undefined;
   readonly UUID: string;
   readonly EventSourceMappingArn: SimLambdaEventSourceMappingArn;
   readonly EventSourceArn: string;
@@ -83,6 +93,7 @@ export interface SimLambdaEventSourceMappingConfiguration extends Partial<SimLam
  * it.
  */
 export class SimLambdaEventSourceMapping {
+  public readonly destinations: SimLambdaDestinationTargets;
   public readonly uuid: string = randomUUID();
   public readonly eventSourceArn: string;
   public readonly functionName: string;
@@ -114,12 +125,18 @@ export class SimLambdaEventSourceMapping {
    */
   public readonly streamRetryLimits: SimLambdaStreamRetryLimits | undefined;
 
+  private readonly destinationConfig:
+    | SimLambdaStreamDestinationConfiguration
+    | undefined;
   private readonly accountRegionScope: SimAwsAccountRegionScope;
   private readonly enabled: boolean;
   private readonly lastModified: Date;
   #state: SimLambdaEventSourceMappingState = "Creating";
 
   constructor(properties: SimLambdaEventSourceMappingProperties) {
+    this.destinationConfig = properties.destinationConfig;
+    this.destinations =
+      properties.destinations ?? new SimLambdaNoDestinationTargets();
     this.accountRegionScope = properties.accountRegionScope;
     this.eventSourceArn = properties.eventSourceArn;
     this.functionName = properties.functionName;
@@ -135,9 +152,12 @@ export class SimLambdaEventSourceMapping {
     this.lastModified = properties.createdAt;
   }
 
-  /**
-   * The ARN naming this mapping.
-   */
+  /** The configured failure queue or topic ARN. */
+  get failureDestinationArn(): string | undefined {
+    return this.destinationConfig?.OnFailure?.Destination;
+  }
+
+  /** The ARN naming this mapping. */
   get arn(): SimLambdaEventSourceMappingArn {
     const { regionName, accountId } = this.accountRegionScope;
 
@@ -182,6 +202,7 @@ export class SimLambdaEventSourceMapping {
    */
   configuration(): SimLambdaEventSourceMappingConfiguration {
     return {
+      DestinationConfig: structuredClone(this.destinationConfig),
       UUID: this.uuid,
       EventSourceMappingArn: this.arn,
       EventSourceArn: this.eventSourceArn,

--- a/src/service/lambda/event-source/sim-lambda-stream-destination-config.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-destination-config.iso.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { simLambdaStreamDestinationConfig } from "./sim-lambda-stream-destination-config.js";
+import { simAwsWithSqsEventSource } from "../../../../test/lambda/event-source-fixture.js";
+
+describe("stream destination configuration", () => {
+  it.each([
+    undefined,
+    {},
+    { OnFailure: {} },
+    { OnFailure: { Destination: "" } },
+  ])("preserves an empty configuration %j", (config) => {
+    // Given a configuration with no destination.
+    // When it is validated.
+    const parsed = simLambdaStreamDestinationConfig(config);
+    // Then the empty configuration is preserved.
+    expect(parsed).toStrictEqual(config);
+  });
+
+  it.each([
+    null,
+    "queue",
+    [],
+    { OnSuccess: {} },
+    { OnFailure: null },
+    { OnFailure: { Extra: true } },
+    { OnFailure: { Destination: 1 } },
+    { OnFailure: { Destination: "bad-arn" } },
+    { OnFailure: { Destination: "arn:aws:s3:::failures" } },
+    {
+      OnFailure: {
+        Destination: "arn:aws:lambda:us-east-1:111111111111:function:failure",
+      },
+    },
+    {
+      OnFailure: {
+        Destination: "arn:aws:sqs:us-east-1:111111111111:failure.fifo",
+      },
+    },
+    {
+      OnFailure: {
+        Destination: "arn:aws:sns:us-east-1:111111111111:failure.fifo",
+      },
+    },
+  ])("refuses an unsupported configuration %j", (config) => {
+    // Given a malformed or unsupported destination configuration.
+    // When it is validated.
+    // Then it fails before a mapping can silently ignore it.
+    expect(() => simLambdaStreamDestinationConfig(config)).toThrow();
+  });
+
+  it("refuses destination configuration on a queue mapping", async () => {
+    // Given an existing SQS event source.
+    const { simAws } = await simAwsWithSqsEventSource();
+    const mappings = await simAws
+      .lambda()
+      .listEventSourceMappings({ input: {} });
+    const mapping = mappings.EventSourceMappings[0];
+    // When another queue mapping requests a destination.
+    // Then it is refused as an unsupported source configuration.
+    await expect(
+      simAws.lambda().createEventSourceMapping({
+        input: {
+          EventSourceArn: mapping?.EventSourceArn,
+          FunctionName: mapping?.FunctionArn,
+          DestinationConfig: {},
+        },
+      }),
+    ).rejects.toThrow("DestinationConfig");
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-stream-destination-config.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-destination-config.ts
@@ -1,0 +1,55 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+import { SimLambdaDestinationArn } from "../destination/sim-lambda-destination-arn.js";
+import { SimLambdaInvalidParameterValueException } from "../error/sim-lambda.error.js";
+
+export interface SimLambdaStreamDestinationConfiguration {
+  readonly OnFailure?:
+    | { readonly Destination?: string | undefined }
+    | undefined;
+}
+
+/** Validate the same destination shape for SDK and CloudFormation requests. */
+export function simLambdaStreamDestinationConfig(
+  value: unknown,
+  sourceKind?: string,
+): SimLambdaStreamDestinationConfiguration | undefined {
+  if (value === undefined) return undefined;
+  if (sourceKind === "sqs") {
+    throw new SimLambdaInvalidParameterValueException(
+      "DestinationConfig is not supported for SQS event source mappings.",
+    );
+  }
+  if (
+    !isRecord(value) ||
+    Object.keys(value).some((key) => key !== "OnFailure")
+  ) {
+    throw invalid();
+  }
+  const failure = value["OnFailure"];
+  if (failure === undefined) return {};
+  if (
+    !isRecord(failure) ||
+    Object.keys(failure).some((key) => key !== "Destination")
+  ) {
+    throw invalid();
+  }
+  const destination = failure["Destination"];
+  if (destination === undefined) return { OnFailure: {} };
+  if (typeof destination !== "string") throw invalid();
+  if (destination !== "") {
+    const arn = SimLambdaDestinationArn.of(destination);
+    if (
+      (arn.service !== "sqs" && arn.service !== "sns") ||
+      arn.resource.endsWith(".fifo")
+    ) {
+      throw invalid();
+    }
+  }
+  return { OnFailure: { Destination: destination } };
+}
+
+function invalid(): Error {
+  return new SimLambdaInvalidParameterValueException(
+    "DestinationConfig supports only OnFailure with a standard SQS queue or SNS topic ARN.",
+  );
+}

--- a/src/service/lambda/event-source/sim-lambda-stream-destinations.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-destinations.iso.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { assertNonNullable } from "@kensio/smartass";
+import { stream_destination_fixture as setup } from "../../../../test/lambda/stream-destination-fixture.js";
+
+describe("stream batch failure destinations", () => {
+  for (const source of ["dynamodb", "kinesis"]) {
+    for (const destination of ["sqs", "sns"]) {
+      for (const boundary of ["retries", "age"]) {
+        it(`delivers ${source} metadata to ${destination} after ${boundary} exhaustion`, async () => {
+          // Given a failing stream consumer with a permitted destination.
+          const fixture = await setup(source, destination, boundary);
+          const { simAws, uuid, streamArn, destinationArn } = fixture;
+
+          // When its record exhausts the configured limit.
+          await fixture.write();
+          await simAws.backgroundTasksComplete();
+          expect(await fixture.receive()).toStrictEqual([]);
+          await simAws.clock().advanceBy({ hours: 1 });
+
+          // Then the destination identifies the batch, and mapping reads retain the configuration.
+          const records = await fixture.receive();
+          expect(records).toHaveLength(1);
+          const record = records[0];
+          assertNonNullable(record);
+          const mapping = await simAws
+            .lambda()
+            .getEventSourceMapping({ input: { UUID: uuid } });
+          const listed = await simAws
+            .lambda()
+            .listEventSourceMappings({ input: { EventSourceArn: streamArn } });
+          expect(mapping.DestinationConfig).toStrictEqual({
+            OnFailure: { Destination: destinationArn },
+          });
+          expect(
+            listed.EventSourceMappings[0]?.DestinationConfig,
+          ).toStrictEqual(mapping.DestinationConfig);
+          expect(record.requestContext).toMatchObject({
+            functionArn: mapping.FunctionArn,
+            condition:
+              boundary === "age"
+                ? "RecordAgeExceeded"
+                : "RetryAttemptsExhausted",
+            approximateInvokeCount: fixture.events.length,
+          });
+          expect(record.responseContext).toStrictEqual({
+            statusCode: 200,
+            executedVersion: "$LATEST",
+            functionError: "Unhandled",
+          });
+          expect(record.version).toBe("1.0");
+          expect(Number.isNaN(Date.parse(record.timestamp))).toBe(false);
+          const info = record.DDBStreamBatchInfo ?? record.KinesisBatchInfo;
+          assertNonNullable(info);
+          expect(info).toMatchObject({ streamArn, batchSize: 1 });
+          expect(info.shardId).toMatch(/^shardId-/u);
+          expect(info.startSequenceNumber).toBe(info.endSequenceNumber);
+          const firstEvent = fixture.events[0]?.Records[0];
+          assertNonNullable(firstEvent);
+          const sequenceNumber =
+            "dynamodb" in firstEvent
+              ? firstEvent.dynamodb.SequenceNumber
+              : firstEvent.kinesis.sequenceNumber;
+          expect(info.startSequenceNumber).toBe(sequenceNumber);
+          expect(record).not.toHaveProperty("requestPayload");
+          expect(record).not.toHaveProperty("responsePayload");
+          await simAws.clock().advanceBy({ hours: 1 });
+          expect(await fixture.receive()).toStrictEqual([]);
+        });
+      }
+
+      it(`does not notify ${destination} for successful ${source} batches`, async () => {
+        // Given a stream consumer that succeeds.
+        const fixture = await setup(source, destination, "retries", true, true);
+        // When a record is processed and time advances.
+        await fixture.write();
+        await fixture.simAws.backgroundTasksComplete();
+        await fixture.simAws.clock().advanceBy({ hours: 1 });
+        // Then there is no failure notification.
+        expect(await fixture.receive()).toStrictEqual([]);
+      });
+
+      it(`refuses ${source} failure delivery without ${destination} permission`, async () => {
+        // Given a consumer whose role can poll but cannot send to the destination.
+        const fixture = await setup(source, destination, "retries", false);
+        // When the batch exhausts its retries.
+        await fixture.write();
+        await fixture.simAws.backgroundTasksComplete();
+        await expect(
+          fixture.simAws.clock().advanceBy({ seconds: 1 }),
+        ).rejects.toThrow();
+        // Then the failed delivery changed no destination state, and the shard advances.
+        expect(await fixture.receive()).toStrictEqual([]);
+        await fixture.simAws.clock().advanceBy({ hours: 1 });
+        expect(await fixture.receive()).toStrictEqual([]);
+      });
+    }
+  }
+});

--- a/src/service/lambda/event-source/sim-lambda-stream-discarded-records.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-discarded-records.iso.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { assertNonNullable } from "@kensio/smartass";
+import { stream_discarded_records_fixture as setup } from "../../../../test/lambda/stream-discarded-records-fixture.js";
+
+describe("records identified by stream failure notifications", () => {
+  for (const source of ["dynamodb", "kinesis"]) {
+    for (const boundary of ["retries", "age"]) {
+      it(`notifies only the failed suffix of a ${source} batch at ${boundary} exhaustion`, async () => {
+        // Given a partial-batch consumer that reports the second record as failed.
+        const fixture = await setup(source);
+        const { simAws, uuid, streamArn, functionName, destinationArn } =
+          fixture;
+        await simAws
+          .lambda()
+          .deleteEventSourceMapping({ input: { UUID: uuid } });
+        await simAws.lambda().createEventSourceMapping({
+          input: {
+            EventSourceArn: streamArn,
+            FunctionName: functionName,
+            StartingPosition: "TRIM_HORIZON",
+            FunctionResponseTypes: ["ReportBatchItemFailures"],
+            MaximumRetryAttempts: boundary === "retries" ? 0 : -1,
+            MaximumRecordAgeInSeconds: 60,
+            DestinationConfig: { OnFailure: { Destination: destinationArn } },
+          },
+        });
+        // When three records reach the limit.
+        await fixture.write();
+        await fixture.write();
+        await fixture.write();
+        await simAws.backgroundTasksComplete();
+        await simAws.clock().advanceBy({ minutes: 2 });
+        // Then the successful prefix is absent from the notification.
+        const records = await fixture.receive();
+        expect(records).toHaveLength(1);
+        const info =
+          records[0]?.DDBStreamBatchInfo ?? records[0]?.KinesisBatchInfo;
+        const lastBatch = fixture.seen.at(-1);
+        assertNonNullable(lastBatch);
+        expect(info?.startSequenceNumber).toBe(
+          lastBatch.at(1) ?? lastBatch.at(0),
+        );
+        expect(info?.endSequenceNumber).toBe(fixture.seen[0]?.at(-1));
+        expect(info?.startSequenceNumber).not.toBe(fixture.seen[0]?.at(0));
+        expect(records[0]?.responseContext).not.toHaveProperty("functionError");
+      });
+    }
+  }
+});

--- a/src/service/lambda/event-source/sim-lambda-stream-expiry-destinations.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-expiry-destinations.iso.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { stream_discarded_records_fixture as setup } from "../../../../test/lambda/stream-discarded-records-fixture.js";
+
+describe("stream expiry notifications", () => {
+  for (const source of ["dynamodb", "kinesis"]) {
+    it(`discards only the expired prefix of a ${source} batch`, async () => {
+      // Given a failing consumer and two records written thirty seconds apart.
+      const fixture = await setup(source, false);
+      await fixture.write();
+      await fixture.simAws.backgroundTasksComplete();
+      await fixture.simAws.clock().advanceBy({ seconds: 30 });
+      await fixture.write();
+      await fixture.simAws.backgroundTasksComplete();
+      // When only the first record has expired.
+      await fixture.simAws.clock().advanceBy({ seconds: 34 });
+      // Then its notification excludes the younger record, which was invoked again.
+      const records = await fixture.receive();
+      expect(records).toHaveLength(1);
+      const info =
+        records[0]?.DDBStreamBatchInfo ?? records[0]?.KinesisBatchInfo;
+      expect(info?.batchSize).toBe(1);
+      expect(info?.startSequenceNumber).toBe(fixture.seen[0]?.[0]);
+      expect(fixture.seen.at(-1)).not.toContain(info?.startSequenceNumber);
+    });
+
+    it(`notifies for ${source} records already expired before the first poll`, async () => {
+      // Given an unmapped stream holding an expired record.
+      const fixture = await setup(source);
+      const { simAws, uuid, streamArn, functionName, destinationArn } = fixture;
+      await simAws.lambda().deleteEventSourceMapping({ input: { UUID: uuid } });
+      await fixture.write();
+      await simAws.backgroundTasksComplete();
+      await simAws.clock().advanceBy({ seconds: 61 });
+      // When a new mapping reads from the start with a one-minute record age.
+      await simAws.lambda().createEventSourceMapping({
+        input: {
+          EventSourceArn: streamArn,
+          FunctionName: functionName,
+          StartingPosition: "TRIM_HORIZON",
+          MaximumRecordAgeInSeconds: 60,
+          DestinationConfig: { OnFailure: { Destination: destinationArn } },
+        },
+      });
+      await simAws.backgroundTasksComplete();
+      // Then the notification reports zero invocations and the handler never saw the record.
+      const records = await fixture.receive();
+      expect(records).toHaveLength(1);
+      expect(records[0]?.requestContext).toMatchObject({
+        condition: "RecordAgeExceeded",
+        approximateInvokeCount: 0,
+      });
+      expect(fixture.seen).toStrictEqual([]);
+    });
+  }
+});

--- a/src/service/lambda/event-source/stream/kinesis/sim-kinesis-event-source-streams.ts
+++ b/src/service/lambda/event-source/stream/kinesis/sim-kinesis-event-source-streams.ts
@@ -71,6 +71,7 @@ export class SimKinesisEventSourceStreams implements SimLambdaKinesisStreams {
 
     return {
       records: output.Records,
+      shardId: request.shardId,
       next: { kind: "iterator", shardIterator: output.NextShardIterator },
       drained: false,
     };

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-reader.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-reader.ts
@@ -49,6 +49,7 @@ export class SimDynamoDbEventSourceStreamReader {
 
     return {
       records: output.Records ?? [],
+      shardId: await this.shard.shardId(request),
       next: simDynamoDbEventSourceNextPosition(next, position),
       drained: next === undefined,
     };

--- a/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.ts
+++ b/src/service/lambda/event-source/stream/sim-dynamodb-event-source-stream-shard.ts
@@ -74,6 +74,14 @@ export class SimDynamoDbEventSourceStreamShard {
     return iterator.ShardIterator;
   }
 
+  async shardId(request: SimLambdaEventSourceStreamRequest): Promise<string> {
+    const description = await this.describe(request);
+    const shardId = description.Shards?.[0]?.ShardId;
+    if (shardId === undefined)
+      refuse(request, "reports no shard to read records from");
+    return shardId;
+  }
+
   private async describe(
     request: SimLambdaEventSourceStreamRequest,
   ): Promise<SimLambdaEventSourceStreamDescription> {

--- a/src/service/lambda/event-source/stream/sim-lambda-event-source-streams.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-event-source-streams.ts
@@ -86,6 +86,7 @@ export interface SimLambdaEventSourceStreamReadRequest extends SimLambdaEventSou
 export interface SimLambdaEventSourceStreamProgressBatch {
   readonly next: SimLambdaEventSourceStreamPosition;
   readonly drained: boolean;
+  readonly shardId?: string;
 }
 
 /**

--- a/src/service/lambda/index.ts
+++ b/src/service/lambda/index.ts
@@ -57,3 +57,8 @@ export type {
   SimLambdaDestinationResponseContext,
 } from "./destination/sim-lambda-destination-record.js";
 export type { SimLambdaInvocationCondition } from "./function/event-invoke/sim-lambda-event-invoke-config.js";
+
+export type {
+  SimLambdaStreamFailureRecord,
+  SimLambdaStreamFailureCondition,
+} from "./event-source/poll/sim-lambda-stream-failure-record.js";

--- a/src/service/lambda/sim-lambda-commands.ts
+++ b/src/service/lambda/sim-lambda-commands.ts
@@ -191,6 +191,7 @@ export class SimLambdaCommands {
       background,
     });
     this.eventSourceMappings = new SimLambdaEventSourceMappingCommands({
+      destinations,
       accountRegionScope,
       pollers: new SimLambdaEventSourcePollers({
         functions: this.functionLookup,

--- a/test/lambda/kinesis-event-source-fixture.ts
+++ b/test/lambda/kinesis-event-source-fixture.ts
@@ -102,6 +102,7 @@ interface KinesisEventSourceOptions {
   readonly startingPosition?: EventSourcePosition;
   readonly startingPositionTimestamp?: Date;
   readonly functionResponseTypes?: readonly "ReportBatchItemFailures"[];
+  readonly destinationArn?: string;
   readonly maximumRetryAttempts?: number;
   readonly maximumRecordAgeInSeconds?: number;
 }
@@ -138,6 +139,11 @@ export async function simAwsWithKinesisEventSource(
     new CreateEventSourceMappingCommand({
       EventSourceArn: stream.arn,
       FunctionName: functionName,
+      ...(options.destinationArn !== undefined && {
+        DestinationConfig: {
+          OnFailure: { Destination: options.destinationArn },
+        },
+      }),
       StartingPosition: options.startingPosition ?? "TRIM_HORIZON",
       ...(options.startingPositionTimestamp !== undefined && {
         StartingPositionTimestamp: options.startingPositionTimestamp,

--- a/test/lambda/stream-destination-fixture.ts
+++ b/test/lambda/stream-destination-fixture.ts
@@ -1,0 +1,145 @@
+import type { SimDynamoDbStreamEventSourceFixture } from "./stream-event-source-fixture.js";
+import type { SimKinesisEventSourceFixture } from "./kinesis-event-source-fixture.js";
+import { faker } from "@faker-js/faker";
+import { assertNonNullable } from "@kensio/smartass";
+import { simAwsWithKinesisEventSource } from "./kinesis-event-source-fixture.js";
+import { simAwsWithStreamEventSource } from "./stream-event-source-fixture.js";
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimLambdaStreamFailureRecord } from "../../src/service/lambda/event-source/poll/sim-lambda-stream-failure-record.js";
+
+/** Create a stream consumer and a queue that receives its destination notifications. */
+type DestinationFixture = (
+  | SimDynamoDbStreamEventSourceFixture
+  | SimKinesisEventSourceFixture
+) & {
+  readonly destinationArn: string;
+  readonly write: () => Promise<void>;
+  readonly receive: () => Promise<SimLambdaStreamFailureRecord[]>;
+};
+
+/** Create a stream consumer and a queue that receives its destination notifications. */
+export async function stream_destination_fixture(
+  source: string,
+  destination: string,
+  boundary: string,
+  permission = true,
+  succeeds = false,
+): Promise<DestinationFixture> {
+  const simAws = new SimAws();
+  const name = faker.string.uuid();
+  const queue = await simAws.sqs().createQueue({ input: { QueueName: name } });
+  const queueUrl = queue.QueueUrl;
+  const attributes = await simAws.sqs().getQueueAttributes({
+    input: { QueueUrl: queueUrl, AttributeNames: ["QueueArn"] },
+  });
+  const queueArn = attributes.Attributes?.["QueueArn"];
+  assertNonNullable(queueArn);
+  let destinationArn = queueArn;
+  if (destination === "sns") {
+    const topic = await simAws.sns().createTopic({ input: { Name: name } });
+    assertNonNullable(topic.TopicArn);
+    destinationArn = topic.TopicArn;
+    await simAws.sqs().setQueueAttributes({
+      input: {
+        QueueUrl: queueUrl,
+        Attributes: {
+          Policy: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "sns.amazonaws.com" },
+                Action: "sqs:SendMessage",
+                Resource: queueArn,
+              },
+            ],
+          }),
+        },
+      },
+    });
+    await simAws.sns().subscribe({
+      input: {
+        TopicArn: destinationArn,
+        Protocol: "sqs",
+        Endpoint: queueArn,
+        Attributes: { RawMessageDelivery: "true" },
+      },
+    });
+  }
+  const options = {
+    simAws,
+    destinationArn,
+    ...limits(boundary),
+    handlerResult: (): undefined => {
+      if (!succeeds) throw new Error("Cannot process the record");
+      return;
+    },
+  };
+  const fixture =
+    source === "dynamodb"
+      ? await simAwsWithStreamEventSource(options)
+      : await simAwsWithKinesisEventSource(options);
+  if (permission) {
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: "OrderProjectorRole",
+        PolicyName: "DeliverFailure",
+        PolicyDocument: JSON.stringify({
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Action: `${destination}:*`,
+              Resource: destinationArn,
+            },
+          ],
+        }),
+      },
+    });
+  }
+  async function write(): Promise<void> {
+    if (source === "dynamodb") {
+      await simAws.dynamoDb().putItem({
+        input: {
+          TableName: "orders",
+          Item: { orderId: { S: faker.string.uuid() } },
+        },
+      });
+    } else {
+      await simAws.kinesis().putRecord({
+        input: {
+          StreamName: "orders",
+          PartitionKey: name,
+          Data: new TextEncoder().encode(name),
+        },
+      });
+    }
+  }
+  async function receive(): Promise<SimLambdaStreamFailureRecord[]> {
+    const result = await simAws.sqs().receiveMessage({
+      input: { QueueUrl: queueUrl, MaxNumberOfMessages: 10 },
+    });
+    await Promise.all(
+      (result.Messages ?? []).map(async (message) => {
+        await simAws.sqs().deleteMessage({
+          input: {
+            QueueUrl: queueUrl,
+            ReceiptHandle: message.ReceiptHandle,
+          },
+        });
+      }),
+    );
+    return (result.Messages ?? []).map(
+      (message) => JSON.parse(message.Body) as SimLambdaStreamFailureRecord,
+    );
+  }
+  return { ...fixture, write, receive, destinationArn };
+}
+
+function limits(boundary: string): {
+  maximumRetryAttempts?: number;
+  maximumRecordAgeInSeconds?: number;
+} {
+  if (boundary === "age") return { maximumRecordAgeInSeconds: 60 };
+  return { maximumRetryAttempts: 1 };
+}

--- a/test/lambda/stream-discarded-records-fixture.ts
+++ b/test/lambda/stream-discarded-records-fixture.ts
@@ -1,0 +1,110 @@
+import type { SimDynamoDbStreamEventSourceFixture } from "./stream-event-source-fixture.js";
+import type { SimKinesisEventSourceFixture } from "./kinesis-event-source-fixture.js";
+import { faker } from "@faker-js/faker";
+import { assertNonNullable } from "@kensio/smartass";
+import { simAwsWithKinesisEventSource } from "./kinesis-event-source-fixture.js";
+import { simAwsWithStreamEventSource } from "./stream-event-source-fixture.js";
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import type { SimLambdaKinesisStreamEvent } from "../../src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+import type { SimLambdaDynamoDbStreamEvent } from "../../src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.types.js";
+import type { SimLambdaStreamFailureRecord } from "../../src/service/lambda/event-source/poll/sim-lambda-stream-failure-record.js";
+
+function sequenceNumbers(
+  event: SimLambdaDynamoDbStreamEvent | SimLambdaKinesisStreamEvent,
+): string[] {
+  return event.Records.map((record) => {
+    if ("dynamodb" in record) return record.dynamodb.SequenceNumber;
+    return record.kinesis.sequenceNumber;
+  });
+}
+
+/** Create a stream consumer that records the sequence numbers in each invocation. */
+type DestinationFixture = (
+  | SimDynamoDbStreamEventSourceFixture
+  | SimKinesisEventSourceFixture
+) & {
+  readonly destinationArn: string;
+  readonly write: () => Promise<void>;
+  readonly receive: () => Promise<SimLambdaStreamFailureRecord[]>;
+  readonly seen: string[][];
+};
+
+/** Create a stream consumer that records the sequence numbers in each invocation. */
+export async function stream_discarded_records_fixture(
+  source: string,
+  partial = true,
+): Promise<DestinationFixture> {
+  const simAws = new SimAws();
+  const queue = await simAws
+    .sqs()
+    .createQueue({ input: { QueueName: faker.string.uuid() } });
+  const attributes = await simAws.sqs().getQueueAttributes({
+    input: { QueueUrl: queue.QueueUrl, AttributeNames: ["QueueArn"] },
+  });
+  const destinationArn = attributes.Attributes?.["QueueArn"];
+  assertNonNullable(destinationArn);
+  const seen: string[][] = [];
+  const options = {
+    simAws,
+    destinationArn,
+    maximumRecordAgeInSeconds: 60,
+    functionResponseTypes: ["ReportBatchItemFailures"] as const,
+    handlerResult: (
+      event: SimLambdaDynamoDbStreamEvent | SimLambdaKinesisStreamEvent,
+    ): { batchItemFailures: { itemIdentifier: string | undefined }[] } => {
+      const numbers = sequenceNumbers(event);
+      seen.push(numbers);
+      if (!partial) throw new Error("Failed batch");
+      return {
+        batchItemFailures: [{ itemIdentifier: numbers.at(1) ?? numbers.at(0) }],
+      };
+    },
+  };
+  const fixture =
+    source === "dynamodb"
+      ? await simAwsWithStreamEventSource(options)
+      : await simAwsWithKinesisEventSource(options);
+  await simAws.iam().putRolePolicy({
+    input: {
+      RoleName: "OrderProjectorRole",
+      PolicyName: "SendFailures",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: "sqs:SendMessage",
+            Resource: destinationArn,
+          },
+        ],
+      }),
+    },
+  });
+  async function write(): Promise<void> {
+    if (source === "dynamodb") {
+      await simAws.dynamoDb().putItem({
+        input: {
+          TableName: "orders",
+          Item: { orderId: { S: faker.string.uuid() } },
+        },
+      });
+    } else {
+      await simAws.kinesis().putRecord({
+        input: {
+          StreamName: "orders",
+          PartitionKey: "one-shard",
+          Data: new TextEncoder().encode(faker.string.uuid()),
+        },
+      });
+    }
+  }
+  async function receive(): Promise<SimLambdaStreamFailureRecord[]> {
+    const messages = await simAws.sqs().receiveMessage({
+      input: { QueueUrl: queue.QueueUrl, MaxNumberOfMessages: 10 },
+    });
+    return (messages.Messages ?? []).map(
+      (message) => JSON.parse(message.Body) as SimLambdaStreamFailureRecord,
+    );
+  }
+  return { ...fixture, destinationArn, seen, write, receive };
+}

--- a/test/lambda/stream-event-source-fixture.ts
+++ b/test/lambda/stream-event-source-fixture.ts
@@ -138,6 +138,7 @@ interface StreamEventSourceOptions {
   readonly batchSize?: number;
   readonly startingPosition?: EventSourcePosition;
   readonly functionResponseTypes?: readonly "ReportBatchItemFailures"[];
+  readonly destinationArn?: string;
   readonly maximumRetryAttempts?: number;
   readonly maximumRecordAgeInSeconds?: number;
 }
@@ -168,6 +169,11 @@ export async function simAwsWithStreamEventSource(
     new CreateEventSourceMappingCommand({
       EventSourceArn: stream.streamArn,
       FunctionName: functionName,
+      ...(options.destinationArn !== undefined && {
+        DestinationConfig: {
+          OnFailure: { Destination: options.destinationArn },
+        },
+      }),
       StartingPosition: options.startingPosition ?? "TRIM_HORIZON",
       ...(options.batchSize !== undefined && { BatchSize: options.batchSize }),
       ...(options.functionResponseTypes !== undefined && {


### PR DESCRIPTION
Stream event-source mappings rejected `DestinationConfig`, preventing local deployment of applications with stream failure queues. DynamoDB Streams and Kinesis mappings now accept standard SQS and SNS `OnFailure` destinations and send batch metadata when retries or record age are exhausted. Delivery uses the function's execution role and the destination service's IAM checks.

Record age is checked before invocation, including the first poll. Notifications identify the discarded sequence-number range after partial-batch checkpointing or prefix expiry. Destination failures surface through background tasks after the checkpoint advances. Delivery retries, delivery-failure metrics, and S3 destinations remain outside this change.

Validation passed for formatting and lint, FTA, type checking, documentation examples, and full test coverage (12,692 tests). The full suite includes synthesized CDK DynamoDB-to-SQS and Kinesis-to-SNS destinations. Local Terraform fixtures were initialized with `pnpm tf:init` before rerunning coverage.

Resolves #1293


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for SQS and SNS failure destinations for DynamoDB Streams and Kinesis event sources.
  - Failure notifications include stream, shard, sequence, timing, and invocation details.
  - Destination settings are preserved in event source mapping configuration and support IAM-authorized delivery.

- **Bug Fixes**
  - Expired records are discarded before invocation, including during the initial poll.
  - Checkpoints advance correctly after discarded records, while successful batches avoid unnecessary notifications.
  - Partial failures notify destinations only for the failed records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->