### PR TITLE
feat: bisect a failing Lambda stream batch

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2033,6 +2033,38 @@ discarded, and the mapping reads on from behind it.
 10,000 retries, `-1` to 604,800 seconds) is a `ValidationException`. A queue mapping takes neither,
 because a message the handler never takes is left to the queue's own redrive policy.
 
+### Splitting a failed batch around the record that broke it
+
+`BisectBatchOnFunctionError` splits a batch the handler threw on in half, and delivers each half as
+its own batch. A half that fails is split again, down to a single record. That is how the records
+beside a poison record get through, and how the poison record ends up delivered on its own and
+discarded on its own.
+
+```json
+{
+  "StartingPosition": "TRIM_HORIZON",
+  "BatchSize": 100,
+  "MaximumRetryAttempts": 10,
+  "BisectBatchOnFunctionError": true
+}
+```
+
+A batch of four whose third record the handler cannot take is delivered as `1, 2, 3, 4`, then
+`1, 2`, then `3, 4`, then `3` on its own, and finally `4`. The record that broke every batch it was
+in leaves the mapping under the retry and record-age limits, and reaches the
+[failure destination](#sending-discarded-stream-batches-to-a-destination) naming one record rather
+than four.
+
+Splitting puts the retry count back to the start, so a batch always reaches a single record before
+the count decides anything. Once it is down to one record, the limits count as they do for any other
+failing batch. A batch the handler reported partial failures on is left whole, because the report
+already says which record to go back to. The limit is dropped as soon as a batch goes through, so
+the rest of a split batch is read at the mapping's own batch size again.
+
+`GetEventSourceMapping` and `ListEventSourceMappings` report the setting, and
+`AWS::Lambda::EventSourceMapping` takes it in a template. Both stream sources have it. A queue
+mapping is refused for naming it, the way real Lambda refuses one.
+
 ### Sending discarded stream batches to a destination
 
 DynamoDB Streams and Kinesis mappings accept `DestinationConfig.OnFailure` with a standard SQS
@@ -2324,8 +2356,10 @@ this, and deploys without hand-editing. The grant CDK writes alongside it is an 
 the three stream actions on the stream ARN and `dynamodb:ListStreams` on every stream, exactly what
 the mapping's execution-role check is looking for.
 
-The properties a non-default `DynamoEventSource` adds are recorded rather than acted on. Those are
-`FilterCriteria`, `ParallelizationFactor`, `BisectBatchOnFunctionError` and `TumblingWindowInSeconds`.
+`bisectBatchOnError` is simulated, and is covered under
+[Splitting a failed batch around the record that broke it](#splitting-a-failed-batch-around-the-record-that-broke-it).
+The other properties a non-default `DynamoEventSource` adds are recorded rather than acted on. Those
+are `FilterCriteria`, `ParallelizationFactor` and `TumblingWindowInSeconds`.
 The mapping deploys, delivers every record whole and unfiltered, and each property it was created
 without is listed in
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without "Properties a Resource was created without")
@@ -4303,8 +4337,8 @@ Current documented limitations:
   it stands.
 - SQS queues, DynamoDB streams and Kinesis streams are the only event sources. Kafka, DocumentDB and
   Kinesis enhanced fan-out consumers are refused outright. `CreateEventSourceMapping` also refuses
-  `FilterCriteria`, `ScalingConfig`, `BisectBatchOnFunctionError`, `ParallelizationFactor`,
-  `TumblingWindowInSeconds` and the other inputs this simulation has no behaviour for. An
+  `FilterCriteria`, `ScalingConfig`, `ParallelizationFactor`, `TumblingWindowInSeconds` and the
+  other inputs this simulation has no behaviour for. An
   `AWS::Lambda::EventSourceMapping` naming any of them deploys instead, and records each one against
   the Resource (see
   [Properties a Resource was created without](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without "Properties a Resource was created without")).
@@ -4315,6 +4349,10 @@ Current documented limitations:
   discards the batch, where AWS goes on until the records age out a day later. A batch item failure
   report counts against the same retries, and never starts them again for the records it rewound
   to.
+- Splitting a batch under `BisectBatchOnFunctionError` puts the retry count back to the start, where
+  AWS counts a bisected batch's deliveries against the same quota. Without that, the simulator's own
+  cap of five attempts would discard a batch of a hundred long before it was down to one record. The
+  splitting still ends on its own, because a batch halves at every step.
 - A handler writing into the table whose stream invoked it is refused with
   `SimLambdaStreamCascadeError` rather than being delivered its own writes forever. Real Lambda runs
   that loop.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2058,8 +2058,11 @@ than four.
 Splitting puts the retry count back to the start, so a batch always reaches a single record before
 the count decides anything. Once it is down to one record, the limits count as they do for any other
 failing batch. A batch the handler reported partial failures on is left whole, because the report
-already says which record to go back to. The limit is dropped as soon as a batch goes through, so
-the rest of a split batch is read at the mapping's own batch size again.
+already says which record to go back to.
+
+The halves carry the batch that failed and nothing else. A record written while the splitting is
+going on waits behind it and is delivered as part of the batch after it, and the mapping reads at its
+own batch size again once the whole of the split batch is through.
 
 `GetEventSourceMapping` and `ListEventSourceMappings` report the setting, and
 `AWS::Lambda::EventSourceMapping` takes it in a template. Both stream sources have it. A queue

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-dynamodb-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-dynamodb-event-source-mapping.iso.test.ts
@@ -1,11 +1,13 @@
 import { PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { ListEventSourceMappingsCommand } from "@aws-sdk/client-lambda";
 import {
+  assertArrayEmpty,
   assertArrayLength,
   assertIdentical,
   assertNonNullable,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertTrue,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
@@ -217,6 +219,39 @@ describe("Lambda CloudFormation DynamoDB stream event source mapping", () => {
       listed.EventSourceMappings[0].MaximumRecordAgeInSeconds,
       300,
     );
+  });
+
+  it("deploys a mapping that bisects a failed batch, as CDK synthesises one", async () => {
+    // Given a template asking the mapping to bisect, which is what a
+    // DynamoEventSource with bisectBatchOnError set synthesises.
+    const simAws = new SimAws();
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName: "orders-stack",
+      template: projectorTemplate({
+        ...mappingProperties,
+        BisectBatchOnFunctionError: true,
+      }),
+      bindings: [
+        {
+          logicalId: "ProjectorFunction",
+          handler: (): undefined => undefined,
+        },
+      ],
+    });
+    await stack.waitForDeployComplete();
+
+    // When the mappings of the deployed function are listed.
+    const listed = await simAws
+      .lambda()
+      .listEventSourceMappings(
+        new ListEventSourceMappingsCommand({ FunctionName: "order-projector" }),
+      );
+
+    // Then the mapping deployed with the setting, and nothing was recorded as
+    // left out of it.
+    assertArrayLength(listed.EventSourceMappings, 1);
+    assertTrue(listed.EventSourceMappings[0].BisectBatchOnFunctionError);
+    assertArrayEmpty(stack.ignoredProperties);
   });
 
   it("refuses a failed-batch limit outside the range Lambda takes", async () => {

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
@@ -92,6 +92,11 @@ export class SimCfnLambdaEventSourceMappingProperties {
         this.properties["MaximumRecordAgeInSeconds"],
         "MaximumRecordAgeInSeconds",
       ),
+      BisectBatchOnFunctionError: this.parser.optionalBoolean(
+        this.resource,
+        this.properties["BisectBatchOnFunctionError"],
+        "BisectBatchOnFunctionError",
+      ),
       StartingPosition: this.parser.optionalString(
         this.resource,
         this.properties["StartingPosition"],

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-names.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-names.ts
@@ -18,6 +18,7 @@ export const simulatedPropertyNames: ReadonlySet<string> = new Set([
   "MaximumBatchingWindowInSeconds",
   "MaximumRecordAgeInSeconds",
   "MaximumRetryAttempts",
+  "BisectBatchOnFunctionError",
   "DestinationConfig",
   "StartingPosition",
   "StartingPositionTimestamp",
@@ -45,11 +46,6 @@ const absentEventSource =
  */
 export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
   ["AmazonManagedKafkaEventSourceConfig", absentEventSource],
-  [
-    "BisectBatchOnFunctionError",
-    "a failing stream batch is retried whole, and is never split in half " +
-      "around the record the function threw on",
-  ],
   ["DocumentDBEventSourceConfig", absentEventSource],
   [
     "FilterCriteria",

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
@@ -249,8 +249,8 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
   });
 
   it("records mapping settings it cannot act on rather than failing the stack", async () => {
-    // Given a mapping asking for batch bisection and event filtering, as a CDK
-    // event source carrying those options synthesises one.
+    // Given a mapping asking for a tumbling window and event filtering, as a
+    // CDK event source carrying those options synthesises one.
     const simAws = new SimAws();
     const events: SimLambdaSqsEvent[] = [];
 
@@ -259,7 +259,7 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
       stackName: "orders-stack",
       template: consumerTemplate({
         ...mappingProperties,
-        BisectBatchOnFunctionError: true,
+        TumblingWindowInSeconds: 30,
         FilterCriteria: { Filters: [{ Pattern: '{"body":["order-2"]}' }] },
       }),
       bindings: [
@@ -283,11 +283,11 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
 
     assertArrayIncludesAll(
       resource.ignoredProperties.map((ignored) => ignored.path),
-      ["BisectBatchOnFunctionError", "FilterCriteria"],
+      ["TumblingWindowInSeconds", "FilterCriteria"],
     );
     assertArrayIncludesAll(
       stack.ignoredProperties.map((ignored) => ignored.path),
-      ["BisectBatchOnFunctionError", "FilterCriteria"],
+      ["TumblingWindowInSeconds", "FilterCriteria"],
     );
 
     // And it delivers, unfiltered, as the recorded reason says it does.

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -117,6 +117,7 @@ export class SimLambdaEventSourceMappingInput {
       streamRetryLimits: eventSourceArn.retryLimitRules.limitsIn({
         maximumRetryAttempts: input.MaximumRetryAttempts,
         maximumRecordAgeInSeconds: input.MaximumRecordAgeInSeconds,
+        bisectBatchOnFunctionError: input.BisectBatchOnFunctionError,
       }),
     });
   }

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -15,11 +15,6 @@ const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
   ["ScalingConfig", "polling concurrency is not simulated"],
   ["ProvisionedPollerConfig", "polling concurrency is not simulated"],
   [
-    "BisectBatchOnFunctionError",
-    "batch bisection is not simulated, so a failing stream batch is retried " +
-      "whole",
-  ],
-  [
     "ParallelizationFactor",
     "polling concurrency is not simulated, so each shard of a stream is read " +
       "by one reader",

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -141,6 +141,24 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     );
   });
 
+  it("refuses bisection on a queue mapping, which does not count attempts", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping on the queue asks to bisect a batch its function threw on.
+    const error = await refusedMapping(ready, {
+      BisectBatchOnFunctionError: true,
+    });
+
+    // Then it is refused, as real Lambda refuses it: a message the function
+    // never handles is the queue's own problem once the batch goes back.
+    assertIdentical(error.name, "InvalidParameterValueException");
+    assertStringIncludes(
+      error.message,
+      "BisectBatchOnFunctionError is not valid for a queue",
+    );
+  });
+
   it("refuses a queue in another Account or Region", async () => {
     // Given a queue and a function.
     const ready = await simAwsReadyToMap();

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-poller.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-poller.ts
@@ -97,7 +97,7 @@ export class SimLambdaKinesisShardPoller implements SimLambdaEventSourcePolls {
     // simulated IAM decides whether this mapping may read its stream.
     const batch = await this.shard.read(
       progress.position,
-      this.mapping.batchSize,
+      progress.batchSizeWithin(this.mapping.batchSize),
     );
 
     await processSimLambdaStreamBatch({

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-polling.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-polling.ts
@@ -33,7 +33,7 @@ export class SimLambdaDynamoDbStreamPolling {
     const batch = await stream.read(
       simFunction.roleArn,
       progress.position,
-      mapping.batchSize,
+      progress.batchSizeWithin(mapping.batchSize),
     );
 
     await processSimLambdaStreamBatch({

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-bisect.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-bisect.ts
@@ -1,0 +1,61 @@
+import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
+
+/**
+ * How many records the next delivery of a failing batch may carry.
+ *
+ * A mapping asked to bisect halves a batch its function threw on, and halves
+ * again on each further error, until a failing batch holds one record. That is
+ * how the record that broke the batch ends up delivered on its own, and how the
+ * records beside it get through.
+ *
+ * A split is progress rather than another attempt at the same work, so it puts
+ * the retry count back to the start. Without that the simulator's own cap of
+ * five attempts would discard a batch of a hundred long before it was down to
+ * one record. A batch halves at every step, so the splitting ends on its own,
+ * and the single record it ends on is then counted and discarded as any failing
+ * batch is.
+ *
+ * The limit is dropped as soon as a batch goes through. The rest of a split
+ * batch is read at the mapping's own batch size again, and a poison record
+ * still in it splits the batch it lands in.
+ */
+export class SimLambdaStreamBisect {
+  #limit: number | undefined;
+
+  constructor(private readonly enabled: boolean) {}
+
+  /**
+   * How many records the next read may take, within the mapping's batch size.
+   */
+  sizeWithin(batchSize: number): number {
+    const limit = this.#limit;
+
+    return limit === undefined ? batchSize : Math.min(limit, batchSize);
+  }
+
+  /**
+   * Split a batch the function threw on, answering with whether it split.
+   *
+   * A batch the function reported partial failures on is left alone. Lambda
+   * bisects around an error the handler raised, and a report already says which
+   * record to go back to.
+   */
+  split(outcome: SimLambdaStreamBatchOutcome): boolean {
+    const count = outcome.records.length;
+
+    if (!this.enabled || !outcome.functionError || count < 2) {
+      return false;
+    }
+
+    this.#limit = Math.ceil(count / 2);
+
+    return true;
+  }
+
+  /**
+   * Read whole batches again, which a batch that is finished with does.
+   */
+  reset(): void {
+    this.#limit = undefined;
+  }
+}

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-bisect.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-bisect.ts
@@ -1,7 +1,7 @@
 import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 
 /**
- * How many records the next delivery of a failing batch may carry.
+ * How much of a failing batch the next delivery may carry.
  *
  * A mapping asked to bisect halves a batch its function threw on, and halves
  * again on each further error, until a failing batch holds one record. That is
@@ -15,12 +15,17 @@ import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outc
  * and the single record it ends on is then counted and discarded as any failing
  * batch is.
  *
- * The limit is dropped as soon as a batch goes through. The rest of a split
- * batch is read at the mapping's own batch size again, and a poison record
- * still in it splits the batch it lands in.
+ * Two numbers say what the next read may take. The half is how many records a
+ * delivery may carry, and the remainder is how many records of the batch being
+ * split are still to get through. Reading the lower of the two is what keeps a
+ * record written while the splitting is going on out of it: the halves are the
+ * batch that failed, and a record that arrived afterwards belongs to the batch
+ * after it. The mapping's own batch size comes back once the whole of the split
+ * batch is through.
  */
 export class SimLambdaStreamBisect {
-  #limit: number | undefined;
+  #half: number | undefined;
+  #remaining = 0;
 
   constructor(private readonly enabled: boolean) {}
 
@@ -28,9 +33,11 @@ export class SimLambdaStreamBisect {
    * How many records the next read may take, within the mapping's batch size.
    */
   sizeWithin(batchSize: number): number {
-    const limit = this.#limit;
+    const half = this.#half;
 
-    return limit === undefined ? batchSize : Math.min(limit, batchSize);
+    return half === undefined
+      ? batchSize
+      : Math.min(half, this.#remaining, batchSize);
   }
 
   /**
@@ -47,15 +54,36 @@ export class SimLambdaStreamBisect {
       return false;
     }
 
-    this.#limit = Math.ceil(count / 2);
+    this.#half = Math.ceil(count / 2);
+    this.#remaining = count;
 
     return true;
   }
 
   /**
-   * Read whole batches again, which a batch that is finished with does.
+   * Take records of the batch being split that the mapping is finished with,
+   * whether the function handled them, they were discarded, or they aged out.
+   *
+   * The whole of the split batch being through is what puts the mapping back on
+   * full batches.
+   */
+  finished(count: number): void {
+    if (this.#half === undefined || count <= 0) {
+      return;
+    }
+
+    this.#remaining -= count;
+
+    if (this.#remaining <= 0) {
+      this.reset();
+    }
+  }
+
+  /**
+   * Read whole batches again.
    */
   reset(): void {
-    this.#limit = undefined;
+    this.#half = undefined;
+    this.#remaining = 0;
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress-state.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress-state.ts
@@ -55,7 +55,6 @@ export class SimLambdaStreamProgressState {
   handled(batch: SimLambdaEventSourceStreamProgressBatch): void {
     this.failures.reset();
     this.retry.reset();
-    this.bisect.reset();
     this.cursor.handled(batch);
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress-state.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress-state.ts
@@ -3,6 +3,7 @@ import { SimLambdaStreamBatchAge } from "./sim-lambda-stream-batch-age.js";
 import { SimLambdaStreamFailureDestination } from "./sim-lambda-stream-failure-destination.js";
 import { SimLambdaStreamCursor } from "./sim-lambda-stream-cursor.js";
 import { SimLambdaStreamRetry } from "./sim-lambda-stream-retry.js";
+import { SimLambdaStreamBisect } from "./sim-lambda-stream-bisect.js";
 import { PollSchedule } from "../../../../util/background/poll-schedule.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
 import type {
@@ -23,6 +24,7 @@ export class SimLambdaStreamProgressState {
   readonly failures: SimLambdaStreamFailureDestination;
   readonly cursor: SimLambdaStreamCursor;
   readonly retry: SimLambdaStreamRetry;
+  readonly bisect: SimLambdaStreamBisect;
   constructor(properties: SimLambdaStreamProgressProperties) {
     const { mapping, background } = properties;
     this.failures = new SimLambdaStreamFailureDestination(mapping);
@@ -38,6 +40,9 @@ export class SimLambdaStreamProgressState {
       new PollSchedule(properties),
     );
     this.retry = new SimLambdaStreamRetry(streamRetryLimits, background);
+    this.bisect = new SimLambdaStreamBisect(
+      streamRetryLimits.bisectBatchOnFunctionError,
+    );
     this.expiry = new SimLambdaStreamExpiry({
       age: new SimLambdaStreamBatchAge(streamRetryLimits, background),
       cursor: this.cursor,
@@ -50,6 +55,7 @@ export class SimLambdaStreamProgressState {
   handled(batch: SimLambdaEventSourceStreamProgressBatch): void {
     this.failures.reset();
     this.retry.reset();
+    this.bisect.reset();
     this.cursor.handled(batch);
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
@@ -31,6 +31,14 @@ export class SimLambdaStreamProgress {
   }
 
   /**
+   * How many records the next read may take, which is the mapping's batch size
+   * until a batch is being bisected.
+   */
+  batchSizeWithin(batchSize: number): number {
+    return this.state.bisect.sizeWithin(batchSize);
+  }
+
+  /**
    * Take a read that came back with nothing.
    *
    * The place is still worth keeping: it is what a starting position of LATEST
@@ -50,7 +58,8 @@ export class SimLambdaStreamProgress {
   }
 
   /**
-   * Take what became of a batch: move past it, or wait and try it again.
+   * Take what became of a batch: move past it, split it, or wait and try it
+   * again.
    */
   async after(
     outcome: SimLambdaStreamBatchOutcome,
@@ -62,6 +71,10 @@ export class SimLambdaStreamProgress {
       this.handled(batch);
 
       return;
+    }
+
+    if (this.state.bisect.split(outcome)) {
+      this.state.retry.reset();
     }
 
     const again = this.state.retry.after(outcome, this.position);

--- a/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-stream-progress.ts
@@ -49,12 +49,27 @@ export class SimLambdaStreamProgress {
     this.state.cursor.advanceTo(batch.next);
   }
 
+  /**
+   * Drop the records at the front of a batch that are too old to hand over,
+   * answering with where the live ones start.
+   *
+   * Records that aged out are as finished with as records the function took, so
+   * a batch being split counts them off its remainder too.
+   */
   async before(
     records: readonly SimLambdaStreamRecordTime[],
     batch: SimLambdaEventSourceStreamProgressBatch,
     simFunction: SimLambdaFunction,
   ): Promise<number> {
-    return await this.state.expiry.before(records, batch, simFunction);
+    const firstLive = await this.state.expiry.before(
+      records,
+      batch,
+      simFunction,
+    );
+
+    this.state.bisect.finished(firstLive);
+
+    return firstLive;
   }
 
   /**
@@ -68,6 +83,7 @@ export class SimLambdaStreamProgress {
   ): Promise<void> {
     this.state.failures.invoked(outcome);
     if (outcome.isHandled) {
+      this.state.bisect.finished(outcome.records.length);
       this.handled(batch);
 
       return;
@@ -85,6 +101,7 @@ export class SimLambdaStreamProgress {
       simFunction,
     );
     if (again === undefined) {
+      this.state.bisect.finished(outcome.records.length);
       this.handled(batch);
     } else {
       this.state.cursor.resume(again);

--- a/src/service/lambda/event-source/sim-lambda-event-source-retry-limits.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-retry-limits.ts
@@ -5,13 +5,14 @@ import {
 } from "./sim-lambda-stream-retry-limits.js";
 
 /**
- * Whether the event source a mapping names has failed-batch limits at all.
+ * Whether the event source a mapping names decides for itself what becomes of
+ * a failed batch.
  *
- * A stream does: a record stays on the stream whatever the function makes of
- * it, so the mapping is the only thing that decides when to stop trying. A
- * queue does not, because a message the function never handles goes to the
- * queue's own redrive policy, and real Lambda refuses a request that names
- * either limit for one.
+ * A stream leaves it to the mapping: a record stays on the stream whatever the
+ * function makes of it, so the mapping is the only thing that decides when to
+ * stop trying and whether to split the batch first. A queue does not, because a
+ * message the function never handles goes to the queue's own redrive policy,
+ * and real Lambda refuses a request that names any of the three for one.
  */
 export interface SimLambdaEventSourceRetryLimitRules {
   /**
@@ -36,7 +37,7 @@ export class SimLambdaNoRetryLimits implements SimLambdaEventSourceRetryLimitRul
   }
 
   /**
-   * Refuse both limits, since this source is not the one counting.
+   * Refuse all three, since this source is not the one counting.
    */
   limitsIn(
     input: SimLambdaEventSourceRetryLimitsInput,
@@ -80,7 +81,11 @@ function namedLimit(
     return "MaximumRetryAttempts";
   }
 
-  return input.maximumRecordAgeInSeconds === undefined
+  if (input.maximumRecordAgeInSeconds !== undefined) {
+    return "MaximumRecordAgeInSeconds";
+  }
+
+  return input.bisectBatchOnFunctionError === undefined
     ? undefined
-    : "MaximumRecordAgeInSeconds";
+    : "BisectBatchOnFunctionError";
 }

--- a/src/service/lambda/event-source/sim-lambda-stream-bisect.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-bisect.iso.test.ts
@@ -1,0 +1,276 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import { PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateQueueCommand,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertNonNullable,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimLambdaStreamFailureRecord } from "./poll/sim-lambda-stream-failure-record.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.types.js";
+import type { SimLambdaKinesisStreamEvent } from "./poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+
+/**
+ * The orders written to the source, one of which the function cannot handle.
+ */
+const orderIds = ["order-1", "order-2", "order-3", "order-4"];
+
+/**
+ * The order whose record breaks every batch it is in.
+ */
+const poisonOrderId = "order-3";
+
+/**
+ * A handler that throws on any batch holding the poison record, and takes every
+ * other batch.
+ *
+ * This is what a bisecting mapping is for. The batch has to be split before the
+ * three records beside the poison one can be handled.
+ */
+function throwingOnPoison<EventType>(
+  orderIdsIn: (event: EventType) => readonly string[],
+): (event: EventType) => unknown {
+  return (event: EventType): unknown => {
+    if (orderIdsIn(event).includes(poisonOrderId)) {
+      throw new Error(`Projector cannot handle ${poisonOrderId}`);
+    }
+
+    return undefined;
+  };
+}
+
+function streamOrderIds(
+  event: SimLambdaDynamoDbStreamEvent,
+): readonly string[] {
+  return event.Records.map(
+    (record) => record.dynamodb.Keys?.["orderId"]?.S ?? "",
+  );
+}
+
+function kinesisOrderIds(
+  event: SimLambdaKinesisStreamEvent,
+): readonly string[] {
+  return event.Records.map((record) =>
+    new TextDecoder().decode(Buffer.from(record.kinesis.data, "base64")),
+  );
+}
+
+/**
+ * The orders each delivery carried, one line per delivery, in the order they
+ * were delivered.
+ */
+function deliveries<EventType>(
+  events: readonly EventType[],
+  orderIdsIn: (event: EventType) => readonly string[],
+): string[] {
+  return events.map((event) => orderIdsIn(event).join(", "));
+}
+
+/**
+ * Write every order to the table at once, so one poll reads them as one batch.
+ */
+async function writeOrders(simAws: SimAws, tableName: string): Promise<void> {
+  await Promise.all(
+    orderIds.map(async (orderId) =>
+      simAws.dynamoDb().putItem(
+        new PutItemCommand({
+          TableName: tableName,
+          Item: { orderId: { S: orderId } },
+        }),
+      ),
+    ),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+/**
+ * Put every order onto one Kinesis shard at once.
+ */
+async function putOrders(simAws: SimAws): Promise<void> {
+  await Promise.all(
+    orderIds.map(async (orderId) =>
+      simAws.kinesis().putRecord(
+        new PutRecordCommand({
+          StreamName: "orders",
+          PartitionKey: "customer-1",
+          Data: new TextEncoder().encode(orderId),
+        }),
+      ),
+    ),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+describe("bisecting a stream batch a function threw on", () => {
+  it("splits a failed batch until the record that broke it is on its own", async () => {
+    // Given a bisecting stream mapping allowing a failed batch one retry,
+    // whose function throws on any batch holding one of the four records.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwingOnPoison(streamOrderIds),
+      bisectBatchOnFunctionError: true,
+      maximumRetryAttempts: 1,
+    });
+
+    // When the four records are written and the retries are waited out.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the batch halved around the record that broke it, the three
+    // records beside it were handled, and it was delivered on its own.
+    assertArrayEquals(deliveries(events, streamOrderIds), [
+      "order-1, order-2, order-3, order-4",
+      "order-1, order-2",
+      "order-3, order-4",
+      "order-3",
+      "order-4",
+    ]);
+  });
+
+  it("retries the whole batch when the mapping did not ask to bisect", async () => {
+    // Given the same mapping and function, without the bisect setting.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwingOnPoison(streamOrderIds),
+      maximumRetryAttempts: 1,
+    });
+
+    // When the four records are written and the retry is waited out.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the batch was delivered whole both times, and the three records
+    // beside the poison one were discarded with it.
+    assertArrayEquals(deliveries(events, streamOrderIds), [
+      "order-1, order-2, order-3, order-4",
+      "order-1, order-2, order-3, order-4",
+    ]);
+  });
+
+  it("splits a failed Kinesis batch the same way", async () => {
+    // Given a bisecting Kinesis mapping allowing a failed batch one retry.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      handlerResult: throwingOnPoison(kinesisOrderIds),
+      bisectBatchOnFunctionError: true,
+      maximumRetryAttempts: 1,
+    });
+
+    // When the four records are put onto one shard and the retries are waited
+    // out.
+    await putOrders(simAws);
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the shard's batch halved around the record that broke it.
+    assertArrayEquals(deliveries(events, kinesisOrderIds), [
+      "order-1, order-2, order-3, order-4",
+      "order-1, order-2",
+      "order-3, order-4",
+      "order-3",
+      "order-4",
+    ]);
+  });
+
+  it("sends only the isolated record to the failure destination", async () => {
+    // Given a queue for failure notifications, and a bisecting mapping
+    // allowed to send to it that has one retry for a batch it cannot handle.
+    const simAws = new SimAws();
+    const queueUrl = await makeFailureQueue(simAws);
+    const queueArn = await queueArnOf(simAws, queueUrl);
+    const { tableName } = await simAwsWithStreamEventSource({
+      simAws,
+      handlerResult: throwingOnPoison(streamOrderIds),
+      bisectBatchOnFunctionError: true,
+      maximumRetryAttempts: 1,
+      destinationArn: queueArn,
+    });
+
+    await allowSendingTo(simAws, queueArn);
+
+    // When the four records are written and the retries are waited out.
+    await writeOrders(simAws, tableName);
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then one notification arrives, and it names the one record the splitting
+    // isolated rather than the batch of four it started as.
+    const records = await receiveFailures(simAws, queueUrl);
+
+    assertArrayLength(records, 1);
+
+    const info = records[0].DDBStreamBatchInfo;
+
+    assertNonNullable(info);
+    assertIdentical(info.batchSize, 1);
+    assertIdentical(info.startSequenceNumber, info.endSequenceNumber);
+  });
+});
+
+/**
+ * A queue for the mapping to send its failure notifications to.
+ */
+async function makeFailureQueue(simAws: SimAws): Promise<string> {
+  const queue = await simAws
+    .sqs()
+    .createQueue(new CreateQueueCommand({ QueueName: "discarded-orders" }));
+
+  assertNonNullable(queue.QueueUrl);
+
+  return queue.QueueUrl;
+}
+
+async function queueArnOf(simAws: SimAws, queueUrl: string): Promise<string> {
+  const attributes = await simAws.sqs().getQueueAttributes(
+    new GetQueueAttributesCommand({
+      QueueUrl: queueUrl,
+      AttributeNames: ["QueueArn"],
+    }),
+  );
+  const queueArn = attributes.Attributes?.["QueueArn"];
+
+  assertNonNullable(queueArn);
+
+  return queueArn;
+}
+
+/**
+ * Let the execution role send to the destination, which is what real Lambda
+ * checks before delivering a failure notification.
+ */
+async function allowSendingTo(simAws: SimAws, queueArn: string): Promise<void> {
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "OrderProjectorRole",
+      PolicyName: "DeliverFailure",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          { Effect: "Allow", Action: "sqs:SendMessage", Resource: queueArn },
+        ],
+      }),
+    }),
+  );
+}
+
+async function receiveFailures(
+  simAws: SimAws,
+  queueUrl: string,
+): Promise<SimLambdaStreamFailureRecord[]> {
+  const received = await simAws.sqs().receiveMessage(
+    new ReceiveMessageCommand({
+      QueueUrl: queueUrl,
+      MaxNumberOfMessages: 10,
+    }),
+  );
+
+  return (received.Messages ?? []).map(
+    (message) => JSON.parse(message.Body) as SimLambdaStreamFailureRecord,
+  );
+}

--- a/src/service/lambda/event-source/sim-lambda-stream-bisect.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-bisect.iso.test.ts
@@ -78,38 +78,50 @@ function deliveries<EventType>(
 }
 
 /**
+ * The order written after the first delivery has already failed, which belongs
+ * to the batch behind the one being split rather than to a half of it.
+ */
+const laterOrderId = "order-5";
+
+/**
  * Write every order to the table at once, so one poll reads them as one batch.
  */
 async function writeOrders(simAws: SimAws, tableName: string): Promise<void> {
   await Promise.all(
-    orderIds.map(async (orderId) =>
-      simAws.dynamoDb().putItem(
-        new PutItemCommand({
-          TableName: tableName,
-          Item: { orderId: { S: orderId } },
-        }),
-      ),
-    ),
+    orderIds.map(async (orderId) => writeOrder(simAws, tableName, orderId)),
   );
   await simAws.backgroundTasksComplete();
+}
+
+async function writeOrder(
+  simAws: SimAws,
+  tableName: string,
+  orderId: string,
+): Promise<void> {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: { orderId: { S: orderId } },
+    }),
+  );
 }
 
 /**
  * Put every order onto one Kinesis shard at once.
  */
 async function putOrders(simAws: SimAws): Promise<void> {
-  await Promise.all(
-    orderIds.map(async (orderId) =>
-      simAws.kinesis().putRecord(
-        new PutRecordCommand({
-          StreamName: "orders",
-          PartitionKey: "customer-1",
-          Data: new TextEncoder().encode(orderId),
-        }),
-      ),
-    ),
-  );
+  await Promise.all(orderIds.map(async (orderId) => putOrder(simAws, orderId)));
   await simAws.backgroundTasksComplete();
+}
+
+async function putOrder(simAws: SimAws, orderId: string): Promise<void> {
+  await simAws.kinesis().putRecord(
+    new PutRecordCommand({
+      StreamName: "orders",
+      PartitionKey: "customer-1",
+      Data: new TextEncoder().encode(orderId),
+    }),
+  );
 }
 
 describe("bisecting a stream batch a function threw on", () => {
@@ -176,6 +188,61 @@ describe("bisecting a stream batch a function threw on", () => {
       "order-3, order-4",
       "order-3",
       "order-4",
+    ]);
+  });
+
+  it("keeps a record written mid-split out of the halves", async () => {
+    // Given a bisecting stream mapping whose first delivery of four records
+    // has already failed, leaving a split under way.
+    const { simAws, tableName, events } = await simAwsWithStreamEventSource({
+      handlerResult: throwingOnPoison(streamOrderIds),
+      bisectBatchOnFunctionError: true,
+      maximumRetryAttempts: 1,
+    });
+
+    await writeOrders(simAws, tableName);
+
+    // When a fifth record is written before the halves are delivered.
+    await writeOrder(simAws, tableName, laterOrderId);
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the halves carry the batch that failed and nothing else, and the
+    // later record is delivered behind it rather than being retried with it.
+    assertArrayEquals(deliveries(events, streamOrderIds), [
+      "order-1, order-2, order-3, order-4",
+      "order-1, order-2",
+      "order-3, order-4",
+      "order-3",
+      "order-4",
+      "order-5",
+    ]);
+  });
+
+  it("keeps a Kinesis record written mid-split out of the halves", async () => {
+    // Given a bisecting Kinesis mapping whose first delivery has failed.
+    const { simAws, events } = await simAwsWithKinesisEventSource({
+      handlerResult: throwingOnPoison(kinesisOrderIds),
+      bisectBatchOnFunctionError: true,
+      maximumRetryAttempts: 1,
+    });
+
+    await putOrders(simAws);
+
+    // When a fifth record is put onto the shard before the halves are
+    // delivered.
+    await putOrder(simAws, laterOrderId);
+    await simAws.backgroundTasksComplete();
+    await simAws.clock().advanceBy({ hours: 1 });
+
+    // Then the halves carry the batch that failed and nothing else.
+    assertArrayEquals(deliveries(events, kinesisOrderIds), [
+      "order-1, order-2, order-3, order-4",
+      "order-1, order-2",
+      "order-3, order-4",
+      "order-3",
+      "order-4",
+      "order-5",
     ]);
   });
 

--- a/src/service/lambda/event-source/sim-lambda-stream-retry-limits.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-retry-limits.iso.test.ts
@@ -5,9 +5,11 @@ import {
 } from "@aws-sdk/client-lambda";
 import {
   assertArrayLength,
+  assertFalse,
   assertIdentical,
   assertStringIncludes,
   assertThrowsErrorAsync,
+  assertTrue,
   assertUndefined,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -27,6 +29,7 @@ import { makeLambdaZipFileInput } from "../function/code/lambda-zip-file-input.j
 interface RetryLimitsRequest {
   readonly MaximumRetryAttempts?: number;
   readonly MaximumRecordAgeInSeconds?: number;
+  readonly BisectBatchOnFunctionError?: boolean;
 }
 
 /**
@@ -128,6 +131,38 @@ describe("the failed-batch limits a stream event source mapping is created with"
       listed.EventSourceMappings[0].MaximumRecordAgeInSeconds,
       120,
     );
+  });
+
+  it("reports whether the mapping was asked to bisect a failed batch", async () => {
+    // Given a stream and a function to map it to.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping is created asking for batch bisection.
+    const created = await createStreamMapping(ready, {
+      BisectBatchOnFunctionError: true,
+    });
+
+    // Then it reports the setting back, and a Get reports the same.
+    assertTrue(created.BisectBatchOnFunctionError);
+
+    const read = await ready.simAws
+      .lambda()
+      .getEventSourceMapping(
+        new GetEventSourceMappingCommand({ UUID: created.UUID }),
+      );
+
+    assertTrue(read.BisectBatchOnFunctionError);
+  });
+
+  it("reports no bisection for a mapping that did not ask for it", async () => {
+    // Given a stream and a function to map it to.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping is created without the setting.
+    const created = await createStreamMapping(ready, {});
+
+    // Then it reports false, and a failed batch is retried whole.
+    assertFalse(created.BisectBatchOnFunctionError);
   });
 
   it("reports no limit for a mapping that asked for neither", async () => {

--- a/src/service/lambda/event-source/sim-lambda-stream-retry-limits.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-retry-limits.ts
@@ -39,6 +39,7 @@ const millisecondsPerSecond = 1000;
 export interface SimLambdaEventSourceRetryLimitsInput {
   readonly maximumRetryAttempts?: number | undefined;
   readonly maximumRecordAgeInSeconds?: number | undefined;
+  readonly bisectBatchOnFunctionError?: boolean | undefined;
 }
 
 /**
@@ -47,20 +48,28 @@ export interface SimLambdaEventSourceRetryLimitsInput {
 export interface SimLambdaStreamRetryLimitsConfiguration {
   readonly MaximumRetryAttempts: number;
   readonly MaximumRecordAgeInSeconds: number;
+  readonly BisectBatchOnFunctionError: boolean;
 }
 
 /**
- * When a stream mapping stops delivering a batch its function keeps failing.
+ * What a stream mapping does with a batch its function keeps failing.
  *
- * The two limits are one thing rather than two, because they end the same
- * lifecycle: a record leaves the mapping when it has had its retries or when it
- * is too old to be worth another, whichever comes first. Both are held as
- * Lambda states them, with `-1` for no limit, so a Get or a List reports back
- * exactly what was asked for.
+ * The three settings are one thing rather than three, because they run the same
+ * lifecycle. A failing batch is split around the record that broke it where the
+ * mapping was asked to bisect, and a record leaves the mapping when it has had
+ * its retries or when it is too old to be worth another, whichever comes first.
+ * The limits are held as Lambda states them, with `-1` for no limit, so a Get
+ * or a List reports back exactly what was asked for.
  */
 export class SimLambdaStreamRetryLimits {
   public readonly maximumRetryAttempts: number;
   public readonly maximumRecordAgeInSeconds: number;
+
+  /**
+   * Whether a batch the function threw on is split in half and delivered again
+   * as two batches.
+   */
+  public readonly bisectBatchOnFunctionError: boolean;
 
   constructor(input: SimLambdaEventSourceRetryLimitsInput = {}) {
     this.maximumRetryAttempts = checkedLimit({
@@ -75,15 +84,17 @@ export class SimLambdaStreamRetryLimits {
       maximum: maximumRecordAgeLimit,
       unit: "seconds",
     });
+    this.bisectBatchOnFunctionError = input.bisectBatchOnFunctionError ?? false;
   }
 
   /**
-   * The two limits as a Get, a List or a create response reports them.
+   * The three settings as a Get, a List or a create response reports them.
    */
   configuration(): SimLambdaStreamRetryLimitsConfiguration {
     return {
       MaximumRetryAttempts: this.maximumRetryAttempts,
       MaximumRecordAgeInSeconds: this.maximumRecordAgeInSeconds,
+      BisectBatchOnFunctionError: this.bisectBatchOnFunctionError,
     };
   }
 

--- a/test/lambda/kinesis-event-source-fixture.ts
+++ b/test/lambda/kinesis-event-source-fixture.ts
@@ -105,6 +105,7 @@ interface KinesisEventSourceOptions {
   readonly destinationArn?: string;
   readonly maximumRetryAttempts?: number;
   readonly maximumRecordAgeInSeconds?: number;
+  readonly bisectBatchOnFunctionError?: boolean;
 }
 
 /**
@@ -157,6 +158,9 @@ export async function simAwsWithKinesisEventSource(
       }),
       ...(options.maximumRecordAgeInSeconds !== undefined && {
         MaximumRecordAgeInSeconds: options.maximumRecordAgeInSeconds,
+      }),
+      ...(options.bisectBatchOnFunctionError !== undefined && {
+        BisectBatchOnFunctionError: options.bisectBatchOnFunctionError,
       }),
     }),
   );

--- a/test/lambda/stream-event-source-fixture.ts
+++ b/test/lambda/stream-event-source-fixture.ts
@@ -141,6 +141,7 @@ interface StreamEventSourceOptions {
   readonly destinationArn?: string;
   readonly maximumRetryAttempts?: number;
   readonly maximumRecordAgeInSeconds?: number;
+  readonly bisectBatchOnFunctionError?: boolean;
 }
 
 /**
@@ -184,6 +185,9 @@ export async function simAwsWithStreamEventSource(
       }),
       ...(options.maximumRecordAgeInSeconds !== undefined && {
         MaximumRecordAgeInSeconds: options.maximumRecordAgeInSeconds,
+      }),
+      ...(options.bisectBatchOnFunctionError !== undefined && {
+        BisectBatchOnFunctionError: options.bisectBatchOnFunctionError,
       }),
     }),
   );


### PR DESCRIPTION
A DynamoDB Streams or Kinesis mapping carrying `BisectBatchOnFunctionError` splits a batch its handler threw on in half and delivers each half as its own batch, halving again until a failing batch holds one record. The records beside the record that broke the batch get through, and that record is discarded on its own under the retry and record-age limits and reaches the failure destination naming one record. A split puts the retry count back to the start, so a batch always reaches a single record before the count decides anything; the splitting still ends on its own because a batch halves at every step. A queue mapping is refused for naming the setting, as real Lambda refuses one.

Stacked on #1298, which this needs for the property rules it changes. Retarget to `main` once that merges.

Resolves #1296


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `BisectBatchOnFunctionError` on DynamoDB Streams and Kinesis event source mappings.
  - Failed batches can be recursively split to isolate individual records, with retry limits applied after splitting.
  - Configuration is preserved and reported through mapping creation and retrieval.
  - Isolated failed records can be delivered to an SQS failure destination.

- **Bug Fixes**
  - Queue-based event source mappings now reject this stream-only setting with a validation error.

- **Documentation**
  - Documented batch bisection behavior, configuration, CloudFormation/CDK support, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->