### PR TITLE
feat: run a schedule in the timezone it names

### DIFF
--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -68,8 +68,8 @@ Scheduler accepts three expression forms:
 ### The zone a schedule runs in
 
 `ScheduleExpressionTimezone` says which zone the wall-clock time belongs to, and a schedule created
-without one runs in UTC. Any IANA name works, and a name no zone answers to is refused when the
-schedule is created.
+without one runs in UTC. Any IANA name the host's own `Intl` timezone data recognises works, and a
+name it does not is refused when the schedule is created.
 
 ```typescript
 await simAws.scheduler().createSchedule(
@@ -85,9 +85,12 @@ await simAws.scheduler().createSchedule(
 
 That schedule is due at 01:00 UTC through British Summer Time and at 02:00 UTC through the winter,
 which is what a nightly job written for a zone actually does. The two days a year a zone changes
-offset are read the same way, so a schedule keeps its hour on the clock across both. A wall-clock
-time the clocks skip over falls due at the instant they moved, and one the clocks read twice falls
-due on the first of the two.
+offset are read the same way. A schedule keeps its hour on the clock across both.
+
+The hour the clocks move takes the rule real Scheduler uses. A wall-clock time inside the hour that
+never happens falls due at the first instant after it (02:30 on the morning the clocks go forward
+fires at 03:30). A wall-clock time the clocks read twice falls due once, at the first of the two
+readings.
 
 `GetSchedule` reports the zone back as it was written.
 

--- a/docs/services/scheduler/README.md
+++ b/docs/services/scheduler/README.md
@@ -61,10 +61,35 @@ Scheduler accepts three expression forms:
 - `rate(<value> <unit>)` runs from when the schedule was created. The unit is `minute`, `hour` or
   `day`, and Scheduler lets it disagree with its value. `rate(1 hours)` is an hour here and a
   refusal on an EventBridge rule.
-- `cron(<six fields>)` names absolute instants in UTC. Minutes, hours, day-of-month, month,
-  day-of-week and year, so every day at two in the morning is `cron(0 2 * * ? *)`. The day-of-month
-  and day-of-week fields cannot both say something. Whichever is not deciding the day is written
-  `?`.
+- `cron(<six fields>)` names a wall-clock time. Minutes, hours, day-of-month, month, day-of-week and
+  year, so every day at two in the morning is `cron(0 2 * * ? *)`. The day-of-month and day-of-week
+  fields cannot both say something. Whichever is not deciding the day is written `?`.
+
+### The zone a schedule runs in
+
+`ScheduleExpressionTimezone` says which zone the wall-clock time belongs to, and a schedule created
+without one runs in UTC. Any IANA name works, and a name no zone answers to is refused when the
+schedule is created.
+
+```typescript
+await simAws.scheduler().createSchedule(
+  new CreateScheduleCommand({
+    Name: "nightly-rollup",
+    ScheduleExpression: "cron(0 2 * * ? *)",
+    ScheduleExpressionTimezone: "Europe/London",
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: { Arn: functionArn, RoleArn: roleArn },
+  }),
+);
+```
+
+That schedule is due at 01:00 UTC through British Summer Time and at 02:00 UTC through the winter,
+which is what a nightly job written for a zone actually does. The two days a year a zone changes
+offset are read the same way, so a schedule keeps its hour on the clock across both. A wall-clock
+time the clocks skip over falls due at the instant they moved, and one the clocks read twice falls
+due on the first of the two.
+
+`GetSchedule` reports the zone back as it was written.
 
 ## Firing a schedule
 
@@ -819,8 +844,9 @@ Resources of the same stack.
 - `FlexibleTimeWindow` with `Mode: "FLEXIBLE"` is refused. Real Scheduler invokes the target at an
   unpredictable moment inside the window, and firing at the exact due time instead would let a test
   rely on timing AWS leaves unpromised.
-- `ScheduleExpressionTimezone` other than `UTC` is refused outright, since running a schedule in the
-  wrong zone fires it at the wrong hour.
+- `ScheduleExpressionTimezone` is read from the host's own timezone data through `Intl`, so a zone
+  the host has never heard of is refused even where AWS would take it. A schedule that names none
+  runs in UTC.
 - `StartDate` and `EndDate` are refused outright.
 - Targets are Lambda, SQS, SNS and ECS. The universal target
   (`arn:aws:scheduler:::aws-sdk:<service>:<action>`) and every other target service are refused when

--- a/src/service/scheduler/command/schedule/schedule.command.ts
+++ b/src/service/scheduler/command/schedule/schedule.command.ts
@@ -107,6 +107,7 @@ export interface SimGetScheduleCommandOutput {
   readonly Name?: string | undefined;
   readonly GroupName?: string | undefined;
   readonly ScheduleExpression?: string | undefined;
+  readonly ScheduleExpressionTimezone?: string | undefined;
   readonly State?: string | undefined;
   readonly Description?: string | undefined;
   readonly ActionAfterCompletion?: string | undefined;

--- a/src/service/scheduler/command/schedule/sim-scheduler-described-schedule.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-described-schedule.ts
@@ -20,6 +20,7 @@ export function describedSchedule(
     Name: schedule.name.value,
     GroupName: schedule.groupName,
     ScheduleExpression: schedule.schedule.source,
+    ScheduleExpressionTimezone: schedule.timeZone,
     State: schedule.state.value,
     Description: schedule.description,
     ActionAfterCompletion: schedule.actionAfterCompletion,

--- a/src/service/scheduler/command/schedule/sim-scheduler-schedule-validation.iso.test.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-schedule-validation.iso.test.ts
@@ -80,16 +80,16 @@ describe("Scheduler schedule validation", () => {
     assertStringIncludes(error.message, "Schedule group reporting");
   });
 
-  it("refuses a timezone rather than running the schedule in UTC anyway", async () => {
-    // Given a nightly schedule written for London.
+  it("refuses a timezone no zone answers to, naming the parameter", async () => {
+    // Given a schedule written for a zone that does not exist.
     const error = await refusedSchedule({
-      ScheduleExpressionTimezone: "Europe/London",
+      ScheduleExpressionTimezone: "Europe/Nowhere",
     });
 
-    // Then it is refused: running it in UTC would fire it at the wrong hour,
-    // which is the thing a test of a nightly job is checking.
-    assertInstanceOf(error, SimSchedulerUnsimulatedInputException);
-    assertStringIncludes(error.message, "wrong hour");
+    // Then it is refused against the parameter it came in on, naming the zone.
+    assertInstanceOf(error, SimSchedulerValidationException);
+    assertStringIncludes(error.message, "ScheduleExpressionTimezone");
+    assertStringIncludes(error.message, "Europe/Nowhere");
   });
 
   it("refuses a target service it cannot invoke", async () => {

--- a/src/service/scheduler/command/schedule/sim-scheduler-schedule-writer.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-schedule-writer.ts
@@ -50,7 +50,11 @@ export class SimSchedulerScheduleWriter {
       name: requested.name,
       groupName: requested.groupName,
       accountRegionScope: this.accountRegionScope,
-      schedule: schedulerSchedule(input.ScheduleExpression),
+      schedule: schedulerSchedule(
+        input.ScheduleExpression,
+        input.ScheduleExpressionTimezone,
+      ),
+      timeZone: input.ScheduleExpressionTimezone,
       target: SimSchedulerTarget.of(input.Target),
       state: SimSchedulerScheduleState.of(input.State),
       actionAfterCompletion: actionAfterCompletionIn(

--- a/src/service/scheduler/command/schedule/sim-scheduler-unsimulated-input.ts
+++ b/src/service/scheduler/command/schedule/sim-scheduler-unsimulated-input.ts
@@ -2,15 +2,30 @@ import {
   SimSchedulerUnsimulatedInputException,
   SimSchedulerValidationException,
 } from "../../error/sim-scheduler.error.js";
+import { SimScheduleZone } from "../../../../util/schedule/sim-schedule-zone.js";
 import { refuseUnsimulatedTarget } from "./sim-scheduler-unsimulated-target.js";
 import type { SimSchedulerScheduleInput } from "./schedule.command.js";
 
 const maximumDescriptionLength = 512;
 
 /**
- * The timezone every simulated schedule runs in.
+ * Refuse a timezone no zone answers to, naming the parameter it came in on.
  */
-const simulatedTimezone = "UTC";
+function refuseUnknownTimezone(timezone: string | undefined): void {
+  if (timezone === undefined) {
+    return;
+  }
+
+  try {
+    SimScheduleZone.of(timezone);
+  } catch {
+    throw new SimSchedulerValidationException(
+      `Invalid parameter: ScheduleExpressionTimezone Reason: ` +
+        `'${timezone}' is not a timezone. A timezone is an IANA name such ` +
+        `as 'Europe/London', or 'UTC'`,
+    );
+  }
+}
 
 /**
  * Read the flexible time window, which AWS requires on every request.
@@ -49,9 +64,9 @@ function refuseFlexibleWindow(input: SimSchedulerScheduleInput): void {
 /**
  * Refuse the schedule request inputs this simulation does not model.
  *
- * A timezone is refused rather than ignored: a schedule whose cron expression
- * quietly ran in UTC when it was written for another zone would fire at the
- * wrong hour, which is precisely the thing a test of a nightly job is checking.
+ * A timezone is one it does model. A name no zone answers to is refused here
+ * rather than left to the expression reader, which would report it against
+ * `ScheduleExpression` and send the caller to the wrong parameter.
  */
 export function refuseUnsimulatedScheduleInput(
   input: SimSchedulerScheduleInput,
@@ -59,15 +74,7 @@ export function refuseUnsimulatedScheduleInput(
   refuseFlexibleWindow(input);
   refuseUnsimulatedTarget(input.Target);
 
-  const timezone = input.ScheduleExpressionTimezone;
-
-  if (timezone !== undefined && timezone !== simulatedTimezone) {
-    throw new SimSchedulerUnsimulatedInputException(
-      `ScheduleExpressionTimezone '${timezone}' is not simulated. Every ` +
-        `simulated schedule runs in ${simulatedTimezone}, and running this ` +
-        `one there anyway would fire it at the wrong hour.`,
-    );
-  }
+  refuseUnknownTimezone(input.ScheduleExpressionTimezone);
 
   if (input.StartDate !== undefined || input.EndDate !== undefined) {
     throw new SimSchedulerUnsimulatedInputException(

--- a/src/service/scheduler/schedule/sim-scheduler-schedule-expression.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-schedule-expression.ts
@@ -31,13 +31,18 @@ export const schedulerScheduleDialect: SimScheduleDialect = {
 };
 
 /**
- * Read the `ScheduleExpression` a request carried.
+ * Read the `ScheduleExpression` a request carried, in the zone it named.
  *
  * The shared parser knows nothing about Scheduler, so its refusals become this
  * service's own errors here. Which of the two a caller gets tells them whether
- * the expression is wrong or whether it is right and unsimulated.
+ * the expression is wrong or whether it is right and unsimulated. A timezone no
+ * zone answers to is refused the same way, since the parser is what knows which
+ * names there are.
  */
-export function schedulerSchedule(source: string | undefined): SimSchedule {
+export function schedulerSchedule(
+  source: string | undefined,
+  timeZone?: string,
+): SimSchedule {
   if (source === undefined || source === "") {
     throw new SimSchedulerValidationException("ScheduleExpression is required");
   }
@@ -50,7 +55,7 @@ export function schedulerSchedule(source: string | undefined): SimSchedule {
   }
 
   try {
-    return SimSchedule.of(source, schedulerScheduleDialect);
+    return SimSchedule.of(source, schedulerScheduleDialect, timeZone);
   } catch (error) {
     if (error instanceof SimUnsimulatedScheduleExpressionError) {
       throw new SimSchedulerUnsimulatedInputException(

--- a/src/service/scheduler/schedule/sim-scheduler-schedule.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-schedule.ts
@@ -25,6 +25,9 @@ interface SimSchedulerScheduleProperties {
   readonly state: SimSchedulerScheduleState;
   readonly actionAfterCompletion: SimSchedulerActionAfterCompletion;
   readonly description?: string | undefined;
+
+  /** The timezone the request named, which a describe reports back. */
+  readonly timeZone?: string | undefined;
   readonly createdAt: Date;
 }
 
@@ -59,6 +62,14 @@ export class SimSchedulerSchedule {
   public readonly target: SimSchedulerTarget;
   public readonly actionAfterCompletion: SimSchedulerActionAfterCompletion;
   public readonly description: string | undefined;
+
+  /**
+   * The timezone the schedule was created with, if it named one.
+   *
+   * A schedule created without one runs in UTC, and reports no timezone rather
+   * than reporting the one it fell back to.
+   */
+  public readonly timeZone: string | undefined;
   public readonly creationDate: Date;
 
   /**
@@ -86,6 +97,7 @@ export class SimSchedulerSchedule {
     this.target = properties.target;
     this.actionAfterCompletion = properties.actionAfterCompletion;
     this.description = properties.description;
+    this.timeZone = properties.timeZone;
     this.creationDate = properties.createdAt;
     this.modified = properties.createdAt;
     this.held = properties.state;

--- a/src/service/scheduler/schedule/sim-scheduler-timezone.iso.test.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-timezone.iso.test.ts
@@ -109,6 +109,51 @@ describe("Scheduler firing in the zone a schedule names", () => {
     await simAws.close();
   });
 
+  it("falls due once on the day the clocks go back", async () => {
+    // Given a schedule due at 01:30 in New York, which the clocks read twice
+    // on the first Sunday of November.
+    const { simAws } = await aSimulationFrom("2026-10-31T12:00:00Z");
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(
+          nightlyIn("America/New_York", "cron(30 1 * * ? *)"),
+        ),
+      );
+
+    // Then it is due at the first of the two readings and then not again until
+    // the next day, as real Scheduler fires it once.
+    assertArrayEquals(dueInstants(simAws, "2026-10-31T12:00:00Z", 2), [
+      "2026-11-01T05:30:00.000Z",
+      "2026-11-02T06:30:00.000Z",
+    ]);
+
+    await simAws.close();
+  });
+
+  it("falls due after the hour the clocks skip over", async () => {
+    // Given a one-time schedule for 02:30 in New York on the morning the
+    // clocks go forward, which is a wall-clock time that never happens.
+    const { simAws } = await aSimulationFrom("2026-03-07T12:00:00Z");
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(
+          nightlyIn("America/New_York", "at(2026-03-08T02:30:00)"),
+        ),
+      );
+
+    // Then it is due at the first instant after the missing hour rather than
+    // at one inside the hour before it.
+    assertArrayEquals(dueInstants(simAws, "2026-03-07T12:00:00Z", 1), [
+      "2026-03-08T07:30:00.000Z",
+    ]);
+
+    await simAws.close();
+  });
+
   it("reports the timezone a schedule was created with", async () => {
     // Given a schedule created in a named zone.
     const { simAws } = await aSimulationFrom("2026-06-30T12:00:00Z");

--- a/src/service/scheduler/schedule/sim-scheduler-timezone.iso.test.ts
+++ b/src/service/scheduler/schedule/sim-scheduler-timezone.iso.test.ts
@@ -1,0 +1,134 @@
+import {
+  CreateScheduleCommand,
+  GetScheduleCommand,
+} from "@aws-sdk/client-scheduler";
+import {
+  assertArrayEquals,
+  assertArrayLength,
+  assertIdentical,
+} from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import {
+  aSimulationFrom,
+  dueInstants,
+  nightlyIn,
+} from "../../../../test/scheduler/timezone-schedule-fixture.js";
+
+describe("Scheduler firing in the zone a schedule names", () => {
+  it("falls due at the named zone's instant rather than at UTC's", async () => {
+    // Given a schedule due at 02:00 in London, in a month London is an hour
+    // ahead of UTC.
+    const { simAws } = await aSimulationFrom("2026-06-30T12:00:00Z");
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(
+          nightlyIn("Europe/London", "cron(0 2 * * ? *)"),
+        ),
+      );
+
+    // Then it is due at 01:00 UTC, which is 02:00 in London.
+    assertArrayEquals(dueInstants(simAws, "2026-06-30T12:00:00Z", 1), [
+      "2026-07-01T01:00:00.000Z",
+    ]);
+
+    await simAws.close();
+  });
+
+  it("keeps the wall-clock hour across the day the clocks change", async () => {
+    // Given a schedule due at 03:30 in New York, read from before the spring
+    // change to after it.
+    const { simAws } = await aSimulationFrom("2026-03-07T00:00:00Z");
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(
+          nightlyIn("America/New_York", "cron(30 3 * * ? *)"),
+        ),
+      );
+
+    // Then each one is 03:30 in New York, which is an hour earlier in UTC once
+    // the clocks have gone forward on the second Sunday of March.
+    assertArrayEquals(dueInstants(simAws, "2026-03-07T00:00:00Z", 3), [
+      "2026-03-07T08:30:00.000Z",
+      "2026-03-08T07:30:00.000Z",
+      "2026-03-09T07:30:00.000Z",
+    ]);
+
+    await simAws.close();
+  });
+
+  it("falls due in UTC when the schedule names no zone", async () => {
+    // Given the same nightly schedule with no zone named.
+    const { simAws } = await aSimulationFrom("2026-06-30T12:00:00Z");
+    const request = nightlyIn("Europe/London", "cron(0 2 * * ? *)");
+
+    await simAws.scheduler().createSchedule(
+      new CreateScheduleCommand({
+        ...request,
+        ScheduleExpressionTimezone: undefined,
+      }),
+    );
+
+    // Then it is due at 02:00 UTC, as every schedule was before zones were
+    // read.
+    assertArrayEquals(dueInstants(simAws, "2026-06-30T12:00:00Z", 1), [
+      "2026-07-01T02:00:00.000Z",
+    ]);
+
+    await simAws.close();
+  });
+
+  it("invokes the target at the zone's instant and not at UTC's", async () => {
+    // Given a schedule due at 02:00 in London.
+    const { simAws, invocations } = await aSimulationFrom(
+      "2026-07-01T00:00:00Z",
+    );
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(
+          nightlyIn("Europe/London", "cron(0 2 * * ? *)"),
+        ),
+      );
+
+    // When the clock reaches 00:59 UTC, and then 01:00.
+    await simAws.clock().advanceBy({ minutes: 59 });
+    const beforeDue = invocations.length;
+
+    await simAws.clock().advanceBy({ minutes: 1 });
+
+    // Then nothing fired until London read 02:00.
+    assertIdentical(beforeDue, 0);
+    assertArrayLength(invocations, 1);
+
+    await simAws.close();
+  });
+
+  it("reports the timezone a schedule was created with", async () => {
+    // Given a schedule created in a named zone.
+    const { simAws } = await aSimulationFrom("2026-06-30T12:00:00Z");
+
+    await simAws
+      .scheduler()
+      .createSchedule(
+        new CreateScheduleCommand(
+          nightlyIn("Europe/London", "cron(0 2 * * ? *)"),
+        ),
+      );
+
+    // When it is read back.
+    const described = await simAws
+      .scheduler()
+      .getSchedule(new GetScheduleCommand({ Name: "reconciliation" }));
+
+    // Then the zone is reported as it was written.
+    assertIdentical(described.ScheduleExpressionTimezone, "Europe/London");
+
+    await simAws.close();
+  });
+});

--- a/src/util/schedule/at/sim-at-expression.ts
+++ b/src/util/schedule/at/sim-at-expression.ts
@@ -1,4 +1,5 @@
 import { SimScheduleExpressionError } from "../sim-schedule.error.js";
+import type { SimScheduleZone } from "../sim-schedule-zone.js";
 
 /**
  * The instant an `at()` expression names, written without a timezone.
@@ -8,6 +9,8 @@ import { SimScheduleExpressionError } from "../sim-schedule.error.js";
  * schedule rather than part of the expression, which is why one written here
  * would be ambiguous rather than helpful.
  */
+const millisecondsPerSecond = 1000;
+
 const atInstant =
   /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})$/u;
 
@@ -31,7 +34,7 @@ export class SimAtExpression {
   /**
    * Read the instant inside an `at(...)`.
    */
-  static of(source: string): SimAtExpression {
+  static of(source: string, zone: SimScheduleZone): SimAtExpression {
     const read = atInstant.exec(source.trim())?.groups;
 
     if (read === undefined) {
@@ -57,14 +60,27 @@ export class SimAtExpression {
     // JavaScript rolls an impossible date over rather than refusing it, so the
     // thirtieth of February quietly becomes the second of March and half past
     // twenty-five becomes tomorrow morning. Writing the instant back out is
-    // what catches every one of those in one comparison.
+    // what catches every one of those in one comparison. The calendar is read
+    // in UTC for this, since which instant the wall-clock time is depends on
+    // the zone and whether it is a real time of day does not.
     if (!at.toISOString().startsWith(written)) {
       throw new SimScheduleExpressionError(
         `an at expression names a real instant, and '${source}' is not one`,
       );
     }
 
-    return new this(source, at);
+    const minuteStart = zone.instantOf(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+    );
+
+    return new this(
+      source,
+      new Date(minuteStart + Number(second) * millisecondsPerSecond),
+    );
   }
 
   /**

--- a/src/util/schedule/cron/sim-cron-expression.ts
+++ b/src/util/schedule/cron/sim-cron-expression.ts
@@ -1,8 +1,6 @@
 import { SimScheduleExpressionError } from "../sim-schedule.error.js";
-import type {
-  SimScheduleZone,
-  SimScheduleZoneParts,
-} from "../sim-schedule-zone.js";
+import type { SimScheduleZone } from "../sim-schedule-zone.js";
+import type { SimScheduleZoneParts } from "../sim-schedule-zone-clock.js";
 import type { SimCronFieldSpec } from "./sim-cron-field-spec.js";
 import { readFields, type SimCronFields } from "./sim-cron-fields.js";
 
@@ -78,11 +76,6 @@ export class SimCronExpression {
    *
    * Nothing comes back once the search has run past the last year the dialect
    * has, since a cron expression naming only years in the past falls due never.
-   *
-   * A skip that does not move the search on is taken as a minute instead. The
-   * hour a zone skips over when the clocks go forward is a wall-clock time that
-   * never happens, and asking for the instant of one answers with the moment
-   * the clocks moved, which can be behind where the search already is.
    */
   nextAfter(instant: Date): Date | undefined {
     const end = this.zone.instantOf(this.fields.year.maximum + 1, 0, 1);
@@ -95,8 +88,7 @@ export class SimCronExpression {
         return new Date(candidate);
       }
 
-      candidate =
-        skipTo > candidate ? skipTo : candidate + millisecondsPerMinute;
+      candidate = skipTo;
     }
 
     return undefined;
@@ -135,7 +127,10 @@ export class SimCronExpression {
       return at + millisecondsPerMinute;
     }
 
-    return undefined;
+    // The second of a repeated hour reads the same wall clock as the first and
+    // has already been answered with. Real Scheduler fires once when the clocks
+    // go back, rather than twice.
+    return this.zone.isCanonical(at) ? undefined : at + millisecondsPerMinute;
   }
 
   /**

--- a/src/util/schedule/cron/sim-cron-expression.ts
+++ b/src/util/schedule/cron/sim-cron-expression.ts
@@ -1,4 +1,8 @@
 import { SimScheduleExpressionError } from "../sim-schedule.error.js";
+import type {
+  SimScheduleZone,
+  SimScheduleZoneParts,
+} from "../sim-schedule-zone.js";
 import type { SimCronFieldSpec } from "./sim-cron-field-spec.js";
 import { readFields, type SimCronFields } from "./sim-cron-fields.js";
 
@@ -24,17 +28,24 @@ function startOfNextMinute(instant: Date): number {
 /**
  * One cron expression, read into the instants it falls due at.
  *
- * Everything is read in UTC. AWS runs scheduled rules in UTC and offers a
- * timezone as a separate setting, so a local timezone never enters into this.
+ * The fields name a wall-clock time, and the schedule's zone is what says which
+ * instants those are. An EventBridge rule has no timezone setting and gets the
+ * UTC zone, which reads exactly as the UTC calendar does.
  */
 export class SimCronExpression {
   public readonly source: string;
 
   private readonly fields: SimCronFields;
+  private readonly zone: SimScheduleZone;
 
-  private constructor(source: string, fields: SimCronFields) {
+  private constructor(
+    source: string,
+    fields: SimCronFields,
+    zone: SimScheduleZone,
+  ) {
     this.source = source;
     this.fields = fields;
+    this.zone = zone;
   }
 
   /**
@@ -47,6 +58,7 @@ export class SimCronExpression {
   static of(
     specs: readonly SimCronFieldSpec[],
     source: string,
+    zone: SimScheduleZone,
   ): SimCronExpression {
     const written = source.trim().split(whitespace);
 
@@ -58,7 +70,7 @@ export class SimCronExpression {
       );
     }
 
-    return new this(source, readFields(specs, written));
+    return new this(source, readFields(specs, written), zone);
   }
 
   /**
@@ -66,9 +78,14 @@ export class SimCronExpression {
    *
    * Nothing comes back once the search has run past the last year the dialect
    * has, since a cron expression naming only years in the past falls due never.
+   *
+   * A skip that does not move the search on is taken as a minute instead. The
+   * hour a zone skips over when the clocks go forward is a wall-clock time that
+   * never happens, and asking for the instant of one answers with the moment
+   * the clocks moved, which can be behind where the search already is.
    */
   nextAfter(instant: Date): Date | undefined {
-    const end = Date.UTC(this.fields.year.maximum + 1, 0, 1);
+    const end = this.zone.instantOf(this.fields.year.maximum + 1, 0, 1);
     let candidate = startOfNextMinute(instant);
 
     while (candidate < end) {
@@ -78,7 +95,8 @@ export class SimCronExpression {
         return new Date(candidate);
       }
 
-      candidate = skipTo;
+      candidate =
+        skipTo > candidate ? skipTo : candidate + millisecondsPerMinute;
     }
 
     return undefined;
@@ -94,32 +112,26 @@ export class SimCronExpression {
    * steps rather than the million minutes they hold.
    */
   private skipUnmatched(at: number): number | undefined {
-    const date = new Date(at);
-    const year = date.getUTCFullYear();
+    const read = this.zone.partsAt(at);
+    const { year, month, day, hour } = read;
 
     if (!this.fields.year.allows(year)) {
-      return Date.UTC(year + 1, 0, 1);
+      return this.zone.instantOf(year + 1, 0, 1);
     }
-
-    const month = date.getUTCMonth();
 
     if (!this.fields.month.allows(month + 1)) {
-      return Date.UTC(year, month + 1, 1);
+      return this.zone.instantOf(year, month + 1, 1);
     }
 
-    const day = date.getUTCDate();
-
-    if (!this.allowsDay(date)) {
-      return Date.UTC(year, month, day + 1);
+    if (!this.allowsDay(read)) {
+      return this.zone.instantOf(year, month, day + 1);
     }
-
-    const hour = date.getUTCHours();
 
     if (!this.fields.hours.allows(hour)) {
-      return Date.UTC(year, month, day, hour + 1);
+      return this.zone.instantOf(year, month, day, hour + 1);
     }
 
-    if (!this.fields.minutes.allows(date.getUTCMinutes())) {
+    if (!this.fields.minutes.allows(read.minute)) {
       return at + millisecondsPerMinute;
     }
 
@@ -132,13 +144,13 @@ export class SimCronExpression {
    * Whichever of the two day fields is not `?` is the one that decides, which
    * is why they cannot both say something.
    */
-  private allowsDay(date: Date): boolean {
+  private allowsDay(read: SimScheduleZoneParts): boolean {
     if (this.fields.dayOfMonth.isAny) {
       // AWS numbers the week from Sunday as one, and JavaScript from Sunday as
       // zero.
-      return this.fields.dayOfWeek.allows(date.getUTCDay() + 1);
+      return this.fields.dayOfWeek.allows(read.weekday + 1);
     }
 
-    return this.fields.dayOfMonth.allows(date.getUTCDate());
+    return this.fields.dayOfMonth.allows(read.day);
   }
 }

--- a/src/util/schedule/sim-schedule-zone-clock.ts
+++ b/src/util/schedule/sim-schedule-zone-clock.ts
@@ -1,0 +1,85 @@
+import { SimScheduleExpressionError } from "./sim-schedule.error.js";
+
+/**
+ * The wall-clock reading of one instant, as a schedule expression names it.
+ */
+export interface SimScheduleZoneParts {
+  readonly year: number;
+
+  /** The month as a JavaScript `Date` numbers it, January being zero. */
+  readonly month: number;
+  readonly day: number;
+  readonly hour: number;
+  readonly minute: number;
+
+  /** The day of the week, Sunday being zero. */
+  readonly weekday: number;
+}
+
+const weekdays: readonly string[] = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+];
+
+/**
+ * Reads what a clock in one zone says at an instant.
+ */
+export type SimScheduleZoneClock = (instant: number) => SimScheduleZoneParts;
+
+/**
+ * A clock for one zone, refusing a name no zone answers to.
+ *
+ * `Intl.DateTimeFormat` is what knows the offsets, including the two days a
+ * year a zone changes one, so no timezone database travels with this. Which
+ * names there are is therefore the host's own, and a name it has never heard
+ * of is refused here.
+ */
+export function simScheduleZoneClock(name: string): SimScheduleZoneClock {
+  const format = zoneFormat(name);
+
+  return (instant: number): SimScheduleZoneParts => {
+    const parts = new Map(
+      format
+        .formatToParts(new Date(instant))
+        .map((part) => [part.type, part.value]),
+    );
+
+    return {
+      year: Number(parts.get("year")),
+      month: Number(parts.get("month")) - 1,
+      day: Number(parts.get("day")),
+      // Midnight reads as 24 under some locales rather than as zero.
+      hour: Number(parts.get("hour")) % 24,
+      minute: Number(parts.get("minute")),
+      weekday: weekdays.indexOf(parts.get("weekday") ?? ""),
+    };
+  };
+}
+
+/**
+ * The formatter for a zone, which is also what decides the name is one.
+ */
+function zoneFormat(name: string): Intl.DateTimeFormat {
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: name,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      weekday: "short",
+    });
+  } catch {
+    throw new SimScheduleExpressionError(
+      `'${name}' is not a timezone. A timezone is an IANA name such as ` +
+        `'Europe/London', or 'UTC'`,
+    );
+  }
+}

--- a/src/util/schedule/sim-schedule-zone.ts
+++ b/src/util/schedule/sim-schedule-zone.ts
@@ -1,30 +1,10 @@
-import { SimScheduleExpressionError } from "./sim-schedule.error.js";
+import {
+  simScheduleZoneClock,
+  type SimScheduleZoneClock,
+  type SimScheduleZoneParts,
+} from "./sim-schedule-zone-clock.js";
 
-/**
- * The wall-clock reading of one instant, as a schedule expression names it.
- */
-export interface SimScheduleZoneParts {
-  readonly year: number;
-
-  /** The month as a JavaScript `Date` numbers it, January being zero. */
-  readonly month: number;
-  readonly day: number;
-  readonly hour: number;
-  readonly minute: number;
-
-  /** The day of the week, Sunday being zero. */
-  readonly weekday: number;
-}
-
-const weekdays: readonly string[] = [
-  "Sun",
-  "Mon",
-  "Tue",
-  "Wed",
-  "Thu",
-  "Fri",
-  "Sat",
-];
+const minuteMs = 60_000;
 
 /**
  * The zone a schedule expression is read in.
@@ -34,9 +14,6 @@ const weekdays: readonly string[] = [
  * with a calendar therefore goes through one of these, and a schedule created
  * without a timezone gets the UTC one, which is what every schedule used to
  * get.
- *
- * `Intl.DateTimeFormat` is what knows the offsets, including the two days a
- * year a zone changes one, so no timezone database travels with this.
  */
 export class SimScheduleZone {
   /**
@@ -44,62 +21,36 @@ export class SimScheduleZone {
    */
   public readonly name: string;
 
-  private readonly format: Intl.DateTimeFormat;
+  private readonly clock: SimScheduleZoneClock;
 
-  private constructor(name: string, format: Intl.DateTimeFormat) {
+  private constructor(name: string, clock: SimScheduleZoneClock) {
     this.name = name;
-    this.format = format;
+    this.clock = clock;
   }
 
   /**
    * The zone a name calls for, refusing a name no zone answers to.
    */
   static of(name = "UTC"): SimScheduleZone {
-    try {
-      return new this(
-        name,
-        new Intl.DateTimeFormat("en-US", {
-          timeZone: name,
-          hourCycle: "h23",
-          year: "numeric",
-          month: "2-digit",
-          day: "2-digit",
-          hour: "2-digit",
-          minute: "2-digit",
-          weekday: "short",
-        }),
-      );
-    } catch {
-      throw new SimScheduleExpressionError(
-        `'${name}' is not a timezone. A timezone is an IANA name such as ` +
-          `'Europe/London', or 'UTC'`,
-      );
-    }
+    return new this(name, simScheduleZoneClock(name));
   }
 
   /**
    * What a clock in this zone reads at an instant.
    */
   partsAt(instant: number): SimScheduleZoneParts {
-    const read = this.read(instant);
-
-    return {
-      year: read.year,
-      month: read.month - 1,
-      day: read.day,
-      hour: read.hour,
-      minute: read.minute,
-      weekday: read.weekday,
-    };
+    return this.clock(instant);
   }
 
   /**
    * The instant a clock in this zone reads a wall-clock time at.
    *
-   * The offset is read at a first guess and then at the instant that guess
-   * gives, which is what carries a time across the day a zone changes offset. A
-   * wall-clock time the zone skips over lands on the instant the clocks went
-   * forward, and one it reads twice lands on the first of the two.
+   * Two offsets are in play on the day a zone changes one, so both are tried
+   * and the answer is whichever of them the zone actually reads back. A time
+   * the clocks read twice has two, and the earlier is the answer, which is the
+   * one real Scheduler fires at. A time the clocks skip over has neither, and
+   * the answer is the later of the two, which is the first instant after the
+   * hour that never happened.
    */
   instantOf(
     year: number,
@@ -109,48 +60,61 @@ export class SimScheduleZone {
     minute = 0,
   ): number {
     const wanted = Date.UTC(year, month, day, hour, minute);
-    const guessed = wanted - this.offsetAt(wanted);
+    const candidates = this.candidatesFor(wanted);
+    const read = candidates.filter(
+      (candidate) => this.wallClockOf(candidate) === wanted,
+    );
 
-    return wanted - this.offsetAt(guessed);
+    return read.length === 0 ? Math.max(...candidates) : Math.min(...read);
+  }
+
+  /**
+   * Whether an instant is the one this zone puts its own wall-clock reading at.
+   *
+   * The second of a repeated hour reads the same as the first and is not the
+   * instant that reading resolves to, which is what tells the two apart.
+   */
+  isCanonical(instant: number): boolean {
+    const read = this.clock(instant);
+
+    return (
+      this.instantOf(
+        read.year,
+        read.month,
+        read.day,
+        read.hour,
+        read.minute,
+      ) === instant
+    );
+  }
+
+  /**
+   * The instants a wall-clock time could be, under the offsets either side of
+   * a change.
+   */
+  private candidatesFor(wanted: number): readonly number[] {
+    const first = wanted - this.offsetAt(wanted);
+    const second = wanted - this.offsetAt(first);
+
+    return first === second ? [first] : [first, second];
   }
 
   /**
    * How far ahead of UTC this zone is at an instant, in milliseconds.
    */
   private offsetAt(instant: number): number {
-    const read = this.read(instant);
-
     return (
-      Date.UTC(read.year, read.month - 1, read.day, read.hour, read.minute) -
-      Math.floor(instant / 60_000) * 60_000
+      this.wallClockOf(instant) - Math.floor(instant / minuteMs) * minuteMs
     );
   }
 
   /**
-   * One instant taken apart, in the numbering the formatter reports.
+   * What a clock in this zone reads at an instant, as a UTC instant of the same
+   * wall-clock fields, which is what makes two readings comparable.
    */
-  private read(instant: number): {
-    year: number;
-    month: number;
-    day: number;
-    hour: number;
-    minute: number;
-    weekday: number;
-  } {
-    const parts = new Map(
-      this.format
-        .formatToParts(new Date(instant))
-        .map((part) => [part.type, part.value]),
-    );
+  private wallClockOf(instant: number): number {
+    const read = this.clock(instant);
 
-    return {
-      year: Number(parts.get("year")),
-      month: Number(parts.get("month")),
-      day: Number(parts.get("day")),
-      // Midnight reads as 24 under some locales rather than as zero.
-      hour: Number(parts.get("hour")) % 24,
-      minute: Number(parts.get("minute")),
-      weekday: weekdays.indexOf(parts.get("weekday") ?? ""),
-    };
+    return Date.UTC(read.year, read.month, read.day, read.hour, read.minute);
   }
 }

--- a/src/util/schedule/sim-schedule-zone.ts
+++ b/src/util/schedule/sim-schedule-zone.ts
@@ -1,0 +1,156 @@
+import { SimScheduleExpressionError } from "./sim-schedule.error.js";
+
+/**
+ * The wall-clock reading of one instant, as a schedule expression names it.
+ */
+export interface SimScheduleZoneParts {
+  readonly year: number;
+
+  /** The month as a JavaScript `Date` numbers it, January being zero. */
+  readonly month: number;
+  readonly day: number;
+  readonly hour: number;
+  readonly minute: number;
+
+  /** The day of the week, Sunday being zero. */
+  readonly weekday: number;
+}
+
+const weekdays: readonly string[] = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+];
+
+/**
+ * The zone a schedule expression is read in.
+ *
+ * A cron expression names wall-clock fields, and which instants those are
+ * depends on the zone the schedule was created with. Everything a schedule does
+ * with a calendar therefore goes through one of these, and a schedule created
+ * without a timezone gets the UTC one, which is what every schedule used to
+ * get.
+ *
+ * `Intl.DateTimeFormat` is what knows the offsets, including the two days a
+ * year a zone changes one, so no timezone database travels with this.
+ */
+export class SimScheduleZone {
+  /**
+   * The zone name as the request wrote it, which a describe reports back.
+   */
+  public readonly name: string;
+
+  private readonly format: Intl.DateTimeFormat;
+
+  private constructor(name: string, format: Intl.DateTimeFormat) {
+    this.name = name;
+    this.format = format;
+  }
+
+  /**
+   * The zone a name calls for, refusing a name no zone answers to.
+   */
+  static of(name = "UTC"): SimScheduleZone {
+    try {
+      return new this(
+        name,
+        new Intl.DateTimeFormat("en-US", {
+          timeZone: name,
+          hourCycle: "h23",
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          weekday: "short",
+        }),
+      );
+    } catch {
+      throw new SimScheduleExpressionError(
+        `'${name}' is not a timezone. A timezone is an IANA name such as ` +
+          `'Europe/London', or 'UTC'`,
+      );
+    }
+  }
+
+  /**
+   * What a clock in this zone reads at an instant.
+   */
+  partsAt(instant: number): SimScheduleZoneParts {
+    const read = this.read(instant);
+
+    return {
+      year: read.year,
+      month: read.month - 1,
+      day: read.day,
+      hour: read.hour,
+      minute: read.minute,
+      weekday: read.weekday,
+    };
+  }
+
+  /**
+   * The instant a clock in this zone reads a wall-clock time at.
+   *
+   * The offset is read at a first guess and then at the instant that guess
+   * gives, which is what carries a time across the day a zone changes offset. A
+   * wall-clock time the zone skips over lands on the instant the clocks went
+   * forward, and one it reads twice lands on the first of the two.
+   */
+  instantOf(
+    year: number,
+    month: number,
+    day: number,
+    hour = 0,
+    minute = 0,
+  ): number {
+    const wanted = Date.UTC(year, month, day, hour, minute);
+    const guessed = wanted - this.offsetAt(wanted);
+
+    return wanted - this.offsetAt(guessed);
+  }
+
+  /**
+   * How far ahead of UTC this zone is at an instant, in milliseconds.
+   */
+  private offsetAt(instant: number): number {
+    const read = this.read(instant);
+
+    return (
+      Date.UTC(read.year, read.month - 1, read.day, read.hour, read.minute) -
+      Math.floor(instant / 60_000) * 60_000
+    );
+  }
+
+  /**
+   * One instant taken apart, in the numbering the formatter reports.
+   */
+  private read(instant: number): {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    weekday: number;
+  } {
+    const parts = new Map(
+      this.format
+        .formatToParts(new Date(instant))
+        .map((part) => [part.type, part.value]),
+    );
+
+    return {
+      year: Number(parts.get("year")),
+      month: Number(parts.get("month")),
+      day: Number(parts.get("day")),
+      // Midnight reads as 24 under some locales rather than as zero.
+      hour: Number(parts.get("hour")) % 24,
+      minute: Number(parts.get("minute")),
+      weekday: weekdays.indexOf(parts.get("weekday") ?? ""),
+    };
+  }
+}

--- a/src/util/schedule/sim-schedule.ts
+++ b/src/util/schedule/sim-schedule.ts
@@ -2,6 +2,7 @@ import { SimAtExpression } from "./at/sim-at-expression.js";
 import { SimCronExpression } from "./cron/sim-cron-expression.js";
 import { SimRateExpression } from "./rate/sim-rate-expression.js";
 import type { SimScheduleDialect } from "./sim-schedule-dialect.js";
+import { SimScheduleZone } from "./sim-schedule-zone.js";
 import { SimScheduleExpressionError } from "./sim-schedule.error.js";
 
 /**
@@ -40,7 +41,11 @@ export class SimSchedule {
   /**
    * Read a schedule expression under a dialect's rules.
    */
-  static of(source: string, dialect: SimScheduleDialect): SimSchedule {
+  static of(
+    source: string,
+    dialect: SimScheduleDialect,
+    timeZone?: string,
+  ): SimSchedule {
     const read = expression.exec(source.trim())?.groups;
 
     if (read === undefined) {
@@ -50,7 +55,10 @@ export class SimSchedule {
       );
     }
 
-    return new this(source, this.occurrencesOf(read, dialect));
+    return new this(
+      source,
+      this.occurrencesOf(read, dialect, SimScheduleZone.of(timeZone)),
+    );
   }
 
   /**
@@ -59,6 +67,7 @@ export class SimSchedule {
   private static occurrencesOf(
     read: Partial<Record<string, string>>,
     dialect: SimScheduleDialect,
+    zone: SimScheduleZone,
   ): SimScheduleOccurrences {
     const body = read["body"] ?? "";
 
@@ -67,11 +76,11 @@ export class SimSchedule {
     }
 
     if (read["kind"] === "cron") {
-      return SimCronExpression.of(dialect.cronFields, body);
+      return SimCronExpression.of(dialect.cronFields, body, zone);
     }
 
     if (read["kind"] === "at" && dialect.allowsOneTime) {
-      return SimAtExpression.of(body);
+      return SimAtExpression.of(body, zone);
     }
 
     const forms = dialect.allowsOneTime

--- a/test/scheduler/timezone-schedule-fixture.ts
+++ b/test/scheduler/timezone-schedule-fixture.ts
@@ -1,0 +1,126 @@
+/**
+ * The parts a Scheduler timezone test needs before it can say anything about
+ * when a schedule falls due: a clock starting where the test says, a function
+ * to invoke, and a role allowed to invoke it.
+ *
+ * These live under `test/` for the same reason as the other service fixtures.
+ * eslint rejects a test file exporting helpers alongside its own `describe`
+ * calls.
+ */
+
+import { CreateRoleCommand, PutRolePolicyCommand } from "@aws-sdk/client-iam";
+import type { CreateScheduleCommandInput } from "@aws-sdk/client-scheduler";
+
+import { SimFixedClock } from "../../src/util/clock/sim-clock.js";
+import { SimAws } from "../../src/service/aws/sim-aws.js";
+import { makeLambdaZipFileInput } from "../../src/service/lambda/index.js";
+
+export const functionArn =
+  "arn:aws:lambda:us-east-1:888888888888:function:reconcile";
+
+export const roleArn = "arn:aws:iam::888888888888:role/SchedulerRole";
+
+export interface SimSchedulerZoneSimulation {
+  readonly simAws: SimAws;
+
+  /** One entry per invocation the schedule made. */
+  readonly invocations: unknown[];
+}
+
+/**
+ * A simulation whose clock starts where a test says, with a function to invoke
+ * and a role allowed to invoke it.
+ */
+export async function aSimulationFrom(
+  startedAt: string,
+): Promise<SimSchedulerZoneSimulation> {
+  const simAws = new SimAws({ clock: new SimFixedClock(new Date(startedAt)) });
+  const invocations: unknown[] = [];
+
+  await simAws.lambda().createFunction({
+    input: {
+      FunctionName: "reconcile",
+      Role: "arn:aws:iam::888888888888:role/ReconcileRole",
+      Code: {
+        ZipFile: makeLambdaZipFileInput((event: unknown) => {
+          invocations.push(event);
+
+          return { ok: true };
+        }),
+      },
+    },
+  });
+
+  await simAws.iam().createRole(
+    new CreateRoleCommand({
+      RoleName: "SchedulerRole",
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Principal: { Service: "scheduler.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      }),
+    }),
+  );
+
+  await simAws.iam().putRolePolicy(
+    new PutRolePolicyCommand({
+      RoleName: "SchedulerRole",
+      PolicyName: "InvokeReconcile",
+      PolicyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: {
+          Effect: "Allow",
+          Action: "lambda:InvokeFunction",
+          Resource: functionArn,
+        },
+      }),
+    }),
+  );
+
+  return { simAws, invocations };
+}
+
+/**
+ * A nightly schedule in a named zone.
+ */
+export function nightlyIn(
+  timeZone: string,
+  expression: string,
+): CreateScheduleCommandInput {
+  return {
+    Name: "reconciliation",
+    ScheduleExpression: expression,
+    ScheduleExpressionTimezone: timeZone,
+    FlexibleTimeWindow: { Mode: "OFF" },
+    Target: { Arn: functionArn, RoleArn: roleArn },
+  };
+}
+
+/**
+ * The instants a created schedule falls due at, from an instant, as ISO text.
+ */
+export function dueInstants(
+  simAws: SimAws,
+  from: string,
+  count: number,
+): readonly string[] {
+  const schedule = simAws.scheduler().findSchedule("reconciliation");
+  const due: string[] = [];
+  let at = new Date(from);
+
+  for (let taken = 0; taken < count; taken += 1) {
+    const next = schedule?.schedule.nextAfter(at);
+
+    if (next === undefined) {
+      break;
+    }
+
+    due.push(next.toISOString());
+    at = next;
+  }
+
+  return due;
+}


### PR DESCRIPTION
A schedule carrying `ScheduleExpressionTimezone` was refused, and a stack holding one failed whole, so a CDK app scheduling anything in a named zone had no way to test the rest of that stack either. A cron expression now names a wall-clock time in the schedule's zone, and the instants it falls due at come from that zone's offsets, including the two days a year one changes. `Intl` is what knows the offsets, so no timezone data travels with this. A schedule that names no zone runs in UTC as every schedule did, and an EventBridge rule is unchanged. A name no zone answers to is refused against the parameter it arrived on, and `GetSchedule` reports the zone back.

Resolves https://github.com/KensioSoftware/yulin/issues/1343

- [x] Conventional commit message, used as the title
- [x] Conventional branch name, like `feat/concise-description`
- [x] Full check with `pnpm run check` passed
- [x] Rebased off latest main
- [x] User-facing behaviour is documented in `docs/`

Worth a look in review: the search for the next occurrence now steps a minute where a skip fails to move it on. A wall-clock time the clocks skip over resolves to the instant they moved, which can be behind where the search already is, and without that guard a schedule due inside the spring-forward hour searched for ever.

The `pnpm run check` run fails four `src/cli/watch/*.loc.test.ts` filesystem-watch files on this machine. They fail the same way on an unmodified `main`, and which of them fails varies run to run. Everything else passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Scheduler schedules with valid IANA time zones.
  - Schedule execution now respects wall-clock times and daylight-saving transitions.
  - Configured time zones are included when schedules are described.
  - UTC remains the default when no time zone is specified.
- **Bug Fixes**
  - Invalid time zones now produce clear validation errors.
- **Documentation**
  - Updated Scheduler guidance to explain time zones, DST behavior, defaults, and host time-zone data limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->