### PR TITLE
fix: refuse an ORDER BY aggregate over its alias

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -381,6 +381,36 @@ Strict mode is off unless a test asks for it, and `disable()` takes it off with 
 declaration written against one exact query text still answers, with no failure, because that is a
 test's own statement about a query the engine gets wrong.
 
+### Failing a statement Athena refuses
+
+One failure ignores strict mode. Where the engine can see that Athena would refuse a statement
+outright, the query fails whether strict mode is on or off. A turn-down means the engine reached its
+limits, and a declaration is a fair answer to that. A rejection means the SQL is invalid, and
+answering from a declaration would leave a test green on a query that fails against AWS.
+
+The one shape it catches today is an `ORDER BY` that aggregates over an output alias which is itself
+an aggregate.
+
+```sql
+SELECT sku, coalesce(sum(qty), 0) AS qty
+FROM rainlytics.lines
+GROUP BY sku
+ORDER BY sum(qty) DESC
+```
+
+Trino resolves the bare `qty` in `ORDER BY` against the select list before the table. The sort then
+asks for an aggregate over an aggregate, and Athena answers `COLUMN_NOT_FOUND: Invalid reference to
+output projection attribute from ORDER BY aggregation`. SQLite resolves the same name against the
+table's column, runs the statement and orders it correctly. That is how a green test shipped a
+command that failed against the service.
+
+`ORDER BY qty DESC` over the same select list is the form Athena takes, and it is what to write.
+`ORDER BY sum(revenue_total) DESC` beside `coalesce(sum(revenue_total), 0) AS revenue` is fine as
+well, since the two names differ and nothing shadows.
+
+Trino and SQLite resolve names by different rules in other places too, and the engine catches this
+one. A statement that behaves differently under the two is worth reporting.
+
 ### The objects it reads
 
 The SerDe class name in the table's storage descriptor says how its objects are decoded.

--- a/src/service/athena/README.md
+++ b/src/service/athena/README.md
@@ -149,7 +149,7 @@ same shape of thing under its delivery stream's role. A write that fails leaves 
 `engine/` holds it. `SimAthenaQueryEngine` is the whole of the public surface. A query it cannot run is turned down,
 and the declared result answers instead.
 
-Three decisions shape the rest of the directory.
+Four decisions shape the rest of the directory.
 
 **It is opt-in.** A project holding `node-sql-parser` for a reason of its own would otherwise find
 simulated Athena answering differently from the version before it. `enable()` loads the parser there and then. A project without
@@ -167,6 +167,25 @@ required one, and a failure to resolve it is reported as something to go and add
 in a format there is no reader for, an object the caller cannot open and a statement SQLite will not
 run all end with no result and the declared result answering. `sim-athena-engine-run.ts` is where
 that catch sits.
+
+**A statement Athena refuses fails the query, strict or not.** This is the one outcome that skips
+the fallback, and `sim-athena-rejected-statement.ts` holds it. A turn-down says the engine reached
+its limits, and a declaration is a fair answer to that. A rejection says the statement is SQL the
+service would have refused, and falling back would leave the test green on a query that fails
+against AWS. The engine has to be on for any of this, so a project that never enables it sees no
+change.
+
+The shape it catches is an `ORDER BY` aggregate over an output alias that is itself an aggregate.
+`SELECT sku, coalesce(sum(qty), 0) AS qty ... ORDER BY sum(qty) DESC` is the statement that reached
+production. Trino resolves the bare `qty` against the select list before the table. It reads as
+`sum(<the aggregate>)`, and Athena answers `COLUMN_NOT_FOUND: Invalid reference to output projection
+attribute from ORDER BY aggregation`. SQLite resolves the same name against the table column, runs
+it, and orders correctly. `ORDER BY qty DESC` is the form Athena takes, and it is what the engine
+leaves alone, along with `ORDER BY sum(revenue_total)` beside `sum(revenue_total) AS revenue`, where
+the two names differ and nothing shadows.
+
+Trino and SQLite part company over name resolution in more places than this one. The shape above is
+the one seen reaching production, and the file is where the next one goes.
 
 ### The seam
 

--- a/src/service/athena/engine/sim-athena-engine-answer.ts
+++ b/src/service/athena/engine/sim-athena-engine-answer.ts
@@ -1,0 +1,50 @@
+import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+
+/**
+ * What the engine came to for one query.
+ *
+ * A turn-down carries why, because a strict engine fails the query with it and
+ * a reader of that failing test has to learn which of them it hit.
+ */
+export interface SimAthenaEngineAnswer {
+  /** The rows, where the engine ran the statement. */
+  readonly result: SimAthenaResolvedResult | undefined;
+
+  /** What the engine could not do, where it turned the query down. */
+  readonly turnedDown: string | undefined;
+
+  /** Why Athena refuses the statement, where the engine found it invalid. */
+  readonly rejected: string | undefined;
+}
+
+/** One answer the engine ran for real. */
+export function simAthenaEngineAnswered(
+  result: SimAthenaResolvedResult,
+): SimAthenaEngineAnswer {
+  return { result, turnedDown: undefined, rejected: undefined };
+}
+
+/** One query the engine turned down, and why. */
+export function simAthenaEngineTurnedDown(
+  turnedDown: string,
+): SimAthenaEngineAnswer {
+  return { result: undefined, turnedDown, rejected: undefined };
+}
+
+/**
+ * One statement Athena refuses, and why.
+ *
+ * The engine ran nothing. A query that reaches this fails whether or not the
+ * engine is strict, since the alternative is a green test on SQL the service
+ * rejects.
+ */
+export function simAthenaEngineRejected(
+  rejected: string,
+): SimAthenaEngineAnswer {
+  return { result: undefined, turnedDown: undefined, rejected };
+}
+
+/** An engine nobody turned on, which has no opinion about the query. */
+export function simAthenaEngineSilent(): SimAthenaEngineAnswer {
+  return { result: undefined, turnedDown: undefined, rejected: undefined };
+}

--- a/src/service/athena/engine/sim-athena-engine-run.ts
+++ b/src/service/athena/engine/sim-athena-engine-run.ts
@@ -1,6 +1,10 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
-import type { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
+import {
+  simAthenaEngineAnswered,
+  simAthenaEngineTurnedDown,
+  type SimAthenaEngineAnswer,
+} from "./sim-athena-engine-answer.js";
 import { simAthenaRunFailure } from "./sim-athena-turn-down.js";
 import { simAthenaEngineResult } from "./sim-athena-engine-result.js";
 import type { SimAthenaSqlParser } from "./sim-athena-parser-module.js";
@@ -8,34 +12,6 @@ import { simAthenaSqliteDatabase } from "./sim-athena-sqlite-database.js";
 import type { SimAthenaSqliteModule } from "./sim-athena-sqlite-module.js";
 import { simAthenaLoadedTables } from "./sim-athena-loaded-tables.js";
 import type { SimAthenaTableObjects } from "./sim-athena-table-objects.js";
-
-/**
- * What the engine came to for one query.
- *
- * A turn-down carries why, because a strict engine fails the query with it and
- * a reader of that failing test has to learn which of them it hit.
- */
-export interface SimAthenaEngineAnswer {
-  /** The rows, where the engine ran the statement. */
-  readonly result: SimAthenaResolvedResult | undefined;
-
-  /** What the engine could not do, where it turned the query down. */
-  readonly turnedDown: string | undefined;
-}
-
-/** One answer the engine ran for real. */
-export function simAthenaEngineAnswered(
-  result: SimAthenaResolvedResult,
-): SimAthenaEngineAnswer {
-  return { result, turnedDown: undefined };
-}
-
-/** One query the engine turned down, and why. */
-export function simAthenaEngineTurnedDown(
-  turnedDown: string,
-): SimAthenaEngineAnswer {
-  return { result: undefined, turnedDown };
-}
 
 /** What one query is run with, once the engine is on and has somewhere to read. */
 export interface SimAthenaEngineRun {

--- a/src/service/athena/engine/sim-athena-query-engine.ts
+++ b/src/service/athena/engine/sim-athena-query-engine.ts
@@ -1,10 +1,12 @@
 import type { SimAwsCaller } from "../../aws/caller/sim-aws-caller.js";
 import type { SimAthenaPlannedTable } from "../execution/sim-athena-query-refusal.js";
 import {
-  simAthenaEngineRun,
+  simAthenaEngineRejected,
+  simAthenaEngineSilent,
   simAthenaEngineTurnedDown,
   type SimAthenaEngineAnswer,
-} from "./sim-athena-engine-run.js";
+} from "./sim-athena-engine-answer.js";
+import { simAthenaEngineRun } from "./sim-athena-engine-run.js";
 import {
   simAthenaSqlParser,
   type SimAthenaSqlParser,
@@ -109,7 +111,7 @@ export class SimAthenaQueryEngine {
     const { objects } = request;
 
     if (parser === undefined || sqlite === undefined) {
-      return { result: undefined, turnedDown: undefined };
+      return simAthenaEngineSilent();
     }
 
     if (objects === undefined) {
@@ -121,6 +123,10 @@ export class SimAthenaQueryEngine {
       athenaSql: request.queryString,
       tables: request.tables.map((planned) => planned.table),
     });
+
+    if (translated.rejected !== undefined) {
+      return simAthenaEngineRejected(translated.rejected);
+    }
 
     return translated.sql === undefined
       ? simAthenaEngineTurnedDown(translated.turnedDown)

--- a/src/service/athena/engine/sim-athena-rejected-statement.ts
+++ b/src/service/athena/engine/sim-athena-rejected-statement.ts
@@ -1,0 +1,135 @@
+import {
+  isColumnRef,
+  simAthenaAstNodes,
+  type SimAthenaAstNode,
+} from "./sim-athena-ast-nodes.js";
+
+/**
+ * Why Athena refuses one parsed statement, where it does.
+ *
+ * Everything here is a statement SQLite runs happily and the real service
+ * rejects. A translation that hands such a statement to SQLite answers a test
+ * with rows, and the command then fails against AWS. Each shape is spotted on
+ * the tree the Athena grammar produced, before anything is written out for
+ * SQLite.
+ *
+ * Trino and SQLite resolve names by different rules in more places than this.
+ * One shape is covered, the one seen reaching production. Add the next when a
+ * query hits it.
+ */
+export function simAthenaRejectedStatement(ast: unknown): string | undefined {
+  for (const node of simAthenaAstNodes(ast)) {
+    const sort = node["orderby"];
+    const columns = node["columns"];
+
+    if (!Array.isArray(sort) || !Array.isArray(columns)) {
+      continue;
+    }
+
+    const alias = aggregatedAlias(sort, columns);
+
+    if (alias !== undefined) {
+      return orderByAggregateOverAlias(alias);
+    }
+  }
+
+  return undefined;
+}
+
+/** What Athena says about an `ORDER BY` aggregate over an aggregate alias. */
+function orderByAggregateOverAlias(alias: string): string {
+  return (
+    `Athena refuses this statement. Its ORDER BY aggregates over ${alias}, ` +
+    `and the select list names ${alias} as the output alias of an aggregate. ` +
+    `Trino resolves a bare name in ORDER BY against the select list before ` +
+    `the table. That makes the sort an aggregate over an aggregate, and the ` +
+    `service answers "Invalid reference to output projection attribute from ` +
+    `ORDER BY aggregation". Sort by ${alias} on its own, or give the alias a ` +
+    `name the sort leaves alone.`
+  );
+}
+
+/**
+ * The output alias one `ORDER BY` aggregates over, where the alias aggregates
+ * too.
+ *
+ * A select list of `sum(qty) AS qty` sorted by `ORDER BY sum(qty)` is the
+ * shape. SQLite reads that `qty` as the table's column and sorts correctly.
+ * Trino reads it as the alias and refuses the query.
+ *
+ * `ORDER BY qty` over the same select list is the form Athena takes, with no
+ * aggregate wrapped around the name. An aggregate over a name the select list
+ * leaves alone is legal too, as in `ORDER BY sum(revenue_total)` beside
+ * `coalesce(sum(revenue_total), 0) AS revenue`. The aliases are what tell this
+ * shape from those two.
+ */
+function aggregatedAlias(
+  sort: readonly unknown[],
+  columns: readonly SimAthenaAstNode[],
+): string | undefined {
+  const aliases = aggregateAliases(columns);
+
+  if (aliases.size === 0) {
+    return undefined;
+  }
+
+  for (const node of simAthenaAstNodes(sort)) {
+    if (!isAggregate(node)) {
+      continue;
+    }
+
+    const arguments_ = simAthenaAstNodes(node["args"]);
+
+    for (const inner of arguments_) {
+      const alias =
+        isColumnRef(inner) && inner.table === null
+          ? aliases.get(inner.column.toLowerCase())
+          : undefined;
+
+      if (alias !== undefined) {
+        return alias;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/** Every output alias of one select list whose own expression aggregates. */
+function aggregateAliases(
+  columns: readonly SimAthenaAstNode[],
+): Map<string, string> {
+  const aliases = new Map<string, string>();
+
+  for (const column of columns) {
+    const alias = column["as"];
+
+    if (typeof alias === "string" && holdsAggregate(column["expr"])) {
+      aliases.set(alias.toLowerCase(), alias);
+    }
+  }
+
+  return aliases;
+}
+
+/** Whether anything under this expression aggregates. */
+function holdsAggregate(expression: unknown): boolean {
+  for (const node of simAthenaAstNodes(expression)) {
+    if (isAggregate(node)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Whether this node is a grouped aggregate call.
+ *
+ * A window function carries `over` and is computed once the grouped aggregates
+ * have been. It takes an output alias in `ORDER BY` happily, and stays out of
+ * this.
+ */
+function isAggregate(node: SimAthenaAstNode): boolean {
+  return node["type"] === "aggr_func" && (node["over"] ?? null) === null;
+}

--- a/src/service/athena/engine/sim-athena-sql-translation.ts
+++ b/src/service/athena/engine/sim-athena-sql-translation.ts
@@ -9,12 +9,26 @@ import {
   simAthenaUnrewrittenUnnest,
   simAthenaUnwrittenStatement,
 } from "./sim-athena-turn-down.js";
+import { simAthenaRejectedStatement } from "./sim-athena-rejected-statement.js";
 import { simAthenaRewriteUnnest } from "./sim-athena-unnest-rewrite.js";
 
-/** One statement translated for SQLite, or why it could not be. */
+/** One statement translated for SQLite, or why it was not. */
 export type SimAthenaTranslatedSql =
-  | { readonly sql: string; readonly turnedDown: undefined }
-  | { readonly sql: undefined; readonly turnedDown: string };
+  | {
+      readonly sql: string;
+      readonly turnedDown: undefined;
+      readonly rejected: undefined;
+    }
+  | {
+      readonly sql: undefined;
+      readonly turnedDown: string;
+      readonly rejected: undefined;
+    }
+  | {
+      readonly sql: undefined;
+      readonly turnedDown: undefined;
+      readonly rejected: string;
+    };
 
 interface SimAthenaSqlTranslationRequest {
   readonly parser: SimAthenaSqlParser;
@@ -25,13 +39,18 @@ interface SimAthenaSqlTranslationRequest {
 }
 
 /**
- * One Athena statement written back out for SQLite, or why it cannot be.
+ * One Athena statement written back out for SQLite, or why it is not.
  *
- * Three things stop it, and each is told apart because a strict engine fails
- * the query with the reason. The Athena grammar can refuse the statement, an
- * `UNNEST` in it can have no `json_each` to become, and the parser can decline
- * to write the statement back out. A lenient engine answers all three the same
- * way, by turning the query down and letting the declared result take it.
+ * Three things turn the query down, and each is told apart because a strict
+ * engine fails the query with the reason. The Athena grammar can refuse the
+ * statement, an `UNNEST` in it can have no `json_each` to become, and the
+ * parser can decline to write the statement back out. A lenient engine answers
+ * all three the same way, by letting the declared result take the query.
+ *
+ * A rejection is the fourth outcome and a different thing. The statement
+ * parsed, and Athena would still refuse to run it. That fails the query
+ * whether or not the engine is strict, since falling back would leave a test
+ * green on SQL the service rejects.
  */
 export function simAthenaSqliteSql(
   request: SimAthenaSqlTranslationRequest,
@@ -45,6 +64,12 @@ export function simAthenaSqliteSql(
     ast = parser.astify(read.sql, { database: "athena" });
   } catch {
     return turnedDown(simAthenaUnparsedStatement);
+  }
+
+  const rejected = simAthenaRejectedStatement(ast);
+
+  if (rejected !== undefined) {
+    return { sql: undefined, turnedDown: undefined, rejected };
   }
 
   try {
@@ -61,6 +86,7 @@ export function simAthenaSqliteSql(
     return {
       sql: simAthenaSqlForSqlite(parser.sqlify(ast, { database: "sqlite" })),
       turnedDown: undefined,
+      rejected: undefined,
     };
   } catch {
     return turnedDown(simAthenaUnwrittenStatement);
@@ -68,5 +94,5 @@ export function simAthenaSqliteSql(
 }
 
 function turnedDown(reason: string): SimAthenaTranslatedSql {
-  return { sql: undefined, turnedDown: reason };
+  return { sql: undefined, turnedDown: reason, rejected: undefined };
 }

--- a/src/service/athena/result/sim-athena-query-answer.ts
+++ b/src/service/athena/result/sim-athena-query-answer.ts
@@ -57,6 +57,10 @@ interface SimAthenaQueryAnswerRequest {
  * A strict engine is the exception, and it fails the query it turned down.
  * The declaration keeps its place ahead of that, since a test writing one
  * against this exact statement has already said what the engine gets wrong.
+ *
+ * A statement Athena refuses fails whichever mode the engine is in. That is
+ * SQL the service would never have run, and falling back would leave the query
+ * green on it.
  */
 export async function simAthenaQueryAnswer(
   request: SimAthenaQueryAnswerRequest,
@@ -83,7 +87,8 @@ export async function simAthenaQueryAnswer(
   return {
     result: request.declared,
     source: "declaration",
-    refusal: strictRefusal(request.engine, computed.turnedDown),
+    refusal:
+      computed.rejected ?? strictRefusal(request.engine, computed.turnedDown),
   };
 }
 

--- a/src/service/athena/sim-athena-rejected-statements.iso.test.ts
+++ b/src/service/athena/sim-athena-rejected-statements.iso.test.ts
@@ -1,0 +1,184 @@
+import {
+  assertIdentical,
+  assertObjectEquals,
+  assertStringIncludes,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+/** Three order lines over two SKUs, so a sort has something to get wrong. */
+const someLines = [
+  { sku: "aerial", qty: 1, revenue_total: 4 },
+  { sku: "aerial", qty: 2, revenue_total: 6 },
+  { sku: "brolly", qty: 9, revenue_total: 1 },
+];
+
+/**
+ * A simulation over one lines table, with a default declaration behind it.
+ *
+ * The declaration is what a lenient engine falls back to. A statement Athena
+ * refuses has to get past it whichever mode the engine is in, and these tests
+ * have to be able to see that happen.
+ */
+async function aLinesSimulation(
+  strict: boolean,
+): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "lines",
+    columns: [
+      { Name: "sku", Type: "string" },
+      { Name: "qty", Type: "int" },
+      { Name: "revenue_total", Type: "int" },
+    ],
+  });
+
+  await aSeededJson(simulation.simAws, "lines/part-0.json", someLines);
+
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["sku"], rows: [["declared"]] });
+
+  await simulation.simAws.athena().engine().enable({ strict });
+
+  return simulation;
+}
+
+/** The statement Athena refuses, which SQLite runs and orders correctly. */
+const aggregateOverAlias =
+  "SELECT sku, coalesce(sum(qty), 0) AS qty FROM rainlytics.lines " +
+  "GROUP BY sku ORDER BY sum(qty) DESC";
+
+describe("a statement Athena refuses", () => {
+  it("fails a strict engine, naming the alias", async () => {
+    // Given a strict engine over a lines table.
+    const simulation = await aLinesSimulation(true);
+
+    // When a statement sorts by an aggregate over its own aggregate alias.
+    const answered = await anAnsweredQuery(simulation, aggregateOverAlias);
+
+    // Then the query failed, and the reason names the alias and what the
+    // service says about it. SQLite would have run this and ordered it right.
+    assertIdentical(answered.state, "FAILED");
+    assertStringIncludes(answered.reason ?? "", "qty");
+    assertStringIncludes(
+      answered.reason ?? "",
+      "Invalid reference to output projection attribute",
+    );
+  });
+
+  it("fails a lenient engine too", async () => {
+    // Given an engine turned on without strict mode.
+    const simulation = await aLinesSimulation(false);
+
+    // When the same statement runs.
+    const answered = await anAnsweredQuery(simulation, aggregateOverAlias);
+
+    // Then the default declaration did not take it. A turn-down means the
+    // engine reached its limits and a declaration is the right answer. This is
+    // SQL the service would have refused, and a green test on it is the whole
+    // problem.
+    assertIdentical(answered.state, "FAILED");
+    assertStringIncludes(
+      answered.reason ?? "",
+      "Athena refuses this statement",
+    );
+  });
+
+  it("answers the same select list sorted by the alias", async () => {
+    // Given a strict engine over the same table.
+    const simulation = await aLinesSimulation(true);
+
+    // When the sort names the output alias with no aggregate around it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, coalesce(sum(qty), 0) AS qty FROM rainlytics.lines " +
+        "GROUP BY sku ORDER BY qty DESC",
+    );
+
+    // Then the query ran and sorted by the summed quantity. This is the form
+    // Athena takes, and it is what the refused statement should have said.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["brolly", "9"],
+      ["aerial", "3"],
+    ]);
+  });
+
+  it("answers an aggregate over a column the select list leaves alone", async () => {
+    // Given a strict engine over the same table.
+    const simulation = await aLinesSimulation(true);
+
+    // When the sort aggregates a column, and the select list aliases its own
+    // aggregate to a different name.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, coalesce(sum(revenue_total), 0) AS revenue " +
+        "FROM rainlytics.lines GROUP BY sku ORDER BY sum(revenue_total) DESC",
+    );
+
+    // Then it ran. Nothing shadows anything here and Athena takes this
+    // statement, which is what stops the check from banning aggregates in
+    // ORDER BY outright.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["aerial", "10"],
+      ["brolly", "1"],
+    ]);
+  });
+
+  it("answers an aggregate over a qualified name", async () => {
+    // Given a strict engine over the same table.
+    const simulation = await aLinesSimulation(true);
+
+    // When the sort aggregates the table's own column, named through the
+    // table's alias.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT sku, coalesce(sum(qty), 0) AS qty FROM rainlytics.lines AS l " +
+        "GROUP BY sku ORDER BY sum(l.qty) DESC",
+    );
+
+    // Then it ran. A qualified name in ORDER BY resolves against the table,
+    // and the output alias never comes into it.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["brolly", "9"],
+      ["aerial", "3"],
+    ]);
+  });
+
+  it("keeps the declaration written against one exact statement", async () => {
+    // Given a strict engine and a declaration for the refused statement.
+    const simulation = await aLinesSimulation(true);
+
+    simulation.simAws
+      .athena()
+      .results()
+      .onQuery(aggregateOverAlias, {
+        columns: ["sku"],
+        rows: [["written down"]],
+      });
+
+    // When that statement runs.
+    const answered = await anAnsweredQuery(simulation, aggregateOverAlias);
+
+    // Then the test's own statement about it wins, as it does over every other
+    // reason the engine has for not answering a query.
+    assertIdentical(answered.state, "SUCCEEDED");
+    assertIdentical(answered.answeredBy, "declaration");
+    assertObjectEquals(answered.rows, [["written down"]]);
+  });
+});


### PR DESCRIPTION
The simulated Athena query engine translated a statement to SQLite and ran it where the real service refuses it. Trino resolves a bare name in `ORDER BY` against the select list before the table, and `ORDER BY sum(qty)` beside `coalesce(sum(qty), 0) AS qty` therefore asks for an aggregate over an aggregate. Athena answers `COLUMN_NOT_FOUND: Invalid reference to output projection attribute from ORDER BY aggregation`. SQLite resolves the same name against the table's column and orders correctly. That is how a strict-mode integration test in a downstream project stayed green on a command that then failed against AWS.

`sim-athena-rejected-statement.ts` spots the shape on the tree the Athena grammar produced, before anything is written out for SQLite, and the query fails whether or not strict mode is on. That is the one design call worth reading the diff for. A turn-down falls back to a declaration when strict mode is off, which would have left the same test green on the same invalid SQL. Every other turn-down means the engine reached its limits, and a declaration is a fair answer to that. This one means Athena would have refused the statement. A declaration written against one exact query text still wins, since that is a test's own statement about a query and it is checked before the engine runs at all.

The check reads the output aliases whose own expression aggregates, then looks for one of those names inside an aggregate in the sort. `ORDER BY qty DESC` over the same select list still runs and still orders by the summed quantity. So does `ORDER BY sum(revenue_total) DESC` beside `coalesce(sum(revenue_total), 0) AS revenue`, where the two names differ and nothing shadows, and so does a qualified `ORDER BY sum(l.qty)`. Windowed aggregates stay out of it.

`SimAthenaEngineAnswer` and its constructors moved to `sim-athena-engine-answer.ts` to keep `sim-athena-engine-run.ts` under the FTA threshold. Both READMEs record the decision. Trino and SQLite part company over name resolution in other places too, and the new file is where the next shape goes.

No issue was filed for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Athena-simulated queries now distinguish between unsupported statements and statements Athena explicitly rejects.
  * Queries using an aggregate alias inside another `ORDER BY` aggregate now fail consistently with Athena behavior.
  * Valid alternative forms, such as ordering directly by the alias, continue to work.

* **Documentation**
  * Added guidance explaining Athena rejection behavior and recommended query workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->