### PR TITLE
fix: settle a handler waiting on a running clock

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -3270,10 +3270,15 @@ interval runs it five times. A delay of zero, or none at all, is due at the inst
 for, and a handler yielding with `setTimeout(resolve, 0)` gets going again without the clock moving.
 
 Where the clock is left running, the delay passes in real time and nothing has to move it.
-`simAws.backgroundTasksComplete()` waits for a handler sleeping on a running clock. An S3 event
-notification, a stream record or an asynchronous invocation whose handler uses a timer has finished
-by the time the drain returns. Under a frozen clock the drain comes back while the handler sleeps,
-and moving the clock is what releases it.
+`simAws.backgroundTasksComplete()` waits for a handler sleeping on a clock that is moving. An S3
+event notification, a stream record or an asynchronous invocation whose handler uses a timer has
+finished by the time the drain returns, and the function's `Timeout` bounds how long that wait can
+last.
+
+Two things leave a clock standing still. `freeze()`, `advanceBy(...)` and `setTo(...)` all leave it
+frozen, and a `SimAws` built on a `SimFixedClock` reports one instant however long the host runs.
+Under either the drain comes back while the handler sleeps, and moving the clock is what releases
+it.
 
 The function's `Timeout` is a deadline on the same clock. Where it arrives before the handler
 answers, the invocation ends in the error the real runtime reports.

--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -3269,6 +3269,12 @@ An interval runs once for each period an advance covers. Advancing eleven second
 interval runs it five times. A delay of zero, or none at all, is due at the instant it was asked
 for, and a handler yielding with `setTimeout(resolve, 0)` gets going again without the clock moving.
 
+Where the clock is left running, the delay passes in real time and nothing has to move it.
+`simAws.backgroundTasksComplete()` waits for a handler sleeping on a running clock. An S3 event
+notification, a stream record or an asynchronous invocation whose handler uses a timer has finished
+by the time the drain returns. Under a frozen clock the drain comes back while the handler sleeps,
+and moving the clock is what releases it.
+
 The function's `Timeout` is a deadline on the same clock. Where it arrives before the handler
 answers, the invocation ends in the error the real runtime reports.
 

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -64,10 +64,11 @@ example, a simulation advanced by one hour continues to run one hour ahead of th
 Read `simAws.clock().isFrozen` to check the current mode.
 
 The mode also decides what waiting for the simulation to settle means.
-`simAws.backgroundTasksComplete()` waits for background work sleeping on a running clock, because
-the instant that work sleeps until arrives by itself. Under a frozen clock the same work is left
-where it is, and `advanceBy(...)` or `setTo(...)` is what brings the instant and waits for what
-follows from it.
+`simAws.backgroundTasksComplete()` waits for background work sleeping on a clock that is moving,
+because the instant that work sleeps until arrives by itself. Under a clock standing still the same
+work is left where it is, and `advanceBy(...)` or a forward `setTo(...)` is what brings the instant
+and waits for what follows from it. A simulation built on a `SimFixedClock` stands still under a
+running mode too, since simulated time here moves only as far as the clock underneath moves.
 
 ## Advancing time
 

--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -63,6 +63,12 @@ example, a simulation advanced by one hour continues to run one hour ahead of th
 
 Read `simAws.clock().isFrozen` to check the current mode.
 
+The mode also decides what waiting for the simulation to settle means.
+`simAws.backgroundTasksComplete()` waits for background work sleeping on a running clock, because
+the instant that work sleeps until arrives by itself. Under a frozen clock the same work is left
+where it is, and `advanceBy(...)` or `setTo(...)` is what brings the instant and waits for what
+follows from it.
+
 ## Advancing time
 
 `advanceBy(...)` accepts days, hours, minutes, seconds, and milliseconds. The values are added

--- a/src/service/eventbridge/delivery/sim-event-bridge-delivery-settling.iso.test.ts
+++ b/src/service/eventbridge/delivery/sim-event-bridge-delivery-settling.iso.test.ts
@@ -1,0 +1,79 @@
+import {
+  PutEventsCommand,
+  PutRuleCommand,
+  PutTargetsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { AddPermissionCommand } from "@aws-sdk/client-lambda";
+import { assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../lambda/index.js";
+
+const functionArn = "arn:aws:lambda:us-east-1:888888888888:function:fulfilment";
+
+/** How long the handler waits on the clock before it works. */
+const handlerDelayMilliseconds = 5;
+
+describe("Settling a simulated EventBridge target delivery", () => {
+  it("waits for a Lambda target that waits on the clock", async () => {
+    // Given a rule targeting a function that waits on a timer before it works
+    const simAws = new SimAws();
+    const fulfilled: string[] = [];
+
+    await simAws.lambda().createFunction({
+      input: {
+        FunctionName: "fulfilment",
+        Role: "arn:aws:iam::888888888888:role/FulfilmentRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(async () => {
+            await new Promise((resolve) => {
+              setTimeout(resolve, handlerDelayMilliseconds);
+            });
+            fulfilled.push("fulfilled");
+
+            return { ok: true };
+          }),
+        },
+      },
+    });
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "fulfilment",
+        StatementId: "events",
+        Action: "lambda:InvokeFunction",
+        Principal: "events.amazonaws.com",
+      }),
+    );
+    await simAws.eventBridge().putRule(
+      new PutRuleCommand({
+        Name: "orders",
+        EventPattern: JSON.stringify({ source: ["orders.service"] }),
+      }),
+    );
+    await simAws.eventBridge().putTargets(
+      new PutTargetsCommand({
+        Rule: "orders",
+        Targets: [{ Id: "fulfilment", Arn: functionArn }],
+      }),
+    );
+
+    // When a matching event is put and the simulation is asked to settle once
+    await simAws.eventBridge().putEvents(
+      new PutEventsCommand({
+        Entries: [
+          {
+            Source: "orders.service",
+            DetailType: "OrderPlaced",
+            Detail: JSON.stringify({ orderId: "order-1" }),
+          },
+        ],
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler has finished, rather than being left part way through
+    // for a later drain to catch
+    assertArrayLength(fulfilled, 1);
+  });
+});

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -308,6 +308,30 @@ code never has its `Date` replaced at all: `Date` is a much busier global than `
 `getRemainingTimeInMillis()` reads the same clock (`sim-lambda-invoke-context-builder.ts`), so a
 stopped clock leaves a handler with a constant budget.
 
+### The timers a handler gets, and what settling does about them
+
+`invoke/timer/` puts a handler's `setTimeout`, `clearTimeout`, `setInterval` and `clearInterval` on
+the simulation's clock. Both paths from the clock section arrive here. Sandboxed zip code is handed
+the substitutes as its own globals, and an in-process handler finds them through the same
+`AsyncLocalStorage` store, resolved by `sim-lambda-process-timers.ts`. Outside an invocation the
+substitutes call the host timers and answer with what they answer.
+
+`SimLambdaClockTimer` holds one instant on two timelines. A test reaches the simulation's queue by
+moving the clock. An unreferenced host timer asks the clock again when the host gets to the delay,
+and that is what makes a running clock reach the instant without anything moving it. Whichever
+timeline arrives first takes the timer off both and runs it once.
+
+A timer with a delay above zero says the invocation is waiting on the clock
+(`SimLambdaInvocationTimers`), and that is what decides whether settling waits for it.
+`BackgroundPendingTasks.complete` leaves clock-waiting work out where simulated time stands still,
+because only a caller moving the clock brings the instant and that caller is the one waiting. A
+running clock brings it by itself, and completion waits for the invocation to get through it. A
+delay of zero is due at the instant the clock already reads and parks nothing.
+
+The function's `Timeout` is a `SimLambdaClockTimer` of its own. It bounds how long completion waits
+for a handler sleeping on a running clock, because the deadline arrives whether the handler does or
+not. See KensioSoftware/yulin#1320 for the drain this contract came from.
+
 ### The HTTP clients function code reaches for
 
 `function/outbound/` owns what happens when function code makes an HTTP request.
@@ -871,6 +895,4 @@ and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
   variables" above), and the same limitation for a time read there or a request made there
 - outbound HTTP from any client other than `fetch`, `node:http` and `node:https`, and following a
   redirect the simulation answered with
-- timers: `setTimeout` inside a handler is a host timer, not one the simulation's clock releases
-- timeouts interrupting handler execution
 - SAM's `EventInvokeConfig` and `DeadLetterQueue` on `AWS::Serverless::Function`

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -328,6 +328,10 @@ because only a caller moving the clock brings the instant and that caller is the
 running clock brings it by itself, and completion waits for the invocation to get through it. A
 delay of zero is due at the instant the clock already reads and parks nothing.
 
+`SimClock.advances` is what says which of the two a clock is. A frozen mode reports `false`, and so
+does a running mode over a base that stands still, such as the `SimFixedClock` a test hands
+`SimAws`. Waiting on one of those would be waiting for an instant nothing brings.
+
 The function's `Timeout` is a `SimLambdaClockTimer` of its own. It bounds how long completion waits
 for a handler sleeping on a running clock, because the deadline arrives whether the handler does or
 not. See KensioSoftware/yulin#1320 for the drain this contract came from.

--- a/src/service/lambda/event-source/sim-lambda-stream-settling.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-stream-settling.iso.test.ts
@@ -1,0 +1,39 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { assertArrayLength } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+
+/** How long the handler waits on the clock before it works. */
+const handlerDelayMilliseconds = 5;
+
+describe("Settling a simulated DynamoDB stream delivery", () => {
+  it("waits for a handler that waits on the clock", async () => {
+    // Given a table's stream mapped to a function that waits on a timer before
+    // it works
+    const projected: string[] = [];
+    const { simAws, tableName } = await simAwsWithStreamEventSource({
+      handlerResult: async (): Promise<undefined> => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, handlerDelayMilliseconds);
+        });
+        projected.push("projected");
+
+        return undefined;
+      },
+    });
+
+    // When an item is written and the simulation is asked to settle once
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" }, total: { N: "42" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler has finished, rather than being left part way through
+    // for a later drain to catch
+    assertArrayLength(projected, 1);
+  });
+});

--- a/src/service/lambda/function/invoke/timer/sim-lambda-timer-settling.iso.test.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-timer-settling.iso.test.ts
@@ -1,0 +1,117 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertArrayEmpty,
+  assertArrayLength,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../../aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../../sim-lambda-handler.type.js";
+
+const functionName = "worker";
+const roleArn = "arn:aws:iam::888888888888:role/WorkerRole";
+const startedAt = new Date("2026-09-07T09:00:00.000Z");
+
+/** How long the handler waits on the clock before it does its work. */
+const handlerDelayMilliseconds = 5;
+
+/**
+ * A function that waits on the clock and then records that it worked.
+ */
+async function functionWaitingOnTheClock(
+  simAws: SimAws,
+  worked: string[],
+  timeoutSeconds?: number,
+  delayMilliseconds = handlerDelayMilliseconds,
+): Promise<void> {
+  const handler: SimLambdaHandler = async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, delayMilliseconds);
+    });
+    worked.push("worked");
+
+    return "done";
+  };
+
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: roleArn,
+      Timeout: timeoutSeconds,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+}
+
+/**
+ * Invoke the function without waiting for it, as an event source does.
+ */
+async function invokeAsynchronously(simAws: SimAws): Promise<void> {
+  await simAws.lambda().invoke(
+    new InvokeCommand({
+      FunctionName: functionName,
+      InvocationType: "Event",
+    }),
+  );
+}
+
+describe("Settling a simulated Lambda invocation that waits on the clock", () => {
+  it("waits for a handler timer while simulated time runs", async () => {
+    // Given a function whose handler waits on a timer before it works
+    const simAws = new SimAws();
+    const worked: string[] = [];
+    await functionWaitingOnTheClock(simAws, worked);
+
+    // When it is invoked asynchronously and the simulation is asked to settle
+    await invokeAsynchronously(simAws);
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler has finished, because a running clock reaches the
+    // instant the timer waits for without anything moving it
+    assertArrayLength(worked, 1);
+  });
+
+  it("leaves a handler timer to the clock once time is frozen", async () => {
+    // Given the same function in a simulation stopped at an instant
+    const simAws = new SimAws();
+    const worked: string[] = [];
+    await simAws.clock().setTo(startedAt);
+    await functionWaitingOnTheClock(simAws, worked);
+
+    // When it is invoked asynchronously and the simulation is asked to settle
+    await invokeAsynchronously(simAws);
+    await simAws.backgroundTasksComplete();
+
+    // Then it came back with the handler still waiting, since only moving the
+    // clock brings the instant it waits for
+    assertArrayEmpty(worked);
+
+    // And moving the clock is what releases it
+    await simAws.clock().advanceBy(handlerDelayMilliseconds);
+    assertArrayLength(worked, 1);
+  });
+
+  it("still ends a handler whose timer outlives its deadline", async () => {
+    // Given a function with one second to answer in, whose handler waits five
+    // seconds before it works
+    const simAws = new SimAws();
+    const worked: string[] = [];
+    await functionWaitingOnTheClock(simAws, worked, 1, 5000);
+
+    // When it is invoked and waited for
+    const invoked = await simAws.lambda().invoke(
+      new InvokeCommand({
+        FunctionName: functionName,
+        InvocationType: "RequestResponse",
+      }),
+    );
+
+    // Then the deadline ended it rather than the timer, and settling came back
+    // rather than waiting out the five second timer
+    assertStringIncludes(String(invoked.FunctionError), "Unhandled");
+    await simAws.backgroundTasksComplete();
+    assertArrayEmpty(worked);
+  });
+});

--- a/src/service/lambda/function/invoke/timer/sim-lambda-timer-settling.iso.test.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-timer-settling.iso.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../../../util/clock/sim-clock.js";
 import { makeLambdaZipFileInput } from "../../code/lambda-zip-file-input.js";
 import type { SimLambdaHandler } from "../../sim-lambda-handler.type.js";
 
@@ -91,6 +92,24 @@ describe("Settling a simulated Lambda invocation that waits on the clock", () =>
     // And moving the clock is what releases it
     await simAws.clock().advanceBy(handlerDelayMilliseconds);
     assertArrayLength(worked, 1);
+  });
+
+  it("comes back from a clock that stands still under a running mode", async () => {
+    // Given the same function in a simulation built on a fixed clock, which
+    // reports one instant however long the host runs
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    const worked: string[] = [];
+    await functionWaitingOnTheClock(simAws, worked);
+
+    // When it is invoked asynchronously and the simulation is asked to settle
+    await invokeAsynchronously(simAws);
+    await simAws.backgroundTasksComplete();
+
+    // Then it came back rather than waiting for an instant nothing brings.
+    // Simulated time here moves only as far as the clock underneath moves, and
+    // a fixed clock moves nowhere. The handler is left where a frozen clock
+    // leaves one
+    assertArrayEmpty(worked);
   });
 
   it("still ends a handler whose timer outlives its deadline", async () => {

--- a/src/service/lambda/function/invoke/timer/sim-lambda-timer-settling.iso.test.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-timer-settling.iso.test.ts
@@ -2,6 +2,7 @@ import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
 import {
   assertArrayEmpty,
   assertArrayLength,
+  assertNumberBetween,
   assertStringIncludes,
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
@@ -17,6 +18,14 @@ const startedAt = new Date("2026-09-07T09:00:00.000Z");
 
 /** How long the handler waits on the clock before it does its work. */
 const handlerDelayMilliseconds = 5;
+
+/**
+ * The longest a drain bounded by a one second deadline should take.
+ *
+ * Well under the five second timer the handler asks for, and well over the
+ * deadline, so a loaded host stays inside it.
+ */
+const drainBoundMilliseconds = 4000;
 
 /**
  * A function that waits on the clock and then records that it worked.
@@ -110,6 +119,25 @@ describe("Settling a simulated Lambda invocation that waits on the clock", () =>
     // a fixed clock moves nowhere. The handler is left where a frozen clock
     // leaves one
     assertArrayEmpty(worked);
+  });
+
+  it("bounds the wait for an asynchronous handler by its deadline", async () => {
+    // Given a function with one second to answer in, whose handler waits five
+    // seconds before it works
+    const simAws = new SimAws();
+    const worked: string[] = [];
+    await functionWaitingOnTheClock(simAws, worked, 1, 5000);
+
+    // When it is invoked asynchronously and the simulation is asked to settle
+    const startedAt = Date.now();
+    await invokeAsynchronously(simAws);
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler that ran out of time did no work, and the drain came
+    // back around the deadline rather than waiting out the five second timer.
+    // The bound is loose because it is real time on whatever host runs it
+    assertArrayEmpty(worked);
+    assertNumberBetween(Date.now() - startedAt, 0, drainBoundMilliseconds);
   });
 
   it("still ends a handler whose timer outlives its deadline", async () => {

--- a/src/service/s3/notification/sim-s3-notification-delivery.iso.test.ts
+++ b/src/service/s3/notification/sim-s3-notification-delivery.iso.test.ts
@@ -24,7 +24,71 @@ import { simIamRoleWithPolicyFactory } from "../../iam/role/sim-iam-role-with-po
 const thumbnailerArn =
   "arn:aws:lambda:us-east-1:888888888888:function:thumbnailer";
 
+/** How long a handler in these cases waits on the clock before it works. */
+const handlerDelayMilliseconds = 5;
+
 describe("Delivering a simulated S3 event notification", () => {
+  it("settles a delivery whose handler waits on the clock", async () => {
+    // Given a configured Bucket whose function waits on a timer before it works
+    const simAws = new SimAws();
+    const thumbnailed: string[] = [];
+    await simAws
+      .s3()
+      .createBucket(new CreateBucketCommand({ Bucket: "uploads" }));
+    await simAws.lambda().createFunction(
+      new CreateFunctionCommand({
+        FunctionName: "thumbnailer",
+        Role: "arn:aws:iam::888888888888:role/ThumbnailerRole",
+        Code: {
+          ZipFile: makeLambdaZipFileInput(async () => {
+            await new Promise((resolve) => {
+              setTimeout(resolve, handlerDelayMilliseconds);
+            });
+            thumbnailed.push("thumbnailed");
+
+            return "thumbnailed";
+          }),
+        },
+      }),
+    );
+    await simAws.lambda().addPermission(
+      new AddPermissionCommand({
+        FunctionName: "thumbnailer",
+        StatementId: "AllowS3",
+        Action: "lambda:InvokeFunction",
+        Principal: "s3.amazonaws.com",
+        SourceArn: "arn:aws:s3:::uploads",
+      }),
+    );
+    await simAws.s3().putBucketNotificationConfiguration(
+      new PutBucketNotificationConfigurationCommand({
+        Bucket: "uploads",
+        NotificationConfiguration: {
+          LambdaFunctionConfigurations: [
+            {
+              Events: ["s3:ObjectCreated:*"],
+              LambdaFunctionArn: thumbnailerArn,
+            },
+          ],
+        },
+      }),
+    );
+
+    // When an Object is written and the simulation is asked to settle once
+    await simAws.s3().putObject(
+      new PutObjectCommand({
+        Bucket: "uploads",
+        Key: "cat.jpg",
+        Body: "cat",
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler has finished, rather than being left part way through
+    // for a later drain to catch
+    assertArrayLength(thumbnailed, 1);
+  });
+
   it("stops delivering when the permission is removed afterwards", async () => {
     // Given a configured Bucket whose function allowed S3 to invoke it
     const simAws = new SimAws();

--- a/src/util/background/background-clock-waits.iso.test.ts
+++ b/src/util/background/background-clock-waits.iso.test.ts
@@ -7,7 +7,11 @@ import {
 import { describe, it } from "vitest";
 
 import { BackgroundTasks } from "./background.js";
+import { SimFixedClock } from "../clock/sim-clock.js";
 import { NonDeterministicBackgroundTasks } from "./non-deterministic-background.js";
+
+/** How long a task in these cases waits for the host to reach an instant. */
+const timerMilliseconds = 5;
 
 describe("work a background scheduler is waiting for", () => {
   it("waits for work a caller started rather than handed over", async () => {
@@ -83,9 +87,12 @@ describe("work a background scheduler is waiting for", () => {
     assertTrue(settled);
   });
 
-  it("stops waiting for a task while it waits on the clock", async () => {
-    // Given a task that goes on to wait for something only the clock brings.
-    const tasks = new BackgroundTasks();
+  it("stops waiting for a task on a clock that stands still", async () => {
+    // Given a simulation whose time moves only where something moves it, and
+    // a task that goes on to wait for something only the clock brings.
+    const tasks = new BackgroundTasks({
+      clock: new SimFixedClock(new Date("2026-01-01T00:00:00.000Z")),
+    });
     const held = Promise.withResolvers<undefined>();
     let release = (): void => {
       //
@@ -109,6 +116,54 @@ describe("work a background scheduler is waiting for", () => {
     release();
     held.resolve(undefined);
     await tasks.complete();
+    assertTrue(finished);
+  });
+
+  it("waits for a task on the clock while simulated time runs", async () => {
+    // Given a running clock and a task waiting on it, released once the host
+    // gets to the instant, as a simulated Lambda handler timer is.
+    const tasks = new BackgroundTasks();
+    const held = Promise.withResolvers<undefined>();
+    let finished = false;
+    tasks.schedule(async () => {
+      const release = tasks.waitingOnClock();
+      setTimeout(() => {
+        release();
+        held.resolve(undefined);
+      }, timerMilliseconds);
+
+      await held.promise;
+      finished = true;
+    });
+
+    // When the simulation is asked to settle.
+    await tasks.complete();
+
+    // Then it waited for the task, because a running clock reaches the instant
+    // on its own and nothing else has to bring it.
+    assertTrue(finished);
+  });
+
+  it("waits for a running clock out of sequence too", async () => {
+    // Given the same, on the scheduler that lets work finish out of order.
+    const tasks = new NonDeterministicBackgroundTasks({ maxJitterMs: 1 });
+    const held = Promise.withResolvers<undefined>();
+    let finished = false;
+    tasks.schedule(async () => {
+      const release = tasks.waitingOnClock();
+      setTimeout(() => {
+        release();
+        held.resolve(undefined);
+      }, timerMilliseconds);
+
+      await held.promise;
+      finished = true;
+    });
+
+    // When the simulation is asked to settle.
+    await tasks.complete();
+
+    // Then it waited for the task here too.
     assertTrue(finished);
   });
 
@@ -158,9 +213,12 @@ describe("work a background scheduler is waiting for", () => {
     });
   });
 
-  it("stops waiting for a task waiting on the clock out of sequence too", async () => {
+  it("stops waiting for a still clock out of sequence too", async () => {
     // Given the same, on the scheduler that lets work finish out of order.
-    const tasks = new NonDeterministicBackgroundTasks({ maxJitterMs: 1 });
+    const tasks = new NonDeterministicBackgroundTasks({
+      maxJitterMs: 1,
+      clock: new SimFixedClock(new Date("2026-01-01T00:00:00.000Z")),
+    });
     const held = Promise.withResolvers<undefined>();
     let release = (): void => {
       //

--- a/src/util/background/background-clock-waits.ts
+++ b/src/util/background/background-clock-waits.ts
@@ -36,17 +36,27 @@ export class BackgroundClockWaits {
   }
 
   /**
-   * The work in a set that is neither waiting on the clock nor the work asking
-   * about it.
+   * The work in a set that completion has anything to wait for.
+   *
+   * The work asking is always left out. Waiting for the invocation the asking
+   * code is part of would be waiting for itself.
+   *
+   * Work waiting on the clock is left out where simulated time stands still,
+   * since only a caller moving the clock brings the instant it waits for, and
+   * that caller is the one waiting here. A running clock reaches the instant on
+   * its own, and this waits for the work to get there.
    */
   runnable(
     held: ReadonlyMap<Promise<unknown>, BackgroundClockWait>,
+    clockIsRunning = false,
   ): Promise<unknown>[] {
     const own = this.storage.getStore();
 
     return held
       .entries()
-      .filter(([, wait]) => wait.count === 0 && wait !== own)
+      .filter(
+        ([, wait]) => wait !== own && (clockIsRunning || wait.count === 0),
+      )
       .map(([promise]) => promise)
       .toArray();
   }

--- a/src/util/background/background-pending-tasks.ts
+++ b/src/util/background/background-pending-tasks.ts
@@ -66,15 +66,19 @@ export class BackgroundPendingTasks {
   }
 
   /**
-   * Wait until nothing is outstanding but work that is waiting on the clock.
+   * Wait until nothing is outstanding that can still get somewhere.
    *
-   * Work that parks part way through ends the wait rather than extending it:
-   * only moving the clock releases it, and moving the clock is what waits
-   * here. The loop then looks again at what is left running, so work that
-   * carries on is waited for again.
+   * Where simulated time stands still, work that parks on the clock ends the
+   * wait rather than extending it. Only moving the clock releases it, and
+   * moving the clock is what waits here. The loop then looks again at what is
+   * left running, so work that carries on is waited for again.
+   *
+   * A running clock reaches those instants by itself, and the work parked on
+   * them is waited for like any other. What bounds the wait is the instant
+   * itself, which arrives in the real time between here and there.
    */
-  async complete(): Promise<void> {
-    let running = this.running();
+  async complete(clockIsRunning = false): Promise<void> {
+    let running = this.running(clockIsRunning);
 
     while (running.length > 0) {
       // oxlint-disable-next-line no-await-in-loop
@@ -85,20 +89,22 @@ export class BackgroundPendingTasks {
 
       new BackgroundSettledTasks(settled).throwFirstFailure();
 
-      running = this.running();
+      running = this.running(clockIsRunning);
     }
   }
 
   /**
-   * The work completion has anything to wait for, which is whatever is
-   * neither waiting on the clock nor waiting for completion itself.
+   * The work completion has anything to wait for.
    *
    * Work that asks for the simulation to settle from inside itself is left
    * out. A handler advancing the clock is the ordinary case, and waiting for
    * the invocation it is part of would be waiting for itself.
+   *
+   * Work waiting on the clock joins it once simulated time is running, since
+   * a running clock is what brings the instant it waits for.
    */
-  running(): Promise<unknown>[] {
-    return this.#clockWaits.runnable(this.#held);
+  running(clockIsRunning = false): Promise<unknown>[] {
+    return this.#clockWaits.runnable(this.#held, clockIsRunning);
   }
 
   /**

--- a/src/util/background/background.ts
+++ b/src/util/background/background.ts
@@ -200,12 +200,14 @@ export class BackgroundTasks
    * Wait until all tasks currently scheduled have finished.
    * If tasks schedule more tasks, this will continue draining until idle.
    *
-   * Work waiting on the clock is not waited for: it is not outstanding, it is
-   * scheduled for a simulated instant that has not arrived. Only moving the
-   * clock releases it.
+   * What happens to work waiting on the clock follows the clock. Where
+   * simulated time stands still the work stays where it is, scheduled for an
+   * instant only a caller can bring, and this returns without it. Where
+   * simulated time runs, the instant arrives by itself and this waits for the
+   * work to get through it.
    */
   public async complete(): Promise<void> {
-    await this.pending.complete();
+    await this.pending.complete(this.clockIsRunning);
   }
 
   /**
@@ -220,5 +222,14 @@ export class BackgroundTasks
    */
   public get dueTaskCount(): number {
     return this.dueTasks.size;
+  }
+
+  /**
+   * Whether simulated time reaches a scheduled instant on its own.
+   *
+   * A clock with nothing to say about it advances, as the host clock does.
+   */
+  private get clockIsRunning(): boolean {
+    return this.clock.advances !== false;
   }
 }

--- a/src/util/background/non-deterministic-background.ts
+++ b/src/util/background/non-deterministic-background.ts
@@ -104,9 +104,13 @@ export class NonDeterministicBackgroundTasks
   /**
    * Wait until all tasks currently scheduled have finished.
    * If tasks schedule more tasks, this will continue draining until idle.
+   *
+   * Work waiting on the clock is waited for where simulated time runs, and
+   * left where it is where simulated time stands still, exactly as it is on
+   * the deterministic scheduler.
    */
   public async complete(): Promise<void> {
-    await this.pending.complete();
+    await this.pending.complete(this.clock.advances !== false);
   }
 
   /**

--- a/src/util/clock/sim-clock.ts
+++ b/src/util/clock/sim-clock.ts
@@ -11,6 +11,19 @@ export interface SimClock {
    * Get the current time in this simulation.
    */
   now(): Date;
+
+  /**
+   * Whether simulated time moves on this clock by itself.
+   *
+   * A scheduler reads this to decide what waiting for a simulation to settle
+   * means. Time that advances brings the instant a task is scheduled for on
+   * its own, and settling waits for that task. Time that stands still leaves
+   * the instant to whoever moves the clock, and settling leaves the task where
+   * it is.
+   *
+   * A clock that says nothing advances, as the host clock does.
+   */
+  readonly advances?: boolean;
 }
 
 /**
@@ -20,6 +33,9 @@ export interface SimClock {
  * something deliberately replaces it.
  */
 export class SimRealClock implements SimClock {
+  /** Real time moves by itself. */
+  public readonly advances = true;
+
   /**
    * Get the current real system time.
    */
@@ -35,6 +51,9 @@ export class SimRealClock implements SimClock {
  * reaching for a library that replaces the clock for the whole process.
  */
 export class SimFixedClock implements SimClock {
+  /** A fixed instant is the whole of this clock. Time stands still on it. */
+  public readonly advances = false;
+
   private readonly instant: Date;
 
   constructor(instant: Date) {

--- a/src/util/clock/sim-controllable-clock.ts
+++ b/src/util/clock/sim-controllable-clock.ts
@@ -51,6 +51,20 @@ export class SimControllableClock implements SimClock {
   }
 
   /**
+   * Whether simulated time moves here by itself.
+   *
+   * A frozen clock moves only where something moves it. So does a running
+   * clock over a base that stands still. The offset a running mode applies is
+   * fixed, so simulated time here moves exactly as far as the clock underneath
+   * moves, and a fixed clock underneath moves nowhere. Freezing and resuming
+   * such a clock changes which instant it reports and leaves it as still as it
+   * was.
+   */
+  get advances(): boolean {
+    return !this.mode.isFrozen && this.base.advances !== false;
+  }
+
+  /**
    * Stop simulated time where it currently reads.
    */
   freeze(): void {


### PR DESCRIPTION
Resolves https://github.com/KensioSoftware/yulin/issues/1320

`backgroundTasksComplete()` waited only for work the scheduler was holding that had not parked on the clock, and a simulated Lambda invocation parks the moment its handler starts a timer with a delay above zero. Any invocation dispatched as background work therefore dropped out of the drain, and an S3 event notification, a DynamoDB stream record or an asynchronous invoke came back with the handler part way through. Settling now follows the clock. Where simulated time runs, the instant a handler sleeps until arrives by itself and completion waits for the invocation to get through it, bounded by the function's own deadline. Where simulated time stands still, the work stays where it is and moving the clock is still what releases it. A running clock over a base that stands still counts as standing still, and `SimClock.advances` is what says so.

The reproduction from the issue, a CDK `Custom::S3BucketNotifications` Bucket notifying a Lambda that reads the Object and writes a DynamoDB item, went from 0 of 20 runs to 20 of 20 on one drain.

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Background task settling now correctly handles timer-based work when simulated time is running.
  - Work waiting on timers remains pending with a frozen clock until time is advanced.
  - Lambda handlers now respect simulated timers and configured timeouts across invocation and event-driven deliveries.
  - EventBridge, S3, and DynamoDB stream deliveries now reliably wait for asynchronous Lambda handlers to finish.

- **Documentation**
  - Documented timer behavior, timeout handling, and `backgroundTasksComplete()` differences between running and frozen clocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->