### PR TITLE
feat: write HTTP API access logs from AccessLogSettings

### DIFF
--- a/docs/services/apigatewayv2/README.md
+++ b/docs/services/apigatewayv2/README.md
@@ -666,8 +666,146 @@ route configured that way is served unthrottled.
 `GetStages` answers with the settings a stage was created with. `AWS::ApiGatewayV2::Stage` deploys
 both properties as well (see [CloudFormation](#cloudformation)). The three members of `RouteSettings`
 that say nothing about throttling, `DetailedMetricsEnabled`, `LoggingLevel` and `DataTraceEnabled`,
-are refused by `CreateStage`. A template carrying one deploys, and the member it named is recorded on
-`stack.ignoredProperties`.
+are refused by `CreateStage`. They are execution logging, which is a different log from the one
+[`AccessLogSettings` writes](#writing-a-stages-access-log). A template carrying one deploys, and the
+member it named is recorded on `stack.ignoredProperties`.
+
+## Writing a stage's access log
+
+`AccessLogSettings` sends one line per request to a CloudWatch Logs log group. `DestinationArn` names
+the group and `Format` is the line, with `$context` variables substituted from the request that
+produced it.
+
+The line is written whether or not an integration ran. A request the stage throttle refused, one a
+Lambda authorizer denied, and one with no identity source header all reach the log group, and for
+those the access log is the only record of the request.
+
+```typescript sim-apigatewayv2-access-log
+/**
+ * Recording a simulated HTTP API stage's access log, including a request the
+ * stage's throttle refused.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  CreateLogGroupCommand,
+  FilterLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/vendedlogs/user-api";
+
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "users",
+    Role: "arn:aws:iam::111111111111:role/UsersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: "ok",
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "users", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /user/profile",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({
+    ApiId,
+    StageName: "$default",
+    AutoDeploy: true,
+    DefaultRouteSettings: { ThrottlingRateLimit: 1, ThrottlingBurstLimit: 1 },
+    AccessLogSettings: {
+      DestinationArn: `arn:aws:logs:us-east-1:888888888888:log-group:${logGroupName}:*`,
+      Format:
+        "$context.httpMethod $context.path $context.status " +
+        "$context.error.message",
+    },
+  }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "users",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+simAws.clock().freeze();
+
+const profile = srv.localUrl(`${ApiEndpoint}/user/profile`);
+await fetch(profile);
+await fetch(profile);
+
+const { events } = await simAws
+  .logs()
+  .filterLogEvents(new FilterLogEventsCommand({ logGroupName }));
+
+const lines = events ?? [];
+
+for (const event of lines) {
+  console.log(event.message);
+}
+
+await srv.close();
+```
+
+The served request and the throttled one are both there. A variable with no value renders as a dash,
+which is what `$context.error.message` does for the request the integration answered:
+
+```text
+GET /user/profile 200 -
+GET /user/profile 429 Too Many Requests
+```
+
+The lines go to the log group and nowhere else. An API answering a few hundred requests in one test
+file would otherwise bury the suite's own output, so nothing here is forwarded to the console the way
+a [Lambda handler's output](https://yulinsim.dev/services/lambda/#capturing-handler-output) is.
+
+A `DestinationArn` naming a log group nothing has created yet is written to anyway, and the group is
+made by the first line. `Format` is copied through apart from its `$context` references, so a JSON
+format string arrives as JSON.
 
 ## Protecting a route with a Cognito user pool
 
@@ -2287,7 +2425,7 @@ parts behaves differently to the template. The simulated properties are:
 - `Integration`: `ApiId`, `IntegrationType`, `IntegrationUri`, `PayloadFormatVersion`, `Description`
 - `Route`: `ApiId`, `RouteKey`, `Target`, `AuthorizationType`, `AuthorizerId`, `AuthorizationScopes`
 - `Stage`: `ApiId`, `StageName`, `AutoDeploy`, `StageVariables`, `Description`,
-  `DefaultRouteSettings`, `RouteSettings`
+  `DefaultRouteSettings`, `RouteSettings`, `AccessLogSettings`
 
 CDK's `HttpIamAuthorizer` deploys too. It emits no `AWS::ApiGatewayV2::Authorizer` and no
 `AuthorizerId`, only `AuthorizationType: "AWS_IAM"` on the `Route`, and the deployed route then
@@ -2436,6 +2574,9 @@ the simulation without being given one. See the
   under their own path segment, including stage variables
 - `DefaultRouteSettings` and `RouteSettings` throttling, with a token bucket per route refilling
   against the simulated clock and a 429 for the requests past it
+- `AccessLogSettings`, writing one line per request to the log group `DestinationArn` names, with the
+  `Format` string's `$context` variables substituted, including for a request the throttle or an
+  authorizer refused before any integration ran
 - Serving the generated endpoint through `serveSimAws`, invoking the integrated function with a
   payload format 2.0 event and turning its result back into an HTTP response
 - The invoke permission of an integration's function and of an authorizer's, each evaluated against
@@ -2474,9 +2615,24 @@ Current documented limitations:
 - Deployments are outside the simulation, so `CreateStage` requires `AutoDeploy: true`. A stage
   without it serves whichever Deployment it was given, which on real AWS is nothing until one is
   created.
-- `AccessLogSettings` on a stage is refused, as is any other option `CreateStage` takes and this one
-  lacks. `RouteSettings` and `DefaultRouteSettings` are taken, and only their throttling members are
-  read. `DetailedMetricsEnabled`, `LoggingLevel` and `DataTraceEnabled` are refused by name.
+- Any option `CreateStage` takes and this one lacks is refused. `RouteSettings` and
+  `DefaultRouteSettings` are taken, and only their throttling members are read.
+  `DetailedMetricsEnabled`, `LoggingLevel` and `DataTraceEnabled` are refused by name. Those three
+  are execution logging, which is a different log from the access log and is not simulated.
+- An access log `DestinationArn` has to name a CloudWatch Logs log group. A Kinesis Data Firehose
+  delivery stream, which a REST API stage may name, is refused.
+- The access log variables carrying a value are `accountId`, `apiId`, `domainName`, `domainPrefix`,
+  `stage`, `routeKey`, `httpMethod`, `path`, `protocol`, `requestId`, `extendedRequestId`,
+  `requestTime`, `requestTimeEpoch`, `status`, `responseLength`, `responseLatency`,
+  `identity.sourceIp`, `identity.userAgent`, `integrationStatus`, `integrationLatency`,
+  `integrationErrorMessage`, `authorizer.error`, `error.message`, `error.messageString`,
+  `customDomain.basePathMatched`, the `integration.*` aliases, and `authorizer.claims.<property>` and
+  `authorizer.<property>` from the route's authorizer. Anything else AWS documents renders as a dash.
+- `responseLatency` and `integrationLatency` are simulated milliseconds, so a test holding the clock
+  still logs zero rather than however long the process took.
+- The access log stream is named for the hour it was written in, dated from the simulation's clock.
+  Real API Gateway appends an identifier this simulation has no counterpart for, so a test should
+  filter the log group rather than name the stream.
 - `AWS_PROXY` is the only integration type, and its URI must name a Lambda function ARN, written
   either as that ARN or as the
   `arn:aws:apigateway:<region>:lambda:path/2015-03-31/functions/<function-arn>/invocations` form.

--- a/docs/services/apigatewayv2/sim-apigatewayv2-access-log.example.ts
+++ b/docs/services/apigatewayv2/sim-apigatewayv2-access-log.example.ts
@@ -1,0 +1,108 @@
+/**
+ * Recording a simulated HTTP API stage's access log, including a request the
+ * stage's throttle refused.
+ */
+
+import {
+  CreateApiCommand,
+  CreateIntegrationCommand,
+  CreateRouteCommand,
+  CreateStageCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  CreateLogGroupCommand,
+  FilterLogEventsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+
+import { SimAws } from "@kensio/yulin";
+import { makeLambdaZipFileInput } from "@kensio/yulin/lambda";
+import { serveSimAws } from "@kensio/yulin/serve";
+
+const simAws = new SimAws();
+const logGroupName = "/aws/vendedlogs/user-api";
+
+await simAws.logs().createLogGroup(new CreateLogGroupCommand({ logGroupName }));
+
+const { FunctionArn } = await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "users",
+    Role: "arn:aws:iam::111111111111:role/UsersRole",
+    Code: {
+      ZipFile: makeLambdaZipFileInput(() => ({
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: "ok",
+      })),
+    },
+  }),
+);
+
+const apiGateway = simAws.apiGatewayV2();
+const { ApiId, ApiEndpoint } = await apiGateway.createApi(
+  new CreateApiCommand({ Name: "users", ProtocolType: "HTTP" }),
+);
+
+const { IntegrationId } = await apiGateway.createIntegration(
+  new CreateIntegrationCommand({
+    ApiId,
+    IntegrationType: "AWS_PROXY",
+    IntegrationUri: FunctionArn,
+    PayloadFormatVersion: "2.0",
+  }),
+);
+
+await apiGateway.createRoute(
+  new CreateRouteCommand({
+    ApiId,
+    RouteKey: "GET /user/profile",
+    Target: `integrations/${IntegrationId}`,
+  }),
+);
+
+await apiGateway.createStage(
+  new CreateStageCommand({
+    ApiId,
+    StageName: "$default",
+    AutoDeploy: true,
+    DefaultRouteSettings: { ThrottlingRateLimit: 1, ThrottlingBurstLimit: 1 },
+    AccessLogSettings: {
+      DestinationArn: `arn:aws:logs:us-east-1:888888888888:log-group:${logGroupName}:*`,
+      Format:
+        "$context.httpMethod $context.path $context.status " +
+        "$context.error.message",
+    },
+  }),
+);
+
+await simAws.lambda().addPermission(
+  new AddPermissionCommand({
+    FunctionName: "users",
+    StatementId: "api-gateway-invoke",
+    Action: "lambda:InvokeFunction",
+    Principal: "apigateway.amazonaws.com",
+    SourceArn: `arn:aws:execute-api:us-east-1:888888888888:${ApiId}/*/*`,
+  }),
+);
+
+const srv = await serveSimAws({ simAws });
+simAws.clock().freeze();
+
+const profile = srv.localUrl(`${ApiEndpoint}/user/profile`);
+await fetch(profile);
+await fetch(profile);
+
+const { events } = await simAws
+  .logs()
+  .filterLogEvents(new FilterLogEventsCommand({ logGroupName }));
+
+const lines = events ?? [];
+
+for (const event of lines) {
+  console.log(event.message);
+}
+
+await srv.close();

--- a/src/serve/payload-2/sim-payload-2-endpoint.ts
+++ b/src/serve/payload-2/sim-payload-2-endpoint.ts
@@ -29,6 +29,15 @@ export interface SimPayload2Endpoint {
   readonly pathParameters?: Record<string, string> | undefined;
   /** The stage's variables, if it has any. */
   readonly stageVariables?: Record<string, string> | undefined;
+  /**
+   * The id the endpoint assigned to this request, where the endpoint assigns
+   * one before building the event.
+   *
+   * An HTTP API settles it up front so that the request's access log line, its
+   * authorizer event and its integration event all name the same request.
+   * Absent for an endpoint that leaves the event builder to issue one.
+   */
+  readonly requestId?: string | undefined;
 }
 
 /**

--- a/src/serve/payload-2/sim-payload-2-request-context.ts
+++ b/src/serve/payload-2/sim-payload-2-request-context.ts
@@ -73,7 +73,7 @@ export class SimPayload2RequestContextBuilder {
         sourceIp: simAwsProxiedSourceIp,
         userAgent: request.headers.get("user-agent") ?? "",
       },
-      requestId: randomUUID(),
+      requestId: endpoint.requestId ?? randomUUID(),
       routeKey: endpoint.routeKey,
       stage: endpoint.stage,
       time: simProxyEventTime(at),

--- a/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
+++ b/src/service/apigatewayv2/api/sim-http-api-lambda-proxy.factory.ts
@@ -6,6 +6,7 @@ import { simApiGatewayServicePrincipal } from "../../apigateway/sim-api-gateway-
 import { DEFAULT_SIM_AWS_ACCOUNT_ID } from "../../aws/sim-aws-account.js";
 import type { SimAws } from "../../aws/sim-aws.js";
 import { makeLambdaZipFileInput } from "../../lambda/function/code/lambda-zip-file-input.js";
+import type { SimHttpApiAccessLogSettingsInput } from "./stage/access-log/sim-http-api-access-log-settings.type.js";
 import type {
   SimHttpApiRouteSettings,
   SimHttpApiRouteSettingsMap,
@@ -60,6 +61,11 @@ export interface SimHttpApiLambdaProxyInput {
   /** The throttles those stages apply to the route keys they name. */
   readonly routeSettings: SimHttpApiRouteSettingsMap | undefined;
   /**
+   * Where those stages write an access log line per request, or undefined for
+   * stages that log nothing.
+   */
+  readonly accessLogSettings: SimHttpApiAccessLogSettingsInput | undefined;
+  /**
    * Whether the function grants the API permission to invoke it, which it
    * needs before any route serves anything.
    *
@@ -113,6 +119,7 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
     stageVariables: {},
     defaultRouteSettings: undefined,
     routeSettings: undefined,
+    accessLogSettings: undefined,
     invokePermission: true,
   }),
   async (input, simAws) => {
@@ -193,6 +200,7 @@ export const simHttpApiLambdaProxyFactory = new AsyncMappedFactory<
             StageVariables: input.stageVariables,
             DefaultRouteSettings: input.defaultRouteSettings,
             RouteSettings: input.routeSettings,
+            AccessLogSettings: input.accessLogSettings,
           },
         }),
       ),

--- a/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-format.ts
+++ b/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-format.ts
@@ -31,9 +31,12 @@ export function simHttpApiAccessLogLine(
 ): string {
   return format.replaceAll(contextReference, (reference) => {
     // A trailing dot belongs to the text around the reference rather than to
-    // the name, as in a format ending one variable with a full stop.
-    const name = reference.slice("$context.".length).replace(/\.+$/, "");
+    // the name, as in a format ending one variable with a full stop. It is put
+    // back after the value, so the punctuation survives the substitution.
+    const written = reference.slice("$context.".length);
+    const name = written.replace(/\.+$/, "");
+    const punctuation = written.slice(name.length);
 
-    return variables.get(name) ?? noValue;
+    return (variables.get(name) ?? noValue) + punctuation;
   });
 }

--- a/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-format.ts
+++ b/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-format.ts
@@ -1,0 +1,39 @@
+/**
+ * What a variable with no value renders as.
+ *
+ * Real API Gateway writes a single dash where a `$context` variable has
+ * nothing behind it, such as `$context.integrationStatus` on a request no
+ * integration ran for. AWS publishes the variables and leaves this rendering
+ * undocumented, so it is what the service was observed to do.
+ */
+const noValue = "-";
+
+/**
+ * A `$context` reference, which is the name after the prefix and may carry
+ * dots of its own, as `$context.identity.sourceIp` does.
+ *
+ * The name is matched as one run of word characters and dots. Written as a
+ * repeated group it would nest two quantifiers, which is a shape a scanner
+ * flags however the input is bounded, and this matches the same names.
+ */
+const contextReference = /\$context\.[A-Za-z0-9_.]+/g;
+
+/**
+ * Substitute a stage's access log format into the line one request writes.
+ *
+ * Everything outside a `$context` reference is copied through, which is what
+ * carries the punctuation of a JSON format string into the log group. A
+ * reference this simulation has no value for renders as a dash.
+ */
+export function simHttpApiAccessLogLine(
+  format: string,
+  variables: ReadonlyMap<string, string>,
+): string {
+  return format.replaceAll(contextReference, (reference) => {
+    // A trailing dot belongs to the text around the reference rather than to
+    // the name, as in a format ending one variable with a full stop.
+    const name = reference.slice("$context.".length).replace(/\.+$/, "");
+
+    return variables.get(name) ?? noValue;
+  });
+}

--- a/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-request.ts
+++ b/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-request.ts
@@ -1,0 +1,57 @@
+import type {
+  SimPayload2JwtAuthorizer,
+  SimPayload2LambdaAuthorizer,
+} from "../../../../../serve/payload-2/sim-payload-2-event.type.js";
+
+/**
+ * Everything one served request contributes to its access log line.
+ *
+ * A request refused before an integration ran fills in what it knows and
+ * leaves the rest out. That is the case the access log exists for: a Lambda
+ * authorizer denial, an absent identity source and a throttled request each
+ * produce a line describing a request no handler ever saw.
+ */
+export interface SimHttpApiAccessLogRequest {
+  readonly requestId: string;
+  /** The simulated instant the request arrived. */
+  readonly at: Date;
+  readonly accountId: string;
+  readonly apiId: string;
+  readonly domainName: string;
+  readonly domainPrefix: string;
+  readonly stage: string;
+  readonly routeKey: string;
+  readonly method: string;
+  readonly path: string;
+  readonly protocol: string;
+  readonly sourceIp: string;
+  readonly userAgent: string;
+  readonly status: number;
+  readonly responseLength: number;
+  /** Milliseconds of simulated time the whole request took. */
+  readonly responseLatency: number;
+  /**
+   * The status the integrated function's own code returned, which is what
+   * `$context.integration.status` reports. Absent where no integration ran.
+   */
+  readonly integrationStatus?: number | undefined;
+  /**
+   * The status Lambda answered the invocation with, which is what
+   * `$context.integrationStatus` reports for a Lambda proxy integration. It is
+   * 200 for an invocation that reached the handler, whatever the handler then
+   * returned.
+   */
+  readonly lambdaInvokeStatus?: number | undefined;
+  readonly integrationLatency?: number | undefined;
+  readonly integrationErrorMessage?: string | undefined;
+  /** The message an authorizer refusal leaves behind, where it left one. */
+  readonly authorizerError?: string | undefined;
+  /** The message the endpoint answered with, such as `Forbidden`. */
+  readonly errorMessage?: string | undefined;
+  /** The base path an API mapping matched, for a custom domain request. */
+  readonly basePathMatched?: string | undefined;
+  /** What a `JWT` route's authorizer accepted, where one did. */
+  readonly jwt?: SimPayload2JwtAuthorizer | undefined;
+  /** What a `CUSTOM` route's Lambda authorizer passed on, where one did. */
+  readonly lambda?: SimPayload2LambdaAuthorizer | null | undefined;
+}

--- a/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-settings.ts
+++ b/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-settings.ts
@@ -1,0 +1,62 @@
+import { simLogsParsedLogGroupArn } from "../../../../logs/group/sim-logs-arn.js";
+import type { SimHttpApiAccessLogSettingsView } from "./sim-http-api-access-log-settings.type.js";
+
+interface SimHttpApiAccessLogSettingsProperties {
+  readonly destinationArn: string;
+  readonly format: string;
+  readonly accountId: string;
+  readonly regionName: string;
+  readonly logGroupName: string;
+}
+
+/**
+ * Where one stage writes its access log, and the line it writes there.
+ *
+ * The destination is held as the ARN the stage was created with and as the
+ * account, region and group that ARN resolves to. A log group in another
+ * Account is written to in that Account, the way an integration invokes the
+ * function its own URI names.
+ */
+export class SimHttpApiAccessLogSettings {
+  readonly destinationArn: string;
+  readonly format: string;
+  readonly accountId: string;
+  readonly regionName: string;
+  readonly logGroupName: string;
+
+  private constructor(properties: SimHttpApiAccessLogSettingsProperties) {
+    this.destinationArn = properties.destinationArn;
+    this.format = properties.format;
+    this.accountId = properties.accountId;
+    this.regionName = properties.regionName;
+    this.logGroupName = properties.logGroupName;
+  }
+
+  /**
+   * Read settings from a destination ARN and a format, or answer with nothing
+   * where the ARN names no log group.
+   */
+  static from(
+    destinationArn: string,
+    format: string,
+  ): SimHttpApiAccessLogSettings | undefined {
+    const parsed = simLogsParsedLogGroupArn(destinationArn);
+
+    if (parsed === undefined) {
+      return undefined;
+    }
+
+    return new SimHttpApiAccessLogSettings({
+      destinationArn,
+      format,
+      ...parsed,
+    });
+  }
+
+  /**
+   * What CreateStage and GetStages report of these settings.
+   */
+  view(): SimHttpApiAccessLogSettingsView {
+    return { DestinationArn: this.destinationArn, Format: this.format };
+  }
+}

--- a/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-settings.type.ts
+++ b/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-settings.type.ts
@@ -1,0 +1,22 @@
+/**
+ * The `AccessLogSettings` a stage is created with.
+ *
+ * `DestinationArn` names a CloudWatch Logs log group. HTTP APIs accept no
+ * other destination, and a Kinesis Data Firehose delivery stream is a REST API
+ * option that this shape leaves out.
+ *
+ * `Format` is the line written per request, with `$context` variables
+ * substituted from the request that produced it.
+ */
+export interface SimHttpApiAccessLogSettingsInput {
+  readonly DestinationArn?: string | undefined;
+  readonly Format?: string | undefined;
+}
+
+/**
+ * What a stage reports of the access log settings it was created with.
+ */
+export interface SimHttpApiAccessLogSettingsView {
+  DestinationArn: string;
+  Format: string;
+}

--- a/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-stream-name.ts
+++ b/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-stream-name.ts
@@ -1,0 +1,27 @@
+import type { SimClock } from "../../../../../util/clock/sim-clock.js";
+
+function twoDigits(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+/**
+ * The stream a stage's access log events are written to.
+ *
+ * Real API Gateway rolls access log streams over time and appends an
+ * identifier this simulation has no counterpart for. The hour is what decides
+ * the stream here, dated from the simulation's clock, so a test that froze
+ * time gets one stream and a predictable name for it. The shape is chosen for
+ * the simulation rather than copied from an observed account, and a test
+ * reading its lines back should filter the log group rather than name the
+ * stream.
+ */
+export function simHttpApiAccessLogStreamName(clock: SimClock): string {
+  const at = clock.now();
+
+  return [
+    String(at.getUTCFullYear()),
+    twoDigits(at.getUTCMonth() + 1),
+    twoDigits(at.getUTCDate()),
+    twoDigits(at.getUTCHours()),
+  ].join("-");
+}

--- a/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-variables.ts
+++ b/src/service/apigatewayv2/api/stage/access-log/sim-http-api-access-log-variables.ts
@@ -1,0 +1,107 @@
+import { simProxyEventTime } from "../../../../../serve/proxy/sim-proxy-event-time.js";
+import type { SimHttpApiAccessLogRequest } from "./sim-http-api-access-log-request.js";
+
+function numberOrUndefined(value: number | undefined): string | undefined {
+  return value === undefined ? undefined : String(value);
+}
+
+/**
+ * The `$context` variables one request answers, keyed by the name that follows
+ * `$context.`.
+ *
+ * A variable this simulation has no value for is left out of the map. The
+ * substitution writes `-` for it, which is what real API Gateway writes for a
+ * variable with no value. That rendering is what the service was observed to
+ * do rather than something AWS publishes.
+ *
+ * `$context.extendedRequestId` and `$context.integration.latency` are
+ * documented as equivalents of the flat names, and carry the same values here.
+ * `$context.integrationStatus` is the status Lambda answered the invocation
+ * with, and `$context.integration.status` the one the handler's own code
+ * returned, which is the distinction AWS draws between the two.
+ */
+export function simHttpApiAccessLogVariables(
+  request: SimHttpApiAccessLogRequest,
+): ReadonlyMap<string, string> {
+  const variables = new Map<string, string | undefined>([
+    ["accountId", request.accountId],
+    ["apiId", request.apiId],
+    ["domainName", request.domainName],
+    ["domainPrefix", request.domainPrefix],
+    ["stage", request.stage],
+    ["routeKey", request.routeKey],
+    ["httpMethod", request.method],
+    ["path", request.path],
+    ["protocol", request.protocol],
+    ["requestId", request.requestId],
+    ["extendedRequestId", request.requestId],
+    ["requestTime", simProxyEventTime(request.at)],
+    ["requestTimeEpoch", String(request.at.getTime())],
+    ["status", String(request.status)],
+    ["responseLength", String(request.responseLength)],
+    ["responseLatency", String(request.responseLatency)],
+    ["identity.sourceIp", request.sourceIp],
+    ["identity.userAgent", request.userAgent],
+    ["integrationStatus", numberOrUndefined(request.lambdaInvokeStatus)],
+    [
+      "integration.integrationStatus",
+      numberOrUndefined(request.lambdaInvokeStatus),
+    ],
+    ["integrationLatency", numberOrUndefined(request.integrationLatency)],
+    ["integration.latency", numberOrUndefined(request.integrationLatency)],
+    ["integration.status", numberOrUndefined(request.integrationStatus)],
+    ["integrationErrorMessage", request.integrationErrorMessage],
+    ["integration.error", request.integrationErrorMessage],
+    ["authorizer.error", request.authorizerError],
+    ["error.message", request.errorMessage],
+    ["customDomain.basePathMatched", request.basePathMatched],
+  ]);
+
+  addQuotedMessage(variables, request);
+  addAuthorizerProperties(variables, request);
+
+  return new Map(
+    [...variables].flatMap(([name, value]) =>
+      value === undefined ? [] : [[name, value] as const],
+    ),
+  );
+}
+
+/**
+ * `$context.error.messageString` is the quoted form of the message, which is
+ * what a JSON format string uses to keep its own quoting intact.
+ */
+function addQuotedMessage(
+  variables: Map<string, string | undefined>,
+  request: SimHttpApiAccessLogRequest,
+): void {
+  if (request.errorMessage !== undefined) {
+    variables.set("error.messageString", `"${request.errorMessage}"`);
+  }
+}
+
+/**
+ * The claims a `JWT` route's authorizer accepted and the context map a
+ * `CUSTOM` route's authorizer returned.
+ *
+ * Both are reached by naming the property. `$context.authorizer.claims` and
+ * `$context.authorizer` name no property, and AWS documents the first of those
+ * as returning null, so neither is given a value here.
+ */
+function addAuthorizerProperties(
+  variables: Map<string, string | undefined>,
+  request: SimHttpApiAccessLogRequest,
+): void {
+  const claims = Object.entries(request.jwt?.claims ?? {});
+  const authorizerContext = Object.entries(request.lambda ?? {});
+
+  for (const [claim, value] of claims) {
+    variables.set(`authorizer.claims.${claim}`, value);
+  }
+
+  for (const [key, value] of authorizerContext) {
+    if (value !== null && typeof value !== "object") {
+      variables.set(`authorizer.${key}`, String(value));
+    }
+  }
+}

--- a/src/service/apigatewayv2/api/stage/sim-http-api-stage.ts
+++ b/src/service/apigatewayv2/api/stage/sim-http-api-stage.ts
@@ -1,3 +1,5 @@
+import type { SimHttpApiAccessLogSettings } from "./access-log/sim-http-api-access-log-settings.js";
+import type { SimHttpApiAccessLogSettingsView } from "./access-log/sim-http-api-access-log-settings.type.js";
 import type { SimHttpApiRouteSettingsView } from "./settings/sim-http-api-route-settings.type.js";
 import type { SimHttpApiStageRouteSettings } from "./settings/sim-http-api-stage-route-settings.js";
 
@@ -14,6 +16,7 @@ interface SimHttpApiStageProperties {
   readonly description?: string | undefined;
   readonly createdDate: Date;
   readonly routeSettings?: SimHttpApiStageRouteSettings | undefined;
+  readonly accessLogSettings?: SimHttpApiAccessLogSettings | undefined;
 }
 
 /**
@@ -25,6 +28,7 @@ export interface SimHttpApiStageView extends SimHttpApiRouteSettingsView {
   CreatedDate: Date;
   StageVariables?: Record<string, string>;
   Description?: string;
+  AccessLogSettings?: SimHttpApiAccessLogSettingsView;
 }
 
 /**
@@ -47,6 +51,12 @@ export class SimHttpApiStage {
    */
   public readonly routeSettings?: SimHttpApiStageRouteSettings | undefined;
 
+  /**
+   * Where this stage writes an access log line per request, or undefined for a
+   * stage that was given no access log settings and so logs nothing.
+   */
+  public readonly accessLogSettings?: SimHttpApiAccessLogSettings | undefined;
+
   constructor(properties: SimHttpApiStageProperties) {
     this.stageName = properties.stageName;
     this.autoDeploy = properties.autoDeploy;
@@ -54,6 +64,7 @@ export class SimHttpApiStage {
     this.description = properties.description;
     this.createdDate = properties.createdDate;
     this.routeSettings = properties.routeSettings;
+    this.accessLogSettings = properties.accessLogSettings;
   }
 
   /**
@@ -86,6 +97,10 @@ export class SimHttpApiStage {
 
     if (this.description !== undefined) {
       view.Description = this.description;
+    }
+
+    if (this.accessLogSettings !== undefined) {
+      view.AccessLogSettings = this.accessLogSettings.view();
     }
 
     return view;

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-access-log.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-access-log.iso.test.ts
@@ -1,0 +1,109 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import {
+  deployHttpApi,
+  ignoredReasons,
+  simAwsInEuWest2,
+} from "../../../../test/apigatewayv2/cfn-deploy.js";
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import { simCfnHttpApiTemplateFactory } from "./sim-cfn-http-api-template.factory.js";
+
+const logGroupName = "orders-access";
+
+/** A log group declared alongside the API, as a CDK app declares one. */
+const logGroupResource = {
+  AccessLogGroup: {
+    Type: "AWS::Logs::LogGroup",
+    Properties: { LogGroupName: logGroupName },
+  },
+};
+
+/**
+ * `Fn::GetAtt` on a log group's `Arn`, which is the form CDK emits and which
+ * ends in the `:*` wildcard.
+ */
+const destinationArn = { "Fn::GetAtt": ["AccessLogGroup", "Arn"] };
+
+function localUrl(endpoint: string, path = "/"): string {
+  return new SimAwsLocalUrl({ input: `${endpoint}${path}` }).toString();
+}
+
+async function accessLogLines(simAws: SimAws): Promise<readonly string[]> {
+  const { events } = await simAws
+    .logs()
+    .filterLogEvents({ input: { logGroupName } });
+
+  return (events ?? []).map((event) => event.message);
+}
+
+describe("Deploying an HTTP API stage's AccessLogSettings", () => {
+  it("logs a served request to the log group the template named", async () => {
+    // Given a template whose stage writes an access log to a declared group
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        routeKeys: ["GET /orders"],
+        resources: logGroupResource,
+        stageProperties: {
+          AccessLogSettings: {
+            DestinationArn: destinationArn,
+            Format: "$context.httpMethod $context.path $context.status",
+          },
+        },
+      }),
+    );
+
+    // Then the property deployed rather than being recorded as ignored
+    expect(ignoredReasons(stack)).toStrictEqual([]);
+
+    // When a request is served
+    const apiEndpoint = stack.outputs.get("ApiEndpoint")?.value;
+    assertTypeString(apiEndpoint);
+    await new SimAwsHttp({ simAws }).fetch(localUrl(apiEndpoint, "/orders"));
+
+    // Then the line is in the group the template named
+    expect(await accessLogLines(simAws)).toStrictEqual(["GET /orders 200"]);
+  });
+
+  it("reports the settings the stage was deployed with", async () => {
+    // Given the same template
+    const simAws = simAwsInEuWest2();
+    const stack = await deployHttpApi(
+      simAws,
+      simCfnHttpApiTemplateFactory.make({
+        resources: logGroupResource,
+        stageProperties: {
+          AccessLogSettings: {
+            DestinationArn: destinationArn,
+            Format: "$context.requestId",
+          },
+        },
+      }),
+    );
+
+    // When the stages are read back off the deployment
+    const apiId = stack.getResource("Api")?.refValue;
+    assertTypeString(apiId);
+    const { Items: stages } = await simAws
+      .apiGatewayV2()
+      .getStages({ input: { ApiId: apiId } });
+
+    // Then GetStages reports what the template asked for
+    const [stage] = stages;
+    assertNonNullable(stage);
+    const settings = stage.AccessLogSettings;
+    assertNonNullable(settings);
+    assertIdentical(settings.Format, "$context.requestId");
+    expect(settings.DestinationArn).toMatch(
+      /^arn:aws:logs:eu-west-2:\d{12}:log-group:orders-access:\*$/,
+    );
+  });
+});

--- a/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
+++ b/src/service/apigatewayv2/cfn/sim-cfn-http-api-validation.iso.test.ts
@@ -162,21 +162,19 @@ describe("API Gateway v2 CloudFormation validation", () => {
   });
 
   it("creates a stage without a property outside the simulated set", async () => {
-    // Given a stage asking for access logging
+    // Given a stage carrying tags, which nothing here reads
     const simAws = simAwsInEuWest2();
 
     // When the template is deployed
     const stack = await deployHttpApi(
       simAws,
       simCfnHttpApiTemplateFactory.make({
-        stageProperties: {
-          AccessLogSettings: { Format: "$context.requestId" },
-        },
+        stageProperties: { Tags: { Team: "orders" } },
       }),
     );
 
-    // Then the stage is created logging nothing, and the record names the
-    // Resource type, the logical ID, the property and what is simulated
+    // Then the stage is created untagged, and the record names the Resource
+    // type, the logical ID, the property and what is simulated
     assertTrue(stack.getResource("Stage")?.deployed);
 
     const [reason] = ignoredReasons(stack);
@@ -184,12 +182,13 @@ describe("API Gateway v2 CloudFormation validation", () => {
     assertStringIncludes(reason, "Stage");
     assertStringIncludes(
       reason,
-      "AWS::ApiGatewayV2::Stage property AccessLogSettings is not simulated",
+      "AWS::ApiGatewayV2::Stage property Tags is not simulated",
     );
     assertStringIncludes(
       reason,
       "The simulated properties are ApiId, StageName, AutoDeploy, " +
-        "StageVariables, Description, DefaultRouteSettings, RouteSettings.",
+        "StageVariables, Description, DefaultRouteSettings, RouteSettings, " +
+        "AccessLogSettings.",
     );
   });
 

--- a/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-access-log-settings-properties.ts
+++ b/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-access-log-settings-properties.ts
@@ -1,0 +1,60 @@
+import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValue } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
+import type { SimHttpApiAccessLogSettingsInput } from "../../api/stage/access-log/sim-http-api-access-log-settings.type.js";
+import type { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+
+interface SimCfnHttpApiAccessLogSettingsPropertiesProperties {
+  readonly resource: SimCfnResource;
+  readonly propertyParser: SimCfnApiGatewayV2PropertyParser;
+}
+
+/**
+ * Reads the `AccessLogSettings` of an AWS::ApiGatewayV2::Stage.
+ *
+ * `DestinationArn` reaches the template as a `Fn::GetAtt` on the log group's
+ * `Arn`, which CDK emits and which resolves to the form ending in `:*`. The
+ * form without it, as `DescribeLogGroups` reports, names the same group.
+ */
+export class SimCfnHttpApiAccessLogSettingsProperties {
+  readonly #resource: SimCfnResource;
+  readonly #propertyParser: SimCfnApiGatewayV2PropertyParser;
+
+  constructor(properties: SimCfnHttpApiAccessLogSettingsPropertiesProperties) {
+    this.#resource = properties.resource;
+    this.#propertyParser = properties.propertyParser;
+  }
+
+  /**
+   * Read the `AccessLogSettings` a stage was declared with.
+   */
+  settings(
+    value: SimCfnTemplateValue | undefined,
+    label: string,
+  ): SimHttpApiAccessLogSettingsInput | undefined {
+    const record = this.#propertyParser.optionalRecord(
+      this.#resource,
+      value,
+      label,
+    );
+
+    if (record === undefined) {
+      return undefined;
+    }
+
+    const destinationArn = this.#propertyParser.optionalString(
+      this.#resource,
+      record["DestinationArn"],
+      `${label}.DestinationArn`,
+    );
+    const format = this.#propertyParser.optionalString(
+      this.#resource,
+      record["Format"],
+      `${label}.Format`,
+    );
+
+    return {
+      ...(destinationArn !== undefined && { DestinationArn: destinationArn }),
+      ...(format !== undefined && { Format: format }),
+    };
+  }
+}

--- a/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-properties.ts
+++ b/src/service/apigatewayv2/cfn/stage/sim-cfn-http-api-stage-properties.ts
@@ -2,15 +2,14 @@ import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-re
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
 import type { SimCreateStageCommandInput } from "../../command/stage/stage.command.js";
 import { SimCfnApiGatewayV2PropertyParser } from "../sim-cfn-api-gateway-v2-property-parser.js";
+import { SimCfnHttpApiAccessLogSettingsProperties } from "./sim-cfn-http-api-access-log-settings-properties.js";
 import { SimCfnHttpApiRouteSettingsProperties } from "./sim-cfn-http-api-route-settings-properties.js";
 
 /**
  * The AWS::ApiGatewayV2::Stage properties this simulation deploys.
  *
- * `DeploymentId`, `AccessLogSettings` and `Tags` are left out, so a template
- * carrying one is recorded and the stage is created without it. None of them
- * is modelled, and a stage that looked logged to the template and logged
- * nothing when serving is the failure worth recording.
+ * `DeploymentId` and `Tags` are left out, so a template carrying one is
+ * recorded and the stage is created without it. Neither is modelled.
  */
 const simulatedProperties = [
   "ApiId",
@@ -20,6 +19,7 @@ const simulatedProperties = [
   "Description",
   "DefaultRouteSettings",
   "RouteSettings",
+  "AccessLogSettings",
 ];
 
 interface SimCfnHttpApiStagePropertiesProperties {
@@ -40,6 +40,7 @@ export class SimCfnHttpApiStageProperties {
   });
 
   private readonly routeSettingsParser: SimCfnHttpApiRouteSettingsProperties;
+  private readonly accessLogSettingsParser: SimCfnHttpApiAccessLogSettingsProperties;
 
   constructor(properties: SimCfnHttpApiStagePropertiesProperties) {
     this.resource = properties.resource;
@@ -48,6 +49,12 @@ export class SimCfnHttpApiStageProperties {
       resource: this.resource,
       propertyParser: this.propertyParser,
     });
+    this.accessLogSettingsParser = new SimCfnHttpApiAccessLogSettingsProperties(
+      {
+        resource: this.resource,
+        propertyParser: this.propertyParser,
+      },
+    );
 
     this.propertyParser.ignoreUnsimulated(this.resource, this.properties);
   }
@@ -109,6 +116,10 @@ export class SimCfnHttpApiStageProperties {
       RouteSettings: this.routeSettingsParser.settingsMap(
         this.properties["RouteSettings"],
         "RouteSettings",
+      ),
+      AccessLogSettings: this.accessLogSettingsParser.settings(
+        this.properties["AccessLogSettings"],
+        "AccessLogSettings",
       ),
     };
   }

--- a/src/service/apigatewayv2/command/stage/sim-http-api-access-log-settings-input.ts
+++ b/src/service/apigatewayv2/command/stage/sim-http-api-access-log-settings-input.ts
@@ -1,0 +1,58 @@
+import { SimHttpApiAccessLogSettings } from "../../api/stage/access-log/sim-http-api-access-log-settings.js";
+import type { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
+import { SimApiGatewayV2BadRequest } from "../../error/sim-api-gateway-v2.error.js";
+import type { SimCreateStageCommandInput } from "./stage.command.js";
+
+/** The `AccessLogSettings` members an HTTP API stage takes. */
+const acceptedAccessLogSettings = ["DestinationArn", "Format"];
+
+/**
+ * Reads the access log settings a CreateStage input asks for.
+ *
+ * Both members are required together. AWS types each as optional and a stage
+ * carrying one alone has either nowhere to write or nothing to write, so the
+ * pair is refused rather than half applied.
+ *
+ * `DestinationArn` has to name a CloudWatch Logs log group. HTTP APIs accept
+ * no other destination, and a Kinesis Data Firehose delivery stream, which a
+ * REST API stage may name, is refused here by the same check.
+ */
+export function simHttpApiAccessLogSettings(
+  input: SimCreateStageCommandInput,
+  unsimulated: SimApiGatewayV2UnsimulatedInput,
+): SimHttpApiAccessLogSettings | undefined {
+  const settings = input.AccessLogSettings;
+
+  if (settings === undefined) {
+    return undefined;
+  }
+
+  unsimulated.refuseUnaccepted(
+    settings,
+    acceptedAccessLogSettings,
+    "AccessLogSettings.",
+  );
+
+  const { DestinationArn: destinationArn, Format: format } = settings;
+
+  if (destinationArn === undefined || format === undefined) {
+    throw new SimApiGatewayV2BadRequest(
+      "CreateStage AccessLogSettings requires both DestinationArn and Format",
+    );
+  }
+
+  const accessLogSettings = SimHttpApiAccessLogSettings.from(
+    destinationArn,
+    format,
+  );
+
+  if (accessLogSettings === undefined) {
+    throw new SimApiGatewayV2BadRequest(
+      `CreateStage AccessLogSettings DestinationArn '${destinationArn}' is ` +
+        `not a CloudWatch Logs log group ARN. An HTTP API stage writes its ` +
+        `access log to a log group and to nothing else.`,
+    );
+  }
+
+  return accessLogSettings;
+}

--- a/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.ts
+++ b/src/service/apigatewayv2/command/stage/sim-http-api-stage-commands.ts
@@ -4,6 +4,7 @@ import { SimApiGatewayV2NotFound } from "../../error/sim-api-gateway-v2.error.js
 import type { SimApiGatewayV2RequestOptions } from "../sim-api-gateway-v2-request-options.js";
 import { SimApiGatewayV2UnsimulatedInput } from "../sim-api-gateway-v2-unsimulated-input.js";
 import type { SimHttpApiAccess } from "../sim-http-api-access.js";
+import { simHttpApiAccessLogSettings } from "./sim-http-api-access-log-settings-input.js";
 import { simHttpApiStageRouteSettings } from "./sim-http-api-stage-route-settings-input.js";
 import { SimHttpApiStageRules } from "./sim-http-api-stage-rules.js";
 import type {
@@ -25,6 +26,7 @@ const acceptedCreateStageOptions = [
   "Description",
   "DefaultRouteSettings",
   "RouteSettings",
+  "AccessLogSettings",
 ];
 
 interface SimHttpApiStageCommandsProperties {
@@ -64,6 +66,7 @@ export class SimHttpApiStageCommands {
       unsimulated,
       clock: this.clock,
     });
+    const accessLogSettings = simHttpApiAccessLogSettings(input, unsimulated);
 
     const httpApi = this.access.api({
       method: "POST",
@@ -80,6 +83,7 @@ export class SimHttpApiStageCommands {
       description: input.Description,
       createdDate: this.clock.now(),
       routeSettings,
+      accessLogSettings,
     });
     httpApi.stages.add(stage);
 

--- a/src/service/apigatewayv2/command/stage/stage.command.ts
+++ b/src/service/apigatewayv2/command/stage/stage.command.ts
@@ -3,6 +3,7 @@ import type {
   SimHttpApiRouteSettings,
   SimHttpApiRouteSettingsMap,
 } from "../../api/stage/settings/sim-http-api-route-settings.type.js";
+import type { SimHttpApiAccessLogSettingsInput } from "../../api/stage/access-log/sim-http-api-access-log-settings.type.js";
 import type { SimHttpApiStageView } from "../../api/stage/sim-http-api-stage.js";
 
 /**
@@ -22,6 +23,7 @@ export interface SimCreateStageCommandInput {
   readonly Description?: string | undefined;
   readonly DefaultRouteSettings?: SimHttpApiRouteSettings | undefined;
   readonly RouteSettings?: SimHttpApiRouteSettingsMap | undefined;
+  readonly AccessLogSettings?: SimHttpApiAccessLogSettingsInput | undefined;
 }
 
 export interface SimCreateStageCommandOutput extends SimHttpApiStageView {

--- a/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorize-input.ts
+++ b/src/service/apigatewayv2/serve/auth/sim-http-api-route-authorize-input.ts
@@ -36,4 +36,10 @@ export interface SimHttpApiRouteAuthorizeInput {
    * integrated function's.
    */
   readonly iam: SimIamInterServiceAuthZ;
+  /**
+   * The id the endpoint stamped this request with, which a `REQUEST`
+   * authorizer's event reports as its own. The authorizer and the integration
+   * behind the same request name one id, as they do on real AWS.
+   */
+  readonly requestId?: string | undefined;
 }

--- a/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
+++ b/src/service/apigatewayv2/serve/sim-api-gateway-v2-controller.ts
@@ -1,13 +1,14 @@
+import { randomUUID } from "node:crypto";
+
 import type {
   SimAwsServiceController,
   SimAwsServiceRequest,
 } from "../../../serve/controller/sim-service-controller.js";
 import { SimAws } from "../../aws/sim-aws.js";
-import { SimHttpApiRouteAuthorizer } from "./auth/sim-http-api-route-authorizer.js";
+import { SimHttpApiAccessLog } from "./sim-http-api-access-log.js";
 import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
 import { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
-import { SimHttpApiIntegrationInvocation } from "./sim-http-api-integration-invocation.js";
-import { SimHttpApiRefusalResponse } from "./sim-http-api-refusal-response.js";
+import { SimHttpApiServePipeline } from "./sim-http-api-serve-pipeline.js";
 import {
   type SimHttpApiServing,
   SimHttpApiServingResolver,
@@ -23,42 +24,30 @@ interface SimApiGatewayV2ServiceControllerProperties {
  *
  * A request reaching the generated endpoint, or a custom domain mapped to the
  * API, is matched to a route, and the route's integration invokes a simulated
- * Lambda function with a payload format 2.0 event. The function runs as its execution Role, as it does for
- * any other invocation.
+ * Lambda function with a payload format 2.0 event. The function runs as its
+ * execution Role, as it does for any other invocation. The throttle and the
+ * authorization standing in front of that are the pipeline's.
  *
- * The stage's throttle comes before any of that. A route whose bucket is empty
- * is answered 429, and neither its authorizer nor its integration runs.
- *
- * A route that authorizes anybody is checked next: a JWT route's
- * token has to verify and meet the route's scopes, an `AWS_IAM` route's caller
- * has to be allowed `execute-api:Invoke` on the route, and a `CUSTOM` route's
- * Lambda authorizer has to allow the request, or the request is refused and the
- * integration is never invoked. Whether the API may invoke a function is a
- * separate question, and the API's own rather than the client's.
+ * Every request the resolver matches is stamped with an id before anything
+ * runs, so the stage's access log line, the authorizer event and the
+ * integration event all name the same request, as they do on real AWS.
  */
 export class SimApiGatewayV2ServiceController implements SimAwsServiceController {
   private readonly router: SimApiGatewayV2Router;
-  private readonly routeAuthorizer: SimHttpApiRouteAuthorizer;
-  private readonly integration: SimHttpApiIntegrationInvocation;
+  private readonly pipeline: SimHttpApiServePipeline;
   private readonly serving: SimHttpApiServingResolver;
+  private readonly accessLog: SimHttpApiAccessLog;
   private readonly errorResponse = new SimApiGatewayV2ErrorResponse();
-  private readonly refusalResponse = new SimHttpApiRefusalResponse();
 
   constructor(properties: SimApiGatewayV2ServiceControllerProperties = {}) {
     const { simAws = new SimAws() } = properties;
     this.router = properties.router ?? new SimApiGatewayV2Router({ simAws });
-    // The clock is taken from the router rather than from properties, so a
-    // supplied router, the event timestamps and the token expiry checks all
-    // belong to the same simulation.
-    this.routeAuthorizer = new SimHttpApiRouteAuthorizer({
-      clock: this.router.simAws,
-      functions: this.router,
-    });
-    this.integration = new SimHttpApiIntegrationInvocation({
-      router: this.router,
-      clock: this.router.simAws,
-    });
+    this.pipeline = new SimHttpApiServePipeline({ router: this.router });
     this.serving = new SimHttpApiServingResolver({ router: this.router });
+    this.accessLog = new SimHttpApiAccessLog({
+      simAws: this.router.simAws,
+      clock: this.router.simAws,
+    });
   }
 
   /**
@@ -78,49 +67,25 @@ export class SimApiGatewayV2ServiceController implements SimAwsServiceController
         return this.errorResponse.forbiddenHost();
       }
       case "served": {
-        return await this.invoke(resolution.serving, serviceRequest);
+        return await this.serve(resolution.serving, serviceRequest);
       }
     }
   }
 
-  private async invoke(
-    serving: SimHttpApiServing,
+  /**
+   * Serve one request the resolver matched to a stage, and record it in that
+   * stage's access log.
+   */
+  private async serve(
+    resolved: SimHttpApiServing,
     serviceRequest: SimAwsServiceRequest,
   ): Promise<Response> {
-    const { request } = serviceRequest;
-    const { api, match } = serving;
+    const serving = { ...resolved, requestId: randomUUID() };
+    const at = this.router.simAws.now();
+    const served = await this.pipeline.run(serving, serviceRequest);
 
-    // The stage's throttle is asked before the route's authorizer. A flood of
-    // requests to a throttled route invokes neither. AWS publishes no order
-    // between the two.
-    if (!match.stage.admits(match.route.routeKey)) {
-      return this.errorResponse.tooManyRequests();
-    }
+    await this.accessLog.served(serving, serviceRequest.request, served, at);
 
-    // The client's own authorization comes next: a request with no
-    // credentials is refused whether or not the integration behind the route
-    // would work.
-    const authorization = await this.routeAuthorizer.authorize({
-      api,
-      match,
-      request,
-      caller: serviceRequest.caller,
-      iam: this.router.iamFor(api),
-      domainName: serving.domainName,
-      rawPath: serving.rawPath,
-    });
-
-    if (!authorization.admitted) {
-      return this.refusalResponse.build(authorization);
-    }
-
-    return await this.integration.invoke({
-      api,
-      match,
-      request,
-      authorization,
-      domainName: serving.domainName,
-      rawPath: serving.rawPath,
-    });
+    return served.response;
   }
 }

--- a/src/service/apigatewayv2/serve/sim-http-api-access-log-record.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-access-log-record.ts
@@ -1,0 +1,108 @@
+import { simAwsProxiedSourceIp } from "../../../serve/http/sim-aws-proxied-connection.js";
+import type { SimHttpApiAccessLogRequest } from "../api/stage/access-log/sim-http-api-access-log-request.js";
+import type { SimHttpApiAuthorization } from "../api/authorizer/sim-http-api-authorization.js";
+import type { SimHttpApiServing } from "./sim-http-api-serving.js";
+import type { SimHttpApiIntegrationOutcome } from "./sim-http-api-integration-outcome.js";
+
+/**
+ * The `$context.error.message` an endpoint's own refusal carries.
+ *
+ * These are the bodies `SimApiGatewayV2ErrorResponse` answers with, keyed by
+ * the status they answer with. A response an integration produced has no entry
+ * here, and leaves the variable empty as real API Gateway does.
+ */
+const refusalMessages = new Map<number, string>([
+  [401, "Unauthorized"],
+  [403, "Forbidden"],
+  [429, "Too Many Requests"],
+  [500, "Internal Server Error"],
+]);
+
+interface SimHttpApiAccessLogRecordInput {
+  readonly serving: SimHttpApiServing;
+  readonly requestId: string;
+  readonly request: Request;
+  readonly response: Response;
+  /** Simulated milliseconds the whole request took. */
+  readonly responseLatency: number;
+  /** How long the response body is, measured from the response itself. */
+  readonly responseLength: number;
+  /** The simulated instant the request arrived. */
+  readonly at: Date;
+  /** Absent for a request refused before the route's authorizer ran. */
+  readonly authorization?: SimHttpApiAuthorization | undefined;
+  /** Absent for a request no integration was invoked for. */
+  readonly integration?: SimHttpApiIntegrationOutcome | undefined;
+}
+
+/**
+ * Describe one served request as its stage's access log records it.
+ *
+ * Every path through the endpoint arrives here, including the ones that
+ * refused the request. A throttled request has no authorization and no
+ * integration, and an authorizer that said no has an authorization and no
+ * integration. What each one knows is what its line carries, and the rest of
+ * the format's variables render as dashes.
+ */
+export function simHttpApiAccessLogRecord(
+  input: SimHttpApiAccessLogRecordInput,
+): SimHttpApiAccessLogRequest {
+  const { serving, request, response, authorization, integration } = input;
+  const { api, match, domainName } = serving;
+  const admitted = authorization?.admitted === true ? authorization : undefined;
+
+  return {
+    requestId: input.requestId,
+    at: input.at,
+    accountId: api.accountRegionScope.accountId,
+    apiId: api.apiId,
+    domainName,
+    domainPrefix: domainName.split(".", 1).join(""),
+    stage: match.stage.stageName,
+    routeKey: match.route.routeKey,
+    method: request.method,
+    path: serving.rawPath,
+    protocol: "HTTP/1.1",
+    sourceIp: simAwsProxiedSourceIp,
+    userAgent: request.headers.get("user-agent") ?? "",
+    status: response.status,
+    responseLength: input.responseLength,
+    responseLatency: input.responseLatency,
+    ...(refusalMessage(response, integration) !== undefined && {
+      errorMessage: refusalMessage(response, integration),
+    }),
+    ...(authorization?.admitted === false &&
+      authorization.errorDescription !== undefined && {
+        authorizerError: authorization.errorDescription,
+      }),
+    ...(integration?.integrationStatus !== undefined && {
+      integrationStatus: integration.integrationStatus,
+    }),
+    ...(integration?.lambdaInvokeStatus !== undefined && {
+      lambdaInvokeStatus: integration.lambdaInvokeStatus,
+    }),
+    ...(integration?.integrationErrorMessage !== undefined && {
+      integrationErrorMessage: integration.integrationErrorMessage,
+    }),
+    ...(admitted?.jwt !== undefined && { jwt: admitted.jwt }),
+    ...(admitted?.lambda !== undefined && { lambda: admitted.lambda }),
+    ...(serving.basePathMatched !== undefined && {
+      basePathMatched: serving.basePathMatched,
+    }),
+  };
+}
+
+/**
+ * The message the endpoint answered with, where the endpoint answered rather
+ * than the integration.
+ */
+function refusalMessage(
+  response: Response,
+  integration: SimHttpApiIntegrationOutcome | undefined,
+): string | undefined {
+  if (integration?.integrationStatus !== undefined) {
+    return undefined;
+  }
+
+  return refusalMessages.get(response.status);
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-access-log-record.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-access-log-record.ts
@@ -75,20 +75,41 @@ export function simHttpApiAccessLogRecord(
       authorization.errorDescription !== undefined && {
         authorizerError: authorization.errorDescription,
       }),
-    ...(integration?.integrationStatus !== undefined && {
-      integrationStatus: integration.integrationStatus,
-    }),
-    ...(integration?.lambdaInvokeStatus !== undefined && {
-      lambdaInvokeStatus: integration.lambdaInvokeStatus,
-    }),
-    ...(integration?.integrationErrorMessage !== undefined && {
-      integrationErrorMessage: integration.integrationErrorMessage,
-    }),
+    ...integrationFields(integration),
     ...(admitted?.jwt !== undefined && { jwt: admitted.jwt }),
     ...(admitted?.lambda !== undefined && { lambda: admitted.lambda }),
     ...(serving.basePathMatched !== undefined && {
       basePathMatched: serving.basePathMatched,
     }),
+  };
+}
+
+/**
+ * What the integration contributed, with the members it has no value for left
+ * out so that they render as dashes.
+ *
+ * A request no integration ran for contributes nothing at all, which is what a
+ * throttled or refused request does.
+ */
+function integrationFields(
+  integration: SimHttpApiIntegrationOutcome | undefined,
+): Partial<SimHttpApiAccessLogRequest> {
+  if (integration === undefined) {
+    return {};
+  }
+
+  const {
+    integrationStatus,
+    lambdaInvokeStatus,
+    integrationErrorMessage,
+    integrationLatency,
+  } = integration;
+
+  return {
+    ...(integrationStatus !== undefined && { integrationStatus }),
+    ...(lambdaInvokeStatus !== undefined && { lambdaInvokeStatus }),
+    ...(integrationErrorMessage !== undefined && { integrationErrorMessage }),
+    ...(integrationLatency !== undefined && { integrationLatency }),
   };
 }
 

--- a/src/service/apigatewayv2/serve/sim-http-api-access-log.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-access-log.iso.test.ts
@@ -127,7 +127,9 @@ describe("Writing a sim HTTP API stage's access log", () => {
     );
     const http = new SimAwsHttp({ simAws });
 
-    // When one more request arrives than the throttle admits
+    // When one more request arrives than the throttle admits. The clock is
+    // held still, so the bucket refills only when this test moves it.
+    simAws.clock().freeze();
     await http.fetch(localUrl(api.apiEndpoint));
     const refused = await http.fetch(localUrl(api.apiEndpoint));
 
@@ -228,6 +230,55 @@ describe("Writing a sim HTTP API stage's access log", () => {
     // Then the lines are in the log group and none of them reached the console
     expect(await accessLogLines(simAws)).toHaveLength(2);
     expect(written.join("")).toBe("");
+  });
+
+  it("keeps punctuation written around a context reference", async () => {
+    // Given a format whose variables carry the punctuation of a sentence
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): string => "hello",
+        accessLogSettings: {
+          DestinationArn: destinationArn(simAws),
+          Format: "answered $context.status. path=$context.path, done",
+        },
+      },
+      simAws,
+    );
+
+    // When a request is served
+    await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/orders"),
+    );
+
+    // Then the full stop and the comma are still there
+    expect(await accessLogLines(simAws)).toStrictEqual([
+      "answered 200. path=/orders, done",
+    ]);
+  });
+
+  it("reports how long the integration took", async () => {
+    // Given a stage logging the integration's latency, and a handler that
+    // takes a second of simulated time
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): string => "hello",
+        accessLogSettings: {
+          DestinationArn: destinationArn(simAws),
+          Format: "$context.integrationStatus $context.integrationLatency",
+        },
+      },
+      simAws,
+    );
+    simAws.clock().freeze();
+
+    // When a request is served
+    await new SimAwsHttp({ simAws }).fetch(localUrl(api.apiEndpoint));
+
+    // Then the latency is measured rather than left as a dash. The clock is
+    // held still, so it is zero.
+    expect(await accessLogLines(simAws)).toStrictEqual(["200 0"]);
   });
 
   it("writes nothing for a stage that was given no access log settings", async () => {

--- a/src/service/apigatewayv2/serve/sim-http-api-access-log.iso.test.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-access-log.iso.test.ts
@@ -1,0 +1,253 @@
+import {
+  assertIdentical,
+  assertResponseStatus,
+  describeResponse,
+} from "@kensio/smartass";
+import { describe, expect, it, vi } from "vitest";
+
+import { SimAwsHttp } from "../../../serve/http/sim-aws-http.js";
+import { SimAwsLocalUrl } from "../../../serve/http/url/sim-aws-local-url.js";
+import type { SimPayload2Event } from "../../../serve/payload-2/sim-payload-2-event.type.js";
+import { assertDefined } from "../../../util/type-guard/defined.js";
+import { SimAws } from "../../aws/sim-aws.js";
+import { simHttpApiLambdaProxyFactory } from "../api/sim-http-api-lambda-proxy.factory.js";
+
+const logGroupName = "/aws/vendedlogs/orders-access";
+
+function destinationArn(simAws: SimAws): string {
+  const { accountId, regionName } =
+    simAws.accountRegionScope().accountRegionScope;
+
+  return `arn:aws:logs:${regionName}:${accountId}:log-group:${logGroupName}:*`;
+}
+
+function localUrl(apiEndpoint: string, path = ""): string {
+  return new SimAwsLocalUrl({ input: `${apiEndpoint}${path}` }).toString();
+}
+
+/** Every line the access log group holds, in the order it was written. */
+async function accessLogLines(simAws: SimAws): Promise<readonly string[]> {
+  const { events } = await simAws.logs().filterLogEvents({
+    input: { logGroupName },
+  });
+
+  return (events ?? []).map((event) => event.message);
+}
+
+/**
+ * Capture what reaches the host's standard output, which is the console a test
+ * run prints to.
+ */
+function captureHostStdout(): string[] {
+  const written: string[] = [];
+
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk): boolean => {
+    written.push(String(chunk));
+    return true;
+  });
+
+  return written;
+}
+
+describe("Writing a sim HTTP API stage's access log", () => {
+  it("writes one line per served request, with the format substituted", async () => {
+    // Given a stage that logs the request id, method, path and status
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): string => "hello",
+        accessLogSettings: {
+          DestinationArn: destinationArn(simAws),
+          Format:
+            "$context.requestId $context.httpMethod $context.path $context.status",
+        },
+      },
+      simAws,
+    );
+
+    // When a request is served
+    await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint, "/orders"),
+    );
+
+    // Then the line describes it, and the request id is the one the endpoint
+    // assigned rather than a placeholder
+    const [line] = await accessLogLines(simAws);
+    assertDefined(line, "the access log line for the served request");
+    const [requestId, method, path, status] = line.split(" ", 4);
+    expect(requestId).toMatch(/^[\da-f-]{36}$/);
+    assertIdentical(method, "GET");
+    assertIdentical(path, "/orders");
+    assertIdentical(status, "200");
+  });
+
+  it("names the same request in the access log and in the handler's event", async () => {
+    // Given a stage logging the request id, behind a handler that reports the
+    // one its own event carries
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (event: SimPayload2Event): string =>
+          event.requestContext.requestId,
+        accessLogSettings: {
+          DestinationArn: destinationArn(simAws),
+          Format: "$context.requestId",
+        },
+      },
+      simAws,
+    );
+
+    // When the request is served
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint),
+    );
+
+    // Then both name one request. The handler returned a string, which the
+    // proxy response builder answers as JSON.
+    const [line] = await accessLogLines(simAws);
+    assertIdentical(line, (await response.json()) as string);
+  });
+
+  it("writes a line for a request the stage's throttle refused", async () => {
+    // Given a stage that admits one request and logs what it answers
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): string => "hello",
+        defaultRouteSettings: {
+          ThrottlingRateLimit: 1,
+          ThrottlingBurstLimit: 1,
+        },
+        accessLogSettings: {
+          DestinationArn: destinationArn(simAws),
+          Format: "$context.status $context.error.message",
+        },
+      },
+      simAws,
+    );
+    const http = new SimAwsHttp({ simAws });
+
+    // When one more request arrives than the throttle admits
+    await http.fetch(localUrl(api.apiEndpoint));
+    const refused = await http.fetch(localUrl(api.apiEndpoint));
+
+    // Then the refused request is logged, though no integration ran for it
+    assertResponseStatus(refused, 429, await describeResponse(refused));
+    expect(await accessLogLines(simAws)).toStrictEqual([
+      "200 -",
+      "429 Too Many Requests",
+    ]);
+  });
+
+  it("writes a line for a request a Lambda authorizer refused", async () => {
+    // Given a stage behind an authorizer that denies the request
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): string => "hello",
+        requestAuthorizer: {
+          functionName: "origin-check",
+          identitySource: ["$request.header.x-origin-secret"],
+          handler: (): unknown => ({ isAuthorized: false }),
+          enableSimpleResponses: true,
+          resultTtlSeconds: 0,
+          invokePermission: true,
+        },
+        accessLogSettings: {
+          DestinationArn: destinationArn(simAws),
+          Format: "$context.status $context.routeKey",
+        },
+      },
+      simAws,
+    );
+
+    // When a request carrying the identity source is refused
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint),
+      { headers: { "x-origin-secret": "wrong" } },
+    );
+
+    // Then the refusal is in the access log, which is the only record of it
+    assertResponseStatus(response, 403, await describeResponse(response));
+    expect(await accessLogLines(simAws)).toStrictEqual(["403 $default"]);
+  });
+
+  it("writes a line for a request with no identity source header", async () => {
+    // Given the same authorizer, which never runs without its identity source
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): string => "hello",
+        requestAuthorizer: {
+          functionName: "origin-check",
+          identitySource: ["$request.header.x-origin-secret"],
+          handler: (): unknown => ({ isAuthorized: true }),
+          enableSimpleResponses: true,
+          resultTtlSeconds: 0,
+          invokePermission: true,
+        },
+        accessLogSettings: {
+          DestinationArn: destinationArn(simAws),
+          Format: "$context.status",
+        },
+      },
+      simAws,
+    );
+
+    // When the header is absent
+    const response = await new SimAwsHttp({ simAws }).fetch(
+      localUrl(api.apiEndpoint),
+    );
+
+    // Then the 401 is logged
+    assertResponseStatus(response, 401, await describeResponse(response));
+    expect(await accessLogLines(simAws)).toStrictEqual(["401"]);
+  });
+
+  it("keeps its lines out of the host console", async () => {
+    // Given a stage logging every request, behind a handler that prints
+    // nothing of its own
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      {
+        handler: (): string => "hello",
+        accessLogSettings: {
+          DestinationArn: destinationArn(simAws),
+          Format: "$context.requestId $context.status",
+        },
+      },
+      simAws,
+    );
+    const written = captureHostStdout();
+
+    // When requests are served
+    const http = new SimAwsHttp({ simAws });
+    await http.fetch(localUrl(api.apiEndpoint));
+    await http.fetch(localUrl(api.apiEndpoint));
+
+    // Then the lines are in the log group and none of them reached the console
+    expect(await accessLogLines(simAws)).toHaveLength(2);
+    expect(written.join("")).toBe("");
+  });
+
+  it("writes nothing for a stage that was given no access log settings", async () => {
+    // Given a stage with no access log
+    const simAws = new SimAws();
+    const api = await simHttpApiLambdaProxyFactory.make(
+      { handler: (): string => "hello" },
+      simAws,
+    );
+
+    // When a request is served
+    await new SimAwsHttp({ simAws }).fetch(localUrl(api.apiEndpoint));
+
+    // Then no access log group was made. The function's own group is there,
+    // since the handler ran.
+    expect(
+      simAws
+        .logs()
+        .allLogGroups()
+        .map((group) => group.logGroupName),
+    ).toStrictEqual(["/aws/lambda/orders"]);
+  });
+});

--- a/src/service/apigatewayv2/serve/sim-http-api-access-log.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-access-log.ts
@@ -1,0 +1,113 @@
+import type { AwsRegionName } from "../../aws/sim-aws-region.js";
+import type { SimAws } from "../../aws/sim-aws.js";
+import type { SimAwsAccountId } from "../../aws/sim-aws-account.js";
+import type { SimClock } from "../../../util/clock/sim-clock.js";
+import { simHttpApiAccessLogLine } from "../api/stage/access-log/sim-http-api-access-log-format.js";
+import type { SimHttpApiAccessLogRequest } from "../api/stage/access-log/sim-http-api-access-log-request.js";
+import { simHttpApiAccessLogStreamName } from "../api/stage/access-log/sim-http-api-access-log-stream-name.js";
+import { simHttpApiAccessLogVariables } from "../api/stage/access-log/sim-http-api-access-log-variables.js";
+import type { SimHttpApiStage } from "../api/stage/sim-http-api-stage.js";
+import { simHttpApiAccessLogRecord } from "./sim-http-api-access-log-record.js";
+import type { SimHttpApiServed } from "./sim-http-api-served.js";
+import type { SimHttpApiServing } from "./sim-http-api-serving.js";
+
+interface SimHttpApiAccessLogProperties {
+  readonly simAws: SimAws;
+  readonly clock: SimClock;
+}
+
+/**
+ * Writes a stage's access log line for one request.
+ *
+ * The line goes to the log group alone. Sim Lambda forwards a handler's output
+ * to the host console as well, and an API answering a few hundred requests in
+ * one test file would bury the suite's own output the same way. Writing
+ * through `SimLogsServiceWriter` keeps it out of the console, and a test reads
+ * the lines back with `FilterLogEvents`.
+ *
+ * Nothing here fails. A destination log group that was never declared is
+ * created by the write, and a stage with no access log settings writes
+ * nothing, which is how a request is served whether or not anybody is logging
+ * it.
+ */
+export class SimHttpApiAccessLog {
+  readonly #simAws: SimAws;
+  readonly #clock: SimClock;
+
+  constructor(properties: SimHttpApiAccessLogProperties) {
+    this.#simAws = properties.simAws;
+    this.#clock = properties.clock;
+  }
+
+  /**
+   * Record one finished request against the stage that served it.
+   *
+   * A stage with no access log settings does nothing here, including none of
+   * the measuring a line needs. The response body is measured from a clone,
+   * since the one the client gets still has to be readable, and the latency is
+   * simulated milliseconds, so a test holding the clock logs a latency of zero
+   * rather than however long the process happened to take.
+   */
+  async served(
+    serving: SimHttpApiServing,
+    request: Request,
+    served: SimHttpApiServed,
+    at: Date,
+  ): Promise<void> {
+    const { match, requestId = "" } = serving;
+
+    if (match.stage.accessLogSettings === undefined) {
+      return;
+    }
+
+    const body = await served.response.clone().arrayBuffer();
+
+    this.record(
+      match.stage,
+      simHttpApiAccessLogRecord({
+        serving,
+        requestId,
+        request,
+        response: served.response,
+        responseLength: body.byteLength,
+        responseLatency: this.#clock.now().getTime() - at.getTime(),
+        at,
+        ...(served.authorization !== undefined && {
+          authorization: served.authorization,
+        }),
+        ...(served.integration !== undefined && {
+          integration: served.integration,
+        }),
+      }),
+    );
+  }
+
+  /**
+   * Record one described request against the stage that served it.
+   */
+  record(stage: SimHttpApiStage, request: SimHttpApiAccessLogRequest): void {
+    const settings = stage.accessLogSettings;
+
+    if (settings === undefined) {
+      return;
+    }
+
+    const line = simHttpApiAccessLogLine(
+      settings.format,
+      simHttpApiAccessLogVariables(request),
+    );
+
+    this.#simAws
+      .accountRegionScope(
+        settings.accountId as SimAwsAccountId,
+        settings.regionName as AwsRegionName,
+      )
+      .logs()
+      .serviceWriter()
+      .write(
+        settings.logGroupName,
+        simHttpApiAccessLogStreamName(this.#clock),
+        [line],
+      );
+  }
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-endpoint.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-endpoint.ts
@@ -24,6 +24,7 @@ export function simHttpApiEndpoint(
   const { api, match, domainName } = serving;
 
   return {
+    ...(serving.requestId !== undefined && { requestId: serving.requestId }),
     apiId: api.apiId,
     domainName,
     // The first label, which is the API id for a generated endpoint and the

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-input.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-input.ts
@@ -1,0 +1,23 @@
+import type { SimHttpApiAdmitted } from "../api/authorizer/sim-http-api-authorization.js";
+import type { SimHttpApiMatch } from "../api/sim-http-api-match.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+
+/**
+ * One request an integration is invoked for, as the endpoint resolved it.
+ */
+export interface SimHttpApiIntegrationInvocationInput {
+  readonly api: SimHttpApi;
+  readonly match: SimHttpApiMatch;
+  readonly request: Request;
+  /** What the route's authorization knows about the caller. */
+  readonly authorization: SimHttpApiAdmitted;
+  /** The AWS-shaped hostname the request arrived on. */
+  readonly domainName: string;
+  /** The path the invocation event reports, which the resolver settled. */
+  readonly rawPath: string;
+  /**
+   * The id the endpoint stamped this request with, which the invocation event
+   * reports as its own.
+   */
+  readonly requestId?: string | undefined;
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-invocation.ts
@@ -1,32 +1,20 @@
 import { SimPayload2EventBuilder } from "../../../serve/payload-2/sim-payload-2-event-builder.js";
 import { SimPayload2ResponseBuilder } from "../../../serve/payload-2/sim-payload-2-response-builder.js";
 import type { SimClock } from "../../../util/clock/sim-clock.js";
-import type { SimHttpApiAdmitted } from "../api/authorizer/sim-http-api-authorization.js";
-import type { SimHttpApiMatch } from "../api/sim-http-api-match.js";
-import { SimHttpApiExecuteApiArn } from "../api/sim-http-api-execute-api-arn.js";
-import type { SimHttpApi } from "../api/sim-http-api.js";
-import { SimHttpApiInvokeAuthorizer } from "./auth/sim-http-api-invoke-authorizer.js";
 import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
 import type { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
-import type { SimHttpApiFunctionTarget } from "./sim-http-api-function-target.js";
+import { simHttpApiMayNotInvoke } from "./sim-http-api-may-invoke.js";
 import { simHttpApiEndpoint } from "./sim-http-api-endpoint.js";
+import type { SimHttpApiIntegrationInvocationInput } from "./sim-http-api-integration-input.js";
+import {
+  type SimHttpApiIntegrationOutcome,
+  simHttpApiIntegrationFailure,
+} from "./sim-http-api-integration-outcome.js";
 
 interface SimHttpApiIntegrationInvocationProperties {
   readonly router: SimApiGatewayV2Router;
   /** Clock the invocation event is stamped with. */
   readonly clock: SimClock;
-}
-
-interface SimHttpApiIntegrationInvocationInput {
-  readonly api: SimHttpApi;
-  readonly match: SimHttpApiMatch;
-  readonly request: Request;
-  /** What the route's authorization knows about the caller. */
-  readonly authorization: SimHttpApiAdmitted;
-  /** The AWS-shaped hostname the request arrived on. */
-  readonly domainName: string;
-  /** The path the invocation event reports, which the resolver settled. */
-  readonly rawPath: string;
 }
 
 /**
@@ -54,15 +42,17 @@ export class SimHttpApiIntegrationInvocation {
   /**
    * Invoke the integration for one authorized request.
    */
-  async invoke(input: SimHttpApiIntegrationInvocationInput): Promise<Response> {
+  async invoke(
+    input: SimHttpApiIntegrationInvocationInput,
+  ): Promise<SimHttpApiIntegrationOutcome> {
     const { match, request, authorization } = input;
     const target = this.router.targetFor(match.integration);
 
-    if (target === undefined || this.mayNotInvoke(input, target)) {
+    if (target === undefined || simHttpApiMayNotInvoke(input, target)) {
       // The integration names a function that is not there, or one that
       // granted the API nothing. Real API Gateway discovers both only when it
       // tries to invoke, answers 500, and leaves the reason in its own logs.
-      return this.errorResponse.internalServerError();
+      return this.failed("The integration could not be invoked");
     }
 
     try {
@@ -76,36 +66,31 @@ export class SimHttpApiIntegrationInvocation {
         },
       );
 
-      return this.responseBuilder.build(await target.simFunction.invoke(event));
-    } catch {
+      const response = this.responseBuilder.build(
+        await target.simFunction.invoke(event),
+      );
+
+      // Lambda answered the invocation, whatever the handler then returned.
+      // That is the distinction between the two statuses AWS logs.
+      return {
+        response,
+        integrationStatus: response.status,
+        lambdaInvokeStatus: 200,
+      };
+    } catch (error) {
       // Real API Gateway reports an unhandled integration error as a 500, with
       // the error itself only visible in the function's logs. Reading the
       // request body can fail the same way, so building the event is inside
       // this too.
-      return this.errorResponse.internalServerError();
+      return this.failed(error);
     }
   }
 
-  /**
-   * Whether the API lacks permission to invoke the integrated function.
-   *
-   * The route the request matched is supplied as the source ARN, so a
-   * permission granted for one route does not open another.
-   */
-  private mayNotInvoke(
-    input: SimHttpApiIntegrationInvocationInput,
-    target: SimHttpApiFunctionTarget,
-  ): boolean {
-    const { api, match, request } = input;
-
-    return new SimHttpApiInvokeAuthorizer({ iam: target.iam }).authorize({
-      api,
-      target,
-      sourceArn: SimHttpApiExecuteApiArn.forMatchedRoute(
-        api,
-        match,
-        request.method,
-      ),
-    }).isDenied;
+  /** The 500 answered whenever a handler was never reached. */
+  private failed(error: unknown): SimHttpApiIntegrationOutcome {
+    return simHttpApiIntegrationFailure(
+      this.errorResponse.internalServerError(),
+      error,
+    );
   }
 }

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-outcome.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-outcome.ts
@@ -1,0 +1,32 @@
+/**
+ * What invoking an integration produced, beyond the response the client gets.
+ *
+ * The two statuses are the pair AWS distinguishes in its access log variables.
+ * `lambdaInvokeStatus` is Lambda's own answer to the invocation, and
+ * `integrationStatus` the status the handler's code returned. An invocation
+ * that never reached a handler has neither.
+ */
+export interface SimHttpApiIntegrationOutcome {
+  readonly response: Response;
+  readonly integrationStatus?: number | undefined;
+  readonly lambdaInvokeStatus?: number | undefined;
+  readonly integrationErrorMessage?: string | undefined;
+}
+
+/**
+ * The 500 every way of failing to reach a handler produces, carrying the
+ * reason the access log reports as `$context.integrationErrorMessage`.
+ *
+ * The message never reaches the client. Real API Gateway answers the same
+ * body whatever went wrong, and leaves the reason in its own logs.
+ */
+export function simHttpApiIntegrationFailure(
+  response: Response,
+  error: unknown,
+): SimHttpApiIntegrationOutcome {
+  return {
+    response,
+    integrationErrorMessage:
+      error instanceof Error ? error.message : String(error),
+  };
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-integration-outcome.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-integration-outcome.ts
@@ -11,6 +11,11 @@ export interface SimHttpApiIntegrationOutcome {
   readonly integrationStatus?: number | undefined;
   readonly lambdaInvokeStatus?: number | undefined;
   readonly integrationErrorMessage?: string | undefined;
+  /**
+   * Simulated milliseconds the invocation took. A test holding the clock still
+   * measures zero, the way the whole request's latency does.
+   */
+  readonly integrationLatency?: number | undefined;
 }
 
 /**

--- a/src/service/apigatewayv2/serve/sim-http-api-may-invoke.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-may-invoke.ts
@@ -1,0 +1,37 @@
+import { SimHttpApiExecuteApiArn } from "../api/sim-http-api-execute-api-arn.js";
+import type { SimHttpApiMatch } from "../api/sim-http-api-match.js";
+import type { SimHttpApi } from "../api/sim-http-api.js";
+import { SimHttpApiInvokeAuthorizer } from "./auth/sim-http-api-invoke-authorizer.js";
+import type { SimHttpApiFunctionTarget } from "./sim-http-api-function-target.js";
+
+interface SimHttpApiMayInvokeInput {
+  readonly api: SimHttpApi;
+  readonly match: SimHttpApiMatch;
+  readonly request: Request;
+}
+
+/**
+ * Whether the API lacks permission to invoke a function behind one of its
+ * routes.
+ *
+ * The route the request matched is supplied as the source ARN, so a permission
+ * granted for one route does not open another. This is the API's own question
+ * rather than the client's, whose was already answered by the route's
+ * authorization.
+ */
+export function simHttpApiMayNotInvoke(
+  input: SimHttpApiMayInvokeInput,
+  target: SimHttpApiFunctionTarget,
+): boolean {
+  const { api, match, request } = input;
+
+  return new SimHttpApiInvokeAuthorizer({ iam: target.iam }).authorize({
+    api,
+    target,
+    sourceArn: SimHttpApiExecuteApiArn.forMatchedRoute(
+      api,
+      match,
+      request.method,
+    ),
+  }).isDenied;
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-pipeline.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-pipeline.ts
@@ -83,10 +83,13 @@ export class SimHttpApiServePipeline {
       };
     }
 
-    const integration = await this.#integration.invoke({
-      ...asked,
-      authorization,
-    });
+    const clock = this.#router.simAws;
+    const invokedAt = clock.now().getTime();
+    const outcome = await this.#integration.invoke({ ...asked, authorization });
+    const integration = {
+      ...outcome,
+      integrationLatency: clock.now().getTime() - invokedAt,
+    };
 
     return { response: integration.response, authorization, integration };
   }

--- a/src/service/apigatewayv2/serve/sim-http-api-serve-pipeline.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serve-pipeline.ts
@@ -1,0 +1,93 @@
+import type { SimAwsServiceRequest } from "../../../serve/controller/sim-service-controller.js";
+import { SimHttpApiRouteAuthorizer } from "./auth/sim-http-api-route-authorizer.js";
+import { SimApiGatewayV2ErrorResponse } from "./sim-api-gateway-v2-error-response.js";
+import type { SimApiGatewayV2Router } from "./sim-api-gateway-v2-router.js";
+import { SimHttpApiIntegrationInvocation } from "./sim-http-api-integration-invocation.js";
+import { SimHttpApiRefusalResponse } from "./sim-http-api-refusal-response.js";
+import type {
+  SimHttpApiServed,
+  SimHttpApiServedRequest,
+} from "./sim-http-api-served.js";
+
+interface SimHttpApiServePipelineProperties {
+  readonly router: SimApiGatewayV2Router;
+}
+
+/**
+ * Takes one request the resolver matched to a stage through the three things
+ * that stand between it and a response.
+ *
+ * The stage's throttle is asked first. A flood of requests to a throttled
+ * route invokes neither the authorizer nor the integration, and AWS publishes
+ * no order between the two. The client's own authorization comes next, so a
+ * request with no credentials is refused whether or not the integration
+ * behind the route would work. What each step decided is carried out with the
+ * response, because the stage's access log describes the request afterwards
+ * and a refused request is the case that log exists for.
+ */
+export class SimHttpApiServePipeline {
+  readonly #router: SimApiGatewayV2Router;
+  readonly #routeAuthorizer: SimHttpApiRouteAuthorizer;
+  readonly #integration: SimHttpApiIntegrationInvocation;
+  readonly #errorResponse = new SimApiGatewayV2ErrorResponse();
+  readonly #refusalResponse = new SimHttpApiRefusalResponse();
+
+  constructor(properties: SimHttpApiServePipelineProperties) {
+    this.#router = properties.router;
+    // The clock is the router's, so the event timestamps and the token expiry
+    // checks belong to the same simulation.
+    this.#routeAuthorizer = new SimHttpApiRouteAuthorizer({
+      clock: properties.router.simAws,
+      functions: properties.router,
+    });
+    this.#integration = new SimHttpApiIntegrationInvocation({
+      router: properties.router,
+      clock: properties.router.simAws,
+    });
+  }
+
+  /**
+   * Serve one request, and report what each step of serving it decided.
+   */
+  async run(
+    serving: SimHttpApiServedRequest,
+    serviceRequest: SimAwsServiceRequest,
+  ): Promise<SimHttpApiServed> {
+    const { request } = serviceRequest;
+    const { api, match, domainName, rawPath, requestId } = serving;
+    // What the authorizer's event and the integration's event both describe.
+    const asked = { api, match, request, domainName, rawPath, requestId };
+
+    // The throttle takes a token from the route's bucket, and a route whose
+    // bucket is empty is answered here. Neither the authorizer nor the
+    // integration runs for it, and the stage's access log is the only place
+    // the refusal is recorded.
+    if (!match.stage.admits(match.route.routeKey)) {
+      return { response: this.#errorResponse.tooManyRequests() };
+    }
+
+    const authorization = await this.#routeAuthorizer.authorize({
+      ...asked,
+      caller: serviceRequest.caller,
+      iam: this.#router.iamFor(api),
+    });
+
+    // A refusal is carried out alongside its response, because the access log
+    // line reports what the authorizer said. An unmet route scope, an
+    // `AWS_IAM` route IAM did not allow, and a Lambda authorizer that said no
+    // all arrive here.
+    if (!authorization.admitted) {
+      return {
+        response: this.#refusalResponse.build(authorization),
+        authorization,
+      };
+    }
+
+    const integration = await this.#integration.invoke({
+      ...asked,
+      authorization,
+    });
+
+    return { response: integration.response, authorization, integration };
+  }
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-served.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-served.ts
@@ -1,0 +1,24 @@
+import type { SimHttpApiAuthorization } from "../api/authorizer/sim-http-api-authorization.js";
+import type { SimHttpApiIntegrationOutcome } from "./sim-http-api-integration-outcome.js";
+import type { SimHttpApiServing } from "./sim-http-api-serving.js";
+
+/**
+ * What one request through the endpoint produced, gathered as it happened so
+ * that the stage's access log can describe it afterwards.
+ *
+ * A request the stage's throttle refused has neither an authorization nor an
+ * integration, and one an authorizer refused has an authorization alone.
+ */
+export interface SimHttpApiServed {
+  readonly response: Response;
+  readonly authorization?: SimHttpApiAuthorization | undefined;
+  readonly integration?: SimHttpApiIntegrationOutcome | undefined;
+}
+
+/**
+ * A serving the controller has stamped with the id this request is logged and
+ * reported under, which every path below it then names.
+ */
+export interface SimHttpApiServedRequest extends SimHttpApiServing {
+  readonly requestId: string;
+}

--- a/src/service/apigatewayv2/serve/sim-http-api-serving.ts
+++ b/src/service/apigatewayv2/serve/sim-http-api-serving.ts
@@ -26,6 +26,18 @@ export interface SimHttpApiServing {
    * carrying.
    */
   readonly rawPath: string;
+  /**
+   * The id this request is logged and reported under, settled by the
+   * controller before anything runs. The resolver leaves it out, and the
+   * controller adds it to the serving it passes on.
+   */
+  readonly requestId?: string | undefined;
+  /**
+   * The API mapping base path this request matched, for a request that
+   * reached a custom domain. It is the empty string for a mapping serving the
+   * root of its domain, and absent for the generated endpoint.
+   */
+  readonly basePathMatched?: string | undefined;
 }
 
 /**
@@ -182,6 +194,7 @@ export class SimHttpApiServingResolver {
         match,
         domainName: domain.domainName,
         rawPath: mapping.apiMappingKey.remainingPath(path),
+        basePathMatched: mapping.apiMappingKey.value,
       },
     };
   }

--- a/src/service/logs/group/sim-logs-arn.iso.test.ts
+++ b/src/service/logs/group/sim-logs-arn.iso.test.ts
@@ -1,0 +1,65 @@
+import { assertUndefined } from "@kensio/smartass";
+import { describe, expect, it } from "vitest";
+
+import { simLogsParsedLogGroupArn } from "./sim-logs-arn.js";
+
+const logGroupArn =
+  "arn:aws:logs:us-east-1:111111111111:log-group:/aws/vendedlogs/orders";
+
+describe("Reading a CloudWatch Logs log group ARN", () => {
+  it("reads the account, region and name off both written forms", () => {
+    // Given the form DescribeLogGroups reports and the form CDK emits, which
+    // carries the wildcard covering the group's streams
+
+    // When each is read
+    const reported = simLogsParsedLogGroupArn(logGroupArn);
+    const withWildcard = simLogsParsedLogGroupArn(`${logGroupArn}:*`);
+
+    // Then both name the same group
+    const parsed = {
+      accountId: "111111111111",
+      regionName: "us-east-1",
+      logGroupName: "/aws/vendedlogs/orders",
+    };
+    expect(reported).toStrictEqual(parsed);
+    expect(withWildcard).toStrictEqual(parsed);
+  });
+
+  it("reads nothing from a string that is not a log group ARN", () => {
+    // Given strings that each fail one part of the shape
+
+    // When each is read
+
+    // Then none of them names a group. A string merely ending in something
+    // ARN-shaped is the one worth naming: it would otherwise be accepted as a
+    // destination that could never be written to.
+    assertUndefined(
+      simLogsParsedLogGroupArn(`not-an-${logGroupArn}`),
+      "an ARN not starting with the arn prefix",
+    );
+    assertUndefined(
+      simLogsParsedLogGroupArn("arn:aws:logs::111111111111:log-group:orders"),
+      "an ARN with no region",
+    );
+    assertUndefined(
+      simLogsParsedLogGroupArn("arn:aws:logs:us-east-1::log-group:orders"),
+      "an ARN with no account",
+    );
+    assertUndefined(
+      simLogsParsedLogGroupArn("arn:aws:s3:::orders"),
+      "an ARN of another service",
+    );
+    assertUndefined(
+      simLogsParsedLogGroupArn(
+        "arn:aws:logs:us-east-1:111111111111:delivery-source:orders",
+      ),
+      "a CloudWatch Logs ARN of another resource type",
+    );
+    assertUndefined(
+      simLogsParsedLogGroupArn(
+        "arn:aws:logs:us-east-1:111111111111:log-group:",
+      ),
+      "an ARN with no group name",
+    );
+  });
+});

--- a/src/service/logs/group/sim-logs-arn.ts
+++ b/src/service/logs/group/sim-logs-arn.ts
@@ -58,3 +58,47 @@ export function simLogsLogStreamArn(
 ): string {
   return `${simLogsLogGroupArn(scope, logGroupName)}:log-stream:${logStreamName}`;
 }
+
+/**
+ * The account, region and group name a log group ARN carries, or undefined
+ * for a string that is not one.
+ *
+ * Both forms are read. `DescribeLogGroups` reports `logGroupArn` without a
+ * trailing wildcard, while the `arn` field and CDK's `logGroup.logGroupArn`
+ * both end in `:*`, and a template naming either means the same group. A log
+ * group name cannot contain a colon, so what follows `log-group:` is the name
+ * up to an optional trailing `:*`.
+ */
+export function simLogsParsedLogGroupArn(arn: string):
+  | {
+      readonly accountId: string;
+      readonly regionName: string;
+      readonly logGroupName: string;
+    }
+  | undefined {
+  const [, partition, service, regionName, accountId, resourceType, ...rest] =
+    arn.split(":");
+
+  if (
+    partition === undefined ||
+    service !== "logs" ||
+    regionName === undefined ||
+    accountId === undefined ||
+    resourceType !== "log-group"
+  ) {
+    return undefined;
+  }
+
+  const [logGroupName, wildcard, ...extra] = rest;
+
+  if (
+    logGroupName === undefined ||
+    logGroupName.length === 0 ||
+    extra.length > 0 ||
+    (wildcard !== undefined && wildcard !== "*")
+  ) {
+    return undefined;
+  }
+
+  return { accountId, regionName, logGroupName };
+}

--- a/src/service/logs/group/sim-logs-arn.ts
+++ b/src/service/logs/group/sim-logs-arn.ts
@@ -76,15 +76,16 @@ export function simLogsParsedLogGroupArn(arn: string):
       readonly logGroupName: string;
     }
   | undefined {
-  const [, partition, service, regionName, accountId, resourceType, ...rest] =
+  const [prefix, partition, service, region, account, resourceType, ...rest] =
     arn.split(":");
 
   if (
-    partition === undefined ||
+    prefix !== "arn" ||
     service !== "logs" ||
-    regionName === undefined ||
-    accountId === undefined ||
-    resourceType !== "log-group"
+    resourceType !== "log-group" ||
+    !isPresent(partition) ||
+    !isPresent(region) ||
+    !isPresent(account)
   ) {
     return undefined;
   }
@@ -100,5 +101,10 @@ export function simLogsParsedLogGroupArn(arn: string):
     return undefined;
   }
 
-  return { accountId, regionName, logGroupName };
+  return { accountId: account, regionName: region, logGroupName };
+}
+
+/** Whether an ARN component was written at all. */
+function isPresent(component: string | undefined): component is string {
+  return component !== undefined && component.length > 0;
 }


### PR DESCRIPTION
A stage created with `AccessLogSettings` writes one line per request to the log group its `DestinationArn` names, with the `Format` string's `$context` variables substituted. The line is written whether or not an integration ran, so a request the stage throttle refused, one a Lambda authorizer denied, and one with no identity source header each leave a record where nothing else does. The events go to the log group alone and never to the host console. Every request the resolver matches is now stamped with an id before anything runs, so the access log line, the authorizer event and the integration event all name one request.

Resolves #1302


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP API access logging to CloudWatch Logs, configurable through stage settings and CloudFormation.
  * Supports `$context` variables, request details, authorization and integration outcomes, throttling, errors, custom domains, and deterministic log streams.
  * Access logs now preserve request IDs across API Gateway and Lambda events.
  * Improved handling and reporting of throttled, unauthorized, and failed requests.

* **Documentation**
  * Added access-logging guidance, limitations, examples, and an executable simulation walkthrough.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->