### PR TITLE
feat: filter event source mapping records on FilterCriteria

### DIFF
--- a/docs/services/lambda/README.md
+++ b/docs/services/lambda/README.md
@@ -2365,9 +2365,11 @@ the mapping's execution-role check is looking for.
 
 `bisectBatchOnError` is simulated, and is covered under
 [Splitting a failed batch around the record that broke it](#splitting-a-failed-batch-around-the-record-that-broke-it).
-The other properties a non-default `DynamoEventSource` adds are recorded rather than acted on. Those
-are `FilterCriteria`, `ParallelizationFactor` and `TumblingWindowInSeconds`.
-The mapping deploys, delivers every record whole and unfiltered, and each property it was created
+So is `filters`, which is covered under
+[Filtering the records a mapping delivers](#filtering-the-records-a-mapping-delivers). The other
+properties a non-default `DynamoEventSource` adds are recorded and left alone. Those are
+`ParallelizationFactor` and `TumblingWindowInSeconds`.
+The mapping deploys, delivers every record whole, and each property it was created
 without is listed in
 [`stack.ignoredProperties`](https://yulinsim.dev/services/cloudformation/#properties-a-resource-was-created-without "Properties a Resource was created without")
 with what the mapping does in its place. `CreateEventSourceMapping` still refuses the same
@@ -2534,6 +2536,137 @@ work the same way here, and each shard counts its own attempts.
 
 A mapping naming an enhanced fan-out consumer ARN is refused, since consumers are unsimulated.
 `AWS::Lambda::EventSourceMapping` deploys a Kinesis mapping the same way it deploys a DynamoDB one.
+
+## Filtering the records a mapping delivers
+
+`FilterCriteria` on an event source mapping decides which records reach the function. A record that
+matches is delivered. One that does not is treated as handled. A stream moves its checkpoint past it
+and a queue deletes it, the way real Lambda handles a record it filtered out. A batch that comes back
+empty invokes nothing at all.
+
+AWS documents Lambda's filter rules as EventBridge event patterns, and simulated EventBridge's
+matcher is what evaluates them here. Exact values, `prefix`, `suffix`, `anything-but`, `numeric` and
+`exists` all work. A mapping naming an operator the matcher has no behaviour for is refused when it
+is created. A mapping carrying several filters delivers a record any one of them matches.
+
+What a pattern reads depends on the source:
+
+- **SQS** filters on `body` alone, as real Lambda does. A body holding JSON is read as the object it
+  parses to, and one holding anything else is read as the string it is. A pattern naming any other
+  key is refused when the mapping is created.
+- **DynamoDB streams** filter on the record the function would have received, so `eventName` and
+  `dynamodb.NewImage.status.S` both work, with the attribute values in their DynamoDB shapes.
+- **Kinesis streams** filter on the record with the payload decoded, under a top-level `data` key.
+  The payload has to hold JSON for a pattern to read inside it.
+
+```typescript sim-lambda-event-source-filter-criteria
+/**
+ * Delivering only the queue messages a filter matches.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaSqsEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ShippedOrdersRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ShippedOrdersRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+const shipped: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "shipped-orders",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaSqsEvent) => {
+        for (const record of event.Records) {
+          shipped.push(
+            (JSON.parse(record.body) as { orderId: string }).orderId,
+          );
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "shipped-orders",
+    FilterCriteria: {
+      Filters: [{ Pattern: JSON.stringify({ body: { status: ["shipped"] } }) }],
+    },
+  }),
+);
+
+for (const order of [
+  { orderId: "order-1", status: "placed" },
+  { orderId: "order-2", status: "shipped" },
+]) {
+  await simAws
+    .sqs()
+    .sendMessage(
+      new SendMessageCommand({ QueueUrl, MessageBody: JSON.stringify(order) }),
+    );
+}
+
+await simAws.backgroundTasksComplete();
+
+console.log(shipped); // ["order-2"]
+```
+
+`GetEventSourceMappingCommand` reports the patterns back as they were written. A mapping created
+without filters reports none.
+
+An `AWS::Lambda::EventSourceMapping` carrying `FilterCriteria` deploys with it, and so does a SAM
+function's queue or stream event. A CDK `SqsEventSource` or `DynamoEventSource` given `filters`
+therefore filters here the way it does deployed.
 
 ## Function URLs
 
@@ -4203,6 +4336,8 @@ Sim Lambda currently supports:
   `CreateEventSourceMappingCommand` and read with `GetEventSourceMappingCommand`,
   `ListEventSourceMappingsCommand` and `DeleteEventSourceMappingCommand`, delivering real-shaped SQS,
   DynamoDB stream and Kinesis events and honouring `BatchSize`
+- `FilterCriteria` on any of those mappings, evaluated with EventBridge event patterns, delivering
+  the records that match and handling the rest without an invocation
 - `StartingPosition: "TRIM_HORIZON"` and `"LATEST"` on a stream mapping, and `"AT_TIMESTAMP"` on a
   Kinesis one, with a failing batch blocking its shard until it is through or discarded
 - `MaximumRetryAttempts` and `MaximumRecordAgeInSeconds` on a stream mapping, ending the retries at
@@ -4365,7 +4500,7 @@ Current documented limitations:
   it stands.
 - SQS queues, DynamoDB streams and Kinesis streams are the only event sources. Kafka, DocumentDB and
   Kinesis enhanced fan-out consumers are refused outright. `CreateEventSourceMapping` also refuses
-  `FilterCriteria`, `ScalingConfig`, `ParallelizationFactor`, `TumblingWindowInSeconds` and the
+  `ScalingConfig`, `ParallelizationFactor`, `TumblingWindowInSeconds` and the
   other inputs this simulation has no behaviour for. An
   `AWS::Lambda::EventSourceMapping` naming any of them deploys instead, and records each one against
   the Resource (see
@@ -4385,6 +4520,10 @@ Current documented limitations:
   invoked it, are refused with `SimLambdaStreamCascadeError`. Real Lambda runs that loop for as long
   as it is paid for. A handler that writes back and then settles is delivered its own writes and
   finishes.
+- `FilterCriteria` is evaluated by simulated EventBridge's pattern matcher, which leaves out the
+  `equals-ignore-case` and `$or` operators real Lambda takes. A pattern naming one is refused when
+  the mapping is created. The limits AWS puts on the number and length of patterns go unenforced,
+  and `KMSKeyArn` is refused, so criteria are held in plaintext.
 - A shard iterator never expires, where a real one is good for 15 minutes.
 - `MaximumBatchingWindowInSeconds` is only simulated as 0. A partial batch is delivered as soon as
   anything is on the event source, leaving a batching window nothing to wait for. A non-zero value

--- a/docs/services/lambda/sim-lambda-event-source-filter-criteria.example.ts
+++ b/docs/services/lambda/sim-lambda-event-source-filter-criteria.example.ts
@@ -1,0 +1,99 @@
+/**
+ * Delivering only the queue messages a filter matches.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import {
+  CreateEventSourceMappingCommand,
+  CreateFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { CreateQueueCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+
+import { SimAws } from "@kensio/yulin";
+import {
+  makeLambdaZipFileInput,
+  type SimLambdaSqsEvent,
+} from "@kensio/yulin/lambda";
+
+const simAws = new SimAws();
+const queueArn = `arn:aws:sqs:${simAws.defaultRegionName}:${simAws.defaultAccountId}:orders`;
+
+const { QueueUrl } = await simAws
+  .sqs()
+  .createQueue(new CreateQueueCommand({ QueueName: "orders" }));
+
+const role = await simAws.iam().createRole(
+  new CreateRoleCommand({
+    RoleName: "ShippedOrdersRole",
+    AssumeRolePolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Principal: { Service: "lambda.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    }),
+  }),
+);
+
+await simAws.iam().putRolePolicy(
+  new PutRolePolicyCommand({
+    RoleName: "ShippedOrdersRole",
+    PolicyName: "ConsumeOrders",
+    PolicyDocument: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: {
+        Effect: "Allow",
+        Action: [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ],
+        Resource: queueArn,
+      },
+    }),
+  }),
+);
+
+const shipped: string[] = [];
+
+await simAws.lambda().createFunction(
+  new CreateFunctionCommand({
+    FunctionName: "shipped-orders",
+    Role: role.Role.Arn,
+    Code: {
+      ZipFile: makeLambdaZipFileInput((event: SimLambdaSqsEvent) => {
+        for (const record of event.Records) {
+          shipped.push(
+            (JSON.parse(record.body) as { orderId: string }).orderId,
+          );
+        }
+      }),
+    },
+  }),
+);
+
+await simAws.lambda().createEventSourceMapping(
+  new CreateEventSourceMappingCommand({
+    EventSourceArn: queueArn,
+    FunctionName: "shipped-orders",
+    FilterCriteria: {
+      Filters: [{ Pattern: JSON.stringify({ body: { status: ["shipped"] } }) }],
+    },
+  }),
+);
+
+for (const order of [
+  { orderId: "order-1", status: "placed" },
+  { orderId: "order-2", status: "shipped" },
+]) {
+  await simAws
+    .sqs()
+    .sendMessage(
+      new SendMessageCommand({ QueueUrl, MessageBody: JSON.stringify(order) }),
+    );
+}
+
+await simAws.backgroundTasksComplete();
+
+console.log(shipped); // ["order-2"]

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -461,7 +461,8 @@ that differs from an `Invoke`.
 
 ## Event source mappings
 
-`event-source/` owns delivery from a simulated SQS queue or DynamoDB stream to a function.
+`event-source/` owns delivery from a simulated SQS queue, DynamoDB stream or Kinesis stream to a
+function.
 
 The machinery is split by event source kind rather than assuming one.
 `sim-lambda-event-source-arn.ts` reads the ARN a mapping names into a union discriminated by `kind`,

--- a/src/service/lambda/README.md
+++ b/src/service/lambda/README.md
@@ -881,7 +881,7 @@ and are skipped by the CloudFormation engine with an "Unsupported" diagnostic.
 - `AWS::Lambda::*` CloudFormation resource types other than `AWS::Lambda::Function`,
   `AWS::Lambda::Url`, `AWS::Lambda::Permission`, `AWS::Lambda::Version`, `AWS::Lambda::Alias`,
   `AWS::Lambda::EventSourceMapping` and `AWS::Lambda::EventInvokeConfig`
-- event sources other than SQS queues and DynamoDB streams, `FilterCriteria`,
+- event sources other than SQS queues, DynamoDB streams and Kinesis streams,
   `UpdateEventSourceMapping`, and polling concurrency
 - `InvokeMode: RESPONSE_STREAM`, which is accepted and reported but always served buffered
 - ES module function code (`.mjs` / `export` syntax) in the vm runtime

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-properties.ts
@@ -1,3 +1,4 @@
+import { simLambdaFilterCriteriaInput } from "../../event-source/filter/sim-lambda-filter-criteria.js";
 import { simLambdaStreamDestinationConfig } from "../../event-source/sim-lambda-stream-destination-config.js";
 import type { SimCfnResource } from "../../../cloudformation/resource/sim-cfn-resource.js";
 import type { SimCfnTemplateValueRecord } from "../../../cloudformation/template/value/sim-cfn-template-value.js";
@@ -104,6 +105,9 @@ export class SimCfnLambdaEventSourceMappingProperties {
       ),
       StartingPositionTimestamp: this.startingPositionTimestamp(),
       FunctionResponseTypes: this.functionResponseTypes(),
+      FilterCriteria: simLambdaFilterCriteriaInput(
+        this.properties["FilterCriteria"],
+      ),
     };
   }
 

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-names.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping-property-names.ts
@@ -48,12 +48,8 @@ export const unsimulatedPropertyReasons: ReadonlyMap<string, string> = new Map([
   ["AmazonManagedKafkaEventSourceConfig", absentEventSource],
   ["DocumentDBEventSourceConfig", absentEventSource],
   [
-    "FilterCriteria",
-    "every record on the event source is delivered to the function, unfiltered",
-  ],
-  [
     "KmsKeyArn",
-    "the key encrypts filter criteria, and filter criteria are not simulated",
+    "filter criteria are simulated in plaintext, and encrypting them is not",
   ],
   ["MetricsConfig", "the mapping publishes no CloudWatch metrics"],
   [

--- a/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
+++ b/src/service/lambda/cfn/event-source-mapping/sim-cfn-lambda-event-source-mapping.iso.test.ts
@@ -248,7 +248,7 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
     assertStringIncludes(error.message, "Nonsense");
   });
 
-  it("records mapping settings it cannot act on rather than failing the stack", async () => {
+  it("records a mapping setting it cannot act on rather than failing the stack", async () => {
     // Given a mapping asking for a tumbling window and event filtering, as a
     // CDK event source carrying those options synthesises one.
     const simAws = new SimAws();
@@ -283,24 +283,31 @@ describe("Lambda CloudFormation event source mapping deployment", () => {
 
     assertArrayIncludesAll(
       resource.ignoredProperties.map((ignored) => ignored.path),
-      ["TumblingWindowInSeconds", "FilterCriteria"],
+      ["TumblingWindowInSeconds"],
     );
     assertArrayIncludesAll(
       stack.ignoredProperties.map((ignored) => ignored.path),
-      ["TumblingWindowInSeconds", "FilterCriteria"],
+      ["TumblingWindowInSeconds"],
     );
 
-    // And it delivers, unfiltered, as the recorded reason says it does.
-    await simAws.sqs().sendMessage(
-      new SendMessageCommand({
-        QueueUrl: simAws.sqs().findQueue("orders")?.url,
-        MessageBody: "order-1",
-      }),
-    );
+    // And the filter the template asked for is applied, so only the message it
+    // names reaches the function.
+    const queueUrl = simAws.sqs().findQueue("orders")?.url;
+
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-1" }),
+      );
+    await simAws
+      .sqs()
+      .sendMessage(
+        new SendMessageCommand({ QueueUrl: queueUrl, MessageBody: "order-2" }),
+      );
     await simAws.backgroundTasksComplete();
 
     assertArrayLength(events, 1);
-    assertIdentical(events[0].Records[0]?.body, "order-1");
+    assertIdentical(events[0].Records[0]?.body, "order-2");
   });
 
   it("records a property AWS::Lambda::EventSourceMapping does not have", async () => {

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-input.ts
@@ -8,6 +8,7 @@ import {
   simLambdaEventSourceArnOf,
 } from "../../event-source/sim-lambda-event-source-arn.js";
 import type { SimLambdaFunctionResponseType } from "../../event-source/sim-lambda-event-source-mapping.js";
+import { SimLambdaFilterCriteria } from "../../event-source/filter/sim-lambda-filter-criteria.js";
 import type { SimLambdaStreamRetryLimits } from "../../event-source/sim-lambda-stream-retry-limits.js";
 import type { SimLambdaEventSourceStart } from "../../event-source/sim-lambda-event-source-starting-position.js";
 import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
@@ -34,6 +35,7 @@ interface SimLambdaEventSourceMappingInputProperties {
     | SimLambdaStreamDestinationConfiguration
     | undefined;
   readonly streamRetryLimits: SimLambdaStreamRetryLimits | undefined;
+  readonly filterCriteria: SimLambdaFilterCriteria | undefined;
 }
 
 /**
@@ -73,6 +75,11 @@ export class SimLambdaEventSourceMappingInput {
    */
   public readonly streamRetryLimits: SimLambdaStreamRetryLimits | undefined;
 
+  /**
+   * The filters this mapping delivers through, if it was created with any.
+   */
+  public readonly filterCriteria: SimLambdaFilterCriteria | undefined;
+
   private constructor(properties: SimLambdaEventSourceMappingInputProperties) {
     this.eventSourceArn = properties.eventSourceArn;
     this.functionName = properties.functionName;
@@ -83,6 +90,7 @@ export class SimLambdaEventSourceMappingInput {
     this.functionResponseTypes = properties.functionResponseTypes;
     this.destinationConfig = properties.destinationConfig;
     this.streamRetryLimits = properties.streamRetryLimits;
+    this.filterCriteria = properties.filterCriteria;
   }
 
   /**
@@ -114,6 +122,10 @@ export class SimLambdaEventSourceMappingInput {
       }),
       enabled: input.Enabled ?? true,
       functionResponseTypes: functionResponseTypesIn(input),
+      filterCriteria: SimLambdaFilterCriteria.of(
+        input.FilterCriteria,
+        eventSourceArn.kind,
+      ),
       streamRetryLimits: eventSourceArn.retryLimitRules.limitsIn({
         maximumRetryAttempts: input.MaximumRetryAttempts,
         maximumRecordAgeInSeconds: input.MaximumRecordAgeInSeconds,

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-refusals.ts
@@ -11,7 +11,6 @@ import type { SimCreateEventSourceMappingCommandInput } from "./event-source-map
  * would not have.
  */
 const unsimulatedInputs: ReadonlyMap<string, string> = new Map([
-  ["FilterCriteria", "event filtering is not simulated"],
   ["ScalingConfig", "polling concurrency is not simulated"],
   ["ProvisionedPollerConfig", "polling concurrency is not simulated"],
   [

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping-validation.iso.test.ts
@@ -248,18 +248,34 @@ describe("sim Lambda CreateEventSourceMapping validation", () => {
     assertStringIncludes(error.message, "ReportEverything");
   });
 
-  it("refuses filter criteria, which would change what the function sees", async () => {
+  it("refuses a queue filter on anything but the message body", async () => {
     // Given a queue and a function.
     const ready = await simAwsReadyToMap();
 
-    // When a mapping asks for event filtering.
+    // When a mapping asks to filter on a message's metadata.
     const error = await refusedMapping(ready, {
-      FilterCriteria: { Filters: [{ Pattern: "{}" }] },
+      FilterCriteria: { Filters: [{ Pattern: '{"messageId":["order-1"]}' }] },
     });
 
-    // Then it is refused rather than delivering everything.
+    // Then it is refused, since real Lambda filters a queue on the body alone.
     assertStringIncludes(error.message, "FilterCriteria");
-    assertStringIncludes(error.message, "not simulated");
+    assertStringIncludes(error.message, "messageId");
+  });
+
+  it("refuses a filter pattern the simulated matcher cannot evaluate", async () => {
+    // Given a queue and a function.
+    const ready = await simAwsReadyToMap();
+
+    // When a mapping asks for an operator this simulation has no behaviour for.
+    const error = await refusedMapping(ready, {
+      FilterCriteria: {
+        Filters: [{ Pattern: '{"body":[{"wildcard":"order-*"}]}' }],
+      },
+    });
+
+    // Then it is refused by name rather than matching nothing.
+    assertStringIncludes(error.message, "FilterCriteria");
+    assertStringIncludes(error.message, "wildcard");
   });
 
   it("refuses a mapping on a standalone simulated Lambda with no queues", async () => {

--- a/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
+++ b/src/service/lambda/command/event-source-mapping/create-event-source-mapping.handler.ts
@@ -147,6 +147,7 @@ export class CreateEventSourceMappingCommandHandler implements CommandHandler<
       enabled: input.enabled,
       functionResponseTypes: input.functionResponseTypes,
       streamRetryLimits: input.streamRetryLimits,
+      filterCriteria: input.filterCriteria,
       destinationConfig: input.destinationConfig,
       destinations: this.properties.destinations,
       createdAt: this.properties.background.now(),

--- a/src/service/lambda/command/event-source-mapping/event-source-mapping.command.ts
+++ b/src/service/lambda/command/event-source-mapping/event-source-mapping.command.ts
@@ -1,3 +1,4 @@
+import type { SimLambdaFilterCriteriaInput } from "../../event-source/filter/sim-lambda-filter-criteria.js";
 /**
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/command/CreateEventSourceMappingCommand/
  *
@@ -35,7 +36,7 @@ export interface SimCreateEventSourceMappingCommandInput {
   readonly BatchSize?: number | undefined;
   readonly MaximumBatchingWindowInSeconds?: number | undefined;
   readonly FunctionResponseTypes?: readonly string[] | undefined;
-  readonly FilterCriteria?: object | undefined;
+  readonly FilterCriteria?: SimLambdaFilterCriteriaInput | undefined;
   readonly ScalingConfig?: object | undefined;
   readonly DestinationConfig?: object | undefined;
   readonly SelfManagedEventSource?: object | undefined;

--- a/src/service/lambda/event-source/filter/sim-lambda-filter-criteria.ts
+++ b/src/service/lambda/event-source/filter/sim-lambda-filter-criteria.ts
@@ -1,0 +1,183 @@
+import { SimEventPattern } from "../../../eventbridge/pattern/sim-event-pattern.js";
+import { SimLambdaInvalidParameterValueException } from "../../error/sim-lambda.error.js";
+import { isRecord } from "../../../../util/type-guard/record.js";
+
+/**
+ * The `FilterCriteria` a CreateEventSourceMapping request carries, as the
+ * command takes it.
+ */
+export interface SimLambdaFilterCriteriaInput {
+  readonly Filters?:
+    | readonly { readonly Pattern?: string | undefined }[]
+    | undefined;
+}
+
+/**
+ * The one key an SQS mapping may filter on.
+ *
+ * Real Lambda filters an SQS message on its body alone, where a stream mapping
+ * filters on the whole record. A pattern naming anything else is refused here,
+ * since accepting one would match nothing and read as a pattern that was
+ * simply too specific.
+ */
+const sqsFilterKey = "body";
+
+/**
+ * Read a `FilterCriteria` value of unknown shape, as a template carries one.
+ *
+ * The same shape check for an SDK request and a CloudFormation Resource, so a
+ * mapping a template deployed filters the way an SDK caller's would.
+ */
+export function simLambdaFilterCriteriaInput(
+  value: unknown,
+): SimLambdaFilterCriteriaInput | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const filters = isRecord(value) ? value["Filters"] : undefined;
+
+  if (!Array.isArray(filters)) {
+    throw new SimLambdaInvalidParameterValueException(
+      `FilterCriteria carries a Filters list, and this one carries ${JSON.stringify(
+        value,
+      )}`,
+    );
+  }
+
+  return { Filters: filters.map((filter) => ({ Pattern: patternIn(filter) })) };
+}
+
+/**
+ * The pattern one filter of a list carries.
+ */
+function patternIn(filter: unknown): string | undefined {
+  const pattern = isRecord(filter) ? filter["Pattern"] : undefined;
+
+  if (pattern !== undefined && typeof pattern !== "string") {
+    throw new SimLambdaInvalidParameterValueException(
+      "A filter in FilterCriteria carries a Pattern string, and this one " +
+        `carries ${JSON.stringify(pattern)}`,
+    );
+  }
+
+  return pattern;
+}
+
+/**
+ * The filters a mapping delivers through, read from what a request asked for.
+ *
+ * A record is delivered when any one of the filters matches it, which is how
+ * real Lambda ORs a list of patterns together. A mapping with no criteria has
+ * none of these, and delivers everything.
+ *
+ * The patterns are EventBridge event patterns. Lambda documents its filter
+ * rules as EventBridge's own syntax, so simulated EventBridge's matcher is what
+ * evaluates them, down to the operators it refuses.
+ */
+export class SimLambdaFilterCriteria {
+  private readonly patterns: readonly SimEventPattern[];
+
+  private constructor(patterns: readonly SimEventPattern[]) {
+    this.patterns = patterns;
+  }
+
+  /**
+   * Read the criteria a request carries, refusing a pattern this simulation
+   * cannot evaluate.
+   *
+   * The refusal comes before the mapping exists, because a mapping created
+   * with a filter it cannot apply would deliver the wrong records rather than
+   * none.
+   */
+  static of(
+    criteria: SimLambdaFilterCriteriaInput | undefined,
+    eventSourceKind: string,
+  ): SimLambdaFilterCriteria | undefined {
+    const filters = criteria?.Filters ?? [];
+
+    if (filters.length === 0) {
+      return undefined;
+    }
+
+    return new this(
+      filters.map((filter) => patternOf(filter.Pattern, eventSourceKind)),
+    );
+  }
+
+  /**
+   * The criteria as Create, Get and List report them back.
+   */
+  configuration(): SimLambdaFilterCriteriaInput {
+    return {
+      Filters: this.patterns.map((pattern) => ({ Pattern: pattern.source })),
+    };
+  }
+
+  /**
+   * Whether a record, as a pattern reads it, passes any of these filters.
+   */
+  matches(document: Record<string, unknown>): boolean {
+    return this.patterns.some((pattern) => pattern.matches(document));
+  }
+}
+
+/**
+ * One filter's pattern, refused as a Lambda parameter rather than as an
+ * EventBridge one.
+ *
+ * The matcher is EventBridge's and says so when it refuses a pattern, and the
+ * caller here sent a Lambda request. The reason survives and the exception type
+ * changes.
+ */
+function patternOf(
+  source: string | undefined,
+  eventSourceKind: string,
+): SimEventPattern {
+  if (source === undefined || source === "") {
+    throw new SimLambdaInvalidParameterValueException(
+      "A filter in FilterCriteria carries a Pattern, and this one carries " +
+        "none",
+    );
+  }
+
+  refuseUnfilterableKeys(source, eventSourceKind);
+
+  try {
+    return SimEventPattern.of(source);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+
+    throw new SimLambdaInvalidParameterValueException(
+      `FilterCriteria pattern ${source} cannot be evaluated. ${reason}`,
+    );
+  }
+}
+
+/**
+ * Refuse a pattern naming a key the event source does not filter on.
+ */
+function refuseUnfilterableKeys(source: string, eventSourceKind: string): void {
+  if (eventSourceKind !== "sqs") {
+    return;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    // An unparseable pattern is the matcher's refusal to make, in its own
+    // words, and it is about to make it.
+    return;
+  }
+
+  const named = isRecord(parsed) ? Object.keys(parsed) : [];
+  const unfilterable = named.filter((key) => key !== sqsFilterKey);
+
+  if (unfilterable.length > 0) {
+    throw new SimLambdaInvalidParameterValueException(
+      `FilterCriteria on an SQS event source mapping filters on ${sqsFilterKey} alone, and this pattern names ${unfilterable.join(", ")}`,
+    );
+  }
+}

--- a/src/service/lambda/event-source/filter/sim-lambda-filtered-delivery.ts
+++ b/src/service/lambda/event-source/filter/sim-lambda-filtered-delivery.ts
@@ -1,0 +1,44 @@
+import type { SimLambdaFilterCriteria } from "./sim-lambda-filter-criteria.js";
+import { simLambdaFilteredRecords } from "./sim-lambda-filtered-records.js";
+
+interface SimLambdaFilteredDeliveryProperties<RecordType, Outcome> {
+  readonly criteria: SimLambdaFilterCriteria | undefined;
+  readonly records: readonly RecordType[];
+
+  /**
+   * What a pattern reads one record as, which is the source's translation.
+   */
+  readonly documentOf: (record: RecordType) => Record<string, unknown>;
+
+  /**
+   * What becomes of a batch the filters emptied.
+   */
+  readonly handled: () => Outcome;
+
+  /**
+   * Hand the records that matched to the function.
+   */
+  readonly invoke: (delivered: readonly RecordType[]) => Promise<Outcome>;
+}
+
+/**
+ * Deliver the records of a batch a mapping's filters let through.
+ *
+ * A batch the filters emptied is finished with and the function is never
+ * invoked, which is the one rule every source shares. What being finished with
+ * means is the source's own, and so is what a pattern reads a record as, so
+ * both are handed in.
+ */
+export async function simLambdaFilteredDelivery<RecordType, Outcome>(
+  properties: SimLambdaFilteredDeliveryProperties<RecordType, Outcome>,
+): Promise<Outcome> {
+  const delivered = simLambdaFilteredRecords(
+    properties.criteria,
+    properties.records,
+    properties.documentOf,
+  );
+
+  return delivered.length === 0
+    ? properties.handled()
+    : await properties.invoke(delivered);
+}

--- a/src/service/lambda/event-source/filter/sim-lambda-filtered-records.ts
+++ b/src/service/lambda/event-source/filter/sim-lambda-filtered-records.ts
@@ -1,0 +1,42 @@
+import type { SimLambdaFilterCriteria } from "./sim-lambda-filter-criteria.js";
+
+/**
+ * The records of a batch a mapping's filters let through.
+ *
+ * A mapping with no criteria delivers the batch it read. One with criteria
+ * delivers the records that match, and treats the rest as handled: a stream
+ * moves its checkpoint past them and a queue deletes them, which is what real
+ * Lambda does with a record it filtered out.
+ *
+ * What a pattern reads is the record as the function would have received it,
+ * with the source's own data field decoded. That translation is the source's,
+ * so it is handed in.
+ */
+export function simLambdaFilteredRecords<RecordType>(
+  criteria: SimLambdaFilterCriteria | undefined,
+  records: readonly RecordType[],
+  documentOf: (record: RecordType) => Record<string, unknown>,
+): readonly RecordType[] {
+  if (criteria === undefined) {
+    return records;
+  }
+
+  return records.filter((record) => criteria.matches(documentOf(record)));
+}
+
+/**
+ * The JSON a data field holds, or the text it is when it holds no JSON.
+ *
+ * Real Lambda filters a record's data only when both the data and the pattern
+ * for it are JSON. Text that parses is handed to the pattern as the object it
+ * parses to, and text that does not is handed over as itself, which a pattern
+ * written for an object then fails to match. Either way the record is dropped
+ * exactly where AWS drops it.
+ */
+export function simLambdaFilterData(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-delivery.ts
@@ -2,11 +2,16 @@ import type { SimLambdaFunction } from "../../../function/sim-lambda-function.js
 import type { SimLambdaEventSourceMapping } from "../../sim-lambda-event-source-mapping.js";
 import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
 import type { SimLambdaKinesisStreamRecord } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
+import type { SimLambdaFilterCriteria } from "../../filter/sim-lambda-filter-criteria.js";
+import { simLambdaFilteredDelivery } from "../../filter/sim-lambda-filtered-delivery.js";
 import { SimLambdaStreamCascadeGuard } from "../../stream/sim-lambda-stream-cascade-guard.js";
 import { SimLambdaStreamHalt } from "../../stream/sim-lambda-stream-halt.js";
 import { countSimLambdaKinesisIteratorAge } from "../sim-lambda-stream-iterator-age.js";
-import { simLambdaKinesisStreamRecordTimes } from "../sim-lambda-stream-record-times.js";
-import type { SimLambdaStreamBatchOutcome } from "../sim-lambda-stream-batch-outcome.js";
+import {
+  simLambdaKinesisStreamRecordTimes,
+  type SimLambdaStreamRecordTime,
+} from "../sim-lambda-stream-record-times.js";
+import { SimLambdaStreamBatchOutcome } from "../sim-lambda-stream-batch-outcome.js";
 import { SimLambdaStreamBatchResponse } from "../sim-lambda-stream-batch-response.js";
 import { SimLambdaKinesisStreamEventBuilder } from "./sim-lambda-kinesis-stream-event.js";
 
@@ -33,9 +38,12 @@ export class SimLambdaKinesisStreamDelivery {
   private readonly batchResponse: SimLambdaStreamBatchResponse;
   private readonly cascade: SimLambdaStreamCascadeGuard;
   private readonly halt = new SimLambdaStreamHalt();
+  private readonly filterCriteria: SimLambdaFilterCriteria | undefined;
 
   constructor(properties: SimLambdaKinesisStreamDeliveryProperties) {
     const { eventSourceArn } = properties;
+
+    this.filterCriteria = properties.mapping.filterCriteria;
 
     this.eventBuilder = new SimLambdaKinesisStreamEventBuilder({
       eventSourceArn,
@@ -98,10 +106,28 @@ export class SimLambdaKinesisStreamDelivery {
   ): Promise<SimLambdaStreamBatchOutcome> {
     const times = simLambdaKinesisStreamRecordTimes(records);
 
+    return await simLambdaFilteredDelivery({
+      criteria: this.filterCriteria,
+      records,
+      documentOf: (record) => this.eventBuilder.filterDocumentOf(record),
+      // A batch the filters emptied is finished with even though the function
+      // never saw it, as a filtered record advances a real checkpoint too.
+      handled: () => SimLambdaStreamBatchOutcome.handled(times),
+      invoke: async (delivered) =>
+        await this.invoked(simFunction, delivered, times, records),
+    });
+  }
+
+  private async invoked(
+    simFunction: SimLambdaFunction,
+    delivered: readonly SimLambdaKinesisStreamRecord[],
+    times: readonly SimLambdaStreamRecordTime[],
+    records: readonly SimLambdaKinesisStreamRecord[],
+  ): Promise<SimLambdaStreamBatchOutcome> {
     try {
       return this.batchResponse.handled(
         times,
-        await simFunction.invoke(this.eventBuilder.of(records)),
+        await simFunction.invoke(this.eventBuilder.of(delivered)),
       );
     } catch {
       // As on real Lambda, the handler error goes to the function's logs. What

--- a/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event.ts
+++ b/src/service/lambda/event-source/poll/kinesis/sim-lambda-kinesis-stream-event.ts
@@ -1,5 +1,6 @@
 import type { SimLambdaKinesisEventSourceArn } from "../../stream/kinesis/sim-lambda-kinesis-event-source-arn.js";
 import type { SimLambdaKinesisStreamRecord } from "../../stream/kinesis/sim-lambda-kinesis-streams.js";
+import { simLambdaFilterData } from "../../filter/sim-lambda-filtered-records.js";
 import type {
   SimLambdaKinesisStreamEvent,
   SimLambdaKinesisStreamEventRecord,
@@ -51,7 +52,28 @@ export class SimLambdaKinesisStreamEventBuilder {
   of(
     records: readonly SimLambdaKinesisStreamRecord[],
   ): SimLambdaKinesisStreamEvent {
-    return { Records: records.map((record) => this.record(record)) };
+    return { Records: records.map((record) => this.recordOf(record)) };
+  }
+
+  /**
+   * What a mapping's filters read one record as.
+   *
+   * The event record carries the payload base64 encoded under `kinesis`, and a
+   * Lambda filter pattern addresses it as JSON under a top-level `data`. Both
+   * are here, so a pattern can name the payload the way AWS documents it and
+   * the record's metadata the way the event carries it.
+   */
+  filterDocumentOf(
+    record: SimLambdaKinesisStreamRecord,
+  ): Record<string, unknown> {
+    const eventRecord = this.recordOf(record);
+
+    return {
+      ...eventRecord,
+      data: simLambdaFilterData(
+        Buffer.from(eventRecord.kinesis.data, "base64").toString("utf8"),
+      ),
+    };
   }
 
   /**
@@ -65,7 +87,10 @@ export class SimLambdaKinesisStreamEventBuilder {
     return `${this.shardId}:${record.SequenceNumber ?? ""}`;
   }
 
-  private record(
+  /**
+   * The event record one polled record becomes.
+   */
+  recordOf(
     record: SimLambdaKinesisStreamRecord,
   ): SimLambdaKinesisStreamEventRecord {
     return {

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-delivery.ts
@@ -2,12 +2,17 @@ import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimLambdaEventSourceMapping } from "../sim-lambda-event-source-mapping.js";
 import type { SimLambdaDynamoDbStreamEventSourceArn } from "../stream/sim-lambda-dynamodb-stream-event-source-arn.js";
 import type { SimLambdaEventSourceStreamRecord } from "../stream/sim-lambda-event-source-streams.js";
+import type { SimLambdaFilterCriteria } from "../filter/sim-lambda-filter-criteria.js";
+import { simLambdaFilteredDelivery } from "../filter/sim-lambda-filtered-delivery.js";
 import { SimLambdaStreamCascadeGuard } from "../stream/sim-lambda-stream-cascade-guard.js";
 import { SimLambdaStreamHalt } from "../stream/sim-lambda-stream-halt.js";
 import { SimLambdaDynamoDbStreamEventBuilder } from "./sim-lambda-dynamodb-stream-event.js";
 import { countSimLambdaDynamoDbIteratorAge } from "./sim-lambda-stream-iterator-age.js";
-import { simLambdaDynamoDbStreamRecordTimes } from "./sim-lambda-stream-record-times.js";
-import type { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
+import {
+  simLambdaDynamoDbStreamRecordTimes,
+  type SimLambdaStreamRecordTime,
+} from "./sim-lambda-stream-record-times.js";
+import { SimLambdaStreamBatchOutcome } from "./sim-lambda-stream-batch-outcome.js";
 import { SimLambdaStreamBatchResponse } from "./sim-lambda-stream-batch-response.js";
 
 interface SimLambdaDynamoDbStreamDeliveryProperties {
@@ -36,8 +41,10 @@ export class SimLambdaDynamoDbStreamDelivery {
   private readonly batchResponse: SimLambdaStreamBatchResponse;
   private readonly cascade: SimLambdaStreamCascadeGuard;
   private readonly halt = new SimLambdaStreamHalt();
+  private readonly filterCriteria: SimLambdaFilterCriteria | undefined;
 
   constructor(properties: SimLambdaDynamoDbStreamDeliveryProperties) {
+    this.filterCriteria = properties.mapping.filterCriteria;
     this.eventBuilder = new SimLambdaDynamoDbStreamEventBuilder(
       properties.eventSourceArn,
     );
@@ -97,10 +104,30 @@ export class SimLambdaDynamoDbStreamDelivery {
   ): Promise<SimLambdaStreamBatchOutcome> {
     const times = simLambdaDynamoDbStreamRecordTimes(records);
 
+    return await simLambdaFilteredDelivery({
+      criteria: this.filterCriteria,
+      records,
+      // A pattern reads the record as the function would have received it, so
+      // the event builder makes what it matches against.
+      documentOf: (record) => ({ ...this.eventBuilder.recordOf(record) }),
+      // A batch the filters emptied is finished with even though the function
+      // never saw it, as a filtered record advances a real checkpoint too.
+      handled: () => SimLambdaStreamBatchOutcome.handled(times),
+      invoke: async (delivered) =>
+        await this.invoked(simFunction, delivered, times, records),
+    });
+  }
+
+  private async invoked(
+    simFunction: SimLambdaFunction,
+    delivered: readonly SimLambdaEventSourceStreamRecord[],
+    times: readonly SimLambdaStreamRecordTime[],
+    records: readonly SimLambdaEventSourceStreamRecord[],
+  ): Promise<SimLambdaStreamBatchOutcome> {
     try {
       return this.batchResponse.handled(
         times,
-        await simFunction.invoke(this.eventBuilder.of(records)),
+        await simFunction.invoke(this.eventBuilder.of(delivered)),
       );
     } catch {
       // As on real Lambda, the handler error goes to the function's logs. What

--- a/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-dynamodb-stream-event.ts
@@ -33,10 +33,14 @@ export class SimLambdaDynamoDbStreamEventBuilder {
   of(
     records: readonly SimLambdaEventSourceStreamRecord[],
   ): SimLambdaDynamoDbStreamEvent {
-    return { Records: records.map((record) => this.record(record)) };
+    return { Records: records.map((record) => this.recordOf(record)) };
   }
 
-  private record(
+  /**
+   * The event record one polled record becomes, which is also what a mapping's
+   * filters are matched against.
+   */
+  recordOf(
     record: SimLambdaEventSourceStreamRecord,
   ): SimLambdaDynamoDbStreamEventRecord {
     const identity = record.userIdentity;

--- a/src/service/lambda/event-source/poll/sim-lambda-event-source-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-event-source-delivery.ts
@@ -1,9 +1,11 @@
 import type { SimLambdaFunction } from "../../function/sim-lambda-function.js";
 import type { SimSqsPollMessage } from "../../../sqs/poll/sim-sqs-poll-message.js";
-import type {
+import {
   SimLambdaEventSourceBatchOutcome,
-  SimLambdaEventSourceBatchResponse,
+  type SimLambdaEventSourceBatchResponse,
 } from "./sim-lambda-event-source-batch-response.js";
+import type { SimLambdaFilterCriteria } from "../filter/sim-lambda-filter-criteria.js";
+import { simLambdaFilteredDelivery } from "../filter/sim-lambda-filtered-delivery.js";
 
 /**
  * One record of an event source event.
@@ -31,11 +33,18 @@ export interface SimLambdaEventSourceEvent {
  */
 export interface SimLambdaEventSourceEventBuilder {
   of(messages: readonly SimSqsPollMessage[]): SimLambdaEventSourceEvent;
+
+  /**
+   * What a mapping's filters read one message as, which is the source's own
+   * translation.
+   */
+  filterDocumentOf(message: SimSqsPollMessage): Record<string, unknown>;
 }
 
 interface SimLambdaEventSourceDeliveryProperties {
   readonly eventBuilder: SimLambdaEventSourceEventBuilder;
   readonly batchResponse: SimLambdaEventSourceBatchResponse;
+  readonly filterCriteria: SimLambdaFilterCriteria | undefined;
 }
 
 /**
@@ -51,10 +60,12 @@ interface SimLambdaEventSourceDeliveryProperties {
 export class SimLambdaEventSourceDelivery {
   private readonly eventBuilder: SimLambdaEventSourceEventBuilder;
   private readonly batchResponse: SimLambdaEventSourceBatchResponse;
+  private readonly filterCriteria: SimLambdaFilterCriteria | undefined;
 
   constructor(properties: SimLambdaEventSourceDeliveryProperties) {
     this.eventBuilder = properties.eventBuilder;
     this.batchResponse = properties.batchResponse;
+    this.filterCriteria = properties.filterCriteria;
   }
 
   /**
@@ -64,16 +75,55 @@ export class SimLambdaEventSourceDelivery {
     simFunction: SimLambdaFunction,
     messages: readonly SimSqsPollMessage[],
   ): Promise<SimLambdaEventSourceBatchOutcome> {
+    return await simLambdaFilteredDelivery({
+      criteria: this.filterCriteria,
+      records: messages,
+      documentOf: (message) => this.eventBuilder.filterDocumentOf(message),
+      // A message the filters excluded is deleted from the queue without the
+      // function seeing it, the way real Lambda deletes one.
+      handled: () => new SimLambdaEventSourceBatchOutcome(messages, []),
+      invoke: async (delivered) =>
+        this.alsoHandling(messages, await this.invoked(simFunction, delivered)),
+    });
+  }
+
+  /**
+   * One batch of matching messages, handed over and read back.
+   */
+  private async invoked(
+    simFunction: SimLambdaFunction,
+    delivered: readonly SimSqsPollMessage[],
+  ): Promise<SimLambdaEventSourceBatchOutcome> {
     try {
       return this.batchResponse.handled(
-        messages,
-        await simFunction.invoke(this.eventBuilder.of(messages)),
+        delivered,
+        await simFunction.invoke(this.eventBuilder.of(delivered)),
       );
     } catch {
       // As on real Lambda, the handler error goes to the function's logs and
       // not to whoever sent the message. What the sender sees is the batch
       // coming back to the source.
-      return this.batchResponse.failed(messages);
+      return this.batchResponse.failed(delivered);
     }
+  }
+
+  /**
+   * An outcome with the filtered-out messages counted as handled, which deletes
+   * them whatever the function said about the rest.
+   *
+   * A message the function never saw is in neither list the outcome carries,
+   * which is what picks it out of the batch that was read.
+   */
+  private alsoHandling(
+    messages: readonly SimSqsPollMessage[],
+    outcome: SimLambdaEventSourceBatchOutcome,
+  ): SimLambdaEventSourceBatchOutcome {
+    const seen = new Set([...outcome.handled, ...outcome.returned]);
+    const excluded = messages.filter((message) => !seen.has(message));
+
+    return new SimLambdaEventSourceBatchOutcome(
+      [...outcome.handled, ...excluded],
+      outcome.returned,
+    );
   }
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-delivery.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-delivery.ts
@@ -24,5 +24,6 @@ export function makeSimLambdaSqsDelivery(
     batchResponse: new SimLambdaSqsBatchResponse(
       properties.mapping.reportsBatchItemFailures,
     ),
+    filterCriteria: properties.mapping.filterCriteria,
   });
 }

--- a/src/service/lambda/event-source/poll/sim-lambda-sqs-event.ts
+++ b/src/service/lambda/event-source/poll/sim-lambda-sqs-event.ts
@@ -2,6 +2,7 @@ import type {
   SimSqsPollMessage,
   SimSqsPollMessageAttribute,
 } from "../../../sqs/poll/sim-sqs-poll-message.js";
+import { simLambdaFilterData } from "../filter/sim-lambda-filtered-records.js";
 import type { SimLambdaSqsEventSourceArn } from "../queue/sim-lambda-sqs-event-source-arn.js";
 
 /**
@@ -62,6 +63,17 @@ export class SimLambdaSqsEventBuilder {
    */
   of(messages: readonly SimSqsPollMessage[]): SimLambdaSqsEvent {
     return { Records: messages.map((message) => this.record(message)) };
+  }
+
+  /**
+   * What a mapping's filters read one message as.
+   *
+   * Real Lambda filters an SQS message on its body alone, and reads the body as
+   * JSON where it holds JSON. Nothing else about the message is here, because a
+   * pattern naming anything else was refused when the mapping was created.
+   */
+  filterDocumentOf(message: SimSqsPollMessage): Record<string, unknown> {
+    return { body: simLambdaFilterData(message.Body) };
   }
 
   private record(message: SimSqsPollMessage): SimLambdaSqsEventRecord {

--- a/src/service/lambda/event-source/sim-lambda-event-source-filtering.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-filtering.iso.test.ts
@@ -178,8 +178,9 @@ describe("sim Lambda event source mapping filter criteria", () => {
     );
     await simAws.backgroundTasksComplete();
 
-    // Then the checkpoint moved past the excluded record and the matching one
-    // arrived behind it.
+    // Then the excluded record was never handed over at all, the checkpoint
+    // moved past it, and the matching one arrived behind it.
+    assertArrayLength(events, 1);
     assertArrayEquals(events.flatMap(streamedOrderIds), ["order-2"]);
   });
 

--- a/src/service/lambda/event-source/sim-lambda-event-source-filtering.iso.test.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-filtering.iso.test.ts
@@ -1,0 +1,275 @@
+import { PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { GetEventSourceMappingCommand } from "@aws-sdk/client-lambda";
+import { PutRecordCommand } from "@aws-sdk/client-kinesis";
+import { ReceiveMessageCommand, SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  assertArrayEmpty,
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+  assertUndefined,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { simAwsWithKinesisEventSource } from "../../../../test/lambda/kinesis-event-source-fixture.js";
+import { simAwsWithSqsEventSource } from "../../../../test/lambda/event-source-fixture.js";
+import { simAwsWithStreamEventSource } from "../../../../test/lambda/stream-event-source-fixture.js";
+import type { SimLambdaDynamoDbStreamEvent } from "./poll/sim-lambda-dynamodb-stream-event.types.js";
+import type { SimLambdaKinesisStreamEvent } from "./poll/kinesis/sim-lambda-kinesis-stream-event.types.js";
+
+/**
+ * A record carrying one order, as a producer puts it onto a stream.
+ */
+function orderRecord(type: string): PutRecordCommand {
+  const data = JSON.stringify({ order: { type, stock: "ANYCO" } });
+
+  return new PutRecordCommand({
+    StreamName: "orders",
+    PartitionKey: "customer-1",
+    Data: new TextEncoder().encode(data),
+  });
+}
+
+/**
+ * What one Kinesis record's base64 payload says.
+ */
+function kinesisPayload(data: string): { order: { type: string } } {
+  const decoded = Buffer.from(data, "base64").toString("utf8");
+
+  return JSON.parse(decoded) as { order: { type: string } };
+}
+
+/**
+ * The order ids a DynamoDB stream batch carries.
+ */
+function streamedOrderIds(
+  event: SimLambdaDynamoDbStreamEvent,
+): readonly string[] {
+  return event.Records.map(
+    (record) => record.dynamodb.Keys?.["orderId"]?.S ?? "",
+  );
+}
+
+describe("sim Lambda event source mapping filter criteria", () => {
+  it("delivers a queue message its filter matches and deletes one it does not", async () => {
+    // Given a queue mapping filtering on a field of the message body.
+    const { queueUrl, events, simAws } = await simAwsWithSqsEventSource({
+      filterPatterns: ['{"body":{"status":["shipped"]}}'],
+    });
+
+    // When one order of each status is sent.
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: JSON.stringify({ orderId: "order-1", status: "placed" }),
+      }),
+    );
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: JSON.stringify({ orderId: "order-2", status: "shipped" }),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the shipped order reached the function.
+    const records = events.flatMap((event) => event.Records);
+    const bodies = records.map(
+      (record) => JSON.parse(record.body) as { orderId: string },
+    );
+
+    assertArrayEquals(
+      bodies.map((body) => body.orderId),
+      ["order-2"],
+    );
+
+    // And the message the filter excluded was deleted rather than left on the
+    // queue, as real Lambda deletes one.
+    const left = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertArrayEmpty(left.Messages ?? []);
+  });
+
+  it("invokes nothing when a queue batch is filtered out in full", async () => {
+    // Given a queue mapping whose filter matches nothing that is sent.
+    const { queueUrl, events, simAws } = await simAwsWithSqsEventSource({
+      filterPatterns: ['{"body":{"status":["shipped"]}}'],
+    });
+
+    // When an order the filter excludes is sent.
+    await simAws.sqs().sendMessage(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: JSON.stringify({ orderId: "order-1", status: "placed" }),
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the function was never invoked, and the message is gone.
+    assertArrayEmpty(events);
+
+    const left = await simAws
+      .sqs()
+      .receiveMessage(new ReceiveMessageCommand({ QueueUrl: queueUrl }));
+
+    assertArrayEmpty(left.Messages ?? []);
+  });
+
+  it("delivers a stream record its filter matches and moves past one it does not", async () => {
+    // Given a stream mapping filtering on the event name and an image field.
+    const { tableName, events, simAws } = await simAwsWithStreamEventSource({
+      filterPatterns: [
+        '{"eventName":["MODIFY"],"dynamodb":{"NewImage":{"status":{"S":["shipped"]}}}}',
+      ],
+    });
+
+    // When an order is written and then twice modified.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" }, status: { S: "placed" } },
+      }),
+    );
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" }, status: { S: "packed" } },
+      }),
+    );
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" }, status: { S: "shipped" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then only the shipping change reached the function.
+    const delivered = events.flatMap((event) => event.Records);
+
+    assertArrayLength(delivered, 1);
+    assertIdentical(delivered[0].dynamodb.NewImage?.["status"]?.S, "shipped");
+  });
+
+  it("keeps reading a stream past a batch its filter excluded in full", async () => {
+    // Given a stream mapping reading one record at a time, filtering on a
+    // status the first write does not carry.
+    const { tableName, events, simAws } = await simAwsWithStreamEventSource({
+      batchSize: 1,
+      filterPatterns: [
+        '{"dynamodb":{"NewImage":{"status":{"S":["shipped"]}}}}',
+      ],
+    });
+
+    // When an excluded order is written before a matching one.
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-1" }, status: { S: "placed" } },
+      }),
+    );
+    await simAws.dynamoDb().putItem(
+      new PutItemCommand({
+        TableName: tableName,
+        Item: { orderId: { S: "order-2" }, status: { S: "shipped" } },
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then the checkpoint moved past the excluded record and the matching one
+    // arrived behind it.
+    assertArrayEquals(events.flatMap(streamedOrderIds), ["order-2"]);
+  });
+
+  it("delivers a Kinesis record whose decoded payload its filter matches", async () => {
+    // Given a Kinesis mapping filtering on a field of the record's JSON data.
+    const { events, simAws } = await simAwsWithKinesisEventSource({
+      filterPatterns: ['{"data":{"order":{"type":["buy"]}}}'],
+    });
+
+    // When a sell and a buy are put onto the stream.
+    await simAws.kinesis().putRecord(orderRecord("sell"));
+    await simAws.kinesis().putRecord(orderRecord("buy"));
+    await simAws.backgroundTasksComplete();
+
+    // Then only the buy reached the function.
+    const delivered = events.flatMap(
+      (event: SimLambdaKinesisStreamEvent) => event.Records,
+    );
+    const payloads = delivered.map((record) =>
+      kinesisPayload(record.kinesis.data),
+    );
+
+    assertArrayEquals(
+      payloads.map((payload) => payload.order.type),
+      ["buy"],
+    );
+  });
+
+  it("delivers a record matching any one of several filters", async () => {
+    // Given a queue mapping carrying two patterns, which real Lambda ORs.
+    const { queueUrl, events, simAws } = await simAwsWithSqsEventSource({
+      filterPatterns: [
+        '{"body":{"status":["shipped"]}}',
+        '{"body":{"status":["cancelled"]}}',
+      ],
+    });
+
+    // When one order of each of three statuses is sent.
+    await Promise.all(
+      ["placed", "shipped", "cancelled"].map(async (status) => {
+        await simAws.sqs().sendMessage(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: JSON.stringify({ status }),
+          }),
+        );
+      }),
+    );
+    await simAws.backgroundTasksComplete();
+
+    // Then both of the named statuses reached the function.
+    const statuses = events
+      .flatMap((event) => event.Records)
+      .map((record) => (JSON.parse(record.body) as { status: string }).status);
+
+    assertArrayEquals(
+      statuses.toSorted((a, b) => a.localeCompare(b)),
+      ["cancelled", "shipped"],
+    );
+  });
+
+  it("reports the filters a mapping was created with", async () => {
+    // Given a mapping created with a filter.
+    const pattern = '{"body":{"status":["shipped"]}}';
+    const { uuid, simAws } = await simAwsWithSqsEventSource({
+      filterPatterns: [pattern],
+    });
+
+    // When the mapping is read back.
+    const mapping = await simAws
+      .lambda()
+      .getEventSourceMapping(new GetEventSourceMappingCommand({ UUID: uuid }));
+
+    // Then it reports the pattern as it was written.
+    assertArrayEquals(
+      (mapping.FilterCriteria?.Filters ?? []).map((filter) => filter.Pattern),
+      [pattern],
+    );
+  });
+
+  it("reports no filters for a mapping created without any", async () => {
+    // Given a mapping created with no filter.
+    const { uuid, simAws } = await simAwsWithSqsEventSource();
+
+    // When the mapping is read back.
+    const mapping = await simAws
+      .lambda()
+      .getEventSourceMapping(new GetEventSourceMappingCommand({ UUID: uuid }));
+
+    // Then it reports none, rather than an empty list of them.
+    assertUndefined(mapping.FilterCriteria);
+  });
+});

--- a/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
+++ b/src/service/lambda/event-source/sim-lambda-event-source-mapping.ts
@@ -4,6 +4,10 @@ import { SimLambdaNoDestinationTargets } from "../destination/sim-lambda-destina
 import { randomUUID } from "node:crypto";
 
 import type { SimAwsAccountRegionScope } from "../../aws/sim-aws-account-region-scope.js";
+import type {
+  SimLambdaFilterCriteria,
+  SimLambdaFilterCriteriaInput,
+} from "./filter/sim-lambda-filter-criteria.js";
 import type { SimLambdaFunctionArn } from "../function/sim-lambda-function-configuration.js";
 import type {
   SimLambdaStreamRetryLimits,
@@ -56,6 +60,7 @@ interface SimLambdaEventSourceMappingProperties {
     | SimLambdaStreamDestinationConfiguration
     | undefined;
   readonly destinations?: SimLambdaDestinationTargets | undefined;
+  readonly filterCriteria?: SimLambdaFilterCriteria | undefined;
   readonly createdAt: Date;
 }
 
@@ -77,6 +82,7 @@ export interface SimLambdaEventSourceMappingConfiguration extends Partial<SimLam
   readonly StartingPositionTimestamp?: Date | undefined;
   readonly MaximumBatchingWindowInSeconds: number;
   readonly FunctionResponseTypes: readonly SimLambdaFunctionResponseType[];
+  readonly FilterCriteria?: SimLambdaFilterCriteriaInput | undefined;
   readonly State: SimLambdaEventSourceMappingState;
   readonly StateTransitionReason: string;
   readonly LastModified: Date;
@@ -117,6 +123,14 @@ export class SimLambdaEventSourceMapping {
   public readonly functionResponseTypes: readonly SimLambdaFunctionResponseType[];
 
   /**
+   * The filters a record has to match before it is delivered, if this mapping
+   * was created with any.
+   *
+   * A mapping with none delivers every record its source hands it.
+   */
+  public readonly filterCriteria: SimLambdaFilterCriteria | undefined;
+
+  /**
    * When this mapping stops delivering a batch its function keeps failing, for
    * a source that leaves the counting to the mapping.
    *
@@ -148,6 +162,7 @@ export class SimLambdaEventSourceMapping {
     // cannot change what this mapping does with a batch afterwards.
     this.functionResponseTypes = [...(properties.functionResponseTypes ?? [])];
     this.streamRetryLimits = properties.streamRetryLimits;
+    this.filterCriteria = properties.filterCriteria;
     this.enabled = properties.enabled ?? true;
     this.lastModified = properties.createdAt;
   }
@@ -218,6 +233,9 @@ export class SimLambdaEventSourceMapping {
       // them out rather than reporting a limit it does not have.
       ...this.streamRetryLimits?.configuration(),
       FunctionResponseTypes: this.functionResponseTypes,
+      // A mapping created without filters reports none, as real Lambda does,
+      // rather than reporting an empty list of them.
+      FilterCriteria: this.filterCriteria?.configuration(),
       State: this.#state,
       StateTransitionReason: "USER_INITIATED",
       LastModified: this.lastModified,

--- a/test/lambda/event-source-fixture.ts
+++ b/test/lambda/event-source-fixture.ts
@@ -168,6 +168,7 @@ interface SqsEventSourceOptions {
   readonly handlerResult?: (event: SimLambdaSqsEvent) => unknown;
   readonly batchSize?: number;
   readonly functionResponseTypes?: readonly "ReportBatchItemFailures"[];
+  readonly filterPatterns?: readonly string[];
 }
 
 /**
@@ -194,6 +195,11 @@ export async function simAwsWithSqsEventSource(
       ...(options.batchSize !== undefined && { BatchSize: options.batchSize }),
       ...(options.functionResponseTypes !== undefined && {
         FunctionResponseTypes: [...options.functionResponseTypes],
+      }),
+      ...(options.filterPatterns !== undefined && {
+        FilterCriteria: {
+          Filters: options.filterPatterns.map((Pattern) => ({ Pattern })),
+        },
       }),
     }),
   );

--- a/test/lambda/kinesis-event-source-fixture.ts
+++ b/test/lambda/kinesis-event-source-fixture.ts
@@ -106,6 +106,7 @@ interface KinesisEventSourceOptions {
   readonly maximumRetryAttempts?: number;
   readonly maximumRecordAgeInSeconds?: number;
   readonly bisectBatchOnFunctionError?: boolean;
+  readonly filterPatterns?: readonly string[];
 }
 
 /**
@@ -161,6 +162,11 @@ export async function simAwsWithKinesisEventSource(
       }),
       ...(options.bisectBatchOnFunctionError !== undefined && {
         BisectBatchOnFunctionError: options.bisectBatchOnFunctionError,
+      }),
+      ...(options.filterPatterns !== undefined && {
+        FilterCriteria: {
+          Filters: options.filterPatterns.map((Pattern) => ({ Pattern })),
+        },
       }),
     }),
   );

--- a/test/lambda/stream-event-source-fixture.ts
+++ b/test/lambda/stream-event-source-fixture.ts
@@ -142,6 +142,7 @@ interface StreamEventSourceOptions {
   readonly maximumRetryAttempts?: number;
   readonly maximumRecordAgeInSeconds?: number;
   readonly bisectBatchOnFunctionError?: boolean;
+  readonly filterPatterns?: readonly string[];
 }
 
 /**
@@ -188,6 +189,11 @@ export async function simAwsWithStreamEventSource(
       }),
       ...(options.bisectBatchOnFunctionError !== undefined && {
         BisectBatchOnFunctionError: options.bisectBatchOnFunctionError,
+      }),
+      ...(options.filterPatterns !== undefined && {
+        FilterCriteria: {
+          Filters: options.filterPatterns.map((Pattern) => ({ Pattern })),
+        },
       }),
     }),
   );


### PR DESCRIPTION
An event source mapping delivered every record its source handed it, and `CreateEventSourceMapping` refused `FilterCriteria` outright. A mapping now delivers the records its filters match and treats the rest as handled, so a stream moves its checkpoint past an excluded record and a queue deletes an excluded message, and a batch the filters empty invokes nothing. The patterns are EventBridge event patterns, which is how AWS documents Lambda's filter rules, so simulated EventBridge's matcher evaluates them and refuses an operator it has no behaviour for by name. SQS filters on the message body alone, a DynamoDB stream on the record the function would have received, and a Kinesis stream on that record with the payload decoded under a top-level `data` key. An `AWS::Lambda::EventSourceMapping` carrying the property now deploys with it rather than recording it as unsimulated.

Resolves https://github.com/KensioSoftware/yulin/issues/1347

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

The `pnpm run check` run fails three `*.loc.test.ts` filesystem-watch files on this machine. They fail the same way on an unmodified `main`, and which of them fails varies run to run. Everything else passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Lambda event-source filtering for SQS, Kinesis, and DynamoDB Streams.
  - Matching records are delivered to functions; nonmatching records are acknowledged or removed without invocation.
  - Added CloudFormation support and examples for configuring filter criteria.
  - Filtered Kinesis payloads can be matched using decoded data.

- **Documentation**
  - Documented supported filtering behavior, configuration options, limitations, and deployment-tool support.

- **Bug Fixes**
  - Empty filtered batches no longer invoke Lambda handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->