### PR TITLE
fix: authorize a custom Resource's provider invoke

### DIFF
--- a/docs/services/cloudformation/README.md
+++ b/docs/services/cloudformation/README.md
@@ -2549,6 +2549,94 @@ working simulation with a hand-written one.
 The provider is found through the `ServiceToken` its custom resource names it by, not by the logical
 ID CDK generated for it. That ID is a hash of the construct path, and no kind of thing to match on.
 
+### What a custom resource costs the deploy Role
+
+Real CloudFormation answers a `Custom::` resource by invoking the provider function its `ServiceToken`
+names, as the stack's execution role. Yulin carries several of these out itself instead of running the
+provider, and it authorizes that invoke anyway. A deploy Role holding no `lambda:InvokeFunction` on the
+provider fails the stack where the real deployment fails.
+
+The `ServiceToken` decides the ARN. A token written as an ARN is taken as it stands. CDK's `Fn::GetAtt`
+for the provider's `Arn` is resolved back to the function the stack declares, since the provider is
+left uncreated and has no ARN of its own to give.
+
+The work the resource does is authorized too, as the deployment's principal.
+`Custom::S3BucketNotifications` costs `s3:PutBucketNotification` and
+`Custom::CrossRegionStringParameterReader` costs `ssm:GetParameter`. `Custom::CDKBucketDeployment`
+writes its Objects into the simulated Bucket without sending `PutObject`, so nothing there reaches IAM.
+
+```typescript sim-cloudformation-custom-resource-invoke
+/**
+ * A deploy Role refused the provider invoke its custom resource needs.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const { Role } = await simAws.iam().createRole({
+  input: {
+    RoleName: "DeployRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  },
+});
+
+// Everything the template needs apart from the invoke of the provider.
+await simAws.iam().putRolePolicy({
+  input: {
+    RoleName: "DeployRole",
+    PolicyName: "DeployPolicy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ["cloudformation:*", "s3:*"],
+          Resource: "*",
+        },
+      ],
+    }),
+  },
+});
+
+try {
+  await simAws.cloudFormation().deployTemplate({
+    stackName: "uploads-stack",
+    caller: { kind: "arn", arn: Role.Arn },
+    template: {
+      Resources: {
+        Bucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "uploads" },
+        },
+        BucketNotifications: {
+          Type: "Custom::S3BucketNotifications",
+          Properties: {
+            ServiceToken: "arn:aws:lambda:us-east-1:888888888888:function:cdk",
+            BucketName: { Ref: "Bucket" },
+            NotificationConfiguration: {},
+            Managed: true,
+          },
+        },
+      },
+    },
+  });
+} catch (error) {
+  // is not authorized to perform: lambda:InvokeFunction on resource:
+  // arn:aws:lambda:us-east-1:888888888888:function:cdk
+  console.log((error as Error).message);
+}
+```
+
 ## S3 Bucket notifications
 
 The `NotificationConfiguration` property of `AWS::S3::Bucket` deploys through the ordinary

--- a/docs/services/cloudformation/sim-cloudformation-custom-resource-invoke.example.ts
+++ b/docs/services/cloudformation/sim-cloudformation-custom-resource-invoke.example.ts
@@ -1,0 +1,69 @@
+/**
+ * A deploy Role refused the provider invoke its custom resource needs.
+ */
+
+import { SimAws } from "@kensio/yulin";
+
+const simAws = new SimAws();
+
+const { Role } = await simAws.iam().createRole({
+  input: {
+    RoleName: "DeployRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "cloudformation.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    }),
+  },
+});
+
+// Everything the template needs apart from the invoke of the provider.
+await simAws.iam().putRolePolicy({
+  input: {
+    RoleName: "DeployRole",
+    PolicyName: "DeployPolicy",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ["cloudformation:*", "s3:*"],
+          Resource: "*",
+        },
+      ],
+    }),
+  },
+});
+
+try {
+  await simAws.cloudFormation().deployTemplate({
+    stackName: "uploads-stack",
+    caller: { kind: "arn", arn: Role.Arn },
+    template: {
+      Resources: {
+        Bucket: {
+          Type: "AWS::S3::Bucket",
+          Properties: { BucketName: "uploads" },
+        },
+        BucketNotifications: {
+          Type: "Custom::S3BucketNotifications",
+          Properties: {
+            ServiceToken: "arn:aws:lambda:us-east-1:888888888888:function:cdk",
+            BucketName: { Ref: "Bucket" },
+            NotificationConfiguration: {},
+            Managed: true,
+          },
+        },
+      },
+    },
+  });
+} catch (error) {
+  // is not authorized to perform: lambda:InvokeFunction on resource:
+  // arn:aws:lambda:us-east-1:888888888888:function:cdk
+  console.log((error as Error).message);
+}

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-invoke-arn.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-invoke-arn.ts
@@ -1,0 +1,90 @@
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { namesSimCfnUnansweredAttribute } from "../../resource/cfn/sim-cfn-unanswered-attribute.js";
+import { parseSimLambdaFunctionArn } from "../../../lambda/function/sim-lambda-function-arn-parts.js";
+import {
+  type SimLambdaFunctionArn,
+  simLambdaFunctionArn,
+} from "../../../lambda/function/sim-lambda-function-configuration.js";
+
+const lambdaFunctionResourceType = "AWS::Lambda::Function";
+
+/**
+ * The provider function a custom Resource's `ServiceToken` names, as an ARN.
+ *
+ * Nothing comes back where the Resource names no provider this Stack can put
+ * an ARN to. A `ServiceToken` built from a Parameter, or one pointing at a
+ * Resource type that is not a function, both leave the deployment with nothing
+ * to authorize against, and inventing an ARN for it would refuse a template
+ * over a permission real CloudFormation never asked for.
+ */
+export function simCdkProviderInvokeArn(
+  resolvedProperties: SimCfnTemplateValueRecord,
+  resources: ReadonlyMap<string, SimCfnResource>,
+): SimLambdaFunctionArn | undefined {
+  const serviceToken = resolvedProperties["ServiceToken"];
+
+  if (typeof serviceToken !== "string" || serviceToken === "") {
+    return undefined;
+  }
+
+  return (
+    writtenFunctionArn(serviceToken) ??
+    standInFunctionArn(serviceToken, resources)
+  );
+}
+
+/**
+ * The ARN a `ServiceToken` already carries.
+ *
+ * A provider deployed outside this Stack is named by its ARN outright, and a
+ * template written by hand can name one in the same Stack that way too.
+ */
+function writtenFunctionArn(
+  serviceToken: string,
+): SimLambdaFunctionArn | undefined {
+  return parseSimLambdaFunctionArn(serviceToken) === undefined
+    ? undefined
+    : (serviceToken as SimLambdaFunctionArn);
+}
+
+/**
+ * The ARN behind a `ServiceToken` that resolved to an attribute stand-in.
+ *
+ * CDK writes `ServiceToken` as an `Fn::GetAtt` for the provider function's
+ * `Arn`, and this simulator leaves that provider uncreated: the function is
+ * declined on its Python runtime and then reported as scaffolding for the
+ * custom Resource the simulator carries out itself. An uncreated Resource
+ * answers `Fn::GetAtt` with {@link namesSimCfnUnansweredAttribute}'s stand-in
+ * rather than an ARN.
+ *
+ * The name survives that refusal. Sim Lambda works out the name real
+ * CloudFormation would have given the function before declining it, so the
+ * Resource's `Ref` holds a function name to build the ARN from. A provider
+ * that reached neither creation nor a name has only its logical ID behind
+ * `Ref`, and an ARN built from that would be denied by a policy naming the
+ * function real CloudFormation invokes.
+ */
+function standInFunctionArn(
+  serviceToken: string,
+  resources: ReadonlyMap<string, SimCfnResource>,
+): SimLambdaFunctionArn | undefined {
+  if (!namesSimCfnUnansweredAttribute(serviceToken, resources.keys())) {
+    return undefined;
+  }
+
+  const provider = resources.get(serviceToken.split(".", 1)[0] ?? "");
+
+  if (
+    provider?.type !== lambdaFunctionResourceType ||
+    (!provider.deployed && provider.uncreatedPhysicalName === undefined)
+  ) {
+    return undefined;
+  }
+
+  const { refValue } = provider;
+
+  return typeof refValue === "string" && refValue !== ""
+    ? simLambdaFunctionArn(provider.accountRegionScope, refValue)
+    : undefined;
+}

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-invoke-auth-z.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-invoke-auth-z.ts
@@ -1,0 +1,77 @@
+import type { SimAws } from "../../../aws/sim-aws.js";
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { simScopeIamAuthZ } from "../../../iam/authorize/sim-iam-region-auth-z.js";
+import { SimIamAccessDenied } from "../../../iam/error/sim-iam.error.js";
+import type { SimCloudFormationParsedResourceType } from "../../resource/factory/sim-cfn-resource-factory.type.js";
+import type { SimCfnResource } from "../../resource/sim-cfn-resource.js";
+import type { SimCfnTemplateValueRecord } from "../../template/value/sim-cfn-template-value.js";
+import { simCdkProviderInvokeArn } from "./sim-cdk-provider-invoke-arn.js";
+
+const customResourceProviderName = "Custom";
+const invokeAction = "lambda:InvokeFunction";
+
+/**
+ * What authorizing one custom Resource's provider invoke needs.
+ */
+export interface SimCdkProviderInvokeAuthZProperties {
+  readonly resourceType: SimCloudFormationParsedResourceType;
+  readonly resource: SimCfnResource;
+  readonly resolvedProperties: SimCfnTemplateValueRecord;
+  readonly resources: ReadonlyMap<string, SimCfnResource>;
+  readonly simAws: SimAws;
+  readonly caller?: SimAwsCaller | undefined;
+}
+
+/**
+ * Authorize the invoke a custom Resource costs the deployment.
+ *
+ * Real CloudFormation answers a `Custom::` Resource by invoking the function
+ * its `ServiceToken` names, as the Stack's execution role. That invoke is the
+ * first thing a deployment pays for, and a role without `lambda:InvokeFunction`
+ * on the provider fails the Stack there rather than at the work the provider
+ * would have done.
+ *
+ * This simulator carries several custom Resources out itself instead of
+ * running the provider, which leaves the invoke unpaid for unless it is
+ * authorized here. A deploy Role standing in for a real CloudFormation
+ * execution policy is meant to fail the same template the real one refuses.
+ *
+ * Only the caller's identity policies decide it. The provider function is
+ * uncreated in the usual case, so there is no simulated function holding a
+ * resource policy to consult, and CDK grants the invoke on the execution role
+ * anyway.
+ */
+export function authorizeSimCdkProviderInvoke(
+  properties: SimCdkProviderInvokeAuthZProperties,
+): void {
+  if (properties.resourceType.providerName !== customResourceProviderName) {
+    return;
+  }
+
+  const functionArn = simCdkProviderInvokeArn(
+    properties.resolvedProperties,
+    properties.resources,
+  );
+
+  if (functionArn === undefined) {
+    return;
+  }
+
+  const { accountId, regionName } = properties.resource.accountRegionScope;
+  const decision = simScopeIamAuthZ(
+    properties.simAws.accountRegionScope(accountId, regionName),
+  ).authorize({
+    action: invokeAction,
+    resource: functionArn,
+    caller: properties.caller,
+  });
+
+  if (decision.isDenied) {
+    throw new SimIamAccessDenied({
+      principal: decision.caller.principal,
+      reason: decision.denialReason,
+      action: invokeAction,
+      resource: functionArn,
+    });
+  }
+}

--- a/src/service/cloudformation/cdk/provider/sim-cdk-provider-invoke-authorization.iso.test.ts
+++ b/src/service/cloudformation/cdk/provider/sim-cdk-provider-invoke-authorization.iso.test.ts
@@ -1,0 +1,240 @@
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertStringNotIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
+import { faker } from "@faker-js/faker";
+import { describe, it } from "vitest";
+
+import type { SimAwsCaller } from "../../../aws/caller/sim-aws-caller.js";
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamPolicyDocumentFactory } from "../../../iam/policy/sim-iam-policy-document.factory.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import { simCdkBucketNotificationsTemplateFactory } from "../s3/bucket-notifications/sim-cdk-bucket-notifications-template.factory.js";
+
+describe("the invoke a custom Resource's provider costs a deployment", () => {
+  /** The provider ARN the bucket notification template's ServiceToken names. */
+  const providerArn = "arn:aws:lambda:us-east-1:888888888888:function:cdk";
+
+  /** A deploy Role allowed the actions it is given, on every resource. */
+  async function deployRole(
+    simAws: SimAws,
+    actions: readonly string[],
+  ): Promise<{ readonly caller: SimAwsCaller; readonly roleName: string }> {
+    const roleName = `deployer-${faker.string.uuid()}`;
+    const role = await simIamRoleWithPolicyFactory.make(
+      { roleName, policyName: `${roleName}-policy`, actions },
+      simAws,
+    );
+
+    return { caller: { kind: "arn", arn: role.Arn }, roleName };
+  }
+
+  /** Every action deploying the notification template needs but the invoke. */
+  const deployActions = [
+    "s3:CreateBucket",
+    "s3:PutBucketNotification",
+    "lambda:CreateFunction",
+    "lambda:AddPermission",
+    "iam:CreateRole",
+    "iam:PassRole",
+  ];
+
+  it("refuses a Stack whose deploy Role cannot invoke the provider", async () => {
+    // Given a deploy Role holding everything the template needs except the
+    // invoke of the provider function CloudFormation answers the custom
+    // Resource with.
+    const simAws = new SimAws();
+    const stackName = `uploads-${faker.string.uuid()}`;
+    const { caller, roleName } = await deployRole(simAws, deployActions);
+
+    // When the Stack is deployed as that Role.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName,
+        template: simCdkBucketNotificationsTemplateFactory.make({}),
+        caller,
+      });
+    });
+
+    // Then it is refused on the invoke, as the real deployment is.
+    assertStringIncludes(error.message, "lambda:InvokeFunction");
+    assertStringIncludes(error.message, providerArn);
+    assertStringIncludes(error.message, `role/${roleName}`);
+    assertIdentical(
+      simAws
+        .cloudFormation()
+        .getStackByName(stackName)
+        ?.getResource("BucketNotifications")?.status,
+      "CREATE_FAILED",
+    );
+  });
+
+  it("deploys a Stack whose deploy Role may invoke the provider", async () => {
+    // Given a deploy Role allowed the invoke alongside the rest.
+    const simAws = new SimAws();
+    const stackName = `uploads-${faker.string.uuid()}`;
+    const bucketName = `uploads-${faker.string.uuid()}`;
+    const { caller } = await deployRole(simAws, [
+      ...deployActions,
+      "lambda:InvokeFunction",
+    ]);
+
+    // When the Stack is deployed as that Role.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName,
+      template: simCdkBucketNotificationsTemplateFactory.make({ bucketName }),
+      caller,
+    });
+
+    // Then the notification configuration reached the Bucket.
+    assertIdentical(
+      stack.getResource("BucketNotifications")?.status,
+      "CREATE_COMPLETE",
+    );
+    const configuration = await simAws
+      .s3()
+      .getBucketNotificationConfiguration({ input: { Bucket: bucketName } });
+    assertIdentical(configuration.LambdaFunctionConfigurations?.length, 1);
+  });
+
+  it("refuses a teardown whose deploy Role cannot invoke the provider", async () => {
+    // Given a Stack deployed by a Role that could invoke the provider, whose
+    // policy is narrowed to take that invoke away again before the teardown.
+    const simAws = new SimAws();
+    const stackName = `uploads-${faker.string.uuid()}`;
+    const { caller, roleName } = await deployRole(simAws, [
+      ...deployActions,
+      "lambda:InvokeFunction",
+    ]);
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName,
+      template: simCdkBucketNotificationsTemplateFactory.make({}),
+      caller,
+    });
+
+    await simAws.iam().putRolePolicy({
+      input: {
+        RoleName: roleName,
+        PolicyName: `${roleName}-policy`,
+        PolicyDocument: simIamPolicyDocumentFactory.make({
+          Statement: { Action: deployActions, Resource: "*" },
+        }),
+      },
+    });
+
+    // When the Stack is torn down.
+    const error = await assertThrowsErrorAsync(async () => {
+      await stack.teardown();
+    });
+
+    // Then the teardown is refused, as CloudFormation sends the provider a
+    // Delete event of its own.
+    assertStringIncludes(error.message, "lambda:InvokeFunction");
+    assertStringIncludes(error.message, providerArn);
+  });
+
+  it("authorizes the notification put as the deploying caller", async () => {
+    // Given a deploy Role that may invoke the provider and may do everything
+    // else the template needs, apart from writing the Bucket's notification
+    // configuration.
+    const simAws = new SimAws();
+    const stackName = `uploads-${faker.string.uuid()}`;
+    const { caller, roleName } = await deployRole(simAws, [
+      ...deployActions.filter(
+        (action) => action !== "s3:PutBucketNotification",
+      ),
+      "lambda:InvokeFunction",
+    ]);
+
+    // When the Stack is deployed as that Role.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName,
+        template: simCdkBucketNotificationsTemplateFactory.make({}),
+        caller,
+      });
+    });
+
+    // Then the custom Resource's own S3 call is refused too, rather than
+    // being decided as the Account root.
+    assertStringIncludes(error.message, "s3:PutBucketNotification");
+    assertStringIncludes(error.message, `role/${roleName}`);
+  });
+
+  it("names the provider function CDK's Fn::GetAtt stands in for", async () => {
+    // Given the shape CDK synthesizes, where ServiceToken is an Fn::GetAtt for
+    // a Python provider function this simulator declines and leaves uncreated,
+    // so the attribute resolves to a stand-in rather than to an ARN.
+    const simAws = new SimAws();
+    const stackName = `uploads-${faker.string.uuid()}`;
+    const { caller } = await deployRole(simAws, deployActions);
+
+    // When a Stack holding it is deployed as a Role without the invoke.
+    const error = await assertThrowsErrorAsync(async () => {
+      await simAws.cloudFormation().deployTemplate({
+        stackName,
+        template: simCdkBucketNotificationsTemplateFactory.make({
+          notificationProperties: {
+            ServiceToken: { "Fn::GetAtt": ["Provider", "Arn"] },
+          },
+          resources: {
+            ProviderRole: {
+              Type: "AWS::IAM::Role",
+              Properties: {
+                RoleName: `provider-${faker.string.uuid()}`,
+                AssumeRolePolicyDocument: {
+                  Version: "2012-10-17",
+                  Statement: [
+                    {
+                      Effect: "Allow",
+                      Principal: { Service: "lambda.amazonaws.com" },
+                      Action: "sts:AssumeRole",
+                    },
+                  ],
+                },
+              },
+            },
+            Provider: {
+              Type: "AWS::Lambda::Function",
+              Properties: {
+                Role: { "Fn::GetAtt": ["ProviderRole", "Arn"] },
+                Code: { ZipFile: "def handler(event, context): pass" },
+                Handler: "index.handler",
+                Runtime: "python3.13",
+              },
+            },
+          },
+        }),
+        caller,
+      });
+    });
+
+    // Then the refusal names the function ARN real CloudFormation invokes,
+    // rather than the stand-in the attribute resolved to.
+    assertStringIncludes(error.message, "lambda:InvokeFunction");
+    assertStringIncludes(error.message, "arn:aws:lambda:us-east-1:");
+    assertStringIncludes(error.message, ":function:");
+    assertStringNotIncludes(error.message, "Provider.Arn");
+  });
+
+  it("deploys a custom Resource for a deployment naming no caller", async () => {
+    // Given a deployment that names no principal, which is decided as the
+    // Account root.
+    const simAws = new SimAws();
+    const stackName = `uploads-${faker.string.uuid()}`;
+
+    // When the Stack is deployed.
+    const stack = await simAws.cloudFormation().deployTemplate({
+      stackName,
+      template: simCdkBucketNotificationsTemplateFactory.make({}),
+    });
+
+    // Then nothing new is asked of it.
+    const resource = stack.getResource("BucketNotifications");
+    assertNonNullable(resource);
+    assertIdentical(resource.status, "CREATE_COMPLETE");
+  });
+});

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/property/sim-cdk-bucket-notification-properties.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/property/sim-cdk-bucket-notification-properties.ts
@@ -7,9 +7,11 @@ import { bucketNotificationsError } from "../error/sim-cdk-bucket-notification-e
 /**
  * The properties CDK puts on a Custom::S3BucketNotifications Resource.
  *
- * `ServiceToken` is read and ignored. It points at CDK's own Python provider
- * function, whose whole job is the PutBucketNotificationConfiguration call this
- * factory makes instead.
+ * `ServiceToken` is accepted and read no further here. It points at CDK's own
+ * Python provider function, whose whole job is the
+ * PutBucketNotificationConfiguration call this factory makes instead. The
+ * deployment reads it once more, to authorize the invoke real CloudFormation
+ * makes of that function.
  */
 const knownPropertyNames: ReadonlySet<string> = new Set([
   "BucketName",

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-remover.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications-remover.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../resource/sim-cfn-resource.js";
 import { bucketNotificationsError } from "./error/sim-cdk-bucket-notification-error.js";
 import { SimCdkBucketNotificationProperties } from "./property/sim-cdk-bucket-notification-properties.js";
+import { simCfnResourceCallerOptions } from "../../../resource/caller/sim-cfn-resource-caller-options.js";
 
 /**
  * Removes the notification configuration a Custom::S3BucketNotifications
@@ -44,11 +45,14 @@ export class SimCdkBucketNotificationsRemover {
         resource.accountRegionScope.regionName,
       )
       .s3()
-      .putBucketNotificationConfiguration({
-        input: {
-          Bucket: properties.bucketName,
-          NotificationConfiguration: {},
+      .putBucketNotificationConfiguration(
+        {
+          input: {
+            Bucket: properties.bucketName,
+            NotificationConfiguration: {},
+          },
         },
-      });
+        simCfnResourceCallerOptions(context.caller),
+      );
   }
 }

--- a/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.ts
+++ b/src/service/cloudformation/cdk/s3/bucket-notifications/sim-cdk-bucket-notifications.ts
@@ -8,6 +8,7 @@ import { SimCdkBucketNotificationConfiguration } from "./configuration/sim-cdk-b
 import { bucketNotificationsError } from "./error/sim-cdk-bucket-notification-error.js";
 import { SimCdkBucketNotificationProperties } from "./property/sim-cdk-bucket-notification-properties.js";
 import { SimCdkBucketNotificationsRemover } from "./sim-cdk-bucket-notifications-remover.js";
+import { simCfnResourceCallerOptions } from "../../../resource/caller/sim-cfn-resource-caller-options.js";
 
 /**
  * CloudFormation Resource factory for CDK Bucket event notifications.
@@ -25,10 +26,13 @@ import { SimCdkBucketNotificationsRemover } from "./sim-cdk-bucket-notifications
  * bucket alongside the function's `AWS::Lambda::Permission` is the circular
  * dependency this Resource type exists to break.
  *
- * `ServiceToken` is read for the provider function it names, and otherwise
- * ignored. That function is declined on its runtime, as CDK's BucketDeployment
- * provider is, and recorded as inert rather than as a gap, since this factory
- * has already made the call it would have made.
+ * `ServiceToken` is read for the provider function it names. That function is
+ * declined on its runtime, as CDK's BucketDeployment provider is, and recorded
+ * as inert rather than as a gap, since this factory has already made the call
+ * it would have made. The deployment still pays for the invoke real
+ * CloudFormation makes, which
+ * {@link import("../../provider/sim-cdk-provider-invoke-auth-z.js").authorizeSimCdkProviderInvoke}
+ * authorizes for every custom Resource ahead of its factory.
  */
 export class SimCdkBucketNotificationsResourceFactory implements SimCfnServiceResourceFactory {
   /**
@@ -67,13 +71,16 @@ export class SimCdkBucketNotificationsResourceFactory implements SimCfnServiceRe
         resource.accountRegionScope.regionName,
       )
       .s3()
-      .putBucketNotificationConfiguration({
-        input: {
-          Bucket: properties.bucketName,
-          NotificationConfiguration: configuration,
-          SkipDestinationValidation: properties.skipDestinationValidation,
+      .putBucketNotificationConfiguration(
+        {
+          input: {
+            Bucket: properties.bucketName,
+            NotificationConfiguration: configuration,
+            SkipDestinationValidation: properties.skipDestinationValidation,
+          },
         },
-      });
+        simCfnResourceCallerOptions(context.caller),
+      );
 
     return undefined;
   }

--- a/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-properties.ts
+++ b/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-properties.ts
@@ -8,9 +8,10 @@ import { crossRegionParameterError } from "./sim-cdk-cross-region-parameter-erro
  * The properties CDK puts on a Custom::CrossRegionStringParameterReader
  * Resource.
  *
- * `ServiceToken` is read and ignored. It points at CDK's own provider
- * function, whose whole job is the GetParameter call this factory makes
- * instead. `RefreshToken` is the logical ID of the function version the
+ * `ServiceToken` is accepted and read no further here. It points at CDK's own
+ * provider function, whose whole job is the GetParameter call this factory
+ * makes instead, and the deployment reads it once more to authorize the invoke
+ * real CloudFormation makes of that function. `RefreshToken` is the logical ID of the function version the
  * parameter was written from, and CDK puts it there so that publishing a new
  * version makes CloudFormation run the reader again. The reader here runs on
  * every deployment either way, so the token has nothing left to say.

--- a/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reader.ts
+++ b/src/service/cloudformation/cdk/ssm/cross-region-parameter/sim-cdk-cross-region-parameter-reader.ts
@@ -11,6 +11,7 @@ import {
 } from "./sim-cdk-cross-region-parameter-error.js";
 import { SimCdkCrossRegionParameterProperties } from "./sim-cdk-cross-region-parameter-properties.js";
 import { SimCdkCrossRegionParameterReading } from "./sim-cdk-cross-region-parameter-reading.js";
+import { simCfnResourceCallerOptions } from "../../../resource/caller/sim-cfn-resource-caller-options.js";
 
 /**
  * CloudFormation Resource factory for CDK's cross-Region parameter reader.
@@ -100,7 +101,10 @@ export class SimCdkCrossRegionParameterReaderResourceFactory implements SimCfnSe
       const output = await context.simAws
         .accountRegionScope(resource.accountRegionScope.accountId, regionName)
         .ssm()
-        .getParameter({ input: { Name: parameterName } });
+        .getParameter(
+          { input: { Name: parameterName } },
+          simCfnResourceCallerOptions(context.caller),
+        );
 
       return output.Parameter?.Value;
     } catch (error) {

--- a/src/service/cloudformation/resource/create/sim-cfn-resource-creator.ts
+++ b/src/service/cloudformation/resource/create/sim-cfn-resource-creator.ts
@@ -6,6 +6,7 @@ import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-f
 import { parseSimCloudFormationResourceType } from "../parser/sim-cfn-resource-parser.js";
 import { resolveSimCloudFormationServiceResourceFactory } from "../resolve/service/sim-cfn-service-resolver.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { authorizeSimCdkProviderInvoke } from "../../cdk/provider/sim-cdk-provider-invoke-auth-z.js";
 
 interface SimCfnResourceCreatorProperties<T extends object> {
   readonly resource: SimCfnResource<T>;
@@ -60,9 +61,20 @@ export class SimCfnResourceCreator<T extends object = object> {
         resourceType,
       );
 
+    const resolvedProperties = await this.resource.resolvedProperties(context);
+
+    authorizeSimCdkProviderInvoke({
+      resourceType,
+      resource: this.resource,
+      resolvedProperties,
+      resources: context.resources,
+      simAws: context.simAws,
+      caller: context.caller,
+    });
+
     const resolvedContext: SimCloudFormationResourceCreateContext = {
       ...context,
-      resolvedProperties: await this.resource.resolvedProperties(context),
+      resolvedProperties,
     };
 
     return await factory.create(

--- a/src/service/cloudformation/resource/delete/sim-cfn-resource-deleter.ts
+++ b/src/service/cloudformation/resource/delete/sim-cfn-resource-deleter.ts
@@ -4,6 +4,7 @@ import type { SimCfnServiceResourceFactory } from "../factory/sim-cfn-resource-f
 import { parseSimCloudFormationResourceType } from "../parser/sim-cfn-resource-parser.js";
 import { resolveSimCloudFormationServiceResourceFactory } from "../resolve/service/sim-cfn-service-resolver.js";
 import { assertDefined } from "../../../../util/type-guard/defined.js";
+import { authorizeSimCdkProviderInvoke } from "../../cdk/provider/sim-cdk-provider-invoke-auth-z.js";
 
 interface SimCfnResourceDeleterProperties<T extends object> {
   readonly resource: SimCfnResource<T>;
@@ -61,9 +62,20 @@ export class SimCfnResourceDeleter<T extends object = object> {
         resourceType,
       );
 
+    const resolvedProperties = await this.resource.resolvedProperties(context);
+
+    authorizeSimCdkProviderInvoke({
+      resourceType,
+      resource: this.resource,
+      resolvedProperties,
+      resources: context.resources,
+      simAws: context.simAws,
+      caller: context.caller,
+    });
+
     await factory.delete(resourceType.resourceTypeName, this.resource, {
       ...context,
-      resolvedProperties: await this.resource.resolvedProperties(context),
+      resolvedProperties,
     });
   }
 }


### PR DESCRIPTION
Real CloudFormation answers a `Custom::` Resource by invoking the function its `ServiceToken` names, as the stack's execution role, and a role without `lambda:InvokeFunction` on that function fails the stack there. Sim CloudFormation carries three of these Resources out itself and asked IAM nothing about Lambda, so a deploy Role standing in for a real execution policy deployed a template the real account refuses. The invoke is now authorized for every custom Resource, on create and on delete, against the ARN the `ServiceToken` names. CDK writes that token as an `Fn::GetAtt` for a provider this simulator leaves uncreated, whose `Arn` resolves to an attribute stand-in, so the ARN is built from the name the declined function kept. The bucket notification and cross-Region parameter factories now also make their own service calls as the deployment's caller, which they were making as the Account root.

Resolves #1329


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CloudFormation custom resources now verify that the deployment role can invoke their provider functions during deployment and removal.
  * Provider references from direct ARNs and function attributes are resolved for authorization.
  * Provider actions, including S3 notification and cross-region parameter operations, now use the deployment caller’s permissions.

* **Bug Fixes**
  * Unauthorized provider invocations now fail with an access-denied error instead of proceeding.

* **Documentation**
  * Added guidance and examples for custom-resource deployment-role authorization and expected failures.

* **Tests**
  * Added coverage for authorized, unauthorized, deployment, and teardown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->