### PR TITLE
fix: read the document client's marshallOptions

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -282,7 +282,8 @@ service throws `SimSdkUnknownServiceError`.
 - Simulated errors have SDK-shaped `name` and `$metadata` fields. They are separate classes from the
   SDK exceptions, so match them by `error.name` instead of `instanceof`.
 - The callback form of `send(command, callback)` is not supported. Use the promise form.
-- Yulin ignores the translation options in
-  `DynamoDBDocumentClient.from(client, { marshallOptions, unmarshallOptions })`. The conversion uses
-  the defaults. `removeUndefinedValues: true` has no effect. Yulin refuses an `undefined` attribute
-  that the configured document client would otherwise remove.
+- Yulin reads the `marshallOptions` in
+  `DynamoDBDocumentClient.from(client, { marshallOptions, unmarshallOptions })` and ignores the
+  `unmarshallOptions`. A stored value comes back the way a document client built with no options of
+  its own reads it. See
+  [the DynamoDB docs](https://yulinsim.dev/services/dynamodb/#marshalling-options).

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3040,6 +3040,84 @@ Intercept the document client itself. `DynamoDBDocumentClient.from(client)` buil
 outside the `DynamoDBClient` class, so intercepting the base client leaves Commands sent through the
 document one untouched. See [the SDK docs](https://yulinsim.dev/sdk/#the-dynamodb-document-client).
 
+### Marshalling options
+
+`DynamoDBDocumentClient.from(client, { marshallOptions })` changes what the conversion does with a
+value the defaults refuse. Yulin reads those options off the client each Command was sent through.
+Two document clients over one simulation each convert by their own.
+
+- `removeUndefinedValues` drops an `undefined` out of a map, a list or a `Set`. Without it, an
+  `undefined` in any of the three is refused. The real client refuses it in the same place.
+- `convertEmptyValues` writes an empty string, an empty binary value and an empty `Set` as `NULL`.
+- `convertClassInstanceToMap` reads an object with behaviour as a map of its own properties.
+- `allowImpreciseNumbers` writes a number past `Number.MAX_SAFE_INTEGER` with the digits it has
+  already been rounded to.
+
+An `undefined` attribute of an item, a key or a set of expression values is left out whatever the
+client was built with. `removeUndefinedValues` governs the values held inside an attribute, and the
+attributes of an item sit a level above that (the real client drops an undefined one there without
+being asked to).
+
+```typescript sim-dynamodb-document-marshall-options
+/**
+ * Writing a partly filled object through a document client that drops
+ * undefined values.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+  { marshallOptions: { removeUndefinedValues: true } },
+);
+simSdk.intercept(documents);
+
+await documents.send(
+  new CreateTableCommand({
+    TableName: "PagesTable",
+    KeySchema: [{ AttributeName: "pageId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "pageId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simSdk.simAws.backgroundTasksComplete();
+
+// The summary was never filled in, and one section is still to be written.
+await documents.send(
+  new PutCommand({
+    TableName: "PagesTable",
+    Item: {
+      pageId: "page-1",
+      meta: { title: "Home", summary: undefined },
+      sections: ["intro", undefined, "outro"],
+    },
+  }),
+);
+
+const read = await documents.send(
+  new GetCommand({ TableName: "PagesTable", Key: { pageId: "page-1" } }),
+);
+
+const meta = read.Item?.["meta"] as Record<string, string>;
+console.log(Object.keys(meta)); // [ 'title' ]
+
+// A dropped member takes its position with it.
+const sections = read.Item?.["sections"] as string[];
+console.log(sections); // [ 'intro', 'outro' ]
+```
+
+`unmarshallOptions` are ignored. A stored value comes back the way a document client built with no
+options of its own reads it.
+
 ### Querying and scanning through the document client
 
 `@aws-sdk/lib-dynamodb` names its `QueryCommand` and `ScanCommand` exactly as

--- a/docs/services/dynamodb/README.md
+++ b/docs/services/dynamodb/README.md
@@ -3230,8 +3230,9 @@ A simulated table holds a number's digits exactly, but the document client conve
 JavaScript numbers, and that is where digits are lost. It is the same loss AWS has. A test that
 passes here is telling you something true about the real thing.
 
-- Writing a `number` outside the safe integer range is refused, never stored already rounded. Write
-  a `bigint`, or a `NumberValue` from `@aws-sdk/lib-dynamodb`, to keep the digits.
+- Writing a `number` outside the safe integer range is refused unless the client was built with
+  `allowImpreciseNumbers`. Write a `bigint`, or a `NumberValue` from `@aws-sdk/lib-dynamodb`, to keep
+  the digits.
 - Reading a stored number outside the safe integer range gives a `bigint`.
 - Reading a stored decimal with more digits than a JavaScript number carries gives a rounded
   `number`. The table still holds every digit, and the rounding is the document client's. Read

--- a/docs/services/dynamodb/sim-dynamodb-document-marshall-options.example.ts
+++ b/docs/services/dynamodb/sim-dynamodb-document-marshall-options.example.ts
@@ -1,0 +1,54 @@
+/**
+ * Writing a partly filled object through a document client that drops
+ * undefined values.
+ */
+
+import { CreateTableCommand, DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { SimSdk } from "@kensio/yulin/sdk";
+
+using simSdk = new SimSdk();
+
+const documents = DynamoDBDocumentClient.from(
+  new DynamoDBClient({ region: "eu-west-2" }),
+  { marshallOptions: { removeUndefinedValues: true } },
+);
+simSdk.intercept(documents);
+
+await documents.send(
+  new CreateTableCommand({
+    TableName: "PagesTable",
+    KeySchema: [{ AttributeName: "pageId", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "pageId", AttributeType: "S" }],
+    BillingMode: "PAY_PER_REQUEST",
+  }),
+);
+await simSdk.simAws.backgroundTasksComplete();
+
+// The summary was never filled in, and one section is still to be written.
+await documents.send(
+  new PutCommand({
+    TableName: "PagesTable",
+    Item: {
+      pageId: "page-1",
+      meta: { title: "Home", summary: undefined },
+      sections: ["intro", undefined, "outro"],
+    },
+  }),
+);
+
+const read = await documents.send(
+  new GetCommand({ TableName: "PagesTable", Key: { pageId: "page-1" } }),
+);
+
+const meta = read.Item?.["meta"] as Record<string, string>;
+console.log(Object.keys(meta)); // [ 'title' ]
+
+// A dropped member takes its position with it.
+const sections = read.Item?.["sections"] as string[];
+console.log(sections); // [ 'intro', 'outro' ]

--- a/src/sdk/router/sim-sdk-command-router.type.ts
+++ b/src/sdk/router/sim-sdk-command-router.type.ts
@@ -24,6 +24,16 @@ export interface SimSdkCommandContext {
    * session needs that split, because its session ARN owns no policies.
    */
   readonly caller?: SimAwsCaller | undefined;
+
+  /**
+   * The SDK client the Command was sent through, when the send came from one.
+   *
+   * A route needs it only for configuration the Command itself does not
+   * carry, such as the marshalling options a `DynamoDBDocumentClient` was
+   * built with. A request bridged from the wire has no client object behind
+   * it, so this is left out there.
+   */
+  readonly client?: unknown;
 }
 
 /**

--- a/src/sdk/sim-sdk-command-dispatcher.ts
+++ b/src/sdk/sim-sdk-command-dispatcher.ts
@@ -75,7 +75,7 @@ export class SimSdkCommandDispatcher {
       );
     }
 
-    return await route(command, { caller });
+    return await route(command, { caller, client });
   }
 
   /**

--- a/src/service/dynamodb/README.md
+++ b/src/service/dynamodb/README.md
@@ -1103,10 +1103,17 @@ intercepted send never runs it and the conversion happens at the interception bo
   `convertWithoutMapWrapper`, amount to converting one value at a time with no top-level unwrapping,
   which is what these functions do. The `util-dynamodb` defaults would drop the `M` wrapper off a
   nested object, which is not an attribute value at all.
+- `sim-dynamodb-document-marshall-options.ts` reads the `marshallOptions` a client was built with
+  off its resolved config, where `DynamoDBDocumentClient` keeps them. `SimSdkCommandContext` carries
+  the client the Command was sent through for that. Options are resolved per send, the way the real
+  middleware resolves them. Two document clients over one simulation each convert by their own.
+  `unmarshallOptions` are not read.
 - `sim-dynamodb-document-path.ts` says where in a Command the native values sit, since a Command
   carries ordinary request values everywhere else. `-command-paths.ts` states them per Command,
   mirroring the key nodes the real client declares on its own Commands, which are `protected` and so
-  not read from it.
+  not read from it. An undefined attribute of an item, a key or a set of expression values is left
+  out here rather than in the marshaller. `lib-dynamodb` drops it in `processObj` before `marshall`
+  reaches the value, and `removeUndefinedValues` governs the marshaller alone.
 - `sim-dynamodb-document-route.ts` converts, sends to the ordinary facade method, and converts back.
   `-routes.ts` builds one per Command for the SDK router to merge in.
 

--- a/src/service/dynamodb/document/sim-dynamodb-document-guards.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-guards.iso.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@kensio/smartass";
 import { describe, it } from "vitest";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+import { simDynamoDbDocumentMarshallDefaults } from "./sim-dynamodb-document-marshall-options.js";
 import { simDynamoDbDocumentSetAttribute } from "./sim-dynamodb-document-set.js";
 import { simDynamoDbDocumentNativeValue } from "./sim-dynamodb-document-unmarshall.js";
 
@@ -20,7 +21,11 @@ describe("simulated DynamoDB document conversion guards", () => {
   it("refuses a Set holding undefined", () => {
     // When a Set carrying an undefined member is converted.
     const error = assertThrowsError(() =>
-      simDynamoDbDocumentSetAttribute(new Set([undefined]), "input.Item.tags"),
+      simDynamoDbDocumentSetAttribute(
+        new Set([undefined]),
+        "input.Item.tags",
+        simDynamoDbDocumentMarshallDefaults,
+      ),
     );
 
     // Then it is refused as an undefined value rather than as an empty set,

--- a/src/service/dynamodb/document/sim-dynamodb-document-marshall-options.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-marshall-options.iso.test.ts
@@ -1,0 +1,247 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  type TranslateConfig,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+import {
+  simDynamoDbDocumentMarshallDefaults,
+  simDynamoDbDocumentMarshallOptions,
+} from "./sim-dynamodb-document-marshall-options.js";
+
+/**
+ * An object with behaviour, which is what `convertClassInstanceToMap` decides
+ * the fate of.
+ */
+class Address {
+  readonly street: string;
+
+  constructor(street: string) {
+    this.street = street;
+  }
+
+  label(): string {
+    return this.street;
+  }
+}
+
+/**
+ * An intercepted document client over a table keyed by `id`.
+ */
+async function interceptedDocuments(
+  simSdk: SimSdk,
+  translateConfig?: TranslateConfig,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+    translateConfig,
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "OptionsTable",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  return documents;
+}
+
+/**
+ * Write one attribute natively and read the descriptor it was stored as.
+ */
+async function storedAs(
+  simSdk: SimSdk,
+  documents: DynamoDBDocumentClient,
+  value: unknown,
+): Promise<unknown> {
+  await documents.send(
+    new PutCommand({ TableName: "OptionsTable", Item: { id: "a", value } }),
+  );
+
+  const read = await simSdk.simAws
+    .region("eu-west-2")
+    .dynamoDb()
+    .getItem(
+      new GetItemCommand({
+        TableName: "OptionsTable",
+        Key: { id: { S: "a" } },
+      }),
+    );
+
+  return read.Item?.["value"];
+}
+
+describe("simulated DynamoDB document marshalling options", () => {
+  it("writes an empty string as NULL for convertEmptyValues", async () => {
+    // Given a client that converts empty values.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, {
+      marshallOptions: { convertEmptyValues: true },
+    });
+
+    // When an empty string is written.
+    const stored = await storedAs(simSdk, documents, "");
+
+    // Then it went in as NULL rather than as an empty string.
+    assertObjectEquals(stored, { NULL: true });
+  });
+
+  it("writes an empty string as it stands when the client asked for none", async () => {
+    // Given a client built with no options of its own.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When an empty string is written.
+    const stored = await storedAs(simSdk, documents, "");
+
+    // Then it went in as the string it is, which DynamoDB has held since it
+    // started accepting empty non-key attributes.
+    assertObjectEquals(stored, { S: "" });
+  });
+
+  it("writes an empty Set as NULL for convertEmptyValues", async () => {
+    // Given a client that converts empty values.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, {
+      marshallOptions: { convertEmptyValues: true },
+    });
+
+    // When an empty Set is written, which DynamoDB has no attribute for.
+    const stored = await storedAs(simSdk, documents, new Set());
+
+    // Then it went in as NULL rather than being refused.
+    assertObjectEquals(stored, { NULL: true });
+  });
+
+  it("writes an empty binary value as NULL for convertEmptyValues", async () => {
+    // Given a client that converts empty values.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, {
+      marshallOptions: { convertEmptyValues: true },
+    });
+
+    // When a binary value holding no bytes is written.
+    const stored = await storedAs(simSdk, documents, new Uint8Array(0));
+
+    // Then it went in as NULL.
+    assertObjectEquals(stored, { NULL: true });
+  });
+
+  it("writes a class instance as a map for convertClassInstanceToMap", async () => {
+    // Given a client that converts class instances.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, {
+      marshallOptions: { convertClassInstanceToMap: true },
+    });
+
+    // When an object with behaviour is written.
+    const stored = await storedAs(simSdk, documents, new Address("1 High St"));
+
+    // Then its own properties went in as a map, and its methods did not.
+    assertObjectEquals(stored, { M: { street: { S: "1 High St" } } });
+  });
+
+  it("refuses a class instance when the client asked for none", async () => {
+    // Given a client built with no options of its own.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When an object with behaviour is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await storedAs(simSdk, documents, new Address("1 High St"));
+    });
+
+    // Then it is refused rather than quietly flattened into attributes.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "input.Item.value");
+  });
+
+  it("writes a number past the safe range for allowImpreciseNumbers", async () => {
+    // Given a client that allows imprecise numbers.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, {
+      marshallOptions: { allowImpreciseNumbers: true },
+    });
+
+    // When a number too large for a JavaScript number to hold exactly is
+    // written.
+    const stored = await storedAs(simSdk, documents, 2 ** 60);
+
+    // Then it went in with the digits it had already been rounded to, which
+    // is the loss the option takes on.
+    assertObjectEquals(stored, { N: "1152921504606847000" });
+  });
+
+  it("reads the options of the client each Command was sent through", async () => {
+    // Given two document clients over one simulation, one dropping undefined
+    // values and one built with no options of its own.
+    using simSdk = new SimSdk();
+    const dropping = await interceptedDocuments(simSdk, {
+      marshallOptions: { removeUndefinedValues: true },
+    });
+    const strict = DynamoDBDocumentClient.from(
+      new DynamoDBClient({ region: "eu-west-2" }),
+    );
+    simSdk.intercept(strict);
+
+    // When the same item is written through each.
+    const item = { id: "a", page: { title: "t", summary: undefined } };
+    await dropping.send(
+      new PutCommand({ TableName: "OptionsTable", Item: item }),
+    );
+    const error = await assertThrowsErrorAsync(async () => {
+      await strict.send(
+        new PutCommand({ TableName: "OptionsTable", Item: item }),
+      );
+    });
+
+    // Then each Command was converted by the options of the client it was sent
+    // through, rather than by whichever client was intercepted first.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "removeUndefinedValues");
+  });
+});
+
+describe("simulated DynamoDB document marshalling option defaults", () => {
+  it("converts by the defaults for a send with no client behind it", () => {
+    // When the options are read off nothing, as a request bridged from the
+    // wire arrives with, or off a client whose config has yet to resolve.
+    const nothing = simDynamoDbDocumentMarshallOptions(undefined);
+    const unresolved = simDynamoDbDocumentMarshallOptions({});
+
+    // Then every option is off, which is where the real client leaves them.
+    assertObjectEquals(nothing, simDynamoDbDocumentMarshallDefaults);
+    assertObjectEquals(unresolved, simDynamoDbDocumentMarshallDefaults);
+  });
+
+  it("converts by the defaults for a client that named no options", () => {
+    // When the options are read off a client built with no translate config,
+    // and off one whose translate config named no marshalling options.
+    const untranslated = simDynamoDbDocumentMarshallOptions({ config: {} });
+    const unnamed = simDynamoDbDocumentMarshallOptions({
+      config: { translateConfig: {} },
+    });
+
+    // Then both convert by the defaults.
+    assertObjectEquals(untranslated, simDynamoDbDocumentMarshallDefaults);
+    assertObjectEquals(unnamed, simDynamoDbDocumentMarshallDefaults);
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-marshall-options.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-marshall-options.ts
@@ -1,0 +1,76 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+
+/**
+ * The marshalling options a document client was built with.
+ *
+ * `DynamoDBDocumentClient.from(client, { marshallOptions })` changes what the
+ * real conversion does with values it would otherwise refuse, so the simulated
+ * conversion reads the same options rather than always applying the defaults.
+ * Every one of them is off unless the client asked for it, which is how the
+ * real document client leaves them.
+ */
+export interface SimDynamoDbDocumentMarshallOptions {
+  /**
+   * Drop an undefined value out of a map, a list or a set instead of refusing
+   * it.
+   */
+  readonly removeUndefinedValues: boolean;
+
+  /**
+   * Write an empty string, an empty binary value and an empty set as NULL.
+   */
+  readonly convertEmptyValues: boolean;
+
+  /**
+   * Read a class instance as a map of its own properties.
+   */
+  readonly convertClassInstanceToMap: boolean;
+
+  /**
+   * Write a number outside the safe integer range, digits already lost, rather
+   * than refusing it.
+   */
+  readonly allowImpreciseNumbers: boolean;
+}
+
+/**
+ * What a document client built with no options of its own converts by.
+ */
+export const simDynamoDbDocumentMarshallDefaults: SimDynamoDbDocumentMarshallOptions =
+  {
+    removeUndefinedValues: false,
+    convertEmptyValues: false,
+    convertClassInstanceToMap: false,
+    allowImpreciseNumbers: false,
+  };
+
+/**
+ * Read the marshalling options off the client a Command was sent through.
+ *
+ * `DynamoDBDocumentClient` keeps the translation config it was built with on
+ * its resolved config, which is where the real marshalling middleware reads it
+ * from. A client that named none, and anything that is not a document client
+ * at all, converts by the defaults.
+ */
+export function simDynamoDbDocumentMarshallOptions(
+  client: unknown,
+): SimDynamoDbDocumentMarshallOptions {
+  const config = isRecord(client) ? client["config"] : undefined;
+  const translateConfig = isRecord(config)
+    ? config["translateConfig"]
+    : undefined;
+  const options = isRecord(translateConfig)
+    ? translateConfig["marshallOptions"]
+    : undefined;
+
+  if (!isRecord(options)) {
+    return simDynamoDbDocumentMarshallDefaults;
+  }
+
+  return {
+    removeUndefinedValues: options["removeUndefinedValues"] === true,
+    convertEmptyValues: options["convertEmptyValues"] === true,
+    convertClassInstanceToMap: options["convertClassInstanceToMap"] === true,
+    allowImpreciseNumbers: options["allowImpreciseNumbers"] === true,
+  };
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-marshall.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-marshall.ts
@@ -1,10 +1,7 @@
 import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
-import { isSimDynamoDbDocumentBinary } from "./sim-dynamodb-document-binary.js";
-import {
-  isSimDynamoDbDocumentNumberValue,
-  simDynamoDbDocumentNumberAttribute,
-} from "./sim-dynamodb-document-number.js";
+import type { SimDynamoDbDocumentMarshallOptions } from "./sim-dynamodb-document-marshall-options.js";
+import { simDynamoDbDocumentScalarAttribute } from "./sim-dynamodb-document-scalar.js";
 import { simDynamoDbDocumentSetAttribute } from "./sim-dynamodb-document-set.js";
 
 /**
@@ -15,20 +12,21 @@ import { simDynamoDbDocumentSetAttribute } from "./sim-dynamodb-document-set.js"
  * order, so a value that reaches a simulated table through the document client
  * is the value that would have reached the real one.
  *
- * `undefined` is refused rather than dropped. The real document client drops it
- * when the client was built with `removeUndefinedValues`, which is a translate
- * config this simulation does not read yet, so refusing is what keeps a test
- * from passing against an item AWS would have written differently.
+ * The options are the ones the document client was built with. They decide
+ * what happens to a value the defaults refuse: an undefined member, an empty
+ * string or binary value, a class instance, and a number past the range a
+ * JavaScript number holds exactly.
  */
 export function simDynamoDbDocumentAttributeValue(
   value: unknown,
   path: string,
+  options: SimDynamoDbDocumentMarshallOptions,
 ): SimDynamoDbAttributeValue {
   if (value === undefined) {
     throw new SimDynamoDbDocumentValueError(
-      `${path} is undefined. The real document client drops it only when it ` +
-        `was built with removeUndefinedValues, which simulated DynamoDB does ` +
-        `not read yet, so leave the attribute out instead`,
+      `${path} is undefined. Build the document client with ` +
+        `removeUndefinedValues to drop it, which is what the real one asks ` +
+        `for, or leave the attribute out instead`,
     );
   }
 
@@ -37,10 +35,10 @@ export function simDynamoDbDocumentAttributeValue(
   }
 
   if (Array.isArray(value)) {
-    return { L: listMembers(value, path) };
+    return { L: listMembers(value, path, options) };
   }
 
-  return containerOrScalar(value, path);
+  return containerOrScalar(value, path, options);
 }
 
 /**
@@ -49,48 +47,31 @@ export function simDynamoDbDocumentAttributeValue(
 function containerOrScalar(
   value: unknown,
   path: string,
+  options: SimDynamoDbDocumentMarshallOptions,
 ): SimDynamoDbAttributeValue {
   if (value instanceof Set) {
-    return simDynamoDbDocumentSetAttribute(value, path);
+    return simDynamoDbDocumentSetAttribute(value, path, options);
   }
 
   if (value instanceof Map) {
-    return { M: mapEntries([...value], path) };
+    return { M: mapEntries([...value], path, options) };
   }
 
   if (isPlainObject(value)) {
-    return { M: mapEntries(Object.entries(value), path) };
+    return { M: mapEntries(Object.entries(value), path, options) };
   }
 
-  return scalar(value, path);
-}
-
-/**
- * Read a value that stands for one attribute on its own.
- */
-function scalar(value: unknown, path: string): SimDynamoDbAttributeValue {
-  if (isSimDynamoDbDocumentBinary(value)) {
-    return { B: value as Uint8Array };
+  const scalar = simDynamoDbDocumentScalarAttribute(value, path, options);
+  if (scalar !== undefined) {
+    return scalar;
   }
 
-  if (typeof value === "boolean") {
-    return { BOOL: value };
-  }
-
-  if (typeof value === "number") {
-    return simDynamoDbDocumentNumberAttribute(value, path);
-  }
-
-  if (isSimDynamoDbDocumentNumberValue(value)) {
-    return { N: value.toAttributeValue().N };
-  }
-
-  if (typeof value === "bigint") {
-    return { N: value.toString() };
-  }
-
-  if (typeof value === "string") {
-    return { S: value };
+  // A class instance is read as a map only when the client asked for it, which
+  // is the last thing the real conversion tries before giving up. Null reached
+  // an answer of its own before any of this.
+  if (typeof value === "object" && options.convertClassInstanceToMap) {
+    const instance = value as Record<string, unknown>;
+    return { M: mapEntries(Object.entries(instance), path, options) };
   }
 
   throw new SimDynamoDbDocumentValueError(
@@ -102,15 +83,28 @@ function scalar(value: unknown, path: string): SimDynamoDbAttributeValue {
 /**
  * The members of a list, with the functions left out as the real one leaves
  * them out.
+ *
+ * A dropped undefined member takes its position with it, so the members after
+ * it move up. That is what the real conversion does: it filters before it
+ * converts, rather than writing a NULL where the member was.
  */
 function listMembers(
   values: readonly unknown[],
   path: string,
+  options: SimDynamoDbDocumentMarshallOptions,
 ): SimDynamoDbAttributeValue[] {
   return values
-    .filter((member) => typeof member !== "function")
+    .filter(
+      (member) =>
+        typeof member !== "function" &&
+        !(member === undefined && options.removeUndefinedValues),
+    )
     .map((member, index) =>
-      simDynamoDbDocumentAttributeValue(member, `${path}[${index.toString()}]`),
+      simDynamoDbDocumentAttributeValue(
+        member,
+        `${path}[${index.toString()}]`,
+        options,
+      ),
     );
 }
 
@@ -120,11 +114,16 @@ function listMembers(
 function mapEntries(
   entries: readonly (readonly [unknown, unknown])[],
   path: string,
+  options: SimDynamoDbDocumentMarshallOptions,
 ): Record<string, SimDynamoDbAttributeValue> {
   const attributes: Record<string, SimDynamoDbAttributeValue> = {};
 
   for (const [name, member] of entries) {
     if (typeof member === "function") {
+      continue;
+    }
+
+    if (member === undefined && options.removeUndefinedValues) {
       continue;
     }
 
@@ -134,7 +133,11 @@ function mapEntries(
     // an ordinary attribute instead of reaching the prototype setter. The real
     // document client assigns, and so loses that attribute.
     Object.defineProperty(attributes, key, {
-      value: simDynamoDbDocumentAttributeValue(member, `${path}.${key}`),
+      value: simDynamoDbDocumentAttributeValue(
+        member,
+        `${path}.${key}`,
+        options,
+      ),
       enumerable: true,
       writable: true,
       configurable: true,

--- a/src/service/dynamodb/document/sim-dynamodb-document-number.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-number.ts
@@ -1,5 +1,6 @@
 import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+import type { SimDynamoDbDocumentMarshallOptions } from "./sim-dynamodb-document-marshall-options.js";
 
 /**
  * A value carrying its own Number attribute, which is what lib-dynamodb's
@@ -34,11 +35,13 @@ export function isSimDynamoDbDocumentNumberValue(
  * than storing one that has already lost digits. A simulated table holds the
  * digits it is given exactly, so this refusal is the only thing standing
  * between an application and a silently rounded identifier, which is why it is
- * kept rather than relaxed. A decimal inside the range is written as it stands.
+ * kept until a client asks for `allowImpreciseNumbers` and takes the rounding
+ * on. A decimal inside the range is written as it stands.
  */
 export function simDynamoDbDocumentNumberAttribute(
   value: number,
   path: string,
+  options: SimDynamoDbDocumentMarshallOptions,
 ): SimDynamoDbAttributeValue {
   if (!Number.isFinite(value)) {
     throw new SimDynamoDbDocumentValueError(
@@ -46,7 +49,10 @@ export function simDynamoDbDocumentNumberAttribute(
     );
   }
 
-  if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
+  if (
+    !options.allowImpreciseNumbers &&
+    (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER)
+  ) {
     throw new SimDynamoDbDocumentValueError(
       `${path} is ${value.toString()}, which is outside the range a ` +
         `JavaScript number holds exactly. Write it as a bigint, or as a ` +

--- a/src/service/dynamodb/document/sim-dynamodb-document-path.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-path.ts
@@ -28,15 +28,34 @@ export interface SimDynamoDbDocumentPath {
 }
 
 /**
- * One attribute value, converted where it stands.
+ * Every attribute value of an item, a key or a set of expression values.
+ *
+ * An attribute whose value is undefined is left out rather than converted, and
+ * that happens whatever the document client was built with. The real client
+ * drops it in the same place: `removeUndefinedValues` governs the values
+ * inside an attribute, and an item is not itself one of them.
  */
-class SimDynamoDbDocumentValuePath implements SimDynamoDbDocumentPath {
+class SimDynamoDbDocumentValuesPath implements SimDynamoDbDocumentPath {
   convert(
     value: unknown,
     conversion: SimDynamoDbDocumentConversion,
     path: string,
   ): unknown {
-    return conversion(value, path);
+    if (Array.isArray(value)) {
+      return value.map((member, index) =>
+        conversion(member, `${path}[${index.toString()}]`),
+      );
+    }
+
+    if (!isRecord(value)) {
+      return value;
+    }
+
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, member]) => member !== undefined)
+        .map(([name, member]) => [name, conversion(member, `${path}.${name}`)]),
+    );
   }
 }
 
@@ -113,18 +132,11 @@ class SimDynamoDbDocumentFieldsPath implements SimDynamoDbDocumentPath {
 }
 
 /**
- * A path to one attribute value.
- */
-export function simDynamoDbDocumentValue(): SimDynamoDbDocumentPath {
-  return new SimDynamoDbDocumentValuePath();
-}
-
-/**
  * A path to a record or list whose every member is one attribute value, which
  * is what an Item, a Key and a set of expression values are.
  */
 export function simDynamoDbDocumentValues(): SimDynamoDbDocumentPath {
-  return simDynamoDbDocumentEach(simDynamoDbDocumentValue());
+  return new SimDynamoDbDocumentValuesPath();
 }
 
 /**

--- a/src/service/dynamodb/document/sim-dynamodb-document-route.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-route.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../sdk/index.js";
 import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import type { SimDynamoDbRequestOptions } from "../sim-dynamodb.types.js";
+import { simDynamoDbDocumentMarshallOptions } from "./sim-dynamodb-document-marshall-options.js";
 import { simDynamoDbDocumentAttributeValue } from "./sim-dynamodb-document-marshall.js";
 import type { SimDynamoDbDocumentPath } from "./sim-dynamodb-document-path.js";
 import { simDynamoDbDocumentNativeValue } from "./sim-dynamodb-document-unmarshall.js";
@@ -46,9 +47,14 @@ export class SimDynamoDbDocumentRoute {
    */
   route(): SimSdkCommandRoute {
     return async (command, context): Promise<unknown> => {
+      // Read per send, as the real middleware reads it, so the same route
+      // serves document clients built with different options.
+      const options = simDynamoDbDocumentMarshallOptions(context.client);
+
       const input = this.input.convert(
         command.input,
-        (value, path) => simDynamoDbDocumentAttributeValue(value, path),
+        (value, path) =>
+          simDynamoDbDocumentAttributeValue(value, path, options),
         "input",
       );
 

--- a/src/service/dynamodb/document/sim-dynamodb-document-scalar.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-scalar.ts
@@ -1,0 +1,63 @@
+import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
+import { isSimDynamoDbDocumentBinary } from "./sim-dynamodb-document-binary.js";
+import type { SimDynamoDbDocumentMarshallOptions } from "./sim-dynamodb-document-marshall-options.js";
+import {
+  isSimDynamoDbDocumentNumberValue,
+  simDynamoDbDocumentNumberAttribute,
+} from "./sim-dynamodb-document-number.js";
+
+/**
+ * Read a value that stands for one attribute on its own.
+ *
+ * The kinds are tried in the order the real conversion tries them. A value
+ * that is none of them answers with nothing, and what happens to it next is
+ * for the caller to decide.
+ *
+ * An empty string and a binary value holding no bytes are written as NULL when
+ * the client was built with `convertEmptyValues`, and as themselves otherwise.
+ */
+export function simDynamoDbDocumentScalarAttribute(
+  value: unknown,
+  path: string,
+  options: SimDynamoDbDocumentMarshallOptions,
+): SimDynamoDbAttributeValue | undefined {
+  if (isSimDynamoDbDocumentBinary(value)) {
+    return isEmptyLength(value) && options.convertEmptyValues
+      ? { NULL: true }
+      : { B: value as Uint8Array };
+  }
+
+  if (typeof value === "boolean") {
+    return { BOOL: value };
+  }
+
+  if (typeof value === "number") {
+    return simDynamoDbDocumentNumberAttribute(value, path, options);
+  }
+
+  if (isSimDynamoDbDocumentNumberValue(value)) {
+    return { N: value.toAttributeValue().N };
+  }
+
+  if (typeof value === "bigint") {
+    return { N: value.toString() };
+  }
+
+  if (typeof value === "string") {
+    return value.length === 0 && options.convertEmptyValues
+      ? { NULL: true }
+      : { S: value };
+  }
+
+  return undefined;
+}
+
+/**
+ * Whether a value holds nothing, by the length the real conversion reads.
+ *
+ * An ArrayBuffer reports `byteLength` rather than `length`, so an empty one is
+ * not empty by this measure, and the real conversion leaves it alone too.
+ */
+function isEmptyLength(value: unknown): boolean {
+  return (value as { length?: unknown }).length === 0;
+}

--- a/src/service/dynamodb/document/sim-dynamodb-document-set.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-set.ts
@@ -1,6 +1,7 @@
 import type { SimDynamoDbAttributeValue } from "../command/item/item.types.js";
 import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
 import { isSimDynamoDbDocumentBinary } from "./sim-dynamodb-document-binary.js";
+import type { SimDynamoDbDocumentMarshallOptions } from "./sim-dynamodb-document-marshall-options.js";
 import {
   isSimDynamoDbDocumentNumberValue,
   simDynamoDbDocumentNumberAttribute,
@@ -15,28 +16,40 @@ import {
  * further down, where the table reads the value. That is what the real one
  * does, so a set written this way behaves the same either side.
  *
- * DynamoDB has no empty set, so an empty one is refused rather than written as
- * something else.
+ * An undefined member is dropped when the client was built with
+ * `removeUndefinedValues`, and refused otherwise. DynamoDB has no empty set, so
+ * a set with nothing left in it is written as NULL when the client was built
+ * with `convertEmptyValues`, and refused otherwise. The two are read in that
+ * order, so a set holding nothing but undefined is an empty set by the time its
+ * size is looked at, which is where the real conversion looks at it too.
  */
 export function simDynamoDbDocumentSetAttribute(
   set: ReadonlySet<unknown>,
   path: string,
+  options: SimDynamoDbDocumentMarshallOptions,
 ): SimDynamoDbAttributeValue {
-  if (set.size === 0) {
+  const members = [...set].filter(
+    (member) => !(member === undefined && options.removeUndefinedValues),
+  );
+
+  if (!options.removeUndefinedValues && set.has(undefined)) {
+    throw new SimDynamoDbDocumentValueError(
+      `${path} is a Set holding undefined. Build the document client with ` +
+        `removeUndefinedValues to drop it, which is what the real one asks for`,
+    );
+  }
+
+  if (members.length === 0) {
+    if (options.convertEmptyValues) {
+      return { NULL: true };
+    }
+
     throw new SimDynamoDbDocumentValueError(
       `${path} is an empty Set, and DynamoDB has no empty set`,
     );
   }
 
-  if (set.has(undefined)) {
-    throw new SimDynamoDbDocumentValueError(
-      `${path} is a Set holding undefined. The real document client drops it ` +
-        `only when it was built with removeUndefinedValues, which simulated ` +
-        `DynamoDB does not read yet`,
-    );
-  }
-
-  return membersAttribute([...set], path);
+  return membersAttribute(members, path, options);
 }
 
 /**
@@ -45,6 +58,7 @@ export function simDynamoDbDocumentSetAttribute(
 function membersAttribute(
   members: readonly unknown[],
   path: string,
+  options: SimDynamoDbDocumentMarshallOptions,
 ): SimDynamoDbAttributeValue {
   const first = members[0];
 
@@ -54,7 +68,9 @@ function membersAttribute(
 
   if (isNumberMember(first)) {
     return {
-      NS: members.map((member, index) => numberText(member, path, index)),
+      NS: members.map((member, index) =>
+        numberText(member, path, index, options),
+      ),
     };
   }
 
@@ -85,7 +101,12 @@ function isNumberMember(member: unknown): boolean {
 /**
  * The digits one member of a number set is written with.
  */
-function numberText(member: unknown, path: string, index: number): string {
+function numberText(
+  member: unknown,
+  path: string,
+  index: number,
+  options: SimDynamoDbDocumentMarshallOptions,
+): string {
   if (typeof member === "bigint") {
     return member.toString();
   }
@@ -97,6 +118,7 @@ function numberText(member: unknown, path: string, index: number): string {
   const attribute = simDynamoDbDocumentNumberAttribute(
     Number(member),
     `${path}[${index.toString()}]`,
+    options,
   );
 
   // A number attribute is the only thing that function answers with.

--- a/src/service/dynamodb/document/sim-dynamodb-document-undefined.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-undefined.iso.test.ts
@@ -1,0 +1,330 @@
+import {
+  CreateTableCommand,
+  DynamoDBClient,
+  GetItemCommand,
+} from "@aws-sdk/client-dynamodb";
+import {
+  BatchWriteCommand,
+  DynamoDBDocumentClient,
+  PutCommand,
+  type TranslateConfig,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  assertInstanceOf,
+  assertObjectEquals,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+import { SimSdk } from "../../../sdk/index.js";
+import { SimDynamoDbDocumentValueError } from "../error/dynamodb.error.js";
+
+/**
+ * A document client that drops undefined values, as an application asks for
+ * one when it hands the client a partly filled object.
+ */
+const dropsUndefined: TranslateConfig = {
+  marshallOptions: { removeUndefinedValues: true },
+};
+
+/**
+ * An intercepted document client over a table keyed by `id`.
+ */
+async function interceptedDocuments(
+  simSdk: SimSdk,
+  translateConfig?: TranslateConfig,
+): Promise<DynamoDBDocumentClient> {
+  const documents = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: "eu-west-2" }),
+    translateConfig,
+  );
+  simSdk.intercept(documents);
+
+  await documents.send(
+    new CreateTableCommand({
+      TableName: "ItemsTable",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      BillingMode: "PAY_PER_REQUEST",
+    }),
+  );
+  await simSdk.simAws.backgroundTasksComplete();
+
+  return documents;
+}
+
+/**
+ * The descriptors one attribute of the written item was stored as.
+ */
+async function storedAs(simSdk: SimSdk, name: string): Promise<unknown> {
+  const read = await simSdk.simAws
+    .region("eu-west-2")
+    .dynamoDb()
+    .getItem(
+      new GetItemCommand({ TableName: "ItemsTable", Key: { id: { S: "a" } } }),
+    );
+
+  // oxlint-disable-next-line security/detect-object-injection -- an attribute name this test named itself.
+  return read.Item?.[name];
+}
+
+describe("simulated DynamoDB document undefined values", () => {
+  it("drops an undefined value out of a map", async () => {
+    // Given a client that drops undefined values, and an item whose nested
+    // object has one field filled and one left undefined.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, dropsUndefined);
+
+    // When the item is written.
+    await documents.send(
+      new PutCommand({
+        TableName: "ItemsTable",
+        Item: { id: "a", page: { title: "t", summary: undefined } },
+      }),
+    );
+
+    // Then the map holds the field that was filled, and nothing stands where
+    // the undefined one was.
+    assertObjectEquals(await storedAs(simSdk, "page"), {
+      M: { title: { S: "t" } },
+    });
+  });
+
+  it("drops an undefined member out of a list, closing the gap", async () => {
+    // Given a client that drops undefined values, and an item carrying a list
+    // with a hole in the middle.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, dropsUndefined);
+
+    // When the item is written.
+    await documents.send(
+      new PutCommand({
+        TableName: "ItemsTable",
+        Item: { id: "a", lines: ["first", undefined, "third"] },
+      }),
+    );
+
+    // Then the members after it moved up, rather than a NULL standing where
+    // the undefined one was. That is what the real conversion does: it filters
+    // the list before it converts it.
+    assertObjectEquals(await storedAs(simSdk, "lines"), {
+      L: [{ S: "first" }, { S: "third" }],
+    });
+  });
+
+  it("drops an undefined member out of a set", async () => {
+    // Given a client that drops undefined values, and an item carrying a Set
+    // with one.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, dropsUndefined);
+
+    // When the item is written.
+    await documents.send(
+      new PutCommand({
+        TableName: "ItemsTable",
+        Item: { id: "a", tags: new Set(["priority", undefined]) },
+      }),
+    );
+
+    // Then the set holds the members that were there.
+    assertObjectEquals(await storedAs(simSdk, "tags"), { SS: ["priority"] });
+  });
+
+  it("drops an undefined value out of an updated map", async () => {
+    // Given a client that drops undefined values.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, dropsUndefined);
+
+    // When an update sets an attribute to a partly filled object.
+    const updated = await documents.send(
+      new UpdateCommand({
+        TableName: "ItemsTable",
+        Key: { id: "a" },
+        UpdateExpression: "SET page = :page",
+        ExpressionAttributeValues: {
+          ":page": { title: "t", summary: undefined },
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+
+    // Then the expression value went in without the undefined field.
+    assertObjectEquals(updated.Attributes, {
+      id: "a",
+      page: { title: "t" },
+    });
+  });
+
+  it("drops an undefined value out of a batch-written map", async () => {
+    // Given a client that drops undefined values.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk, dropsUndefined);
+
+    // When a batch writes an item whose nested object has one.
+    await documents.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          ItemsTable: [
+            {
+              PutRequest: {
+                Item: { id: "a", page: { title: "t", summary: undefined } },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then the item was written without it.
+    assertObjectEquals(await storedAs(simSdk, "page"), {
+      M: { title: { S: "t" } },
+    });
+  });
+
+  it("refuses an undefined value in a map when the client asked for none", async () => {
+    // Given a client built with no options of its own.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When an item carrying an undefined field inside a map is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new PutCommand({
+          TableName: "ItemsTable",
+          Item: { id: "a", page: { title: "t", summary: undefined } },
+        }),
+      );
+    });
+
+    // Then it is refused where it sat, naming the option that would drop it,
+    // which is where the real client refuses it too.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "input.Item.page.summary is undefined");
+    assertStringIncludes(error.message, "removeUndefinedValues");
+  });
+
+  it("refuses an undefined member of a list when the client asked for none", async () => {
+    // Given a client built with no options of its own.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When an item carrying a list with a hole in it is written.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new PutCommand({
+          TableName: "ItemsTable",
+          Item: { id: "a", lines: ["first", undefined, "third"] },
+        }),
+      );
+    });
+
+    // Then it is refused at the position it sat at.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(error.message, "input.Item.lines[1] is undefined");
+  });
+
+  it("refuses an undefined value in an updated map when the client asked for none", async () => {
+    // Given a client built with no options of its own.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When an update sets an attribute to a partly filled object.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new UpdateCommand({
+          TableName: "ItemsTable",
+          Key: { id: "a" },
+          UpdateExpression: "SET page = :page",
+          ExpressionAttributeValues: {
+            ":page": { title: "t", summary: undefined },
+          },
+        }),
+      );
+    });
+
+    // Then it is refused, naming the expression value it sat in.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(
+      error.message,
+      "input.ExpressionAttributeValues.:page.summary is undefined",
+    );
+  });
+
+  it("refuses an undefined value in a batch-written map when the client asked for none", async () => {
+    // Given a client built with no options of its own.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When a batch writes an item whose nested object has one.
+    const error = await assertThrowsErrorAsync(async () => {
+      await documents.send(
+        new BatchWriteCommand({
+          RequestItems: {
+            ItemsTable: [
+              {
+                PutRequest: {
+                  Item: { id: "a", page: { title: "t", summary: undefined } },
+                },
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    // Then it is refused, naming the request it sat in.
+    assertInstanceOf(error, SimDynamoDbDocumentValueError);
+    assertStringIncludes(
+      error.message,
+      "RequestItems.ItemsTable[0].PutRequest.Item.page.summary is undefined",
+    );
+  });
+
+  it("leaves out an undefined attribute of a batch-written item", async () => {
+    // Given a client built with no options of its own.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When a batch writes an item with an undefined attribute.
+    await documents.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          ItemsTable: [
+            {
+              PutRequest: { Item: { id: "a", kept: "here", gone: undefined } },
+            },
+          ],
+        },
+      }),
+    );
+
+    // Then the attribute is not there and the rest of the item is. An item is
+    // not a map, so the real client drops it without being asked to.
+    assertObjectEquals(await storedAs(simSdk, "kept"), { S: "here" });
+    assertUndefined(await storedAs(simSdk, "gone"));
+  });
+
+  it("leaves out an undefined expression value", async () => {
+    // Given a client built with no options of its own.
+    using simSdk = new SimSdk();
+    const documents = await interceptedDocuments(simSdk);
+
+    // When an update carries an expression value the caller left undefined,
+    // alongside the one its expression uses.
+    const updated = await documents.send(
+      new UpdateCommand({
+        TableName: "ItemsTable",
+        Key: { id: "a" },
+        UpdateExpression: "SET kept = :kept",
+        ExpressionAttributeValues: { ":kept": "here", ":gone": undefined },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
+
+    // Then the undefined one never reached the request, so nothing was left
+    // over for the table to complain about.
+    assertObjectEquals(updated.Attributes, { id: "a", kept: "here" });
+  });
+});

--- a/src/service/dynamodb/document/sim-dynamodb-document-value.iso.test.ts
+++ b/src/service/dynamodb/document/sim-dynamodb-document-value.iso.test.ts
@@ -174,26 +174,26 @@ describe("simulated DynamoDB document values", () => {
     assertArrayEquals([...read], [1, 2, 3]);
   });
 
-  it("refuses an undefined attribute rather than dropping it", async () => {
-    // Given an item carrying an undefined value.
+  it("leaves out an undefined attribute of an item", async () => {
+    // Given an item carrying an undefined value alongside a defined one.
     using simSdk = new SimSdk();
     const documents = await interceptedDocuments(simSdk);
 
-    // When it is written.
-    const error = await assertThrowsErrorAsync(async () => {
-      await documents.send(
-        new PutCommand({
-          TableName: "ValuesTable",
-          Item: { id: "a", value: undefined },
-        }),
-      );
-    });
+    // When it is written, then read back.
+    await documents.send(
+      new PutCommand({
+        TableName: "ValuesTable",
+        Item: { id: "a", value: undefined, kept: "here" },
+      }),
+    );
+    const read = await documents.send(
+      new GetCommand({ TableName: "ValuesTable", Key: { id: "a" } }),
+    );
 
-    // Then it is refused, naming where it sat and why the real client would
-    // have dropped it.
-    assertInstanceOf(error, SimDynamoDbDocumentValueError);
-    assertStringIncludes(error.message, "input.Item.value is undefined");
-    assertStringIncludes(error.message, "removeUndefinedValues");
+    // Then the attribute is not there, and the rest of the item is. The real
+    // client drops it here whatever it was built with: removeUndefinedValues
+    // governs the values inside an attribute, and an item is not one of them.
+    assertObjectEquals(read.Item, { id: "a", kept: "here" });
   });
 
   it("refuses an empty Set, as DynamoDB has no empty set", async () => {


### PR DESCRIPTION
The conversion at the interception boundary applied the marshalling defaults whatever `DynamoDBDocumentClient.from(client, translateConfig)` was given. An application that sets `removeUndefinedValues` and hands the client a partly filled object failed here while working on AWS. Those options are now read off the client each Command was sent through, and `removeUndefinedValues`, `convertEmptyValues`, `convertClassInstanceToMap` and `allowImpreciseNumbers` each do what `convertToAttr` does with them. An undefined attribute of an item, a key or a set of expression values is left out whatever the client was built with, because `lib-dynamodb` drops it in `processObj` before the marshaller reaches the value. A dropped list member takes its position with it, since the real conversion filters the list before converting it. `SimSdkCommandContext` now carries the client the Command was sent through, and the route reads the options off it per send. `unmarshallOptions` are still ignored.

Resolves #1326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for DynamoDB document-client marshalling options, including removal of undefined values, empty-value conversion, class-instance mapping, and imprecise-number handling.
  - Options are applied independently for each document client.
  - Undefined values can now be removed from maps, lists, sets, updates, and batch writes when configured.

- **Documentation**
  - Added comprehensive guidance and examples covering supported marshalling options, nested values, defaults, and ignored unmarshalling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->