### PR TITLE
feat: flatten a split expression with UNNEST

### DIFF
--- a/docs/services/athena/README.md
+++ b/docs/services/athena/README.md
@@ -486,7 +486,7 @@ Every ascending sort is emitted carrying `NULLS LAST`, because Trino orders null
 direction it sorts and SQLite orders them first ascending. Both were cases where a query answered
 differently while still succeeding, which is the failure that costs the most to find.
 
-### Flattening an array or a map
+### Flattening an array, a map or a split value
 
 `UNNEST` runs. An array or a map column is held as its JSON text, and SQLite reads that with
 `json_each`, so a statement flattening one returns a row per element the way Athena does.
@@ -505,6 +505,22 @@ falls back rather than reading a scalar as a collection.
 One flattening per statement is what this covers, joined with `CROSS JOIN`. A second `UNNEST`, a
 `LEFT JOIN UNNEST`, a `SELECT *` beside one, and a position taken from a map all fall back.
 
+A table with no array column in it can still be flattened. `split` answers an array, and an `UNNEST`
+over the call cuts one stored string into a row per part. This is how a packed access log row is
+read, since Glue builds a log table's columns from what the delivery was configured with.
+
+```sql
+SELECT t.part
+FROM rainlytics.logs
+CROSS JOIN UNNEST(split(url_extract_parameter(cs_uri_stem || '?' || cs_uri_query, 'b'), ';'))
+  AS t(part)
+```
+
+Splitting an empty value answers one empty part, as it does on Trino. A row whose value is null
+answers no parts at all and drops out, the way an empty array column does. The call is what says the
+value is a collection (an expression has no schema entry to read). `split` and `slice` are the two
+calls the flattening reaches, and any other expression under an `UNNEST` falls back.
+
 ### The functions a statement can call
 
 SQLite carries a much smaller function library than Trino, and the engine fills the gap for the ones
@@ -516,7 +532,7 @@ its declared result.
 | Date and time | `current_date`, `current_timestamp`, `date_add`, `date_diff`, `date_trunc`, `date_format`, `at_timezone`, `from_unixtime`, `to_unixtime`, `from_iso8601_timestamp`, `from_iso8601_date`, `to_iso8601` |
 | JSON          | `json_extract`, `json_extract_scalar`, `json_parse`, `json_size`                                                                                                                                      |
 | Array and map | `array_agg`, `cardinality`, `contains`, `element_at`, `array_join`, `slice`                                                                                                                           |
-| String        | `regexp_like`, `regexp_extract`, `regexp_replace`, `split_part`, `strpos`                                                                                                                             |
+| String        | `regexp_like`, `regexp_extract`, `regexp_replace`, `split`, `split_part`, `strpos`                                                                                                                    |
 | Binary        | `md5`, `sha1`, `sha256`, `sha512`, `xxhash64`, `murmur3`, `crc32`, `to_hex`, `from_hex`, `to_base64`, `from_base64`, `to_utf8`, `from_utf8`                                                           |
 | URL           | `url_extract_host`, `url_extract_path`, `url_extract_protocol`, `url_extract_port`, `url_extract_query`, `url_extract_fragment`, `url_extract_parameter`, `url_decode`, `url_encode`                  |
 | Approximate   | `approx_distinct`, `approx_percentile`                                                                                                                                                                |
@@ -992,6 +1008,7 @@ own and authorizes work on one against the workgroup it belongs to. This asks th
 - `StartQueryExecution`, `GetQueryExecution`, `GetQueryResults` and `StopQueryExecution`
 - A `SELECT` run for real over JSON lines and CSV objects in simulated S3, answered by SQLite
 - `UNNEST` over an array or a map column, with `WITH ORDINALITY` where a query wants the position
+- `UNNEST` over a `split` or a `slice` call, flattening one stored string into a row per part
 - Trino's date, JSON, array, string and URL functions, with `current_timestamp` reading the
   simulated clock
 - Declared results, matched on the query text, ahead of the engine for one statement and behind it
@@ -1027,6 +1044,8 @@ Current documented limitations:
   gives a map's keys rather than its positions.
 - `UNNEST` over a `ROW` or a struct array falls back. The element needs field access and the
   flattened column is JSON text here.
+- `UNNEST` over an expression reaches `split` and `slice`. The engine reads the call to decide that
+  a value is a collection, and a call to anything else falls back.
 - The Trino function library reaches as far as the table under
   [the functions a statement can call](#the-functions-a-statement-can-call). A query reaching for
   anything else Trino has and SQLite lacks falls back.

--- a/src/service/athena/engine/sim-athena-ast-nodes.ts
+++ b/src/service/athena/engine/sim-athena-ast-nodes.ts
@@ -21,6 +21,34 @@ export interface SimAthenaFromItem extends SimAthenaAstNode {
   as?: string | null;
 }
 
+/** One value as a node, or nothing where it is not an object. */
+export function asAstNode(value: unknown): SimAthenaAstNode | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as SimAthenaAstNode)
+    : undefined;
+}
+
+/**
+ * The name a call carries, where the statement wrote it as one part.
+ *
+ * The parser holds a name as a list, one entry per piece of a qualified name,
+ * and it holds an `UNNEST` alias as a call of its own. A name written in more
+ * than one part answers with nothing, since neither the engine's functions nor
+ * an alias is reached that way.
+ */
+export function simAthenaCalledName(
+  node: SimAthenaAstNode | undefined,
+): string | undefined {
+  const parts = asAstNode(node?.["name"])?.["name"];
+  const first =
+    Array.isArray(parts) && parts.length === 1
+      ? asAstNode(parts[0])
+      : undefined;
+  const name = first?.["value"];
+
+  return typeof name === "string" ? name : undefined;
+}
+
 /** Every node in the tree, the outermost first. */
 export function* simAthenaAstNodes(root: unknown): Generator<SimAthenaAstNode> {
   if (Array.isArray(root)) {

--- a/src/service/athena/engine/sim-athena-string-shims.ts
+++ b/src/service/athena/engine/sim-athena-string-shims.ts
@@ -1,6 +1,8 @@
 import type { DatabaseSync } from "node:sqlite";
 
+import { SimAthenaSetUpError } from "../error/sim-athena.error.js";
 import {
+  isExplicitNull,
   shimNumber,
   shimText,
   simAthenaScalarShim,
@@ -15,12 +17,56 @@ import {
  * with something that works less well.
  */
 export function simAthenaInstallStringShims(database: DatabaseSync): void {
+  simAthenaScalarShim(database, "split", (...values) =>
+    isExplicitNull(values, 2)
+      ? null
+      : split(
+          shimText(values.at(0)),
+          shimText(values.at(1)),
+          shimNumber(values.at(2)),
+        ),
+  );
   simAthenaScalarShim(database, "split_part", (value, delimiter, index) =>
     splitPart(shimText(value), shimText(delimiter), shimNumber(index)),
   );
   simAthenaScalarShim(database, "strpos", (value, search) =>
     position(shimText(value), shimText(search)),
   );
+}
+
+/**
+ * One value cut into an array, written as the JSON text an array is held as.
+ *
+ * Trino answers with one empty element over an empty value, and refuses an
+ * empty delimiter rather than answering a character at a time. A limit caps
+ * how many elements come back and leaves the rest of the value in the last of
+ * them.
+ */
+function split(
+  value: string | undefined,
+  delimiter: string | undefined,
+  limit: number | undefined,
+): string | null {
+  if (value === undefined || delimiter === undefined) {
+    return null;
+  }
+
+  if (delimiter === "" || (limit !== undefined && limit < 1)) {
+    throw new SimAthenaSetUpError(
+      "split takes a delimiter of at least one character and a limit from one",
+    );
+  }
+
+  const parts = value.split(delimiter);
+
+  if (limit === undefined || parts.length <= limit) {
+    return JSON.stringify(parts);
+  }
+
+  return JSON.stringify([
+    ...parts.slice(0, limit - 1),
+    parts.slice(limit - 1).join(delimiter),
+  ]);
 }
 
 /** Trino counts the fields from one, and has no field below that. */

--- a/src/service/athena/engine/sim-athena-unnest-item.ts
+++ b/src/service/athena/engine/sim-athena-unnest-item.ts
@@ -1,5 +1,7 @@
 import {
+  asAstNode,
   simAthenaAstNodes,
+  simAthenaCalledName,
   type SimAthenaAstNode,
 } from "./sim-athena-ast-nodes.js";
 
@@ -50,9 +52,9 @@ export function simAthenaUnnestItem(ast: unknown): SimAthenaUnnestRead {
 
   const alias = aliasOf(item);
   const columns = aliasColumns(item);
-  const source = item["expr"];
+  const source = asAstNode(item["expr"]);
 
-  if (alias === undefined || columns === undefined || !isNode(source)) {
+  if (alias === undefined || columns === undefined || source === undefined) {
     return { kind: "unreadable" };
   }
 
@@ -74,32 +76,20 @@ function isCrossJoined(item: SimAthenaAstNode): boolean {
 
 /** The alias name, which the parser holds as a function's name. */
 function aliasOf(item: SimAthenaAstNode): string | undefined {
-  const parts = asNode(asNode(item["as"])?.["name"])?.["name"];
-  const first = Array.isArray(parts) ? asNode(parts[0]) : undefined;
-  const value = first?.["value"];
-
-  return typeof value === "string" ? value : undefined;
+  return simAthenaCalledName(asAstNode(item["as"]));
 }
 
 /** The names inside the alias, which the parser holds as a function's arguments. */
 function aliasColumns(item: SimAthenaAstNode): readonly string[] | undefined {
-  const values = asNode(asNode(item["as"])?.["args"])?.["value"];
+  const values = asAstNode(asAstNode(item["as"])?.["args"])?.["value"];
 
   if (!Array.isArray(values) || values.length === 0) {
     return undefined;
   }
 
-  const columns = values.map((value) => asNode(value)?.["column"]);
+  const columns = values.map((value) => asAstNode(value)?.["column"]);
 
   return columns.every((column) => typeof column === "string")
     ? columns
     : undefined;
-}
-
-function isNode(value: unknown): value is SimAthenaAstNode {
-  return typeof value === "object" && value !== null;
-}
-
-function asNode(value: unknown): SimAthenaAstNode | undefined {
-  return isNode(value) ? value : undefined;
 }

--- a/src/service/athena/engine/sim-athena-unnest-rewrite.ts
+++ b/src/service/athena/engine/sim-athena-unnest-rewrite.ts
@@ -22,10 +22,10 @@ interface SimAthenaUnnestRewriteRequest {
 /**
  * Turn an `UNNEST` into the `json_each` SQLite flattens JSON with.
  *
- * An array or a map column is held as its JSON text, and `json_each` reads that
- * as one row per element with a `key` and a `value`. The `FROM` entry becomes a
- * call to it and every reference to the alias is pointed at the column it
- * answers with.
+ * An array or a map column is held as its JSON text, as is what a function like
+ * `split` answers, and `json_each` reads that as one row per element with a
+ * `key` and a `value`. The `FROM` entry becomes a call to it and every
+ * reference to the alias is pointed at the column it answers with.
  *
  * Answers with whether the statement can run. A statement carrying no `UNNEST`
  * runs untouched, and one carrying an `UNNEST` this cannot turn into

--- a/src/service/athena/engine/sim-athena-unnest-source.ts
+++ b/src/service/athena/engine/sim-athena-unnest-source.ts
@@ -3,6 +3,7 @@ import {
   isColumnRef,
   isFromItem,
   simAthenaAstNodes,
+  simAthenaCalledName,
   type SimAthenaAstNode,
 } from "./sim-athena-ast-nodes.js";
 
@@ -10,17 +11,27 @@ import {
 export type SimAthenaUnnestKind = "array" | "map";
 
 /**
- * What the statement is flattening, read off the Glue schema.
+ * The engine's own functions that answer an array.
  *
- * The catalog is the only thing that says whether a column holds an array, a
- * map or a scalar, and `json_each` answers with different columns for the first
- * two. A column the schema calls anything else answers with nothing here, and
- * the query falls back rather than reading a value as a collection it never
- * was.
+ * An expression has no catalog entry to read, so the call itself is what says
+ * the value is a collection. Each of these answers with the JSON text an array
+ * column is held as, which is what `json_each` reads.
+ */
+const arrayFunctions = new Set(["split", "slice"]);
+
+/**
+ * What the statement is flattening.
  *
- * An expression that is not a plain column reference answers with nothing too.
- * `UNNEST(split(x, ','))` is a real Athena query and the schema says nothing
- * about what it comes to.
+ * A column is read off the Glue schema. The catalog is the only thing that says
+ * whether a column holds an array, a map or a scalar, and `json_each` answers
+ * with different columns for the first two. A column the schema calls anything
+ * else answers with nothing here, and the query falls back rather than reading
+ * a value as a collection it never was.
+ *
+ * An expression is read off the function it calls. `UNNEST(split(x, ','))` is
+ * how a statement flattens a delimited string, and nothing but the call says
+ * what it comes to. A call to anything else answers with nothing, since the
+ * flattening would otherwise run over whatever SQLite made of a scalar.
  */
 export function simAthenaUnnestKind(
   source: SimAthenaAstNode,
@@ -28,7 +39,7 @@ export function simAthenaUnnestKind(
   tables: readonly SimAthenaCatalogTable[],
 ): SimAthenaUnnestKind | undefined {
   if (!isColumnRef(source)) {
-    return undefined;
+    return answersArray(source) ? "array" : undefined;
   }
 
   const declared = declaredType(source, ast, tables);
@@ -44,6 +55,14 @@ export function simAthenaUnnestKind(
   }
 
   return type.startsWith("map") ? "map" : undefined;
+}
+
+/** Whether this expression is a call to a function answering an array. */
+function answersArray(source: SimAthenaAstNode): boolean {
+  const name =
+    source["type"] === "function" ? simAthenaCalledName(source) : undefined;
+
+  return name !== undefined && arrayFunctions.has(name.toLowerCase());
 }
 
 /** Every catalog table the statement reads, by the name it reaches each one by. */

--- a/src/service/athena/engine/sim-athena-value-shims.iso.test.ts
+++ b/src/service/athena/engine/sim-athena-value-shims.iso.test.ts
@@ -1,4 +1,4 @@
-import { assertIdentical } from "@kensio/smartass";
+import { assertIdentical, assertThrowsErrorAsync } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import {
@@ -133,6 +133,58 @@ describe("Trino's string functions on SQLite", () => {
     assertIdentical(await anAnsweredExpression("strpos('abc', 'c')"), 3);
     assertIdentical(await anAnsweredExpression("strpos('abc', 'z')"), 0);
     assertIdentical(await anAnsweredExpression("strpos('abc', NULL)"), null);
+  });
+
+  it("cuts a value into an array of its parts", async () => {
+    // Given a delimited value, an empty one, and a null.
+    // When each is split.
+    // Then the parts come back as the JSON text an array is held as, and an
+    // empty value answers with one empty part the way Trino does.
+    assertIdentical(
+      await anAnsweredExpression("split('a,b,c', ',')"),
+      '["a","b","c"]',
+    );
+    assertIdentical(await anAnsweredExpression("split('', ',')"), '[""]');
+    assertIdentical(
+      await anAnsweredExpression("split('a,,b', ',')"),
+      '["a","","b"]',
+    );
+    assertIdentical(await anAnsweredExpression("split(NULL, ',')"), null);
+    assertIdentical(await anAnsweredExpression("split('a,b', NULL)"), null);
+  });
+
+  it("leaves the rest of the value in the last part under a limit", async () => {
+    // Given a value with three parts in it.
+    // When a limit is put on how many come back.
+    // Then the last part carries everything left, and a limit past the parts
+    // changes nothing. An explicit null limit answers null, since a Trino
+    // function answers null for any null argument.
+    assertIdentical(
+      await anAnsweredExpression("split('a.b.c', '.', 2)"),
+      '["a","b.c"]',
+    );
+    assertIdentical(
+      await anAnsweredExpression("split('a.b', '.', 9)"),
+      '["a","b"]',
+    );
+    assertIdentical(
+      await anAnsweredExpression("split('a.b', '.', NULL)"),
+      null,
+    );
+  });
+
+  it("refuses an empty delimiter and a limit below one", async () => {
+    // Given a value to split.
+    // When the delimiter is empty and when the limit is zero.
+    // Then the statement raises, which leaves the declared result to answer.
+    // Trino refuses both, where JavaScript would split an empty delimiter a
+    // character at a time and answer something else.
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("split('abc', '')"),
+    );
+    await assertThrowsErrorAsync(async () =>
+      anAnsweredExpression("split('a.b', '.', 0)"),
+    );
   });
 });
 

--- a/src/service/athena/sim-athena-engine-unnest-expressions.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-unnest-expressions.iso.test.ts
@@ -1,0 +1,104 @@
+import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
+import { describe, it } from "vitest";
+
+import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
+import { anEventSimulation } from "./sim-athena-flattened-events.fixture.js";
+
+describe("flattening an Athena expression with UNNEST", () => {
+  it("returns one row per element of a split value", async () => {
+    // Given a table whose packed column holds a delimited string.
+    const simulation = await anEventSimulation();
+
+    // When a query cuts it up and flattens the result.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT e.id, t.part FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(split(e.packed, ';')) AS t(part) " +
+        "ORDER BY e.id, t.part",
+    );
+
+    // Then each part is a row of its own. The empty value answers one empty
+    // part the way Trino does, and the event holding no value at all drops
+    // out, since there is nothing to flatten.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [
+      ["1", "blue"],
+      ["1", "red"],
+      ["2", ""],
+    ]);
+  });
+
+  it("counts the rows the flattening left in the pass", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query rolls the parts up by event.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT e.id, count(*) AS parts FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(split(e.packed, ';')) AS t(part) " +
+        "GROUP BY e.id ORDER BY e.id",
+    );
+
+    // Then the event whose value answered no parts is counted nowhere, and
+    // the others are counted as the parts they came to.
+    assertObjectEquals(answered.rows, [
+      ["1", "2"],
+      ["2", "1"],
+    ]);
+  });
+
+  it("counts the parts from one with ORDINALITY", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query asks each part for its position.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.part, t.place FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(split(e.packed, ';')) WITH ORDINALITY AS " +
+        "t(part, place) WHERE e.id = 1 ORDER BY t.place",
+    );
+
+    // Then the positions run over the parts the split answered with.
+    assertObjectEquals(answered.rows, [
+      ["red", "1"],
+      ["blue", "2"],
+    ]);
+  });
+
+  it("flattens what a whole expression tree comes to", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query reads the parts out of a query string it builds itself,
+    // which is the shape a packed access log row is read with.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.part FROM rainlytics.events e CROSS JOIN UNNEST(split(" +
+        "url_extract_parameter('https://rain.example/r?b=' || e.packed, 'b')" +
+        ", ';')) AS t(part) WHERE e.id = 1 ORDER BY t.part",
+    );
+
+    // Then the call the flattening names is what decides, however much sits
+    // underneath it.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["blue"], ["red"]]);
+  });
+
+  it("flattens a run taken out of an array column", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens part of an array rather than all of it.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.tag FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(slice(e.tags, 2, 1)) AS t(tag)",
+    );
+
+    // Then `slice` answers an array as well, so the flattening reaches it.
+    assertIdentical(answered.answeredBy, "engine");
+    assertObjectEquals(answered.rows, [["blue"]]);
+  });
+});

--- a/src/service/athena/sim-athena-engine-unnest.iso.test.ts
+++ b/src/service/athena/sim-athena-engine-unnest.iso.test.ts
@@ -2,47 +2,7 @@ import { assertIdentical, assertObjectEquals } from "@kensio/smartass";
 import { describe, it } from "vitest";
 
 import { anAnsweredQuery } from "./sim-athena-answered-query.fixture.js";
-import {
-  aCatalogTable,
-  anEngineSimulation,
-  aSeededJson,
-  type SimAthenaEngineSimulation,
-} from "./sim-athena-engine.fixture.js";
-
-const events = [
-  { id: 1, tags: ["red", "blue"], attrs: { size: "large" }, name: "one" },
-  { id: 2, tags: [], attrs: {}, name: "two" },
-  {
-    id: 3,
-    tags: ["green"],
-    attrs: { size: "small", colour: "green" },
-    name: "three",
-  },
-];
-
-/** A simulation holding the events, with the engine on. */
-async function anEventSimulation(): Promise<SimAthenaEngineSimulation> {
-  const simulation = await anEngineSimulation();
-
-  aCatalogTable(simulation.simAws, {
-    name: "events",
-    columns: [
-      { Name: "id", Type: "int" },
-      { Name: "tags", Type: "array<string>" },
-      { Name: "attrs", Type: "map<string,string>" },
-      { Name: "name", Type: "string" },
-    ],
-  });
-
-  await aSeededJson(simulation.simAws, "events/part-0.json", events);
-  await simulation.simAws.athena().engine().enable();
-  simulation.simAws
-    .athena()
-    .results()
-    .byDefault({ columns: ["fallback"], rows: [["declared"]] });
-
-  return simulation;
-}
+import { anEventSimulation } from "./sim-athena-flattened-events.fixture.js";
 
 describe("flattening an Athena array with UNNEST", () => {
   it("returns one row per element", async () => {
@@ -218,19 +178,36 @@ describe("an UNNEST the engine turns down", () => {
     assertIdentical(answered.answeredBy, "declaration");
   });
 
-  it("falls back over an expression the catalog says nothing about", async () => {
+  it("falls back over an expression answering no collection", async () => {
     // Given the events, with the engine on.
     const simulation = await anEventSimulation();
 
-    // When a query flattens something that is not a column.
+    // When a query flattens a call that answers a scalar.
     const answered = await anAnsweredQuery(
       simulation,
       "SELECT t.part FROM rainlytics.events e " +
         "CROSS JOIN UNNEST(split_part(e.name, 'n', 1)) AS t(part)",
     );
 
-    // Then the declaration answers it. Only the schema says what a value
-    // holds, and it says nothing about an expression.
+    // Then the declaration answers it. An expression has no schema entry, so
+    // the call is what says the value is a collection, and `split_part`
+    // answers one field rather than all of them.
+    assertIdentical(answered.answeredBy, "declaration");
+  });
+
+  it("falls back over an array the statement wrote out", async () => {
+    // Given the events, with the engine on.
+    const simulation = await anEventSimulation();
+
+    // When a query flattens an array literal.
+    const answered = await anAnsweredQuery(
+      simulation,
+      "SELECT t.tag FROM rainlytics.events e " +
+        "CROSS JOIN UNNEST(ARRAY['red', 'blue']) AS t(tag)",
+    );
+
+    // Then the declaration answers it. A column and a call are the two things
+    // the flattening reads, and a literal is neither.
     assertIdentical(answered.answeredBy, "declaration");
   });
 

--- a/src/service/athena/sim-athena-flattened-events.fixture.ts
+++ b/src/service/athena/sim-athena-flattened-events.fixture.ts
@@ -1,0 +1,56 @@
+import {
+  aCatalogTable,
+  anEngineSimulation,
+  aSeededJson,
+  type SimAthenaEngineSimulation,
+} from "./sim-athena-engine.fixture.js";
+
+/**
+ * The events a flattening query reads.
+ *
+ * Each holds a collection of every shape an `UNNEST` reaches. An array and a
+ * map that are empty, a delimited string that is empty, and a row carrying no
+ * delimited string at all, which is what a flattening answering no rows runs
+ * over.
+ */
+const events = [
+  {
+    id: 1,
+    tags: ["red", "blue"],
+    attrs: { size: "large" },
+    name: "one",
+    packed: "red;blue",
+  },
+  { id: 2, tags: [], attrs: {}, name: "two", packed: "" },
+  {
+    id: 3,
+    tags: ["green"],
+    attrs: { size: "small", colour: "green" },
+    name: "three",
+  },
+];
+
+/** A simulation holding the events, with the engine on. */
+export async function anEventSimulation(): Promise<SimAthenaEngineSimulation> {
+  const simulation = await anEngineSimulation();
+
+  aCatalogTable(simulation.simAws, {
+    name: "events",
+    columns: [
+      { Name: "id", Type: "int" },
+      { Name: "tags", Type: "array<string>" },
+      { Name: "attrs", Type: "map<string,string>" },
+      { Name: "name", Type: "string" },
+      { Name: "packed", Type: "string" },
+    ],
+  });
+
+  await aSeededJson(simulation.simAws, "events/part-0.json", events);
+  await simulation.simAws.athena().engine().enable();
+  simulation.simAws
+    .athena()
+    .results()
+    .byDefault({ columns: ["fallback"], rows: [["declared"]] });
+
+  return simulation;
+}


### PR DESCRIPTION
`split` answers an array under the Athena query engine, and an `UNNEST` takes an expression as well as a column. A call to `split` or `slice` is what says a value is a collection where the Glue schema has nothing to say about it, and `json_each` flattens what the call comes to. A packed access log row needs this, since Glue builds a log table's columns from the delivery and leaves no array column anywhere to flatten.

Resolves #1353