### PR TITLE
fix: keep the scale a rounded Athena result was asked for

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -1107,6 +1107,11 @@ Current documented limitations:
 - A null in a result row reads as an empty string. Real Athena leaves the value out of the row.
 - A computed boolean reads as `1` and `0`. The Glue column type is what makes a boolean column read
   as `true` and `false`, and an expression has no column type behind it.
+- `round(x, 1)` keeps the one decimal place it was asked for, so `25` reads as `25.0` the way Trino
+  renders it, and the column reports `double`. The scale is read off the statement, so a `round`
+  whose scale is an expression rather than a number keeps none of it. Real Athena reports `decimal`
+  where the value being rounded came from a decimal literal, and nothing here tracks decimal
+  precision.
 - An expression nobody named is called `_col0` upward, as Athena calls one. An alias that needed
   quotes around it is renamed the same way.
 - The engine reads every object under the prefixes a query reaches and holds the rows in memory.

--- a/src/service/athena/engine/sim-athena-engine-result.ts
+++ b/src/service/athena/engine/sim-athena-engine-result.ts
@@ -6,7 +6,18 @@ import type { DatabaseSync, SQLOutputValue } from "node:sqlite";
 import type { SimAthenaDeclaredColumn } from "../result/sim-athena-declared-result.js";
 import { SimAthenaResolvedResult } from "../result/sim-athena-resolved-result.js";
 import { simAthenaResultColumns } from "./sim-athena-result-columns.js";
+import { simAthenaRoundedText } from "./sim-athena-round-scales.js";
 import type { SimAthenaLoadedTable } from "./sim-athena-table-rows.js";
+
+/** What one statement is run and read back with. */
+export interface SimAthenaEngineResultRun {
+  readonly database: DatabaseSync;
+  readonly sql: string;
+  readonly loaded: readonly SimAthenaLoadedTable[];
+
+  /** The decimal places each result column was rounded to, by position. */
+  readonly scales: ReadonlyMap<number, number>;
+}
 
 /**
  * Run one translated statement and read its answer back as a result set.
@@ -16,11 +27,9 @@ import type { SimAthenaLoadedTable } from "./sim-athena-table-rows.js";
  * them.
  */
 export function simAthenaEngineResult(
-  database: DatabaseSync,
-  sql: string,
-  loaded: readonly SimAthenaLoadedTable[],
+  run: SimAthenaEngineResultRun,
 ): SimAthenaResolvedResult {
-  const statement = database.prepare(sql);
+  const statement = run.database.prepare(run.sql);
 
   statement.setReturnArrays(true);
 
@@ -31,14 +40,37 @@ export function simAthenaEngineResult(
   statement.setReadBigInts(true);
 
   const rows = statement.all() as unknown as readonly SQLOutputValue[][];
-  const columns = simAthenaResultColumns(statement.columns(), rows, loaded);
+  const columns = simAthenaResultColumns(
+    statement.columns(),
+    rows,
+    run.loaded,
+    run.scales,
+  );
 
   return new SimAthenaResolvedResult({
     columns,
     rows: rows.map((row) =>
-      columns.map((column, index) => rendered(row[index], column)),
+      columns.map((column, index) =>
+        renderedCell(row[index], column, run.scales.get(index)),
+      ),
     ),
   });
+}
+
+/**
+ * One value as `GetQueryResults` carries it, with the scale its column was
+ * rounded to where the statement asked for one.
+ */
+function renderedCell(
+  value: SQLOutputValue | undefined,
+  column: SimAthenaDeclaredColumn,
+  scale: number | undefined,
+): string {
+  const text = rendered(value, column);
+
+  return scale === undefined || text === ""
+    ? text
+    : simAthenaRoundedText(value, scale);
 }
 
 /**

--- a/src/service/athena/engine/sim-athena-engine-run.ts
+++ b/src/service/athena/engine/sim-athena-engine-run.ts
@@ -23,6 +23,9 @@ export interface SimAthenaEngineRun {
   readonly caller: SimAwsCaller | undefined;
   readonly startedAt: Date;
   readonly sql: string;
+
+  /** The decimal places each result column was rounded to, by position. */
+  readonly scales: ReadonlyMap<number, number>;
 }
 
 /**
@@ -57,7 +60,12 @@ export async function simAthenaEngineRun(
 
     try {
       return simAthenaEngineAnswered(
-        simAthenaEngineResult(database, run.sql, loaded),
+        simAthenaEngineResult({
+          database,
+          sql: run.sql,
+          loaded,
+          scales: run.scales,
+        }),
       );
     } finally {
       database.close();

--- a/src/service/athena/engine/sim-athena-query-engine.ts
+++ b/src/service/athena/engine/sim-athena-query-engine.ts
@@ -136,6 +136,7 @@ export class SimAthenaQueryEngine {
           sqlite,
           objects,
           sql: translated.sql,
+          scales: translated.scales,
         });
   }
 }

--- a/src/service/athena/engine/sim-athena-result-columns.ts
+++ b/src/service/athena/engine/sim-athena-result-columns.ts
@@ -31,16 +31,31 @@ export function simAthenaResultColumns(
   metadata: readonly StatementColumnMetadata[],
   rows: readonly (readonly SQLOutputValue[])[],
   loaded: readonly SimAthenaLoadedTable[],
+  scales: ReadonlyMap<number, number> = new Map(),
 ): readonly SimAthenaDeclaredColumn[] {
   const types = glueColumnTypes(loaded);
 
   return metadata.map((column, index) => ({
     name: nameOf(column, index),
-    type:
-      column.column === null
-        ? inferredType(rows, index)
-        : simAthenaResultType(types.get(originOf(column))),
+    // A column the statement rounded to a scale is a double whatever value it
+    // happens to hold, since a whole number rounded to one place is still one.
+    type: scales.has(index)
+      ? "double"
+      : columnType({ column, rows, index, types }),
   }));
+}
+
+interface SimAthenaColumnTypeRead {
+  readonly column: StatementColumnMetadata;
+  readonly rows: readonly (readonly SQLOutputValue[])[];
+  readonly index: number;
+  readonly types: ReadonlyMap<string, string | undefined>;
+}
+
+function columnType(read: SimAthenaColumnTypeRead): string {
+  return read.column.column === null
+    ? inferredType(read.rows, read.index)
+    : simAthenaResultType(read.types.get(originOf(read.column)));
 }
 
 function nameOf(column: StatementColumnMetadata, index: number): string {

--- a/src/service/athena/engine/sim-athena-round-scales.ts
+++ b/src/service/athena/engine/sim-athena-round-scales.ts
@@ -1,0 +1,102 @@
+import { isRecord } from "../../../util/type-guard/record.js";
+
+/**
+ * The decimal places each result column was rounded to, by position.
+ *
+ * `round(x, 1)` answers `25.0` on Trino and `25` here, because SQLite hands
+ * back a double and nothing downstream knows how many places the statement
+ * asked to keep. The statement is the only thing that knows, so the scale is
+ * read off the syntax tree while it is still there and travels with the query.
+ *
+ * Only a literal scale is read. `round(x, n)` over a column is a scale that
+ * differs per row, and a result column has one rendering for every row in it.
+ */
+export function simAthenaRoundScales(
+  ast: unknown,
+): ReadonlyMap<number, number> {
+  const scales = new Map<number, number>();
+
+  for (const [index, item] of selectItems(ast).entries()) {
+    const scale = roundScaleOf(item);
+
+    if (scale !== undefined) {
+      scales.set(index, scale);
+    }
+  }
+
+  return scales;
+}
+
+/**
+ * One rounded value as its column renders it.
+ *
+ * A whole number keeps the trailing zeros the scale asked for, which is the
+ * whole point of carrying the scale this far.
+ */
+export function simAthenaRoundedText(value: unknown, scale: number): string {
+  return typeof value === "number" ? value.toFixed(scale) : String(value);
+}
+
+/**
+ * The select list of the statement, which is the first one where a query
+ * carries several.
+ */
+function selectItems(ast: unknown): readonly unknown[] {
+  const statement: unknown = Array.isArray(ast) ? ast[0] : ast;
+  const columns = isRecord(statement) ? statement["columns"] : undefined;
+
+  return Array.isArray(columns) ? columns : [];
+}
+
+/**
+ * The scale one select item was rounded to, for an item that is a `round` call
+ * over a literal scale.
+ */
+function roundScaleOf(item: unknown): number | undefined {
+  const expression = isRecord(item) ? item["expr"] : undefined;
+
+  if (!isRecord(expression) || functionNameOf(expression) !== "round") {
+    return undefined;
+  }
+
+  const arguments_ = callArguments(expression);
+
+  return arguments_.length === 2 ? literalScale(arguments_[1]) : undefined;
+}
+
+/**
+ * The name a function call node carries, which the parser holds as a list of
+ * the parts a qualified name would have.
+ */
+function functionNameOf(expression: Record<string, unknown>): string {
+  const name = isRecord(expression["name"])
+    ? expression["name"]["name"]
+    : undefined;
+  const first: unknown = Array.isArray(name) ? name[0] : undefined;
+  const value = isRecord(first) ? first["value"] : undefined;
+
+  return typeof value === "string" ? value.toLowerCase() : "";
+}
+
+/**
+ * The arguments a function call node carries.
+ */
+function callArguments(
+  expression: Record<string, unknown>,
+): readonly unknown[] {
+  const arguments_ = expression["args"];
+  const value = isRecord(arguments_) ? arguments_["value"] : undefined;
+
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * A whole number written into the statement, or nothing for anything else.
+ */
+function literalScale(node: unknown): number | undefined {
+  const value =
+    isRecord(node) && node["type"] === "number" ? node["value"] : undefined;
+  const scale = Number(value);
+
+  return Number.isSafeInteger(scale) && scale >= 0 ? scale : undefined;
+}

--- a/src/service/athena/engine/sim-athena-sql-translation.ts
+++ b/src/service/athena/engine/sim-athena-sql-translation.ts
@@ -10,22 +10,33 @@ import {
   simAthenaUnwrittenStatement,
 } from "./sim-athena-turn-down.js";
 import { simAthenaRejectedStatement } from "./sim-athena-rejected-statement.js";
+import { simAthenaRoundScales } from "./sim-athena-round-scales.js";
 import { simAthenaRewriteUnnest } from "./sim-athena-unnest-rewrite.js";
 
 /** One statement translated for SQLite, or why it was not. */
 export type SimAthenaTranslatedSql =
   | {
       readonly sql: string;
+
+      /**
+       * The decimal places each result column was rounded to, by position.
+       *
+       * Read here because the syntax tree is the only place that knows, and
+       * the tree is gone by the time the answer is rendered.
+       */
+      readonly scales: ReadonlyMap<number, number>;
       readonly turnedDown: undefined;
       readonly rejected: undefined;
     }
   | {
       readonly sql: undefined;
+      readonly scales: undefined;
       readonly turnedDown: string;
       readonly rejected: undefined;
     }
   | {
       readonly sql: undefined;
+      readonly scales: undefined;
       readonly turnedDown: undefined;
       readonly rejected: string;
     };
@@ -69,7 +80,12 @@ export function simAthenaSqliteSql(
   const rejected = simAthenaRejectedStatement(ast);
 
   if (rejected !== undefined) {
-    return { sql: undefined, turnedDown: undefined, rejected };
+    return {
+      sql: undefined,
+      scales: undefined,
+      turnedDown: undefined,
+      rejected,
+    };
   }
 
   try {
@@ -83,8 +99,13 @@ export function simAthenaSqliteSql(
       return turnedDown(simAthenaUnrewrittenUnnest);
     }
 
+    // Read before the tree is written back out, since the rewrites above can
+    // move a select item and the scale travels by position.
+    const scales = simAthenaRoundScales(ast);
+
     return {
       sql: simAthenaSqlForSqlite(parser.sqlify(ast, { database: "sqlite" })),
+      scales,
       turnedDown: undefined,
       rejected: undefined,
     };
@@ -94,5 +115,10 @@ export function simAthenaSqliteSql(
 }
 
 function turnedDown(reason: string): SimAthenaTranslatedSql {
-  return { sql: undefined, turnedDown: reason, rejected: undefined };
+  return {
+    sql: undefined,
+    scales: undefined,
+    turnedDown: reason,
+    rejected: undefined,
+  };
 }

--- a/src/service/athena/sim-athena-engine-rounding.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-rounding.iso.test.ts
@@ -1,0 +1,98 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+const hits = [
+  { served: 1, asked: 4 },
+  { served: 2506, asked: 100 },
+];
+
+/** A simulation holding two rows of counts, with the engine on. */
+async function aCountsSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "hits",
+    columns: [
+      { Name: "served", Type: "bigint" },
+      { Name: "asked", Type: "bigint" },
+    ],
+  });
+
+  await aSeededJson(simulation.simAws, "hits/part-0.json", hits);
+  await simulation.simAws.athena().engine().enable();
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["fallback"], rows: [["declared"]] });
+
+  return simulation;
+}
+
+describe("the scale a rounded Athena result keeps", () => {
+  it("keeps the decimal places a rounded percentage was asked for", async () => {
+    // Given a simulation holding counts the engine can read.
+    const simulation = await aCountsSimulation();
+
+    // When a query rounds a percentage to one decimal place.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT round(100.0 * served / asked, 1) AS pct " +
+        "FROM rainlytics.hits ORDER BY served",
+    );
+
+    // Then the whole number keeps its trailing zero, as Trino renders one.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["25.0"], ["2506.0"]]);
+  });
+
+  it("rounds to the place it was asked for rather than to the nearest whole", async () => {
+    // Given a simulation holding counts the engine can read.
+    const simulation = await aCountsSimulation();
+
+    // When a query rounds a value that has more places than it keeps.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT round(25.06, 1) AS pct FROM rainlytics.hits LIMIT 1",
+    );
+
+    // Then it keeps one place.
+    assertObjectEquals(answered.rows, [["25.1"]]);
+  });
+
+  it("reports a rounded column as a double", async () => {
+    // Given a simulation holding counts the engine can read.
+    const simulation = await aCountsSimulation();
+
+    // When a query rounds a value that lands on a whole number.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT round(25, 1) AS pct FROM rainlytics.hits LIMIT 1",
+    );
+
+    // Then the column is a double rather than the bigint its value looks like.
+    assertObjectEquals(answered.columns, ["double"]);
+    assertObjectEquals(answered.rows, [["25.0"]]);
+  });
+
+  it("leaves a round with no scale alone", async () => {
+    // Given a simulation holding counts the engine can read.
+    const simulation = await aCountsSimulation();
+
+    // When a query rounds to the nearest whole number.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT round(25) AS a, round(25.4) AS b FROM rainlytics.hits LIMIT 1",
+    );
+
+    // Then neither grows a decimal place it was never asked for.
+    assertObjectEquals(answered.rows, [["25", "25"]]);
+  });
+});


### PR DESCRIPTION
`round(x, 1)` rendered `25` where Trino renders `25.0`, so a test asserting on a percentage as Athena writes it passed against one engine and failed against the other. SQLite hands back a double and loses the places the statement asked to keep, and the syntax tree is the only thing that still knows them, so the scale is read off the select list during translation and travels with the query to the answer. A column rounded to a scale renders with that many places and reports `double` rather than the `bigint` a whole value looked like. A `round` with no scale is unchanged.

Resolves https://github.com/KensioSoftware/yulin/issues/1344

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

Real Athena reports `decimal` where the rounded value came from a decimal literal, and nothing here tracks decimal precision. That is recorded in the Athena limitations alongside the new behaviour.

The `pnpm run check` run fails two `src/cli/watch/*.loc.test.ts` filesystem-watch files on this machine. They fail the same way on an unmodified `main`, and which of them fails varies run to run. Everything else passes.
