### PR TITLE
feat: evaluate the IAM Null condition operator

### DIFF
--- a/docs/services/iam/README.md
+++ b/docs/services/iam/README.md
@@ -236,7 +236,7 @@ repository that still says it is there.
 ## Policy conditions
 
 Policy statements can carry `Condition` blocks. Sim IAM currently supports the `StringEquals`,
-`StringLike`, `ArnLike`, `ArnEquals` and `NumericLessThanEquals` operators, along with the
+`StringLike`, `ArnLike`, `ArnEquals`, `NumericLessThanEquals` and `Null` operators, along with the
 `ForAllValues:` and `ForAnyValue:` set variants of `StringEquals` and `StringLike`.
 
 The negated operators `StringNotEquals`, `StringNotLike`, `ArnNotEquals` and `ArnNotLike` are
@@ -337,8 +337,20 @@ request value is there to satisfy it.
 
 A `ForAllValues:` operator answers true for an absent key, which is also AWS behaviour. Every value
 the request carries matches when it carries none. AWS warns that this leaves a `ForAllValues:`
-`Allow` overly permissive, and asks for a `Null` check with a `false` value beside it. `Null` is
-absent from the operators above. A statement written that way fails closed here.
+`Allow` overly permissive, and asks for a `Null` check with a `false` value beside it. Write the
+guard and sim IAM evaluates it.
+
+`Null` asks whether the request carries a value for a context key rather than comparing one. `"true"`
+matches where the key is absent and `"false"` where it is present. A key carrying an empty string or
+an empty list of values counts as absent, which is the null dataset AWS describes. The two values
+can also be written as JSON booleans. Any other policy value leaves the condition matching nothing.
+
+```json
+"Condition": {
+  "ForAllValues:StringLike": { "dynamodb:LeadingKeys": ["ORDER#*"] },
+  "Null": { "dynamodb:LeadingKeys": "false" }
+}
+```
 
 ### Statements left unevaluated
 
@@ -1689,6 +1701,8 @@ Sim IAM models the policy behaviour that multi-service tests most commonly need.
 - Only the condition operators listed above are supported. A statement using any other operator
   fails closed, matching no request. `decision.unevaluatedStatements` names those statements, and a
   test can assert that a decision was reached over policies read in full
+- The `...IfExists` operator suffix is absent. AWS reads it as the sibling of `Null`, treating a
+  condition on a key the request leaves out as true. A statement using it fails closed here
 - A positive `ForAllValues:` condition fails to match an empty value set, where AWS matches one. An
   absent context key matches, as it does on AWS. A service here leaves a key out where the request
   carries no value for it, and the empty set is reached only by a caller passing one to `authorize`

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-all-values-string-operator.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-all-values-string-operator.ts
@@ -12,9 +12,14 @@ import { simIamStringValues } from "../string/sim-iam-string-values.js";
  * matches, as an absent key does.
  */
 export class SimIamNegatedForAllValuesStringOperator implements SimIamConditionOperator {
-  readonly matchesAbsentKey = true;
-
   constructor(private readonly comparison: SimIamStringComparison) {}
+
+  /**
+   * Answer for a request carrying no value for the key.
+   */
+  matchesAbsentKey(): boolean {
+    return true;
+  }
 
   /**
    * Check whether every request value differs from every policy value.

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-for-any-value-string-operator.ts
@@ -13,9 +13,14 @@ import { simIamStringValues } from "../string/sim-iam-string-values.js";
  * absent key here, ahead of the rule that a negated operator matches one.
  */
 export class SimIamNegatedForAnyValueStringOperator implements SimIamConditionOperator {
-  readonly matchesAbsentKey = false;
-
   constructor(private readonly comparison: SimIamStringComparison) {}
+
+  /**
+   * Answer for a request carrying no value for the key.
+   */
+  matchesAbsentKey(): boolean {
+    return false;
+  }
 
   /**
    * Check whether any request value differs from every policy value.

--- a/src/service/iam/authorize/match/condition/negated/sim-iam-negated-scalar-string-operator.ts
+++ b/src/service/iam/authorize/match/condition/negated/sim-iam-negated-scalar-string-operator.ts
@@ -12,9 +12,14 @@ import { simIamStringValues } from "../string/sim-iam-string-values.js";
  * three.
  */
 export class SimIamNegatedScalarStringOperator implements SimIamConditionOperator {
-  readonly matchesAbsentKey = true;
-
   constructor(private readonly comparison: SimIamStringComparison) {}
+
+  /**
+   * Answer for a request carrying no value for the key.
+   */
+  matchesAbsentKey(): boolean {
+    return true;
+  }
 
   /**
    * Check whether a request value differs from every policy value.

--- a/src/service/iam/authorize/match/condition/null/sim-iam-null.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/null/sim-iam-null.iso.test.ts
@@ -1,0 +1,174 @@
+import { assertTrue } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimIam } from "../../../../sim-iam.js";
+import { simIamAuthZResourcePolicySourceFactory } from "../../../context/sim-iam-auth-z-context.factory.js";
+import type {
+  SimIamConditionValue,
+  SimIamPolicyDocumentCondition,
+} from "../../../../policy/sim-iam-policy.js";
+import type { SimIamPolicyDecision } from "../../../sim-iam-decision.js";
+
+const orderItems = "arn:aws:dynamodb:us-east-1:123456789012:table/Orders";
+
+/**
+ * Authorize a write against a resource policy allowing it on one condition,
+ * with the request context supplied alongside.
+ */
+function decide(
+  condition: SimIamPolicyDocumentCondition,
+  conditionContext: Readonly<Record<string, SimIamConditionValue>> = {},
+): SimIamPolicyDecision {
+  const simIam = new SimIam();
+
+  return simIam.authorize({
+    action: "dynamodb:UpdateItem",
+    resource: orderItems,
+    caller: { kind: "anonymous" },
+    conditionContext,
+    resourcePolicies: [
+      simIamAuthZResourcePolicySourceFactory.make({
+        document: {
+          Statement: {
+            Effect: "Allow",
+            Principal: "*",
+            Action: "dynamodb:UpdateItem",
+            Resource: orderItems,
+            Condition: condition,
+          },
+        },
+      }),
+    ],
+  });
+}
+
+describe("sim IAM Null condition operator", () => {
+  it("matches a false check when the request carries the key", () => {
+    // Given a grant requiring the request to name a partition key
+    // When it names one
+    const decision = decide(
+      { Null: { "dynamodb:LeadingKeys": "false" } },
+      { "dynamodb:LeadingKeys": ["ORDER#1"] },
+    );
+
+    // Then the key exists, so the condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("refuses a false check when the request carries no value for the key", () => {
+    // Given the same grant
+    // When the request names no partition key at all
+    const decision = decide({ Null: { "dynamodb:LeadingKeys": "false" } });
+
+    // Then the key is absent and the statement does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches a true check when the request carries no value for the key", () => {
+    // Given a grant reserved for requests naming no partition key
+    // When the request names none
+    const decision = decide({ Null: { "dynamodb:LeadingKeys": "true" } });
+
+    // Then the condition matches
+    assertTrue(decision.isAllowed);
+  });
+
+  it("refuses a true check when the request carries the key", () => {
+    // Given the same grant
+    // When the request names a partition key
+    const decision = decide(
+      { Null: { "dynamodb:LeadingKeys": "true" } },
+      { "dynamodb:LeadingKeys": ["ORDER#1"] },
+    );
+
+    // Then the key exists and the statement does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("guards a ForAllValues Allow against a request carrying no value", () => {
+    // Given the guarded form AWS recommends, which is a ForAllValues condition
+    // beside a Null check, on a request reaching no partition key value
+    const decision = decide({
+      "ForAllValues:StringLike": { "dynamodb:LeadingKeys": ["ORDER#*"] },
+      Null: { "dynamodb:LeadingKeys": "false" },
+    });
+
+    // Then the guard refuses what ForAllValues would have matched vacuously
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("leaves a guarded ForAllValues Allow standing for a matching request", () => {
+    // Given the same guarded grant
+    // When the request reaches a partition key the pattern covers
+    const decision = decide(
+      {
+        "ForAllValues:StringLike": { "dynamodb:LeadingKeys": ["ORDER#*"] },
+        Null: { "dynamodb:LeadingKeys": "false" },
+      },
+      { "dynamodb:LeadingKeys": ["ORDER#1", "ORDER#2"] },
+    );
+
+    // Then both operators match and the grant stands
+    assertTrue(decision.isAllowed);
+  });
+
+  it("reads a JSON boolean policy value the way it reads the string", () => {
+    // Given a grant whose Null check is written as a boolean rather than the
+    // quoted form AWS documents
+    // When the request carries the key
+    const decision = decide(
+      { Null: { "dynamodb:LeadingKeys": false } },
+      { "dynamodb:LeadingKeys": ["ORDER#1"] },
+    );
+
+    // Then it means what the string means
+    assertTrue(decision.isAllowed);
+  });
+
+  it("treats a key carrying no values as absent", () => {
+    // Given a grant requiring the request to name a partition key
+    // When the request carries the key with an empty list of values, which AWS
+    // calls a null dataset
+    const decision = decide(
+      { Null: { "dynamodb:LeadingKeys": "false" } },
+      { "dynamodb:LeadingKeys": [] },
+    );
+
+    // Then the value is null and the statement does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("treats an empty string as absent", () => {
+    // Given the same grant
+    // When the request carries the key with an empty string, the example AWS
+    // gives of a null dataset
+    const decision = decide(
+      { Null: { "dynamodb:LeadingKeys": "false" } },
+      { "dynamodb:LeadingKeys": "" },
+    );
+
+    // Then the value is null and the statement does not match
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches nothing where the policy value is neither true nor false", () => {
+    // Given a Null check written with a value it has no meaning for
+    // When the request carries the key
+    const decision = decide(
+      { Null: { "dynamodb:LeadingKeys": "yes" } },
+      { "dynamodb:LeadingKeys": ["ORDER#1"] },
+    );
+
+    // Then the operator answers neither way and the statement is skipped
+    assertTrue(decision.isImplicitDeny);
+  });
+
+  it("matches nothing where an absent key meets a policy value it cannot read", () => {
+    // Given the same unreadable check
+    // When the request carries no value for the key
+    const decision = decide({ Null: { "dynamodb:LeadingKeys": "yes" } });
+
+    // Then it fails closed the same way
+    assertTrue(decision.isImplicitDeny);
+  });
+});

--- a/src/service/iam/authorize/match/condition/null/sim-iam-null.ts
+++ b/src/service/iam/authorize/match/condition/null/sim-iam-null.ts
@@ -1,0 +1,73 @@
+import type { SimIamConditionValue } from "../../../../policy/sim-iam-policy.js";
+import type { SimIamConditionOperator } from "../sim-iam-condition-operator.js";
+
+/**
+ * Read the policy value of a `Null` condition.
+ *
+ * AWS documents `"true"` and `"false"` as strings, which is the form a policy
+ * document and the CDK both write. The condition value type also admits a JSON
+ * boolean, and a policy written that way means the same thing. Anything else
+ * has no meaning here and leaves the condition matching nothing.
+ */
+function expectsAbsentKey(expected: SimIamConditionValue): boolean | undefined {
+  if (typeof expected === "boolean") {
+    return expected;
+  }
+
+  if (expected === "true") {
+    return true;
+  }
+
+  return expected === "false" ? false : undefined;
+}
+
+/**
+ * Whether a request value counts as present for a `Null` check.
+ *
+ * AWS asks whether the key exists and its value is not null. A multi-valued key
+ * carrying no values resolves to a null dataset, and an empty string is the
+ * example AWS gives of one.
+ */
+function isPresent(actual: SimIamConditionValue): boolean {
+  if (Array.isArray(actual)) {
+    return actual.length > 0;
+  }
+
+  return actual !== "";
+}
+
+/**
+ * IAM `Null` condition operator.
+ *
+ * `Null` checks whether the request carries a value for a context key, rather
+ * than comparing one. `"true"` matches where the key is absent and `"false"`
+ * where it is present. AWS names it and the `...IfExists` suffix as the two
+ * exceptions to the rule that an absent key fails a condition.
+ *
+ * It is what guards a `ForAllValues` `Allow`, which matches an absent key on
+ * its own. See `SimIamForAllValuesStringConditionOperator`.
+ */
+export class SimIamNull implements SimIamConditionOperator {
+  /**
+   * Answer for a request carrying no value for the key.
+   */
+  matchesAbsentKey(expected: SimIamConditionValue): boolean {
+    return expectsAbsentKey(expected) === true;
+  }
+
+  /**
+   * Answer for a request carrying a value for the key.
+   */
+  matches(
+    actual: SimIamConditionValue,
+    expected: SimIamConditionValue,
+  ): boolean {
+    const absentExpected = expectsAbsentKey(expected);
+
+    if (absentExpected === undefined) {
+      return false;
+    }
+
+    return absentExpected !== isPresent(actual);
+  }
+}

--- a/src/service/iam/authorize/match/condition/numeric/less-than-equals/sim-iam-number-lte.ts
+++ b/src/service/iam/authorize/match/condition/numeric/less-than-equals/sim-iam-number-lte.ts
@@ -16,7 +16,12 @@ import type { SimIamConditionOperator } from "../../sim-iam-condition-operator.j
  * are rejected rather than being converted through JavaScript coercion rules.
  */
 export class SimIamNumericLessThanEquals implements SimIamConditionOperator {
-  readonly matchesAbsentKey = false;
+  /**
+   * Answer for a request carrying no value for the key.
+   */
+  matchesAbsentKey(): boolean {
+    return false;
+  }
 
   /**
    * Compare one request value with one or more policy limits.

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.iso.test.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.iso.test.ts
@@ -19,6 +19,14 @@ const positiveKeywords = ["StringEquals", "StringLike"];
 
 const setQualifiers = ["ForAnyValue", "ForAllValues"];
 
+/**
+ * A policy value to ask the absent-key question with.
+ *
+ * Only `Null` reads the value it is asked about. Every comparison operator
+ * answers the same way whatever the policy says.
+ */
+const policyValue = "arn:aws:iam::123456789012:role/OrdersService";
+
 describe("sim IAM condition operator parsing", () => {
   it("has an operator for every form of every negated keyword", () => {
     // Given the keywords a service control policy writes a carve-out with
@@ -41,11 +49,12 @@ describe("sim IAM condition operator parsing", () => {
     // Given the same keywords
     const parser = new SimIamConditionOperatorParser();
 
-    // When each form is asked whether an absent context key matches it
+    // When each form is asked whether an absent context key matches it. The
+    // policy value goes unread by every operator but `Null`
     const matchesAbsentKey = negatedKeywords.flatMap((keyword) => [
-      parser.parse(keyword)?.matchesAbsentKey,
-      parser.parse(`ForAllValues:${keyword}`)?.matchesAbsentKey,
-      parser.parse(`ForAnyValue:${keyword}`)?.matchesAbsentKey,
+      parser.parse(keyword)?.matchesAbsentKey(policyValue),
+      parser.parse(`ForAllValues:${keyword}`)?.matchesAbsentKey(policyValue),
+      parser.parse(`ForAnyValue:${keyword}`)?.matchesAbsentKey(policyValue),
     ]);
 
     // Then only the `ForAnyValue` forms answer false, because no request value
@@ -62,9 +71,9 @@ describe("sim IAM condition operator parsing", () => {
 
     // When each form is asked whether an absent context key matches it
     const matchesAbsentKey = positiveKeywords.flatMap((keyword) => [
-      parser.parse(keyword)?.matchesAbsentKey,
-      parser.parse(`ForAllValues:${keyword}`)?.matchesAbsentKey,
-      parser.parse(`ForAnyValue:${keyword}`)?.matchesAbsentKey,
+      parser.parse(keyword)?.matchesAbsentKey(policyValue),
+      parser.parse(`ForAllValues:${keyword}`)?.matchesAbsentKey(policyValue),
+      parser.parse(`ForAnyValue:${keyword}`)?.matchesAbsentKey(policyValue),
     ]);
 
     // Then only the `ForAllValues` forms answer true. AWS matches those where
@@ -73,6 +82,20 @@ describe("sim IAM condition operator parsing", () => {
       matchesAbsentKey,
       positiveKeywords.flatMap(() => [false, true, false]),
     );
+  });
+
+  it("reads a Null policy value rather than answering a constant", () => {
+    // Given the parser
+    const parser = new SimIamConditionOperatorParser();
+
+    // When `Null` is asked whether an absent context key matches each of the
+    // two values AWS documents for it
+    const operator = parser.parse("Null");
+
+    // Then the answer follows the policy value, which is the one operator that
+    // reads it
+    assertTrue(operator?.matchesAbsentKey("true") === true);
+    assertTrue(operator?.matchesAbsentKey("false") === false);
   });
 
   it("has no operator for a keyword it cannot evaluate", () => {

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator-parser.ts
@@ -12,6 +12,7 @@ import { SimIamStringLike } from "./string/like/sim-iam-string-like.js";
 import { SimIamNumericLessThanEquals } from "./numeric/less-than-equals/sim-iam-number-lte.js";
 import { SimIamArnEquals } from "./arn/equals/sim-iam-arn-equals.js";
 import { SimIamArnLike } from "./arn/like/sim-iam-arn-like.js";
+import { SimIamNull } from "./null/sim-iam-null.js";
 
 const operatorFactories = new Map<string, SimIamConditionOperatorFactory>([
   ["ArnEquals", (): SimIamConditionOperator => new SimIamArnEquals()],
@@ -22,6 +23,7 @@ const operatorFactories = new Map<string, SimIamConditionOperatorFactory>([
   ],
   ["StringEquals", (): SimIamConditionOperator => new SimIamStringEquals()],
   ["StringLike", (): SimIamConditionOperator => new SimIamStringLike()],
+  ["Null", (): SimIamConditionOperator => new SimIamNull()],
   [
     "ForAnyValue:StringEquals",
     (): SimIamConditionOperator => new SimIamForAnyValueStringEquals(),

--- a/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-condition-operator.ts
@@ -20,8 +20,12 @@ export interface SimIamConditionOperator {
    * true, because every value the request carries matches vacuously. AWS
    * documents all three rules, and warns that the `ForAllValues` rule leaves
    * an `Allow` overly permissive without a `Null` guard beside it.
+   *
+   * The policy value is passed because `Null` reads it. Every comparison
+   * operator answers the same way whatever the policy says, and takes no
+   * argument.
    */
-  readonly matchesAbsentKey: boolean;
+  matchesAbsentKey(expected: SimIamConditionValue): boolean;
 
   /**
    * Determine whether an actual request value satisfies the expected policy value.

--- a/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
+++ b/src/service/iam/authorize/match/condition/sim-iam-policy-condition-matcher.ts
@@ -91,7 +91,7 @@ export class SimIamPolicyConditionMatcher {
     const actual = this.conditionContext.get(this.normalizeContextKey(key));
 
     if (actual === undefined) {
-      return operator.matchesAbsentKey;
+      return operator.matchesAbsentKey(expected);
     }
 
     return operator.matches(actual, expected);

--- a/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/all-values/sim-iam-for-all-values-string-condition-operator.ts
@@ -10,7 +10,12 @@ import { simIamStringValues } from "../sim-iam-string-values.js";
  * guard beside it to stay tight.
  */
 export abstract class SimIamForAllValuesStringConditionOperator implements SimIamConditionOperator {
-  readonly matchesAbsentKey = true;
+  /**
+   * Answer for a request carrying no value for the key.
+   */
+  matchesAbsentKey(): boolean {
+    return true;
+  }
 
   /**
    * Check whether a given value matches the expected value.

--- a/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/any-value/sim-iam-for-any-value-string-condition-operator.ts
@@ -6,7 +6,12 @@ import { simIamStringValues } from "../sim-iam-string-values.js";
  * Base for `ForAnyValue` IAM string operators.
  */
 export abstract class SimIamForAnyValueStringConditionOperator implements SimIamConditionOperator {
-  readonly matchesAbsentKey = false;
+  /**
+   * Answer for a request carrying no value for the key.
+   */
+  matchesAbsentKey(): boolean {
+    return false;
+  }
 
   /**
    * Check whether a given value matches the expected value.

--- a/src/service/iam/authorize/match/condition/string/sim-iam-scalar-string-condition-operator.ts
+++ b/src/service/iam/authorize/match/condition/string/sim-iam-scalar-string-condition-operator.ts
@@ -9,7 +9,12 @@ import { simIamStringValues } from "./sim-iam-string-values.js";
  * scalar or an array, with multiple policy values using OR semantics.
  */
 export abstract class SimIamScalarStringConditionOperator implements SimIamConditionOperator {
-  readonly matchesAbsentKey = false;
+  /**
+   * Answer for a request carrying no value for the key.
+   */
+  matchesAbsentKey(): boolean {
+    return false;
+  }
 
   /**
    * Check whether a given value matches the expected value.


### PR DESCRIPTION
Sim IAM registered no `Null` operator. A policy AWS allows was denied here, and the `Null` guard the simulator's own docs recommend beside a `ForAllValues` Allow went unevaluated. `Null` now answers from the policy value, matching an absent key for `"true"` and a present one for `"false"`, with an empty string or an empty value list counting as the null dataset AWS describes. The absent-key member of `SimIamConditionOperator` becomes a method taking the policy value, because the old boolean could not carry what `Null` reads.

Resolves https://github.com/KensioSoftware/yulin/issues/1315

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`
