### PR TITLE
fix: match a ForAllValues condition with no key

### DIFF
--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.iso.test.ts
@@ -15,6 +15,8 @@ const negatedKeywords = [
   "StringNotLike",
 ];
 
+const positiveKeywords = ["StringEquals", "StringLike"];
+
 const setQualifiers = ["ForAnyValue", "ForAllValues"];
 
 describe("sim IAM condition operator parsing", () => {
@@ -51,6 +53,25 @@ describe("sim IAM condition operator parsing", () => {
     assertArrayEquals(
       matchesAbsentKey,
       negatedKeywords.flatMap(() => [true, true, false]),
+    );
+  });
+
+  it("matches an absent context key only in the ForAllValues form of a positive keyword", () => {
+    // Given the positive keywords carrying both set forms
+    const parser = new SimIamConditionOperatorParser();
+
+    // When each form is asked whether an absent context key matches it
+    const matchesAbsentKey = positiveKeywords.flatMap((keyword) => [
+      parser.parse(keyword)?.matchesAbsentKey,
+      parser.parse(`ForAllValues:${keyword}`)?.matchesAbsentKey,
+      parser.parse(`ForAnyValue:${keyword}`)?.matchesAbsentKey,
+    ]);
+
+    // Then only the `ForAllValues` forms answer true. AWS matches those where
+    // the request carries no value for the key
+    assertArrayEquals(
+      matchesAbsentKey,
+      positiveKeywords.flatMap(() => [false, true, false]),
     );
   });
 

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
@@ -16,7 +16,10 @@ export interface SimIamConditionOperator {
    * there is none for the policy value to equal.
    *
    * A `ForAnyValue` operator answers false whatever it wraps, because no
-   * request value is there to satisfy it. AWS documents both rules.
+   * request value is there to satisfy it. A `ForAllValues` operator answers
+   * true, because every value the request carries matches vacuously. AWS
+   * documents all three rules, and warns that the `ForAllValues` rule leaves
+   * an `Allow` overly permissive without a `Null` guard beside it.
    */
   readonly matchesAbsentKey: boolean;
 

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-condition-operator.ts
@@ -4,9 +4,13 @@ import { simIamStringValues } from "../sim-iam-string-values.js";
 
 /**
  * Base for `ForAllValues` IAM string operators.
+ *
+ * An absent context key matches. AWS answers true where the request carries
+ * no value for the key. A `ForAllValues` `Allow` therefore needs a `Null`
+ * guard beside it to stay tight.
  */
 export abstract class SimIamForAllValuesStringConditionOperator implements SimIamConditionOperator {
-  readonly matchesAbsentKey = false;
+  readonly matchesAbsentKey = true;
 
   /**
    * Check whether a given value matches the expected value.

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-equals.iso.test.ts
@@ -148,7 +148,7 @@ describe("sim IAM ForAllValues:StringEquals authorization", () => {
     assertTrue(decision.isImplicitDeny);
   });
 
-  it("implicitly denies a request when the required context key is absent", () => {
+  it("allows a request when the context key is absent", () => {
     // Given a policy requiring all supplied tag keys to be accepted.
     const simIam = new SimIam();
     const policy = simIamAuthZResourcePolicySourceFactory.make({
@@ -167,7 +167,7 @@ describe("sim IAM ForAllValues:StringEquals authorization", () => {
       },
     });
 
-    // When authorization omits the required tag-key context.
+    // When authorization omits the tag-key context.
     const decision = simIam.authorize({
       action: "s3:PutObjectTagging",
       resource: "arn:aws:s3:::example-bucket/example-key.txt",
@@ -177,8 +177,8 @@ describe("sim IAM ForAllValues:StringEquals authorization", () => {
       resourcePolicies: [policy],
     });
 
-    // Then the incomplete context does not allow the request.
-    assertTrue(decision.isImplicitDeny);
+    // Then the condition matches vacuously, as it does in AWS.
+    assertTrue(decision.isAllowed);
   });
 
   it("matches the principal ARN derived from the caller", () => {

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-like.iso.test.ts
@@ -148,7 +148,7 @@ describe("sim IAM ForAllValues:StringLike authorization", () => {
     assertTrue(decision.isImplicitDeny);
   });
 
-  it("implicitly denies a request when the required context key is absent", () => {
+  it("allows a request when the context key is absent", () => {
     // Given a policy requiring every tag key to match an app pattern.
     const simIam = new SimIam();
     const policy = simIamAuthZResourcePolicySourceFactory.make({
@@ -167,7 +167,7 @@ describe("sim IAM ForAllValues:StringLike authorization", () => {
       },
     });
 
-    // When authorization omits the required tag-key context.
+    // When authorization omits the tag-key context.
     const decision = simIam.authorize({
       action: "s3:PutObjectTagging",
       resource: "arn:aws:s3:::example-bucket/example-key.txt",
@@ -177,8 +177,8 @@ describe("sim IAM ForAllValues:StringLike authorization", () => {
       resourcePolicies: [policy],
     });
 
-    // Then the incomplete context does not allow the request.
-    assertTrue(decision.isImplicitDeny);
+    // Then the condition matches vacuously, as it does in AWS.
+    assertTrue(decision.isAllowed);
   });
 
   it("matches a pattern against the principal ARN derived from the caller", () => {


### PR DESCRIPTION
AWS returns true for a ForAllValues condition where the request carries no value for the context key, and warns that this leaves an `Allow` overly permissive without a `Null` guard beside it. Sim IAM returned false, refusing a policy AWS accepts and hiding the over-permissiveness AWS warns about. `SimIamForAllValuesStringConditionOperator` now declares `matchesAbsentKey` as true. The `ForAnyValue` operator still answers false, as AWS documents for that form, and the negated `ForAllValues` form already answered true.

Resolves https://github.com/KensioSoftware/yulin/issues/1309

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [ ] User-facing behaviour is documented in `docs/`

`docs/` carries no condition-operator reference, so there is nothing there to correct.
