### PR TITLE
fix: refuse a stream cascade that never settles

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -1738,8 +1738,8 @@ const { TableDescription } = await simAws.dynamoDb().createTable(
 const streamArn = TableDescription?.LatestStreamArn;
 
 // The projection goes into a second table. A function writing back into the
-// table whose stream invoked it would be delivered its own writes, which the
-// simulator refuses rather than looping on.
+// table whose stream invoked it is delivered its own writes, and the simulator
+// refuses a chain of those that keeps going.
 await simAws.dynamoDb().createTable(
   new CreateTableCommand({
     TableName: "order-totals",
@@ -2161,12 +2161,16 @@ created without `FunctionResponseTypes` ignores a report entirely.
 
 ### Writing back to the source table
 
-A handler that writes into the table whose stream invoked it is delivered its own write, which
-writes again. Real Lambda runs that loop for as long as the account is willing to pay for it. The
-simulation refuses instead, with an error naming the function, the stream and the table, before the
-test times out.
+A handler that writes into the table whose stream invoked it is delivered its own write. Where that
+write brings on another, and that one another, the simulation is going round a loop. Real Lambda
+runs the loop for as long as the account is willing to pay for it. Yulin counts the deliveries a
+handler's own writes bring on and refuses after ten of them in a row, with an error naming the
+function, the stream, the table and the count.
 
-The write itself succeeds. The refusal comes afterwards, from whatever is waiting for the simulation
+A handler that settles is left to finish. Writing back once and then finding the work already done
+ends the chain at one link, and the delivery that link caused writes nothing.
+
+The write itself succeeds. A refusal comes afterwards, from whatever is waiting for the simulation
 to settle:
 
 ```typescript
@@ -2177,7 +2181,7 @@ Only the handler's own writes count. Items written at the same time by the test,
 in the simulation, are an ordinary batch however many of them there are, because the guard tells them
 apart by where the write came from, and never by when it landed.
 
-Writing the projection into a second table is what the guard is asking for, and is what a real
+A projection that writes back on every delivery belongs in a second table. That is what a real
 aggregation or search index does anyway.
 
 ### Making a stream event without a table
@@ -4377,9 +4381,10 @@ Current documented limitations:
   AWS counts a bisected batch's deliveries against the same quota. Without that, the simulator's own
   cap of five attempts would discard a batch of a hundred long before it was down to one record. The
   splitting still ends on its own, because a batch halves at every step.
-- A handler writing into the table whose stream invoked it is refused with
-  `SimLambdaStreamCascadeError` rather than being delivered its own writes forever. Real Lambda runs
-  that loop.
+- Ten deliveries in a row, each one brought on by the handler's own writes to the source that
+  invoked it, are refused with `SimLambdaStreamCascadeError`. Real Lambda runs that loop for as long
+  as it is paid for. A handler that writes back and then settles is delivered its own writes and
+  finishes.
 - A shard iterator never expires, where a real one is good for 15 minutes.
 - `MaximumBatchingWindowInSeconds` is only simulated as 0. A partial batch is delivered as soon as
   anything is on the event source, leaving a batching window nothing to wait for. A non-zero value

--- a/docs/services/lambda/sim-lambda-dynamodb-stream-event-source.example.ts
+++ b/docs/services/lambda/sim-lambda-dynamodb-stream-event-source.example.ts
@@ -37,8 +37,8 @@ const { TableDescription } = await simAws.dynamoDb().createTable(
 const streamArn = TableDescription?.LatestStreamArn;
 
 // The projection goes into a second table. A function writing back into the
-// table whose stream invoked it would be delivered its own writes, which the
-// simulator refuses rather than looping on.
+// table whose stream invoked it is delivered its own writes, and the simulator
+// refuses a chain of those that keeps going.
 await simAws.dynamoDb().createTable(
   new CreateTableCommand({
     TableName: "order-totals",

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -597,14 +597,18 @@ records twice. `SimLambdaEventSourcePollTurn` is the one-at-a-time guard, and it
 its `finally` block rather than dropping a poll that was asked for mid-turn, because `PollSchedule`
 clears its own flag when the task starts.
 
-`SimLambdaStreamCascadeGuard` is what stops a function writing back into the table whose stream
-invoked it. The delivery runs inside an asynchronous context
+`SimLambdaStreamCascadeGuard` is what stops a function feeding the table whose stream invoked it
+round a loop. The delivery runs inside an asynchronous context
 (`sim-lambda-event-source-delivery-context.ts`), so a record written by the handler is told apart
 from one written by anything else that happened to be running at the same time. Several items
 written in one `Promise.all` by a test, or by anything other than this mapping's own handler, are an
-ordinary batch. Writes the handler itself makes to its own source are the loop, however many of them
-it makes and however it makes them, and are refused with `SimLambdaStreamCascadeError` once the
-delivery is over rather than left to spin.
+ordinary batch.
+
+What the guard counts is the chain, and never the shape of one write. A delivery the handler fed
+takes the count up by one, and any other delivery puts it back to zero. A handler that writes back
+and then finds its own work done settles at one link. `simLambdaStreamCascadeLimit` links in a row
+are refused with `SimLambdaStreamCascadeError` once the delivery is over, and the guard's
+`refused` is what stops the mapping polling on from a checkpoint the refusal left where it was.
 
 `SimDynamoDbEventSourceStreams` implements the port over the DynamoDB Streams commands, as the
 execution role. `SimDynamoDbEventSourceStreamShard` is the part that finds the table and the shard,

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-poller.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-shard-poller.ts
@@ -41,8 +41,6 @@ export class SimLambdaKinesisShardPoller implements SimLambdaEventSourcePolls {
   private readonly progress: SimLambdaStreamProgress;
   private readonly turn = new SimLambdaEventSourcePollTurn(this);
 
-  private stopped = false;
-
   constructor(properties: SimLambdaKinesisShardPollerProperties) {
     this.mapping = properties.mapping;
     this.functions = properties.functions;
@@ -64,15 +62,15 @@ export class SimLambdaKinesisShardPoller implements SimLambdaEventSourcePolls {
 
   /** Stop polling this shard. */
   stop(): void {
-    this.stopped = true;
+    this.delivery.stop();
   }
 
   /**
-   * Note a record put onto the stream, answering with whether this mapping's
-   * own function put it.
+   * Note a record put onto the stream, which counts only while this shard is
+   * mid-delivery.
    */
-  noteRecordWritten(): boolean {
-    return this.delivery.noteRecordWritten();
+  noteRecordWritten(): void {
+    this.delivery.noteRecordWritten();
   }
 
   /**
@@ -80,12 +78,16 @@ export class SimLambdaKinesisShardPoller implements SimLambdaEventSourcePolls {
    *
    * Only ever called through the turn, which is what keeps two polls from
    * reading the same records.
+   *
+   * A refused shard polls no further. Its checkpoint stayed where the refused
+   * delivery found it, and reading on from there would deliver those records
+   * again.
    */
   async poll(): Promise<void> {
     const simFunction = simLambdaEventSourceFunction(
       this.functions,
       this.mapping,
-      this.stopped,
+      this.delivery.stopped,
     );
 
     if (simFunction === undefined) {

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
@@ -3,6 +3,7 @@ import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-
 import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
 import type { SimLambdaKinesisStreamRecord } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
 import { SimLambdaStreamCascadeGuard } from "../../stream/sim-lambda-stream-cascade-guard.js";
+import { SimLambdaStreamHalt } from "../../stream/sim-lambda-stream-halt.js";
 import { countSimLambdaKinesisIteratorAge } from "../sim-lambda-stream-iterator-age.js";
 import { simLambdaKinesisStreamRecordTimes } from "../sim-lambda-stream-record-times.js";
 import type { SimLambdaStreamBatchOutcome } from "../sim-lambda-stream-batch-outcome.js";
@@ -31,6 +32,7 @@ export class SimLambdaKinesisStreamDelivery {
   private readonly eventBuilder: SimLambdaKinesisStreamEventBuilder;
   private readonly batchResponse: SimLambdaStreamBatchResponse;
   private readonly cascade: SimLambdaStreamCascadeGuard;
+  private readonly halt = new SimLambdaStreamHalt();
 
   constructor(properties: SimLambdaKinesisStreamDeliveryProperties) {
     const { eventSourceArn } = properties;
@@ -45,6 +47,7 @@ export class SimLambdaKinesisStreamDelivery {
     );
     this.cascade = new SimLambdaStreamCascadeGuard({
       mapping: properties.mapping,
+      halt: this.halt,
       source: {
         streamArn: eventSourceArn.value,
         wroteTo: `put a record onto the stream ${eventSourceArn.streamName}`,
@@ -67,11 +70,26 @@ export class SimLambdaKinesisStreamDelivery {
   }
 
   /**
-   * Note a record put onto the polled stream, answering with whether this
-   * mapping's own function put it.
+   * Whether this shard has finished polling, which stopping it and refusing it
+   * both settle.
    */
-  noteRecordWritten(): boolean {
-    return this.cascade.noteRecordWritten();
+  get stopped(): boolean {
+    return this.halt.stopped;
+  }
+
+  /**
+   * Finish this shard, as stopping the mapping does.
+   */
+  stop(): void {
+    this.halt.stop();
+  }
+
+  /**
+   * Note a record put onto the polled stream, which counts only while this
+   * mapping's own function is running.
+   */
+  noteRecordWritten(): void {
+    this.cascade.noteRecordWritten();
   }
 
   private async handled(

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event-source-poller.ts
@@ -78,19 +78,14 @@ export class SimLambdaKinesisStreamEventSourcePoller implements SimLambdaEventSo
    * Take a record arriving on the stream as something to poll for.
    *
    * A record put while this mapping's own function is running is the function
-   * writing back into its own source stream. That never settles, so the mapping
-   * stops here and the delivery refuses once it is over. Only the shard that is
-   * mid-delivery answers, since only it is inside the delivery.
+   * writing back into its own source stream. The delivery it brings on is what
+   * settles the work or carries the chain on, so the mapping polls for it
+   * either way and the guard counts the chain. Every shard is told, and only
+   * the one that is mid-delivery counts it.
    */
   recordsAvailable(): void {
-    const cascading = this.shardPollers.made.some((shardPoller) =>
-      shardPoller.noteRecordWritten(),
-    );
-
-    if (cascading) {
-      this.stop();
-
-      return;
+    for (const shardPoller of this.shardPollers.made) {
+      shardPoller.noteRecordWritten();
     }
 
     this.schedule.now();

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
@@ -3,6 +3,7 @@ import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-map
 import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
 import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
 import { SimLambdaStreamCascadeGuard } from "../stream/sim-lambda-stream-cascade-guard.js";
+import { SimLambdaStreamHalt } from "../stream/sim-lambda-stream-halt.js";
 import { SimLambdaDynamoDbStreamEventBuilder } from "./sim-lambda-dynamodb-stream-event.js";
 import { countSimLambdaDynamoDbIteratorAge } from "./sim-lambda-stream-iterator-age.js";
 import { simLambdaDynamoDbStreamRecordTimes } from "./sim-lambda-stream-record-times.js";
@@ -26,13 +27,15 @@ interface SimLambdaDynamoDbStreamDeliveryProperties {
  * what the function said, so the batch response decides it.
  *
  * What the function did with the table while it ran is part of the same
- * question, so the cascade guard belongs here too: a handler writing back into
- * its own source table is refused rather than handled.
+ * question, so the cascade guard belongs here too. It counts the deliveries a
+ * handler's own writes bring on, and refuses the mapping once that chain is
+ * long enough to say the simulation will never settle.
  */
 export class SimLambdaDynamoDbStreamDelivery {
   private readonly eventBuilder: SimLambdaDynamoDbStreamEventBuilder;
   private readonly batchResponse: SimLambdaStreamBatchResponse;
   private readonly cascade: SimLambdaStreamCascadeGuard;
+  private readonly halt = new SimLambdaStreamHalt();
 
   constructor(properties: SimLambdaDynamoDbStreamDeliveryProperties) {
     this.eventBuilder = new SimLambdaDynamoDbStreamEventBuilder(
@@ -43,6 +46,7 @@ export class SimLambdaDynamoDbStreamDelivery {
     );
     this.cascade = new SimLambdaStreamCascadeGuard({
       mapping: properties.mapping,
+      halt: this.halt,
       source: {
         streamArn: properties.eventSourceArn.value,
         wroteTo: `wrote to the table ${properties.eventSourceArn.tableName}`,
@@ -65,11 +69,26 @@ export class SimLambdaDynamoDbStreamDelivery {
   }
 
   /**
-   * Note a record written to the polled stream, answering with whether this
-   * mapping's own function wrote it.
+   * Whether this mapping has finished polling, which deleting it and refusing
+   * it both settle.
    */
-  noteRecordWritten(): boolean {
-    return this.cascade.noteRecordWritten();
+  get stopped(): boolean {
+    return this.halt.stopped;
+  }
+
+  /**
+   * Finish this mapping, as deleting it does.
+   */
+  stop(): void {
+    this.halt.stop();
+  }
+
+  /**
+   * Note a record written to the polled stream, which counts only while this
+   * mapping's own function is running.
+   */
+  noteRecordWritten(): void {
+    this.cascade.noteRecordWritten();
   }
 
   private async handled(

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event-source-poller.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event-source-poller.ts
@@ -43,8 +43,6 @@ export class SimLambdaDynamoDbStreamEventSourcePoller
   private readonly progress: SimLambdaStreamProgress;
   private readonly turn = new SimLambdaEventSourcePollTurn(this);
 
-  private stopped = false;
-
   constructor(properties: SimLambdaDynamoDbStreamEventSourcePollerProperties) {
     const { eventSourceArn, mapping } = properties;
 
@@ -96,7 +94,7 @@ export class SimLambdaDynamoDbStreamEventSourcePoller
    * Stop polling, as deleting the mapping does.
    */
   stop(): void {
-    this.stopped = true;
+    this.delivery.stop();
     this.stream.unwatch(this);
   }
 
@@ -104,16 +102,12 @@ export class SimLambdaDynamoDbStreamEventSourcePoller
    * Take a record arriving on the stream as something to poll for.
    *
    * A record written while this mapping's own function is running is the
-   * function writing back into its own source table. That never settles, so the
-   * mapping stops here and the delivery refuses once it is over.
+   * function writing back into its own source table. The delivery it brings on
+   * is what settles the work or carries the chain on, so the mapping polls for
+   * it either way and the guard counts the chain.
    */
   recordsAvailable(): void {
-    if (this.delivery.noteRecordWritten()) {
-      this.stopped = true;
-
-      return;
-    }
-
+    this.delivery.noteRecordWritten();
     this.progress.pollNow();
   }
 
@@ -122,8 +116,12 @@ export class SimLambdaDynamoDbStreamEventSourcePoller
    *
    * Only ever called through the turn, which is what keeps two polls from
    * reading the same records.
+   *
+   * A refused mapping polls no further. Its checkpoint stayed where the refused
+   * delivery found it, and reading on from there would deliver those records
+   * again.
    */
   async poll(): Promise<void> {
-    await this.polling.poll(this.stopped);
+    await this.polling.poll(this.delivery.stopped);
   }
 }

--- a/src/service/lambda/event-source/sim-lambda-dynamodb-stream-cascade.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-dynamodb-stream-cascade.iso.test.ts
@@ -1,5 +1,10 @@
 import { PutItemCommand } from "@aws-sdk/client-dynamodb";
-import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { SimAws } from "../../aws/sim-aws.js";
@@ -8,11 +13,21 @@ import {
   simAwsWithStreamEventSource,
 } from "../../../../test/lambda/stream-event-source-fixture.js";
 import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.types.js";
+import { simLambdaStreamCascadeLimit } from "./stream/sim-lambda-stream-cascade-guard.js";
+
+/**
+ * The order ids a batch carries.
+ */
+function orderIds(event: SimLambdaDynamoDbStreamEvent): readonly string[] {
+  return event.Records.map(
+    (record) => record.dynamodb.Keys?.["orderId"]?.S ?? "",
+  );
+}
 
 describe("sim Lambda DynamoDB stream event source write cascades", () => {
-  it("refuses a function that writes back into its own source table", async () => {
+  it("refuses a function that writes back into its own source table on every delivery", async () => {
     // Given a function whose handler writes an aggregate into the table whose
-    // stream invoked it, which is a loop rather than a projection.
+    // stream invoked it, and does it again for the aggregate's own record.
     const simAws = new SimAws();
     const { tableName } = await simAwsWithStreamEventSource({
       simAws,
@@ -44,7 +59,58 @@ describe("sim Lambda DynamoDB stream event source write cascades", () => {
     assertStringIncludes(error.message, "order-projector");
     assertStringIncludes(error.message, "the table orders");
     assertStringIncludes(error.message, "own stream");
+    assertStringIncludes(
+      error.message,
+      `${String(simLambdaStreamCascadeLimit)} deliveries in a row`,
+    );
     assertStringIncludes(error.message, "Write the result to a different");
+  });
+
+  it("delivers a write back into the source table and settles when the next delivery writes nothing", async () => {
+    // Given a function whose handler writes a total for an order into the
+    // table that invoked it, and leaves a total it is given alone.
+    const simAws = new SimAws();
+    const { tableName, events } = await simAwsWithStreamEventSource({
+      simAws,
+      handlerResult: async (
+        event: SimLambdaDynamoDbStreamEvent,
+      ): Promise<void> => {
+        const untotalled = orderIds(event).filter(
+          (id) => !id.startsWith("total-"),
+        );
+
+        await Promise.all(
+          untotalled.map(async (orderId) => {
+            await simAws.dynamoDb().putItem(
+              new PutItemCommand({
+                TableName: "orders",
+                Item: { orderId: { S: `total-${orderId}` } },
+              }),
+            );
+          }),
+        );
+      },
+    });
+
+    // When an order is written to the table.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler's own write was delivered back to it, that delivery
+    // wrote nothing, and the simulation settled.
+    assertArrayLength(events, 2);
+    assertArrayEquals(orderIds(events[1]), ["total-order-1"]);
+
+    const orders = await simAws
+      .dynamoDb()
+      .scan({ input: { TableName: tableName } });
+
+    assertArrayLength(orders.Items ?? [], 2);
   });
 
   it("allows a function that writes into a second table", async () => {

--- a/src/service/lambda/event-source/sim-lambda-kinesis-cascade.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-kinesis-cascade.iso.test.ts
@@ -1,11 +1,17 @@
 import { PutRecordCommand } from "@aws-sdk/client-kinesis";
-import { assertStringIncludes, assertThrowsErrorAsync } from "@kensio/smartass";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertStringIncludes,
+  assertThrowsErrorAsync,
+} from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
 import { SimAws } from "../../aws/sim-aws.js";
 import { simKinesisStreamFactory } from "../../kinesis/stream/sim-kinesis-stream.factory.js";
 import type { SimLambdaKinesisStreamEvent } from "./poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+import { simLambdaStreamCascadeLimit } from "./stream/sim-lambda-stream-cascade-guard.js";
 
 /**
  * A record carrying how many records the batch before it held.
@@ -21,10 +27,19 @@ function totalRecord(
   });
 }
 
+/**
+ * What a batch's records say.
+ */
+function payloads(event: SimLambdaKinesisStreamEvent): readonly string[] {
+  return event.Records.map((record) =>
+    Buffer.from(record.kinesis.data, "base64").toString("utf8"),
+  );
+}
+
 describe("sim Lambda Kinesis stream event source write cascades", () => {
-  it("refuses a function that puts records back onto its own source stream", async () => {
+  it("refuses a function that puts records back onto its own source stream on every delivery", async () => {
     // Given a function whose handler puts an aggregate onto the stream that
-    // invoked it, which is a loop rather than a projection.
+    // invoked it, and does it again for the aggregate's own record.
     const simAws = new SimAws();
     await simAwsWithKinesisEventSource({
       simAws,
@@ -50,7 +65,54 @@ describe("sim Lambda Kinesis stream event source write cascades", () => {
     assertStringIncludes(error.message, "order-projector");
     assertStringIncludes(error.message, "the stream orders");
     assertStringIncludes(error.message, "that same stream");
+    assertStringIncludes(
+      error.message,
+      `${String(simLambdaStreamCascadeLimit)} deliveries in a row`,
+    );
     assertStringIncludes(error.message, "Put the result onto a different");
+  });
+
+  it("delivers a record put back onto the source stream and settles when the next delivery puts nothing", async () => {
+    // Given a function whose handler totals an order onto the stream that
+    // invoked it, and leaves a total it is given alone.
+    const simAws = new SimAws();
+    const { events } = await simAwsWithKinesisEventSource({
+      simAws,
+      handlerResult: async (
+        event: SimLambdaKinesisStreamEvent,
+      ): Promise<void> => {
+        const untotalled = payloads(event).filter(
+          (data) => !data.startsWith("total-"),
+        );
+
+        await Promise.all(
+          untotalled.map(async (payload) => {
+            await simAws.kinesis().putRecord(
+              new PutRecordCommand({
+                StreamName: "orders",
+                PartitionKey: "totals",
+                Data: new TextEncoder().encode(`total-${payload}`),
+              }),
+            );
+          }),
+        );
+      },
+    });
+
+    // When a record is put onto the stream.
+    await simAws.kinesis().putRecord(
+      new PutRecordCommand({
+        StreamName: "orders",
+        PartitionKey: "customer-1",
+        Data: new TextEncoder().encode("order-1"),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the handler's own record was delivered back to it, that delivery
+    // put nothing, and the simulation settled.
+    assertArrayLength(events, 2);
+    assertArrayEquals(payloads(events[1]), ["total-order-1"]);
   });
 
   it("allows a function that puts records onto a second stream", async () => {

--- a/src/service/lambda/event-source/stream/sim-lambda-stream-cascade-guard.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-stream-cascade-guard.ts
@@ -1,6 +1,18 @@
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
 import { simLambdaEventSourceDeliveryContext } from "./sim-lambda-event-source-delivery-context.js";
 import { SimLambdaStreamCascadeError } from "./sim-lambda-stream-cascade.error.js";
+import type { SimLambdaStreamHalt } from "./sim-lambda-stream-halt.js";
+
+/**
+ * How many deliveries in a row may feed the source that invoked them before the
+ * simulation is refused.
+ *
+ * One write back is a handler doing its job, and the delivery it causes is the
+ * chance for that work to finish. A handler that settles takes two or three
+ * links of chain. A handler that loops takes every link there is, and the
+ * simulation has to say so before the test times out.
+ */
+export const simLambdaStreamCascadeLimit = 10;
 
 /**
  * The source a guard watches, said in the terms its own service uses.
@@ -27,41 +39,61 @@ export interface SimLambdaStreamCascadeSource {
 interface SimLambdaStreamCascadeGuardProperties {
   readonly mapping: SimLambdaEventSourceMapping;
   readonly source: SimLambdaStreamCascadeSource;
+
+  /**
+   * What a refusal stops, since a mapping polling on from a checkpoint the
+   * refusal left where it was would deliver the same records again.
+   */
+  readonly halt: SimLambdaStreamHalt;
 }
 
 /**
- * Watches one mapping's deliveries for the function writing back into the
+ * Watches one mapping's deliveries for a chain of the function feeding the
  * source whose stream invoked it.
  *
  * The delivery runs inside its own asynchronous context, so a record written by
  * the handler is told apart from one written by anything else that happened to
  * be running at the same time. That distinction is the whole point: several
  * records written at once are an ordinary batch, and a handler feeding its own
- * source is a loop.
+ * source is the start of a chain.
+ *
+ * What the guard counts is the chain, and never the shape of one write. A
+ * handler that writes back and then finds its own work done writes nothing the
+ * second time round, the chain ends at one link, and the simulation settles. A
+ * handler that writes back every time takes the chain to
+ * `simLambdaStreamCascadeLimit` and is refused there.
  */
 export class SimLambdaStreamCascadeGuard {
   private readonly properties: SimLambdaStreamCascadeGuardProperties;
-  private cascaded = false;
+  private fedRecords = 0;
+  private chained = 0;
 
   constructor(properties: SimLambdaStreamCascadeGuardProperties) {
     this.properties = properties;
   }
 
   /**
-   * Run one delivery, refusing afterwards if the function fed its own source.
+   * Run one delivery, refusing afterwards if the chain has gone on long enough
+   * to say the simulation will never settle.
    *
    * The refusal comes after the delivery rather than during it, so the handler
-   * sees its own write succeed and the loop is reported to whoever is waiting
+   * sees its own write succeed and the chain is reported to whoever is waiting
    * for the simulation to settle.
    */
   async around<Result>(delivery: () => Promise<Result>): Promise<Result> {
+    const fedBefore = this.fedRecords;
+
     const result = await simLambdaEventSourceDeliveryContext.run(
       this,
       delivery,
     );
 
-    if (this.cascaded) {
+    this.chained = this.fedRecords > fedBefore ? this.chained + 1 : 0;
+
+    if (this.chained >= simLambdaStreamCascadeLimit) {
       const { mapping, source } = this.properties;
+
+      this.properties.halt.stop();
 
       throw new SimLambdaStreamCascadeError({
         functionName: mapping.functionName,
@@ -69,6 +101,7 @@ export class SimLambdaStreamCascadeGuard {
         wroteTo: source.wroteTo,
         sourceRelation: source.sourceRelation,
         advice: source.advice,
+        deliveries: this.chained,
       });
     }
 
@@ -76,16 +109,15 @@ export class SimLambdaStreamCascadeGuard {
   }
 
   /**
-   * Note a record written to the polled stream, answering with whether this
-   * mapping's own function wrote it.
+   * Note a record written to the polled stream, which counts only while this
+   * mapping's own function is the thing that is running.
+   *
+   * Counted rather than flagged, so a delivery can tell whether the count moved
+   * while it ran without the flag having to be put back afterwards.
    */
-  noteRecordWritten(): boolean {
-    if (!simLambdaEventSourceDeliveryContext.isDelivering(this)) {
-      return false;
+  noteRecordWritten(): void {
+    if (simLambdaEventSourceDeliveryContext.isDelivering(this)) {
+      this.fedRecords += 1;
     }
-
-    this.cascaded = true;
-
-    return true;
   }
 }

--- a/src/service/lambda/event-source/stream/sim-lambda-stream-cascade.error.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-stream-cascade.error.ts
@@ -21,20 +21,30 @@ interface SimLambdaStreamCascadeErrorProperties {
    * in a second table, and a Kinesis result belongs on a second stream.
    */
   readonly advice: string;
+
+  /**
+   * How many deliveries in a row fed the source, which is the chain the guard
+   * counted before it gave up on the simulation settling.
+   */
+  readonly deliveries: number;
 }
 
 /**
- * A function writing back into the source whose stream invoked it.
+ * A function feeding the source whose stream invoked it, delivery after
+ * delivery.
  *
  * Every one of those writes is another stream record, which is another
  * delivery, which is another write. Real Lambda runs that loop for as long as
  * the account is willing to pay for it. Nothing here stops on its own, so the
  * simulation would go round until the test timed out with nothing to point at.
  *
+ * A handler that writes back and then settles is left alone. This is the chain
+ * that carried on, counted by `SimLambdaStreamCascadeGuard` up to
+ * `simLambdaStreamCascadeLimit`.
+ *
  * This is a simulator guard rather than AWS behaviour, and it is deliberately
- * not silent: a projection or an aggregate belongs in a second table or on a
- * second stream, and a test whose handler writes to its own source is testing a
- * loop.
+ * not silent: a projection or an aggregate that keeps going belongs in a second
+ * table or on a second stream.
  */
 export class SimLambdaStreamCascadeError extends SimLambdaError {
   public override readonly name = "SimLambdaStreamCascadeError";
@@ -43,8 +53,10 @@ export class SimLambdaStreamCascadeError extends SimLambdaError {
     super(
       `Function ${properties.functionName} ${properties.wroteTo} while ` +
         `handling records from ${properties.sourceRelation} ` +
-        `${properties.streamArn}. Each write would be delivered back to the ` +
-        `function, so the simulation would never settle. ${properties.advice}`,
+        `${properties.streamArn} on ${String(properties.deliveries)} ` +
+        `deliveries in a row. Each of those writes was delivered back to the ` +
+        `function and brought on the next one, and the simulation is still ` +
+        `going round. ${properties.advice}`,
     );
   }
 }

--- a/src/service/lambda/event-source/stream/sim-lambda-stream-halt.ts
+++ b/src/service/lambda/event-source/stream/sim-lambda-stream-halt.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether a mapping has finished polling, and the one place that says so.
+ *
+ * Two things finish a mapping. Deleting it stops the poller, and the cascade
+ * guard refusing a chain of the function's own writes stops it too. A poll
+ * reads one answer either way, and neither side has to know about the other.
+ */
+export class SimLambdaStreamHalt {
+  private halted = false;
+
+  /**
+   * Whether polling has finished.
+   */
+  get stopped(): boolean {
+    return this.halted;
+  }
+
+  /**
+   * Finish polling.
+   */
+  stop(): void {
+    this.halted = true;
+  }
+}


### PR DESCRIPTION
The cascade guard refused a handler on its first write back into the source that invoked it. An idempotent handler that writes once and then finds its own work already done was refused alongside one that loops forever. The guard now counts the deliveries a handler's own writes bring on and refuses at ten in a row. A chain that dies out is left to finish, and a loop is still caught before a test times out. A refusal settles a `SimLambdaStreamHalt` that the poller reads, and a refused mapping polls no further since its checkpoint stayed where the refusal found it.

Resolves https://github.com/KensioSoftware/yulin/issues/1346

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

The `pnpm run check` run fails four `src/cli/watch/*.loc.test.ts` files on this machine. They fail the same way on an unmodified `main`, they vary run to run, and they watch the real filesystem. Everything else passes, including all 12,496 isolated tests, and every file this branch touches is at 100% coverage.
