### PR TITLE
fix: inspect 16 KB of a WAF request body

### DIFF
--- a/docs/services/wafv2/README.md
+++ b/docs/services/wafv2/README.md
@@ -173,9 +173,22 @@ resource, and `CreateWebACL` here refuses it too.
 Matching is case sensitive, as it is on AWS. A rule that means to ignore case says so with a
 `LOWERCASE` transformation and a lower case search string.
 
-WAF stops reading a body, a header set or a cookie set at 8 KB. The rule's `OversizeHandling` says
-what content past that point counts as. `MATCH` and `NO_MATCH` settle the statement without looking,
-and `CONTINUE` inspects as much as WAF would have read.
+WAF stops reading a header set or a cookie set at 8 KB. A body runs to 16 KB, the figure
+CloudFront, API Gateway and Cognito all send for inspection, and a web ACL raises it to 32, 48 or 64
+KB with `AssociationConfig`:
+
+```typescript
+AssociationConfig: {
+  RequestBody: {
+    CLOUDFRONT: { DefaultSizeInspectionLimit: "KB_64" },
+  },
+},
+```
+
+The key is the resource type the raised limit applies to, and `CLOUDFRONT`, `API_GATEWAY` and
+`COGNITO_USER_POOL` are the three a web ACL goes in front of here. The rule's `OversizeHandling`
+says what content past the limit counts as. `MATCH` and `NO_MATCH` settle the statement without
+looking, and `CONTINUE` inspects as much as WAF would have read.
 
 ## Rate limiting
 
@@ -1363,8 +1376,9 @@ fields to match. The `Captcha` and `Challenge` actions are refused, along with t
 `ChallengeConfig` and `TokenDomains` that configure them, because a browser has to answer them.
 
 Tags, logging, sampled requests and CloudWatch metrics for a web ACL are not simulated.
-`AssociationConfig`, `DataProtectionConfig`, `OnSourceDDoSProtectionConfig` and `ApplicationConfig`
-are refused for the same reason, each naming what it would have configured.
+`DataProtectionConfig`, `OnSourceDDoSProtectionConfig` and `ApplicationConfig` are refused for the
+same reason, each naming what it would have configured. An `AssociationConfig` naming a resource
+type this simulation has no association for is refused too.
 
 ## Supported operations
 

--- a/src/service/cloudfront/controller/web-acl/sim-cf-web-acl-guard.ts
+++ b/src/service/cloudfront/controller/web-acl/sim-cf-web-acl-guard.ts
@@ -53,6 +53,7 @@ export class SimCfWebAclGuard {
       webAclArn,
       request,
       body: await requestBody(request),
+      resourceType: "CLOUDFRONT",
     });
 
     return decision.action === "BLOCK"

--- a/src/service/wafv2/association/sim-waf-associations.ts
+++ b/src/service/wafv2/association/sim-waf-associations.ts
@@ -95,7 +95,11 @@ export class SimWafAssociations implements SimWafProtection {
     }
 
     return association.webAcl.evaluate(
-      simWafInspectedRequest(request.request, request.body),
+      simWafInspectedRequest(
+        request.request,
+        request.body,
+        association.webAcl.bodyInspectionLimitBytes(association.resourceType),
+      ),
     );
   }
 

--- a/src/service/wafv2/cfn/sim-cfn-waf-association-config.iso.test.ts
+++ b/src/service/wafv2/cfn/sim-cfn-waf-association-config.iso.test.ts
@@ -1,0 +1,133 @@
+import {
+  assertArrayEmpty,
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertTypeString,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import type { SimCfnDeployedStack } from "../../cloudformation/stack/sim-cfn-deployed-stack.type.js";
+import type { SimCfnTemplateValue } from "../../cloudformation/template/value/sim-cfn-template-value.js";
+import { simWafBrowserRequest } from "../sim-wafv2.fixture.js";
+
+const visibility = {
+  SampledRequestsEnabled: false,
+  CloudWatchMetricsEnabled: false,
+  MetricName: "orders",
+};
+
+/**
+ * A rule blocking any request whose body WAF could not read to the end.
+ *
+ * `MATCH` is what makes the body inspection limit visible from outside: the
+ * rule blocks exactly the bodies that went past it.
+ */
+const blockUnreadBody = {
+  Name: "block-unread-body",
+  Priority: 0,
+  Action: { Block: {} },
+  Statement: {
+    ByteMatchStatement: {
+      FieldToMatch: { Body: { OversizeHandling: "MATCH" } },
+      PositionalConstraint: "CONTAINS",
+      SearchString: "needle",
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  },
+  VisibilityConfig: { ...visibility, MetricName: "block-unread-body" },
+};
+
+/**
+ * Deploy a web ACL carrying one `AssociationConfig`.
+ */
+async function deployWebAcl(
+  simAws: SimAws,
+  associationConfig: SimCfnTemplateValue,
+): Promise<SimCfnDeployedStack> {
+  const stack = await simAws.cloudFormation().deployTemplate({
+    stackName: "orders",
+    template: {
+      Resources: {
+        OrdersAcl: {
+          Type: "AWS::WAFv2::WebACL",
+          Properties: {
+            Name: "orders-acl",
+            Scope: "REGIONAL",
+            DefaultAction: { Allow: {} },
+            VisibilityConfig: visibility,
+            Rules: [blockUnreadBody],
+            AssociationConfig: associationConfig,
+          },
+        },
+      },
+      Outputs: {
+        AclArn: { Value: { "Fn::GetAtt": ["OrdersAcl", "Arn"] } },
+      },
+    },
+  });
+  await stack.waitForDeployComplete();
+
+  return stack;
+}
+
+/**
+ * What the deployed web ACL does with a request carrying a body of one size.
+ */
+function decisionFor(
+  simAws: SimAws,
+  stack: SimCfnDeployedStack,
+  bodyBytes: number,
+): string {
+  const webAclArn = stack.outputs.get("AclArn")?.value;
+
+  assertTypeString(webAclArn);
+
+  return simAws.wafV2().evaluateRequest({
+    webAclArn,
+    request: simWafBrowserRequest("https://orders.example.com/orders", {
+      method: "POST",
+    }),
+    body: new TextEncoder().encode("x".repeat(bodyBytes)),
+    resourceType: "API_GATEWAY",
+  }).action;
+}
+
+describe("AWS::WAFv2::WebACL AssociationConfig", () => {
+  it("deploys the body inspection limit it sets", async () => {
+    // Given a template raising the body a REST API stage sends for inspection
+    // to 48 KB.
+    const simAws = new SimAws();
+    const stack = await deployWebAcl(simAws, {
+      RequestBody: { API_GATEWAY: { DefaultSizeInspectionLimit: "KB_48" } },
+    });
+
+    // Then the member deployed rather than being recorded as unsimulated, and
+    // a 40 KB body is inspected instead of being blocked unread.
+    assertArrayEmpty(stack.ignoredProperties);
+    assertArrayEmpty(stack.skippedResources);
+    assertIdentical(decisionFor(simAws, stack, 40 * 1024), "ALLOW");
+  });
+
+  it("leaves the web ACL out when it names a resource type Yulin cannot protect", async () => {
+    // Given a template setting the limit for a resource type nothing here goes
+    // in front of.
+    const simAws = new SimAws();
+    const stack = await deployWebAcl(simAws, {
+      RequestBody: {
+        VERIFIED_ACCESS_INSTANCE: { DefaultSizeInspectionLimit: "KB_32" },
+      },
+    });
+
+    // Then the web ACL is skipped and the reason names the resource type,
+    // which leaves the rest of the stack deployed.
+    const [skipped] = stack.skippedResources;
+
+    assertNonNullable(skipped);
+    assertStringIncludes(
+      skipped.skippedReason ?? "",
+      "VERIFIED_ACCESS_INSTANCE",
+    );
+  });
+});

--- a/src/service/wafv2/cfn/web-acl/sim-cfn-waf-web-acl-config.ts
+++ b/src/service/wafv2/cfn/web-acl/sim-cfn-waf-web-acl-config.ts
@@ -1,4 +1,5 @@
 import type { SimWafActionInput } from "../../web-acl/sim-waf-action.type.js";
+import type { SimWafAssociationConfigInput } from "../../web-acl/sim-waf-association-config.js";
 import type { SimWafCustomResponseBodies } from "../../web-acl/sim-waf-custom-response.type.js";
 import type { SimWafRuleInput } from "../../web-acl/sim-waf-rule.type.js";
 import type { SimCreateWebAclCommandInput } from "../../command/web-acl/web-acl.command.js";
@@ -42,6 +43,9 @@ export class SimCfnWafWebAclConfig extends SimCfnWafResourceConfig {
       VisibilityConfig: this.value("VisibilityConfig"),
       CustomResponseBodies: this.value("CustomResponseBodies") as
         | SimWafCustomResponseBodies
+        | undefined,
+      AssociationConfig: this.value("AssociationConfig") as
+        | SimWafAssociationConfigInput
         | undefined,
     };
   }

--- a/src/service/wafv2/command/web-acl/sim-waf-web-acl-output.ts
+++ b/src/service/wafv2/command/web-acl/sim-waf-web-acl-output.ts
@@ -21,5 +21,6 @@ export function simWafWebAclOutput(webAcl: SimWafWebAcl): SimWafWebAclOutput {
     Rules: configuration.rules ?? [],
     VisibilityConfig: configuration.visibilityConfig,
     CustomResponseBodies: configuration.customResponseBodies,
+    AssociationConfig: configuration.associationConfig,
   };
 }

--- a/src/service/wafv2/command/web-acl/sim-wafv2-unsimulated-web-acl-input.ts
+++ b/src/service/wafv2/command/web-acl/sim-wafv2-unsimulated-web-acl-input.ts
@@ -20,12 +20,6 @@ const refusedMembers: readonly SimWafRefusedMember[] = [
   [(input): unknown => input.ChallengeConfig, "ChallengeConfig", tokenActions],
   [(input): unknown => input.TokenDomains, "TokenDomains", tokenActions],
   [
-    (input): unknown => input.AssociationConfig,
-    "AssociationConfig",
-    "it sets the body size a web ACL inspects for the resources it is " +
-      "associated with, and nothing is associated with a web ACL yet",
-  ],
-  [
     (input): unknown => input.DataProtectionConfig,
     "DataProtectionConfig",
     "it decides what a request field looks like in logs, and web ACL logging " +

--- a/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
+++ b/src/service/wafv2/command/web-acl/sim-wafv2-web-acl-commands.ts
@@ -232,5 +232,6 @@ function configurationOf(
     customResponseBodies: input.CustomResponseBodies,
     visibilityConfig: input.VisibilityConfig,
     description: checkedSimWafDescription(input.Description),
+    associationConfig: input.AssociationConfig,
   };
 }

--- a/src/service/wafv2/command/web-acl/web-acl.command.ts
+++ b/src/service/wafv2/command/web-acl/web-acl.command.ts
@@ -1,5 +1,6 @@
 import type { SimResponseMetadata } from "../../../aws/metadata/response-metadata.type.js";
 import type { SimWafActionInput } from "../../web-acl/sim-waf-action.type.js";
+import type { SimWafAssociationConfigInput } from "../../web-acl/sim-waf-association-config.js";
 import type { SimWafCustomResponseBodies } from "../../web-acl/sim-waf-custom-response.type.js";
 import type { SimWafRuleInput } from "../../web-acl/sim-waf-rule.type.js";
 
@@ -29,7 +30,7 @@ export interface SimWafWebAclWriteInput {
   readonly CaptchaConfig?: unknown;
   readonly ChallengeConfig?: unknown;
   readonly TokenDomains?: readonly string[] | undefined;
-  readonly AssociationConfig?: unknown;
+  readonly AssociationConfig?: SimWafAssociationConfigInput | undefined;
   readonly DataProtectionConfig?: unknown;
   readonly OnSourceDDoSProtectionConfig?: unknown;
   readonly ApplicationConfig?: unknown;
@@ -80,6 +81,7 @@ export interface SimWafWebAclOutput {
   readonly Rules: readonly SimWafRuleInput[];
   readonly VisibilityConfig: unknown;
   readonly CustomResponseBodies: SimWafCustomResponseBodies | undefined;
+  readonly AssociationConfig: SimWafAssociationConfigInput | undefined;
 }
 
 export interface SimGetWebAclCommandOutput {

--- a/src/service/wafv2/evaluate/sim-waf-evaluation-request.ts
+++ b/src/service/wafv2/evaluate/sim-waf-evaluation-request.ts
@@ -1,3 +1,5 @@
+import type { SimWafBodyInspectionResourceType } from "../web-acl/sim-waf-association-config.js";
+
 /**
  * What a web ACL is asked to decide about.
  */
@@ -12,4 +14,12 @@ export interface SimWafEvaluationRequest {
    * stream that cannot be read twice, so it is passed in already buffered.
    */
   readonly body?: Uint8Array | undefined;
+
+  /**
+   * The type of resource the request reached, when it reached one.
+   *
+   * Only the body inspection limit reads it, and a web ACL evaluated on its
+   * own reads the default limit for every resource type.
+   */
+  readonly resourceType?: SimWafBodyInspectionResourceType | undefined;
 }

--- a/src/service/wafv2/evaluate/sim-waf-inspected-request.ts
+++ b/src/service/wafv2/evaluate/sim-waf-inspected-request.ts
@@ -1,4 +1,5 @@
 import { simAwsRequestHostname } from "../../../serve/http/url/sim-aws-request-hostname.js";
+import { simWafBodyInspectionLimitBytes } from "../web-acl/sim-waf-association-config.js";
 import { SimWafRequestLabels } from "./sim-waf-request-labels.js";
 
 /**
@@ -30,6 +31,16 @@ export interface SimWafInspectedRequest {
   /** The request body, or nothing when the request carried none. */
   readonly body: Uint8Array | undefined;
 
+  /**
+   * How many bytes of the body a rule inspecting it reads.
+   *
+   * This travels with the request because it belongs to the resource the
+   * request reached rather than to the rule. A rule is compiled once, when the
+   * web ACL is written, and the same compiled rule then runs in front of a
+   * distribution and a REST API stage with a different limit for each.
+   */
+  readonly bodyInspectionLimitBytes: number;
+
   /** The labels the rules that have run so far added to this request. */
   readonly labels: SimWafRequestLabels;
 }
@@ -45,10 +56,15 @@ export interface SimWafInspectedRequest {
  * simulated endpoint is served under `*.sim-aws.localhost`, and a rule reading
  * the raw Host header would see that suffix on every request that reached
  * anything at all.
+ *
+ * The body inspection limit defaults to the 16 KB every resource type this
+ * simulation protects reads by default. A web ACL raising it with
+ * `AssociationConfig` passes the raised figure in.
  */
 export function simWafInspectedRequest(
   request: Request,
   body?: Uint8Array,
+  bodyInspectionLimitBytes: number = simWafBodyInspectionLimitBytes,
 ): SimWafInspectedRequest {
   const url = new URL(request.url);
 
@@ -62,6 +78,7 @@ export function simWafInspectedRequest(
     headers: request.headers,
     host: simAwsRequestHostname(request),
     body,
+    bodyInspectionLimitBytes,
     labels: new SimWafRequestLabels(),
   };
 }

--- a/src/service/wafv2/index.ts
+++ b/src/service/wafv2/index.ts
@@ -79,7 +79,12 @@ export {
   type SimWafInspectedRequest,
   simWafInspectedRequest,
 } from "./evaluate/sim-waf-inspected-request.js";
-export { simWafInspectionLimitBytes } from "./statement/sim-waf-field-content.js";
+export { simWafHeaderInspectionLimitBytes } from "./statement/sim-waf-field-content.js";
+export {
+  type SimWafAssociationConfigInput,
+  type SimWafBodyInspectionResourceType,
+  simWafBodyInspectionLimitBytes,
+} from "./web-acl/sim-waf-association-config.js";
 export type { SimWafRateBasedStatementInput } from "./statement/sim-waf-rate-based.type.js";
 export type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
 export {

--- a/src/service/wafv2/managed/sim-waf-managed-request.ts
+++ b/src/service/wafv2/managed/sim-waf-managed-request.ts
@@ -1,5 +1,4 @@
 import type { SimWafInspectedRequest } from "../evaluate/sim-waf-inspected-request.js";
-import { simWafInspectionLimitBytes } from "../statement/sim-waf-field-content.js";
 import { simWafQueryArguments } from "../statement/sim-waf-request-fields.js";
 
 const encoder = new TextEncoder();
@@ -69,7 +68,7 @@ export function simWafManagedRequestParts(
     headerValues: [...request.headers].map(([, value]) => value),
     userAgent: request.headers.get("user-agent") ?? undefined,
     cookieHeader,
-    body: decoder.decode(body.subarray(0, simWafInspectionLimitBytes)),
+    body: decoder.decode(body.subarray(0, request.bodyInspectionLimitBytes)),
     uriPathBytes: simWafByteLength(request.uriPath),
     queryStringBytes: simWafByteLength(request.queryString),
     cookieHeaderBytes: simWafByteLength(cookieHeader),

--- a/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
@@ -219,6 +219,19 @@ describe("SimWafV2 refusals", () => {
     assertStringIncludes(error.message, "KB_24");
   });
 
+  it("refuses a RequestBody entry that sets no body inspection limit", async () => {
+    // When a web ACL names a resource type and says nothing about the limit,
+    // which a hand-written template is where this comes from.
+    const error = await refusalFor({
+      AssociationConfig: { RequestBody: { CLOUDFRONT: undefined } },
+    });
+
+    // Then it is refused the way an unusable size is, ahead of the type error
+    // reading a limit off nothing would have raised.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "DefaultSizeInspectionLimit");
+  });
+
   it("refuses a body inspection limit for a resource type it cannot protect", async () => {
     // When a web ACL sets the limit for a resource type nothing here goes in
     // front of.

--- a/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
+++ b/src/service/wafv2/sim-wafv2-refusals.iso.test.ts
@@ -8,7 +8,10 @@ import { describe, it } from "vitest";
 import { SimAws } from "../aws/sim-aws.js";
 import { simWafCreateWebAclFactory } from "./command/web-acl/sim-waf-create-web-acl.factory.js";
 import type { SimCreateWebAclCommandInput } from "./command/web-acl/web-acl.command.js";
-import { SimWafUnsimulatedInputException } from "./error/sim-wafv2.error.js";
+import {
+  SimWafInvalidParameterException,
+  SimWafUnsimulatedInputException,
+} from "./error/sim-wafv2.error.js";
 import { createSimWafWebAcl } from "./sim-wafv2.fixture.js";
 import type { SimWafStatementInput } from "./statement/sim-waf-statement.type.js";
 import type { SimWafRuleInput } from "./web-acl/sim-waf-rule.type.js";
@@ -203,17 +206,33 @@ describe("SimWafV2 refusals", () => {
     assertStringIncludes(challenge.message, "Challenge");
   });
 
-  it("refuses a web ACL member this simulation does not model", async () => {
-    // When a web ACL sets the body size its associations inspect.
+  it("refuses a body inspection limit that is not one of the four sizes", async () => {
+    // When a web ACL asks for a body inspection limit AWS has no setting for.
     const error = await refusalFor({
       AssociationConfig: {
-        RequestBody: { CLOUDFRONT: { DefaultSizeInspectionLimit: "KB_16" } },
+        RequestBody: { CLOUDFRONT: { DefaultSizeInspectionLimit: "KB_24" } },
       },
     });
 
-    // Then it is refused, since nothing is associated with a web ACL yet.
+    // Then it is refused, the way WAFv2 refuses the value.
+    assertInstanceOf(error, SimWafInvalidParameterException);
+    assertStringIncludes(error.message, "KB_24");
+  });
+
+  it("refuses a body inspection limit for a resource type it cannot protect", async () => {
+    // When a web ACL sets the limit for a resource type nothing here goes in
+    // front of.
+    const error = await refusalFor({
+      AssociationConfig: {
+        RequestBody: {
+          APP_RUNNER_SERVICE: { DefaultSizeInspectionLimit: "KB_32" },
+        },
+      },
+    });
+
+    // Then it is refused rather than accepted and never applied.
     assertInstanceOf(error, SimWafUnsimulatedInputException);
-    assertStringIncludes(error.message, "AssociationConfig");
+    assertStringIncludes(error.message, "APP_RUNNER_SERVICE");
   });
 
   it("refuses tags on a web ACL", async () => {

--- a/src/service/wafv2/sim-wafv2.ts
+++ b/src/service/wafv2/sim-wafv2.ts
@@ -123,8 +123,10 @@ export class SimWafV2 extends SimWafSets {
       );
     }
 
+    const limitBytes = webAcl.bodyInspectionLimitBytes(evaluation.resourceType);
+
     return webAcl.evaluate(
-      simWafInspectedRequest(evaluation.request, evaluation.body),
+      simWafInspectedRequest(evaluation.request, evaluation.body, limitBytes),
     );
   }
 

--- a/src/service/wafv2/statement/sim-waf-body-inspection-limit.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-body-inspection-limit.iso.test.ts
@@ -1,0 +1,202 @@
+import {
+  assertFalse,
+  assertIdentical,
+  assertObjectEquals,
+  assertTrue,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { simWafCreateWebAclFactory } from "../command/web-acl/sim-waf-create-web-acl.factory.js";
+import type { SimCreateWebAclCommandInput } from "../command/web-acl/web-acl.command.js";
+import { createSimWafWebAcl } from "../sim-wafv2.fixture.js";
+import type { SimWafV2 } from "../sim-wafv2.js";
+import type { SimWafBodyInspectionResourceType } from "../web-acl/sim-waf-association-config.js";
+import { simWafRuleFactory } from "../web-acl/sim-waf-rule.factory.js";
+import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
+import { simWafHeaderInspectionLimitBytes } from "./sim-waf-field-content.js";
+import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
+
+const encoder = new TextEncoder();
+
+const kilobytes = 1024;
+
+/**
+ * A statement looking for one string in whichever field it is pointed at.
+ */
+function contains(
+  searchString: string,
+  field: SimWafFieldToMatchInput,
+): SimWafStatementInput {
+  return {
+    ByteMatchStatement: {
+      SearchString: searchString,
+      PositionalConstraint: "CONTAINS",
+      FieldToMatch: field,
+      TextTransformations: [{ Priority: 0, Type: "NONE" }],
+    },
+  };
+}
+
+/**
+ * A body of one size with the search string at the very end of it.
+ *
+ * A rule only finds the needle when WAF read the whole body, which is what
+ * makes the size the thing under test.
+ */
+function bodyEndingIn(needle: string, sizeBytes: number): Uint8Array {
+  return encoder.encode(`${"x".repeat(sizeBytes - needle.length)}${needle}`);
+}
+
+/**
+ * Put requests through a web ACL holding one blocking rule.
+ *
+ * The resource type is the one the request reached, which is what decides how
+ * much of its body the rule reads.
+ */
+async function blocksRequest(
+  simWaf: SimWafV2,
+  statement: SimWafStatementInput,
+  webAcl: Partial<SimCreateWebAclCommandInput> = {},
+): Promise<
+  (body: Uint8Array, resourceType?: SimWafBodyInspectionResourceType) => boolean
+> {
+  const { ARN: webAclArn } = await createSimWafWebAcl(simWaf, {
+    ...simWafCreateWebAclFactory.make(),
+    ...webAcl,
+    Rules: [{ ...simWafRuleFactory.make(), Statement: statement }],
+  });
+
+  return (body, resourceType): boolean =>
+    simWaf.evaluateRequest({
+      webAclArn,
+      request: new Request("https://example.test/", { method: "POST" }),
+      body,
+      resourceType,
+    }).action === "BLOCK";
+}
+
+describe("SimWafV2 body inspection limit", () => {
+  it("reads 16 KB of a body, which is what every protected resource type reads", async () => {
+    // Given a rule looking for a string at the end of a 12 KB body, which is
+    // past the 8 KB an Application Load Balancer would have stopped at.
+    const blocks = await blocksRequest(
+      new SimAws().wafV2(),
+      contains("needle", { Body: { OversizeHandling: "CONTINUE" } }),
+    );
+
+    // Then WAF read that far, and the rule claims the request.
+    assertTrue(blocks(bodyEndingIn("needle", 12 * kilobytes)));
+  });
+
+  it("treats a body as oversize only once it passes 16 KB", async () => {
+    // Given a rule that blocks whatever it could not read.
+    const blocks = await blocksRequest(
+      new SimAws().wafV2(),
+      contains("needle", { Body: { OversizeHandling: "MATCH" } }),
+    );
+
+    // Then a 12 KB body is inspected and goes through, and a 20 KB body is the
+    // one the rule refuses to let past unread.
+    const inspected = encoder.encode("x".repeat(12 * kilobytes));
+    const oversize = encoder.encode("x".repeat(20 * kilobytes));
+
+    assertFalse(blocks(inspected));
+    assertTrue(blocks(oversize));
+  });
+
+  it("reads as far as the AssociationConfig for the resource type says", async () => {
+    // Given a web ACL raising the CloudFront body limit to 64 KB.
+    const blocks = await blocksRequest(
+      new SimAws().wafV2(),
+      contains("needle", { Body: { OversizeHandling: "CONTINUE" } }),
+      {
+        Scope: "CLOUDFRONT",
+        AssociationConfig: {
+          RequestBody: { CLOUDFRONT: { DefaultSizeInspectionLimit: "KB_64" } },
+        },
+      },
+    );
+
+    // Then a 40 KB body reaching a distribution is read to the end.
+    assertTrue(blocks(bodyEndingIn("needle", 40 * kilobytes), "CLOUDFRONT"));
+  });
+
+  it("raises the limit for the resource type the config keyed it under", async () => {
+    // Given a web ACL raising the limit for a REST API stage alone.
+    const blocks = await blocksRequest(
+      new SimAws().wafV2(),
+      contains("needle", { Body: { OversizeHandling: "CONTINUE" } }),
+      {
+        AssociationConfig: {
+          RequestBody: {
+            API_GATEWAY: { DefaultSizeInspectionLimit: "KB_48" },
+          },
+        },
+      },
+    );
+    const body = bodyEndingIn("needle", 40 * kilobytes);
+
+    // Then the stage reads the whole 40 KB body, and a user pool the same web
+    // ACL is in front of stops at the default 16 KB.
+    assertTrue(blocks(body, "API_GATEWAY"));
+    assertFalse(blocks(body, "COGNITO_USER_POOL"));
+  });
+
+  it("holds a header set to 8 KB whatever the body limit is", async () => {
+    // Given a web ACL raising the body limit as far as it goes.
+    const simWaf = new SimAws().wafV2();
+    const { ARN: webAclArn } = await createSimWafWebAcl(simWaf, {
+      ...simWafCreateWebAclFactory.make(),
+      AssociationConfig: {
+        RequestBody: { API_GATEWAY: { DefaultSizeInspectionLimit: "KB_64" } },
+      },
+      Rules: [
+        {
+          ...simWafRuleFactory.make(),
+          Statement: contains("needle", {
+            Headers: {
+              MatchPattern: { All: {} },
+              MatchScope: "VALUE",
+              OversizeHandling: "MATCH",
+            },
+          }),
+        },
+      ],
+    });
+    const headers = new Headers({
+      "x-large": "y".repeat(simWafHeaderInspectionLimitBytes + 1),
+    });
+
+    // Then a header set over 8 KB is still more than WAF reads.
+    assertIdentical(
+      simWaf.evaluateRequest({
+        webAclArn,
+        request: new Request("https://example.test/", { headers }),
+        resourceType: "API_GATEWAY",
+      }).action,
+      "BLOCK",
+    );
+  });
+
+  it("reports the AssociationConfig a web ACL was written with", async () => {
+    // Given a web ACL created with a raised body limit.
+    const simWaf = new SimAws().wafV2();
+    const associationConfig = {
+      RequestBody: {
+        COGNITO_USER_POOL: { DefaultSizeInspectionLimit: "KB_32" },
+      },
+    };
+    const summary = await createSimWafWebAcl(simWaf, {
+      ...simWafCreateWebAclFactory.make(),
+      AssociationConfig: associationConfig,
+    });
+
+    // Then GetWebACL answers with it.
+    const found = await simWaf.getWebAcl({
+      input: { Name: summary.Name, Id: summary.Id, Scope: "REGIONAL" },
+    });
+
+    assertObjectEquals(found.WebACL?.AssociationConfig, associationConfig);
+  });
+});

--- a/src/service/wafv2/statement/sim-waf-field-content.ts
+++ b/src/service/wafv2/statement/sim-waf-field-content.ts
@@ -14,13 +14,13 @@ export type SimWafFieldContent =
   | { readonly outcome: "noMatch" };
 
 /**
- * How much of a request body, header set or cookie set WAF reads.
+ * How much of a header set or a cookie set WAF reads.
  *
- * Real WAF stops at 8 KB for a web ACL as it is created here. A CloudFront
- * association can raise the body limit, which is settled where associations
- * are, so this is the one figure until then.
+ * Real WAF stops at 8 KB and 200 entries for both, whatever the web ACL is in
+ * front of. A body is the component whose limit varies by resource type, and
+ * `simWafBodyInspectionLimitBytes` carries that one.
  */
-export const simWafInspectionLimitBytes = 8192;
+export const simWafHeaderInspectionLimitBytes = 8192;
 
 /**
  * What a rule does about content too large for WAF to read.
@@ -56,15 +56,19 @@ export function requiredSimWafOversizeHandling(
  * settle the statement without looking, and `CONTINUE` inspects as much as WAF
  * would have read: whole entries while they fit, and the first entry cut to
  * the limit when even one does not.
+ *
+ * The limit is passed in because a body's varies with the resource type the
+ * request reached, while a header set and a cookie set are always 8 KB.
  */
 export function simWafFieldContent(
   candidates: readonly string[],
   oversizeHandling: SimWafOversizeHandling,
+  limitBytes: number,
 ): SimWafFieldContent {
   const encoded = candidates.map((candidate) => encoder.encode(candidate));
   const total = encoded.reduce((sum, bytes) => sum + bytes.length, 0);
 
-  if (total <= simWafInspectionLimitBytes) {
+  if (total <= limitBytes) {
     return { outcome: "inspect", candidates };
   }
 
@@ -72,15 +76,21 @@ export function simWafFieldContent(
     return { outcome: oversizeHandling === "MATCH" ? "match" : "noMatch" };
   }
 
-  return { outcome: "inspect", candidates: readWithinLimit(encoded) };
+  return {
+    outcome: "inspect",
+    candidates: readWithinLimit(encoded, limitBytes),
+  };
 }
 
 /**
  * The content WAF would have read before it stopped.
  */
-function readWithinLimit(encoded: readonly Uint8Array[]): readonly string[] {
+function readWithinLimit(
+  encoded: readonly Uint8Array[],
+  limitBytes: number,
+): readonly string[] {
   const read: string[] = [];
-  let budget = simWafInspectionLimitBytes;
+  let budget = limitBytes;
 
   for (const bytes of encoded) {
     if (budget === 0) {

--- a/src/service/wafv2/statement/sim-waf-field-to-match.iso.test.ts
+++ b/src/service/wafv2/statement/sim-waf-field-to-match.iso.test.ts
@@ -4,7 +4,8 @@ import { describe, it } from "vitest";
 import { SimAws } from "../../aws/sim-aws.js";
 import { simWafStatementMatches } from "../sim-wafv2.fixture.js";
 import type { SimWafFieldToMatchInput } from "./sim-waf-field-to-match.type.js";
-import { simWafInspectionLimitBytes } from "./sim-waf-field-content.js";
+import { simWafBodyInspectionLimitBytes } from "../web-acl/sim-waf-association-config.js";
+import { simWafHeaderInspectionLimitBytes } from "./sim-waf-field-content.js";
 import type { SimWafStatementInput } from "./sim-waf-statement.type.js";
 
 /**
@@ -288,7 +289,7 @@ describe("SimWafV2 field to match", () => {
     );
     const headers = new Headers({ "x-first": "needle" });
 
-    headers.set("x-second", "y".repeat(simWafInspectionLimitBytes));
+    headers.set("x-second", "y".repeat(simWafHeaderInspectionLimitBytes));
 
     // Then a header WAF read before it stopped still matches.
     assertTrue(matches(new Request("https://example.test/", { headers })));
@@ -308,7 +309,7 @@ describe("SimWafV2 field to match", () => {
       }),
     );
     const headers = new Headers({
-      "x-first": "y".repeat(simWafInspectionLimitBytes),
+      "x-first": "y".repeat(simWafHeaderInspectionLimitBytes),
       "x-second": "needle",
     });
 
@@ -342,7 +343,7 @@ describe("SimWafV2 field to match", () => {
       contains("needle", { Body: { OversizeHandling: "CONTINUE" } }),
     );
     const body = encoder.encode(
-      `${"x".repeat(simWafInspectionLimitBytes)}needle`,
+      `${"x".repeat(simWafBodyInspectionLimitBytes)}needle`,
     );
 
     // Then it does not match, because WAF never got that far either.
@@ -355,7 +356,7 @@ describe("SimWafV2 field to match", () => {
       new SimAws().wafV2(),
       contains("needle", { Body: { OversizeHandling: "MATCH" } }),
     );
-    const body = encoder.encode("x".repeat(simWafInspectionLimitBytes + 1));
+    const body = encoder.encode("x".repeat(simWafBodyInspectionLimitBytes + 1));
 
     // Then a body over the limit matches without being looked at, which is how
     // a rule refuses to let anything past that it cannot inspect.
@@ -368,7 +369,7 @@ describe("SimWafV2 field to match", () => {
       new SimAws().wafV2(),
       contains("x", { Body: { OversizeHandling: "NO_MATCH" } }),
     );
-    const body = encoder.encode("x".repeat(simWafInspectionLimitBytes + 1));
+    const body = encoder.encode("x".repeat(simWafBodyInspectionLimitBytes + 1));
 
     // Then it does not match, even though what it was looking for is in there.
     assertFalse(matches(new Request("https://example.test/"), body));

--- a/src/service/wafv2/statement/sim-waf-set-field.ts
+++ b/src/service/wafv2/statement/sim-waf-set-field.ts
@@ -3,6 +3,7 @@ import {
   type SimWafFieldContent,
   requiredSimWafOversizeHandling,
   simWafFieldContent,
+  simWafHeaderInspectionLimitBytes,
 } from "./sim-waf-field-content.js";
 import type {
   SimWafFieldToMatchInput,
@@ -58,6 +59,7 @@ export function compileSimWafSetField(
     simWafFieldContent(
       request.body === undefined ? [] : [decoder.decode(request.body)],
       oversize,
+      request.bodyInspectionLimitBytes,
     );
 }
 
@@ -84,5 +86,6 @@ function entriesReader(
         matchScope,
       }),
       oversize,
+      simWafHeaderInspectionLimitBytes,
     );
 }

--- a/src/service/wafv2/web-acl/sim-waf-association-config.ts
+++ b/src/service/wafv2/web-acl/sim-waf-association-config.ts
@@ -54,7 +54,7 @@ export interface SimWafRequestBodyConfigInput {
  */
 export interface SimWafAssociationConfigInput {
   readonly RequestBody?:
-    | Readonly<Record<string, SimWafRequestBodyConfigInput>>
+    | Readonly<Record<string, SimWafRequestBodyConfigInput | undefined>>
     | undefined;
 }
 
@@ -86,7 +86,7 @@ export class SimWafBodyInspectionLimits {
     for (const [resourceType, config] of configured) {
       limits.set(
         simulatedResourceType(resourceType),
-        inspectionLimit(resourceType, config.DefaultSizeInspectionLimit),
+        inspectionLimit(resourceType, config),
       );
     }
 
@@ -132,11 +132,17 @@ function simulatedResourceType(
 
 /**
  * Read one resource type's `DefaultSizeInspectionLimit`.
+ *
+ * An entry carrying no size is refused the same way one carrying a size WAF
+ * has no setting for is. A template writes this part of a web ACL by hand, and
+ * an entry that says nothing about the limit it is there to set is a mistake
+ * worth reporting as one.
  */
 function inspectionLimit(
   resourceType: string,
-  limit: string | undefined,
+  config: SimWafRequestBodyConfigInput | undefined,
 ): number {
+  const limit = config?.DefaultSizeInspectionLimit;
   const bytes = limit === undefined ? undefined : inspectionLimits.get(limit);
 
   if (bytes === undefined) {

--- a/src/service/wafv2/web-acl/sim-waf-association-config.ts
+++ b/src/service/wafv2/web-acl/sim-waf-association-config.ts
@@ -1,0 +1,151 @@
+import {
+  SimWafInvalidParameterException,
+  SimWafUnsimulatedInputException,
+} from "../error/sim-wafv2.error.js";
+
+/**
+ * A resource type whose body inspection limit a web ACL can set.
+ *
+ * Real WAF keys `AssociationConfig.RequestBody` by resource type, and these
+ * three are the ones a web ACL goes in front of here. `APP_RUNNER_SERVICE` and
+ * `VERIFIED_ACCESS_INSTANCE` are keys AWS takes for resources this simulation
+ * has no association for.
+ */
+export type SimWafBodyInspectionResourceType =
+  | "CLOUDFRONT"
+  | "API_GATEWAY"
+  | "COGNITO_USER_POOL";
+
+/**
+ * How much of a request body WAF reads for a resource type given no
+ * `AssociationConfig`.
+ *
+ * CloudFront, API Gateway and Cognito all default to 16 KB. A load balancer
+ * and an AppSync API are fixed at 8 KB, and a web ACL cannot be put in front
+ * of either one here.
+ */
+export const simWafBodyInspectionLimitBytes = 16_384;
+
+/**
+ * The four sizes `DefaultSizeInspectionLimit` names, in bytes.
+ */
+const inspectionLimits = new Map<string, number>([
+  ["KB_16", 16_384],
+  ["KB_32", 32_768],
+  ["KB_48", 49_152],
+  ["KB_64", 65_536],
+]);
+
+const simulatedResourceTypes: readonly SimWafBodyInspectionResourceType[] = [
+  "CLOUDFRONT",
+  "API_GATEWAY",
+  "COGNITO_USER_POOL",
+];
+
+/**
+ * One resource type's entry under `AssociationConfig.RequestBody`.
+ */
+export interface SimWafRequestBodyConfigInput {
+  readonly DefaultSizeInspectionLimit?: string | undefined;
+}
+
+/**
+ * The `AssociationConfig` a web ACL is written with.
+ */
+export interface SimWafAssociationConfigInput {
+  readonly RequestBody?:
+    | Readonly<Record<string, SimWafRequestBodyConfigInput>>
+    | undefined;
+}
+
+/**
+ * How much of a request body a web ACL's rules read, by resource type.
+ *
+ * A web ACL holds one of these whether or not it was written with an
+ * `AssociationConfig`, and a resource type the config left out reads the
+ * default 16 KB.
+ */
+export class SimWafBodyInspectionLimits {
+  private constructor(
+    private readonly limits: ReadonlyMap<
+      SimWafBodyInspectionResourceType,
+      number
+    >,
+  ) {}
+
+  /**
+   * Read the limits an `AssociationConfig` sets, refusing anything WAF would
+   * refuse and anything this simulation cannot apply.
+   */
+  static read(
+    input: SimWafAssociationConfigInput | undefined,
+  ): SimWafBodyInspectionLimits {
+    const configured = Object.entries(input?.RequestBody ?? {});
+    const limits = new Map<SimWafBodyInspectionResourceType, number>();
+
+    for (const [resourceType, config] of configured) {
+      limits.set(
+        simulatedResourceType(resourceType),
+        inspectionLimit(resourceType, config.DefaultSizeInspectionLimit),
+      );
+    }
+
+    return new SimWafBodyInspectionLimits(limits);
+  }
+
+  /**
+   * How many bytes of a body a request reaching one resource type is inspected
+   * for.
+   *
+   * A request evaluated against a web ACL that no resource holds names no
+   * resource type, and reads the default.
+   */
+  bytesFor(resourceType: SimWafBodyInspectionResourceType | undefined): number {
+    if (resourceType === undefined) {
+      return simWafBodyInspectionLimitBytes;
+    }
+
+    return this.limits.get(resourceType) ?? simWafBodyInspectionLimitBytes;
+  }
+}
+
+/**
+ * Hold a `RequestBody` key to the resource types this simulation associates.
+ */
+function simulatedResourceType(
+  resourceType: string,
+): SimWafBodyInspectionResourceType {
+  const simulated = simulatedResourceTypes.find(
+    (candidate) => candidate === resourceType,
+  );
+
+  if (simulated === undefined) {
+    throw new SimWafUnsimulatedInputException(
+      `AssociationConfig sets the body inspection limit for ${resourceType} ` +
+        `resources, and ${simulatedResourceTypes.join(" and ")} are the ` +
+        `types a web ACL goes in front of in Yulin`,
+    );
+  }
+
+  return simulated;
+}
+
+/**
+ * Read one resource type's `DefaultSizeInspectionLimit`.
+ */
+function inspectionLimit(
+  resourceType: string,
+  limit: string | undefined,
+): number {
+  const bytes = limit === undefined ? undefined : inspectionLimits.get(limit);
+
+  if (bytes === undefined) {
+    throw new SimWafInvalidParameterException(
+      `Error reason: The DefaultSizeInspectionLimit ${String(limit)} is one ` +
+        `of ${inspectionLimits.keys().toArray().join(", ")}, field: ` +
+        `ASSOCIATION_CONFIG, parameter: ${resourceType}`,
+    );
+  }
+
+  return bytes;
+}

--- a/src/service/wafv2/web-acl/sim-waf-web-acl-configuration.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl-configuration.ts
@@ -1,5 +1,6 @@
 import { SimWafInvalidParameterException } from "../error/sim-wafv2.error.js";
 import { SimWafAction } from "./sim-waf-action.js";
+import type { SimWafAssociationConfigInput } from "./sim-waf-association-config.js";
 import type { SimWafActionInput } from "./sim-waf-action.type.js";
 import type { SimWafCustomResponseBodies } from "./sim-waf-custom-response.type.js";
 import type { SimWafRuleInput } from "./sim-waf-rule.type.js";
@@ -13,6 +14,7 @@ export interface SimWafWebAclConfiguration {
   readonly customResponseBodies?: SimWafCustomResponseBodies | undefined;
   readonly visibilityConfig?: unknown;
   readonly description?: string | undefined;
+  readonly associationConfig?: SimWafAssociationConfigInput | undefined;
 }
 
 /**

--- a/src/service/wafv2/web-acl/sim-waf-web-acl.ts
+++ b/src/service/wafv2/web-acl/sim-waf-web-acl.ts
@@ -9,6 +9,10 @@ import {
   type SimWafResourceProperties,
 } from "../resource/sim-waf-resource.js";
 import type { SimWafAction } from "./sim-waf-action.js";
+import {
+  type SimWafBodyInspectionResourceType,
+  SimWafBodyInspectionLimits,
+} from "./sim-waf-association-config.js";
 import type { SimWafRule } from "./sim-waf-rule.js";
 import type { SimWafWebAclRuleScope } from "./sim-waf-rule.type.js";
 import { compileSimWafWebAclRules } from "./sim-waf-rules.js";
@@ -50,6 +54,7 @@ export class SimWafWebAcl extends SimWafResource {
   #defaultAction: SimWafAction;
   #rules: readonly SimWafRule[];
   #capacity: number;
+  #bodyInspectionLimits: SimWafBodyInspectionLimits;
 
   constructor(properties: SimWafWebAclProperties) {
     super("webacl", properties);
@@ -62,6 +67,9 @@ export class SimWafWebAcl extends SimWafResource {
       this.#scope,
     );
     this.#capacity = simWafWebAclCapacity(properties.configuration.rules);
+    this.#bodyInspectionLimits = SimWafBodyInspectionLimits.read(
+      properties.configuration.associationConfig,
+    );
     this.labelNamespace =
       `awswaf:${properties.accountRegionScope.accountId}:webacl:` +
       `${properties.name}:`;
@@ -93,6 +101,9 @@ export class SimWafWebAcl extends SimWafResource {
   ): void {
     const defaultAction = readSimWafDefaultAction(configuration);
     const rules = compileSimWafWebAclRules(configuration, this.#scope);
+    const bodyInspectionLimits = SimWafBodyInspectionLimits.read(
+      configuration.associationConfig,
+    );
 
     this.takeLock(lockToken);
     this.replaceDescription(configuration.description);
@@ -100,6 +111,20 @@ export class SimWafWebAcl extends SimWafResource {
     this.#defaultAction = defaultAction;
     this.#rules = rules;
     this.#capacity = simWafWebAclCapacity(configuration.rules);
+    this.#bodyInspectionLimits = bodyInspectionLimits;
+  }
+
+  /**
+   * How many bytes of a request body this web ACL reads in front of one
+   * resource type.
+   *
+   * `AssociationConfig` raises it per resource type, and a web ACL written
+   * without one reads the 16 KB default everything it protects has.
+   */
+  bodyInspectionLimitBytes(
+    resourceType: SimWafBodyInspectionResourceType | undefined,
+  ): number {
+    return this.#bodyInspectionLimits.bytesFor(resourceType);
   }
 
   /**


### PR DESCRIPTION
Simulated WAF cut every inspected field at 8 KB, the Application Load Balancer and AppSync figure. CloudFront distributions, API Gateway REST API stages and Cognito user pools all send 16 KB, and a rule with `OversizeHandling: MATCH` on the body therefore blocked requests AWS lets through. The body limit is now separate from the 8 KB header and cookie limit, travels with the request so one compiled rule reads a different amount in front of each resource type, and `AssociationConfig` raises it to 32, 48 or 64 KB instead of being refused at `CreateWebACL`.

`simWafInspectionLimitBytes` is gone from the `@kensio/yulin/wafv2` exports, replaced by `simWafBodyInspectionLimitBytes` (16 KB) and `simWafHeaderInspectionLimitBytes` (8 KB). A downstream test that sized an oversize body from the old constant gets a compile error out of the rename. Leaving the name in place would have changed what such a test meant without saying so, so this wants a major release rather than a patch.

Resolves #1305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resource-specific WAF request-body inspection limits through association configuration.
  * Added support for configuring and reporting body inspection limits for supported resources, including CloudFront and API Gateway.
  * Added validation for unsupported resource types and invalid inspection-limit values.

* **Bug Fixes**
  * WAF evaluations now apply the appropriate body limit while retaining fixed header and cookie limits.

* **Documentation**
  * Documented inspection limits, supported resources, configuration options, and oversize handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->