### PR TITLE
fix: fail a Lambda invocation the clock cannot end

### DIFF
--- a/docs/time/README.md
+++ b/docs/time/README.md
@@ -197,6 +197,12 @@ simulation's clock during an invocation. Start an invocation without awaiting it
 clock past the timer delay, then await the invocation. Lambda's configured timeout and
 `context.getRemainingTimeInMillis()` use the same clock.
 
+An invocation left waiting on one of those timers while simulated time stands still has nothing to
+end it, because the function's own timeout waits on the same clock. Yulin fails it after a second or
+two of real time with a `Yulin.StalledInvocation` error naming the timer and its delay. Advancing
+the clock resets that wait, in one step or several, so the pattern above keeps working. A handler
+busy with something other than a timer is left alone for as long as it takes.
+
 ### Where real AWS gets the time
 
 Real Lambda has no current-time API. A production handler gets the current time from the machine

--- a/src/service/lambda/function/invoke/sim-lambda-invocation-deadline.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-invocation-deadline.ts
@@ -1,7 +1,10 @@
 import type { BackgroundScheduler } from "../../../../util/background/background.js";
 import { SimLambdaClockTimer } from "./timer/sim-lambda-clock-timer.js";
 import { SimLambdaInvocationTimers } from "./timer/sim-lambda-invocation-timers.js";
+import type { SimLambdaPendingTimer } from "./timer/sim-lambda-pending-timer.js";
 import { simLambdaProcessTimers } from "./timer/sim-lambda-process-timers.js";
+import { SimLambdaStallWatch } from "./sim-lambda-stall-watch.js";
+import { simLambdaStalledError } from "./sim-lambda-stalled.error.js";
 import { simLambdaTimedOutError } from "./sim-lambda-timed-out.error.js";
 
 const millisecondsPerSecond = 1000;
@@ -22,6 +25,10 @@ interface SimLambdaInvocationDeadlineProperties {
  * waits for a handler that has been timed out, and what it goes on to do
  * reaches nobody, which is the closest an in-process simulation gets to an
  * execution environment being taken away.
+ *
+ * Simulated time standing still holds the handler's timers and the deadline
+ * alike. A stall watch on host time ends an invocation neither of them can
+ * reach, with an error saying why.
  */
 export class SimLambdaInvocationDeadline {
   readonly #properties: SimLambdaInvocationDeadlineProperties;
@@ -53,6 +60,7 @@ export class SimLambdaInvocationDeadline {
     const ending = (): void => {
       timers.cancelAll();
       deadline.cancel();
+      stall.cancel();
     };
     const failing = (error: unknown): void => {
       ending();
@@ -75,11 +83,28 @@ export class SimLambdaInvocationDeadline {
       },
     });
 
+    const stall = new SimLambdaStallWatch({
+      background,
+      timeoutSeconds,
+      waitingOn: (): SimLambdaPendingTimer | undefined => timers.pending(),
+      stalled: (waitingOn, waitedMilliseconds): void => {
+        failing(
+          simLambdaStalledError({
+            awsRequestId,
+            at: background.now(),
+            waitingOn,
+            waitedMilliseconds,
+          }),
+        );
+      },
+    });
+
     deadline.startAt(
       new Date(
         background.now().getTime() + timeoutSeconds * millisecondsPerSecond,
       ),
     );
+    stall.start();
 
     try {
       return await background.outstanding(

--- a/src/service/lambda/function/invoke/sim-lambda-stall-watch.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-stall-watch.ts
@@ -1,0 +1,113 @@
+import { clearTimeout, setTimeout } from "node:timers";
+import type { BackgroundScheduler } from "../../../../util/background/background.js";
+import type { SimLambdaPendingTimer } from "./timer/sim-lambda-pending-timer.js";
+
+const millisecondsPerSecond = 1000;
+
+/** The least host time a stopped clock gets before an invocation is stalled. */
+const shortestWatchMilliseconds = 1000;
+
+/** The most host time a stopped clock gets, whatever the function's timeout. */
+const longestWatchMilliseconds = 2000;
+
+interface SimLambdaStallWatchProperties {
+  readonly background: BackgroundScheduler;
+
+  /** The seconds the invocation has to answer in, on the simulated clock. */
+  readonly timeoutSeconds: number;
+
+  /** The timer the invocation is waiting on, where it is waiting on one. */
+  readonly waitingOn: () => SimLambdaPendingTimer | undefined;
+
+  /** What happens once the invocation turns out to have no way to finish. */
+  readonly stalled: (
+    waitingOn: SimLambdaPendingTimer,
+    waitedMilliseconds: number,
+  ) => void;
+}
+
+/**
+ * A watch on host time for an invocation the simulated clock has left behind.
+ *
+ * A handler's timers wait on the simulation's clock, and so does the
+ * invocation's deadline. Simulated time standing still holds both, and the
+ * invocation runs on until the test framework gives up on the test around it.
+ * Elapsed host time is the only thing separating that from a test meaning to
+ * start an invocation, advance the clock and then wait for it, which is why
+ * host time is what this watches.
+ *
+ * A turn that finds simulated time has moved starts the wait again, so a test
+ * advancing the clock in steps is left alone. The host timer is unreferenced,
+ * and an invocation nobody is driving never holds the process open.
+ */
+export class SimLambdaStallWatch {
+  readonly #properties: SimLambdaStallWatchProperties;
+  readonly #delay: number;
+
+  #seenAt = 0;
+  #hostTimer: NodeJS.Timeout | undefined;
+
+  constructor(properties: SimLambdaStallWatchProperties) {
+    this.#properties = properties;
+    this.#delay = simLambdaStallWatchDelay(properties.timeoutSeconds);
+  }
+
+  /**
+   * Start watching, from the instant the clock reads now.
+   */
+  start(): void {
+    this.#seenAt = this.#properties.background.now().getTime();
+    this.#arm();
+  }
+
+  /**
+   * Give up watching, as an invocation that has ended does.
+   */
+  cancel(): void {
+    clearTimeout(this.#hostTimer);
+    this.#hostTimer = undefined;
+  }
+
+  #arm(): void {
+    this.#hostTimer = setTimeout(() => {
+      this.#hostTimer = undefined;
+      this.#check();
+    }, this.#delay);
+    this.#hostTimer.unref();
+  }
+
+  /**
+   * See whether the invocation still has a way to finish, and watch on where
+   * it has: either simulated time has moved since the last turn, or the
+   * handler is busy with something other than a timer.
+   */
+  #check(): void {
+    const now = this.#properties.background.now().getTime();
+    const waitingOn = this.#properties.waitingOn();
+
+    if (waitingOn === undefined || now !== this.#seenAt) {
+      this.#seenAt = now;
+      this.#arm();
+
+      return;
+    }
+
+    this.#properties.stalled(waitingOn, this.#delay);
+  }
+}
+
+/**
+ * How long the host waits before it calls an invocation stalled.
+ *
+ * The function's own timeout is the bound that fits, since an invocation the
+ * deadline would have ended already has nothing left to wait for. It is held
+ * between one and two seconds. Below that a loaded host could fail a test that
+ * was about to advance the clock, and above it a test framework's own timeout
+ * arrives first and takes the diagnostic with it.
+ */
+function simLambdaStallWatchDelay(timeoutSeconds: number): number {
+  return Math.min(
+    Math.max(timeoutSeconds * millisecondsPerSecond, shortestWatchMilliseconds),
+    longestWatchMilliseconds,
+  );
+}

--- a/src/service/lambda/function/invoke/sim-lambda-stalled-invocation.iso.test.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-stalled-invocation.iso.test.ts
@@ -1,0 +1,198 @@
+import { setTimeout as hostSleep } from "node:timers/promises";
+import { CreateFunctionCommand, InvokeCommand } from "@aws-sdk/client-lambda";
+import {
+  assertIdentical,
+  assertNonNullable,
+  assertStringIncludes,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { SimAws } from "../../../aws/sim-aws.js";
+import { SimFixedClock } from "../../../../util/clock/sim-clock.js";
+import { makeLambdaCodeZip } from "../code/make-lambda-code-zip.js";
+import { makeLambdaZipFileInput } from "../code/lambda-zip-file-input.js";
+import type { SimLambdaHandler } from "../sim-lambda-handler.type.js";
+
+const functionName = "sleeper";
+const roleArn = "arn:aws:iam::888888888888:role/SleeperRole";
+const startedAt = new Date("2026-09-10T09:00:00.000Z");
+
+/** What the handler asks for, and what a test has to advance past. */
+const sleepMilliseconds = 100;
+
+/**
+ * A one second function, so the stall watch reaches its shortest wait rather
+ * than the two seconds a default three second function would give it.
+ */
+const timeoutSeconds = 1;
+
+/** An in-process handler that sleeps on the invocation's timers. */
+const sleepingHandler: SimLambdaHandler = async () => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, sleepMilliseconds);
+  });
+
+  return "slept";
+};
+
+/**
+ * An in-process handler with several timers outstanding, the one it waits on
+ * neither the first started nor the last.
+ */
+const crowdedHandler: SimLambdaHandler = async () => {
+  await new Promise((resolve) => {
+    setTimeout(() => undefined, 900);
+    setTimeout(() => undefined, 500);
+    setTimeout(resolve, sleepMilliseconds);
+    setTimeout(() => undefined, 1200);
+  });
+
+  return "slept";
+};
+
+/** Zip code that sleeps on the sandbox timers it was given. */
+const sleepingSource = `
+  exports.handler = async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, ${sleepMilliseconds});
+    });
+
+    return "slept";
+  };
+`;
+
+/** What an Invoke answered with when the invocation failed. */
+interface InvokeFailure {
+  readonly functionError: string | undefined;
+  readonly errorType: string;
+  readonly errorMessage: string;
+}
+
+async function functionSleeping(
+  simAws: SimAws,
+  zipFile: Uint8Array,
+  handlerName?: string,
+): Promise<void> {
+  await simAws.lambda().createFunction(
+    new CreateFunctionCommand({
+      FunctionName: functionName,
+      Role: roleArn,
+      Timeout: timeoutSeconds,
+      Handler: handlerName,
+      Code: { ZipFile: zipFile },
+    }),
+  );
+  await simAws.backgroundTasksComplete();
+}
+
+async function invoking(simAws: SimAws): Promise<InvokeFailure> {
+  const output = await simAws
+    .lambda()
+    .invoke(new InvokeCommand({ FunctionName: functionName }));
+
+  assertNonNullable(output.Payload, "the invocation answered with a payload");
+
+  const document = JSON.parse(Buffer.from(output.Payload).toString()) as {
+    errorType: string;
+    errorMessage: string;
+  };
+
+  return { functionError: output.FunctionError, ...document };
+}
+
+describe("sim Lambda stalled invocation", () => {
+  it("ends an in-process handler waiting on a clock that has stopped", async () => {
+    const simAws = new SimAws();
+    await functionSleeping(simAws, makeLambdaZipFileInput(sleepingHandler));
+    simAws.clock().freeze();
+
+    const failure = await invoking(simAws);
+
+    assertIdentical(failure.functionError, "Unhandled");
+    assertIdentical(failure.errorType, "Yulin.StalledInvocation");
+    assertStringIncludes(failure.errorMessage, `${sleepMilliseconds} ms timer`);
+    assertStringIncludes(
+      failure.errorMessage,
+      "Simulated time has stood still",
+    );
+    assertStringIncludes(
+      failure.errorMessage,
+      "Advance the simulation's clock",
+    );
+  });
+
+  it("ends zip code waiting on a clock that has stopped", async () => {
+    const simAws = new SimAws();
+    await functionSleeping(
+      simAws,
+      makeLambdaCodeZip(sleepingSource),
+      "index.handler",
+    );
+    simAws.clock().freeze();
+
+    const failure = await invoking(simAws);
+
+    assertIdentical(failure.errorType, "Yulin.StalledInvocation");
+    assertStringIncludes(failure.errorMessage, `${sleepMilliseconds} ms timer`);
+  });
+
+  it("ends an invocation in a simulation whose clock never moves", async () => {
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await functionSleeping(simAws, makeLambdaZipFileInput(sleepingHandler));
+
+    const failure = await invoking(simAws);
+
+    assertIdentical(failure.errorType, "Yulin.StalledInvocation");
+    assertStringIncludes(failure.errorMessage, startedAt.toISOString());
+  });
+
+  it("names the earliest timer where several are outstanding", async () => {
+    const simAws = new SimAws();
+    await functionSleeping(simAws, makeLambdaZipFileInput(crowdedHandler));
+    simAws.clock().freeze();
+
+    const failure = await invoking(simAws);
+
+    assertIdentical(failure.errorType, "Yulin.StalledInvocation");
+    assertStringIncludes(failure.errorMessage, `${sleepMilliseconds} ms timer`);
+  });
+
+  it("leaves an invocation the test goes on to release", async () => {
+    const simAws = new SimAws({ clock: new SimFixedClock(startedAt) });
+    await functionSleeping(simAws, makeLambdaZipFileInput(sleepingHandler));
+
+    const invocation = invoking(simAws);
+    await simAws.clock().advanceBy(sleepMilliseconds);
+    const answer = await invocation;
+
+    assertUndefined(answer.functionError);
+  });
+
+  it("leaves a sleeping handler under a running clock alone", async () => {
+    const simAws = new SimAws();
+    await functionSleeping(simAws, makeLambdaZipFileInput(sleepingHandler));
+
+    const answer = await invoking(simAws);
+
+    assertUndefined(answer.functionError);
+  });
+
+  it("leaves a handler that is busy without a timer alone", async () => {
+    const simAws = new SimAws();
+    const busyHandler: SimLambdaHandler = async () => {
+      // Slept on the host rather than on the invocation's timers, so nothing
+      // is waiting on the clock however long this takes.
+      await hostSleep(1500);
+
+      return "worked";
+    };
+
+    await functionSleeping(simAws, makeLambdaZipFileInput(busyHandler));
+    simAws.clock().freeze();
+
+    const answer = await invoking(simAws);
+
+    assertUndefined(answer.functionError);
+  });
+});

--- a/src/service/lambda/function/invoke/sim-lambda-stalled.error.ts
+++ b/src/service/lambda/function/invoke/sim-lambda-stalled.error.ts
@@ -1,0 +1,45 @@
+import { SimLambdaRuntimeError } from "../../error/sim-lambda-runtime.error.js";
+import type { SimLambdaPendingTimer } from "./timer/sim-lambda-pending-timer.js";
+
+/** What Yulin calls an invocation the clock is never going to release. */
+const stalledErrorType = "Yulin.StalledInvocation";
+
+interface SimLambdaStalledProperties {
+  readonly awsRequestId: string;
+
+  /** The simulated instant the clock has stopped at. */
+  readonly at: Date;
+
+  /** The timer the invocation is waiting on. */
+  readonly waitingOn: SimLambdaPendingTimer;
+
+  /** How long the host has watched simulated time stand still. */
+  readonly waitedMilliseconds: number;
+}
+
+/**
+ * The error an invocation gets when nothing is left that could end it.
+ *
+ * A handler's timers wait on the simulation's clock, and so does the
+ * invocation's own deadline. Simulated time standing still holds both, and the
+ * invocation would otherwise run until the test framework gave up on the test
+ * around it, reporting the test rather than the timer. This names the timer
+ * the handler is waiting on, the instant it is due at, and what to do about
+ * it.
+ */
+export function simLambdaStalledError(
+  properties: SimLambdaStalledProperties,
+): SimLambdaRuntimeError {
+  const { awsRequestId, at, waitingOn, waitedMilliseconds } = properties;
+  const error = new SimLambdaRuntimeError(
+    stalledErrorType,
+    `${at.toISOString()} ${awsRequestId} Task is waiting on a ${waitingOn.delay} ms timer due at ${waitingOn.dueTime.toISOString()}. Simulated time has stood still for ${waitedMilliseconds} ms of host time, leaving both that timer and the invocation deadline out of reach. Advance the simulation's clock past the timer delay to release it.`,
+  );
+
+  // Nothing in the handler threw, so its frames say nothing about why the
+  // invocation is stuck, and the simulator's own frames say less. The timeout
+  // this stands in for is reported without a stack too.
+  error.stack = `${error.name}: ${error.message}`;
+
+  return error;
+}

--- a/src/service/lambda/function/invoke/timer/sim-lambda-clock-timer.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-clock-timer.ts
@@ -48,6 +48,16 @@ export class SimLambdaClockTimer {
     this.#dueTime = properties.background.now();
   }
 
+  /** The delay this timer was last started with, in milliseconds. */
+  get delay(): number {
+    return this.#delay;
+  }
+
+  /** The simulated instant this timer's work is due to run at. */
+  get dueTime(): Date {
+    return new Date(this.#dueTime);
+  }
+
   /**
    * Wait a delay of simulated time, and answer with how long that turned out
    * to be. A delay of nothing leaves the timer due where the clock already

--- a/src/service/lambda/function/invoke/timer/sim-lambda-invocation-timers.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-invocation-timers.ts
@@ -1,5 +1,6 @@
 import type { BackgroundScheduler } from "../../../../../util/background/background.js";
 import { SimLambdaClockTimer } from "./sim-lambda-clock-timer.js";
+import type { SimLambdaPendingTimer } from "./sim-lambda-pending-timer.js";
 import {
   type SimLambdaTimerCallback,
   SimLambdaTimerHandle,
@@ -69,6 +70,31 @@ export class SimLambdaInvocationTimers
       timer.again();
       this.#call(callback, arguments_);
     });
+  }
+
+  /**
+   * The timer this invocation is waiting on, the earliest due one where it
+   * has several.
+   *
+   * A timer due at the instant the clock already reads is waiting for nothing:
+   * the next turn of the host event loop runs it. Only a timer the clock has
+   * yet to reach counts.
+   */
+  pending(): SimLambdaPendingTimer | undefined {
+    const now = this.#background.now().getTime();
+    let earliest: SimLambdaClockTimer | undefined;
+
+    for (const timer of this.#running.values()) {
+      if (timer.dueTime.getTime() > now && isEarlier(timer, earliest)) {
+        earliest = timer;
+      }
+    }
+
+    if (earliest === undefined) {
+      return undefined;
+    }
+
+    return { delay: earliest.delay, dueTime: earliest.dueTime };
   }
 
   /**
@@ -150,4 +176,15 @@ export class SimLambdaInvocationTimers
     this.#released?.();
     this.#released = undefined;
   }
+}
+
+/**
+ * Whether a timer comes due before the earliest one found so far. The first
+ * timer looked at has nothing to beat.
+ */
+function isEarlier(
+  timer: SimLambdaClockTimer,
+  earliest: SimLambdaClockTimer | undefined,
+): boolean {
+  return earliest === undefined || timer.dueTime < earliest.dueTime;
 }

--- a/src/service/lambda/function/invoke/timer/sim-lambda-pending-timer.ts
+++ b/src/service/lambda/function/invoke/timer/sim-lambda-pending-timer.ts
@@ -1,0 +1,10 @@
+/**
+ * A timer one invocation is waiting on, and the instant it comes due.
+ */
+export interface SimLambdaPendingTimer {
+  /** The delay the code under test asked for, in milliseconds. */
+  readonly delay: number;
+
+  /** The simulated instant the timer's work runs at. */
+  readonly dueTime: Date;
+}


### PR DESCRIPTION
A handler's timers wait on the simulation's clock, and so does the invocation's own deadline. Simulated time standing still held both. An invocation that slept for any reason then ran until the test framework gave up on the test around it, reporting the test rather than the timer. A stall watch on host time now ends such an invocation with a `Yulin.StalledInvocation` error naming the timer, its delay and what to do about it. Advancing the clock resets the watch, in one step or several. A test that starts an invocation and then drives time keeps working, and a handler busy with something other than a timer is left alone.

The watch waits the function's configured `Timeout` in host time, held between one and two seconds. Below one second a loaded host could fail a test that was about to advance the clock. Above two the test framework's own timeout arrives first and takes the diagnostic with it. Two cases reach the stall without anyone calling `freeze()`: a simulation built on a `SimFixedClock`, which docs/time recommends for a known starting time, and any simulation after a single `advanceBy(...)`.

Resolves #1340
