### PR TITLE
feat: supply dynamodb:LeadingKeys to sim IAM

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3637,6 +3637,101 @@ unauthorized caller cannot find out which names are taken.
 in the same way, each against the `dynamodb:` action of its own name. `ListTables` names no table.
 It authorizes against `*`.
 
+### Fine-grained access control with dynamodb:LeadingKeys
+
+`GetItem`, `BatchGetItem`, `Query`, `PutItem`, `UpdateItem`, `DeleteItem` and `BatchWriteItem`
+supply the partition key values they reach as `dynamodb:LeadingKeys`. A policy conditioned on that
+key restricts a caller to the items under particular partition keys. AWS scopes one user of a
+shared table to their own rows this way.
+
+The condition takes the `ForAllValues:` qualifier, as AWS requires for this key. Every partition key
+value the request reaches has to match. A batch or a write naming one item outside the allowed set
+is refused whole, and nothing it asked for is applied.
+
+```typescript sim-dynamodb-leading-keys
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const region = simAws.defaultRegionName;
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "customerId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+const roleCreation = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "CustomerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "CustomerRole",
+    PolicyName: "OwnItemsOnly",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "dynamodb:PutItem",
+        Resource: `arn:aws:dynamodb:${region}:${accountId}:table/OrdersTable`,
+        Condition: {
+          "ForAllValues:StringEquals": { "dynamodb:LeadingKeys": ["c-1"] },
+        },
+      },
+    }),
+  }),
+);
+
+const caller = { kind: "arn", arn: roleCreation.Role.Arn } as const;
+
+// The customer's own item is written.
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { customerId: { S: "c-1" }, total: { N: "25" } },
+  }),
+  { caller },
+);
+
+// Another customer's item is refused.
+try {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: { customerId: { S: "c-2" }, total: { N: "25" } },
+    }),
+    { caller },
+  );
+} catch (error) {
+  console.log(error instanceof Error ? error.name : "unknown error");
+  // "AccessDenied"
+}
+```
+
+Reading the partition key values needs the table's key schema. The table is found first for that,
+before the caller is authorized against it. A caller with no permission still hears `AccessDenied`
+when the table is missing, and an unauthorized caller cannot find out which table names are taken.
+
+A request carrying no readable partition key value leaves the key out of the condition context. A
+`ForAllValues:` condition matches a request carrying no value for its key, as it does on AWS. The
+condition allows such a request.
+
 A transaction is authorized as the operations it is made of rather than as itself. Each action of a
 `TransactWriteItems` needs `dynamodb:PutItem`, `dynamodb:UpdateItem`, `dynamodb:DeleteItem` or
 `dynamodb:ConditionCheckItem` against the table it names, and each `Get` of a `TransactGetItems`
@@ -3657,6 +3752,9 @@ is written.
   answering with the attributes it projects, and paging with a `LastEvaluatedKey` carrying the index
   key and the table key together. A local secondary index also answers a strongly consistent read,
   and fetches an unprojected attribute from the base table.
+- `dynamodb:LeadingKeys` on `GetItem`, `BatchGetItem`, `Query`, `PutItem`, `UpdateItem`,
+  `DeleteItem` and `BatchWriteItem`, carrying the partition key values the request reaches so a
+  `ForAllValues:` condition can scope a caller to particular items.
 - `DescribeTable`, answering with the full table description, by table name or ARN.
 - `ListTables`, ordered by UTF-8 bytes and paged with `Limit` and `ExclusiveStartTableName`.
 - `DeleteTable`, following the table status DynamoDB moves a deleted table through, and refusing a
@@ -3730,6 +3828,16 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
 
 ## Limitations
 
+- `dynamodb:LeadingKeys` is the only DynamoDB condition key supplied. `dynamodb:Attributes`,
+  `dynamodb:Select` and `dynamodb:ReturnValues` are absent from the condition context, and a
+  statement conditioned on one of them matches no request. The transactional operations supply no
+  leading keys either, and are authorized by action and table alone.
+- A partition key value reaches a policy condition as a string for a `S` key and as its digits for
+  an `N` key. A binary partition key has no documented form for the condition key. A request
+  carrying one leaves the value out.
+- A request against a table that is not there is authorized carrying no leading keys, since there is
+  no key schema to read them with. A `ForAllValues:` condition matches such a request. A caller
+  barred only by that condition learns the table is missing.
 - The document client's PartiQL Commands go unconverted, because PartiQL is an operation this
   simulation lacks yet. `ExecuteStatementCommand`, `BatchExecuteStatementCommand` and
   `ExecuteTransactionCommand` are refused by name, never half converted.

--- a/docs/services/dynamodb/sim-dynamodb-leading-keys.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-leading-keys.example.ts
@@ -1,0 +1,73 @@
+import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+const accountId = simAws.defaultAccountId;
+const region = simAws.defaultRegionName;
+
+await simAws.dynamoDb().createTable(
+  new CreateTableCommand({
+    TableName: "OrdersTable",
+    KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "customerId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+
+const roleCreation = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "CustomerRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${accountId}:root` },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "CustomerRole",
+    PolicyName: "OwnItemsOnly",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: "dynamodb:PutItem",
+        Resource: `arn:aws:dynamodb:${region}:${accountId}:table/OrdersTable`,
+        Condition: {
+          "ForAllValues:StringEquals": { "dynamodb:LeadingKeys": ["c-1"] },
+        },
+      },
+    }),
+  }),
+);
+
+const caller = { kind: "arn", arn: roleCreation.Role.Arn } as const;
+
+// The customer's own item is written.
+await simAws.dynamoDb().putItem(
+  new PutItemCommand({
+    TableName: "OrdersTable",
+    Item: { customerId: { S: "c-1" }, total: { N: "25" } },
+  }),
+  { caller },
+);
+
+// Another customer's item is refused.
+try {
+  await simAws.dynamoDb().putItem(
+    new PutItemCommand({
+      TableName: "OrdersTable",
+      Item: { customerId: { S: "c-2" }, total: { N: "25" } },
+    }),
+    { caller },
+  );
+} catch (error) {
+  console.log(error instanceof Error ? error.name : "unknown error");
+  // "AccessDenied"
+}

--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -335,6 +335,11 @@ matches instead, as AWS documents. With no value in the request there is none fo
 to equal. A `ForAnyValue:` operator answers false for an absent key whatever it wraps, because no
 request value is there to satisfy it.
 
+A `ForAllValues:` operator answers true for an absent key, which is also AWS behaviour. Every value
+the request carries matches when it carries none. AWS warns that this leaves a `ForAllValues:`
+`Allow` overly permissive, and asks for a `Null` check with a `false` value beside it. `Null` is
+absent from the operators above. A statement written that way fails closed here.
+
 ### Statements left unevaluated
 
 An operator from outside the list above fails closed. The statement holding it matches nothing, and
@@ -1684,8 +1689,9 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
 - Only the condition operators listed above are supported. A statement using any other operator
   fails closed, matching no request. `decision.unevaluatedStatements` names those statements, and a
   test can assert that a decision was reached over policies read in full
-- A positive `ForAllValues:` condition fails to match a request carrying no value for the key, and
-  fails to match an empty value set. AWS matches both, and the negated form here matches both
+- A positive `ForAllValues:` condition fails to match an empty value set, where AWS matches one. An
+  absent context key matches, as it does on AWS. A service here leaves a key out where the request
+  carries no value for it, and the empty set is reached only by a caller passing one to `authorize`
 - Signature age is deliberately not enforced. `X-Amz-Date` must be present, well formed, and agree
   with the credential scope date, but is never compared to a clock. A client stamping real time can
   therefore reach a simulation keeping a different one. Session expiry _is_ enforced, against

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-authorizer.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-authorizer.ts
@@ -4,6 +4,24 @@ import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-regi
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simDynamoDbTableArn } from "../../table/sim-dynamodb-table-arn.js";
+import { simDynamoDbLeadingKeysConditionKey } from "./sim-dynamodb-leading-keys.js";
+
+/**
+ * The condition values a request carries for the table it names.
+ *
+ * A request reaching no partition key value supplies none rather than an empty
+ * list, leaving the key absent from the context as it is on AWS for an
+ * operation that names no item.
+ */
+function conditionContextOf(
+  leadingKeys: readonly string[] | undefined,
+): Readonly<Record<string, readonly string[]>> {
+  if (leadingKeys === undefined || leadingKeys.length === 0) {
+    return {};
+  }
+
+  return { [simDynamoDbLeadingKeysConditionKey]: leadingKeys };
+}
 
 interface SimDynamoDbAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -42,11 +60,13 @@ export class SimDynamoDbAuthorizer {
     action: string,
     tableName: string,
     caller?: SimAwsCaller,
+    leadingKeys?: readonly string[],
   ): SimAwsResolvedCaller {
     return this.authorizeResource(
       action,
       simDynamoDbTableArn(this.accountRegionScope, tableName),
       caller,
+      leadingKeys,
     );
   }
 
@@ -85,8 +105,14 @@ export class SimDynamoDbAuthorizer {
     action: string,
     resource: string,
     caller: SimAwsCaller | undefined,
+    leadingKeys?: readonly string[],
   ): SimAwsResolvedCaller {
-    const decision = this.iam.authorize({ action, resource, caller });
+    const decision = this.iam.authorize({
+      action,
+      resource,
+      caller,
+      conditionContext: conditionContextOf(leadingKeys),
+    });
 
     if (decision.isDenied) {
       throw new SimIamAccessDenied({

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-leading-keys.iso.test.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-leading-keys.iso.test.ts
@@ -306,6 +306,31 @@ describe("DynamoDB dynamodb:LeadingKeys authorization", () => {
     assertInstanceOf(error, SimIamAccessDenied);
   });
 
+  it("refuses a caller before checking the key it named", async () => {
+    // Given a caller allowed nothing, and a table it names an item of.
+    const simAws = new SimAws();
+    await simDynamoDbStockedTableFactory.make({}, simAws);
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "NoItemsRole" },
+      simAws,
+    );
+
+    // When it reads with no Key at all, which the command refuses on its own.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws
+        .dynamoDb()
+        .getItem(
+          { input: { TableName: tableName } },
+          { caller: { kind: "arn", arn: role.Arn } },
+        ),
+    );
+
+    // Then it hears AccessDenied rather than what was wrong with the request.
+    // Reading the partition key values happens before authorization, and a
+    // request too malformed to read them from is authorized carrying none.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
   it("allows a request naming no partition key value it can read", async () => {
     // Given a caller scoped to one customer and a table keyed by binary.
     const simAws = new SimAws();

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-leading-keys.iso.test.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-leading-keys.iso.test.ts
@@ -1,0 +1,339 @@
+import {
+  assertIdentical,
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simDynamoDbStockedTableFactory } from "../../table/sim-dynamodb-stocked-table.factory.js";
+
+const tableName = "OrdersTable";
+
+/**
+ * The item actions DynamoDB supplies `dynamodb:LeadingKeys` for.
+ */
+const scopedActions = [
+  "dynamodb:GetItem",
+  "dynamodb:BatchGetItem",
+  "dynamodb:Query",
+  "dynamodb:PutItem",
+  "dynamodb:UpdateItem",
+  "dynamodb:DeleteItem",
+  "dynamodb:BatchWriteItem",
+];
+
+/**
+ * A caller allowed the item actions on the table, for one partition key only.
+ *
+ * This is the fine-grained access control policy the DynamoDB developer guide
+ * writes, with the customer named outright rather than through a federated
+ * identity substitution variable.
+ */
+async function callerScopedTo(
+  simAws: SimAws,
+  allowed: string,
+): Promise<SimAwsCaller> {
+  const simIam = simAws.iam();
+  const roleName = "CustomerRole";
+  const creation = await simIam.createRole({
+    input: {
+      RoleName: roleName,
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    },
+  });
+
+  await simIam.putRolePolicy({
+    input: {
+      RoleName: roleName,
+      PolicyName: "OwnItemsOnly",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Action: scopedActions,
+          Resource: `arn:aws:dynamodb:${simAws.defaultRegionName}:${simAws.defaultAccountId}:table/${tableName}`,
+          Condition: {
+            "ForAllValues:StringEquals": { "dynamodb:LeadingKeys": [allowed] },
+          },
+        },
+      }),
+    },
+  });
+
+  return { kind: "arn", arn: creation.Role.Arn };
+}
+
+/**
+ * One request against the table, named by the customer whose items it reaches.
+ */
+const requests = {
+  "dynamodb:GetItem": async (
+    simAws: SimAws,
+    customerId: string,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().getItem(
+      {
+        input: {
+          TableName: tableName,
+          Key: { customerId: { S: customerId }, orderId: { S: "2026-01" } },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:Query": async (
+    simAws: SimAws,
+    customerId: string,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().query(
+      {
+        input: {
+          TableName: tableName,
+          KeyConditionExpression: "customerId = :customerId",
+          ExpressionAttributeValues: { ":customerId": { S: customerId } },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:PutItem": async (
+    simAws: SimAws,
+    customerId: string,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().putItem(
+      {
+        input: {
+          TableName: tableName,
+          Item: { customerId: { S: customerId }, orderId: { S: "2026-09" } },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:UpdateItem": async (
+    simAws: SimAws,
+    customerId: string,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().updateItem(
+      {
+        input: {
+          TableName: tableName,
+          Key: { customerId: { S: customerId }, orderId: { S: "2026-01" } },
+          UpdateExpression: "SET #status = :status",
+          ExpressionAttributeNames: { "#status": "status" },
+          ExpressionAttributeValues: { ":status": { S: "PAID" } },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:DeleteItem": async (
+    simAws: SimAws,
+    customerId: string,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().deleteItem(
+      {
+        input: {
+          TableName: tableName,
+          Key: { customerId: { S: customerId }, orderId: { S: "2026-01" } },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:BatchGetItem": async (
+    simAws: SimAws,
+    customerId: string,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().batchGetItem(
+      {
+        input: {
+          RequestItems: {
+            [tableName]: {
+              Keys: [
+                { customerId: { S: "c-1" }, orderId: { S: "2026-01" } },
+                { customerId: { S: customerId }, orderId: { S: "2026-02" } },
+              ],
+            },
+          },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:BatchWriteItem": async (
+    simAws: SimAws,
+    customerId: string,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().batchWriteItem(
+      {
+        input: {
+          RequestItems: {
+            [tableName]: [
+              {
+                PutRequest: {
+                  Item: {
+                    customerId: { S: "c-1" },
+                    orderId: { S: "2026-09" },
+                  },
+                },
+              },
+              {
+                PutRequest: {
+                  Item: {
+                    customerId: { S: customerId },
+                    orderId: { S: "2026-10" },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      { caller },
+    ),
+} as const;
+
+describe("DynamoDB dynamodb:LeadingKeys authorization", () => {
+  it.each(scopedActions)(
+    "allows %s where every partition key the request reaches is the caller's",
+    async (action) => {
+      // Given a caller scoped to one customer's items.
+      const simAws = new SimAws();
+      await simDynamoDbStockedTableFactory.make({}, simAws);
+      const caller = await callerScopedTo(simAws, "c-1");
+
+      // When it reaches only that customer's items.
+      const answer = await requests[action as keyof typeof requests](
+        simAws,
+        "c-1",
+        caller,
+      );
+
+      // Then the condition holds and the request is answered.
+      assertNonNullable(answer);
+    },
+  );
+
+  it.each(scopedActions)(
+    "refuses %s where the request reaches another customer's partition key",
+    async (action) => {
+      // Given the same caller, scoped to one customer's items.
+      const simAws = new SimAws();
+      await simDynamoDbStockedTableFactory.make({}, simAws);
+      const caller = await callerScopedTo(simAws, "c-1");
+
+      // When it reaches an item under another customer's partition key.
+      const error = await assertThrowsErrorAsync(async () =>
+        requests[action as keyof typeof requests](simAws, "c-2", caller),
+      );
+
+      // Then the condition fails and the whole request is refused.
+      assertInstanceOf(error, SimIamAccessDenied);
+      assertIdentical(error.action, action);
+    },
+  );
+
+  it("compares a number partition key by its digits", async () => {
+    // Given a table keyed by a number and a caller scoped to one of them.
+    const simAws = new SimAws();
+    await simAws.dynamoDb().createTable({
+      input: {
+        TableName: tableName,
+        KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "N" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      },
+    });
+    const caller = await callerScopedTo(simAws, "42");
+
+    // When it writes the item under that number, written with a trailing zero.
+    await simAws.dynamoDb().putItem(
+      {
+        input: { TableName: tableName, Item: { customerId: { N: "42.0" } } },
+      },
+      { caller },
+    );
+
+    // Then the digits DynamoDB holds the number as are what the policy matched.
+    const error = await assertThrowsErrorAsync(async () =>
+      simAws.dynamoDb().putItem(
+        {
+          input: { TableName: tableName, Item: { customerId: { N: "43" } } },
+        },
+        { caller },
+      ),
+    );
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("refuses a caller before saying whether the table is there", async () => {
+    // Given a caller allowed nothing, and a table that was never created.
+    const simAws = new SimAws();
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName: "NoItemsRole" },
+      simAws,
+    );
+
+    // When it reads an item of that table.
+    const error = await assertThrowsErrorAsync(async () =>
+      requests["dynamodb:GetItem"](simAws, "c-1", {
+        kind: "arn",
+        arn: role.Arn,
+      }),
+    );
+
+    // Then it hears AccessDenied rather than the table being missing. Reading
+    // the partition key values needs the table, and finding it first is what
+    // could otherwise have told a refused caller which names are taken.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("allows a request naming no partition key value it can read", async () => {
+    // Given a caller scoped to one customer and a table keyed by binary.
+    const simAws = new SimAws();
+    await simAws.dynamoDb().createTable({
+      input: {
+        TableName: tableName,
+        KeySchema: [{ AttributeName: "customerId", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "customerId", AttributeType: "B" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+      },
+    });
+    const caller = await callerScopedTo(simAws, "c-1");
+
+    // When it writes an item whose partition key has no policy form.
+    const written = await simAws.dynamoDb().putItem(
+      {
+        input: {
+          TableName: tableName,
+          Item: { customerId: { B: new Uint8Array([1, 2, 3]) } },
+        },
+      },
+      { caller },
+    );
+
+    // Then the key is absent from the condition context, and a ForAllValues
+    // condition matches a request carrying no value for its key.
+    assertNonNullable(written);
+  });
+});

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-leading-keys.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-leading-keys.ts
@@ -1,0 +1,76 @@
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+
+/**
+ * The condition key DynamoDB names a request's partition key values by.
+ */
+export const simDynamoDbLeadingKeysConditionKey = "dynamodb:LeadingKeys";
+
+/**
+ * The partition key values one request reaches in one table.
+ *
+ * Which attribute holds the partition key is the table's to say, so a command
+ * hands over how to read the values rather than the values themselves. The
+ * table is found before the caller is authorized against it, and the values
+ * are read from it in between.
+ */
+export type SimDynamoDbLeadingKeys = (
+  table: SimDynamoDbTable,
+) => readonly string[];
+
+/**
+ * Write one partition key value the way an IAM policy condition holds it.
+ *
+ * A policy condition value is a string. A string key is its text and a number
+ * key is its digits. Binary has no form documented for the condition key, and
+ * a request carrying a binary partition key leaves the value out rather than
+ * inventing an encoding for it.
+ */
+function leadingKeyText(
+  value: SimDynamoDbValue | undefined,
+): string | undefined {
+  if (value?.kind === "S") {
+    return value.text;
+  }
+
+  if (value?.kind === "N") {
+    return value.number.text;
+  }
+
+  return undefined;
+}
+
+/**
+ * Read the partition key values a run of items or keys carries.
+ *
+ * The items are read when authorization asks for them rather than at the call
+ * site, which is what keeps a request DynamoDB would refuse being refused
+ * after the caller has been authorized rather than before.
+ *
+ * An item with no readable partition key value is left out.
+ */
+export function simDynamoDbLeadingKeysOf(
+  items: () => readonly SimDynamoDbItem[],
+): SimDynamoDbLeadingKeys {
+  return (table): readonly string[] =>
+    items()
+      .map((item) =>
+        leadingKeyText(item.attribute(table.keySchema.hashKeyAttributeName)),
+      )
+      .filter((text): text is string => text !== undefined);
+}
+
+/**
+ * Read the one partition key value a key condition names.
+ *
+ * The value is already held against the key schema of what is being read, so
+ * the table says nothing more about it here.
+ */
+export function simDynamoDbLeadingKeyOf(
+  value: SimDynamoDbValue,
+): readonly string[] {
+  const text = leadingKeyText(value);
+
+  return text === undefined ? [] : [text];
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.ts
@@ -17,6 +17,7 @@ import {
   type SimDynamoDbBatchTable,
 } from "./sim-dynamodb-batch-tables.js";
 import { refuseUnsimulatedBatchReadInput } from "./sim-dynamodb-unsimulated-batch-input.js";
+import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
 
 interface SimDynamoDbBatchGetItemProperties {
   readonly access: SimDynamoDbTableAccess;
@@ -67,6 +68,7 @@ export class SimDynamoDbBatchGetItem {
         access: this.access,
         operation: "BatchGetItem",
         caller: options?.caller,
+        leadingKeys: (entry) => simDynamoDbLeadingKeysOf(() => entry.keys),
       },
     );
     const responses = Object.fromEntries(

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-tables.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-tables.ts
@@ -2,6 +2,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import type { SimDynamoDbLeadingKeys } from "../authorize/sim-dynamodb-leading-keys.js";
 
 /**
  * What one table of a batch asks for, against the table it names.
@@ -11,10 +12,18 @@ export interface SimDynamoDbBatchTable<Requested> {
   readonly requested: Requested;
 }
 
-interface SimDynamoDbBatchReach {
+interface SimDynamoDbBatchReach<Requested> {
   readonly access: SimDynamoDbTableAccess;
   readonly operation: string;
   readonly caller: SimAwsCaller | undefined;
+
+  /**
+   * How to read the partition key values one table of the batch is asked for.
+   *
+   * Each table is authorized on its own, so each carries the keys the batch
+   * names in that table and no others.
+   */
+  readonly leadingKeys: (requested: Requested) => SimDynamoDbLeadingKeys;
 }
 
 /**
@@ -30,11 +39,16 @@ export function reachSimDynamoDbBatchTables<
   Requested extends { readonly reference: string },
 >(
   requested: readonly Requested[],
-  reach: SimDynamoDbBatchReach,
+  reach: SimDynamoDbBatchReach<Requested>,
 ): readonly SimDynamoDbBatchTable<Requested>[] {
   const action = `dynamodb:${reach.operation}`;
   const reached = requested.map((entry) => ({
-    table: reach.access.required(action, entry.reference, reach.caller),
+    table: reach.access.required(
+      action,
+      entry.reference,
+      reach.caller,
+      reach.leadingKeys(entry),
+    ),
     requested: entry,
   }));
 

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.ts
@@ -8,6 +8,7 @@ import { assertDistinctBatchItems } from "./sim-dynamodb-batch-request-items.js"
 import { reachSimDynamoDbBatchTables } from "./sim-dynamodb-batch-tables.js";
 import { readSimDynamoDbBatchWrites } from "./sim-dynamodb-batch-writes.js";
 import { refuseUnsimulatedBatchWriteInput } from "./sim-dynamodb-unsimulated-batch-input.js";
+import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
 
 const operation = "BatchWriteItem";
 
@@ -50,7 +51,15 @@ export class SimDynamoDbBatchWriteItem {
 
     const reached = reachSimDynamoDbBatchTables(
       readSimDynamoDbBatchWrites(input.RequestItems),
-      { access: this.access, operation, caller: options?.caller },
+      {
+        access: this.access,
+        operation,
+        caller: options?.caller,
+        leadingKeys: (entry) =>
+          simDynamoDbLeadingKeysOf(() =>
+            entry.writes.map((write) => write.names),
+          ),
+      },
     );
 
     // Marshalling every key checks it against the table's key schema, and is

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write.ts
@@ -17,6 +17,12 @@ import type {
  */
 export interface SimDynamoDbBatchWrite {
   /**
+   * The item or key this write names, which is where a policy condition reads
+   * its partition key value from.
+   */
+  readonly names: SimDynamoDbItem;
+
+  /**
    * The primary key this write works on, as the table marshals it.
    */
   keyIn(table: SimDynamoDbTable): string;
@@ -31,18 +37,18 @@ export interface SimDynamoDbBatchWrite {
  * A put in a batch write, which replaces the whole item as PutItem does.
  */
 class SimDynamoDbBatchPut implements SimDynamoDbBatchWrite {
-  private readonly item: SimDynamoDbItem;
+  public readonly names: SimDynamoDbItem;
 
   constructor(item: SimDynamoDbItem) {
-    this.item = item;
+    this.names = item;
   }
 
   keyIn(table: SimDynamoDbTable): string {
-    return table.keyOfItem(this.item);
+    return table.keyOfItem(this.names);
   }
 
   applyTo(table: SimDynamoDbTable): void {
-    table.putItem(this.item);
+    table.putItem(this.names);
   }
 }
 
@@ -51,18 +57,18 @@ class SimDynamoDbBatchPut implements SimDynamoDbBatchWrite {
  * that is already free is deleted successfully.
  */
 class SimDynamoDbBatchDelete implements SimDynamoDbBatchWrite {
-  private readonly key: SimDynamoDbItem;
+  public readonly names: SimDynamoDbItem;
 
   constructor(key: SimDynamoDbItem) {
-    this.key = key;
+    this.names = key;
   }
 
   keyIn(table: SimDynamoDbTable): string {
-    return table.keyOfKey(this.key);
+    return table.keyOfKey(this.names);
   }
 
   applyTo(table: SimDynamoDbTable): void {
-    table.deleteItem(this.key);
+    table.deleteItem(this.names);
   }
 }
 

--- a/src/service/dynamodb/command/item/sim-dynamodb-delete-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-delete-item.ts
@@ -1,5 +1,6 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
 import type {
   SimDeleteItemCommand,
   SimDeleteItemCommandOutput,
@@ -52,6 +53,7 @@ export class SimDynamoDbDeleteItem {
       "dynamodb:DeleteItem",
       input.TableName,
       options?.caller,
+      simDynamoDbLeadingKeysOf(() => [readSimDynamoDbKey(input.Key)]),
     );
     const asked = SimDynamoDbReturnValues.read(
       input.ReturnValues,

--- a/src/service/dynamodb/command/item/sim-dynamodb-get-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-get-item.ts
@@ -1,5 +1,6 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
 import type {
   SimGetItemCommand,
   SimGetItemCommandOutput,
@@ -52,6 +53,7 @@ export class SimDynamoDbGetItem {
       "dynamodb:GetItem",
       input.TableName,
       options?.caller,
+      simDynamoDbLeadingKeysOf(() => [readSimDynamoDbKey(input.Key)]),
     );
     const found = table.getItem(readSimDynamoDbKey(input.Key));
 

--- a/src/service/dynamodb/command/item/sim-dynamodb-put-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-put-item.ts
@@ -2,6 +2,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
 import type {
   SimPutItemCommand,
   SimPutItemCommandInput,
@@ -65,6 +66,7 @@ export class SimDynamoDbPutItem {
       "dynamodb:PutItem",
       input.TableName,
       options?.caller,
+      simDynamoDbLeadingKeysOf(() => [readItem(input)]),
     );
     const asked = SimDynamoDbReturnValues.read(input.ReturnValues, "PutItem");
     const item = readItem(input);

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-item.ts
@@ -1,5 +1,6 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
 import type {
   SimUpdateItemCommand,
   SimUpdateItemCommandOutput,
@@ -54,6 +55,7 @@ export class SimDynamoDbUpdateItem {
       "dynamodb:UpdateItem",
       input.TableName,
       options?.caller,
+      simDynamoDbLeadingKeysOf(() => [readSimDynamoDbKey(input.Key)]),
     );
     const asked = SimDynamoDbReturnValues.readForUpdate(
       input.ReturnValues,

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.ts
@@ -4,6 +4,7 @@ import { SimDynamoDbReadAnswer } from "../read/sim-dynamodb-read-answer.js";
 import { assertSimDynamoDbConsistentReadAnswerable } from "../read/sim-dynamodb-consistent-read.js";
 import { SimDynamoDbSelect } from "../read/sim-dynamodb-select.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
+import { simDynamoDbLeadingKeyOf } from "../authorize/sim-dynamodb-leading-keys.js";
 import type {
   SimQueryCommand,
   SimQueryCommandOutput,
@@ -53,10 +54,19 @@ export class SimDynamoDbQuery {
     refuseSimDynamoDbQuerySegment(input);
 
     const expressions = readSimDynamoDbQueryExpressions(input);
+
+    // The one partition key the query reads is what authorization needs, and
+    // reading it needs the view rather than the table, so it is read again
+    // here against whichever of the two the request names.
     const table = this.access.required(
       "dynamodb:Query",
       input.TableName,
       options?.caller,
+      (reached) =>
+        simDynamoDbLeadingKeyOf(
+          expressions.terms.forTable(reached.view(input.IndexName))
+            .partitionKeyValue,
+        ),
     );
 
     // What is being read is settled here: the table, or one of its indexes. An

--- a/src/service/dynamodb/command/table/sim-dynamodb-table-access.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-table-access.ts
@@ -6,6 +6,27 @@ import type { SimDynamoDbTableName } from "../../table/sim-dynamodb-table-name.j
 import { readSimDynamoDbTableReference } from "../../table/sim-dynamodb-table-reference.js";
 import type { SimDynamoDbTableStore } from "../../table/sim-dynamodb-table-store.js";
 import type { SimDynamoDbAuthorizer } from "../authorize/sim-dynamodb-authorizer.js";
+import type { SimDynamoDbLeadingKeys } from "../authorize/sim-dynamodb-leading-keys.js";
+
+/**
+ * Read the partition key values a request reaches, or none where they cannot
+ * be read.
+ *
+ * Authorization runs ahead of the checks a command makes on what it was given,
+ * as it does on AWS. A request whose key or key condition is malformed is
+ * authorized carrying no values and refused by the check that follows, so
+ * whatever reading them throws is dropped here.
+ */
+function readLeadingKeys(
+  leadingKeys: SimDynamoDbLeadingKeys | undefined,
+  table: SimDynamoDbTable,
+): readonly string[] | undefined {
+  try {
+    return leadingKeys?.(table);
+  } catch {
+    return undefined;
+  }
+}
 
 interface SimDynamoDbTableAccessProperties {
   readonly tables: SimDynamoDbTableStore;
@@ -18,9 +39,14 @@ interface SimDynamoDbTableAccessProperties {
  *
  * Every table command goes through the same two steps in the same order: read
  * the name or ARN the request carries, then authorize the caller against it
- * before anything looks the table up. Keeping them here is what makes that
- * order the same for all of them, so no command can accidentally tell an
- * unauthorized caller which table names are taken.
+ * before the command is told whether the table is there. Keeping them here is
+ * what makes that order the same for all of them, so no command can
+ * accidentally tell an unauthorized caller which table names are taken.
+ *
+ * A command reaching particular items hands over how to read their partition
+ * key values, which authorization needs the table to read. The table is found
+ * first for that, and a caller refused against a table that is not there still
+ * hears AccessDenied rather than a missing table.
  */
 export class SimDynamoDbTableAccess {
   private readonly tables: SimDynamoDbTableStore;
@@ -41,27 +67,44 @@ export class SimDynamoDbTableAccess {
   }
 
   /**
-   * Find the table a request names, refusing the caller before looking it up.
+   * Find the table a request names, refusing the caller before answering.
    */
   required(
     action: string,
     tableName: string | undefined,
     caller: SimAwsCaller | undefined,
+    leadingKeys?: SimDynamoDbLeadingKeys,
   ): SimDynamoDbTable {
-    return this.requiredByName(action, this.reference(tableName), caller);
+    return this.requiredByName(
+      action,
+      this.reference(tableName),
+      caller,
+      leadingKeys,
+    );
   }
 
   /**
    * Find a table by a name that has already been read.
+   *
+   * A caller with no permission hears AccessDenied whether or not the table is
+   * there, which keeps an unauthorized caller from finding out which table
+   * names are taken.
    */
   requiredByName(
     action: string,
     name: SimDynamoDbTableName,
     caller: SimAwsCaller | undefined,
+    leadingKeys?: SimDynamoDbLeadingKeys,
   ): SimDynamoDbTable {
-    this.authorizer.authorizeTable(action, name.value, caller);
-
     const table = this.tables.find(name);
+
+    this.authorizer.authorizeTable(
+      action,
+      name.value,
+      caller,
+      table === undefined ? undefined : readLeadingKeys(leadingKeys, table),
+    );
+
     if (table === undefined) {
       throw new SimDynamoDbResourceNotFoundException(
         `No DynamoDB Table named ${name.value}`,


### PR DESCRIPTION
DynamoDB authorized every request with no condition context, leaving `dynamodb:LeadingKeys` absent and a policy conditioned on it unsatisfiable by any request. `GetItem`, `BatchGetItem`, `Query`, `PutItem`, `UpdateItem`, `DeleteItem` and `BatchWriteItem` now carry the partition key values they reach, which is the fine-grained access control the DynamoDB developer guide writes. Reading those values needs the table's key schema, so table access finds the table before authorizing against it, and a caller with no permission still hears `AccessDenied` when the table is missing. The IAM docs also carried two statements about `ForAllValues` that the previous change left behind.

Resolves https://github.com/KensioSoftware/yulin/issues/1308

Each table of a batch is authorized on its own and carries the keys the batch names in that table. The transactional operations supply no leading keys and are unchanged, since the developer guide's worked example covers the seven above.

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for DynamoDB fine-grained authorization using `dynamodb:LeadingKeys`.
  - Item, query, and batch operations now enforce permissions based on partition-key values.
  - Unauthorized requests are rejected, including requests involving multiple items with any disallowed keys.
  - Numeric keys are supported; binary partition keys do not contribute authorization values.
  - Authorization is checked before revealing whether an inaccessible table exists.

- **Documentation**
  - Added guidance and examples for DynamoDB leading-key policies and IAM `ForAllValues:` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->