### PR TITLE
fix: record unsimulated event source mapping properties

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2324,8 +2324,13 @@ this, and deploys without hand-editing. The grant CDK writes alongside it is an 
 the three stream actions on the stream ARN and `dynamodb:ListStreams` on every stream, exactly what
 the mapping's execution-role check is looking for.
 
-The properties a non-default `DynamoEventSource` adds are refused by name. Those are
+The properties a non-default `DynamoEventSource` adds are recorded rather than acted on. Those are
 `FilterCriteria`, `ParallelizationFactor`, `BisectBatchOnFunctionError` and `TumblingWindowInSeconds`.
+The mapping deploys, delivers every record whole and unfiltered, and each property it was created
+without is listed in
+[`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without "Properties a Resource was created without")
+with what the mapping does in its place. `CreateEventSourceMapping` still refuses the same
+properties, since a caller naming one is asking for behaviour by hand.
 
 A hand-written template or a SAM application usually gives the function the AWS managed policy
 `AWSLambdaDynamoDBExecutionRole` instead. Simulated IAM has no model for managed policy ARNs, so
@@ -4297,11 +4302,12 @@ Current documented limitations:
   function, and `S3ObjectVersion` on `UpdateFunctionCode`. A versioned location loads the object as
   it stands.
 - SQS queues, DynamoDB streams and Kinesis streams are the only event sources. Kafka, DocumentDB and
-  Kinesis enhanced fan-out consumers are refused outright, and so are `FilterCriteria`,
-  `ScalingConfig`, `BisectBatchOnFunctionError`, `ParallelizationFactor`,
-  `TumblingWindowInSeconds` and the other mapping inputs this simulation has no behaviour for. An
-  `AWS::Lambda::EventSourceMapping` carrying `Tags` is the exception, and deploys with the tags
-  dropped and the property recorded.
+  Kinesis enhanced fan-out consumers are refused outright. `CreateEventSourceMapping` also refuses
+  `FilterCriteria`, `ScalingConfig`, `BisectBatchOnFunctionError`, `ParallelizationFactor`,
+  `TumblingWindowInSeconds` and the other inputs this simulation has no behaviour for. An
+  `AWS::Lambda::EventSourceMapping` naming any of them deploys instead, and records each one against
+  the Resource (see
+  [Properties a Resource was created without](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without "Properties a Resource was created without")).
 - A failed stream batch waits 1, 2, 4, 8 and 16 seconds between attempts, where AWS documents no
   delay. That is deliberate. A delay of zero falls due at the instant the clock already reads, and a
   handler that always throws would leave `advanceBy` with work falling due forever. A mapping that

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
@@ -4,7 +4,7 @@ import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template
 import type { SimCreateEventSourceMappingCommandInput } from "../../command/event-source-mapping/event-source-mapping.command.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
 import { SimCfnLambdaPropertyParser } from "../function/sim-cfn-lambda-property-parser.js";
-import { assertSimulatedEventSourceMappingProperties } from "./sim-cfn-lambda-event-source-mapping-property-rules.js";
+import { recordUnsimulatedEventSourceMappingProperties } from "./sim-cfn-lambda-event-source-mapping-property-rules.js";
 import { simCfnLambdaTargetFunctionName } from "../function/sim-cfn-lambda-target-function.js";
 
 /**
@@ -37,7 +37,7 @@ export class SimCfnLambdaEventSourceMappingProperties {
   }
 
   /**
-   * The create input this Resource asks for, refusing what is not simulated.
+   * The create input this Resource asks for, recording what is left out of it.
    *
    * The event source ARN is read before anything else is judged, as the command
    * reads it first for the same reason: what a mapping may ask for depends on
@@ -50,7 +50,10 @@ export class SimCfnLambdaEventSourceMappingProperties {
       "EventSourceArn",
     );
 
-    assertSimulatedEventSourceMappingProperties(this.resource, this.properties);
+    recordUnsimulatedEventSourceMappingProperties(
+      this.resource,
+      this.properties,
+    );
 
     return {
       EventSourceArn: eventSourceArn,

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-names.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-names.ts
@@ -1,0 +1,100 @@
+/**
+ * The AWS::Lambda::EventSourceMapping properties this simulation acts on.
+ *
+ * The two starting position properties are here rather than among the
+ * unsimulated ones because whether a mapping may carry one is the event
+ * source's own rule: a stream has to be given a position and a queue is refused
+ * for naming one. That is decided by CreateEventSourceMapping, which knows
+ * which source the ARN names, so both are read and passed on. The two
+ * failed-batch limits are read for the same reason: a stream mapping keeps them
+ * and a queue mapping is refused for naming one.
+ */
+export const simulatedPropertyNames: ReadonlySet<string> = new Set([
+  "BatchSize",
+  "Enabled",
+  "EventSourceArn",
+  "FunctionName",
+  "FunctionResponseTypes",
+  "MaximumBatchingWindowInSeconds",
+  "MaximumRecordAgeInSeconds",
+  "MaximumRetryAttempts",
+  "DestinationConfig",
+  "StartingPosition",
+  "StartingPositionTimestamp",
+]);
+
+/**
+ * The event sources a mapping property can only be configuring, none of which
+ * this simulation has.
+ *
+ * A mapping naming one of these has an event source ARN to match, and that ARN
+ * is what the mapping is refused on. The property beside it is recorded.
+ */
+const absentEventSource =
+  "the mapping polls the source its EventSourceArn names, and this " +
+  "simulation has SQS queues, DynamoDB streams and Kinesis streams";
+
+/**
+ * Real AWS::Lambda::EventSourceMapping properties this simulation does not act
+ * on, and what the mapping does in place of each.
+ *
+ * Every one of them changes what the function sees or when it sees it. That is
+ * what the record against the Resource is for. A mapping created without one
+ * still carries the records the template asked for to the function the
+ * template named, and the difference is there to be read.
+ */
+export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
+  ["AmazonManagedKafkaEventSourceConfig", absentEventSource],
+  [
+    "BisectBatchOnFunctionError",
+    "a failing stream batch is retried whole, and is never split in half " +
+      "around the record the function threw on",
+  ],
+  ["DocumentDBEventSourceConfig", absentEventSource],
+  [
+    "FilterCriteria",
+    "every record on the event source is delivered to the function, unfiltered",
+  ],
+  [
+    "KmsKeyArn",
+    "the key encrypts filter criteria, and filter criteria are not simulated",
+  ],
+  ["MetricsConfig", "the mapping publishes no CloudWatch metrics"],
+  [
+    "ParallelizationFactor",
+    "polling concurrency is not simulated, and each shard of a stream is read " +
+      "by one reader",
+  ],
+  ["ProvisionedPollerConfig", "polling concurrency is not simulated"],
+  ["Queues", absentEventSource],
+  ["ScalingConfig", "polling concurrency is not simulated"],
+  ["SelfManagedEventSource", absentEventSource],
+  ["SelfManagedKafkaEventSourceConfig", absentEventSource],
+  [
+    "SourceAccessConfigurations",
+    "event source authentication is not simulated",
+  ],
+  [
+    "Tags",
+    "the mapping is created without them, and nothing reads them back or " +
+      "groups or bills by them",
+  ],
+  ["Topics", absentEventSource],
+  [
+    "TumblingWindowInSeconds",
+    "a batch carries no window state from the batch before it, and the " +
+      "function is handed no state to return",
+  ],
+]);
+
+/**
+ * Why a property name this simulation has never heard of is recorded.
+ *
+ * A typo and a property AWS added after this simulation read the docs look
+ * identical from here. A mapping that deploys with the unread name reported is
+ * more use than a stack that fails over either.
+ */
+export const unknownPropertyReason =
+  "it is not an AWS::Lambda::EventSourceMapping property this simulation " +
+  "knows, whether because AWS added it or because the template misspelled " +
+  "something";

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-rules.ts
@@ -1,126 +1,36 @@
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import {
+  simulatedPropertyNames,
+  unknownPropertyReason,
+  unsimulatedPropertyReasons,
+} from "./sim-cfn-lambda-event-source-mapping-property-names.js";
 
 /**
- * The AWS::Lambda::EventSourceMapping properties this simulation acts on.
+ * Record everything about an AWS::Lambda::EventSourceMapping Resource that the
+ * mapping is created without.
  *
- * The two starting position properties are here rather than among the
- * unsimulated ones because whether a mapping may carry one is the event
- * source's own rule: a stream has to be given a position and a queue is refused
- * for naming one. That is decided by CreateEventSourceMapping, which knows
- * which source the ARN names, so both are read and passed on. The two
- * failed-batch limits are read for the same reason: a stream mapping keeps them
- * and a queue mapping is refused for naming one.
+ * Nothing here fails the Resource. A mapping missing one of these settings
+ * still carries records from the source to the function, and a stack that
+ * refused it would take every other Resource down over one line of a template.
+ * What the mapping does instead is in `stack.ignoredProperties`.
  */
-const simulatedPropertyNames: ReadonlySet<string> = new Set([
-  "BatchSize",
-  "Enabled",
-  "EventSourceArn",
-  "FunctionName",
-  "FunctionResponseTypes",
-  "MaximumBatchingWindowInSeconds",
-  "MaximumRecordAgeInSeconds",
-  "MaximumRetryAttempts",
-  "DestinationConfig",
-  "StartingPosition",
-  "StartingPositionTimestamp",
-]);
-
-/**
- * Real AWS::Lambda::EventSourceMapping properties this simulation does not
- * model.
- *
- * Every one of them changes what the function sees or when it sees it, so a
- * template asking for one fails the Resource rather than deploying a mapping
- * that quietly ignores it.
- */
-const unsimulatedPropertyNames: ReadonlySet<string> = new Set([
-  "AmazonManagedKafkaEventSourceConfig",
-  "BisectBatchOnFunctionError",
-  "DocumentDBEventSourceConfig",
-  "FilterCriteria",
-  "KmsKeyArn",
-  "MetricsConfig",
-  "ParallelizationFactor",
-  "ProvisionedPollerConfig",
-  "Queues",
-  "ScalingConfig",
-  "SelfManagedEventSource",
-  "SelfManagedKafkaEventSourceConfig",
-  "SourceAccessConfigurations",
-  "Topics",
-  "TumblingWindowInSeconds",
-]);
-
-/**
- * Real AWS::Lambda::EventSourceMapping properties this simulation has nothing
- * to act on and no reason to fail a stack over.
- *
- * `Tags` is the whole list. The mapping is created without them and the
- * omission is recorded against the Resource. A mapping delivers the same
- * records with a tag and without one, and a CDK app calling
- * `Tags.of(app).add(...)` tags every mapping in it.
- */
-const ignoredPropertyReasons: ReadonlyMap<string, string> = new Map([
-  [
-    "Tags",
-    "AWS::Lambda::EventSourceMapping property Tags is not simulated, so the " +
-      "mapping is created without them. Nothing reads them back and nothing " +
-      "is grouped or billed by them.",
-  ],
-]);
-
-/**
- * Build the error a property of an AWS::Lambda::EventSourceMapping Resource is
- * refused with.
- *
- * The wording matters: sim CloudFormation skips a Resource whose error reads as
- * an unsupported Resource type, and skipping is the wrong answer for a mapping
- * that cannot be created as the template asks. The stack would deploy with the
- * queue and the function and nothing between them.
- */
-export function eventSourceMappingPropertyError(
-  logicalId: string,
-  reason: string,
-): Error {
-  return new Error(
-    `Invalid AWS::Lambda::EventSourceMapping Resource ${logicalId}: ${reason}`,
-  );
-}
-
-/**
- * Refuse everything about an AWS::Lambda::EventSourceMapping Resource that is
- * not simulated, and record what the mapping is created without.
- */
-export function assertSimulatedEventSourceMappingProperties(
+export function recordUnsimulatedEventSourceMappingProperties(
   resource: SimCfnResource,
   properties: SimCfnTemplateValueRecord,
 ): void {
-  const logicalId = resource.logicalId;
-
   for (const name of Object.keys(properties)) {
-    const ignoredReason = ignoredPropertyReasons.get(name);
-
-    if (ignoredReason !== undefined) {
-      resource.ignoreProperty(name, ignoredReason);
-
+    if (simulatedPropertyNames.has(name)) {
       continue;
     }
 
-    if (unsimulatedPropertyNames.has(name)) {
-      throw eventSourceMappingPropertyError(
-        logicalId,
-        `${name} is a real AWS::Lambda::EventSourceMapping property that ` +
-          "this simulation does not simulate, so it is refused rather than " +
-          "ignored",
-      );
-    }
+    const reason =
+      unsimulatedPropertyReasons.get(name) ?? unknownPropertyReason;
 
-    if (!simulatedPropertyNames.has(name)) {
-      throw eventSourceMappingPropertyError(
-        logicalId,
-        `${name} is not an AWS::Lambda::EventSourceMapping property`,
-      );
-    }
+    resource.ignoreProperty(
+      name,
+      `AWS::Lambda::EventSourceMapping property ${name} is not simulated: ` +
+        `${reason}.`,
+    );
   }
 }

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
@@ -1,5 +1,6 @@
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
 import {
+  assertArrayIncludesAll,
   assertArrayLength,
   assertIdentical,
   assertInstanceOf,
@@ -36,20 +37,6 @@ const mappingProperties: SimCfnTemplateValueRecord = {
   FunctionName: { Ref: "ConsumerFunction" },
   BatchSize: 5,
   FunctionResponseTypes: ["ReportBatchItemFailures"],
-};
-
-/**
- * The same mapping as a Resource created on its own is given it, with the
- * intrinsics already resolved.
- *
- * The event source ARN is read before anything else about the Resource is
- * judged, since what a mapping may ask for depends on the kind of source it
- * names, so a test about another property has to state a real ARN.
- */
-const resolvedMappingProperties: SimCfnTemplateValueRecord = {
-  ...mappingProperties,
-  EventSourceArn: "arn:aws:sqs:eu-west-2:111111111111:orders",
-  FunctionName: "order-consumer",
 };
 
 /**
@@ -261,32 +248,87 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
     assertStringIncludes(error.message, "Nonsense");
   });
 
-  it("refuses a property this simulation does not model", async () => {
-    // Given a template asking a mapping to filter events.
-    const error = await mappingCreationError({
-      ...resolvedMappingProperties,
-      FilterCriteria: { Filters: [{ Pattern: "{}" }] },
-    });
+  it("records mapping settings it cannot act on rather than failing the stack", async () => {
+    // Given a mapping asking for batch bisection and event filtering, as a CDK
+    // event source carrying those options synthesises one.
+    const simAws = new SimAws();
+    const events: SimLambdaSqsEvent[] = [];
 
-    // Then the Resource fails rather than deploying a mapping ignoring it.
-    assertStringIncludes(
-      error.message,
-      "Invalid AWS::Lambda::EventSourceMapping Resource BadMapping: " +
-        "FilterCriteria is a real AWS::Lambda::EventSourceMapping property",
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: consumerTemplate({
+        ...mappingProperties,
+        BisectBatchOnFunctionError: true,
+        FilterCriteria: { Filters: [{ Pattern: '{"body":["order-2"]}' }] },
+      }),
+      bindings: [
+        {
+          logicalId: "ConsumerFunction",
+          handler: (event: SimLambdaSqsEvent): undefined => {
+            events.push(event);
+
+            return undefined;
+          },
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the mapping is there, and both settings are recorded against it.
+    const resource = stack.getResource("OrderConsumerMapping");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimLambdaEventSourceMapping);
+
+    assertArrayIncludesAll(
+      resource.ignoredProperties.map((ignored) => ignored.path),
+      ["BisectBatchOnFunctionError", "FilterCriteria"],
     );
+    assertArrayIncludesAll(
+      stack.ignoredProperties.map((ignored) => ignored.path),
+      ["BisectBatchOnFunctionError", "FilterCriteria"],
+    );
+
+    // And it delivers, unfiltered, as the recorded reason says it does.
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: simAws.sqs().findQueue("orders")?.url,
+        MessageBody: "order-1",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    assertArrayLength(events, 1);
+    assertIdentical(events[0].Records[0]?.body, "order-1");
   });
 
-  it("refuses a property AWS::Lambda::EventSourceMapping does not have", async () => {
-    // Given a template with a made-up property.
-    const error = await mappingCreationError({
-      ...resolvedMappingProperties,
-      Nonsense: "true",
-    });
+  it("records a property AWS::Lambda::EventSourceMapping does not have", async () => {
+    // Given a mapping carrying a name this simulation has never heard of,
+    // which is a template's typo or a property AWS has added since.
+    const simAws = new SimAws();
 
-    // Then the Resource fails rather than dropping it.
+    // When the template is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: consumerTemplate({ ...mappingProperties, Nonsense: "true" }),
+      bindings: [
+        { logicalId: "ConsumerFunction", handler: (): undefined => undefined },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // Then the mapping is there, and the unread name is reported.
+    const resource = stack.getResource("OrderConsumerMapping");
+
+    assertNonNullable(resource);
+    assertInstanceOf(resource.simResource, SimLambdaEventSourceMapping);
+
+    assertArrayLength(resource.ignoredProperties, 1);
+    assertIdentical(resource.ignoredProperties[0].path, "Nonsense");
     assertStringIncludes(
-      error.message,
-      "Nonsense is not an AWS::Lambda::EventSourceMapping property",
+      resource.ignoredProperties[0].reason,
+      "whether because AWS added it or because the template misspelled",
     );
   });
 


### PR DESCRIPTION
An `AWS::Lambda::EventSourceMapping` carrying a property this simulation does not act on failed the Resource, and the Resource failed the stack. A CDK app setting `bisectBatchOnError` on one `DynamoEventSource` lost every other Resource in the stack with it. The mapping now deploys and each property it was created without is recorded in `stack.ignoredProperties` with what the mapping does in its place, which is the best-effort rule CloudFormation deployment already documents. A property name AWS has never had is recorded the same way. `CreateEventSourceMapping` still refuses the same properties, as it already does with `Tags`.

Resolves #1297
