### PR TITLE
fix: supply dynamodb:Attributes to sim IAM

### DIFF
--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3648,6 +3648,22 @@ The condition takes the `ForAllValues:` qualifier, as AWS requires for this key.
 value the request reaches has to match. A batch or a write naming one item outside the allowed set
 is refused whole, and nothing it asked for is applied.
 
+The same commands, along with `Scan`, supply the top-level attribute names they reach as
+`dynamodb:Attributes`. A name reaches the condition wherever the request writes one, in a
+`ProjectionExpression`, an `UpdateExpression`, a `ConditionExpression`, a `FilterExpression`, a
+`KeyConditionExpression`, and in the `Key` or `Item` a request names outright. A `#` placeholder is
+resolved first, so the policy is matched against the attribute rather than the alias. A nested path
+counts as the attribute it starts at, so `address.city` reaches `address`.
+
+A policy conditioned on `dynamodb:Attributes` has to name every primary key and index key attribute
+of the table alongside the attributes it is restricting, as AWS requires. A request names its key,
+and a policy leaving the key attributes out refuses every request that reads or writes an item.
+
+A request reaching no attribute at all leaves the key out of the condition context, which a
+`ForAllValues:` condition matches. A `Scan` carrying no expression is the case to watch. AWS asks
+for a `Null` check beside such a statement to close it, covered under
+[policy conditions](https://yulinsim.dev/services/iam/#policy-conditions).
+
 ```typescript sim-dynamodb-leading-keys
 import { CreateTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
@@ -3755,6 +3771,8 @@ is written.
 - `dynamodb:LeadingKeys` on `GetItem`, `BatchGetItem`, `Query`, `PutItem`, `UpdateItem`,
   `DeleteItem` and `BatchWriteItem`, carrying the partition key values the request reaches so a
   `ForAllValues:` condition can scope a caller to particular items.
+- `dynamodb:Attributes` on those seven and on `Scan`, carrying the top-level attribute names the
+  request reaches, read from every expression it carries and from its `Key` or `Item`.
 - `DescribeTable`, answering with the full table description, by table name or ARN.
 - `ListTables`, ordered by UTF-8 bytes and paged with `Limit` and `ExclusiveStartTableName`.
 - `DeleteTable`, following the table status DynamoDB moves a deleted table through, and refusing a
@@ -3828,10 +3846,11 @@ Arn`, `Fn::GetAtt … StreamArn` and `Fn::GetAtt … TableId` answering. A CDK `
 
 ## Limitations
 
-- `dynamodb:LeadingKeys` is the only DynamoDB condition key supplied. `dynamodb:Attributes`,
-  `dynamodb:Select` and `dynamodb:ReturnValues` are absent from the condition context, and a
-  statement conditioned on one of them matches no request. The transactional operations supply no
-  leading keys either, and are authorized by action and table alone.
+- `dynamodb:LeadingKeys` and `dynamodb:Attributes` are the DynamoDB condition keys supplied.
+  `dynamodb:Select`, `dynamodb:ReturnValues`, `dynamodb:ReturnConsumedCapacity` and the numbered
+  partition key families are absent from the condition context, and a statement conditioned on one
+  of them matches no request. The transactional operations supply neither key, and are authorized by
+  action and table alone.
 - A partition key value reaches a policy condition as a string for a `S` key and as its digits for
   an `N` key. A binary partition key has no documented form for the condition key. A request
   carrying one leaves the value out.

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-attributes.iso.test.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-attributes.iso.test.ts
@@ -1,0 +1,357 @@
+import {
+  assertInstanceOf,
+  assertNonNullable,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+
+const tableName = "OrdersTable";
+
+/**
+ * The item actions a fine-grained access control policy names.
+ */
+const scopedActions = [
+  "dynamodb:GetItem",
+  "dynamodb:BatchGetItem",
+  "dynamodb:Query",
+  "dynamodb:Scan",
+  "dynamodb:PutItem",
+  "dynamodb:UpdateItem",
+  "dynamodb:DeleteItem",
+  "dynamodb:BatchWriteItem",
+];
+
+/**
+ * A table keyed by a customer and an order, holding one item.
+ */
+async function stockedTable(simAws: SimAws): Promise<void> {
+  const simDynamoDb = simAws.dynamoDb();
+
+  await simDynamoDb.createTable({
+    input: {
+      TableName: tableName,
+      KeySchema: [
+        { AttributeName: "customerId", KeyType: "HASH" },
+        { AttributeName: "orderId", KeyType: "RANGE" },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: "customerId", AttributeType: "S" },
+        { AttributeName: "orderId", AttributeType: "S" },
+      ],
+      BillingMode: "PAY_PER_REQUEST",
+    },
+  });
+
+  await simDynamoDb.putItem({
+    input: {
+      TableName: tableName,
+      Item: {
+        customerId: { S: "c-1" },
+        orderId: { S: "2026-01" },
+        status: { S: "PLACED" },
+        address: { M: { city: { S: "Leeds" } } },
+        secret: { S: "hidden" },
+      },
+    },
+  });
+}
+
+/**
+ * A caller allowed the item actions on the table, for named attributes only.
+ *
+ * This is the attribute-level access control policy the DynamoDB developer
+ * guide writes, with the key attributes named alongside the ones being read.
+ */
+async function callerAllowed(
+  simAws: SimAws,
+  attributes: readonly string[],
+): Promise<SimAwsCaller> {
+  const simIam = simAws.iam();
+  const roleName = "OrdersRole";
+  const creation = await simIam.createRole({
+    input: {
+      RoleName: roleName,
+      AssumeRolePolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Principal: { AWS: `arn:aws:iam::${simAws.defaultAccountId}:root` },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    },
+  });
+
+  await simIam.putRolePolicy({
+    input: {
+      RoleName: roleName,
+      PolicyName: "NamedAttributesOnly",
+      PolicyDocument: simIamPolicyDocumentFactory.make({
+        Statement: {
+          Action: scopedActions,
+          Resource: `arn:aws:dynamodb:${simAws.defaultRegionName}:${simAws.defaultAccountId}:table/${tableName}`,
+          Condition: {
+            "ForAllValues:StringEquals": { "dynamodb:Attributes": attributes },
+          },
+        },
+      }),
+    },
+  });
+
+  return { kind: "arn", arn: creation.Role.Arn };
+}
+
+const keyAttributes = ["customerId", "orderId"];
+
+/**
+ * One request against the table, naming `status` and nothing else beyond its
+ * key.
+ */
+const requests = {
+  "dynamodb:GetItem": async (
+    simAws: SimAws,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().getItem(
+      {
+        input: {
+          TableName: tableName,
+          Key: { customerId: { S: "c-1" }, orderId: { S: "2026-01" } },
+          ProjectionExpression: "#s",
+          ExpressionAttributeNames: { "#s": "status" },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:BatchGetItem": async (
+    simAws: SimAws,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().batchGetItem(
+      {
+        input: {
+          RequestItems: {
+            [tableName]: {
+              Keys: [{ customerId: { S: "c-1" }, orderId: { S: "2026-01" } }],
+              ProjectionExpression: "#s",
+              ExpressionAttributeNames: { "#s": "status" },
+            },
+          },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:Query": async (
+    simAws: SimAws,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().query(
+      {
+        input: {
+          TableName: tableName,
+          KeyConditionExpression: "customerId = :customerId",
+          ProjectionExpression: "#s",
+          ExpressionAttributeNames: { "#s": "status" },
+          ExpressionAttributeValues: { ":customerId": { S: "c-1" } },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:Scan": async (
+    simAws: SimAws,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().scan(
+      {
+        input: {
+          TableName: tableName,
+          ProjectionExpression: "#s",
+          ExpressionAttributeNames: { "#s": "status" },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:PutItem": async (
+    simAws: SimAws,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().putItem(
+      {
+        input: {
+          TableName: tableName,
+          Item: {
+            customerId: { S: "c-1" },
+            orderId: { S: "2026-02" },
+            status: { S: "PLACED" },
+          },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:UpdateItem": async (
+    simAws: SimAws,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().updateItem(
+      {
+        input: {
+          TableName: tableName,
+          Key: { customerId: { S: "c-1" }, orderId: { S: "2026-01" } },
+          UpdateExpression: "SET #s = :s",
+          ExpressionAttributeNames: { "#s": "status" },
+          ExpressionAttributeValues: { ":s": { S: "PAID" } },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:DeleteItem": async (
+    simAws: SimAws,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().deleteItem(
+      {
+        input: {
+          TableName: tableName,
+          Key: { customerId: { S: "c-1" }, orderId: { S: "2026-01" } },
+          ConditionExpression: "#s = :s",
+          ExpressionAttributeNames: { "#s": "status" },
+          ExpressionAttributeValues: { ":s": { S: "PLACED" } },
+        },
+      },
+      { caller },
+    ),
+
+  "dynamodb:BatchWriteItem": async (
+    simAws: SimAws,
+    caller: SimAwsCaller,
+  ): Promise<unknown> =>
+    simAws.dynamoDb().batchWriteItem(
+      {
+        input: {
+          RequestItems: {
+            [tableName]: [
+              {
+                PutRequest: {
+                  Item: {
+                    customerId: { S: "c-1" },
+                    orderId: { S: "2026-03" },
+                    status: { S: "PLACED" },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      { caller },
+    ),
+} as const;
+
+describe("DynamoDB dynamodb:Attributes authorization", () => {
+  it.each(scopedActions)(
+    "allows %s naming only attributes the policy names",
+    async (action) => {
+      // Given a caller allowed the key attributes and `status`.
+      const simAws = new SimAws();
+      await stockedTable(simAws);
+      const caller = await callerAllowed(simAws, [...keyAttributes, "status"]);
+
+      // When it makes a request naming those and nothing else.
+      const answer = await requests[action as keyof typeof requests](
+        simAws,
+        caller,
+      );
+
+      // Then the condition holds and the request is answered.
+      assertNonNullable(answer);
+    },
+  );
+
+  it.each(scopedActions)(
+    "refuses %s naming an attribute the policy leaves out",
+    async (action) => {
+      // Given a caller allowed the key attributes and one other attribute,
+      // which is not the one the requests name.
+      const simAws = new SimAws();
+      await stockedTable(simAws);
+      const caller = await callerAllowed(simAws, [...keyAttributes, "total"]);
+
+      // When it makes the same request, which names `status`.
+      const error = await assertThrowsErrorAsync(async () =>
+        requests[action as keyof typeof requests](simAws, caller),
+      );
+
+      // Then the condition fails and the whole request is refused.
+      assertInstanceOf(error, SimIamAccessDenied);
+    },
+  );
+
+  it("counts a nested path as the attribute it starts at", async () => {
+    // Given a caller allowed the key attributes and `address`, where the
+    // request reaches a field inside that map. AWS counts a top-level
+    // attribute as named where anything nested inside it is.
+    const simAws = new SimAws();
+    await stockedTable(simAws);
+    const caller = await callerAllowed(simAws, [...keyAttributes, "address"]);
+
+    // When it projects the nested path.
+    const answer = await simAws.dynamoDb().getItem(
+      {
+        input: {
+          TableName: tableName,
+          Key: { customerId: { S: "c-1" }, orderId: { S: "2026-01" } },
+          ProjectionExpression: "address.city",
+        },
+      },
+      { caller },
+    );
+
+    // Then `address` is what the condition matched, and `city` never reached
+    // it as an attribute of its own.
+    assertNonNullable(answer.Item);
+  });
+
+  it("refuses a request naming the key attributes the policy leaves out", async () => {
+    // Given a caller allowed `status` alone. AWS requires a policy using
+    // `dynamodb:Attributes` to name every primary key attribute of the table,
+    // since DynamoDB needs them to perform the action.
+    const simAws = new SimAws();
+    await stockedTable(simAws);
+    const caller = await callerAllowed(simAws, ["status"]);
+
+    // When it reads an item, which names its key.
+    const error = await assertThrowsErrorAsync(async () =>
+      requests["dynamodb:GetItem"](simAws, caller),
+    );
+
+    // Then the key attributes fail the condition.
+    assertInstanceOf(error, SimIamAccessDenied);
+  });
+
+  it("names no attributes for a request carrying no expression or key", async () => {
+    // Given a caller allowed nothing but `total`, and a scan naming no
+    // expression at all.
+    const simAws = new SimAws();
+    await stockedTable(simAws);
+    const caller = await callerAllowed(simAws, ["total"]);
+
+    // When it scans the whole table.
+    const answer = await simAws
+      .dynamoDb()
+      .scan({ input: { TableName: tableName } }, { caller });
+
+    // Then the key is absent from the condition context, and a `ForAllValues`
+    // condition matches a request carrying no value for it. This is the
+    // over-permissive case AWS warns about, and a `Null` guard is what closes
+    // it.
+    assertNonNullable(answer.Items);
+  });
+});

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-attributes.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-attributes.ts
@@ -1,0 +1,42 @@
+import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
+
+/**
+ * The condition key DynamoDB names a request's attributes by.
+ */
+export const simDynamoDbAttributesConditionKey = "dynamodb:Attributes";
+
+/**
+ * The top-level attribute names a `Key` or an `Item` carries.
+ *
+ * Those parameters name their attributes outright, so there is no expression
+ * to read them out of. Every name is top-level, since an item's attributes are
+ * what nesting starts from.
+ *
+ * The items are read when authorization asks for them, and whatever reading
+ * them throws is dropped. Authorization runs ahead of the checks a command
+ * makes on what it was given, so a request too malformed to read is authorized
+ * naming no attributes and refused by the check that follows.
+ */
+export function simDynamoDbItemAttributeNames(
+  items: () => readonly SimDynamoDbItem[],
+): readonly string[] {
+  try {
+    return items().flatMap((item) => item.attributeNames());
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Gather the attribute names a request reaches, keeping each one once.
+ *
+ * A request names the same attribute in more than one place often enough for
+ * this to matter. An UpdateItem names its key in `Key` and may name it again
+ * in a condition, and AWS supplies one list of attributes rather than one per
+ * parameter.
+ */
+export function simDynamoDbAttributesOf(
+  ...sources: readonly (readonly string[])[]
+): readonly string[] {
+  return [...new Set(sources.flat())];
+}

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-authorizer.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-authorizer.ts
@@ -4,24 +4,8 @@ import type { SimAwsAccountRegionScope } from "../../../aws/sim-aws-account-regi
 import type { SimIamInterServiceAuthZ } from "../../../iam/authorize/sim-iam-inter-service-auth-z.js";
 import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
 import { simDynamoDbTableArn } from "../../table/sim-dynamodb-table-arn.js";
-import { simDynamoDbLeadingKeysConditionKey } from "./sim-dynamodb-leading-keys.js";
-
-/**
- * The condition values a request carries for the table it names.
- *
- * A request reaching no partition key value supplies none rather than an empty
- * list, leaving the key absent from the context as it is on AWS for an
- * operation that names no item.
- */
-function conditionContextOf(
-  leadingKeys: readonly string[] | undefined,
-): Readonly<Record<string, readonly string[]>> {
-  if (leadingKeys === undefined || leadingKeys.length === 0) {
-    return {};
-  }
-
-  return { [simDynamoDbLeadingKeysConditionKey]: leadingKeys };
-}
+import type { SimDynamoDbReached } from "./sim-dynamodb-reached.js";
+import { simDynamoDbConditionContextOf } from "./sim-dynamodb-reached.js";
 
 interface SimDynamoDbAuthorizerProperties {
   readonly iam: SimIamInterServiceAuthZ;
@@ -60,13 +44,13 @@ export class SimDynamoDbAuthorizer {
     action: string,
     tableName: string,
     caller?: SimAwsCaller,
-    leadingKeys?: readonly string[],
+    reached: SimDynamoDbReached = {},
   ): SimAwsResolvedCaller {
     return this.authorizeResource(
       action,
       simDynamoDbTableArn(this.accountRegionScope, tableName),
       caller,
-      leadingKeys,
+      reached,
     );
   }
 
@@ -105,13 +89,13 @@ export class SimDynamoDbAuthorizer {
     action: string,
     resource: string,
     caller: SimAwsCaller | undefined,
-    leadingKeys?: readonly string[],
+    reached: SimDynamoDbReached = {},
   ): SimAwsResolvedCaller {
     const decision = this.iam.authorize({
       action,
       resource,
       caller,
-      conditionContext: conditionContextOf(leadingKeys),
+      conditionContext: simDynamoDbConditionContextOf(reached),
     });
 
     if (decision.isDenied) {

--- a/src/service/dynamodb/command/authorize/sim-dynamodb-reached.ts
+++ b/src/service/dynamodb/command/authorize/sim-dynamodb-reached.ts
@@ -1,0 +1,31 @@
+import { simDynamoDbAttributesConditionKey } from "./sim-dynamodb-attributes.js";
+import { simDynamoDbLeadingKeysConditionKey } from "./sim-dynamodb-leading-keys.js";
+
+/**
+ * What one request reaches in the table it names.
+ *
+ * Each entry becomes a DynamoDB condition key. A request reaching nothing
+ * under one of them leaves it out, as AWS leaves a key out for an operation
+ * that reaches nothing it names.
+ */
+export interface SimDynamoDbReached {
+  /** The partition key values the request reaches. */
+  readonly leadingKeys?: readonly string[] | undefined;
+
+  /** The top-level attribute names the request names. */
+  readonly attributes?: readonly string[] | undefined;
+}
+
+/**
+ * The condition values a request carries for the table it names.
+ */
+export function simDynamoDbConditionContextOf(
+  reached: SimDynamoDbReached,
+): Readonly<Record<string, readonly string[]>> {
+  return Object.fromEntries(
+    [
+      [simDynamoDbLeadingKeysConditionKey, reached.leadingKeys],
+      [simDynamoDbAttributesConditionKey, reached.attributes],
+    ].filter(([, values]) => (values ?? []).length > 0),
+  ) as Readonly<Record<string, readonly string[]>>;
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-get-item.ts
@@ -68,7 +68,10 @@ export class SimDynamoDbBatchGetItem {
         access: this.access,
         operation: "BatchGetItem",
         caller: options?.caller,
-        leadingKeys: (entry) => simDynamoDbLeadingKeysOf(() => entry.keys),
+        reached: (entry) => ({
+          leadingKeys: simDynamoDbLeadingKeysOf(() => entry.keys),
+          attributes: entry.attributes,
+        }),
       },
     );
     const responses = Object.fromEntries(

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-read-limit.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-read-limit.ts
@@ -1,0 +1,29 @@
+import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
+import type { SimDynamoDbKeysAndAttributes } from "./batch.command.js";
+import type { SimDynamoDbBatchTableRequest } from "./sim-dynamodb-batch-request-items.js";
+
+/**
+ * Real DynamoDB reads 100 items in one batch, counted across every table the
+ * request names rather than per table.
+ */
+const greatestKeys = 100;
+
+/**
+ * Refuse a batch asking for more items than DynamoDB reads at once.
+ */
+export function assertSimDynamoDbBatchReadLimit(
+  tables: readonly SimDynamoDbBatchTableRequest<SimDynamoDbKeysAndAttributes>[],
+  operation: string,
+): void {
+  const total = tables.reduce(
+    (count, { requested }) => count + (requested.Keys ?? []).length,
+    0,
+  );
+
+  if (total > greatestKeys) {
+    throw new SimDynamoDbValidationException(
+      `Too many items requested for the ${operation} call: ${total.toString()} ` +
+        `keys, where ${greatestKeys.toString()} is the most a batch reads`,
+    );
+  }
+}

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-reads.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-reads.ts
@@ -3,20 +3,16 @@ import { readSimDynamoDbProjection } from "../../expression/projection/sim-dynam
 import type { SimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import { readSimDynamoDbKey } from "../item/sim-dynamodb-key-input.js";
-import type { SimDynamoDbKeysAndAttributes } from "./batch.command.js";
 import {
-  readSimDynamoDbBatchRequestItems,
-  type SimDynamoDbBatchTableRequest,
-} from "./sim-dynamodb-batch-request-items.js";
+  simDynamoDbAttributesOf,
+  simDynamoDbItemAttributeNames,
+} from "../authorize/sim-dynamodb-attributes.js";
+import type { SimDynamoDbKeysAndAttributes } from "./batch.command.js";
+import { readSimDynamoDbBatchRequestItems } from "./sim-dynamodb-batch-request-items.js";
+import { assertSimDynamoDbBatchReadLimit } from "./sim-dynamodb-batch-read-limit.js";
 import { refuseUnsimulatedBatchKeysAndAttributes } from "./sim-dynamodb-unsimulated-batch-input.js";
 
 const operation = "BatchGetItem";
-
-/**
- * Real DynamoDB reads 100 items in one batch, counted across every table the
- * request names rather than per table.
- */
-const greatestKeys = 100;
 
 /**
  * What a batch read asks one table for.
@@ -28,6 +24,9 @@ export interface SimDynamoDbBatchTableReads {
   readonly reference: string;
   readonly keys: readonly SimDynamoDbItem[];
   readonly projection: SimDynamoDbProjection | undefined;
+
+  /** The top-level attributes this table is asked for, per table as above. */
+  readonly attributes: readonly string[];
 }
 
 /**
@@ -43,32 +42,22 @@ export function readSimDynamoDbBatchReads(
 ): readonly SimDynamoDbBatchTableReads[] {
   const tables = readSimDynamoDbBatchRequestItems(requestItems, operation);
 
-  assertWithinKeyLimit(tables);
+  assertSimDynamoDbBatchReadLimit(tables, operation);
 
-  return tables.map(({ reference, requested }) => ({
-    reference,
-    keys: readTableKeys(reference, requested),
-    projection: readSimDynamoDbProjection(requested),
-  }));
-}
+  return tables.map(({ reference, requested }) => {
+    const keys = readTableKeys(reference, requested);
+    const read = readSimDynamoDbProjection(requested);
 
-/**
- * Refuse a batch asking for more items than DynamoDB reads at once.
- */
-function assertWithinKeyLimit(
-  tables: readonly SimDynamoDbBatchTableRequest<SimDynamoDbKeysAndAttributes>[],
-): void {
-  const total = tables.reduce(
-    (count, { requested }) => count + (requested.Keys ?? []).length,
-    0,
-  );
-
-  if (total > greatestKeys) {
-    throw new SimDynamoDbValidationException(
-      `Too many items requested for the ${operation} call: ${total.toString()} ` +
-        `keys, where ${greatestKeys.toString()} is the most a batch reads`,
-    );
-  }
+    return {
+      reference,
+      keys,
+      projection: read.projection,
+      attributes: simDynamoDbAttributesOf(
+        read.attributes,
+        simDynamoDbItemAttributeNames(() => keys),
+      ),
+    };
+  });
 }
 
 /**

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-tables.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-tables.ts
@@ -2,7 +2,7 @@ import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
-import type { SimDynamoDbLeadingKeys } from "../authorize/sim-dynamodb-leading-keys.js";
+import type { SimDynamoDbTableReach } from "../table/sim-dynamodb-table-reach.js";
 
 /**
  * What one table of a batch asks for, against the table it names.
@@ -18,12 +18,12 @@ interface SimDynamoDbBatchReach<Requested> {
   readonly caller: SimAwsCaller | undefined;
 
   /**
-   * How to read the partition key values one table of the batch is asked for.
+   * What one table of the batch is asked for.
    *
-   * Each table is authorized on its own, so each carries the keys the batch
-   * names in that table and no others.
+   * Each table is authorized on its own, so each carries the keys and the
+   * attributes the batch names in that table and no others.
    */
-  readonly leadingKeys: (requested: Requested) => SimDynamoDbLeadingKeys;
+  readonly reached: (requested: Requested) => SimDynamoDbTableReach;
 }
 
 /**
@@ -47,7 +47,7 @@ export function reachSimDynamoDbBatchTables<
       action,
       entry.reference,
       reach.caller,
-      reach.leadingKeys(entry),
+      reach.reached(entry),
     ),
     requested: entry,
   }));

--- a/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.ts
+++ b/src/service/dynamodb/command/batch/sim-dynamodb-batch-write-item.ts
@@ -9,6 +9,7 @@ import { reachSimDynamoDbBatchTables } from "./sim-dynamodb-batch-tables.js";
 import { readSimDynamoDbBatchWrites } from "./sim-dynamodb-batch-writes.js";
 import { refuseUnsimulatedBatchWriteInput } from "./sim-dynamodb-unsimulated-batch-input.js";
 import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
+import { simDynamoDbItemAttributeNames } from "../authorize/sim-dynamodb-attributes.js";
 
 const operation = "BatchWriteItem";
 
@@ -55,10 +56,14 @@ export class SimDynamoDbBatchWriteItem {
         access: this.access,
         operation,
         caller: options?.caller,
-        leadingKeys: (entry) =>
-          simDynamoDbLeadingKeysOf(() =>
+        reached: (entry) => ({
+          leadingKeys: simDynamoDbLeadingKeysOf(() =>
             entry.writes.map((write) => write.names),
           ),
+          attributes: simDynamoDbItemAttributeNames(() =>
+            entry.writes.map((write) => write.names),
+          ),
+        }),
       },
     );
 

--- a/src/service/dynamodb/command/item/sim-dynamodb-condition-check.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-condition-check.ts
@@ -27,6 +27,7 @@ interface SimDynamoDbConditionCheckInput {
 interface SimDynamoDbConditionCheckProperties {
   readonly condition: SimDynamoDbCondition | undefined;
   readonly reportsItem: boolean;
+  readonly attributeNames: readonly string[];
 }
 
 /**
@@ -37,12 +38,18 @@ interface SimDynamoDbConditionCheckProperties {
  * be nothing: that is what makes `attribute_not_exists` an insert if absent.
  */
 export class SimDynamoDbConditionCheck {
+  /**
+   * The top-level attributes the condition named, for `dynamodb:Attributes`.
+   */
+  public readonly attributeNames: readonly string[];
+
   private readonly condition: SimDynamoDbCondition | undefined;
   private readonly reportsItem: boolean;
 
   private constructor(properties: SimDynamoDbConditionCheckProperties) {
     this.condition = properties.condition;
     this.reportsItem = properties.reportsItem;
+    this.attributeNames = properties.attributeNames;
   }
 
   /**
@@ -55,7 +62,9 @@ export class SimDynamoDbConditionCheck {
     input: SimDynamoDbConditionCheckInput,
     operation: string,
   ): SimDynamoDbConditionCheck {
-    return this.of(readSimDynamoDbCondition(input), input, operation);
+    const read = readSimDynamoDbCondition(input);
+
+    return this.of(read.condition, input, operation, read.attributes);
   }
 
   /**
@@ -68,10 +77,12 @@ export class SimDynamoDbConditionCheck {
     condition: SimDynamoDbCondition | undefined,
     input: SimDynamoDbConditionCheckInput,
     operation: string,
+    attributeNames: readonly string[] = [],
   ): SimDynamoDbConditionCheck {
     return new this({
       condition,
       reportsItem: this.reportsItemFor(input, operation),
+      attributeNames,
     });
   }
 

--- a/src/service/dynamodb/command/item/sim-dynamodb-delete-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-delete-item.ts
@@ -1,6 +1,10 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
+import {
+  simDynamoDbAttributesOf,
+  simDynamoDbItemAttributeNames,
+} from "../authorize/sim-dynamodb-attributes.js";
 import type {
   SimDeleteItemCommand,
   SimDeleteItemCommandOutput,
@@ -53,7 +57,15 @@ export class SimDynamoDbDeleteItem {
       "dynamodb:DeleteItem",
       input.TableName,
       options?.caller,
-      simDynamoDbLeadingKeysOf(() => [readSimDynamoDbKey(input.Key)]),
+      {
+        leadingKeys: simDynamoDbLeadingKeysOf(() => [
+          readSimDynamoDbKey(input.Key),
+        ]),
+        attributes: simDynamoDbAttributesOf(
+          check.attributeNames,
+          simDynamoDbItemAttributeNames(() => [readSimDynamoDbKey(input.Key)]),
+        ),
+      },
     );
     const asked = SimDynamoDbReturnValues.read(
       input.ReturnValues,

--- a/src/service/dynamodb/command/item/sim-dynamodb-get-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-get-item.ts
@@ -8,6 +8,10 @@ import type {
 import { readSimDynamoDbKey } from "./sim-dynamodb-key-input.js";
 import { refuseUnsimulatedItemReadInput } from "./sim-dynamodb-unsimulated-item-read-input.js";
 import { readSimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection-expression.js";
+import {
+  simDynamoDbAttributesOf,
+  simDynamoDbItemAttributeNames,
+} from "../authorize/sim-dynamodb-attributes.js";
 
 interface SimDynamoDbGetItemProperties {
   readonly access: SimDynamoDbTableAccess;
@@ -48,12 +52,21 @@ export class SimDynamoDbGetItem {
 
     // The projection is read before the table is reached, so an expression
     // DynamoDB would refuse is refused whether or not the key holds anything.
-    const projection = readSimDynamoDbProjection(input);
+    const read = readSimDynamoDbProjection(input);
+    const projection = read.projection;
     const table = this.access.required(
       "dynamodb:GetItem",
       input.TableName,
       options?.caller,
-      simDynamoDbLeadingKeysOf(() => [readSimDynamoDbKey(input.Key)]),
+      {
+        leadingKeys: simDynamoDbLeadingKeysOf(() => [
+          readSimDynamoDbKey(input.Key),
+        ]),
+        attributes: simDynamoDbAttributesOf(
+          read.attributes,
+          simDynamoDbItemAttributeNames(() => [readSimDynamoDbKey(input.Key)]),
+        ),
+      },
     );
     const found = table.getItem(readSimDynamoDbKey(input.Key));
 

--- a/src/service/dynamodb/command/item/sim-dynamodb-put-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-put-item.ts
@@ -3,6 +3,10 @@ import { SimDynamoDbValidationException } from "../../error/dynamodb.error.js";
 import { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
+import {
+  simDynamoDbAttributesOf,
+  simDynamoDbItemAttributeNames,
+} from "../authorize/sim-dynamodb-attributes.js";
 import type {
   SimPutItemCommand,
   SimPutItemCommandInput,
@@ -66,7 +70,13 @@ export class SimDynamoDbPutItem {
       "dynamodb:PutItem",
       input.TableName,
       options?.caller,
-      simDynamoDbLeadingKeysOf(() => [readItem(input)]),
+      {
+        leadingKeys: simDynamoDbLeadingKeysOf(() => [readItem(input)]),
+        attributes: simDynamoDbAttributesOf(
+          check.attributeNames,
+          simDynamoDbItemAttributeNames(() => [readItem(input)]),
+        ),
+      },
     );
     const asked = SimDynamoDbReturnValues.read(input.ReturnValues, "PutItem");
     const item = readItem(input);

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-expressions.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-expressions.ts
@@ -19,6 +19,9 @@ export interface SimDynamoDbUpdateExpressionInput extends SimDynamoDbExpressionP
 export interface SimDynamoDbUpdateExpressions {
   readonly update: SimDynamoDbUpdate;
   readonly condition: SimDynamoDbCondition | undefined;
+
+  /** The top-level attributes the expressions named, for `dynamodb:Attributes`. */
+  readonly attributes: readonly string[];
 }
 
 /**
@@ -38,7 +41,7 @@ export function readSimDynamoDbUpdateExpressions(
 
   parameters.assertAllUsed();
 
-  return { update, condition };
+  return { update, condition, attributes: parameters.attributes.topLevel };
 }
 
 /**

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-item.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-item.ts
@@ -1,6 +1,10 @@
 import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
 import type { SimDynamoDbTableAccess } from "../table/sim-dynamodb-table-access.js";
 import { simDynamoDbLeadingKeysOf } from "../authorize/sim-dynamodb-leading-keys.js";
+import {
+  simDynamoDbAttributesOf,
+  simDynamoDbItemAttributeNames,
+} from "../authorize/sim-dynamodb-attributes.js";
 import type {
   SimUpdateItemCommand,
   SimUpdateItemCommandOutput,
@@ -55,7 +59,15 @@ export class SimDynamoDbUpdateItem {
       "dynamodb:UpdateItem",
       input.TableName,
       options?.caller,
-      simDynamoDbLeadingKeysOf(() => [readSimDynamoDbKey(input.Key)]),
+      {
+        leadingKeys: simDynamoDbLeadingKeysOf(() => [
+          readSimDynamoDbKey(input.Key),
+        ]),
+        attributes: simDynamoDbAttributesOf(
+          plan.attributeNames,
+          simDynamoDbItemAttributeNames(() => [readSimDynamoDbKey(input.Key)]),
+        ),
+      },
     );
     const asked = SimDynamoDbReturnValues.readForUpdate(
       input.ReturnValues,

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-plan.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-plan.ts
@@ -1,6 +1,6 @@
-import { SimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection.js";
-import { updateExpressionName } from "../../expression/update/sim-dynamodb-update-refusal.js";
+import type { SimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection.js";
 import type { SimDynamoDbUpdate } from "../../expression/update/sim-dynamodb-update.js";
+import { simDynamoDbTouchedBy } from "./sim-dynamodb-update-touched.js";
 import type { SimDynamoDbItem } from "../../item/sim-dynamodb-item.js";
 import { SimDynamoDbConditionCheck } from "./sim-dynamodb-condition-check.js";
 import {
@@ -15,6 +15,7 @@ interface SimDynamoDbUpdatePlanInput extends SimDynamoDbUpdateExpressionInput {
 interface SimDynamoDbUpdatePlanProperties {
   readonly update: SimDynamoDbUpdate | undefined;
   readonly check: SimDynamoDbConditionCheck;
+  readonly attributeNames: readonly string[];
 }
 
 /**
@@ -23,11 +24,19 @@ interface SimDynamoDbUpdatePlanProperties {
 export class SimDynamoDbUpdatePlan {
   public readonly check: SimDynamoDbConditionCheck;
 
+  /**
+   * The top-level attributes both expressions named, for
+   * `dynamodb:Attributes`. They share one set of placeholders, so the update
+   * and the condition guarding it are gathered together.
+   */
+  public readonly attributeNames: readonly string[];
+
   private readonly update: SimDynamoDbUpdate | undefined;
 
   private constructor(properties: SimDynamoDbUpdatePlanProperties) {
     this.update = properties.update;
     this.check = properties.check;
+    this.attributeNames = properties.attributeNames;
   }
 
   /**
@@ -43,9 +52,12 @@ export class SimDynamoDbUpdatePlan {
     const expression = input.UpdateExpression;
 
     if (expression === undefined) {
+      const check = SimDynamoDbConditionCheck.read(input, operation);
+
       return new this({
         update: undefined,
-        check: SimDynamoDbConditionCheck.read(input, operation),
+        check,
+        attributeNames: check.attributeNames,
       });
     }
 
@@ -54,6 +66,7 @@ export class SimDynamoDbUpdatePlan {
     return new this({
       update: read.update,
       check: SimDynamoDbConditionCheck.of(read.condition, input, operation),
+      attributeNames: read.attributes,
     });
   }
 
@@ -65,20 +78,10 @@ export class SimDynamoDbUpdatePlan {
   }
 
   /**
-   * The parts of an item this update touched, for the reporting modes that
-   * answer with those and nothing else.
-   *
-   * A request that says nothing to change touched nothing, so the projection it
-   * answers with finds nothing in either item.
+   * The parts of an item this update touched.
    */
   touched(): SimDynamoDbProjection {
-    return (
-      this.update?.touched() ??
-      new SimDynamoDbProjection({
-        expressionName: updateExpressionName,
-        paths: [],
-      })
-    );
+    return simDynamoDbTouchedBy(this.update);
   }
 
   /**

--- a/src/service/dynamodb/command/item/sim-dynamodb-update-touched.ts
+++ b/src/service/dynamodb/command/item/sim-dynamodb-update-touched.ts
@@ -1,0 +1,22 @@
+import { SimDynamoDbProjection } from "../../expression/projection/sim-dynamodb-projection.js";
+import { updateExpressionName } from "../../expression/update/sim-dynamodb-update-refusal.js";
+import type { SimDynamoDbUpdate } from "../../expression/update/sim-dynamodb-update.js";
+
+/**
+ * The parts of an item an update touched, for the reporting modes that answer
+ * with those and nothing else.
+ *
+ * A request that says nothing to change touched nothing, so the projection it
+ * answers with finds nothing in either item.
+ */
+export function simDynamoDbTouchedBy(
+  update: SimDynamoDbUpdate | undefined,
+): SimDynamoDbProjection {
+  return (
+    update?.touched() ??
+    new SimDynamoDbProjection({
+      expressionName: updateExpressionName,
+      paths: [],
+    })
+  );
+}

--- a/src/service/dynamodb/command/query/sim-dynamodb-query-expressions.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query-expressions.ts
@@ -14,6 +14,9 @@ export interface SimDynamoDbQueryExpressions {
   readonly terms: SimDynamoDbKeyConditionTerms;
   readonly filter: SimDynamoDbFilter | undefined;
   readonly projection: SimDynamoDbProjection | undefined;
+
+  /** The top-level attributes the expressions named, for `dynamodb:Attributes`. */
+  readonly attributes: readonly string[];
 }
 
 /**
@@ -39,7 +42,12 @@ export function readSimDynamoDbQueryExpressions(
 
   parameters.assertAllUsed();
 
-  return { terms, filter, projection };
+  return {
+    terms,
+    filter,
+    projection,
+    attributes: parameters.attributes.topLevel,
+  };
 }
 
 /**

--- a/src/service/dynamodb/command/query/sim-dynamodb-query.ts
+++ b/src/service/dynamodb/command/query/sim-dynamodb-query.ts
@@ -62,11 +62,14 @@ export class SimDynamoDbQuery {
       "dynamodb:Query",
       input.TableName,
       options?.caller,
-      (reached) =>
-        simDynamoDbLeadingKeyOf(
-          expressions.terms.forTable(reached.view(input.IndexName))
-            .partitionKeyValue,
-        ),
+      {
+        leadingKeys: (reached) =>
+          simDynamoDbLeadingKeyOf(
+            expressions.terms.forTable(reached.view(input.IndexName))
+              .partitionKeyValue,
+          ),
+        attributes: expressions.attributes,
+      },
     );
 
     // What is being read is settled here: the table, or one of its indexes. An

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan-expressions.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan-expressions.ts
@@ -11,6 +11,9 @@ import type { SimScanCommandInput } from "./scan.command.js";
 export interface SimDynamoDbScanExpressions {
   readonly filter: SimDynamoDbFilter | undefined;
   readonly projection: SimDynamoDbProjection | undefined;
+
+  /** The top-level attributes the expressions named, for `dynamodb:Attributes`. */
+  readonly attributes: readonly string[];
 }
 
 /**
@@ -39,7 +42,7 @@ export function readSimDynamoDbScanExpressions(
   ) {
     SimDynamoDbExpressionParameters.assertNoneWithout(input);
 
-    return { filter: undefined, projection: undefined };
+    return { filter: undefined, projection: undefined, attributes: [] };
   }
 
   const parameters = new SimDynamoDbExpressionParameters(input);
@@ -48,7 +51,7 @@ export function readSimDynamoDbScanExpressions(
 
   parameters.assertAllUsed();
 
-  return { filter, projection };
+  return { filter, projection, attributes: parameters.attributes.topLevel };
 }
 
 /**

--- a/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
+++ b/src/service/dynamodb/command/scan/sim-dynamodb-scan.ts
@@ -63,6 +63,7 @@ export class SimDynamoDbScan {
       "dynamodb:Scan",
       input.TableName,
       options?.caller,
+      { attributes: expressions.attributes },
     );
 
     // What is being read is settled here: the table, or one of its indexes.

--- a/src/service/dynamodb/command/table/sim-dynamodb-table-access.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-table-access.ts
@@ -6,27 +6,8 @@ import type { SimDynamoDbTableName } from "../../table/sim-dynamodb-table-name.j
 import { readSimDynamoDbTableReference } from "../../table/sim-dynamodb-table-reference.js";
 import type { SimDynamoDbTableStore } from "../../table/sim-dynamodb-table-store.js";
 import type { SimDynamoDbAuthorizer } from "../authorize/sim-dynamodb-authorizer.js";
-import type { SimDynamoDbLeadingKeys } from "../authorize/sim-dynamodb-leading-keys.js";
-
-/**
- * Read the partition key values a request reaches, or none where they cannot
- * be read.
- *
- * Authorization runs ahead of the checks a command makes on what it was given,
- * as it does on AWS. A request whose key or key condition is malformed is
- * authorized carrying no values and refused by the check that follows, so
- * whatever reading them throws is dropped here.
- */
-function readLeadingKeys(
-  leadingKeys: SimDynamoDbLeadingKeys | undefined,
-  table: SimDynamoDbTable,
-): readonly string[] | undefined {
-  try {
-    return leadingKeys?.(table);
-  } catch {
-    return undefined;
-  }
-}
+import type { SimDynamoDbTableReach } from "./sim-dynamodb-table-reach.js";
+import { simDynamoDbReachedIn } from "./sim-dynamodb-table-reach.js";
 
 interface SimDynamoDbTableAccessProperties {
   readonly tables: SimDynamoDbTableStore;
@@ -73,13 +54,13 @@ export class SimDynamoDbTableAccess {
     action: string,
     tableName: string | undefined,
     caller: SimAwsCaller | undefined,
-    leadingKeys?: SimDynamoDbLeadingKeys,
+    reach: SimDynamoDbTableReach = {},
   ): SimDynamoDbTable {
     return this.requiredByName(
       action,
       this.reference(tableName),
       caller,
-      leadingKeys,
+      reach,
     );
   }
 
@@ -94,7 +75,7 @@ export class SimDynamoDbTableAccess {
     action: string,
     name: SimDynamoDbTableName,
     caller: SimAwsCaller | undefined,
-    leadingKeys?: SimDynamoDbLeadingKeys,
+    reach: SimDynamoDbTableReach = {},
   ): SimDynamoDbTable {
     const table = this.tables.find(name);
 
@@ -102,7 +83,7 @@ export class SimDynamoDbTableAccess {
       action,
       name.value,
       caller,
-      table === undefined ? undefined : readLeadingKeys(leadingKeys, table),
+      simDynamoDbReachedIn(reach, table),
     );
 
     if (table === undefined) {

--- a/src/service/dynamodb/command/table/sim-dynamodb-table-reach.ts
+++ b/src/service/dynamodb/command/table/sim-dynamodb-table-reach.ts
@@ -1,0 +1,50 @@
+import type { SimDynamoDbReached } from "../authorize/sim-dynamodb-reached.js";
+import type { SimDynamoDbLeadingKeys } from "../authorize/sim-dynamodb-leading-keys.js";
+import type { SimDynamoDbTable } from "../../table/sim-dynamodb-table.js";
+
+/**
+ * What one command's request reaches, for the condition keys authorization
+ * supplies.
+ *
+ * The partition key values need the table to read them, so they arrive as a
+ * function of it. The attribute names are read from the request's own
+ * parameters before the table is reached, so they arrive as they are.
+ */
+export interface SimDynamoDbTableReach {
+  readonly leadingKeys?: SimDynamoDbLeadingKeys | undefined;
+  readonly attributes?: readonly string[] | undefined;
+}
+
+/**
+ * Resolve what a request reaches against the table it named.
+ *
+ * Authorization runs ahead of the checks a command makes on what it was given,
+ * as it does on AWS. A request whose key or key condition is malformed is
+ * authorized carrying no values and refused by the check that follows, so
+ * whatever reading them throws is dropped here. A table that is not there
+ * leaves the values unread, since the key schema is what reads them.
+ */
+export function simDynamoDbReachedIn(
+  reach: SimDynamoDbTableReach,
+  table: SimDynamoDbTable | undefined,
+): SimDynamoDbReached {
+  return {
+    leadingKeys: table === undefined ? undefined : leadingKeysIn(reach, table),
+    attributes: reach.attributes,
+  };
+}
+
+/**
+ * Read the partition key values a request reaches, or none where they cannot
+ * be read.
+ */
+function leadingKeysIn(
+  reach: SimDynamoDbTableReach,
+  table: SimDynamoDbTable,
+): readonly string[] | undefined {
+  try {
+    return reach.leadingKeys?.(table);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/service/dynamodb/command/transact/sim-dynamodb-transact-gets.ts
+++ b/src/service/dynamodb/command/transact/sim-dynamodb-transact-gets.ts
@@ -43,7 +43,7 @@ export class SimDynamoDbTransactRead {
     return new this(
       request.TableName,
       readSimDynamoDbKey(request.Key),
-      readSimDynamoDbProjection(request),
+      readSimDynamoDbProjection(request).projection,
     );
   }
 

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-expression.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-expression.ts
@@ -10,6 +10,16 @@ interface SimDynamoDbConditionRequest extends SimDynamoDbExpressionParameterInpu
 }
 
 /**
+ * What a request's ConditionExpression said, once it has been read.
+ */
+export interface SimDynamoDbConditionRead {
+  readonly condition: SimDynamoDbCondition | undefined;
+
+  /** The top-level attributes the expression named, for `dynamodb:Attributes`. */
+  readonly attributes: readonly string[];
+}
+
+/**
  * Read the condition a write is guarded by, if it names one.
  *
  * A request with no ConditionExpression is an unconditional write, so there is
@@ -17,13 +27,13 @@ interface SimDynamoDbConditionRequest extends SimDynamoDbExpressionParameterInpu
  */
 export function readSimDynamoDbCondition(
   request: SimDynamoDbConditionRequest,
-): SimDynamoDbCondition | undefined {
+): SimDynamoDbConditionRead {
   const expression = request.ConditionExpression;
 
   if (expression === undefined) {
     SimDynamoDbExpressionParameters.assertNoneWithout(request);
 
-    return undefined;
+    return { condition: undefined, attributes: [] };
   }
 
   const parameters = new SimDynamoDbExpressionParameters(request);
@@ -31,7 +41,7 @@ export function readSimDynamoDbCondition(
 
   parameters.assertAllUsed();
 
-  return condition;
+  return { condition, attributes: parameters.attributes.topLevel };
 }
 
 /**

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-function.iso.test.ts
@@ -38,7 +38,7 @@ function holds(
   expression: string,
   values?: Readonly<Record<string, SimDynamoDbAttributeValue>>,
 ): boolean {
-  const condition = readSimDynamoDbCondition({
+  const { condition } = readSimDynamoDbCondition({
     ConditionExpression: expression,
     ExpressionAttributeValues: values,
   });
@@ -205,7 +205,7 @@ describe("DynamoDB condition expression functions", () => {
     // Given a status of seven ASCII characters, and the item's other text.
     // When size is compared against the character count of something outside
     // ASCII, then the bytes win: DynamoDB measures a string in bytes.
-    const condition = readSimDynamoDbCondition({
+    const { condition } = readSimDynamoDbCondition({
       ConditionExpression: "size(city) = :three",
       ExpressionAttributeValues: { ":three": { N: "3" } },
     });
@@ -217,7 +217,7 @@ describe("DynamoDB condition expression functions", () => {
   it("reads a function name as an attribute when it is not a call", () => {
     // Given an item with an attribute named after a function, which is not a
     // reserved word.
-    const condition = readSimDynamoDbCondition({
+    const { condition } = readSimDynamoDbCondition({
       ConditionExpression: "contains = :yes",
       ExpressionAttributeValues: { ":yes": { S: "yes" } },
     });

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-grammar.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-grammar.ts
@@ -20,7 +20,7 @@ export function simDynamoDbConditionParser(
       expression,
       "the expression says nothing, and an expression cannot be empty",
     ),
-    names: parameters.names,
+    attributes: parameters.attributes,
     values: parameters.values,
   });
 }

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-operand-parser.ts
@@ -1,6 +1,7 @@
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
 import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
+import type { SimDynamoDbExpressionAttributes } from "../sim-dynamodb-expression-attributes.js";
 import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import {
@@ -19,7 +20,7 @@ const sizeFunctionName = "size";
 
 interface SimDynamoDbConditionOperandParserProperties {
   readonly tokens: SimDynamoDbExpressionTokens;
-  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly attributes: SimDynamoDbExpressionAttributes;
   readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
 }
 
@@ -32,13 +33,13 @@ interface SimDynamoDbConditionOperandParserProperties {
  */
 export class SimDynamoDbConditionOperandParser {
   private readonly tokens: SimDynamoDbExpressionTokens;
-  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly attributes: SimDynamoDbExpressionAttributes;
   private readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
   private readonly read: SimDynamoDbDocumentPath[] = [];
 
   constructor(properties: SimDynamoDbConditionOperandParserProperties) {
     this.tokens = properties.tokens;
-    this.names = properties.names;
+    this.attributes = properties.attributes;
     this.values = properties.values;
   }
 
@@ -130,7 +131,7 @@ export class SimDynamoDbConditionOperandParser {
   private path(): SimDynamoDbPathOperand {
     const path = new SimDynamoDbDocumentPathParser({
       tokens: this.tokens,
-      names: this.names,
+      attributes: this.attributes,
     }).parse();
 
     this.read.push(path);

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition-parser.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition-parser.ts
@@ -1,5 +1,6 @@
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
+import type { SimDynamoDbExpressionAttributes } from "../sim-dynamodb-expression-attributes.js";
 import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import {
@@ -14,7 +15,7 @@ import { SimDynamoDbConditionOperandParser } from "./sim-dynamodb-condition-oper
 
 interface SimDynamoDbConditionParserProperties {
   readonly tokens: SimDynamoDbExpressionTokens;
-  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly attributes: SimDynamoDbExpressionAttributes;
   readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
 }
 
@@ -38,7 +39,7 @@ export class SimDynamoDbConditionParser {
   constructor(properties: SimDynamoDbConditionParserProperties) {
     const operands = new SimDynamoDbConditionOperandParser({
       tokens: properties.tokens,
-      names: properties.names,
+      attributes: properties.attributes,
       values: properties.values,
     });
 

--- a/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
+++ b/src/service/dynamodb/expression/condition/sim-dynamodb-condition.iso.test.ts
@@ -31,7 +31,7 @@ function holdsFor(
   values: Readonly<Record<string, SimDynamoDbAttributeValue>> | undefined,
   subject: SimDynamoDbItemSnapshot,
 ): boolean {
-  const condition = readSimDynamoDbCondition({
+  const { condition } = readSimDynamoDbCondition({
     ConditionExpression: expression,
     ExpressionAttributeValues: values,
   });
@@ -192,7 +192,7 @@ describe("DynamoDB condition expressions", () => {
     };
 
     // When a condition reaches into both, then it reads what is there.
-    const condition = readSimDynamoDbCondition({
+    const { condition } = readSimDynamoDbCondition({
       ConditionExpression: "#a.city = :city AND lines[0] = :line",
       ExpressionAttributeNames: { "#a": "address" },
       ExpressionAttributeValues: {
@@ -213,6 +213,6 @@ describe("DynamoDB condition expressions", () => {
     // Given a request that names no condition, which is an unconditional
     // write.
     // When the condition is read, then there is none to check.
-    assertUndefined(readSimDynamoDbCondition({}));
+    assertUndefined(readSimDynamoDbCondition({}).condition);
   });
 });

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-expression.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-expression.ts
@@ -42,7 +42,7 @@ export function readSimDynamoDbKeyCondition(
       expression,
       "the expression says nothing, and an expression cannot be empty",
     ),
-    names: parameters.names,
+    attributes: parameters.attributes,
     values: parameters.values,
   }).parse();
 

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-operands.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-operands.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbExpressionAttributes } from "../sim-dynamodb-expression-attributes.js";
 import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import { simDynamoDbKeyConditionError } from "./sim-dynamodb-key-condition-error.js";
@@ -23,7 +24,7 @@ const keyComparators: ReadonlySet<string> = new Set([
 
 interface SimDynamoDbKeyConditionOperandsProperties {
   readonly tokens: SimDynamoDbExpressionTokens;
-  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly attributes: SimDynamoDbExpressionAttributes;
   readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
   readonly refusals: SimDynamoDbKeyConditionRefusals;
 }
@@ -37,13 +38,13 @@ interface SimDynamoDbKeyConditionOperandsProperties {
  */
 export class SimDynamoDbKeyConditionOperands {
   private readonly tokens: SimDynamoDbExpressionTokens;
-  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly attributes: SimDynamoDbExpressionAttributes;
   private readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
   private readonly refusals: SimDynamoDbKeyConditionRefusals;
 
   constructor(properties: SimDynamoDbKeyConditionOperandsProperties) {
     this.tokens = properties.tokens;
-    this.names = properties.names;
+    this.attributes = properties.attributes;
     this.values = properties.values;
     this.refusals = properties.refusals;
   }
@@ -111,10 +112,13 @@ export class SimDynamoDbKeyConditionOperands {
    * The attribute a name token stands for, which may be a placeholder.
    */
   private nameOf(kind: string, text: string): string {
-    if (kind === "name") {
-      return text;
-    }
+    const name = kind === "name" ? text : this.attributes.required(text);
 
-    return this.names.required(text);
+    // A key condition reads no document paths, so the attributes it reaches
+    // are noted here rather than by the path parser. A key is scalar, and the
+    // attribute a term names is always a top-level one.
+    this.attributes.reach(name);
+
+    return name;
   }
 }

--- a/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-parser.ts
+++ b/src/service/dynamodb/expression/key-condition/sim-dynamodb-key-condition-parser.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbExpressionAttributes } from "../sim-dynamodb-expression-attributes.js";
 import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import { SimDynamoDbBeginsWithKeyTerm } from "./sim-dynamodb-begins-with-key-term.js";
@@ -10,7 +11,7 @@ import type { SimDynamoDbKeyConditionTerm } from "./sim-dynamodb-key-condition-t
 
 interface SimDynamoDbKeyConditionParserProperties {
   readonly tokens: SimDynamoDbExpressionTokens;
-  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly attributes: SimDynamoDbExpressionAttributes;
   readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
 }
 
@@ -40,7 +41,7 @@ export class SimDynamoDbKeyConditionParser {
     this.refusals = refusals;
     this.operands = new SimDynamoDbKeyConditionOperands({
       tokens: properties.tokens,
-      names: properties.names,
+      attributes: properties.attributes,
       values: properties.values,
       refusals,
     });

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.iso.test.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.iso.test.ts
@@ -29,7 +29,7 @@ describe("readSimDynamoDbProjection", () => {
     // Given a request asking for the whole item.
     // When the projection is read, then there is none, so nothing cuts the
     // item down.
-    assertUndefined(readSimDynamoDbProjection({}));
+    assertUndefined(readSimDynamoDbProjection({}).projection);
   });
 
   it("refuses names with no expression before it looks at their keys", () => {

--- a/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
+++ b/src/service/dynamodb/expression/projection/sim-dynamodb-projection-expression.ts
@@ -3,7 +3,7 @@ import type { SimDynamoDbDocumentPath } from "../sim-dynamodb-document-path.js";
 import { simDynamoDbExpressionError } from "../sim-dynamodb-expression-error.js";
 import type { SimDynamoDbExpressionParameterInput } from "../sim-dynamodb-expression-parameters.js";
 import { SimDynamoDbExpressionParameters } from "../sim-dynamodb-expression-parameters.js";
-import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionAttributes } from "../sim-dynamodb-expression-attributes.js";
 import { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import { SimDynamoDbProjection } from "./sim-dynamodb-projection.js";
 
@@ -11,6 +11,16 @@ const expressionName = "ProjectionExpression";
 
 interface SimDynamoDbProjectionRequest extends SimDynamoDbExpressionParameterInput {
   readonly ProjectionExpression?: string | undefined;
+}
+
+/**
+ * What a request's ProjectionExpression said, once it has been read.
+ */
+export interface SimDynamoDbProjectionRead {
+  readonly projection: SimDynamoDbProjection | undefined;
+
+  /** The top-level attributes the expression named, for `dynamodb:Attributes`. */
+  readonly attributes: readonly string[];
 }
 
 /**
@@ -26,13 +36,13 @@ interface SimDynamoDbProjectionRequest extends SimDynamoDbExpressionParameterInp
  */
 export function readSimDynamoDbProjection(
   request: SimDynamoDbProjectionRequest,
-): SimDynamoDbProjection | undefined {
+): SimDynamoDbProjectionRead {
   const expression = request.ProjectionExpression;
 
   if (expression === undefined) {
     SimDynamoDbExpressionParameters.assertNoneWithout(request);
 
-    return undefined;
+    return { projection: undefined, attributes: [] };
   }
 
   const parameters = new SimDynamoDbExpressionParameters(request);
@@ -40,7 +50,7 @@ export function readSimDynamoDbProjection(
 
   parameters.assertAllUsed();
 
-  return projection;
+  return { projection, attributes: parameters.attributes.topLevel };
 }
 
 /**
@@ -61,7 +71,7 @@ export function parseSimDynamoDbProjection(
       expression,
       "the expression names no attributes, and an expression cannot be empty",
     ),
-    parameters.names,
+    parameters.attributes,
   );
 
   return new SimDynamoDbProjection({ expressionName, paths });
@@ -72,12 +82,14 @@ export function parseSimDynamoDbProjection(
  */
 function projectedPaths(
   tokens: SimDynamoDbExpressionTokens,
-  names: SimDynamoDbExpressionPlaceholders<string>,
+  attributes: SimDynamoDbExpressionAttributes,
 ): readonly SimDynamoDbDocumentPath[] {
   const paths: SimDynamoDbDocumentPath[] = [];
 
   do {
-    paths.push(new SimDynamoDbDocumentPathParser({ tokens, names }).parse());
+    paths.push(
+      new SimDynamoDbDocumentPathParser({ tokens, attributes }).parse(),
+    );
   } while (tokens.takeSymbol(","));
 
   assertReadToEnd(tokens);

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.iso.test.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.iso.test.ts
@@ -10,6 +10,7 @@ import { describe, it } from "vitest";
 import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
 import { SimDynamoDbDocumentPathParser } from "./sim-dynamodb-document-path-parser.js";
 import type { SimDynamoDbDocumentPath } from "./sim-dynamodb-document-path.js";
+import { SimDynamoDbExpressionAttributes } from "./sim-dynamodb-expression-attributes.js";
 import { SimDynamoDbExpressionPlaceholders } from "./sim-dynamodb-expression-placeholders.js";
 import { SimDynamoDbExpressionTokeniser } from "./sim-dynamodb-expression-tokeniser.js";
 import { SimDynamoDbExpressionTokens } from "./sim-dynamodb-expression-tokens.js";
@@ -32,11 +33,13 @@ function parsePath(
 
   return new SimDynamoDbDocumentPathParser({
     tokens,
-    names: new SimDynamoDbExpressionPlaceholders({
-      parameterName: "ExpressionAttributeNames",
-      marker: "#",
-      entries,
-    }),
+    attributes: new SimDynamoDbExpressionAttributes(
+      new SimDynamoDbExpressionPlaceholders({
+        parameterName: "ExpressionAttributeNames",
+        marker: "#",
+        entries,
+      }),
+    ),
   }).parse();
 }
 

--- a/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-document-path-parser.ts
@@ -1,8 +1,9 @@
 import {
   SimDynamoDbDocumentPath,
+  type SimDynamoDbAttributeSegment,
   type SimDynamoDbDocumentPathSegment,
 } from "./sim-dynamodb-document-path.js";
-import type { SimDynamoDbExpressionPlaceholders } from "./sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionAttributes } from "./sim-dynamodb-expression-attributes.js";
 import type { SimDynamoDbExpressionTokens } from "./sim-dynamodb-expression-tokens.js";
 
 /**
@@ -13,7 +14,7 @@ const greatestDepth = 32;
 
 interface SimDynamoDbDocumentPathParserProperties {
   readonly tokens: SimDynamoDbExpressionTokens;
-  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly attributes: SimDynamoDbExpressionAttributes;
 }
 
 /**
@@ -26,19 +27,24 @@ interface SimDynamoDbDocumentPathParserProperties {
  */
 export class SimDynamoDbDocumentPathParser {
   private readonly tokens: SimDynamoDbExpressionTokens;
-  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly attributes: SimDynamoDbExpressionAttributes;
   private readonly segments: SimDynamoDbDocumentPathSegment[] = [];
 
   constructor(properties: SimDynamoDbDocumentPathParserProperties) {
     this.tokens = properties.tokens;
-    this.names = properties.names;
+    this.attributes = properties.attributes;
   }
 
   /**
    * Read a path, from its first attribute to the last thing it dereferences.
    */
   parse(): SimDynamoDbDocumentPath {
-    this.segments.push(this.attribute());
+    const first = this.attribute();
+
+    // The path starts here, so this is the top-level attribute it reaches.
+    // Whatever it dereferences afterwards is inside this one.
+    this.attributes.reach(first.name);
+    this.segments.push(first);
 
     while (this.continues()) {
       this.assertWithinDepth();
@@ -70,7 +76,7 @@ export class SimDynamoDbDocumentPathParser {
    * Read an attribute name, which the request may have written as a
    * placeholder.
    */
-  private attribute(): SimDynamoDbDocumentPathSegment {
+  private attribute(): SimDynamoDbAttributeSegment {
     const token = this.tokens.next("an attribute name");
 
     if (token.kind === "name") {
@@ -78,7 +84,7 @@ export class SimDynamoDbDocumentPathParser {
     }
 
     if (token.kind === "namePlaceholder") {
-      return { kind: "attribute", name: this.names.required(token.text) };
+      return { kind: "attribute", name: this.attributes.required(token.text) };
     }
 
     throw this.tokens.error(

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-attributes.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-attributes.ts
@@ -1,0 +1,46 @@
+import type { SimDynamoDbExpressionPlaceholders } from "./sim-dynamodb-expression-placeholders.js";
+
+/**
+ * The attribute names one request's expressions reach.
+ *
+ * Every expression kind names attributes the same way, either outright or
+ * behind a `#` placeholder, and every one of them reads those names through
+ * here. Noting the names as they are read is what lets a request say which
+ * attributes it names, which is what `dynamodb:Attributes` asks about.
+ *
+ * Only the attribute a document path starts at is noted. AWS counts a
+ * top-level attribute as reached where the request names it or anything nested
+ * inside it, so `Address.City` reaches `Address`.
+ */
+export class SimDynamoDbExpressionAttributes {
+  private readonly placeholders: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly reached = new Set<string>();
+
+  constructor(placeholders: SimDynamoDbExpressionPlaceholders<string>) {
+    this.placeholders = placeholders;
+  }
+
+  /**
+   * What a placeholder stands for, refusing one the request never defined.
+   *
+   * Resolving a placeholder says nothing about where in a path it sits, so
+   * nothing is noted here.
+   */
+  required(placeholder: string): string {
+    return this.placeholders.required(placeholder);
+  }
+
+  /**
+   * Note a top-level attribute an expression named.
+   */
+  reach(name: string): void {
+    this.reached.add(name);
+  }
+
+  /**
+   * The top-level attributes every expression of the request named.
+   */
+  get topLevel(): readonly string[] {
+    return [...this.reached];
+  }
+}

--- a/src/service/dynamodb/expression/sim-dynamodb-expression-parameters.ts
+++ b/src/service/dynamodb/expression/sim-dynamodb-expression-parameters.ts
@@ -2,6 +2,7 @@ import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import { SimDynamoDbValidationException } from "../error/dynamodb.error.js";
 import { readSimDynamoDbValue } from "../item/sim-dynamodb-value-reader.js";
 import type { SimDynamoDbValue } from "../item/sim-dynamodb-value.js";
+import { SimDynamoDbExpressionAttributes } from "./sim-dynamodb-expression-attributes.js";
 import { SimDynamoDbExpressionPlaceholders } from "./sim-dynamodb-expression-placeholders.js";
 
 /**
@@ -28,12 +29,19 @@ export class SimDynamoDbExpressionParameters {
   public readonly names: SimDynamoDbExpressionPlaceholders<string>;
   public readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
 
+  /**
+   * The attribute names the request's expressions reach, gathered as they are
+   * read. Authorization asks for these as `dynamodb:Attributes`.
+   */
+  public readonly attributes: SimDynamoDbExpressionAttributes;
+
   constructor(input: SimDynamoDbExpressionParameterInput) {
     this.names = new SimDynamoDbExpressionPlaceholders({
       parameterName: "ExpressionAttributeNames",
       marker: "#",
       entries: input.ExpressionAttributeNames,
     });
+    this.attributes = new SimDynamoDbExpressionAttributes(this.names);
     this.values = new SimDynamoDbExpressionPlaceholders({
       parameterName: "ExpressionAttributeValues",
       marker: ":",

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-clause.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-clause.ts
@@ -1,5 +1,5 @@
 import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
-import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
+import type { SimDynamoDbExpressionAttributes } from "../sim-dynamodb-expression-attributes.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import { simDynamoDbUpdateError } from "./sim-dynamodb-update-refusal.js";
 import { SimDynamoDbUpdateTarget } from "./sim-dynamodb-update-target.js";
@@ -16,7 +16,7 @@ const clauseWords: ReadonlySet<string> = new Set([
 
 interface SimDynamoDbUpdateClausesProperties {
   readonly tokens: SimDynamoDbExpressionTokens;
-  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly attributes: SimDynamoDbExpressionAttributes;
 }
 
 /**
@@ -28,12 +28,12 @@ interface SimDynamoDbUpdateClausesProperties {
  */
 export class SimDynamoDbUpdateClauses {
   private readonly tokens: SimDynamoDbExpressionTokens;
-  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly attributes: SimDynamoDbExpressionAttributes;
   private readonly read = new Set<string>();
 
   constructor(properties: SimDynamoDbUpdateClausesProperties) {
     this.tokens = properties.tokens;
-    this.names = properties.names;
+    this.attributes = properties.attributes;
   }
 
   /**
@@ -68,7 +68,7 @@ export class SimDynamoDbUpdateClauses {
     return new SimDynamoDbUpdateTarget(
       new SimDynamoDbDocumentPathParser({
         tokens: this.tokens,
-        names: this.names,
+        attributes: this.attributes,
       }).parse(),
     );
   }

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-expression.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-expression.ts
@@ -23,7 +23,7 @@ export function parseSimDynamoDbUpdate(
       expression,
       "the expression says nothing, and an expression cannot be empty",
     ),
-    names: parameters.names,
+    attributes: parameters.attributes,
     values: parameters.values,
   }).parse();
 }

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-operand-parser.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-operand-parser.ts
@@ -1,5 +1,6 @@
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
 import { SimDynamoDbDocumentPathParser } from "../sim-dynamodb-document-path-parser.js";
+import type { SimDynamoDbExpressionAttributes } from "../sim-dynamodb-expression-attributes.js";
 import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import { SimDynamoDbArithmeticOperand } from "./sim-dynamodb-update-computed-operand.js";
@@ -18,7 +19,7 @@ const operators: ReadonlySet<string> = new Set(["+", "-"]);
 
 interface SimDynamoDbUpdateOperandParserProperties {
   readonly tokens: SimDynamoDbExpressionTokens;
-  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly attributes: SimDynamoDbExpressionAttributes;
   readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
 }
 
@@ -35,13 +36,13 @@ interface SimDynamoDbUpdateOperandParserProperties {
  */
 export class SimDynamoDbUpdateOperandParser {
   private readonly tokens: SimDynamoDbExpressionTokens;
-  private readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  private readonly attributes: SimDynamoDbExpressionAttributes;
   private readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
   private readonly functions: SimDynamoDbUpdateFunctionParser;
 
   constructor(properties: SimDynamoDbUpdateOperandParserProperties) {
     this.tokens = properties.tokens;
-    this.names = properties.names;
+    this.attributes = properties.attributes;
     this.values = properties.values;
     this.functions = new SimDynamoDbUpdateFunctionParser({
       tokens: properties.tokens,
@@ -116,7 +117,7 @@ export class SimDynamoDbUpdateOperandParser {
     return new SimDynamoDbUpdatePathOperand(
       new SimDynamoDbDocumentPathParser({
         tokens: this.tokens,
-        names: this.names,
+        attributes: this.attributes,
       }).parse(),
     );
   }

--- a/src/service/dynamodb/expression/update/sim-dynamodb-update-parser.ts
+++ b/src/service/dynamodb/expression/update/sim-dynamodb-update-parser.ts
@@ -1,4 +1,5 @@
 import type { SimDynamoDbValue } from "../../item/sim-dynamodb-value.js";
+import type { SimDynamoDbExpressionAttributes } from "../sim-dynamodb-expression-attributes.js";
 import type { SimDynamoDbExpressionPlaceholders } from "../sim-dynamodb-expression-placeholders.js";
 import type { SimDynamoDbExpressionTokens } from "../sim-dynamodb-expression-tokens.js";
 import {
@@ -14,7 +15,7 @@ import { SimDynamoDbUpdate } from "./sim-dynamodb-update.js";
 
 interface SimDynamoDbUpdateParserProperties {
   readonly tokens: SimDynamoDbExpressionTokens;
-  readonly names: SimDynamoDbExpressionPlaceholders<string>;
+  readonly attributes: SimDynamoDbExpressionAttributes;
   readonly values: SimDynamoDbExpressionPlaceholders<SimDynamoDbValue>;
 }
 


### PR DESCRIPTION
Simulated DynamoDB built a condition context holding `dynamodb:LeadingKeys` alone, so a statement conditioned on `dynamodb:Attributes` matched every request whatever the attribute list said. The seven item actions and `Scan` now supply the top-level attribute names the request reaches, read from every expression it carries and from its `Key` or `Item`. Names are gathered as each document path is parsed, so a `#` placeholder is resolved first and a nested path counts as the attribute it starts at. `SimDynamoDbTableAccess` takes what a request reaches as one object rather than a growing tail of arguments.

Resolves https://github.com/KensioSoftware/yulin/issues/1316

- [x] Conventional commit message, used as the title

- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for DynamoDB attribute-level authorization across reads, writes, queries, scans, updates, deletes, and batch operations.
  - Attribute names are resolved from projections, expressions, conditions, filters, keys, and nested paths.
  - Authorization now includes required table and index key attributes.

- **Bug Fixes**
  - Batch reads now enforce DynamoDB’s 100-item request limit.
  - Requests that reference no attributes omit attribute authorization context.

- **Documentation**
  - Documented supported `dynamodb:Attributes` behavior, condition keys, limitations, and transactional authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->