### PR TITLE
fix: keep a host AWS_PROFILE out of an invocation

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -3158,6 +3158,16 @@ that is where such a handler's configuration comes from when nothing declares it
 variables on the function keeps the test explicit about where they came from. Zip-packaged code in
 the vm runtime gets the function's own variables either way, and never the test process's.
 
+One group of host variables is masked whatever the function declares. `AWS_PROFILE`,
+`AWS_DEFAULT_PROFILE`, `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`,
+`AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_ARN`, `AWS_ROLE_SESSION_NAME` and the
+`AWS_CONTAINER_CREDENTIALS_*` and `AWS_CONTAINER_AUTHORIZATION_*` names go unset for the length of
+an invocation. Each of them points an AWS SDK at credentials held by whoever started the test
+process, and a client built in a handler follows one straight out of the simulation. `AWS_PROFILE`
+does that even with the placeholder credentials above in place, because the Node.js credential
+provider chain skips its environment-variable provider whenever a profile is named. Masking them
+keeps a test independent of the machine running it, and real Lambda sets none of them anyway.
+
 This is also how a function reaches something outside the simulation, such as a Redis or a
 Postgres. See [non-AWS dependencies](https://yulinsim.dev/non-aws-dependencies/).
 

--- a/src/service/lambda/function/environment/sim-lambda-execution-credentials.ts
+++ b/src/service/lambda/function/environment/sim-lambda-execution-credentials.ts
@@ -20,3 +20,54 @@ export const simLambdaExecutionCredentials: readonly (readonly [
   ["AWS_SECRET_ACCESS_KEY", "yulinSimulatedSecretAccessKeyValue000000"],
   ["AWS_SESSION_TOKEN", "yulin-simulated-session-token"],
 ];
+
+/**
+ * The host environment variable names that point an AWS SDK at credentials
+ * outside the invocation.
+ *
+ * A function declaring no variables of its own runs with the host process
+ * environment underneath the AWS-provided ones, which is where an in-process
+ * handler reads its configuration from. These names are not that
+ * configuration. They are how a developer's shell and a CI runner select the
+ * AWS access they hold themselves, and real Lambda sets none of them.
+ *
+ * `AWS_PROFILE` is the one that stops an invocation outright. The Node.js
+ * credential provider chain skips its environment-variable provider whenever
+ * that name is set, reporting "AWS_PROFILE is set, skipping fromEnv
+ * provider.", and the placeholder credentials above go unread. Resolution
+ * leaves the simulation for a shared configuration file or an SSO portal, and
+ * the client throws while resolving, before the request it was building
+ * reaches a simulated service. The rest each name a credential source of their
+ * own and are masked for the same reason.
+ */
+export const hostAwsCredentialVariableNames: ReadonlySet<string> = new Set([
+  "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+  "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+  "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+  "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+  "AWS_CONFIG_FILE",
+  "AWS_DEFAULT_PROFILE",
+  "AWS_PROFILE",
+  "AWS_ROLE_ARN",
+  "AWS_ROLE_SESSION_NAME",
+  "AWS_SHARED_CREDENTIALS_FILE",
+  "AWS_WEB_IDENTITY_TOKEN_FILE",
+]);
+
+/**
+ * The host process variables an invocation keeps, with the ones naming a
+ * credential source of the host's own left out.
+ */
+export function withoutHostAwsCredentialVariables(
+  variables: Record<string, string>,
+): Record<string, string> {
+  const kept: [string, string][] = [];
+
+  for (const [name, value] of Object.entries(variables)) {
+    if (!hostAwsCredentialVariableNames.has(name)) {
+      kept.push([name, value]);
+    }
+  }
+
+  return Object.fromEntries(kept);
+}

--- a/src/service/lambda/function/environment/sim-lambda-host-backed-variables.ts
+++ b/src/service/lambda/function/environment/sim-lambda-host-backed-variables.ts
@@ -1,4 +1,5 @@
 import { simProcessEnvironment } from "../../../../util/process/sim-process-environment.js";
+import { withoutHostAwsCredentialVariables } from "./sim-lambda-execution-credentials.js";
 
 /**
  * The environment of a function that declares no variables of its own.
@@ -7,6 +8,11 @@ import { simProcessEnvironment } from "../../../../util/process/sim-process-envi
  * laid over it. The host variables are read for each invocation rather than
  * merged once, so a variable the test process sets between two invocations
  * reaches the second of them.
+ *
+ * The host's own AWS credential variables are left out. An invocation is
+ * attributed to the function's execution Role, and a name pointing an SDK at
+ * the credentials of whoever started the test process would make the
+ * invocation depend on them. See `hostAwsCredentialVariableNames`.
  *
  * What the handler itself wrote is kept and laid over both, which is the warm
  * execution environment semantics a function declaring variables gets from
@@ -24,7 +30,9 @@ export class SimLambdaHostBackedVariables {
     run: () => Promise<T>,
   ): Promise<T> {
     const merged = {
-      ...simProcessEnvironment.definedHostVariables(),
+      ...withoutHostAwsCredentialVariables(
+        simProcessEnvironment.definedHostVariables(),
+      ),
       ...functionVariables,
       ...Object.fromEntries(this.written),
     };

--- a/src/service/lambda/function/environment/sim-lambda-host-credentials.iso.test.ts
+++ b/src/service/lambda/function/environment/sim-lambda-host-credentials.iso.test.ts
@@ -1,0 +1,152 @@
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  CreateSecretCommand,
+  GetSecretValueCommand,
+  SecretsManagerClient,
+} from "@aws-sdk/client-secrets-manager";
+import { assertNonNullable, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { simIamRoleWithPolicyFactory } from "../../../iam/role/sim-iam-role-with-policy.factory.js";
+import type { SimLambda } from "../../sim-lambda.js";
+import { makeLambdaZipFileInput } from "../code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+
+async function invoke(
+  simLambda: SimLambda,
+  functionName: string,
+): Promise<unknown> {
+  const output = await simLambda.invoke(
+    new InvokeCommand({ FunctionName: functionName, Payload: "{}" }),
+  );
+  assertNonNullable(output.Payload);
+  return JSON.parse(Buffer.from(output.Payload).toString()) as unknown;
+}
+
+/**
+ * A function declaring no variables of its own, backed by an in-process
+ * handler, which is the case that runs on the host process environment.
+ */
+async function boundFunction(
+  simAws: SimAws,
+  handler: SimLambdaHandler,
+  roleArn = `arn:aws:iam::${simAws.defaultAccountId}:role/ReaderRole`,
+): Promise<SimLambda> {
+  const simLambda = simAws.lambda();
+  await simLambda.createFunction(
+    new CreateFunctionCommand({
+      FunctionName: "reader",
+      Role: roleArn,
+      Code: { ZipFile: makeLambdaZipFileInput(handler) },
+    }),
+  );
+
+  return simLambda;
+}
+
+describe("sim Lambda credentials and the host process environment", () => {
+  it("keeps a host AWS_PROFILE out of the invocation", async () => {
+    // Given a test process with an AWS profile selected, as a developer's
+    // shell and a CI runner both often have.
+    process.env["AWS_PROFILE"] = "engineering-sso";
+
+    try {
+      const simAws = new SimAws();
+      const simLambda = await boundFunction(simAws, () => ({
+        profile: process.env["AWS_PROFILE"] ?? null,
+        accessKeyId: process.env["AWS_ACCESS_KEY_ID"] ?? null,
+      }));
+
+      // When a function declaring no variables of its own is invoked.
+      const result = await invoke(simLambda, "reader");
+
+      // Then the handler sees the simulated execution credentials, and no
+      // profile to send an SDK looking for the host's own.
+      assertObjectEquals(result, {
+        profile: null,
+        accessKeyId: "ASIAYULINSIMULATED00",
+      });
+      assertNonNullable(process.env["AWS_PROFILE"]);
+    } finally {
+      delete process.env["AWS_PROFILE"];
+    }
+  });
+
+  it("answers an SDK client the handler builds while a host AWS_PROFILE is set", async () => {
+    // Given a simulated secret, and an execution Role allowed to read it.
+    process.env["AWS_PROFILE"] = "engineering-sso";
+
+    try {
+      const simAws = new SimAws();
+      const secret = await simAws.secretsManager().createSecret(
+        new CreateSecretCommand({
+          Name: "origin-key",
+          SecretString: "s3cret",
+        }),
+      );
+      assertNonNullable(secret.ARN);
+
+      const role = await simIamRoleWithPolicyFactory.make(
+        {
+          roleName: "ReaderRole",
+          policyName: "ReadOriginKey",
+          actions: ["secretsmanager:GetSecretValue"],
+          resource: secret.ARN,
+        },
+        simAws,
+      );
+      assertNonNullable(role.Arn);
+
+      // And a handler building its own SDK client, as function code does.
+      const simLambda = await boundFunction(
+        simAws,
+        async () => {
+          const client = new SecretsManagerClient({});
+          const held = await client.send(
+            new GetSecretValueCommand({ SecretId: "origin-key" }),
+          );
+
+          return { secretString: held.SecretString ?? null };
+        },
+        role.Arn,
+      );
+
+      // When the function is invoked.
+      const result = await invoke(simLambda, "reader");
+
+      // Then the call reached simulated Secrets Manager, authorized as the
+      // execution Role, with the host's profile playing no part in it.
+      assertObjectEquals(result, { secretString: "s3cret" });
+    } finally {
+      delete process.env["AWS_PROFILE"];
+    }
+  });
+
+  it("leaves every other host variable where the handler can read it", async () => {
+    // Given a host process holding both an AWS profile and the configuration
+    // an in-process handler reads.
+    process.env["AWS_PROFILE"] = "engineering-sso";
+    process.env["YULIN_TEST_DATABASE_URL"] = "postgres://localhost/widgets";
+
+    try {
+      const simAws = new SimAws();
+      const simLambda = await boundFunction(simAws, () => ({
+        databaseUrl: process.env["YULIN_TEST_DATABASE_URL"] ?? null,
+        region: process.env["AWS_REGION"] ?? null,
+      }));
+
+      // When the function is invoked.
+      const result = await invoke(simLambda, "reader");
+
+      // Then only the credential variables were masked.
+      assertObjectEquals(result, {
+        databaseUrl: "postgres://localhost/widgets",
+        region: simAws.defaultRegionName,
+      });
+    } finally {
+      delete process.env["AWS_PROFILE"];
+      delete process.env["YULIN_TEST_DATABASE_URL"];
+    }
+  });
+});


### PR DESCRIPTION
A sim Lambda function declaring no environment variables of its own runs with the host process environment underneath the AWS-provided ones, where an in-process handler reads its configuration. A host `AWS_PROFILE` arrived through that door and stopped the invocation, because the Node.js credential provider chain skips its environment-variable provider whenever a profile is named, leaving the placeholder execution credentials unread and sending an SDK client the handler built out of the simulation for a shared configuration file or an SSO portal. The host's AWS credential variables are now masked for the length of an invocation, and everything else the test process sets still reaches the handler.

Resolves #1337
